### PR TITLE
[Cases][Templates] Enable Cases Templates V2 feature flag

### DIFF
--- a/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml
@@ -217,6 +217,7 @@ enabled:
   - x-pack/platform/test/functional_execution_context/config.ts
   - x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/config.ts
   - x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/config.ts
+  - x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/config_legacy.ts
   - x-pack/platform/test/functional_with_es_ssl/apps/cases/basic/config.ts
   - x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/config.ts
   - x-pack/platform/test/functional_with_es_ssl/apps/embeddable_alerts_table/config.ts

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_create.test.ts
@@ -99,6 +99,9 @@ describe('bulkCreate', () => {
     });
 
     const clientArgs = createCasesClientMockArgs();
+    // This suite asserts the exact bulkCreateCases payload; the extended_fields
+    // mirroring (templates flag ON) is covered by dedicated tests below.
+    clientArgs.config = { ...clientArgs.config, templates: { enabled: false } };
 
     clientArgs.services.caseService.bulkCreateCases.mockResolvedValue({
       saved_objects: [caseSO],
@@ -1476,7 +1479,7 @@ describe('bulkCreate', () => {
     it('does not mirror customFields into extended_fields when templates flag is disabled', async () => {
       // FAILURE SCENARIO: adapter runs unconditionally — extended_fields written when flag is off.
       const clientArgs = createCasesClientMockArgs();
-      // config.templates.enabled defaults to false in the mock
+      clientArgs.config = { ...clientArgs.config, templates: { enabled: false } };
       clientArgs.services.caseService.bulkCreateCases.mockResolvedValue({
         saved_objects: [caseSO],
       });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
@@ -1417,6 +1417,9 @@ describe('update', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
+      // These tests assert the exact custom-field patch payload; the extended_fields
+      // mirroring (templates flag ON) is covered by dedicated tests below.
+      clientArgs.config = { ...clientArgs.config, templates: { enabled: false } };
       clientArgs.services.caseService.getCases.mockResolvedValue({ saved_objects: mockCases });
       clientArgs.services.caseService.getAllCaseComments.mockResolvedValue({
         saved_objects: [],
@@ -2877,7 +2880,7 @@ describe('update', () => {
     it('does not mirror customFields when templates flag is disabled', async () => {
       // FAILURE SCENARIO: adapter runs unconditionally — extended_fields is written when flag is off.
       const clientArgs = createCasesClientMockArgs();
-      // config.templates.enabled defaults to false
+      clientArgs.config = { ...clientArgs.config, templates: { enabled: false } };
       setupMocks(clientArgs);
 
       await bulkUpdate(

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
@@ -1048,7 +1048,7 @@ describe('create', () => {
     it('does not mirror customFields into extended_fields when templates flag is disabled', async () => {
       // FAILURE SCENARIO: adapter runs unconditionally — extended_fields written when flag is off.
       const clientArgs = createCasesClientMockArgs();
-      // config.templates.enabled defaults to false in the mock
+      clientArgs.config = { ...clientArgs.config, templates: { enabled: false } };
       clientArgs.services.caseService.createCase.mockResolvedValue(caseSO);
 
       await create({ ...theCase, customFields }, clientArgs, adapterCasesClientMock);

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/replace_custom_field.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/replace_custom_field.test.ts
@@ -31,6 +31,9 @@ describe('Replace custom field', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // These tests assert the exact custom-field patch payload; the extended_fields
+    // mirroring (templates flag ON) is covered by dedicated tests below.
+    clientArgs.config = { ...clientArgs.config, templates: { enabled: false } };
     clientArgs.services.caseService.getCase.mockResolvedValue(theCase);
     clientArgs.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({
       [mockCases[0].id]: 1,
@@ -432,7 +435,7 @@ describe('Replace custom field', () => {
     it('does not mirror into extended_fields when templates flag is disabled', async () => {
       // FAILURE SCENARIO: adapter runs unconditionally — extended_fields is written when flag is off.
       const clientArgsNoFlag = createCasesClientMockArgs();
-      // config.templates.enabled defaults to false
+      clientArgsNoFlag.config = { ...clientArgsNoFlag.config, templates: { enabled: false } };
       clientArgsNoFlag.services.caseService.getCase.mockResolvedValue(theCase);
       clientArgsNoFlag.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue(
         { [mockCases[0].id]: 1 }

--- a/x-pack/platform/plugins/shared/cases/server/client/configure/client.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/configure/client.test.ts
@@ -1269,7 +1269,7 @@ describe('client', () => {
         };
 
         it('does not call fieldDefinitionsService when templates flag is disabled', async () => {
-          // config.templates.enabled defaults to false in createCasesClientMockArgs
+          clientArgs.config = { ...clientArgs.config, templates: { enabled: false } };
           clientArgs.services.caseConfigureService.get.mockResolvedValue(baseGetResult as never);
           clientArgs.services.caseConfigureService.patch.mockResolvedValue(
             basePatchResult as never
@@ -1844,7 +1844,7 @@ describe('client', () => {
       });
 
       it('does not call fieldDefinitionsService when templates flag is disabled', async () => {
-        // config.templates.enabled defaults to false in createCasesClientMockArgs
+        clientArgs.config = { ...clientArgs.config, templates: { enabled: false } };
         await create(
           {
             ...baseRequest,

--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -170,5 +170,15 @@ describe('config validation', () => {
       const config = ConfigSchema.validate({ chat: { enabled: false } });
       expect(config.chat.enabled).toBe(false);
     });
+
+    it('sets templates.enabled default to false', () => {
+      const config = ConfigSchema.validate({});
+      expect(config.templates.enabled).toBe(false);
+    });
+
+    it('allows templates.enabled to be set to false explicitly', () => {
+      const config = ConfigSchema.validate({ templates: { enabled: false } });
+      expect(config.templates.enabled).toBe(false);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -140,7 +140,7 @@ describe('config validation', () => {
             "enabled": true,
           },
           "templates": Object {
-            "enabled": false,
+            "enabled": true,
           },
         }
       `);
@@ -171,9 +171,9 @@ describe('config validation', () => {
       expect(config.chat.enabled).toBe(false);
     });
 
-    it('sets templates.enabled default to false', () => {
+    it('sets templates.enabled default to true', () => {
       const config = ConfigSchema.validate({});
-      expect(config.templates.enabled).toBe(false);
+      expect(config.templates.enabled).toBe(true);
     });
 
     it('allows templates.enabled to be set to false explicitly', () => {

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -160,7 +160,7 @@ export const ConfigSchema = schema.object({
   // after it was on no longer throws "Missing mappings" errors. Any template /
   // field-definition documents created while enabled remain in the index.
   templates: schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
+    enabled: schema.boolean({ defaultValue: true }),
   }),
   // NOTE: exposed to the Browser via `exposeToBrowser` setting in cases/server/index.ts
   // Temporary feature flag for the Cases UX redesign (elastic/security-team#17398).

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/search_cases.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/search_cases.ts
@@ -9,6 +9,7 @@ import expect from '@kbn/expect';
 import { CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
 import { CASES_INTERNAL_URL } from '@kbn/cases-plugin/common/constants';
 import { CaseSeverity } from '@kbn/cases-plugin/common/types/domain';
+import type { CasesFindResponse } from '@kbn/cases-plugin/common/types/api';
 
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { postCaseReq, findCasesResp, getPostCaseRequest } from '../../../../common/lib/mock';
@@ -31,6 +32,14 @@ import {
   obsSecRead,
   obsSec,
 } from '../../../../common/lib/authentication/users';
+
+// Search enriches results with `extended_fields_labels` (populated only when the templates
+// flag is on), which the create response used as the expectation does not carry. Drop it so
+// these filter assertions compare the persisted case shape regardless of the flag state.
+const stripExtendedFieldLabels = (response: CasesFindResponse): CasesFindResponse => ({
+  ...response,
+  cases: response.cases.map(({ extended_fields_labels, ...rest }) => rest),
+});
 
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
@@ -105,7 +114,7 @@ export default ({ getService }: FtrProviderContext): void => {
           body: { customFields: { valid_key_2: [true] }, owner: 'securitySolutionFixture' },
         });
 
-        expect(cases).to.eql({
+        expect(stripExtendedFieldLabels(cases)).to.eql({
           ...findCasesResp,
           total: 1,
           cases: [postedCase],
@@ -193,7 +202,7 @@ export default ({ getService }: FtrProviderContext): void => {
           },
         });
 
-        expect(cases).to.eql({
+        expect(stripExtendedFieldLabels(cases)).to.eql({
           ...findCasesResp,
           total: 1,
           cases: [postedCase2],
@@ -306,10 +315,12 @@ export default ({ getService }: FtrProviderContext): void => {
         });
 
         expect(
-          await searchCases({
-            supertest,
-            body: { customFields: { valid_key_2: [false] }, owner: 'securitySolutionFixture' },
-          })
+          stripExtendedFieldLabels(
+            await searchCases({
+              supertest,
+              body: { customFields: { valid_key_2: [false] }, owner: 'securitySolutionFixture' },
+            })
+          )
         ).to.eql({
           ...findCasesResp,
           total: 1,
@@ -318,10 +329,12 @@ export default ({ getService }: FtrProviderContext): void => {
         });
 
         expect(
-          await searchCases({
-            supertest,
-            body: { customFields: { valid_obs_key_2: [false] }, owner: 'observabilityFixture' },
-          })
+          stripExtendedFieldLabels(
+            await searchCases({
+              supertest,
+              body: { customFields: { valid_obs_key_2: [false] }, owner: 'observabilityFixture' },
+            })
+          )
         ).to.eql({
           ...findCasesResp,
           total: 1,
@@ -396,7 +409,7 @@ export default ({ getService }: FtrProviderContext): void => {
           },
         });
 
-        expect(cases).to.eql({
+        expect(stripExtendedFieldLabels(cases)).to.eql({
           ...findCasesResp,
           total: 1,
           cases: [postedCase],

--- a/x-pack/platform/test/cases_api_integration/spaces_only/config.ts
+++ b/x-pack/platform/test/cases_api_integration/spaces_only/config.ts
@@ -12,4 +12,8 @@ export default createTestConfig('spaces_only', {
   license: 'trial',
   ssl: false,
   testFiles: [require.resolve('./tests/trial')],
+  // The trial suite includes templates / field-definitions coverage that
+  // requires the templates feature. Pin it ON explicitly so the suite is
+  // deterministic regardless of the plugin default (mirrors `config_trial.ts`).
+  kbnServerArgs: ['--xpack.cases.templates.enabled=true'],
 });

--- a/x-pack/platform/test/functional/services/cases/common.ts
+++ b/x-pack/platform/test/functional/services/cases/common.ts
@@ -41,6 +41,17 @@ export function CasesCommonServiceProvider({ getService, getPageObject }: FtrPro
     },
 
     /**
+     * Reveals the legacy custom-fields section on Create Case / Settings / Case Details.
+     * Templates v2 hides it behind a per-owner local-storage switch (default off); flipping
+     * it on keeps legacy custom-field coverage valid regardless of the templates flag. No-op
+     * when templates is off (legacy fields are always shown). Requires the cases app origin
+     * to be loaded first (e.g. after navigating to the app).
+     */
+    async showLegacyCustomFields(owner: string): Promise<void> {
+      await browser.setLocalStorageItem(`${owner}.cases.showLegacyCustomFields`, 'true');
+    },
+
+    /**
      * Waits for the case view page to load in either design (legacy `case-view-title` or the
      * redesign app header title).
      */

--- a/x-pack/platform/test/functional/services/cases/navigation.ts
+++ b/x-pack/platform/test/functional/services/cases/navigation.ts
@@ -44,6 +44,26 @@ export function CasesNavigationProvider({ getPageObject, getService }: FtrProvid
       });
     },
 
+    /**
+     * Navigates to the v2 templates list page (`configure/templates`).
+     * Only reachable when `xpack.cases.templates.enabled` is ON.
+     */
+    async navigateToTemplatesPage(app: string = 'cases') {
+      // The cases app pathname already ends with a trailing slash, so the
+      // sub-path is passed without a leading slash to avoid a double slash.
+      await common.navigateToUrlWithBrowserHistory(app, 'configure/templates');
+      await testSubjects.existOrFail('cases-app');
+    },
+
+    /**
+     * Navigates to the v2 field library page (`configure/field_library`).
+     * Only reachable when `xpack.cases.templates.enabled` is ON.
+     */
+    async navigateToFieldLibraryPage(app: string = 'cases') {
+      await common.navigateToUrlWithBrowserHistory(app, 'configure/field_library');
+      await testSubjects.existOrFail('cases-app');
+    },
+
     async navigateToSingleCase(app: string = 'cases', caseId: string, tabId?: string) {
       const search = tabId != null ? `?tabId=${tabId}` : '';
       await common.navigateToUrlWithBrowserHistory(app, caseId, search);

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts
@@ -159,6 +159,10 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
           return this.skip();
         }
 
+        // Templates v2 hides the legacy inline custom fields on Create behind a switch;
+        // reveal it so this legacy flow is exercised whether or not templates is on.
+        await cases.common.showLegacyCustomFields('cases');
+
         const customFields = [
           {
             key: 'valid_key_1',
@@ -219,6 +223,10 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
         if (await cases.common.isRedesignEnabled()) {
           return this.skip();
         }
+
+        // Templates v2 hides the legacy inline custom fields on Create behind a switch;
+        // reveal it so this legacy flow is exercised whether or not templates is on.
+        await cases.common.showLegacyCustomFields('cases');
 
         const customFields = [
           {

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/config_legacy.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/config_legacy.ts
@@ -7,24 +7,28 @@
 
 import type { FtrConfigProviderContext } from '@kbn/test';
 
+/**
+ * Legacy Cases group2 functional config, pinned with
+ * `--xpack.cases.templates.enabled=false` so the legacy in-page custom-fields /
+ * templates sections keep rendering once the plugin default flips to ON. This
+ * config runs `index_legacy.ts` (only the legacy `configure_legacy` suite). The
+ * default flag-ON suite runs under `config.ts`.
+ */
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const baseConfig = await readConfigFile(require.resolve('../../../config.base.ts'));
 
   return {
     ...baseConfig.getAll(),
-    testFiles: [require.resolve('.')],
+    testFiles: [require.resolve('./index_legacy')],
     kbnTestServer: {
       ...baseConfig.get('kbnTestServer'),
       serverArgs: [
         ...baseConfig.get('kbnTestServer.serverArgs'),
-        // Pin the templates flag ON explicitly so this suite is deterministic
-        // regardless of the plugin default. The flag-OFF legacy counterpart runs
-        // under `config_legacy.ts`.
-        '--xpack.cases.templates.enabled=true',
+        '--xpack.cases.templates.enabled=false',
       ],
     },
     junit: {
-      reportName: 'Chrome X-Pack UI Functional Tests with ES SSL - Cases - group 2',
+      reportName: 'Chrome X-Pack UI Functional Tests with ES SSL - Cases - group 2 (legacy)',
     },
   };
 }

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/configure.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/configure.ts
@@ -5,19 +5,24 @@
  * 2.0.
  */
 
-import { CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
 import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 
+/**
+ * Flag-agnostic Configure-page coverage.
+ *
+ * Closure options and connectors render on the Case Settings page regardless of
+ * the `xpack.cases.templates.enabled` flag. The legacy in-page custom-fields /
+ * templates sections (only rendered when the flag is OFF) are covered in
+ * `configure_legacy.ts`, and the new v2 templates / field-library pages (only
+ * reachable when the flag is ON) are covered in `configure_templates_v2.ts`.
+ */
 export default ({ getPageObject, getService }: FtrProviderContext) => {
   const common = getPageObject('common');
   const testSubjects = getService('testSubjects');
   const cases = getService('cases');
   const toasts = getService('toasts');
   const header = getPageObject('header');
-  const comboBox = getService('comboBox');
-  const find = getService('find');
-  const retry = getService('retry');
 
   describe('Configure', function () {
     before(async () => {
@@ -55,235 +60,6 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await common.clickAndValidate('add-new-connector', 'euiFlyoutCloseButton');
         await testSubjects.click('euiFlyoutCloseButton');
         expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-      });
-    });
-
-    describe('Custom fields', function () {
-      before(async function () {
-        // The redesign settings page does not manage custom fields (moved to the templates v2 UI).
-        if (await cases.common.isRedesignEnabled()) {
-          this.skip();
-        }
-        await cases.api.createConfigWithCustomFields({
-          customFields: [
-            {
-              key: 'o11y_custom_field',
-              label: 'My o11y field',
-              type: CustomFieldTypes.TOGGLE,
-              required: false,
-            },
-          ],
-          owner: 'observability',
-        });
-      });
-
-      it('existing configurations do not interfere', async () => {
-        // A configuration created in o11y should not be visible in stack
-        expect(await testSubjects.getVisibleText('empty-custom-fields')).to.be(
-          'You do not have any fields yet'
-        );
-      });
-
-      it('adds a custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        await common.clickAndValidate('add-custom-field', 'common-flyout');
-
-        await testSubjects.setValue('custom-field-label-input', 'Summary');
-
-        await testSubjects.setCheckbox('text-custom-field-required-wrapper', 'check');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await testSubjects.existOrFail('custom-fields-list');
-
-        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Summary\nText');
-      });
-
-      it('edits a custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        const textField = await find.byCssSelector('[data-test-subj*="-custom-field-edit"]');
-
-        await textField.click();
-
-        const input = await testSubjects.find('custom-field-label-input');
-
-        await input.type('!!!');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await testSubjects.existOrFail('custom-fields-list');
-
-        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Summary!!!\nText');
-      });
-
-      it('deletes a custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        const deleteButton = await find.byCssSelector('[data-test-subj*="-custom-field-delete"]');
-
-        await deleteButton.click();
-
-        await testSubjects.existOrFail('confirm-delete-modal');
-
-        await testSubjects.click('confirmModalConfirmButton');
-
-        await testSubjects.missingOrFail('custom-fields-list');
-      });
-
-      it('adds a number custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        await common.clickAndValidate('add-custom-field', 'common-flyout');
-
-        await testSubjects.setValue('custom-field-label-input', 'Count');
-        await testSubjects.click('custom-field-type-selector');
-        await (await find.byCssSelector('[value="number"]')).click();
-        await testSubjects.setCheckbox('number-custom-field-required-wrapper', 'check');
-
-        const defaultNumberInput = await testSubjects.find('number-custom-field-default-value');
-        await defaultNumberInput.type('0');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await testSubjects.existOrFail('custom-fields-list');
-
-        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Count\nNumber');
-      });
-
-      it('edits a number custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        const numberField = await find.byCssSelector('[data-test-subj*="-custom-field-edit"]');
-
-        await numberField.click();
-
-        const labelInput = await testSubjects.find('custom-field-label-input');
-        await labelInput.type('!');
-
-        await testSubjects.setValue('number-custom-field-default-value', '321');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await testSubjects.existOrFail('custom-fields-list');
-
-        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Count!\nNumber');
-      });
-
-      it('deletes a number custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        const deleteButton = await find.byCssSelector('[data-test-subj*="-custom-field-delete"]');
-
-        await deleteButton.click();
-
-        await testSubjects.existOrFail('confirm-delete-modal');
-
-        await testSubjects.click('confirmModalConfirmButton');
-
-        await testSubjects.missingOrFail('custom-fields-list');
-      });
-    });
-
-    describe('Templates', function () {
-      before(async function () {
-        // The redesign settings page does not manage templates (moved to the templates v2 UI).
-        if (await cases.common.isRedesignEnabled()) {
-          this.skip();
-        }
-        await cases.api.createConfigWithTemplates({
-          templates: [
-            {
-              key: 'o11y_template',
-              name: 'My template 1',
-              description: 'this is my first template',
-              tags: ['foo'],
-              caseFields: null,
-            },
-          ],
-          owner: 'observability',
-        });
-      });
-
-      it('existing configurations do not interfere', async () => {
-        // A configuration created in o11y should not be visible in stack
-        expect(await testSubjects.getVisibleText('empty-templates')).to.be(
-          'You do not have any templates yet'
-        );
-      });
-
-      it('adds a template', async () => {
-        await testSubjects.existOrFail('templates-form-group');
-        await common.clickAndValidate('add-template', 'common-flyout');
-
-        await testSubjects.setValue('template-name-input', 'Template name');
-        await comboBox.setCustom('template-tags', 'tag-t1');
-        await testSubjects.setValue('template-description-input', 'Template description');
-
-        const caseTitle = await find.byCssSelector(
-          `[data-test-subj="input"][aria-describedby="caseTitle"]`
-        );
-        await caseTitle.focus();
-        await caseTitle.type('case with template');
-
-        await cases.create.setDescription('test description');
-
-        await cases.create.setTags('tagme');
-        await cases.create.setCategory('new');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await retry.waitFor('templates-list', async () => {
-          return await testSubjects.exists('templates-list');
-        });
-
-        expect(await testSubjects.getVisibleText('templates-list')).to.be('Template name\ntag-t1');
-      });
-
-      it('updates a template', async () => {
-        await testSubjects.existOrFail('templates-form-group');
-        const editButton = await find.byCssSelector('[data-test-subj*="-template-edit"]');
-
-        await editButton.click();
-
-        await testSubjects.setValue('template-name-input', 'Updated template name!');
-        await comboBox.setCustom('template-tags', 'tag-t1');
-        await testSubjects.setValue('template-description-input', 'Template description updated');
-
-        const caseTitle = await find.byCssSelector(
-          `[data-test-subj="input"][aria-describedby="caseTitle"]`
-        );
-        await caseTitle.focus();
-        await caseTitle.type('!!');
-
-        await cases.create.setDescription('test description!!');
-
-        await cases.create.setTags('case-tag');
-        await cases.create.setCategory('new!');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await retry.waitFor('templates-list', async () => {
-          return await testSubjects.exists('templates-list');
-        });
-
-        expect(await testSubjects.getVisibleText('templates-list')).to.be(
-          'Updated template name!\ntag-t1'
-        );
-      });
-
-      it('deletes a template', async () => {
-        await testSubjects.existOrFail('templates-form-group');
-        const deleteButton = await find.byCssSelector('[data-test-subj*="-template-delete"]');
-
-        await deleteButton.click();
-
-        await testSubjects.existOrFail('confirm-delete-modal');
-
-        await testSubjects.click('confirmModalConfirmButton');
-
-        await testSubjects.missingOrFail('template-list');
       });
     });
   });

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/configure_legacy.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/configure_legacy.ts
@@ -1,0 +1,261 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+
+/**
+ * Legacy in-page custom-fields / templates management on the Case Settings page.
+ *
+ * These sections (`custom-fields-form-group`, `templates-form-group`) only
+ * render when `xpack.cases.templates.enabled` is OFF — once the flag is ON the
+ * legacy sections are replaced by the dedicated v2 templates / field-library
+ * pages (covered by `configure_templates_v2.ts`). This suite therefore only
+ * runs under the flag-OFF config (`group2/config_legacy.ts`, pinned
+ * `--xpack.cases.templates.enabled=false`) and remains valid until the flag is
+ * fully retired.
+ */
+export default ({ getPageObject, getService }: FtrProviderContext) => {
+  const common = getPageObject('common');
+  const testSubjects = getService('testSubjects');
+  const cases = getService('cases');
+  const comboBox = getService('comboBox');
+  const find = getService('find');
+  const retry = getService('retry');
+
+  describe('Configure - legacy custom fields and templates', function () {
+    before(async () => {
+      await cases.navigation.navigateToConfigurationPage();
+    });
+
+    after(async () => {
+      await cases.api.deleteAllCases();
+    });
+
+    describe('Custom fields', function () {
+      before(async () => {
+        await cases.api.createConfigWithCustomFields({
+          customFields: [
+            {
+              key: 'o11y_custom_field',
+              label: 'My o11y field',
+              type: CustomFieldTypes.TOGGLE,
+              required: false,
+            },
+          ],
+          owner: 'observability',
+        });
+      });
+
+      it('existing configurations do not interfere', async () => {
+        // A configuration created in o11y should not be visible in stack
+        expect(await testSubjects.getVisibleText('empty-custom-fields')).to.be(
+          'You do not have any fields yet'
+        );
+      });
+
+      it('adds a custom field', async () => {
+        await testSubjects.existOrFail('custom-fields-form-group');
+        await common.clickAndValidate('add-custom-field', 'common-flyout');
+
+        await testSubjects.setValue('custom-field-label-input', 'Summary');
+
+        await testSubjects.setCheckbox('text-custom-field-required-wrapper', 'check');
+
+        await testSubjects.click('common-flyout-save');
+        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
+
+        await testSubjects.existOrFail('custom-fields-list');
+
+        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Summary\nText');
+      });
+
+      it('edits a custom field', async () => {
+        await testSubjects.existOrFail('custom-fields-form-group');
+        const textField = await find.byCssSelector('[data-test-subj*="-custom-field-edit"]');
+
+        await textField.click();
+
+        const input = await testSubjects.find('custom-field-label-input');
+
+        await input.type('!!!');
+
+        await testSubjects.click('common-flyout-save');
+        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
+
+        await testSubjects.existOrFail('custom-fields-list');
+
+        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Summary!!!\nText');
+      });
+
+      it('deletes a custom field', async () => {
+        await testSubjects.existOrFail('custom-fields-form-group');
+        const deleteButton = await find.byCssSelector('[data-test-subj*="-custom-field-delete"]');
+
+        await deleteButton.click();
+
+        await testSubjects.existOrFail('confirm-delete-modal');
+
+        await testSubjects.click('confirmModalConfirmButton');
+
+        await testSubjects.missingOrFail('custom-fields-list');
+      });
+
+      it('adds a number custom field', async () => {
+        await testSubjects.existOrFail('custom-fields-form-group');
+        await common.clickAndValidate('add-custom-field', 'common-flyout');
+
+        await testSubjects.setValue('custom-field-label-input', 'Count');
+        await testSubjects.click('custom-field-type-selector');
+        await (await find.byCssSelector('[value="number"]')).click();
+        await testSubjects.setCheckbox('number-custom-field-required-wrapper', 'check');
+
+        const defaultNumberInput = await testSubjects.find('number-custom-field-default-value');
+        await defaultNumberInput.type('0');
+
+        await testSubjects.click('common-flyout-save');
+        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
+
+        await testSubjects.existOrFail('custom-fields-list');
+
+        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Count\nNumber');
+      });
+
+      it('edits a number custom field', async () => {
+        await testSubjects.existOrFail('custom-fields-form-group');
+        const numberField = await find.byCssSelector('[data-test-subj*="-custom-field-edit"]');
+
+        await numberField.click();
+
+        const labelInput = await testSubjects.find('custom-field-label-input');
+        await labelInput.type('!');
+
+        await testSubjects.setValue('number-custom-field-default-value', '321');
+
+        await testSubjects.click('common-flyout-save');
+        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
+
+        await testSubjects.existOrFail('custom-fields-list');
+
+        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Count!\nNumber');
+      });
+
+      it('deletes a number custom field', async () => {
+        await testSubjects.existOrFail('custom-fields-form-group');
+        const deleteButton = await find.byCssSelector('[data-test-subj*="-custom-field-delete"]');
+
+        await deleteButton.click();
+
+        await testSubjects.existOrFail('confirm-delete-modal');
+
+        await testSubjects.click('confirmModalConfirmButton');
+
+        await testSubjects.missingOrFail('custom-fields-list');
+      });
+    });
+
+    describe('Templates', function () {
+      before(async () => {
+        await cases.api.createConfigWithTemplates({
+          templates: [
+            {
+              key: 'o11y_template',
+              name: 'My template 1',
+              description: 'this is my first template',
+              tags: ['foo'],
+              caseFields: null,
+            },
+          ],
+          owner: 'observability',
+        });
+      });
+
+      it('existing configurations do not interfere', async () => {
+        // A configuration created in o11y should not be visible in stack
+        expect(await testSubjects.getVisibleText('empty-templates')).to.be(
+          'You do not have any templates yet'
+        );
+      });
+
+      it('adds a template', async () => {
+        await testSubjects.existOrFail('templates-form-group');
+        await common.clickAndValidate('add-template', 'common-flyout');
+
+        await testSubjects.setValue('template-name-input', 'Template name');
+        await comboBox.setCustom('template-tags', 'tag-t1');
+        await testSubjects.setValue('template-description-input', 'Template description');
+
+        const caseTitle = await find.byCssSelector(
+          `[data-test-subj="input"][aria-describedby="caseTitle"]`
+        );
+        await caseTitle.focus();
+        await caseTitle.type('case with template');
+
+        await cases.create.setDescription('test description');
+
+        await cases.create.setTags('tagme');
+        await cases.create.setCategory('new');
+
+        await testSubjects.click('common-flyout-save');
+        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
+
+        await retry.waitFor('templates-list', async () => {
+          return await testSubjects.exists('templates-list');
+        });
+
+        expect(await testSubjects.getVisibleText('templates-list')).to.be('Template name\ntag-t1');
+      });
+
+      it('updates a template', async () => {
+        await testSubjects.existOrFail('templates-form-group');
+        const editButton = await find.byCssSelector('[data-test-subj*="-template-edit"]');
+
+        await editButton.click();
+
+        await testSubjects.setValue('template-name-input', 'Updated template name!');
+        await comboBox.setCustom('template-tags', 'tag-t1');
+        await testSubjects.setValue('template-description-input', 'Template description updated');
+
+        const caseTitle = await find.byCssSelector(
+          `[data-test-subj="input"][aria-describedby="caseTitle"]`
+        );
+        await caseTitle.focus();
+        await caseTitle.type('!!');
+
+        await cases.create.setDescription('test description!!');
+
+        await cases.create.setTags('case-tag');
+        await cases.create.setCategory('new!');
+
+        await testSubjects.click('common-flyout-save');
+        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
+
+        await retry.waitFor('templates-list', async () => {
+          return await testSubjects.exists('templates-list');
+        });
+
+        expect(await testSubjects.getVisibleText('templates-list')).to.be(
+          'Updated template name!\ntag-t1'
+        );
+      });
+
+      it('deletes a template', async () => {
+        await testSubjects.existOrFail('templates-form-group');
+        const deleteButton = await find.byCssSelector('[data-test-subj*="-template-delete"]');
+
+        await deleteButton.click();
+
+        await testSubjects.existOrFail('confirm-delete-modal');
+
+        await testSubjects.click('confirmModalConfirmButton');
+
+        await testSubjects.missingOrFail('template-list');
+      });
+    });
+  });
+};

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/configure_templates_v2.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/configure_templates_v2.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+
+/**
+ * v2 templates / field-library pages.
+ *
+ * These dedicated pages (`configure/templates`, `configure/field_library`)
+ * replace the legacy in-page custom-fields / templates sections and are only
+ * reachable when `xpack.cases.templates.enabled` is ON. This suite runs under
+ * `group2/config.ts` (flag pinned ON) and asserts the pages are wired,
+ * reachable, and render their primary surface.
+ *
+ * The legacy flag-OFF sections are covered by `configure_legacy.ts`.
+ */
+export default ({ getPageObject, getService }: FtrProviderContext) => {
+  const testSubjects = getService('testSubjects');
+  const cases = getService('cases');
+  const header = getPageObject('header');
+
+  describe('Configure - templates v2 pages', function () {
+    after(async () => {
+      await cases.api.deleteAllCases();
+    });
+
+    describe('Templates list page', function () {
+      before(async () => {
+        await cases.navigation.navigateToTemplatesPage();
+        await header.waitUntilLoadingHasFinished();
+      });
+
+      it('renders the templates list page with the empty prompt when there are no templates', async () => {
+        // The empty prompt with a "create template" affordance is the primary
+        // surface when no templates exist — this proves the flag-ON route is
+        // wired and the page renders.
+        await testSubjects.existOrFail('templates-table-empty-prompt-no-templates');
+        await testSubjects.existOrFail('templates-table-add-template');
+      });
+
+      it('exposes the templates table', async () => {
+        await testSubjects.existOrFail('templates-table');
+      });
+    });
+
+    describe('Field library page', function () {
+      before(async () => {
+        await cases.navigation.navigateToFieldLibraryPage();
+        await header.waitUntilLoadingHasFinished();
+      });
+
+      it('renders the field library page with its create affordance', async () => {
+        await testSubjects.existOrFail('fieldDefinitionsTable');
+        await testSubjects.existOrFail('createFieldDefinitionButton');
+      });
+    });
+  });
+};

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/index_legacy.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group2/index_legacy.ts
@@ -7,13 +7,15 @@
 
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 
+/**
+ * Legacy (templates flag OFF) Cases group2 suite.
+ *
+ * Runs only the legacy in-page custom-fields / templates coverage, which is
+ * valid exclusively when `xpack.cases.templates.enabled` is OFF. The default
+ * group2 suite (flag ON) is defined in `index.ts`.
+ */
 export default ({ loadTestFile }: FtrProviderContext) => {
-  describe('Cases', function () {
-    loadTestFile(require.resolve('./list_view'));
-    loadTestFile(require.resolve('./configure'));
-    loadTestFile(require.resolve('./configure_templates_v2'));
-    loadTestFile(require.resolve('./attachment_framework'));
-    loadTestFile(require.resolve('./upgrade'));
-    loadTestFile(require.resolve('./paste_image_to_comment'));
+  describe('Cases - legacy templates', function () {
+    loadTestFile(require.resolve('./configure_legacy'));
   });
 };

--- a/x-pack/platform/test/plugin_api_integration/config.ts
+++ b/x-pack/platform/test/plugin_api_integration/config.ts
@@ -38,6 +38,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.eventLog.indexEntries=true',
         '--xpack.task_manager.monitored_aggregated_stats_refresh_rate=5000',
         '--xpack.task_manager.invalidate_api_key_task.removalDelay="1s"',
+        // Pin the Cases templates flag ON so the `cases_templates_v2_migration`
+        // task type is registered, matching the `check_registered_task_types` guard
+        // list regardless of the plugin default.
+        '--xpack.cases.templates.enabled=true',
         `--xpack.stack_connectors.enableExperimental=${JSON.stringify([
           'crowdstrikeConnectorOn',
           'microsoftDefenderEndpointOn',

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -181,6 +181,7 @@ export default function ({ getService }: FtrProviderContext) {
         'cai:cases_analytics_index_synchronization',
         'cases-telemetry-task',
         'cases_incremental_id_assignment',
+        'cases_templates_v2_migration',
         'cloud_security_posture-stats_task',
         'dashboard_telemetry',
         'endpoint:complete-external-response-actions',

--- a/x-pack/platform/test/screenshot_creation/apps/response_ops_docs/stack_cases/settings.ts
+++ b/x-pack/platform/test/screenshot_creation/apps/response_ops_docs/stack_cases/settings.ts
@@ -10,31 +10,46 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   const cases = getService('cases');
   const commonScreenshots = getService('commonScreenshots');
   const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
+  const header = getPageObject('header');
   const screenshotDirectories = ['response_ops_docs', 'stack_cases'];
 
   describe('case settings', function () {
     it('case settings screenshot', async () => {
+      // With the templates feature flag pinned ON for this suite, custom fields and
+      // templates are managed on the dedicated v2 templates / field-library pages
+      // rather than inline on the Case Settings page.
       await cases.navigation.navigateToApp();
       await cases.navigation.navigateToConfigurationPage();
+      await header.waitUntilLoadingHasFinished();
       await commonScreenshots.takeScreenshot('cases-settings', screenshotDirectories, 1400, 1024);
-      await testSubjects.click('add-template');
+
+      // Templates list page — reachable when the templates flag is ON.
+      await cases.navigation.navigateToTemplatesPage();
+      await header.waitUntilLoadingHasFinished();
+      await retry.waitFor('templates-table exist', async () => {
+        return await testSubjects.exists('templates-table');
+      });
       await commonScreenshots.takeScreenshot(
         'cases-templates-add',
         screenshotDirectories,
         1400,
         1000
       );
-      await testSubjects.click('common-flyout-cancel');
-      await testSubjects.click('add-custom-field');
+
+      // Field library page — reachable when the templates flag is ON.
+      await cases.navigation.navigateToFieldLibraryPage();
+      await header.waitUntilLoadingHasFinished();
+      await retry.waitFor('fieldDefinitionsTable exist', async () => {
+        return await testSubjects.exists('fieldDefinitionsTable');
+      });
       await commonScreenshots.takeScreenshot(
         'cases-custom-fields-add',
         screenshotDirectories,
         1400,
         700
       );
-      await testSubjects.setValue('custom-field-label-input', 'my-field');
-      await testSubjects.click('common-flyout-save');
-      await commonScreenshots.takeScreenshot('cases-settings', screenshotDirectories, 1400, 1024);
+
       await cases.navigation.navigateToApp();
       await testSubjects.click('createNewCaseBtn');
       await commonScreenshots.takeScreenshot('cases-create', screenshotDirectories, 1400, 1900);

--- a/x-pack/platform/test/screenshot_creation/config.ts
+++ b/x-pack/platform/test/screenshot_creation/config.ts
@@ -47,6 +47,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         `--elasticsearch.hosts=https://${servers.elasticsearch.hostname}:${servers.elasticsearch.port}`,
         `--elasticsearch.ssl.certificateAuthorities=${CA_CERT_PATH}`,
         `--xpack.alerting.rules.minimumScheduleInterval.value="2s"`,
+        // Pin the Cases templates flag ON so the case-settings docs screenshots
+        // capture the v2 templates / field-library pages regardless of the plugin
+        // default. The flag only affects Cases, so other docs suites are unaffected.
+        `--xpack.cases.templates.enabled=true`,
       ],
     },
   };

--- a/x-pack/solutions/observability/test/screenshot_creation/apps/response_ops_docs/observability_cases/custom_fields.ts
+++ b/x-pack/solutions/observability/test/screenshot_creation/apps/response_ops_docs/observability_cases/custom_fields.ts
@@ -13,21 +13,42 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const pageObjects = getPageObjects(['common', 'header']);
   const screenshotDirectories = ['response_ops_docs', 'observability_cases'];
   const testSubjects = getService('testSubjects');
+  const browser = getService('browser');
+  const retry = getService('retry');
 
   describe('Observability case settings and custom fields', function () {
     it('case settings screenshots', async () => {
+      // With the templates feature flag pinned ON for this suite, custom fields and
+      // templates are managed on the dedicated v2 templates / field-library pages
+      // rather than inline on the Case Settings page.
       await cases.navigation.navigateToApp('observability/cases', 'cases-all-title');
       await pageObjects.header.waitUntilLoadingHasFinished();
       await testSubjects.click('configure-case-button');
-      await testSubjects.click('add-custom-field');
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await retry.waitFor('case-configure-title exist', async () => {
+        return await testSubjects.exists('case-configure-title');
+      });
+
+      // Field library page — reachable when the templates flag is ON. Strip any
+      // query string / hash so the sub-path is appended cleanly.
+      const configureUrl = (await browser.getCurrentUrl()).split(/[?#]/)[0].replace(/\/$/, '');
+      await browser.get(`${configureUrl}/field_library`);
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await retry.waitFor('fieldDefinitionsTable exist', async () => {
+        return await testSubjects.exists('fieldDefinitionsTable');
+      });
       await commonScreenshots.takeScreenshot(
         'cases-add-custom-field',
         screenshotDirectories,
         1400,
         700
       );
-      await testSubjects.setValue('custom-field-label-input', 'my-field');
-      await testSubjects.click('common-flyout-save');
+
+      await browser.get(`${configureUrl}/templates`);
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await retry.waitFor('templates-table exist', async () => {
+        return await testSubjects.exists('templates-table');
+      });
       await commonScreenshots.takeScreenshot('cases-settings', screenshotDirectories, 1400, 1024);
     });
   });

--- a/x-pack/solutions/observability/test/serverless/functional/configs/config.cases_and_rules.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/configs/config.cases_and_rules.ts
@@ -21,5 +21,9 @@ export default createTestConfig({
 
   // include settings from project controller
   esServerArgs: [],
-  kbnServerArgs: [],
+  // Pin the Cases templates flag ON so the Configure suite exercises the v2
+  // templates / field-library pages regardless of the plugin default. The flag
+  // only affects Cases; the legacy in-page flow is covered by the flag-OFF
+  // stateful `configure_legacy.ts` suite.
+  kbnServerArgs: [`--xpack.cases.templates.enabled=true`],
 });

--- a/x-pack/solutions/observability/test/serverless/functional/configs/config.screenshots.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/configs/config.screenshots.ts
@@ -27,7 +27,12 @@ export default createTestConfig({
   services,
   pageObjects,
   testFiles: [require.resolve('../test_suites/screenshot_creation')],
-  kbnServerArgs: [`--xpack.actions.enabledActionTypes=${JSON.stringify(enabledActionTypes)}`],
+  kbnServerArgs: [
+    `--xpack.actions.enabledActionTypes=${JSON.stringify(enabledActionTypes)}`,
+    // Pin the Cases templates flag ON so the case-settings docs screenshots capture
+    // the v2 templates / field-library pages regardless of the plugin default.
+    `--xpack.cases.templates.enabled=true`,
+  ],
   junit: {
     reportName: 'Serverless Observability Screenshot Creation',
   },

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/configure.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/configure.ts
@@ -15,29 +15,32 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   const svlCommonPage = getPageObject('svlCommonPage');
   const svlObltNavigation = getService('svlObltNavigation');
   const testSubjects = getService('testSubjects');
+  const browser = getService('browser');
   const cases = getService('cases');
   const svlCases = getService('svlCases');
   const toasts = getService('toasts');
   const retry = getService('retry');
-  const find = getService('find');
-  const comboBox = getService('comboBox');
+
+  const navigateToConfigure = async () => {
+    await svlObltNavigation.navigateToLandingPage();
+    await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'observability-overview:cases' });
+    await header.waitUntilLoadingHasFinished();
+
+    await cases.navigation.clickHeaderMenuItem('configure-case-button');
+    await header.waitUntilLoadingHasFinished();
+
+    await retry.waitFor('the configuration page to load', async () => {
+      return (
+        (await testSubjects.exists('case-configure-title')) ||
+        (await testSubjects.exists('cases-redesign-settings-panel'))
+      );
+    });
+  };
 
   describe('Configure Case', function () {
     before(async () => {
       await svlCommonPage.loginWithPrivilegedRole();
-      await svlObltNavigation.navigateToLandingPage();
-      await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'observability-overview:cases' });
-      await header.waitUntilLoadingHasFinished();
-
-      await cases.navigation.clickHeaderMenuItem('configure-case-button');
-      await header.waitUntilLoadingHasFinished();
-
-      await retry.waitFor('the configuration page to load', async () => {
-        return (
-          (await testSubjects.exists('case-configure-title')) ||
-          (await testSubjects.exists('cases-redesign-settings-panel'))
-        );
-      });
+      await navigateToConfigure();
     });
 
     after(async () => {
@@ -71,143 +74,41 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
     });
 
-    describe('Custom fields', function () {
-      before(async function () {
-        // The redesign settings page does not manage custom fields (moved to the templates v2 UI).
-        if (await cases.common.isRedesignEnabled()) {
-          this.skip();
-        }
+    // With the templates feature flag pinned ON for this suite, custom fields and
+    // templates are managed on the dedicated v2 templates / field-library pages,
+    // not inline on the Case Settings page. The legacy in-page flow is covered by
+    // the flag-OFF stateful `configure_legacy.ts` suite.
+    describe('Templates page (v2)', function () {
+      before(async () => {
+        await navigateToConfigure();
+        // The cases app pathname already ends with `configure`, so append the
+        // sub-path after stripping any query string / hash.
+        const configureUrl = (await browser.getCurrentUrl()).split(/[?#]/)[0].replace(/\/$/, '');
+        await browser.get(`${configureUrl}/templates`);
+        await header.waitUntilLoadingHasFinished();
       });
 
-      it('adds a custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        await common.clickAndValidate('add-custom-field', 'common-flyout');
-
-        await testSubjects.setValue('custom-field-label-input', 'Summary');
-
-        await testSubjects.setCheckbox('text-custom-field-required-wrapper', 'check');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await testSubjects.existOrFail('custom-fields-list');
-
-        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Summary\nText');
+      it('renders the templates list page with the empty prompt', async () => {
+        await testSubjects.existOrFail('templates-table-empty-prompt-no-templates');
+        await testSubjects.existOrFail('templates-table-add-template');
       });
 
-      it('edits a custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        const textField = await find.byCssSelector('[data-test-subj*="-custom-field-edit"]');
-
-        await textField.click();
-
-        const input = await testSubjects.find('custom-field-label-input');
-
-        await input.type('!!!');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await testSubjects.existOrFail('custom-fields-list');
-
-        expect(await testSubjects.getVisibleText('custom-fields-list')).to.be('Summary!!!\nText');
-      });
-
-      it('deletes a custom field', async () => {
-        await testSubjects.existOrFail('custom-fields-form-group');
-        const deleteButton = await find.byCssSelector('[data-test-subj*="-custom-field-delete"]');
-
-        await deleteButton.click();
-
-        await testSubjects.existOrFail('confirm-delete-modal');
-
-        await testSubjects.click('confirmModalConfirmButton');
-
-        await testSubjects.missingOrFail('custom-fields-list');
+      it('exposes the templates table', async () => {
+        await testSubjects.existOrFail('templates-table');
       });
     });
 
-    describe('Templates', function () {
-      before(async function () {
-        // The redesign settings page does not manage templates (moved to the templates v2 UI).
-        if (await cases.common.isRedesignEnabled()) {
-          this.skip();
-        }
+    describe('Field library page (v2)', function () {
+      before(async () => {
+        await navigateToConfigure();
+        const configureUrl = (await browser.getCurrentUrl()).split(/[?#]/)[0].replace(/\/$/, '');
+        await browser.get(`${configureUrl}/field_library`);
+        await header.waitUntilLoadingHasFinished();
       });
 
-      it('adds a template', async () => {
-        await testSubjects.existOrFail('templates-form-group');
-        await common.clickAndValidate('add-template', 'common-flyout');
-
-        await testSubjects.setValue('template-name-input', 'Template name');
-        await comboBox.setCustom('template-tags', 'tag-t1');
-        await testSubjects.setValue('template-description-input', 'Template description');
-
-        const caseTitle = await find.byCssSelector(
-          `[data-test-subj="input"][aria-describedby="caseTitle"]`
-        );
-        await caseTitle.focus();
-        await caseTitle.type('case with template');
-
-        await cases.create.setDescription('test description');
-
-        await cases.create.setTags('tagme');
-        await cases.create.setCategory('new');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await retry.waitFor('templates-list', async () => {
-          return await testSubjects.exists('templates-list');
-        });
-
-        expect(await testSubjects.getVisibleText('templates-list')).to.be('Template name\ntag-t1');
-      });
-
-      it('updates a template', async () => {
-        await testSubjects.existOrFail('templates-form-group');
-        const editButton = await find.byCssSelector('[data-test-subj*="-template-edit"]');
-
-        await editButton.click();
-
-        await testSubjects.setValue('template-name-input', 'Updated template name!');
-        await comboBox.setCustom('template-tags', 'tag-t1');
-        await testSubjects.setValue('template-description-input', 'Template description updated');
-
-        const caseTitle = await find.byCssSelector(
-          `[data-test-subj="input"][aria-describedby="caseTitle"]`
-        );
-        await caseTitle.focus();
-        await caseTitle.type('!!');
-
-        await cases.create.setDescription('test description!!');
-
-        await cases.create.setTags('case-tag');
-        await cases.create.setCategory('new!');
-
-        await testSubjects.click('common-flyout-save');
-        expect(await testSubjects.exists('euiFlyoutCloseButton')).to.be(false);
-
-        await retry.waitFor('templates-list', async () => {
-          return await testSubjects.exists('templates-list');
-        });
-
-        expect(await testSubjects.getVisibleText('templates-list')).to.be(
-          'Updated template name!\ntag-t1'
-        );
-      });
-
-      it('deletes a template', async () => {
-        await testSubjects.existOrFail('templates-form-group');
-        const deleteButton = await find.byCssSelector('[data-test-subj*="-template-delete"]');
-
-        await deleteButton.click();
-
-        await testSubjects.existOrFail('confirm-delete-modal');
-
-        await testSubjects.click('confirmModalConfirmButton');
-
-        await testSubjects.missingOrFail('template-list');
+      it('renders the field library page with its create affordance', async () => {
+        await testSubjects.existOrFail('fieldDefinitionsTable');
+        await testSubjects.existOrFail('createFieldDefinitionButton');
       });
     });
   });

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/create_case_form.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/create_case_form.ts
@@ -98,6 +98,10 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
           return this.skip();
         }
 
+        // Templates v2 hides the legacy inline custom fields on Create behind a switch;
+        // reveal it so this legacy flow is exercised whether or not templates is on.
+        await cases.common.showLegacyCustomFields(owner);
+
         const customFields = [
           {
             key: 'valid_key_1',

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/cases/settings.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/cases/settings.ts
@@ -9,11 +9,13 @@ import { OBSERVABILITY_OWNER } from '@kbn/cases-plugin/common';
 import { navigateToCasesApp } from '@kbn/test-suites-xpack-platform/serverless/shared/lib/cases';
 import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
-export default function ({ getPageObject, getPageObjects, getService }: FtrProviderContext) {
+export default function ({ getPageObject, getService }: FtrProviderContext) {
   const retry = getService('retry');
+  const browser = getService('browser');
   const svlCases = getService('svlCases');
   const svlCommonScreenshots = getService('svlCommonScreenshots');
   const svlCommonPage = getPageObject('svlCommonPage');
+  const header = getPageObject('header');
   const screenshotDirectories = ['response_ops_docs', 'observability_cases'];
   const testSubjects = getService('testSubjects');
   const cases = getService('cases');
@@ -28,6 +30,10 @@ export default function ({ getPageObject, getPageObjects, getService }: FtrProvi
     });
 
     it('case settings screenshots', async function () {
+      // With the templates feature flag pinned ON for this suite, custom fields and
+      // templates are managed on the dedicated v2 templates / field-library pages
+      // rather than inline on the Case Settings page. Capture the settings page,
+      // the templates list, the field library, and the add-connector flyout.
       await navigateToCasesApp(getPageObject, getService, owner);
       // The redesigned settings page drops the custom fields and templates management these
       // screenshots document, so skip while the redesign is on.
@@ -38,39 +44,46 @@ export default function ({ getPageObject, getPageObjects, getService }: FtrProvi
         return await testSubjects.exists('configure-case-button');
       });
       await testSubjects.click('configure-case-button');
-      await retry.waitFor('add-custom-field exist', async () => {
-        return await testSubjects.exists('add-custom-field');
+      await header.waitUntilLoadingHasFinished();
+      await retry.waitFor('case-configure-title exist', async () => {
+        return await testSubjects.exists('case-configure-title');
       });
-      await testSubjects.click('add-custom-field');
-      await svlCommonScreenshots.takeScreenshot(
-        'observability-cases-custom-fields',
-        screenshotDirectories,
-        1400,
-        700
-      );
-      await testSubjects.setValue('custom-field-label-input', 'my-field');
-      await retry.waitFor('common-flyout-save exist', async () => {
-        return await testSubjects.exists('common-flyout-save');
-      });
-      await testSubjects.click('common-flyout-save');
       await svlCommonScreenshots.takeScreenshot(
         'observability-cases-settings',
         screenshotDirectories
       );
-      await retry.waitFor('add-template exist', async () => {
-        return await testSubjects.isEnabled('add-template');
+
+      // Templates list page — reachable when the templates flag is ON.
+      // Strip any query string / hash so the sub-path is appended cleanly.
+      const configureUrl = (await browser.getCurrentUrl()).split(/[?#]/)[0].replace(/\/$/, '');
+      await browser.get(`${configureUrl}/templates`);
+      await header.waitUntilLoadingHasFinished();
+      await retry.waitFor('templates-table exist', async () => {
+        return await testSubjects.exists('templates-table');
       });
-      await testSubjects.click('add-template');
       await svlCommonScreenshots.takeScreenshot(
         'observability-cases-templates',
         screenshotDirectories,
         1400,
         1000
       );
-      await retry.waitFor('common-flyout-cancel exist', async () => {
-        return await testSubjects.exists('common-flyout-cancel');
+
+      // Field library page — reachable when the templates flag is ON.
+      await browser.get(`${configureUrl}/field_library`);
+      await header.waitUntilLoadingHasFinished();
+      await retry.waitFor('fieldDefinitionsTable exist', async () => {
+        return await testSubjects.exists('fieldDefinitionsTable');
       });
-      await testSubjects.click('common-flyout-cancel');
+      await svlCommonScreenshots.takeScreenshot(
+        'observability-cases-field-library',
+        screenshotDirectories,
+        1400,
+        700
+      );
+
+      // Add-connector flyout on the settings page (unchanged by the flag).
+      await browser.get(configureUrl);
+      await header.waitUntilLoadingHasFinished();
       await retry.waitFor('dropdown-connectors exist', async () => {
         return await testSubjects.exists('dropdown-connectors');
       });

--- a/x-pack/solutions/security/test/screenshot_creation/apps/response_ops_docs/security_cases/custom_fields.ts
+++ b/x-pack/solutions/security/test/screenshot_creation/apps/response_ops_docs/security_cases/custom_fields.ts
@@ -12,35 +12,49 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const pageObjects = getPageObjects(['common', 'header']);
   const screenshotDirectories = ['response_ops_docs', 'security_cases'];
   const testSubjects = getService('testSubjects');
+  const browser = getService('browser');
+  const retry = getService('retry');
 
   describe('Security case settings and custom fields', function () {
     it('case settings screenshots', async () => {
+      // With the templates feature flag pinned ON for this suite, custom fields and
+      // templates are managed on the dedicated v2 templates / field-library pages
+      // rather than inline on the Case Settings page.
       await pageObjects.common.navigateToApp('security', { path: 'cases' });
       await pageObjects.header.waitUntilLoadingHasFinished();
       await testSubjects.click('configure-case-button');
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await retry.waitFor('case-configure-title exist', async () => {
+        return await testSubjects.exists('case-configure-title');
+      });
       await commonScreenshots.takeScreenshot('cases-settings', screenshotDirectories);
-      await testSubjects.click('add-template');
+
+      // Templates list page — reachable when the templates flag is ON. Strip any
+      // query string / hash so the sub-path is appended cleanly.
+      const configureUrl = (await browser.getCurrentUrl()).split(/[?#]/)[0].replace(/\/$/, '');
+      await browser.get(`${configureUrl}/templates`);
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await retry.waitFor('templates-table exist', async () => {
+        return await testSubjects.exists('templates-table');
+      });
       await commonScreenshots.takeScreenshot(
         'cases-add-template',
         screenshotDirectories,
         1400,
         1000
       );
-      await testSubjects.click('common-flyout-cancel');
-      await testSubjects.click('add-custom-field');
+
+      // Field library page — reachable when the templates flag is ON.
+      await browser.get(`${configureUrl}/field_library`);
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await retry.waitFor('fieldDefinitionsTable exist', async () => {
+        return await testSubjects.exists('fieldDefinitionsTable');
+      });
       await commonScreenshots.takeScreenshot(
         'cases-add-custom-field',
         screenshotDirectories,
         1400,
         700
-      );
-      await testSubjects.setValue('custom-field-label-input', 'my-field');
-      await testSubjects.click('common-flyout-save');
-      await commonScreenshots.takeScreenshot(
-        'cases-custom-field-settings',
-        screenshotDirectories,
-        1400,
-        1024
       );
     });
   });

--- a/x-pack/solutions/security/test/serverless/functional/configs/config.screenshots.ts
+++ b/x-pack/solutions/security/test/serverless/functional/configs/config.screenshots.ts
@@ -19,4 +19,7 @@ export default createTestConfig({
   },
 
   esServerArgs: [],
+  // Pin the Cases templates flag ON so the case-settings docs screenshots capture
+  // the v2 templates / field-library pages regardless of the plugin default.
+  kbnServerArgs: [`--xpack.cases.templates.enabled=true`],
 });

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/create_case_form.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/create_case_form.ts
@@ -98,6 +98,10 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
           return this.skip();
         }
 
+        // Templates v2 hides the legacy inline custom fields on Create behind a switch;
+        // reveal it so this legacy flow is exercised whether or not templates is on.
+        await cases.common.showLegacyCustomFields(owner);
+
         const customFields = [
           {
             key: 'valid_key_1',

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/cases/settings.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/cases/settings.ts
@@ -12,6 +12,7 @@ import type { FtrProviderContext } from '../../../../ftr_provider_context';
 export default function ({ getPageObject, getPageObjects, getService }: FtrProviderContext) {
   const pageObjects = getPageObjects(['common', 'header', 'svlCommonPage', 'svlCommonNavigation']);
   const retry = getService('retry');
+  const browser = getService('browser');
   const svlCases = getService('svlCases');
   const svlCommonScreenshots = getService('svlCommonScreenshots');
   const screenshotDirectories = ['response_ops_docs', 'security_cases'];
@@ -29,6 +30,10 @@ export default function ({ getPageObject, getPageObjects, getService }: FtrProvi
     });
 
     it('case settings screenshot', async function () {
+      // With the templates feature flag pinned ON for this suite, custom fields and
+      // templates are managed on the dedicated v2 templates / field-library pages
+      // rather than inline on the Case Settings page. Capture the settings page,
+      // the templates list, and the field library for the docs.
       await navigateToCasesApp(getPageObject, getService, owner);
       // The redesigned settings page drops the custom fields and templates management these
       // screenshots document, so skip while the redesign is on.
@@ -40,39 +45,38 @@ export default function ({ getPageObject, getPageObjects, getService }: FtrProvi
       });
       await testSubjects.click('configure-case-button');
       await pageObjects.header.waitUntilLoadingHasFinished();
-      await retry.waitFor('add-custom-field exist', async () => {
-        return await testSubjects.exists('add-custom-field');
+      await retry.waitFor('case-configure-title exist', async () => {
+        return await testSubjects.exists('case-configure-title');
       });
-      await testSubjects.click('add-custom-field');
-      await svlCommonScreenshots.takeScreenshot(
-        'security-cases-custom-fields',
-        screenshotDirectories,
-        1400,
-        700
-      );
-      await retry.waitFor('custom-field-label-input exist', async () => {
-        return await testSubjects.exists('custom-field-label-input');
-      });
-      await testSubjects.setValue('custom-field-label-input', 'my-field');
-      await retry.waitFor('common-flyout-save exist', async () => {
-        return await testSubjects.exists('common-flyout-save');
-      });
-      await testSubjects.click('common-flyout-save');
       await svlCommonScreenshots.takeScreenshot('security-cases-settings', screenshotDirectories);
-      await retry.waitFor('add-template to exist', async () => {
-        return await testSubjects.isEnabled('add-template');
+
+      // Templates list page — reachable when the templates flag is ON.
+      // Strip any query string / hash so the sub-path is appended cleanly.
+      const configureUrl = (await browser.getCurrentUrl()).split(/[?#]/)[0].replace(/\/$/, '');
+      await browser.get(`${configureUrl}/templates`);
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await retry.waitFor('templates-table exist', async () => {
+        return await testSubjects.exists('templates-table');
       });
-      await testSubjects.click('add-template');
       await svlCommonScreenshots.takeScreenshot(
         'security-cases-templates',
         screenshotDirectories,
         1400,
         1000
       );
-      await retry.waitFor('common-flyout-cancel to exist', async () => {
-        return await testSubjects.exists('common-flyout-cancel');
+
+      // Field library page — reachable when the templates flag is ON.
+      await browser.get(`${configureUrl}/field_library`);
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await retry.waitFor('fieldDefinitionsTable exist', async () => {
+        return await testSubjects.exists('fieldDefinitionsTable');
       });
-      await testSubjects.click('common-flyout-cancel');
+      await svlCommonScreenshots.takeScreenshot(
+        'security-cases-field-library',
+        screenshotDirectories,
+        1400,
+        700
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Enabled the feature flag `xpack.cases.templates.enabled` and updated existing FTR cases tests. This is an updated version of https://github.com/elastic/kibana/pull/279758.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->