### PR TITLE
Update callout message to include model details link

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
@@ -154,10 +154,24 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
               data-test-subj="manageRegionsCallout"
             >
               <p>
-                {i18n.translate('xpack.searchInferenceEndpoints.manageRegions.callout.body', {
-                  defaultMessage:
-                    "Some models are only available in specific regions. Restricting regions might make those models unavailable. Check each model's details to verify its supported regions.",
-                })}
+                <FormattedMessage
+                  id="xpack.searchInferenceEndpoints.manageRegions.callout.body"
+                  defaultMessage="Some models are only available in specific regions. Restricting regions might make those models unavailable. {modelDetailsLink} to verify its supported regions."
+                  values={{
+                    modelDetailsLink: (
+                      <a
+                        href="https://www.elastic.co/docs/explore-analyze/elastic-inference/eis-supported-models"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {i18n.translate(
+                          'xpack.searchInferenceEndpoints.manageRegions.callout.body.modelDetailsLinkText',
+                          { defaultMessage: "Check each model's details" }
+                        )}
+                      </a>
+                    ),
+                  }}
+                />
               </p>
             </EuiCallOut>
           )}


### PR DESCRIPTION
Currently, our "Some models aren't available in every region" dialog asks the user to check each model's details to verify its supported regions, but it does not provide a link to where they can check this information:

<img width="1003" height="127" alt="image" src="https://github.com/user-attachments/assets/f275b65e-bde0-4006-ac73-f1b20ccf8b81" />

This PR updates the callout message with a link to EIS' supported models page.

@kapiljadhav-eis 
