### PR TITLE
[AI Index] Add ES|QL view source

### DIFF
--- a/x-pack/platform/plugins/shared/context_engine/README.md
+++ b/x-pack/platform/plugins/shared/context_engine/README.md
@@ -28,7 +28,7 @@ Notes:
 - `automations` is an array of `{ "type": "workflow", "value": "<name>" }`
   objects, and `sources` is an array of
   `{ "type": "esql", "value": "<ES|QL query>" }` or
-  `{ "type": "esql_view", "value": "<view name>" }` objects. Both are required
+  `{ "type": "esql_view", "value": "<ES|QL view name>" }` objects. Both are required
   and may be empty arrays.
 - Deleting an AI index deletes **only** the AI index entry. Backing indices
   are left untouched and must be removed with the Delete index API if desired.

--- a/x-pack/platform/plugins/shared/context_engine/README.md
+++ b/x-pack/platform/plugins/shared/context_engine/README.md
@@ -27,7 +27,8 @@ Notes:
   system indices are not allowed.
 - `automations` is an array of `{ "type": "workflow", "value": "<name>" }`
   objects, and `sources` is an array of
-  `{ "type": "esql", "value": "<ES|QL query>" }` objects. Both are required and
-  may be empty arrays.
+  `{ "type": "esql", "value": "<ES|QL query>" }` or
+  `{ "type": "esql_view", "value": "<view name>" }` objects. Both are required
+  and may be empty arrays.
 - Deleting an AI index deletes **only** the AI index entry. Backing indices
   are left untouched and must be removed with the Delete index API if desired.

--- a/x-pack/platform/plugins/shared/context_engine/common/http_api/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/http_api/ai_indices.ts
@@ -16,7 +16,7 @@ export interface AiIndexDest {
   value: string;
 }
 
-export type AiIndexSourceType = 'esql';
+export type AiIndexSourceType = 'esql' | 'esql_view';
 
 export interface AiIndexSource {
   type: AiIndexSourceType;

--- a/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.test.ts
@@ -295,6 +295,18 @@ describe('ai indices routes', () => {
       ).not.toThrow();
     });
 
+    it('rejects an esql_view source with an empty value', () => {
+      expect(() =>
+        validateBody({ ...validBody, sources: [{ type: 'esql_view', value: '' }] })
+      ).toThrow();
+    });
+
+    it('rejects an esql_view source with an invalid view name', () => {
+      expect(() =>
+        validateBody({ ...validBody, sources: [{ type: 'esql_view', value: 'bad name!' }] })
+      ).toThrow();
+    });
+
     it('rejects a disallowed dest type', () => {
       expect(() =>
         validateBody({ ...validBody, dest: { type: 'view', value: 'ai-index-idx-foo' } })

--- a/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.test.ts
@@ -286,6 +286,15 @@ describe('ai indices routes', () => {
       ).not.toThrow();
     });
 
+    it('accepts an esql_view source', () => {
+      expect(() =>
+        validateBody({
+          ...validBody,
+          sources: [{ type: 'esql_view', value: 'customer_support_view' }],
+        })
+      ).not.toThrow();
+    });
+
     it('rejects a disallowed dest type', () => {
       expect(() =>
         validateBody({ ...validBody, dest: { type: 'view', value: 'ai-index-idx-foo' } })

--- a/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
@@ -96,11 +96,19 @@ const putAiIndexBodySchema = schema.object({
   ),
   sources: schema.arrayOf(
     schema.object({
-      type: schema.literal('esql'),
+      type: schema.oneOf([schema.literal('esql'), schema.literal('esql_view')], {
+        meta: {
+          description:
+            'The source type. `esql` for an ES|QL query, or `esql_view` for a view name.',
+        },
+      }),
       value: schema.string({
         minLength: 0,
         maxLength: MAX_AI_INDEX_SOURCE_VALUE_LENGTH,
-        meta: { description: 'The source value; an ES|QL query when `type` is `esql`.' },
+        meta: {
+          description:
+            'The source value; an ES|QL query when `type` is `esql`, or a view name when `type` is `esql_view`.',
+        },
       }),
     }),
     {

--- a/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
@@ -95,22 +95,26 @@ const putAiIndexBodySchema = schema.object({
     }
   ),
   sources: schema.arrayOf(
-    schema.object({
-      type: schema.oneOf([schema.literal('esql'), schema.literal('esql_view')], {
-        meta: {
-          description:
-            'The source type. `esql` for an ES|QL query, or `esql_view` for a view name.',
-        },
+    schema.oneOf([
+      schema.object({
+        type: schema.literal('esql'),
+        value: schema.string({
+          minLength: 0,
+          maxLength: MAX_AI_INDEX_SOURCE_VALUE_LENGTH,
+          meta: { description: 'An ES|QL query.' },
+        }),
       }),
-      value: schema.string({
-        minLength: 0,
-        maxLength: MAX_AI_INDEX_SOURCE_VALUE_LENGTH,
-        meta: {
-          description:
-            'The source value; an ES|QL query when `type` is `esql`, or a view name when `type` is `esql_view`.',
-        },
+      schema.object({
+        type: schema.literal('esql_view'),
+        value: schema.string({
+          minLength: 1,
+          maxLength: MAX_AI_INDEX_SOURCE_VALUE_LENGTH,
+          validate: (value) =>
+            /^[a-zA-Z0-9_\-.]+$/.test(value) ? undefined : 'must be a valid ES|QL view name',
+          meta: { description: 'An ES|QL view name.' },
+        }),
       }),
-    }),
+    ]),
     {
       maxSize: MAX_AI_INDEX_SOURCES,
       meta: { description: 'Additional sources that provide context for the AI index.' },


### PR DESCRIPTION
This PR adds supports for an `esql_view` source and associated view name input, as an alternate syntactic sugar option to the existing `esql` source. If `esql_view` source is specified a valid view name must be specified. 