### PR TITLE
[CI] Test FTR selective testing: @kbn/scout-only change (do not merge)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -8,6 +8,7 @@
  */
 
 // CLI tools
+// Scout CLI entry points used by `node scripts/scout`.
 export * as cli from './src/cli';
 
 // Test framework


### PR DESCRIPTION
## Summary

Test PR for the FTR selective testing introduced in #279801 — do not merge.

The diff is a single comment line in `@kbn/scout` (an `FTR_EXCLUDED_MODULES` entry), so the expected behavior in the `kibana-pull-request` build is:

- No **FTR Configs** group scheduled
- Info annotation `selective-testing-ftr-excluded` on the build page
- "Pick Test Group Run Order" log shows `Skipping FTR configs — diff cannot affect FTR: @kbn/scout`
- Jest (for `@kbn/scout` + downstream) and Scout tests still run

Will close after verifying.

Made with [Cursor](https://cursor.com)