### PR TITLE
Enable data federation and federated identity

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -134,7 +134,8 @@ xpack.remote_clusters.enabled: false
 xpack.snapshot_restore.enabled: false
 xpack.license_management.enabled: false
 xpack.cloud_connect.enabled: false
-xpack.dataFederation.enabled: false
+xpack.dataFederation.enabled: true
+xpack.dataFederation.enableFederatedIdentityAuth: true
 xpack.reindex_service.rollupsEnabled: false
 
 # Management team UI configurations


### PR DESCRIPTION
## Summary

Serverless config change only, enable `xpack.dataFederation.enabled` and `xpack.dataFederation.enableFederatedIdentityAuth`