### PR TITLE
[Fleet] Retry ES asset verification to absorb read-after-write lag

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/verify_es_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/verify_es_assets.test.ts
@@ -51,7 +51,7 @@ describe('verifyEsAssetsExist', () => {
       makeRef(ElasticsearchAssetType.indexTemplate, 'present-tmpl'),
     ];
 
-    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger());
+    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger(), { maxAttempts: 1 });
     expect(missing).toEqual([makeRef(ElasticsearchAssetType.ingestPipeline, 'missing-pipe')]);
   });
 
@@ -93,7 +93,7 @@ describe('verifyEsAssetsExist', () => {
       makeRef(ElasticsearchAssetType.dataStreamIlmPolicy, 'ds-ilm'),
     ];
 
-    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger());
+    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger(), { maxAttempts: 1 });
     expect(missing).toEqual(refs);
     expect(esClient.ilm.getLifecycle).toHaveBeenCalledTimes(2);
   });
@@ -116,7 +116,7 @@ describe('verifyEsAssetsExist', () => {
 
     const refs: EsAssetReference[] = [makeRef(ElasticsearchAssetType.transform, 'my-transform')];
 
-    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger());
+    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger(), { maxAttempts: 1 });
     expect(missing).toEqual(refs);
     expect(esClient.transform.getTransform).toHaveBeenCalledWith(
       { transform_id: 'my-transform' },
@@ -131,11 +131,43 @@ describe('verifyEsAssetsExist', () => {
       makeRef(ElasticsearchAssetType.componentTemplate, 'missing-comp'),
     ];
 
-    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger());
+    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger(), { maxAttempts: 1 });
     expect(missing).toEqual(refs);
     expect(esClient.cluster.existsComponentTemplate).toHaveBeenCalledWith({
       name: 'missing-comp',
     });
+  });
+
+  it('retries missing assets and returns empty once they appear', async () => {
+    esClient.ingest.getPipeline
+      .mockResolvedValueOnce({ statusCode: 404, body: {} } as any)
+      .mockResolvedValueOnce({ statusCode: 200, body: {} } as any);
+
+    const refs: EsAssetReference[] = [
+      makeRef(ElasticsearchAssetType.ingestPipeline, 'lagging-pipe'),
+    ];
+
+    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger(), {
+      maxAttempts: 3,
+      retryDelayMs: 0,
+    });
+
+    expect(missing).toEqual([]);
+    expect(esClient.ingest.getPipeline).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns still-missing assets after exhausting retries', async () => {
+    esClient.ingest.getPipeline.mockResolvedValue({ statusCode: 404, body: {} } as any);
+
+    const refs: EsAssetReference[] = [makeRef(ElasticsearchAssetType.ingestPipeline, 'gone-pipe')];
+
+    const missing = await verifyEsAssetsExist(esClient, refs, makeLogger(), {
+      maxAttempts: 2,
+      retryDelayMs: 0,
+    });
+
+    expect(missing).toEqual(refs);
+    expect(esClient.ingest.getPipeline).toHaveBeenCalledTimes(2);
   });
 
   it('treats @custom component templates as always present without calling ES', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/verify_es_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/verify_es_assets.ts
@@ -5,12 +5,27 @@
  * 2.0.
  */
 
+import { setTimeout as delay } from 'timers/promises';
+
 import type { ElasticsearchClient } from '@kbn/core/server';
 import pMap from 'p-map';
 
 import type { EsAssetReference } from '../../../types';
 import { ElasticsearchAssetType } from '../../../types';
 import { isUserSettingsTemplate } from '../elasticsearch/template/utils';
+
+/**
+ * Assets are verified right after they are written, so a clean 404 is often just read-after-write
+ * lag (cluster-state propagation for templates/pipelines/ILM) rather than a real install failure.
+ * We re-check only the still-missing assets a few times before declaring them missing.
+ */
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 2000;
+
+export interface VerifyEsAssetsOptions {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+}
 
 /**
  * Checks whether a single ES asset exists. Returns true if the asset is present, false if it is
@@ -66,9 +81,40 @@ async function esAssetExists(
 /**
  * Returns the subset of `refs` whose corresponding ES assets do not exist.
  * Per-asset errors are treated as "present" (logged but not surfaced as missing) to prevent
- * transient ES errors from triggering spurious install failures.
+ * transient ES errors from triggering spurious install failures. Missing assets are re-checked
+ * with a short backoff to absorb read-after-write lag right after installation.
  */
 export async function verifyEsAssetsExist(
+  esClient: ElasticsearchClient,
+  refs: EsAssetReference[],
+  logger: { warn: (msg: string) => void },
+  options: VerifyEsAssetsOptions = {}
+): Promise<EsAssetReference[]> {
+  const { maxAttempts = DEFAULT_MAX_ATTEMPTS, retryDelayMs = DEFAULT_RETRY_DELAY_MS } = options;
+
+  let toCheck = refs;
+  let missing: EsAssetReference[] = [];
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    missing = await checkAssets(esClient, toCheck, logger);
+    if (missing.length === 0) {
+      return [];
+    }
+
+    if (attempt < maxAttempts) {
+      logger.warn(
+        `verifyEsAssetsExist: ${missing.length} asset(s) missing on attempt ${attempt}/${maxAttempts}, retrying in ${retryDelayMs}ms`
+      );
+      // Only the still-missing assets need re-checking; present ones won't disappear.
+      toCheck = missing;
+      await delay(retryDelayMs);
+    }
+  }
+
+  return missing;
+}
+
+async function checkAssets(
   esClient: ElasticsearchClient,
   refs: EsAssetReference[],
   logger: { warn: (msg: string) => void }


### PR DESCRIPTION
## Summary

`stepVerifyAssets` (added in #275570) hard-fails an integration install as soon as `verifyEsAssetsExist` reports a single asset missing. But assets are verified immediately after they're written, so a clean `404` is frequently just read-after-write lag (cluster-state propagation for index templates / component templates / ingest pipelines / ILM policies), not a genuine install failure. On a busy CI ES node this turns a transient into a hard failure → uninstall/rollback → retry cascade, and the package never finishes installing.

Observed blast radius: the `cloud_security_dashboard` performance journey (#231554) times out in its `beforeSteps` hook because the CSP plugin never initializes, plus a cluster of other package-install `before all`/`before each` failures (CSP, Endpoint, Observability `dataset_quality`) in the same window.

This makes verification tolerant of that lag: re-check **only** the still-missing assets with a short bounded backoff (default 3 attempts, 2s apart) before declaring them missing. Genuinely-missing assets still surface after retries, preserving the original intent of #275570 (catch silent install failures).

## Test plan

- [x] `verify_es_assets.test.ts` — added coverage for retry-then-succeed and retry-exhaustion; existing missing-asset cases pinned to `maxAttempts: 1`
- [x] `step_verify_assets.test.ts` — unchanged, still green
- [x] Confirm the `cloud_security_dashboard` journey and related package-install before-hooks stop flaking

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->