### PR TITLE
[UIAM OAuth] Show connections for MCP clients not owned by the current user

### DIFF
--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -40,6 +40,7 @@ export interface UiamOAuthClientResponse {
 export interface UiamOAuthConnectionResponse {
   id: string;
   client_id: string;
+  client_name?: string;
   name?: string;
   resource: string;
   creation?: string;

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -964,4 +964,197 @@ describe('ApplicationConnections', () => {
     expect(within(flyout).getByText('client-a')).toBeInTheDocument();
     expect(within(flyout).getByText(mcpServerUrl)).toBeInTheDocument();
   });
+
+  it('renders a connection on a non-owned client (absent from the clients list) as its own row', async () => {
+    setupHttpResponses(coreStart, {
+      clients: { clients: [] },
+      connections: {
+        connections: [
+          {
+            id: 'conn-1',
+            client_id: 'non-owned-client',
+            client_name: 'Other user app',
+            name: 'Laptop session',
+            resource: 'cluster:elastic',
+          },
+        ],
+      },
+    });
+
+    const { findByText, findByTestId } = renderPage(coreStart);
+
+    expect(await findByText('Other user app')).toBeInTheDocument();
+    expect(
+      await findByTestId('applicationConnectionsListRow-non-owned-client')
+    ).toBeInTheDocument();
+    expect(await findByTestId('applicationConnectionsCount-non-owned-client')).toHaveTextContent(
+      '1'
+    );
+  });
+
+  it('falls back to the client id when a non-owned client has no client_name', async () => {
+    setupHttpResponses(coreStart, {
+      clients: { clients: [] },
+      connections: {
+        connections: [
+          {
+            id: 'conn-1',
+            client_id: 'non-owned-client',
+            name: 'Laptop session',
+            resource: 'cluster:elastic',
+          },
+        ],
+      },
+    });
+
+    const { findByText } = renderPage(coreStart);
+
+    expect(await findByText('non-owned-client')).toBeInTheDocument();
+  });
+
+  it('renders a non-owned client connection in the list view', async () => {
+    setupHttpResponses(coreStart, {
+      clients: { clients: [] },
+      connections: {
+        connections: [
+          {
+            id: 'conn-1',
+            client_id: 'non-owned-client',
+            client_name: 'Other user app',
+            name: 'Laptop session',
+            resource: 'cluster:elastic',
+            creation: '2026-04-10T10:00:00.000Z',
+          },
+        ],
+      },
+    });
+
+    const { findByText, findByTestId, getByTestId } = renderPage(coreStart);
+
+    await findByText('Other user app');
+    fireEvent.click(getByTestId('applicationConnectionsViewModeList'));
+
+    const listView = await findByTestId('applicationConnectionsListView');
+    expect(await findByTestId('applicationConnectionsListViewRow-conn-1')).toBeInTheDocument();
+    expect(within(listView).getByText('Other user app')).toBeInTheDocument();
+  });
+
+  it('renames a non-owned client connection inline and PATCHes the update endpoint', async () => {
+    setupHttpResponses(coreStart, {
+      clients: { clients: [] },
+      connections: {
+        connections: [
+          {
+            id: 'conn-1',
+            client_id: 'non-owned-client',
+            client_name: 'Other user app',
+            name: 'Laptop session',
+            resource: 'cluster:elastic',
+          },
+        ],
+      },
+    });
+    coreStart.http.patch.mockResolvedValue({
+      id: 'conn-1',
+      client_id: 'non-owned-client',
+      client_name: 'Other user app',
+      name: 'Renamed session',
+      resource: 'cluster:elastic',
+    });
+
+    const { findByText, findByTestId, getByTestId } = renderPage(coreStart);
+
+    await findByText('Other user app');
+    fireEvent.click(getByTestId('expandRow-non-owned-client'));
+    await findByText('Laptop session');
+
+    const inlineEdit = getByTestId('inlineEditConnectionName-conn-1');
+    fireEvent.click(within(inlineEdit).getByTestId('euiInlineReadModeButton'));
+
+    const input = await findByTestId('inlineEditConnectionNameInput-conn-1');
+    fireEvent.change(input, { target: { value: 'Renamed session' } });
+    fireEvent.click(getByTestId('inlineEditConnectionNameSave-conn-1'));
+
+    await waitFor(() => {
+      expect(coreStart.http.patch).toHaveBeenCalledWith(
+        '/internal/security/oauth/clients/non-owned-client/connections/conn-1',
+        { body: JSON.stringify({ name: 'Renamed session' }) }
+      );
+    });
+  });
+
+  it('revokes a non-owned client connection via the bulk-revoke API', async () => {
+    setupHttpResponses(coreStart, {
+      clients: { clients: [] },
+      connections: {
+        connections: [
+          {
+            id: 'conn-1',
+            client_id: 'non-owned-client',
+            client_name: 'Other user app',
+            name: 'Laptop session',
+            resource: 'cluster:elastic',
+          },
+        ],
+      },
+    });
+    coreStart.http.post.mockResolvedValue({
+      results: [{ client_id: 'non-owned-client', connection_id: 'conn-1', status: 'revoked' }],
+    });
+
+    const { findByText, findByTestId, getByTestId } = renderPage(coreStart);
+
+    await findByText('Other user app');
+    fireEvent.click(getByTestId('expandRow-non-owned-client'));
+
+    const revokeLink = await findByTestId('revokeConnection-conn-1');
+    fireEvent.click(revokeLink);
+
+    const modal = await findByTestId('applicationConnectionsRevokeModal');
+    fireEvent.click(within(modal).getByTestId('applicationConnectionsRevokeConfirmButton'));
+
+    await waitFor(() => {
+      expect(coreStart.http.post).toHaveBeenCalledWith(
+        '/internal/security/oauth/connections/_bulk_revoke',
+        {
+          body: JSON.stringify({
+            connections: [{ client_id: 'non-owned-client', connection_id: 'conn-1' }],
+            reason: undefined,
+          }),
+        }
+      );
+    });
+  });
+
+  it('opens the client details flyout for a non-owned client', async () => {
+    const mcpServerUrl = 'https://cluster.example.com/api/agent_builder/mcp';
+    setupHttpResponses(coreStart, {
+      clients: { clients: [] },
+      connections: {
+        connections: [
+          {
+            id: 'conn-1',
+            client_id: 'non-owned-client',
+            client_name: 'Other user app',
+            name: 'Laptop session',
+            resource: mcpServerUrl,
+          },
+        ],
+      },
+    });
+
+    const { findByText, findByTestId, getByTestId } = renderPage(coreStart);
+
+    await findByText('Other user app');
+    fireEvent.click(getByTestId('applicationConnectionsViewModeList'));
+
+    const listView = await findByTestId('applicationConnectionsListView');
+    const link = await within(listView).findByTestId('viewClientDetailsLink-non-owned-client');
+    fireEvent.click(link);
+
+    const flyout = await findByTestId('mcpClientDetailsFlyout');
+    expect(within(flyout).getByText('Other user app')).toBeInTheDocument();
+    expect(within(flyout).getByText('non-owned-client')).toBeInTheDocument();
+    expect(within(flyout).getByText(mcpServerUrl)).toBeInTheDocument();
+  });
 });

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/hooks/use_application_connections.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/hooks/use_application_connections.ts
@@ -11,6 +11,7 @@ import { useMemo } from 'react';
 import { useClients } from './use_clients';
 import { useConnections } from './use_connections';
 import type { ApplicationConnections } from '../constants/types';
