### PR TITLE
[kbn-evals] Fix `kibana-evals-pr-llm-evals` Post-Build CI-stats failure

### DIFF
--- a/.buildkite/pipeline-resource-definitions/evals/kibana-evals-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/evals/kibana-evals-pr.yml
@@ -20,7 +20,6 @@ spec:
     spec:
       env:
         KBN_EVALS: '1'
-        CI_STATS_DISABLE_PR_REPORT: 'true'
         # Heavy eval steps run on non-preemptible agents here so a lost spot worker
         # or timeout does not silently re-run the whole suite (agents are controlled
         # independently now that evals run outside kibana-pull-request).

--- a/.buildkite/pipeline-resource-definitions/evals/kibana-evals-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/evals/kibana-evals-pr.yml
@@ -20,6 +20,7 @@ spec:
     spec:
       env:
         KBN_EVALS: '1'
+        CI_STATS_DISABLE_PR_REPORT: 'true'
         # Heavy eval steps run on non-preemptible agents here so a lost spot worker
         # or timeout does not silently re-run the whole suite (agents are controlled
         # independently now that evals run outside kibana-pull-request).

--- a/.buildkite/pipeline-utils/ci-stats/on_complete.ts
+++ b/.buildkite/pipeline-utils/ci-stats/on_complete.ts
@@ -27,6 +27,12 @@ export async function onComplete() {
     return;
   }
 
+  // Opt-out for artifact-reuse pipelines (e.g. kibana-evals-pr-llm-evals) with no bundle metrics,
+  // where the PR report always fails. Build already completed above.
+  if (process.env.CI_STATS_DISABLE_PR_REPORT === 'true') {
+    return;
+  }
+
   const report = await ciStats.getPrReport(process.env.CI_STATS_BUILD_ID);
   if (report?.md) {
     // buildkite has a metadata size limit of 100kb, so we only add this, if it's small enough

--- a/.buildkite/scripts/pipelines/evals_pr/pipeline.ts
+++ b/.buildkite/scripts/pipelines/evals_pr/pipeline.ts
@@ -73,4 +73,6 @@ if (!evalsGroup) {
   process.exit(1);
 }
 
-emitPipeline(['steps:', preludeSteps, evalsGroup, postludeSteps]);
+const pipelineEnv = ['env:', `  CI_STATS_DISABLE_PR_REPORT: 'true'`].join('\n');
+
+emitPipeline([pipelineEnv, 'steps:', preludeSteps, evalsGroup, postludeSteps]);


### PR DESCRIPTION
## Summary
`kibana-evals-pr-llm-evals` Post-Build failed on the first attempt with "Failing build due to CI Stats report" ([example](https://buildkite.com/elastic/kibana-evals-pr-llm-evals/builds/16)).

**Why it happened:**
- The pipeline reuses the PR's Kibana artifact, so it never ships the bundle/distributable metrics the CI-stats PR report expects, and the report always fails.
- Retries only "passed" because `post_build.sh` skips `ci_stats_complete.ts` when `BUILDKITE_RETRY_COUNT != 0`, so the report never actually ran.

**Fix:**
- Add a `CI_STATS_DISABLE_PR_REPORT` opt-out in `onComplete()`, applied after the CI-stats build is completed but before `getPrReport()`. The build is still completed; only the inapplicable PR report is skipped.
- Set the flag as pipeline-level `env` in the generated eval pipeline (`evals_pr/pipeline.ts`) rather than the RRE `spec.env`, so it's sourced from the PR checkout and active on pre-merge test builds (RRE `spec.env` only syncs to the live pipeline on merge).

## Test plan
- Add an `evals:*` / `models:*` label to a PR to trigger `kibana-evals-pr-llm-evals`, and confirm Post-Build passes on the first attempt with no "metrics not reported" annotation.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


