### PR TITLE
investigate-rule: wire query-rewrite handoff to detection-rule-edit

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_rules/find_rules_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_rules/find_rules_skill.ts
@@ -46,7 +46,9 @@ Use this skill to list, count, sort, or rank multiple Security detection rules.
 
 ## Read-Only
 
-This skill cannot enable, disable, delete, duplicate, or bulk-edit detection rules. For mutations, direct the user to the Detection Rules UI. Use detection-rule-edit only when a single rule attachment is present in the conversation.
+This skill cannot enable, disable, delete, duplicate, or bulk-edit detection rules.
+
+**Exception — single rule edit:** when the user selects a specific rule from the results and asks to edit it (query, severity, tags, MITRE, schedule, etc.), load the \`detection-rule-edit\` skill from \`skills/security/rules\`. Pass it the rule name and \`rule_id\` so it can find the attachment without a redundant search. The edit skill handles attachment lookup and applies the change.
 
 ## Tools
 
@@ -157,7 +159,9 @@ Examples:
 
 ## No Actions
 
-This skill is read-only. Never suggest or offer to enable, disable, edit, delete, duplicate, or bulk-edit rules. If the user asks to modify a rule, direct them to the Detection Rules UI.
+This skill is read-only. Never suggest or offer to enable, disable, delete, duplicate, or bulk-edit rules. Direct those requests to the Detection Rules UI.
+
+**Exception — single rule edit:** when the user picks one rule from the results to edit, load \`detection-rule-edit\` (see Read-Only above).
 
 **Exception — noise/FP queries:** if the user's request was about noisy rules, high alert volume, or false positives (e.g. "which rules fire the most?", "find my noisiest rules"), end your response with:
 "I can investigate any of these rules individually — just let me know which one."

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/investigate_rule/investigate_rule_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/investigate_rule/investigate_rule_skill.ts
@@ -196,11 +196,15 @@ positive.
 
 ### Step 4: Produce Output
 
-This skill is **read-only and diagnostic**. It explains the noise and suggests
-remediations the user can perform in the Detection Rules UI. It never applies a change,
-offers to apply one, or hands off to a rule-mutation skill. The exception proposal below
-is **plain-text guidance the analyst types into the UI themselves** — describing it in a
-structured way is expected; it is not an auto-applied or machine-actionable change.
+This skill is **diagnostic**. It explains the noise and suggests remediations.
+
+- **Exception, suppression, and threshold changes** are plain-text guidance the analyst
+  applies in the Detection Rules UI themselves — describing a structured exception for the
+  analyst to create is fine; it is not a machine-actionable change.
+- **Query rewrites** (confirmed rule over-matching where narrowing the ES|QL query is the
+  right fix): you **MAY offer to apply the change in-chat**. See Remediation Guidance below
+  for the exact handoff pattern. Do not offer this for unconfirmed open-alert concentration —
+  only when Signal A analyst dispositions confirm a query fix is warranted.
 
 The output must always contain these five sections, in order. Use a \`##\` header for each
 section (e.g. \`## Alert Volume\`) — **do not use numbered list items for sections**; tables
@@ -265,16 +269,38 @@ load the alert-analysis skill."
 
 ## Remediation Guidance
 
-This skill does not change rules and has no in-chat rule-mutation capability.
-When you have identified a fix:
+### Exceptions, suppression, and threshold changes
 
-- Describe it in plain text and tell the user how to perform it themselves in the
-  Detection Rules UI (e.g., add an exception, narrow the query, adjust the
-  threshold, or configure alert suppression).
-- Do **not** offer to make the change, claim you can change the rule, hand off to
-  a mutation skill, or emit an auto-applied / machine-actionable change. (Describing a
-  structured exception in plain text for the analyst to create themselves is fine — that
-  is guidance, not a rule mutation.)
+Describe these in plain text so the analyst can apply them in the Detection Rules UI. Do
+**not** offer to apply exceptions, suppression, or threshold changes in-chat — there is no
+tool for these operations.
+
+### Query rewrites (confirmed over-matching only)
+
+When Signal A analyst dispositions confirm the rule is over-matching (closed
+\`false_positive\` alerts where a narrower query would have avoided the detections), you
+**may offer to apply the query change in-chat** — but only after completing the full
+analysis output above and only when you can express the change as a concrete natural-language
+description. The steps are:
+
+1. **Describe the proposed query change** in your output so the user knows exactly what
+   will change before anything is applied (e.g., "I'll add a filter to exclude
+   \`process.parent.name = \"gitlab-runner\"\` from the query").
+2. **Ask the user to confirm** before proceeding.
+3. **Only after confirmation:** read the \`detection-rule-edit\` skill from
+   \`skills/security/rules\`, then call \`security.create_detection_rule\` with two
+   parameters:
+   - \`user_query\`: a natural-language description of the query change to apply
+   - \`attachment_id\`: the rule attachment ID already present in the conversation (from
+     Step 0 — either the user-opened attachment or the one created by
+     \`resolve_rule_attachment\`)
+4. Render the updated attachment inline after the tool returns.
+
+**Do not offer this path when:**
+- The evidence is Signal B only (open-alert concentration, no confirmed dispositions).
+- The appropriate fix is an exception or suppression rather than a query change.
+- No rule attachment is in the conversation (i.e., \`resolve_rule_attachment\` was never
+  called and the user did not open a rule attachment).
 
 ---
 
@@ -282,8 +308,7 @@ When you have identified a fix:
 
 Use the five \`##\` sections from Step 4 (Alert volume, Confirmed dispositions, Root cause,
 Recommended remediation, Confidence boundary). Within each section, **prose, bullets, or
-tables are all fine** — use whatever reads best for the data. (Read-only: never apply or
-offer to apply a change.)
+tables are all fine** — use whatever reads best for the data.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the hard prohibition in the `investigate-rule` skill against handing off to a mutation skill, replacing it with a conditional: exception/suppression/threshold fixes remain plain-text guidance for the Detection Rules UI; confirmed query over-matching cases may now offer an in-chat query rewrite.
- The handoff uses the rule attachment already present in the conversation (either opened by the user or minted by `resolve_rule_attachment`) — the model reads `detection-rule-edit` from `skills/security/rules`, then calls `security.create_detection_rule` with `user_query` + `attachment_id`.
- Guard conditions prevent offering the path when evidence is Signal B only, when an exception is the right fix, or when no rule attachment is in context.

Addresses elastic/security-team#18135

## How to test

1. Open a noisy ES|QL rule's chat (or use `find-security-rules` → `investigate-rule`).
2. Let `investigate-rule` complete its analysis with closed `false_positive` alerts where the pattern suggests the query is over-matching.
3. Verify the skill offers a specific query narrowing and asks for confirmation before applying.
4. Confirm — verify the skill loads `detection-rule-edit`, calls `security.create_detection_rule` with `attachment_id`, and renders the updated rule card.
5. Verify: for a `benign_positive` pattern, the skill does **not** offer an in-chat query edit — exception/suppression guidance only.
6. Verify: for Signal B only (no closed alerts), the skill does **not** offer the query handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)