### PR TITLE
[Lens as code] Default named palette continuity to `all` so out-of-range values stay colored

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/metric/metric.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/metric/metric.test.ts
@@ -194,7 +194,7 @@ describe('Metric', () => {
       const apiOutput = builder.toAPIFormat(lensState) as MetricConfig;
 
       expect(viz.palette?.params?.rangeType).toBe('number');
-      expect(viz.palette?.params?.continuity).toBe('none');
+      expect(viz.palette?.params?.continuity).toBe('all');
       expect(apiOutput.metrics[0].color).toEqual(config.metrics[0].color);
     });
 
@@ -230,8 +230,8 @@ describe('Metric', () => {
       const viz = so.state.visualization as MetricVisualizationState;
 
       expect(viz.palette?.params?.rangeType).toBe('number');
-      // Continuity has no meaning for a distributed palette and is always set to 'none'
-      expect(viz.palette?.params?.continuity).toBe('none');
+      // A distributed palette always opens both bounds so out-of-range values stay colored
+      expect(viz.palette?.params?.continuity).toBe('all');
       expect(viz.palette?.params?.steps).toBe(3);
       expect(viz.palette?.params?.stops).toBeUndefined();
       expect(viz.palette?.params?.colorStops).toBeUndefined();
@@ -282,8 +282,8 @@ describe('Metric', () => {
 
       expect(outViz.palette?.params?.rangeType).toBe('percent');
       expect(outViz.palette?.params?.steps).toBe(3);
-      // Continuity has no meaning for a distributed palette and is always set to 'none'
-      expect(outViz.palette?.params?.continuity).toBe('none');
+      // A distributed palette always opens both bounds so out-of-range values stay colored
+      expect(outViz.palette?.params?.continuity).toBe('all');
       expect(outViz.palette?.params?.stops).toBeUndefined();
       expect(outViz.palette?.params?.colorStops).toBeUndefined();
     });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/common.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/common.ts
@@ -655,8 +655,8 @@ export function getPaletteNormalizer<T extends LensAttributes>(
         const rangeMax = getRangeValue(palette.params.rangeMax);
 
         if (palette.name !== 'custom') {
-          // Continuity has no meaning for a distributed palette and is always set to 'none'
-          palette.params.continuity = 'none';
+          // A distributed palette always opens both bounds so out-of-range values stay colored
+          palette.params.continuity = 'all';
 
           // The transform canonicalizes the legacy `complimentary` spelling to the GA palette id
           // (`complementary`), matching runtime. Canonicalize the original side too so the

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.test.ts
@@ -182,7 +182,7 @@ describe('Color util transforms', () => {
             progression: 'fixed',
             reverse: false,
             rangeType: 'percent',
-            continuity: 'none',
+            continuity: 'all',
             steps: DEFAULT_COLOR_STEPS,
             maxSteps: DEFAULT_COLOR_STEPS,
           },
@@ -240,7 +240,7 @@ describe('Color util transforms', () => {
             // default range type for distributed palettes
             rangeType: 'percent',
             // default continuity for distributed palettes
-            continuity: 'none',
+            continuity: 'all',
             steps: 3,
             maxSteps: DEFAULT_COLOR_STEPS,
           },
@@ -293,7 +293,7 @@ describe('Color util transforms', () => {
             progression: 'fixed',
             reverse: false,
             rangeType: 'percent', // default range type for distributed palettes
-            continuity: 'none', // default continuity for distributed palettes
+            continuity: 'all', // default continuity for distributed palettes
             steps: 4, // the number of bands defined as argument
             maxSteps: DEFAULT_COLOR_STEPS,
           },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.ts
@@ -105,9 +105,11 @@ function mergeTrailingSameColorStep(steps: ColorByValueStep[]): ColorByValueStep
  * - `rangeType`: `percent` by default, or `number` when `useNumericRange` is `true`. Named
  *   palettes color a percentage domain; single-value charts (single-value metric charts and
  * legacy metric) opt into a numeric one.
- * - `continuity`: always `none`. Continuity is meaningless for a distributed palette — the
- *   palette's colors are spread across the entire domain, and the recalculated `min`/`max`
- *   act as the range bounds.
+ * - `continuity`: always `all`. A distributed palette spreads its colors across the whole
+ *   domain, but the range bounds it colors against are not always the recalculated data
+ *   min/max: charts like `metric` with a user-defined max use that max as the 100% bound, so
+ *   values can fall above (or below) it. Opening both ends (`all`) ensures those out-of-range
+ *   values still receive the nearest band color instead of being left uncolored.
  */
 function buildNamedPaletteLensState({
   palette,
@@ -126,8 +128,10 @@ function buildNamedPaletteLensState({
       progression: 'fixed', // to be removed
       reverse: false, // always applied to steps during transform
       rangeType: useNumericRange ? 'number' : 'percent',
-      // distributed palettes span the full domain; the recalculated min/max act as bounds
-      continuity: 'none',
+      // distributed palettes span the full domain; the recalculated min/max act as bounds except for the cases
+      // where we use a user-defined max or min. In those cases, we need to open both ends to ensure that
+      // values outside the range are still colored.
+      continuity: 'all',
       steps: numberOfBands,
       maxSteps: Math.max(DEFAULT_COLOR_STEPS, numberOfBands),
     },
@@ -136,7 +140,8 @@ function buildNamedPaletteLensState({
 
 /**
  * API -> Lens state for a `distributed_palette` or the deprecated `legacy_dynamic`.
- * - `continuity` is always `none`; the recalculated `min`/`max` act as the range bounds.
+ * - `continuity` is always `all`; opening both bounds keeps values outside the effective range
+ *   (e.g. above a metric's user-defined max) colored with the nearest band.
  * - `numberOfBands` is the per-chart default band count used to split the domain.
  * - `useNumericRange` defaults to `false` (`percent`). Single-value charts (metric without
  *   a max or breakdown, and legacy metric) pass `true` (`number`) instead, since they color a


### PR DESCRIPTION
## Summary

Follow-up to #276774

In #276774 the color-by-value transform for **named / distributed palettes** (`status`, `temperature`, …) defaulted `continuity` to `none` on the reasoning that continuity is meaningless for a palette whose bounds are recalculated from the live data domain.

That assumption doesn't hold for charts with a **user-defined bound**. On a `metric` chart with a `max` value, the palette does **not** color against the auto-recalculated data range, it colors against the user-defined max as the 100% bound. 

Real values can therefore fall **above** that max. 

With `continuity: none`, the shared render-time color resolver (`workoutColorForValue`) returns no color for anything outside `[rangeMin, rangeMax]`, so those out-of-range values render as the panel background instead of the nearest band color.

This is the same class of problem described in #172297 ("Bad Metric color ranges for upper bound percentage values").

This PR changes the default `continuity` for named/distributed palettes from `none` to `all`, opening **both** bounds so out-of-range values receive the nearest band color.

## Dashboards to test
- metric chart with a user-defined max value which is less than the data range max value should color the out of range values:
[metric_with_max.ndjson.txt](https://github.com/user-attachments/files/30237026/metric_with_max.ndjson.txt)

- for every other chart with a non-custom distributed palette the `continuity` now resolves to "all", but rendered colors stay the same:
[named_palettes_dashboard.ndjson.txt](https://github.com/user-attachments/files/30237055/named_palettes_dashboard.ndjson.txt)

## Screenshots

Left: API Flag OFF
Right: API Flag ON

- Before:

<img width="3014" height="1490" alt="Screenshot 2026-07-20 at 6 22 04 PM" src="https://github.com/user-attachments/assets/3cf47b41-9d4e-4432-a8eb-9de885c5f939" />
<img width="2988" height="1460" alt="Screenshot 2026-07-20 at 6 21 48 PM" src="https://github.com/user-attachments/assets/265b4f52-de95-4dbb-8113-092ab4b26eee" />

- After: 

<img width="1495" height="739" alt="Screenshot 2026-07-21 at 7 31 16 PM" src="https://github.com/user-attachments/assets/936d8088-0e7a-43f6-98c7-f88b893e5777" />
<img width="1493" height="733" alt="Screenshot 2026-07-21 at 7 31 03 PM" src="https://github.com/user-attachments/assets/be8fae06-1d61-43e8-b280-66951ec92584" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->