+import type { OAuthClient } from '../service/application_connections_api_client';
 
 const EMPTY_ROWS: ApplicationConnections[] = [];
 
@@ -22,7 +23,25 @@ export const useApplicationConnections = () => {
     if (!clients || !connections) return EMPTY_ROWS;
 
     const byClient = groupBy(connections, (connection) => connection.client_id);
-    return clients.map((client) => ({ client, connections: byClient[client.id] ?? [] }));
+    const ownedRows = clients.map((client) => ({
+      client,
+      connections: byClient[client.id] ?? [],
+    }));
+
+    const ownedClientIds = new Set(clients.map((client) => client.id));
+    const nonOwnedRows = Object.entries(byClient)
+      .filter(([clientId]) => !ownedClientIds.has(clientId))
+      .map(([clientId, clientConnections]) => {
+        const [firstConnection] = clientConnections;
+        const client: OAuthClient = {
+          id: clientId,
+          client_name: firstConnection.client_name,
+          resource: firstConnection.resource,
+        };
+        return { client, connections: clientConnections };
+      });
+
+    return [...ownedRows, ...nonOwnedRows];
   }, [clients, connections]);
 
   return {

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/hooks/use_application_connections.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/hooks/use_application_connections.ts
@@ -32,11 +32,11 @@ export const useApplicationConnections = () => {
     const nonOwnedRows = Object.entries(byClient)
       .filter(([clientId]) => !ownedClientIds.has(clientId))
       .map(([clientId, clientConnections]) => {
-        const [firstConnection] = clientConnections;
+        const [{ client_name, resource }] = clientConnections;
         const client: OAuthClient = {
           id: clientId,
-          client_name: firstConnection.client_name,
-          resource: firstConnection.resource,
+          client_name,
+          resource,
         };
         return { client, connections: clientConnections };
       });

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/service/application_connections_api_client.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/service/application_connections_api_client.ts
@@ -23,6 +23,7 @@ export interface OAuthConnectionUser {
 export interface OAuthConnection {
   id: string;
   client_id: string;
+  client_name?: string;
   name?: string;
   resource: string;
   creation?: string;

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -70,6 +70,29 @@ describe('List OAuth Connections route', () => {
     expect(response.payload).toEqual(mockResponse);
   });
 
+  it('passes through the client_name from the connection response', async () => {
+    const mockResponse = {
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'non-owned-client',
+          client_name: 'Other user app',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        },
+      ],
+    };
+    oauthMock.listConnections.mockResolvedValue(mockResponse);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(mockResponse);
+  });
+
   it('adds user information to connections when available', async () => {
     oauthMock.listConnections.mockResolvedValue({
       connections: [


### PR DESCRIPTION
## Summary

Surfaces OAuth connections whose client is not owned by the current user as their own rows on the Application Connections page. 

Previously, the table only listed connections grouped under clients the current user owns, so connections on MCP clients created by other users were hidden. Revoke and edit will also function as intended once the corresponding UIAM change is deployed.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

