### PR TITLE
[9.4] [Fleet] Update permissions for proxy secrets (#279410)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/agent_policy_yaml_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/agent_policy_yaml_flyout.tsx
@@ -26,7 +26,12 @@ import {
 } from '@elastic/eui';
 
 import { MAX_FLYOUT_WIDTH } from '../constants';
-import { useGetOneAgentPolicyFull, useGetOneAgentPolicy, useStartServices } from '../hooks';
+import {
+  useGetOneAgentPolicyFull,
+  useGetOneAgentPolicy,
+  useStartServices,
+  useAuthz,
+} from '../hooks';
 
 import { agentPolicyRouteService, getYamlFormatters } from '../services';
 import type { YamlFormatters } from '../../../services/yaml_formatters';
@@ -55,6 +60,8 @@ export const AgentPolicyYamlFlyout = memo<{
   }, []);
 
   const core = useStartServices();
+  const authz = useAuthz();
+  const canReadSettings = authz.fleet.readSettings;
   const {
     isLoading: isLoadingYaml,
     data: yamlData,
@@ -149,6 +156,31 @@ export const AgentPolicyYamlFlyout = memo<{
             )}
           </h2>
         </EuiTitle>
+        {!canReadSettings && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              announceOnMount
+              title={
+                <FormattedMessage
+                  id="xpack.fleet.policyDetails.secretsRedactedTitle"
+                  defaultMessage="Some proxy credentials may not be shown"
+                />
+              }
+              size="m"
+              color="warning"
+              iconType="warning"
+            >
+              <FormattedMessage
+                id="xpack.fleet.policyDetails.secretsRedactedDescription"
+                defaultMessage="Proxy headers and TLS private keys are only visible to users with the {privilege} Kibana privilege for Fleet."
+                values={{
+                  privilege: <strong>{'Fleet > Settings: Read'}</strong>,
+                }}
+              />
+            </EuiCallOut>
+          </>
+        )}
         {packagePoliciesContainSecrets && (
           <>
             <EuiSpacer size="m" />

--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/configure_standalone_agent_step.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/configure_standalone_agent_step.tsx
@@ -26,7 +26,7 @@ import { i18n } from '@kbn/i18n';
 import type { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
 
 import type { K8sMode } from '../types';
-import { useStartServices } from '../../../hooks';
+import { useAuthz, useStartServices } from '../../../hooks';
 
 export const ConfigureStandaloneAgentStep = ({
   isK8s,
@@ -49,6 +49,7 @@ export const ConfigureStandaloneAgentStep = ({
   onCopy?: () => void;
 }): EuiContainedStepProps => {
   const core = useStartServices();
+  const canReadSettings = useAuthz().fleet.readSettings;
   const { docLinks } = core;
 
   const policyMsg =
@@ -204,6 +205,28 @@ export const ConfigureStandaloneAgentStep = ({
               </EuiFlexItem>
             </EuiFlexGroup>
             <EuiSpacer size="m" />
+            {!canReadSettings && (
+              <>
+                <EuiCallOut
+                  announceOnMount
+                  title={i18n.translate(
+                    'xpack.fleet.agentEnrollment.secretsRedactedCallout.title',
+                    { defaultMessage: 'Some proxy credentials may not be shown' }
+                  )}
+                  color="warning"
+                  iconType="warning"
+                >
+                  {i18n.translate(
+                    'xpack.fleet.agentEnrollment.secretsRedactedCallout.description',
+                    {
+                      defaultMessage:
+                        'Proxy headers and TLS private keys are only visible to users with the Fleet Settings: Read Kibana privilege.',
+                    }
+                  )}
+                </EuiCallOut>
+                <EuiSpacer size="m" />
+              </>
+            )}
             <EuiCodeBlock
               language="yaml"
               style={{ maxHeight: 300 }}

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
@@ -7,7 +7,8 @@
 
 import { httpServerMock } from '@kbn/core/server/mocks';
 
-import { agentPolicyService } from '../../services';
+import { agentPolicyService, appContextService } from '../../services';
+import { listFleetProxies } from '../../services/fleet_proxies';
 
 import type { FleetRequestHandlerContext } from '../..';
 import { xpackMocks } from '../../mocks';
@@ -16,6 +17,10 @@ import type { AgentPolicy } from '../../types';
 
 import {
   bulkGetAgentPoliciesHandler,
+  copyAgentPolicyHandler,
+  createAgentPolicyHandler,
+  downloadFullAgentPolicy,
+  getFullAgentPolicy,
   GetListAgentPolicyOutputsHandler,
   populateAssignedAgentsCount,
 } from './handlers';
@@ -25,9 +30,23 @@ jest.mock('../../services/agent_policy', () => {
     agentPolicyService: {
       getByIds: jest.fn(),
       listAllOutputsForPolicies: jest.fn(),
+      getFullAgentPolicy: jest.fn(),
+      getFleetServerPolicy: jest.fn(),
+      getFullAgentConfigMap: jest.fn(),
     },
   };
 });
+
+jest.mock('../../services/agent_policy_create', () => {
+  return {
+    createAgentPolicyWithPackages: jest.fn(),
+  };
+});
+
+jest.mock('../../services/fleet_proxies', () => ({
+  listFleetProxies: jest.fn().mockResolvedValue({ items: [] }),
+}));
+
 
 const agentPolicyServiceMock = agentPolicyService as jest.Mocked<typeof agentPolicyService>;
 
@@ -70,6 +89,230 @@ describe('Agent policy API handlers', () => {
         ['1'],
         expect.anything()
       );
+    });
+  });
+
+  describe('getFullAgentPolicy / downloadFullAgentPolicy — proxy secret redaction', () => {
+    const POLICY_WITH_SECRETS = {
+      id: 'policy-1',
+      outputs: {
+        default: {
+          type: 'elasticsearch',
+          hosts: ['https://es:9200'],
+          proxy_url: 'https://proxy.fr',
+          proxy_headers: { Authorization: 'Bearer SECRET' },
+          ssl: { key: 'PRIVATE_KEY', certificate: 'my-cert' },
+        },
+      },
+      fleet: {
+        hosts: ['https://fleet:8220'],
+        proxy_url: 'https://proxy.fr',
+        proxy_headers: { Authorization: 'Bearer SECRET' },
+        ssl: { key: 'PRIVATE_KEY' },
+      },
+      agent: {
+        download: {
+          sourceURI: 'https://artifacts.elastic.co',
+          proxy_headers: { Authorization: 'Bearer SECRET' },
+          ssl: { key: 'PRIVATE_KEY' },
+        },
+        monitoring: { enabled: false, metrics: false, logs: false, traces: false },
+        features: {},
+        protection: { enabled: false, uninstall_token_hash: '', signing_key: '' },
+      },
+      inputs: [],
+      revision: 2,
+      signed: { data: '', signature: '' },
+      secret_references: [],
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('main composition path (no revision / no kubernetes)', () => {
+      it('passes redactProxySecrets:true when caller lacks fleet-settings-read', async () => {
+        const fleetContext = (await context.fleet) as any;
+        fleetContext.authz.fleet.readSettings = false;
+        agentPolicyServiceMock.getFullAgentPolicy.mockResolvedValue(POLICY_WITH_SECRETS as any);
+
+        const request = httpServerMock.createKibanaRequest({
+          params: { agentPolicyId: 'policy-1' },
+          query: {},
+        });
+
+        await getFullAgentPolicy(context, request, response);
+
+        expect(agentPolicyServiceMock.getFullAgentPolicy).toHaveBeenCalledWith(
+          expect.anything(),
+          'policy-1',
+          expect.objectContaining({ redactProxySecrets: true })
+        );
+      });
+
+      it('passes redactProxySecrets:false when caller has fleet-settings-read', async () => {
+        const fleetContext = (await context.fleet) as any;
+        fleetContext.authz.fleet.readSettings = true;
+        agentPolicyServiceMock.getFullAgentPolicy.mockResolvedValue(POLICY_WITH_SECRETS as any);
+
+        const request = httpServerMock.createKibanaRequest({
+          params: { agentPolicyId: 'policy-1' },
+          query: {},
+        });
+
+        await getFullAgentPolicy(context, request, response);
+
+        expect(agentPolicyServiceMock.getFullAgentPolicy).toHaveBeenCalledWith(
+          expect.anything(),
+          'policy-1',
+          expect.objectContaining({ redactProxySecrets: false })
+        );
+      });
+    });
+
+    describe('?revision=N branch', () => {
+      // Deep-clone per test because redactProxySecretsFromPolicy mutates in place
+      const makeStoredDoc = () => ({ data: JSON.parse(JSON.stringify(POLICY_WITH_SECRETS)) });
+
+      it('strips proxy secrets from the response when caller lacks fleet-settings-read', async () => {
+        const fleetContext = (await context.fleet) as any;
+        fleetContext.authz.fleet.readSettings = false;
+        agentPolicyServiceMock.getFleetServerPolicy.mockResolvedValue(makeStoredDoc() as any);
+
+        const request = httpServerMock.createKibanaRequest({
+          params: { agentPolicyId: 'policy-1' },
+          query: { revision: 2 },
+        });
+
+        await getFullAgentPolicy(context, request, response);
+
+        expect(response.ok).toHaveBeenCalled();
+        const body = (response.ok as jest.Mock).mock.calls[0][0].body;
+        // proxy-derived fields are redacted on the proxied output
+        expect(body.item.outputs.default).not.toHaveProperty('proxy_headers');
+        expect(body.item.outputs.default.ssl).not.toHaveProperty('key');
+        expect(body.item.outputs.default.ssl?.certificate).toBe('my-cert');
+        expect(body.item.outputs.default.proxy_url).toBe('https://proxy.fr');
+        // fleet proxy_headers are redacted; ssl.key preserved (proxy has no certificate_key in this test)
+        expect(body.item.fleet).not.toHaveProperty('proxy_headers');
+        expect(body.item.fleet.ssl?.key).toBe('PRIVATE_KEY');
+        // agent.download proxy_headers are redacted; ssl.key preserved (no proxy certificate_key)
+        expect(body.item.agent.download).not.toHaveProperty('proxy_headers');
+        expect(body.item.agent.download.ssl?.key).toBe('PRIVATE_KEY');
+      });
+
+      it('strips fleet and download ssl.key when the proxy has a certificate_key', async () => {
+        const fleetContext = (await context.fleet) as any;
+        fleetContext.authz.fleet.readSettings = false;
+        agentPolicyServiceMock.getFleetServerPolicy.mockResolvedValue(makeStoredDoc() as any);
+        (listFleetProxies as jest.Mock).mockResolvedValueOnce({
+          items: [{ url: 'https://proxy.fr', certificate_key: 'PROXY_CERT_KEY' }],
+        });
+
+        const request = httpServerMock.createKibanaRequest({
+          params: { agentPolicyId: 'policy-1' },
+          query: { revision: 2 },
+        });
+
+        await getFullAgentPolicy(context, request, response);
+
+        expect(response.ok).toHaveBeenCalled();
+        const body = (response.ok as jest.Mock).mock.calls[0][0].body;
+        // fleet ssl.key is proxy-derived — must be redacted when proxy has certificate_key
+        expect(body.item.fleet).not.toHaveProperty('proxy_headers');
+        expect(body.item.fleet.ssl).not.toHaveProperty('key');
+        // agent.download has no proxy_url so its ssl.key cannot be matched — left intact
+        expect(body.item.agent.download).not.toHaveProperty('proxy_headers');
+        expect(body.item.agent.download.ssl?.key).toBe('PRIVATE_KEY');
+      });
+
+      it('returns full secrets in the response when caller has fleet-settings-read', async () => {
+        const fleetContext = (await context.fleet) as any;
+        fleetContext.authz.fleet.readSettings = true;
+        agentPolicyServiceMock.getFleetServerPolicy.mockResolvedValue(makeStoredDoc() as any);
+
+        const request = httpServerMock.createKibanaRequest({
+          params: { agentPolicyId: 'policy-1' },
+          query: { revision: 2 },
+        });
+
+        await getFullAgentPolicy(context, request, response);
+
+        expect(response.ok).toHaveBeenCalled();
+        const body = (response.ok as jest.Mock).mock.calls[0][0].body;
+        expect(body.item.outputs.default.proxy_headers).toEqual({ Authorization: 'Bearer SECRET' });
+        expect(body.item.outputs.default.ssl?.key).toBe('PRIVATE_KEY');
+      });
+
+      it('strips proxy secrets from the download YAML when caller lacks fleet-settings-read', async () => {
+        const fleetContext = (await context.fleet) as any;
+        fleetContext.authz.fleet.readSettings = false;
+        agentPolicyServiceMock.getFleetServerPolicy.mockResolvedValue(makeStoredDoc() as any);
+
+        const request = httpServerMock.createKibanaRequest({
+          params: { agentPolicyId: 'policy-1' },
+          query: { revision: 2 },
+        });
+
+        await downloadFullAgentPolicy(context, request, response);
+
+        expect(response.ok).toHaveBeenCalled();
+        const yaml: string = (response.ok as jest.Mock).mock.calls[0][0].body;
+        // proxy_headers (bearer tokens) must be gone
+        expect(yaml).not.toContain('Bearer SECRET');
+        // proxy_url (non-secret) must remain
+        expect(yaml).toContain('https://proxy.fr');
+        // proxy has no certificate_key in this test — fleet/download ssl.key must remain
+        expect(yaml).toContain('PRIVATE_KEY');
+      });
+    });
+
+    describe('?kubernetes=true branch', () => {
+      it('passes redactProxySecrets:true to getFullAgentConfigMap when caller lacks fleet-settings-read', async () => {
+        const fleetContext = (await context.fleet) as any;
+        fleetContext.authz.fleet.readSettings = false;
+        fleetContext.agentClient.asInternalUser.getLatestAgentAvailableDockerImageVersion.mockResolvedValue(
+          '9.6.0'
+        );
+        agentPolicyServiceMock.getFullAgentConfigMap.mockResolvedValue('configmap-yaml');
+
+        const request = httpServerMock.createKibanaRequest({
+          params: { agentPolicyId: 'policy-1' },
+          query: { kubernetes: true },
+        });
+
+        await getFullAgentPolicy(context, request, response);
+
+        expect(agentPolicyServiceMock.getFullAgentConfigMap).toHaveBeenCalledWith(
+          expect.anything(),
+          'policy-1',
+          '9.6.0',
+          expect.objectContaining({ redactProxySecrets: true })
+        );
+      });
+
+      it('passes redactProxySecrets:false to getFullAgentConfigMap when caller has fleet-settings-read', async () => {
+        const fleetContext = (await context.fleet) as any;
+        fleetContext.authz.fleet.readSettings = true;
+        fleetContext.agentClient.asInternalUser.getLatestAgentAvailableDockerImageVersion.mockResolvedValue(
+          '9.6.0'
+        );
+        agentPolicyServiceMock.getFullAgentConfigMap.mockResolvedValue('configmap-yaml');
+
+        const request = httpServerMock.createKibanaRequest({
+          params: { agentPolicyId: 'policy-1' },
+          query: { kubernetes: true },
+        });
+
+        await getFullAgentPolicy(context, request, response);
+
+        expect(agentPolicyServiceMock.getFullAgentConfigMap).toHaveBeenCalledWith(
+          expect.anything(),
+          'policy-1',
+          '9.6.0',
+          expect.objectContaining({ redactProxySecrets: false })
+        );
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
@@ -7,7 +7,7 @@
 
 import { httpServerMock } from '@kbn/core/server/mocks';
 
-import { agentPolicyService, appContextService } from '../../services';
+import { agentPolicyService } from '../../services';
 import { listFleetProxies } from '../../services/fleet_proxies';
 
 import type { FleetRequestHandlerContext } from '../..';
@@ -17,8 +17,6 @@ import type { AgentPolicy } from '../../types';
 
 import {
   bulkGetAgentPoliciesHandler,
-  copyAgentPolicyHandler,
-  createAgentPolicyHandler,
   downloadFullAgentPolicy,
   getFullAgentPolicy,
   GetListAgentPolicyOutputsHandler,
@@ -46,7 +44,6 @@ jest.mock('../../services/agent_policy_create', () => {
 jest.mock('../../services/fleet_proxies', () => ({
   listFleetProxies: jest.fn().mockResolvedValue({ items: [] }),
 }));
-
 
 const agentPolicyServiceMock = agentPolicyService as jest.Mocked<typeof agentPolicyService>;
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -20,6 +20,8 @@ import {
 } from '../../../common/services/version_specific_policies_utils';
 
 import { fullAgentPolicyToYaml } from '../../../common/services';
+import { redactProxySecretsFromPolicy } from '../../services/agent_policies/full_agent_policy';
+import { listFleetProxies } from '../../services/fleet_proxies';
 import {
   appContextService,
   agentPolicyService,
@@ -754,6 +756,8 @@ export const getFullAgentPolicy: FleetRequestHandler<
     });
   }
 
+  const canReadSettings = fleetContext.authz.fleet.readSettings;
+
   if (request.query.revision) {
     const coreContext = await context.core;
     const esClient = coreContext.elasticsearch.client.asInternalUser;
@@ -768,9 +772,16 @@ export const getFullAgentPolicy: FleetRequestHandler<
         body: { message: 'Agent policy not found' },
       });
     }
-    const body: GetFullAgentPolicyResponse = {
-      item: fleetServerPolicy.data as unknown as FullAgentPolicy,
-    };
+    const item = fleetServerPolicy.data as unknown as FullAgentPolicy;
+    let redactedItem = item;
+    if (!canReadSettings) {
+      const { items: proxies } = await listFleetProxies(soClient);
+      const proxyUrlsWithCertKey = new Set(
+        proxies.filter((p) => p.certificate_key).map((p) => p.url)
+      );
+      redactedItem = redactProxySecretsFromPolicy(item, proxyUrlsWithCertKey);
+    }
+    const body: GetFullAgentPolicyResponse = { item: redactedItem };
     return response.ok({ body });
   }
 
@@ -781,7 +792,7 @@ export const getFullAgentPolicy: FleetRequestHandler<
       soClient,
       agentPolicyId,
       agentVersion,
-      { standalone: request.query.standalone === true }
+      { standalone: request.query.standalone === true, redactProxySecrets: !canReadSettings }
     );
     if (fullAgentConfigMap) {
       const body: GetFullAgentConfigMapResponse = {
@@ -799,6 +810,7 @@ export const getFullAgentPolicy: FleetRequestHandler<
   } else {
     const fullAgentPolicy = await agentPolicyService.getFullAgentPolicy(soClient, agentPolicyId, {
       standalone: request.query.standalone === true,
+      redactProxySecrets: !canReadSettings,
     });
     if (fullAgentPolicy) {
       const body: GetFullAgentPolicyResponse = {
@@ -833,6 +845,8 @@ export const downloadFullAgentPolicy: FleetRequestHandler<
     });
   }
 
+  const canReadSettings = fleetContext.authz.fleet.readSettings;
+
   if (request.query.revision) {
     const coreContext = await context.core;
     const esClient = coreContext.elasticsearch.client.asInternalUser;
@@ -847,8 +861,16 @@ export const downloadFullAgentPolicy: FleetRequestHandler<
         body: { message: 'Agent policy not found' },
       });
     }
-    const fullAgentPolicy = fleetServerPolicy.data as unknown as FullAgentPolicy;
-    const body = fullAgentPolicyToYaml(fullAgentPolicy, yaml);
+    const storedPolicy = fleetServerPolicy.data as unknown as FullAgentPolicy;
+    let policyToSerialize = storedPolicy;
+    if (!canReadSettings) {
+      const { items: proxies } = await listFleetProxies(soClient);
+      const proxyUrlsWithCertKey = new Set(
+        proxies.filter((p) => p.certificate_key).map((p) => p.url)
+      );
+      policyToSerialize = redactProxySecretsFromPolicy(storedPolicy, proxyUrlsWithCertKey);
+    }
+    const body = fullAgentPolicyToYaml(policyToSerialize, yaml);
     const headers: ResponseHeaders = {
       'content-type': 'text/x-yaml',
       'content-disposition': `attachment; filename="elastic-agent.yml"`,
@@ -863,7 +885,7 @@ export const downloadFullAgentPolicy: FleetRequestHandler<
       soClient,
       agentPolicyId,
       agentVersion,
-      { standalone: request.query.standalone === true }
+      { standalone: request.query.standalone === true, redactProxySecrets: !canReadSettings }
     );
     if (!fullAgentConfigMap) {
       return response.customError({
@@ -883,6 +905,7 @@ export const downloadFullAgentPolicy: FleetRequestHandler<
   } else {
     const fullAgentPolicy = await agentPolicyService.getFullAgentPolicy(soClient, agentPolicyId, {
       standalone: request.query.standalone === true,
+      redactProxySecrets: !canReadSettings,
     });
     if (!fullAgentPolicy) {
       return response.customError({

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -2749,6 +2749,39 @@ ssl.test: 123
       }
     `);
   });
+
+  it('should redact proxy_headers and ssl.key when redactProxySecrets=true', () => {
+    const proxy = {
+      id: 'proxy-1',
+      name: 'proxy1',
+      url: 'https://proxy.fr',
+      certificate_authorities: '/tmp/ssl/ca.crt',
+      proxy_headers: { Authorization: 'Bearer SECRET' },
+      certificate: 'my-cert',
+      certificate_key: 'PRIVATE_KEY',
+      is_preconfigured: false,
+    } as any;
+
+    const policyOutput = transformOutputToFullPolicyOutput(
+      {
+        id: 'id123',
+        proxy_id: 'proxy-1',
+        hosts: ['http://host.fr'],
+        is_default: false,
+        is_default_monitoring: false,
+        name: 'test output',
+        type: 'elasticsearch',
+      } as any,
+      proxy,
+      false,
+      true // redactProxySecrets
+    );
+
+    expect(policyOutput.proxy_url).toBe('https://proxy.fr');
+    expect(policyOutput).not.toHaveProperty('proxy_headers');
+    expect(policyOutput.ssl?.certificate).toBe('my-cert');
+    expect(policyOutput.ssl).not.toHaveProperty('key');
+  });
 });
 
 describe('generateFleetConfig', () => {
@@ -2902,6 +2935,49 @@ describe('generateFleetConfig', () => {
         },
       },
     });
+  });
+
+  it('should redact proxy_headers and ssl.key when redactProxySecrets=true', () => {
+    const res = generateFleetConfig(
+      {
+        host_urls: ['https://test.fr'],
+        proxy_id: 'proxy-1',
+      } as any,
+      [
+        {
+          id: 'proxy-1',
+          url: 'https://proxy.fr',
+          certificate_authorities: ['/tmp/ssl/ca.crt'],
+          proxy_headers: { Authorization: 'Bearer SECRET' },
+          certificate: 'my-cert',
+          certificate_key: 'PRIVATE_KEY',
+        } as any,
+      ],
+      true // redactProxySecrets
+    );
+
+    expect(res).toMatchInlineSnapshot(`
+      Object {
+        "hosts": Array [
+          "https://test.fr",
+        ],
+        "proxy_url": "https://proxy.fr",
+        "ssl": Object {
+          "certificate": "my-cert",
+          "certificate_authorities": Array [
+            Array [
+              "/tmp/ssl/ca.crt",
+            ],
+          ],
+          "renegotiation": "never",
+          "verification_mode": "",
+        },
+      }
+    `);
+    expect(res).not.toHaveProperty('proxy_headers');
+    if (res && 'hosts' in res) {
+      expect(res.ssl).not.toHaveProperty('key');
+    }
   });
 });
 
@@ -3227,6 +3303,20 @@ describe('getBinarySourceSettings', () => {
           key: 'PROXY_KEY1',
         },
       });
+    });
+
+    it('should redact proxy_headers and ssl.key when redactProxySecrets=true', () => {
+      const result = getBinarySourceSettings(downloadSource, proxy, true);
+      expect(result).toEqual({
+        proxy_url: 'http://proxy_uri.it',
+        sourceURI: 'http://custom-registry-test',
+        ssl: {
+          certificate: 'proxy_cert',
+          certificate_authorities: ['PROXY_CA'],
+        },
+      });
+      expect(result).not.toHaveProperty('proxy_headers');
+      expect(result.ssl).not.toHaveProperty('key');
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -77,7 +77,13 @@ async function fetchAgentPolicy(soClient: SavedObjectsClientContract, id: string
 export async function getFullAgentPolicy(
   soClient: SavedObjectsClientContract,
   id: string,
-  options?: { standalone?: boolean; agentPolicy?: AgentPolicy; agentVersion?: string }
+  options?: {
+    standalone?: boolean;
+    agentPolicy?: AgentPolicy;
+    agentVersion?: string;
+    /** When true, redact proxy_headers and ssl.key from all proxy references in the response */
+    redactProxySecrets?: boolean;
+  }
 ): Promise<FullAgentPolicy | null> {
   const logger = appContextService.getLogger().get('getFullAgentPolicy');
 
@@ -88,6 +94,7 @@ export async function getFullAgentPolicy(
   );
 
   const standalone = options?.standalone ?? false;
+  const redactProxySecrets = options?.redactProxySecrets ?? false;
 
   let agentPolicy: AgentPolicy | null;
   if (options?.agentPolicy?.package_policies) {
@@ -238,7 +245,8 @@ export async function getFullAgentPolicy(
         acc[getOutputIdForAgentPolicy(output)] = transformOutputToFullPolicyOutput(
           output,
           output.proxy_id ? proxies.find((proxy) => output.proxy_id === proxy.id) : undefined,
-          standalone
+          standalone,
+          redactProxySecrets
         );
         return acc;
       }, {}),
@@ -253,7 +261,7 @@ export async function getFullAgentPolicy(
     ],
     revision: agentPolicy.revision,
     agent: {
-      download: getBinarySourceSettings(downloadSource, downloadSourceProxy),
+      download: getBinarySourceSettings(downloadSource, downloadSourceProxy, redactProxySecrets),
       monitoring: getFullMonitoringSettings(agentPolicy, monitoringOutput),
       features,
       protection: {
@@ -376,7 +384,7 @@ export async function getFullAgentPolicy(
 
   // only add fleet server hosts if not in standalone
   if (!standalone && fleetServerHost) {
-    fullAgentPolicy.fleet = generateFleetConfig(fleetServerHost, proxies);
+    fullAgentPolicy.fleet = generateFleetConfig(fleetServerHost, proxies, redactProxySecrets);
   }
 
   const settingsValues = getSettingsValuesForAgentPolicy(
@@ -443,7 +451,8 @@ export async function getFullAgentPolicy(
 
 export function generateFleetConfig(
   fleetServerHost: FleetServerHost,
-  proxies: FleetProxy[]
+  proxies: FleetProxy[],
+  redactProxySecrets = false
 ): FullAgentPolicy['fleet'] {
   const config: FullAgentPolicy['fleet'] = {
     hosts: fleetServerHost.host_urls,
@@ -481,7 +490,7 @@ export function generateFleetConfig(
     : null;
   if (fleetServerHostproxy) {
     config.proxy_url = fleetServerHostproxy.url;
-    if (fleetServerHostproxy.proxy_headers) {
+    if (!redactProxySecrets && fleetServerHostproxy.proxy_headers) {
       config.proxy_headers = fleetServerHostproxy.proxy_headers;
     }
     if (
@@ -496,7 +505,8 @@ export function generateFleetConfig(
           certificate_authorities: [fleetServerHostproxy.certificate_authorities],
         }),
         ...(fleetServerHostproxy.certificate && { certificate: fleetServerHostproxy.certificate }),
-        ...(fleetServerHostproxy.certificate_key && { key: fleetServerHostproxy.certificate_key }),
+        ...(!redactProxySecrets &&
+          fleetServerHostproxy.certificate_key && { key: fleetServerHostproxy.certificate_key }),
       };
     }
   }
@@ -540,7 +550,8 @@ function generateSSLConfigForFleetServerInput(fleetServerHost: FleetServerHost) 
 export function transformOutputToFullPolicyOutput(
   output: Output,
   proxy?: FleetProxy,
-  standalone = false
+  standalone = false,
+  redactProxySecrets = false
 ): FullAgentPolicyOutput {
   const {
     config_yaml,
@@ -667,7 +678,7 @@ export function transformOutputToFullPolicyOutput(
 
   if (proxy) {
     newOutput.proxy_url = proxy.url;
-    if (proxy.proxy_headers) {
+    if (!redactProxySecrets && proxy.proxy_headers) {
       newOutput.proxy_headers = proxy.proxy_headers;
     }
 
@@ -686,7 +697,7 @@ export function transformOutputToFullPolicyOutput(
       }
       newOutput.ssl.certificate = proxy.certificate;
     }
-    if (proxy.certificate_key) {
+    if (!redactProxySecrets && proxy.certificate_key) {
       if (!newOutput.ssl) {
         newOutput.ssl = {};
       }
@@ -864,7 +875,8 @@ function buildShipperQueueData(shipper: ShipperOutput) {
 
 export function getBinarySourceSettings(
   downloadSource: DownloadSource,
-  downloadSourceProxy: FleetProxy | undefined
+  downloadSourceProxy: FleetProxy | undefined,
+  redactProxySecrets = false
 ) {
   const config: FullAgentPolicyDownload = {
     sourceURI: downloadSource.host,
@@ -944,7 +956,7 @@ export function getBinarySourceSettings(
     if (downloadSourceProxy.url) {
       config.proxy_url = downloadSourceProxy.url;
     }
-    if (downloadSourceProxy.proxy_headers) {
+    if (!redactProxySecrets && downloadSourceProxy.proxy_headers) {
       config.proxy_headers = downloadSourceProxy.proxy_headers;
     }
     // if the proxy is configured, get the ssl settings from it
@@ -955,11 +967,61 @@ export function getBinarySourceSettings(
       ...(downloadSourceProxy?.certificate && {
         certificate: downloadSourceProxy.certificate,
       }),
-      ...(downloadSourceProxy?.certificate_key && {
-        key: downloadSourceProxy?.certificate_key,
-      }),
+      ...(!redactProxySecrets &&
+        downloadSourceProxy?.certificate_key && {
+          key: downloadSourceProxy?.certificate_key,
+        }),
     };
   }
 
   return config;
+}
+
+/**
+ * Strip proxy_headers and proxy-derived ssl.key from a FullAgentPolicy that was already
+ * composed (e.g. retrieved verbatim from the .fleet-policies index via ?revision=N).
+ * Mutates in place and returns the policy for convenience.
+ *
+ * proxyUrlsWithCertKey: URLs of proxies that have a certificate_key. When provided,
+ * ssl.key is redacted on fleet/agent.download sections only if their proxy_url is in this
+ * set — distinguishing proxy-derived keys from the entity's own TLS keys. Without this
+ * set, ssl.key on fleet/agent.download is left untouched (conservative: avoids
+ * over-redaction but may miss proxy keys).
+ */
+export function redactProxySecretsFromPolicy(
+  policy: FullAgentPolicy,
+  proxyUrlsWithCertKey?: Set<string>
+): FullAgentPolicy {
+  if (policy.outputs) {
+    for (const output of Object.values(policy.outputs)) {
+      delete output.proxy_headers;
+      // Output ssl.key is always proxy-derived; safe to redact whenever proxy_url is present
+      if (output.proxy_url && output.ssl) {
+        delete output.ssl.key;
+      }
+    }
+  }
+  if (policy.fleet && 'hosts' in policy.fleet) {
+    delete policy.fleet.proxy_headers;
+    // Only redact ssl.key if we can confirm it came from a proxy with a certificate_key
+    if (
+      policy.fleet.proxy_url &&
+      proxyUrlsWithCertKey?.has(policy.fleet.proxy_url) &&
+      policy.fleet.ssl
+    ) {
+      delete policy.fleet.ssl.key;
+    }
+  }
+  if (policy.agent?.download) {
+    delete policy.agent.download.proxy_headers;
+    // Only redact ssl.key if we can confirm it came from a proxy with a certificate_key
+    if (
+      policy.agent.download.proxy_url &&
+      proxyUrlsWithCertKey?.has(policy.agent.download.proxy_url) &&
+      policy.agent.download.ssl
+    ) {
+      delete (policy.agent.download.ssl as Record<string, unknown>).key;
+    }
+  }
+  return policy;
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -2159,7 +2159,7 @@ class AgentPolicyService {
     soClient: SavedObjectsClientContract,
     id: string,
     agentVersion: string,
-    options?: { standalone: boolean }
+    options?: { standalone: boolean; redactProxySecrets?: boolean }
   ): Promise<string | null> {
     const fullAgentPolicy = await getFullAgentPolicy(soClient, id, options);
     if (fullAgentPolicy) {
@@ -2207,7 +2207,12 @@ class AgentPolicyService {
   public async getFullAgentPolicy(
     soClient: SavedObjectsClientContract,
     id: string,
-    options?: { standalone?: boolean; agentPolicy?: AgentPolicy; agentVersion?: string }
+    options?: {
+      standalone?: boolean;
+      agentPolicy?: AgentPolicy;
+      agentVersion?: string;
+      redactProxySecrets?: boolean;
+    }
   ): Promise<FullAgentPolicy | null> {
     const span = apm.startSpan(
       `getFullAgentPolicy ${id} ${options?.agentVersion ?? ''}`,

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/full_policy_proxy_secret_redaction.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/full_policy_proxy_secret_redaction.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { setupTestUsers, testUsers } from '../test_users';
+
+/**
+ * Verifies that proxy_headers (bearer tokens) and ssl.key (TLS private keys) are
+ * redacted from GET /api/fleet/agent_policies/{id}/full and its /download variant
+ * for callers that hold only fleet-agent-policies-read, while remaining visible to
+ * callers that also have fleet-settings-read.
+
+ */
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const kibanaServer = getService('kibanaServer');
+  const fleetAndAgents = getService('fleetAndAgents');
+
+  describe('GET /api/fleet/agent_policies/{id}/full — proxy secret redaction by privilege', () => {
+    const PROXY_ID = 'proxy-secret-redaction-test';
+    let agentPolicyId: string;
+
+    before(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+      await setupTestUsers(getService('security'));
+      await fleetAndAgents.setup();
+
+      // Create a proxy with bearer-token proxy_headers and a TLS private key
+      await supertest
+        .post('/api/fleet/proxies')
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          id: PROXY_ID,
+          name: 'Proxy secret redaction test proxy',
+          url: 'https://proxy.test.internal:8443',
+          proxy_headers: { Authorization: 'Bearer SUPER_SECRET_TOKEN' },
+          certificate_key:
+            '-----BEGIN PRIVATE KEY-----PRIVATE_KEY_MATERIAL-----END PRIVATE KEY-----',
+        })
+        .expect(200);
+
+      // Create an output that references the proxy
+      const { body: outputRes } = await supertest
+        .post('/api/fleet/outputs')
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'Output with proxy (secret redaction test)',
+          type: 'elasticsearch',
+          hosts: ['https://es.test.internal:9200'],
+          proxy_id: PROXY_ID,
+        })
+        .expect(200);
+
+      // Create an agent policy that uses the proxied output
+      const { body: policyRes } = await supertest
+        .post('/api/fleet/agent_policies')
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: `Proxy secret redaction test policy ${Date.now()}`,
+          namespace: 'default',
+          data_output_id: outputRes.item.id,
+          monitoring_output_id: outputRes.item.id,
+        })
+        .expect(200);
+
+      agentPolicyId = policyRes.item.id;
+    });
+
+    after(async () => {
+      await supertest
+        .post('/api/fleet/agent_policies/delete')
+        .set('kbn-xsrf', 'xxxx')
+        .send({ agentPolicyId })
+        .expect(200);
+      await supertest.delete(`/api/fleet/proxies/${PROXY_ID}`).set('kbn-xsrf', 'xxxx').expect(200);
+      await kibanaServer.savedObjects.cleanStandardList();
+    });
+
+    describe('fleet_agent_policies_read_only user (no settings-read)', () => {
+      it('should NOT expose proxy_headers or ssl.key in the full policy response', async () => {
+        const { body } = await supertestWithoutAuth
+          .get(`/api/fleet/agent_policies/${agentPolicyId}/full`)
+          .set('kbn-xsrf', 'xxxx')
+          .auth(
+            testUsers.fleet_agent_policies_read_only.username,
+            testUsers.fleet_agent_policies_read_only.password
+          )
+          .expect(200);
+
+        const outputs = body.item.outputs as Record<string, any>;
+        for (const output of Object.values(outputs)) {
+          expect(output).not.to.have.property('proxy_headers');
+          if (output.ssl) {
+            expect(output.ssl).not.to.have.property('key');
+          }
+          // proxy_url is non-secret and must still be present
+          if (output.proxy_url) {
+            expect(output.proxy_url).to.be.a('string');
+          }
+        }
+      });
+
+      it('should NOT expose proxy_headers or ssl.key in the download YAML', async () => {
+        const { text } = await supertestWithoutAuth
+          .get(`/api/fleet/agent_policies/${agentPolicyId}/download`)
+          .set('kbn-xsrf', 'xxxx')
+          .auth(
+            testUsers.fleet_agent_policies_read_only.username,
+            testUsers.fleet_agent_policies_read_only.password
+          )
+          .expect(200);
+
+        expect(text).not.to.contain('SUPER_SECRET_TOKEN');
+        expect(text).not.to.contain('PRIVATE_KEY_MATERIAL');
+        // proxy_url must still appear
+        expect(text).to.contain('proxy.test.internal');
+      });
+    });
+
+    describe('fleet_all_only user (has settings-read)', () => {
+      it('should expose proxy_headers and ssl.key in the full policy response', async () => {
+        const { body } = await supertestWithoutAuth
+          .get(`/api/fleet/agent_policies/${agentPolicyId}/full`)
+          .set('kbn-xsrf', 'xxxx')
+          .auth(testUsers.fleet_all_only.username, testUsers.fleet_all_only.password)
+          .expect(200);
+
+        const outputs = body.item.outputs as Record<string, any>;
+        const proxiedOutput = Object.values(outputs).find((o: any) => o.proxy_url);
+        expect(proxiedOutput).to.be.ok();
+        expect(proxiedOutput.proxy_headers).to.eql({ Authorization: 'Bearer SUPER_SECRET_TOKEN' });
+        expect(proxiedOutput.ssl?.key).to.eql(
+          '-----BEGIN PRIVATE KEY-----PRIVATE_KEY_MATERIAL-----END PRIVATE KEY-----'
+        );
+      });
+
+      it('should expose proxy_headers and ssl.key in the download YAML', async () => {
+        const { text } = await supertestWithoutAuth
+          .get(`/api/fleet/agent_policies/${agentPolicyId}/download`)
+          .set('kbn-xsrf', 'xxxx')
+          .auth(testUsers.fleet_all_only.username, testUsers.fleet_all_only.password)
+          .expect(200);
+
+        expect(text).to.contain('SUPER_SECRET_TOKEN');
+        expect(text).to.contain('PRIVATE_KEY_MATERIAL');
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/index.js
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/index.js
@@ -11,6 +11,7 @@ export default function loadTests({ loadTestFile }) {
     loadTestFile(require.resolve('./agent_policy'));
     loadTestFile(require.resolve('./agent_policy_datastream_permissions'));
     loadTestFile(require.resolve('./privileges'));
+    loadTestFile(require.resolve('./full_policy_proxy_secret_redaction'));
     loadTestFile(require.resolve('./agent_policy_root_integrations'));
     loadTestFile(require.resolve('./create_standalone_api_key'));
     loadTestFile(require.resolve('./agent_policy_outputs'));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Fleet] Update permissions for proxy secrets (#279410)](https://github.com/elastic/kibana/pull/279410)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-21T14:06:34Z","message":"[Fleet] Update permissions for proxy secrets (#279410)\n\n## Summary\n\nRestrict proxy credentials from appearing in the full agent policy API\nresponse for users who do not have the fleet-settings-read privilege.\nProxy URL and certificate authority fields are unaffected.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nLow risk: the change is purely additive on the read path and only\naffects users without fleet-settings-read. Users with that privilege see\nno change in behaviour. The underlying policy deployed to agents (via\n.fleet-policies) is not affected.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f0c9db1f6172415bfd3e5844f5ab72f674d4162","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v8.19.0","v9.3.0","v9.4.0","v9.5.0","v9.6.0"],"title":"[Fleet] Update permissions for proxy secrets","number":279410,"url":"https://github.com/elastic/kibana/pull/279410","mergeCommit":{"message":"[Fleet] Update permissions for proxy secrets (#279410)\n\n## Summary\n\nRestrict proxy credentials from appearing in the full agent policy API\nresponse for users who do not have the fleet-settings-read privilege.\nProxy URL and certificate authority fields are unaffected.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nLow risk: the change is purely additive on the read path and only\naffects users without fleet-settings-read. Users with that privilege see\nno change in behaviour. The underlying policy deployed to agents (via\n.fleet-policies) is not affected.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f0c9db1f6172415bfd3e5844f5ab72f674d4162"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.3","9.4"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279866","number":279866,"state":"MERGED","mergeCommit":{"sha":"958d7e2937f8412855bdccd2b086a7a9e2f6f788","message":"[9.5] [Fleet] Update permissions for proxy secrets (#279410) (#279866)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Fleet] Update permissions for proxy secrets\n(#279410)](https://github.com/elastic/kibana/pull/279410)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Cristina Amico <criamico@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279410","number":279410,"mergeCommit":{"message":"[Fleet] Update permissions for proxy secrets (#279410)\n\n## Summary\n\nRestrict proxy credentials from appearing in the full agent policy API\nresponse for users who do not have the fleet-settings-read privilege.\nProxy URL and certificate authority fields are unaffected.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nLow risk: the change is purely additive on the read path and only\naffects users without fleet-settings-read. Users with that privilege see\nno change in behaviour. The underlying policy deployed to agents (via\n.fleet-policies) is not affected.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f0c9db1f6172415bfd3e5844f5ab72f674d4162"}}]}] BACKPORT-->