### PR TITLE
Spread threat-intel generator RSS dates for hub period demos

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/README.md
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/README.md
@@ -139,7 +139,7 @@ Then confirm in Alerts UI that `kibana.alert.rule.name` / severity / MITRE / rea
 
 ## Threat intel RSS (mustard demo)
 
-`--threat-intel` seeds **one enabled RSS source per selected pack** into `.kibana-threat-intel-sources`, plus a digest subscription in `.kibana-threat-intel-subscriptions`. Each feed is a `data:application/rss+xml,...` URL whose article text embeds that pack’s observables so mustard `source_ingestion` + `nl_extraction_behavioral` can extract IOCs and hunt into the pack indices.
+`--threat-intel` seeds **one enabled RSS source per selected pack** into `.kibana-threat-intel-sources`, plus a digest subscription in `.kibana-threat-intel-subscriptions`. Each feed is a `data:application/rss+xml,...` URL with **six dated RSS items** whose `pubDate` values are spread across `--start-date` / `--end-date` (per-pack phase offset) so Intelligence Hub period presets can show different current vs prior report counts. Article text embeds that pack’s observables so mustard `source_ingestion` + `nl_extraction_behavioral` can extract IOCs and hunt into the pack indices.
 
 Observable contract in `lib/threat_intel_fixtures.ts` (`PACK_TI_SCENARIOS`):
 
@@ -155,8 +155,10 @@ Environment telemetry is the Technology Watch packs (`logs-okta.system.*`, `logs
 `--threat-intel` with no `--packs` selects all four packs. Use `--alert-mode preview` so pack hunts mint Detection Engine alerts (needed for non-zero Env. hits via `hit_provenance_backfill`).
 
 ```bash
-# On generate-cli-data-quality (this branch)
-yarn data:generate --clean -n 50 --episodes ep1 \
+# Wider window + more pack telemetry for hub 24h/7d/30d/90d current vs prior counts
+yarn data:generate --clean -n 120 --episodes ep1 \
+  --start-date 180d --end-date now \
+  --packs okta,aws-iam,kubernetes,github-actions \
   --threat-intel \
   --alert-mode preview \
   --kibanaUrl http://127.0.0.1:5601/kbn
@@ -177,7 +179,7 @@ Restart Kibana after flag changes (`iocIndicatorSyncEnabled` syncs extracted IOC
 **A. Seed + pipeline (workflows)**
 
 1. Generate once with the command above (packs + TI RSS + preview alerts).
-2. Run `threat-intel.source_ingestion` → pending reports from the four `ti-rss-*` sources.
+2. Run `threat-intel.source_ingestion` → pending reports from the four `ti-rss-*` sources (six dated items per feed).
 3. Run `threat-intel.nl_extraction_behavioral` → IOCs, behaviors, categories, regions on those reports.
 4. Run `threat-intel.digest_delivery` → seeded `threat-intel-digest` subscription produces a digest row.
 5. Run `threat-intel.hit_provenance_backfill` → updates `provenance.environment_hits*` from **Detection Engine alerts** (Indicator Match / technique overlap), not from raw pack `logs-*`. Expect non-zero Env. hits after preview alerts + indicator sync.

--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/README.md
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/README.md
@@ -139,7 +139,13 @@ Then confirm in Alerts UI that `kibana.alert.rule.name` / severity / MITRE / rea
 
 ## Threat intel RSS (mustard demo)
 
-`--threat-intel` seeds **one enabled RSS source per selected pack** into `.kibana-threat-intel-sources`, plus a digest subscription in `.kibana-threat-intel-subscriptions`. Each feed is a `data:application/rss+xml,...` URL with **six dated RSS items** whose `pubDate` values are spread across `--start-date` / `--end-date` (per-pack phase offset) so Intelligence Hub period presets can show different current vs prior report counts. Article text embeds that pack’s observables so mustard `source_ingestion` + `nl_extraction_behavioral` can extract IOCs and hunt into the pack indices.
+`--threat-intel` seeds **one enabled RSS source per selected pack** into `.kibana-threat-intel-sources`, plus a digest subscription in `.kibana-threat-intel-subscriptions`. Each feed is a `data:application/rss+xml,...` URL with a **single current item** (canonical title, no dated duplicate) so mustard `source_ingestion` demos real ingest once per pack without minting near-duplicate "today" cards.
+
+`--threat-intel-reports` (implies `--threat-intel`) also bulk-writes **seeded historic reports** into `.kibana-threat-reports` from `--start-date` through **`--end-date` minus 24h**. The trailing day is left empty so mustard `source_ingestion` can create the real Last-24h reports. Historic docs rotate distinct per-pack article variants (`historicArticles` in `PACK_TI_SCENARIOS`) so Hub timelines are not the same four titles with date suffixes. The newest ~40% of historic slots also use per-pack emerging `source.name` aliases (older slots stay on the four canonical names) so Hub **Sources** can rise vs prior period; live RSS and the Sources index stay canonical. Newest historic slots use Critical/High so longer presets still show severity variety. Use `--threat-intel-report-count` to override the default **12 historic reports per pack**.
+
+Live RSS stays **one canonical article per pack** (severity ladder for enrich). Article text embeds that pack’s observables so mustard `source_ingestion` + `nl_extraction_behavioral` can extract IOCs from the **current RSS items** and hunt into the pack indices.
+
+**Demo caution:** do **not** demo Threat Correlation on seeded historic reports. Hub Correlate (`report_id` mode) needs stored diamond / enrich outputs that historics lack (`extraction_method: seeded`). Correlate from Last-24h workflow-enriched reports only; use historic cards for timeline density and variety.
 
 Observable contract in `lib/threat_intel_fixtures.ts` (`PACK_TI_SCENARIOS`):
 
@@ -152,17 +158,20 @@ Fixture ids/names stay eval-neutral (`ti-rss-<pack>`, subscription `threat-intel
 
 Environment telemetry is the Technology Watch packs (`logs-okta.system.*`, `logs-aws.cloudtrail.*`, `logs-kubernetes.audit.*`, `logs-github.audit.*`). This path does **not** write `logs-aws.local` or merge with the mustard branch. Generate here, then run mustard Kibana against the same Elasticsearch.
 
-`--threat-intel` with no `--packs` selects all four packs. Use `--alert-mode preview` so pack hunts mint Detection Engine alerts (needed for non-zero Env. hits via `hit_provenance_backfill`).
+`--threat-intel` / `--threat-intel-reports` with no `--packs` selects all four packs. Use `--alert-mode preview` so pack hunts mint Detection Engine alerts (needed for non-zero Env. hits via `hit_provenance_backfill` on workflow-ingested reports).
 
 ```bash
-# Wider window + more pack telemetry for hub 24h/7d/30d/90d current vs prior counts
+# Wider window + historic Hub reports for 24h/7d/30d/90d timelines
 yarn data:generate --clean -n 120 --episodes ep1 \
   --start-date 180d --end-date now \
   --packs okta,aws-iam,kubernetes,github-actions \
   --threat-intel \
+  --threat-intel-reports \
   --alert-mode preview \
   --kibanaUrl http://127.0.0.1:5601/kbn
 ```
+
+Requires mustard Kibana to have created `.kibana-threat-reports` (start Hub once against the same ES) before `--threat-intel-reports` can index. Generate logs should include `Seeded N historic threat report(s)` (expect **48** = 12×4 packs) ending ~24h before `--end-date`. If that line is missing, historic seeding did not run.
 
 ### Mustard demo script (pipeline + Tier 1 / Tier 2 hunts)
 
@@ -178,9 +187,9 @@ Restart Kibana after flag changes (`iocIndicatorSyncEnabled` syncs extracted IOC
 
 **A. Seed + pipeline (workflows)**
 
-1. Generate once with the command above (packs + TI RSS + preview alerts).
-2. Run `threat-intel.source_ingestion` → pending reports from the four `ti-rss-*` sources (six dated items per feed).
-3. Run `threat-intel.nl_extraction_behavioral` → IOCs, behaviors, categories, regions on those reports.
+1. Generate once with the command above (packs + TI RSS + historic Hub reports + preview alerts). Confirm generate logs `Seeded N threat report(s) into .kibana-threat-reports`.
+2. Run `threat-intel.source_ingestion` → pending reports from the four `ti-rss-*` sources (**1 current RSS item each**) into the live 24h window only.
+3. Run `threat-intel.nl_extraction_behavioral` → IOCs, behaviors, categories, regions (and severity, once mustard enrich classifies it) on those workflow-ingested reports.
 4. Run `threat-intel.digest_delivery` → seeded `threat-intel-digest` subscription produces a digest row.
 5. Run `threat-intel.hit_provenance_backfill` → updates `provenance.environment_hits*` from **Detection Engine alerts** (Indicator Match / technique overlap), not from raw pack `logs-*`. Expect non-zero Env. hits after preview alerts + indicator sync.
 
@@ -242,6 +251,8 @@ After step 3 (extraction), in Agent Builder use topic prompts that force the hun
 ### Optional extras
 
 - `--threat-intel`: Per-pack RSS sources + digest subscription for mustard TI workflows (defaults `--packs` to all four when omitted)
+- `--threat-intel-reports`: Also seed historic Hub reports into `.kibana-threat-reports` across the generate window (implies `--threat-intel`)
+- `--threat-intel-report-count`: Historic reports per pack (default: 12) when `--threat-intel-reports` is set
 - `--attacks`: Synthetic Attack Discoveries
 - `--cases`: Cases from ~50% of discoveries (implies `--attacks`)
 - `--no-validate-fixtures`: Disable fixture validation
@@ -260,7 +271,7 @@ After step 3 (extraction), in Agent Builder use topic prompts that force the hun
 3. Optional `--clean`
 4. Scale + index episode events/alerts into concrete indices
 5. Index selected packs (+ install custom MITRE hunts unless `alert-mode=none`)
-6. Optional `--threat-intel`: seed per-pack RSS sources + digest subscription
+6. Optional `--threat-intel` / `--threat-intel-reports`: seed per-pack RSS sources + digest subscription (+ historic Hub reports when reports flag is set)
 7. Initialize detections / ensure preview index (skipped for `none`)
 8. **preview:** honest Rule Preview per producing rule → copy  
    **live:** enable rules for the detection engine (unless `--leave-rules-disabled`)  

--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/generate.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/generate.ts
@@ -50,6 +50,7 @@ import {
   cleanThreatIntelFixtures,
   resolveThreatIntelPackIds,
   seedThreatIntelForPacks,
+  THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT,
 } from './lib/threat_intel_fixtures';
 import { listPacks } from './packs';
 import {
@@ -897,7 +898,25 @@ export const cli = () => {
           `Invalid --fp-count "${cliContext.flags['fp-count']}" (expected integer 0-3)`
         );
       }
-      const threatIntel = Boolean(cliContext.flags['threat-intel']);
+      const threatIntelReports = Boolean(cliContext.flags['threat-intel-reports']);
+      const threatIntel = Boolean(cliContext.flags['threat-intel']) || threatIntelReports;
+      const threatIntelReportCountRaw = getOptionalStringFlag(
+        cliContext.flags,
+        'threat-intel-report-count'
+      );
+      let historicReportsPerPack: number | undefined;
+      if (threatIntelReports) {
+        if (threatIntelReportCountRaw !== undefined && threatIntelReportCountRaw !== '') {
+          historicReportsPerPack = Number(threatIntelReportCountRaw);
+          if (!Number.isFinite(historicReportsPerPack) || historicReportsPerPack < 1) {
+            throw new Error(
+              `Invalid --threat-intel-report-count "${threatIntelReportCountRaw}" (expected integer >= 1)`
+            );
+          }
+        } else {
+          historicReportsPerPack = THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT;
+        }
+      }
       let packIds = parsePacksFlag(getOptionalStringFlag(cliContext.flags, 'packs'));
       if (threatIntel && packIds.length === 0) {
         packIds = resolveThreatIntelPackIds([]);
@@ -1129,6 +1148,7 @@ export const cli = () => {
             startMs,
             endMs,
             spaceId: effectiveSpaceId,
+            historicReportsPerPack,
           });
         }
 
@@ -1274,6 +1294,7 @@ export const cli = () => {
           'rule-from',
           'fp-count',
           'packs',
+          'threat-intel-report-count',
         ],
         boolean: [
           'clean',
@@ -1282,6 +1303,7 @@ export const cli = () => {
           'validate-fixtures',
           'leave-rules-disabled',
           'threat-intel',
+          'threat-intel-reports',
         ],
         alias: {
           n: 'events',
@@ -1308,6 +1330,8 @@ export const cli = () => {
           clean: false,
           'leave-rules-disabled': false,
           'threat-intel': false,
+          'threat-intel-reports': false,
+          'threat-intel-report-count': '',
           attacks: false,
           cases: false,
           'validate-fixtures': true,
@@ -1330,6 +1354,8 @@ export const cli = () => {
         --fp-count                       Max false-positive event templates per hunt that defines them (0-3, Default: 0). FP events/alerts are tagged data-generator-fp (plus data-generator / pack:<id>).
         --max-preview-invocations         Max rule preview invocations per rule (Default: 12). Lower = faster for large time ranges.
         --threat-intel                   Seed per-pack RSS sources (+ digest subscription) for mustard TI workflows. Defaults --packs to all four when omitted. Environment data is the packs (not logs-aws.local).
+        --threat-intel-reports           Also seed historic Hub reports into .kibana-threat-reports from --start-date through --end-date minus 24h (implies --threat-intel). Leaves the last day empty for real workflow ingest. RSS stays current-only.
+        --threat-intel-report-count      Historic reports per pack when --threat-intel-reports is set (Default: 12)
         --attacks                         Generate synthetic Attack Discoveries (opt-in)
         --cases                          Create cases from ~50% of generated Attack Discoveries (implies --attacks)
         --no-validate-fixtures            Disable fixture validation (default: validation enabled)

--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.test.ts
@@ -12,16 +12,22 @@ import { scriptsDataDir } from './indexing';
 import { ensureEcsSourceIp } from './packs';
 import {
   allThreatIntelSourceIds,
+  buildHistoricThreatReportDoc,
   buildPackArticleDataUrl,
+  buildPackHistoricReportItemsForScenario,
+  buildPackRssCurrentReportItems,
   buildPackRssDataUrl,
-  buildPackRssReportItemsForScenario,
   collectPackJoinFieldValues,
   PACK_TI_SCENARIOS,
   reportTimestampRatiosForPack,
   reportTimestampsForWindow,
+  resolveHistoricSourceName,
+  resolveHistoricThreatIntelWindow,
   resolveThreatIntelPackIds,
   scenarioRssMustContain,
-  THREAT_INTEL_REPORTS_PER_PACK,
+  THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT,
+  THREAT_INTEL_LIVE_WINDOW_MS,
+  THREAT_INTEL_RSS_CURRENT_ITEMS_PER_PACK,
   THREAT_INTEL_SUBSCRIPTION_ID,
 } from './threat_intel_fixtures';
 
@@ -52,12 +58,35 @@ describe('PACK_TI_SCENARIOS', () => {
         scenario.name,
         scenario.title,
         scenario.body,
+        scenario.historicSourceAliases.emerging,
+        ...scenario.historicArticles.flatMap((article) => [article.title, article.body]),
         ...scenario.tags,
       ].join('\n');
       expect(blob.toLowerCase()).not.toContain('data-generator');
       expect(blob.toLowerCase()).not.toContain('data generator');
     }
     expect(THREAT_INTEL_SUBSCRIPTION_ID.toLowerCase()).not.toContain('data-generator');
+  });
+
+  it('declares Hub categories and regions for historic report seeding', () => {
+    for (const scenario of Object.values(PACK_TI_SCENARIOS)) {
+      expect(scenario.categories.length).toBeGreaterThan(0);
+      expect(scenario.regions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('declares distinct historic article variants with join and narrative anchors', () => {
+    for (const scenario of Object.values(PACK_TI_SCENARIOS)) {
+      expect(scenario.historicArticles.length).toBeGreaterThanOrEqual(4);
+      const titles = scenario.historicArticles.map((article) => article.title);
+      expect(new Set(titles).size).toEqual(titles.length);
+      for (const article of scenario.historicArticles) {
+        for (const token of scenarioRssMustContain(scenario)) {
+          expect(article.body).toContain(token);
+        }
+        expect(article.body).toMatch(/\d+\[\.\]\d+\[\.\]\d+\[\.\]\d+/);
+      }
+    }
   });
 
   it('builds a data:text/html article URL that embeds the scenario title and body', () => {
@@ -67,17 +96,13 @@ describe('PACK_TI_SCENARIOS', () => {
       const html = decodeURIComponent(articleUrl.replace(/^data:text\/html;charset=utf-8,/, ''));
       expect(html).toContain(scenario.title);
       expect(html).toContain(scenario.name);
-      // Body is HTML-escaped (e.g. ATT&CK → ATT&amp;CK), so match a stable unescaped slice.
       expect(html).toContain(scenario.body.slice(0, 48));
     }
   });
 
-  it('embeds join IOCs, narrative anchors, and the HTML article data URL in the RSS payload', () => {
+  it('embeds join IOCs in a single-item current RSS feed without dated titles', () => {
     for (const scenario of Object.values(PACK_TI_SCENARIOS)) {
-      const reportItems = buildPackRssReportItemsForScenario({
-        packIndex: 0,
-        packCount: 4,
-        startMs: Date.parse('2026-01-01T00:00:00.000Z'),
+      const reportItems = buildPackRssCurrentReportItems({
         endMs: Date.parse('2026-07-01T00:00:00.000Z'),
       });
       const url = buildPackRssDataUrl({
@@ -90,12 +115,10 @@ describe('PACK_TI_SCENARIOS', () => {
         expect(xml).toContain(token);
       }
       expect(xml).toContain(scenario.title);
-      expect(xml).toContain(buildPackArticleDataUrl(scenario));
-      expect(xml).not.toContain('example.elastic.dev');
-      expect(xml).not.toContain('elastic.co/security-labs');
-      expect(xml.toLowerCase()).not.toContain('data-generator');
-      expect(xml.toLowerCase()).not.toContain('data generator');
-      expect(xml.match(/<item>/g)?.length).toEqual(THREAT_INTEL_REPORTS_PER_PACK);
+      expect(xml.match(/<item>/g)?.length).toEqual(THREAT_INTEL_RSS_CURRENT_ITEMS_PER_PACK);
+      expect(xml).toContain('-current-');
+      expect(xml).not.toContain('-historic-');
+      expect(xml).not.toMatch(/\(20\d{2}-\d{2}-\d{2}\)/);
     }
   });
 
@@ -123,12 +146,28 @@ describe('PACK_TI_SCENARIOS', () => {
       false
     );
   });
+
+  it('diversifies live RSS body tone so enrich can classify mixed severities', () => {
+    const { okta, 'aws-iam': awsIam, kubernetes, 'github-actions': github } = PACK_TI_SCENARIOS;
+    // Titles stay natural (no demo prefixes like ACTIVE INCIDENT / Research note).
+    expect(okta.title.toLowerCase()).not.toContain('active incident');
+    expect(awsIam.title.toLowerCase()).not.toContain('investigated campaign');
+    expect(kubernetes.title.toLowerCase()).not.toMatch(/^advisory:/);
+    expect(github.title.toLowerCase()).not.toContain('research note');
+    // Severity ladder lives in body wording for classify_severity.
+    expect(okta.body.toLowerCase()).toMatch(/ongoing breach|ransomware-adjacent|immediately/);
+    expect(awsIam.body.toLowerCase()).toMatch(/confirmed|prioritize|does not assert/);
+    expect(kubernetes.body.toLowerCase()).toMatch(/advisory|monitoring guidance|does not claim/);
+    expect(github.body.toLowerCase()).toMatch(
+      /background research|no immediate incident response|situational awareness/
+    );
+  });
 });
 
 describe('threat intel report timestamps', () => {
-  it('returns six sorted ratios per pack inside the open interval', () => {
+  it('returns twelve sorted ratios per pack inside the open interval by default', () => {
     const ratios = reportTimestampRatiosForPack(1, 4);
-    expect(ratios).toHaveLength(THREAT_INTEL_REPORTS_PER_PACK);
+    expect(ratios).toHaveLength(THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT);
     expect(ratios).toEqual([...ratios].sort((a, b) => a - b));
     for (const ratio of ratios) {
       expect(ratio).toBeGreaterThan(0.02);
@@ -139,11 +178,215 @@ describe('threat intel report timestamps', () => {
   it('offsets timestamps by pack index across the generator window', () => {
     const startMs = Date.parse('2025-01-01T00:00:00.000Z');
     const endMs = Date.parse('2025-07-01T00:00:00.000Z');
-    const ratiosA = reportTimestampRatiosForPack(0, 4);
-    const ratiosB = reportTimestampRatiosForPack(3, 4);
-    const timestampsA = reportTimestampsForWindow(startMs, endMs, ratiosA);
-    const timestampsB = reportTimestampsForWindow(startMs, endMs, ratiosB);
+    const timestampsA = reportTimestampsForWindow(
+      startMs,
+      endMs,
+      reportTimestampRatiosForPack(0, 4)
+    );
+    const timestampsB = reportTimestampsForWindow(
+      startMs,
+      endMs,
+      reportTimestampRatiosForPack(3, 4)
+    );
     expect(timestampsA).not.toEqual(timestampsB);
+  });
+
+  it('places RSS current items near endMs and historic items across the full window', () => {
+    const startMs = Date.parse('2025-01-01T00:00:00.000Z');
+    const endMs = Date.parse('2025-07-01T00:00:00.000Z');
+    const current = buildPackRssCurrentReportItems({ endMs });
+    const historic = buildPackHistoricReportItemsForScenario({
+      packIndex: 0,
+      packCount: 4,
+      startMs,
+      endMs,
+    });
+    expect(current).toHaveLength(THREAT_INTEL_RSS_CURRENT_ITEMS_PER_PACK);
+    expect(historic).toHaveLength(THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT);
+    expect(Date.parse(historic[0].reportTimestamp)).toBeLessThan(
+      Date.parse(current[0].reportTimestamp)
+    );
+  });
+});
+
+describe('buildHistoricThreatReportDoc', () => {
+  it('assigns critical severity to the newest historic slot per pack', () => {
+    const scenario = PACK_TI_SCENARIOS.okta;
+    const endMs = Date.parse('2026-07-21T18:00:00.000Z');
+    const startMs = Date.parse('2026-01-01T00:00:00.000Z');
+    const items = buildPackHistoricReportItemsForScenario({
+      packIndex: 0,
+      packCount: 4,
+      startMs,
+      endMs,
+      reportsPerPack: 4,
+    });
+    const feedUrl = buildPackRssDataUrl({
+      scenario,
+      reportItems: buildPackRssCurrentReportItems({ endMs: Date.parse('2026-07-22T18:00:00.000Z') }),
+    });
+    const newest = buildHistoricThreatReportDoc({
+      scenario,
+      item: items[items.length - 1],
+      itemIndex: items.length - 1,
+      reportsPerPack: 4,
+      spaceId: 'default',
+      feedUrl,
+      kind: 'historic',
+    });
+    const oldest = buildHistoricThreatReportDoc({
+      scenario,
+      item: items[0],
+      itemIndex: 0,
+      reportsPerPack: 4,
+      spaceId: 'default',
+      feedUrl,
+      kind: 'historic',
+    });
+    expect(newest.severity.level).toEqual('critical');
+    expect(oldest.severity.level).not.toEqual('critical');
+  });
+
+  it('rotates historic article variants without date-suffix titles', () => {
+    const scenario = PACK_TI_SCENARIOS.okta;
+    const endMs = Date.parse('2026-07-21T18:00:00.000Z');
+    const startMs = Date.parse('2026-01-01T00:00:00.000Z');
+    const items = buildPackHistoricReportItemsForScenario({
+      packIndex: 0,
+      packCount: 4,
+      startMs,
+      endMs,
+      reportsPerPack: 12,
+    });
+    const feedUrl = buildPackRssDataUrl({
+      scenario,
+      reportItems: buildPackRssCurrentReportItems({ endMs: Date.parse('2026-07-22T18:00:00.000Z') }),
+    });
+    const titles = items.map((item, itemIndex) => {
+      const doc = buildHistoricThreatReportDoc({
+        scenario,
+        item,
+        itemIndex,
+        reportsPerPack: 12,
+        spaceId: 'default',
+        feedUrl,
+        kind: 'historic',
+      });
+      expect(doc.content.title).not.toMatch(/\(20\d{2}-\d{2}-\d{2}\)/);
+      expect(doc.content.body_text).toContain(
+        scenario.historicArticles[itemIndex % scenario.historicArticles.length].body.slice(0, 48)
+      );
+      return doc.content.title;
+    });
+    expect(new Set(titles).size).toBeGreaterThan(1);
+    expect(titles).toContain(scenario.historicArticles[0].title);
+    expect(titles).not.toContain(scenario.title);
+  });
+
+  it('keeps live kind on the canonical scenario title and body', () => {
+    const scenario = PACK_TI_SCENARIOS.okta;
+    const feedUrl = buildPackRssDataUrl({
+      scenario,
+      reportItems: buildPackRssCurrentReportItems({ endMs: Date.parse('2026-07-22T18:00:00.000Z') }),
+    });
+    const doc = buildHistoricThreatReportDoc({
+      scenario,
+      item: { itemKey: 'current-0', reportTimestamp: '2026-07-22T17:00:00.000Z' },
+      itemIndex: 0,
+      spaceId: 'default',
+      feedUrl,
+      kind: 'live',
+    });
+    expect(doc.content.title).toEqual(scenario.title);
+    expect(doc.content.body_text.startsWith(scenario.body)).toBe(true);
+    expect(doc.source.name).toEqual(scenario.name);
+  });
+
+  it('introduces emerging source names only on the newest historic slots', () => {
+    const scenario = PACK_TI_SCENARIOS.okta;
+    const endMs = Date.parse('2026-07-21T18:00:00.000Z');
+    const startMs = Date.parse('2026-01-01T00:00:00.000Z');
+    const items = buildPackHistoricReportItemsForScenario({
+      packIndex: 0,
+      packCount: 4,
+      startMs,
+      endMs,
+      reportsPerPack: 12,
+    });
+    const feedUrl = buildPackRssDataUrl({
+      scenario,
+      reportItems: buildPackRssCurrentReportItems({ endMs: Date.parse('2026-07-22T18:00:00.000Z') }),
+    });
+    const names = items.map((item, itemIndex) => {
+      const doc = buildHistoricThreatReportDoc({
+        scenario,
+        item,
+        itemIndex,
+        reportsPerPack: 12,
+        spaceId: 'default',
+        feedUrl,
+        kind: 'historic',
+      });
+      return doc.source.name;
+    });
+    expect(names[0]).toEqual(scenario.name);
+    expect(names[names.length - 1]).toEqual(scenario.historicSourceAliases.emerging);
+    expect(names.filter((n) => n === scenario.name).length).toBeGreaterThan(
+      names.filter((n) => n === scenario.historicSourceAliases.emerging).length
+    );
+  });
+});
+
+describe('resolveHistoricSourceName', () => {
+  it('keeps older slots canonical and switches to emerging near the end', () => {
+    const scenario = PACK_TI_SCENARIOS.okta;
+    expect(resolveHistoricSourceName({ scenario, itemIndex: 0, reportsPerPack: 12 })).toEqual(
+      scenario.name
+    );
+    expect(resolveHistoricSourceName({ scenario, itemIndex: 6, reportsPerPack: 12 })).toEqual(
+      scenario.name
+    );
+    expect(resolveHistoricSourceName({ scenario, itemIndex: 11, reportsPerPack: 12 })).toEqual(
+      scenario.historicSourceAliases.emerging
+    );
+  });
+
+  it('makes older halves of a pack run smaller source sets than newer halves', () => {
+    const scenarios = Object.values(PACK_TI_SCENARIOS);
+    const reportsPerPack = 12;
+    const older = new Set<string>();
+    const newer = new Set<string>();
+    for (const scenario of scenarios) {
+      for (let i = 0; i < reportsPerPack; i++) {
+        const name = resolveHistoricSourceName({ scenario, itemIndex: i, reportsPerPack });
+        if (i < reportsPerPack / 2) older.add(name);
+        else newer.add(name);
+      }
+    }
+    expect(older.size).toBe(4);
+    expect(newer.size).toBeGreaterThan(older.size);
+  });
+});
+
+describe('resolveHistoricThreatIntelWindow', () => {
+  it('reserves the last 24h for live workflow ingest', () => {
+    const startMs = Date.parse('2026-01-01T00:00:00.000Z');
+    const endMs = Date.parse('2026-07-22T18:00:00.000Z');
+    const { historicStartMs, historicEndMs } = resolveHistoricThreatIntelWindow({
+      startMs,
+      endMs,
+    });
+    expect(historicStartMs).toEqual(startMs);
+    expect(historicEndMs).toEqual(endMs - THREAT_INTEL_LIVE_WINDOW_MS);
+  });
+
+  it('rejects windows that do not leave a live reserve', () => {
+    expect(() =>
+      resolveHistoricThreatIntelWindow({
+        startMs: Date.parse('2026-07-22T12:00:00.000Z'),
+        endMs: Date.parse('2026-07-22T18:00:00.000Z'),
+      })
+    ).toThrow(/wider than the 24h live reserve/);
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.test.ts
@@ -223,7 +223,9 @@ describe('buildHistoricThreatReportDoc', () => {
     });
     const feedUrl = buildPackRssDataUrl({
       scenario,
-      reportItems: buildPackRssCurrentReportItems({ endMs: Date.parse('2026-07-22T18:00:00.000Z') }),
+      reportItems: buildPackRssCurrentReportItems({
+        endMs: Date.parse('2026-07-22T18:00:00.000Z'),
+      }),
     });
     const newest = buildHistoricThreatReportDoc({
       scenario,
@@ -260,7 +262,9 @@ describe('buildHistoricThreatReportDoc', () => {
     });
     const feedUrl = buildPackRssDataUrl({
       scenario,
-      reportItems: buildPackRssCurrentReportItems({ endMs: Date.parse('2026-07-22T18:00:00.000Z') }),
+      reportItems: buildPackRssCurrentReportItems({
+        endMs: Date.parse('2026-07-22T18:00:00.000Z'),
+      }),
     });
     const titles = items.map((item, itemIndex) => {
       const doc = buildHistoricThreatReportDoc({
@@ -287,7 +291,9 @@ describe('buildHistoricThreatReportDoc', () => {
     const scenario = PACK_TI_SCENARIOS.okta;
     const feedUrl = buildPackRssDataUrl({
       scenario,
-      reportItems: buildPackRssCurrentReportItems({ endMs: Date.parse('2026-07-22T18:00:00.000Z') }),
+      reportItems: buildPackRssCurrentReportItems({
+        endMs: Date.parse('2026-07-22T18:00:00.000Z'),
+      }),
     });
     const doc = buildHistoricThreatReportDoc({
       scenario,
@@ -315,7 +321,9 @@ describe('buildHistoricThreatReportDoc', () => {
     });
     const feedUrl = buildPackRssDataUrl({
       scenario,
-      reportItems: buildPackRssCurrentReportItems({ endMs: Date.parse('2026-07-22T18:00:00.000Z') }),
+      reportItems: buildPackRssCurrentReportItems({
+        endMs: Date.parse('2026-07-22T18:00:00.000Z'),
+      }),
     });
     const names = items.map((item, itemIndex) => {
       const doc = buildHistoricThreatReportDoc({

--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.test.ts
@@ -14,10 +14,14 @@ import {
   allThreatIntelSourceIds,
   buildPackArticleDataUrl,
   buildPackRssDataUrl,
+  buildPackRssReportItemsForScenario,
   collectPackJoinFieldValues,
   PACK_TI_SCENARIOS,
+  reportTimestampRatiosForPack,
+  reportTimestampsForWindow,
   resolveThreatIntelPackIds,
   scenarioRssMustContain,
+  THREAT_INTEL_REPORTS_PER_PACK,
   THREAT_INTEL_SUBSCRIPTION_ID,
 } from './threat_intel_fixtures';
 
@@ -70,9 +74,15 @@ describe('PACK_TI_SCENARIOS', () => {
 
   it('embeds join IOCs, narrative anchors, and the HTML article data URL in the RSS payload', () => {
     for (const scenario of Object.values(PACK_TI_SCENARIOS)) {
+      const reportItems = buildPackRssReportItemsForScenario({
+        packIndex: 0,
+        packCount: 4,
+        startMs: Date.parse('2026-01-01T00:00:00.000Z'),
+        endMs: Date.parse('2026-07-01T00:00:00.000Z'),
+      });
       const url = buildPackRssDataUrl({
         scenario,
-        reportTimestamp: '2026-07-16T12:00:00.000Z',
+        reportItems,
       });
       expect(url.startsWith('data:application/rss+xml')).toBe(true);
       const xml = decodeURIComponent(url.replace(/^data:application\/rss\+xml;charset=utf-8,/, ''));
@@ -85,6 +95,7 @@ describe('PACK_TI_SCENARIOS', () => {
       expect(xml).not.toContain('elastic.co/security-labs');
       expect(xml.toLowerCase()).not.toContain('data-generator');
       expect(xml.toLowerCase()).not.toContain('data generator');
+      expect(xml.match(/<item>/g)?.length).toEqual(THREAT_INTEL_REPORTS_PER_PACK);
     }
   });
 
@@ -111,6 +122,28 @@ describe('PACK_TI_SCENARIOS', () => {
     expect(k8s.joinIocs.some((ioc) => ioc.type === 'user' && ioc.value === 'compromised-sa')).toBe(
       false
     );
+  });
+});
+
+describe('threat intel report timestamps', () => {
+  it('returns six sorted ratios per pack inside the open interval', () => {
+    const ratios = reportTimestampRatiosForPack(1, 4);
+    expect(ratios).toHaveLength(THREAT_INTEL_REPORTS_PER_PACK);
+    expect(ratios).toEqual([...ratios].sort((a, b) => a - b));
+    for (const ratio of ratios) {
+      expect(ratio).toBeGreaterThan(0.02);
+      expect(ratio).toBeLessThan(0.98);
+    }
+  });
+
+  it('offsets timestamps by pack index across the generator window', () => {
+    const startMs = Date.parse('2025-01-01T00:00:00.000Z');
+    const endMs = Date.parse('2025-07-01T00:00:00.000Z');
+    const ratiosA = reportTimestampRatiosForPack(0, 4);
+    const ratiosB = reportTimestampRatiosForPack(3, 4);
+    const timestampsA = reportTimestampsForWindow(startMs, endMs, ratiosA);
+    const timestampsB = reportTimestampsForWindow(startMs, endMs, ratiosB);
+    expect(timestampsA).not.toEqual(timestampsB);
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.ts
@@ -1137,8 +1137,12 @@ const seedHistoricThreatReports = async ({
 
   log.info(
     `Seeded ${docs.length} historic threat report(s) into ${THREAT_REPORTS_DATA_STREAM} ` +
-      `across [${new Date(historicStartMs).toISOString()}, ${new Date(historicEndMs).toISOString()}] ` +
-      `(live window (${THREAT_INTEL_LIVE_WINDOW_MS / (60 * 60 * 1000)}h) left empty for real workflow ingest).`
+      `across [${new Date(historicStartMs).toISOString()}, ${new Date(
+        historicEndMs
+      ).toISOString()}] ` +
+      `(live window (${
+        THREAT_INTEL_LIVE_WINDOW_MS / (60 * 60 * 1000)
+      }h) left empty for real workflow ingest).`
   );
   return docs.length;
 };
@@ -1241,9 +1245,9 @@ export const seedThreatIntelForPacks = async ({
 
   log.info(
     `Seeded ${scenarios.length} threat-intel RSS source(s) (${reportItemCount} current RSS item(s) ` +
-      `for workflow ingest) and 1 digest subscription` +
-      (historicReportCount > 0 ? `, plus ${historicReportCount} historic Hub report(s)` : '') +
-      `. Environment telemetry is the Technology Watch pack indices (not logs-aws.local). ` +
+      `for workflow ingest) and 1 digest subscription${
+        historicReportCount > 0 ? `, plus ${historicReportCount} historic Hub report(s)` : ''
+      }. Environment telemetry is the Technology Watch pack indices (not logs-aws.local). ` +
       `On mustard Kibana: run threat-intel.source_ingestion to fill the live ${
         THREAT_INTEL_LIVE_WINDOW_MS / (60 * 60 * 1000)
       }h window with real reports; ` +

--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { createHash } from 'crypto';
 import type { Client } from '@elastic/elasticsearch';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { listPacks } from '../packs';
@@ -45,12 +46,36 @@ export interface PackTiJoinIoc {
   defanged?: string;
 }
 
+/** Distinct historic Hub article copy; live RSS keeps canonical title/body. */
+export interface PackTiHistoricArticle {
+  title: string;
+  body: string;
+}
+
 export interface PackTiScenario {
   packId: string;
   sourceId: string;
   name: string;
+  /** Canonical live RSS title (Last 24h / workflow ingest). */
   title: string;
+  /** Canonical live RSS body (severity ladder for enrich classify_severity). */
   body: string;
+  /**
+   * Historic Hub narratives rotated by itemIndex. Each variant must embed the
+   * pack's join IOCs (canonical + defanged) and narrative anchors so hunts
+   * remain valid if someone opens an older report. Live RSS ignores this list.
+   */
+  historicArticles: PackTiHistoricArticle[];
+  /**
+   * Historic-only emerging `source.name` for Hub Sources cardinality demos.
+   * Applied only to the newest historic slots so older adjacent windows stay on
+   * the four canonical feed names while recent windows also include these
+   * aliases (Sources ↑ vs prior). Live RSS / Sources index keep canonical `name`.
+   */
+  historicSourceAliases: {
+    /** Newest historic slots — newly subscribed feed label. */
+    emerging: string;
+  };
   /**
    * Environment join keys. Must appear in the RSS body (value + optional
    * defanged) AND on pack docs after `ensureEcsSourceIp` + `enrichDocForGraph`
@@ -64,6 +89,13 @@ export interface PackTiScenario {
   narrative: string[];
   tags: string[];
   mitre: string[];
+  /**
+   * Closed-set Hub categories for historic report docs (mustard
+   * `THREAT_CATEGORIES`). Not inferred from tags — keep aligned with Hub UI.
+   */
+  categories: string[];
+  /** Closed-set Hub regions for historic report docs (mustard `THREAT_REGIONS`). */
+  regions: string[];
 }
 
 /** Flat list of strings that must appear in the RSS XML payload. */
@@ -75,6 +107,28 @@ export const scenarioRssMustContain = (scenario: PackTiScenario): string[] => {
   }
   out.push(...scenario.narrative);
   return out;
+};
+
+/**
+ * Age-gate historic `source.name` so Hub Sources cardinality rises in newer
+ * windows. Older slots keep the canonical live feed name; only the newest ~40%
+ * switch to `emerging`. That way a prior equal-length window (older half of the
+ * generate range) stays near 4 sources while the current window can reach ~8.
+ * Symmetric retired+emerging thirds previously produced 8 vs 8 → 0%.
+ */
+export const resolveHistoricSourceName = ({
+  scenario,
+  itemIndex,
+  reportsPerPack,
+}: {
+  scenario: PackTiScenario;
+  itemIndex: number;
+  reportsPerPack: number;
+}): string => {
+  if (reportsPerPack <= 1) return scenario.name;
+  const ratio = itemIndex / Math.max(reportsPerPack - 1, 1);
+  if (ratio >= 0.6) return scenario.historicSourceAliases.emerging;
+  return scenario.name;
 };
 
 /**
@@ -147,20 +201,80 @@ export const collectPackJoinFieldValues = (
 };
 
 export const PACK_TI_SCENARIOS: Record<string, PackTiScenario> = {
+  // Intended enrich severity ladder from body wording only (mustard classify_severity):
+  // okta → critical, aws-iam → high, kubernetes → medium, github-actions → low.
+  // Titles stay natural (no "ACTIVE INCIDENT" / "Research note" demo prefixes).
   okta: {
     packId: 'okta',
     sourceId: 'ti-rss-okta',
     name: 'Okta identity takeover feed',
-    title: 'Okta identity takeover via stolen sessions from Russian IP space',
+    title: 'Okta Super Admin takeover via stolen sessions from Russian IP space',
     body:
       // Keep campaign/actor language explicit so enrich_taxonomy marks diamond_suitable
       // true (generic "threat actors" alone has been gated false and skipped extract_diamond).
-      'LAPSUS$-style identity campaign: operators abusing stolen Okta sessions from Russian IP ' +
-      '192[.]0[.]2[.]50 (192.0.2.50) to reset passwords, strip MFA (user.mfa.factor.deactivate), and ' +
-      'grant Super Admin to finance and IT accounts including cfo@corp.example and ' +
-      'it-admin@corp.example. Follow-on activity includes system.api_token.create and privileged ' +
-      'app group membership. Hunt ATT&CK T1078.004, T1556, T1098, and T1136.003 across ' +
-      'okta.system telemetry.',
+      'Operators linked to a LAPSUS$-style identity campaign are actively abusing stolen Okta ' +
+      'sessions from Russian IP 192[.]0[.]2[.]50 (192.0.2.50) against production tenants. They are ' +
+      'resetting passwords, stripping MFA (user.mfa.factor.deactivate), and granting Super Admin to ' +
+      'finance and IT accounts including cfo@corp.example and it-admin@corp.example. Immediate ' +
+      'business impact includes system.api_token.create and privileged app group membership while ' +
+      'payroll and ERP SSO remain exposed. This is an ongoing breach with ransomware-adjacent ' +
+      'extortion risk; revoke sessions and lock down Super Admin immediately. Hunt ATT&CK ' +
+      'T1078.004, T1556, T1098, and T1136.003 across okta.system telemetry.',
+    historicArticles: [
+      {
+        title: 'Follow-up: Okta session replay still tied to finance SSO abuse',
+        body:
+          'A follow-up bulletin revisits stolen Okta sessions from 192[.]0[.]2[.]50 (192.0.2.50) ' +
+          'where operators continue targeting cfo@corp.example and it-admin@corp.example. Watch for ' +
+          'user.mfa.factor.deactivate ahead of Super Admin grants and api token creation. Prior ' +
+          'detections still map to ATT&CK T1078.004, T1556, T1098, and T1136.003 in okta.system.',
+      },
+      {
+        title: 'Identity campaign note: MFA strip patterns against Okta Super Admin',
+        body:
+          'Campaign analysts catalogued MFA strip sequences (user.mfa.factor.deactivate) before ' +
+          'privileged role changes. Related infrastructure includes 192[.]0[.]2[.]50 (192.0.2.50) and ' +
+          'mailbox pivots into cfo@corp.example plus it-admin@corp.example. Map hunts to T1078.004, ' +
+          'T1556, T1098, and T1136.003 when reviewing Okta admin audit trails.',
+      },
+      {
+        title: 'Okta tenant hardening advisory after Russian IP session theft',
+        body:
+          'Hardening guidance after session theft from Russian IP space 192[.]0[.]2[.]50 (192.0.2.50). ' +
+          'Validate that cfo@corp.example and it-admin@corp.example cannot receive Super Admin without ' +
+          'break-glass review, and alert on user.mfa.factor.deactivate. Coverage should include ' +
+          'T1078.004, T1556, T1098, and T1136.003 across identity telemetry.',
+      },
+      {
+        title: 'Threat research: LAPSUS$-style Okta privilege chains in enterprise tenants',
+        body:
+          'Research summary of LAPSUS$-style Okta privilege chains using 192[.]0[.]2[.]50 (192.0.2.50). ' +
+          'Observed mailbox and admin targets include cfo@corp.example and it-admin@corp.example with ' +
+          'user.mfa.factor.deactivate as an early signal. Technique coverage: T1078.004, T1556, T1098, ' +
+          'and T1136.003.',
+      },
+      {
+        title: 'Okta API token creation spikes after stolen session reuse',
+        body:
+          'Operators reusing stolen sessions from 192[.]0[.]2[.]50 (192.0.2.50) were seen creating API ' +
+          'tokens after elevating cfo@corp.example and it-admin@corp.example. Correlate ' +
+          'user.mfa.factor.deactivate with Super Admin membership changes. Hunt ATT&CK T1078.004, ' +
+          'T1556, T1098, and T1136.003 in okta.system logs.',
+      },
+      {
+        title: 'Detection coverage refresh for Okta Super Admin and MFA disable events',
+        body:
+          'Detection engineering refresh for Okta Super Admin abuse. Seed hunts with IP ' +
+          '192[.]0[.]2[.]50 (192.0.2.50), users cfo@corp.example and it-admin@corp.example, and ' +
+          'user.mfa.factor.deactivate. Retain ATT&CK mappings T1078.004, T1556, T1098, and T1136.003 ' +
+          'for identity takeover playbooks.',
+      },
+    ],
+    categories: ['insider-threat', 'cloud-security'],
+    regions: ['north-america', 'europe'],
+    historicSourceAliases: {
+      emerging: 'Okta session intel digest',
+    },
     joinIocs: [
       { type: 'ip', value: '192.0.2.50', defanged: '192[.]0[.]2[.]50' },
       { type: 'email', value: 'cfo@corp.example' },
@@ -174,14 +288,66 @@ export const PACK_TI_SCENARIOS: Record<string, PackTiScenario> = {
     packId: 'aws-iam',
     sourceId: 'ti-rss-aws-iam',
     name: 'AWS IAM privilege escalation feed',
-    title: 'AWS IAM privilege escalation and data theft in account 123456789012',
+    title: 'AWS IAM privilege escalation and credential theft in account 123456789012',
     body:
-      'Researchers report IAM abuse in AWS account 123456789012 where compromised user ' +
-      'dev-user@corp.example (source IP 192[.]0[.]2[.]30 / 192.0.2.30) attaches AdministratorAccess, ' +
-      'assumes escalated-role, and exfiltrates from S3 bucket corp-prod-data. Post-escalation ' +
-      'activity from 192[.]0[.]2[.]31 (192.0.2.31) includes GetSecretValue on prod/db-credentials ' +
-      'plus StopLogging and DeleteTrail for defense evasion. Hunt ATT&CK T1098.001, T1078.004, ' +
-      'and T1562.008 in aws.cloudtrail logs.',
+      'Security researchers documented a confirmed privilege-escalation campaign in AWS account ' +
+      '123456789012. Compromised user dev-user@corp.example (source IP 192[.]0[.]2[.]30 / 192.0.2.30) ' +
+      'attached AdministratorAccess, assumed escalated-role, and staged access toward S3 bucket ' +
+      'corp-prod-data. Follow-on activity from 192[.]0[.]2[.]31 (192.0.2.31) included GetSecretValue ' +
+      'on prod/db-credentials plus StopLogging and DeleteTrail for defense evasion. The campaign ' +
+      'is well evidenced with reusable IOCs and ATT&CK mappings, so defenders should prioritize ' +
+      'hunts, but this write-up does not assert that customer production is currently offline. ' +
+      'Hunt ATT&CK T1098.001, T1078.004, and T1562.008 in aws.cloudtrail logs.',
+    historicArticles: [
+      {
+        title: 'CloudTrail retrospective: AdministratorAccess attach in account 123456789012',
+        body:
+          'Retrospective for AWS account 123456789012 where user dev-user (dev-user@corp.example) from ' +
+          '192[.]0[.]2[.]30 (192.0.2.30) attached AdministratorAccess and later reached bucket ' +
+          'corp-prod-data. Secondary IP 192[.]0[.]2[.]31 (192.0.2.31) called GetSecretValue on ' +
+          'prod/db-credentials and StopLogging. Map to T1098.001, T1078.004, and T1562.008.',
+      },
+      {
+        title: 'Secrets Manager access after IAM escalation toward corp-prod-data',
+        body:
+          'After privilege escalation in 123456789012, analysts saw GetSecretValue on ' +
+          'prod/db-credentials from 192[.]0[.]2[.]31 (192.0.2.31) following activity by ' +
+          'dev-user@corp.example (dev-user) at 192[.]0[.]2[.]30 (192.0.2.30). AdministratorAccess ' +
+          'and StopLogging preceded S3 staging on corp-prod-data. Hunt T1098.001, T1078.004, T1562.008.',
+      },
+      {
+        title: 'Defense evasion note: StopLogging paired with DeleteTrail in AWS IAM abuse',
+        body:
+          'Defense-evasion note for account 123456789012. Operators used StopLogging after ' +
+          'AdministratorAccess attach by dev-user / dev-user@corp.example from 192[.]0[.]2[.]30 ' +
+          '(192.0.2.30), with follow-on 192[.]0[.]2[.]31 (192.0.2.31) against prod/db-credentials and ' +
+          'corp-prod-data. Techniques: T1098.001, T1078.004, T1562.008.',
+      },
+      {
+        title: 'IAM role assumption playbook for escalated-role in production accounts',
+        body:
+          'Playbook covering escalated-role assumption in 123456789012. Seed with ' +
+          'dev-user@corp.example (dev-user), source IPs 192[.]0[.]2[.]30 (192.0.2.30) and ' +
+          '192[.]0[.]2[.]31 (192.0.2.31), AdministratorAccess attach, corp-prod-data access, ' +
+          'prod/db-credentials reads, and StopLogging. ATT&CK: T1098.001, T1078.004, T1562.008.',
+      },
+      {
+        title: 'S3 staging indicators after credential theft in AWS account 123456789012',
+        body:
+          'S3 staging indicators for corp-prod-data in account 123456789012 following credential ' +
+          'theft by dev-user@corp.example (dev-user). Ingress IPs 192[.]0[.]2[.]30 (192.0.2.30) and ' +
+          '192[.]0[.]2[.]31 (192.0.2.31) align with AdministratorAccess, GetSecretValue on ' +
+          'prod/db-credentials, and StopLogging. Cover T1098.001, T1078.004, and T1562.008.',
+      },
+      {
+        title: 'AWS privilege-escalation IOC refresh for CloudTrail monitoring teams',
+        body:
+          'IOC refresh for CloudTrail monitors in 123456789012: 192[.]0[.]2[.]30 (192.0.2.30), ' +
+          '192[.]0[.]2[.]31 (192.0.2.31), dev-user@corp.example, short name dev-user, ' +
+          'AdministratorAccess, corp-prod-data, prod/db-credentials, and StopLogging. Keep hunts ' +
+          'aligned to T1098.001, T1078.004, and T1562.008.',
+      },
+    ],
     joinIocs: [
       { type: 'ip', value: '192.0.2.30', defanged: '192[.]0[.]2[.]30' },
       { type: 'ip', value: '192.0.2.31', defanged: '192[.]0[.]2[.]31' },
@@ -200,18 +366,73 @@ export const PACK_TI_SCENARIOS: Record<string, PackTiScenario> = {
     ],
     tags: ['threat-intel', 'pack:aws-iam', 'aws', 'cloud-security'],
     mitre: ['T1098.001', 'T1078.004', 'T1562.008'],
+    categories: ['cloud-security', 'insider-threat'],
+    regions: ['north-america', 'global'],
+    historicSourceAliases: {
+      emerging: 'AWS IAM privilege intel stream',
+    },
   },
   kubernetes: {
     packId: 'kubernetes',
     sourceId: 'ti-rss-kubernetes',
     name: 'Kubernetes audit abuse feed',
-    title: 'Compromised Kubernetes service account escalates in prod-us-east-1',
+    title: 'Kubernetes service-account abuse indicators observed near prod-us-east-1',
     body:
-      'A compromised service account system:serviceaccount:default:compromised-sa in cluster ' +
-      'prod-us-east-1 is reading production secrets including db-credentials and creating ' +
-      'clusterrolebindings/escalation-binding to cluster-admin. Activity from 192[.]0[.]2[.]60 ' +
-      '(192.0.2.60) also includes pod exec against exec-pod, kube-system ConfigMap tampering, ' +
-      'and audit cleanup. Hunt ATT&CK T1552.007, T1078, and T1610 in kubernetes.audit logs.',
+      'This advisory summarizes indicators previously associated with Kubernetes audit abuse for ' +
+      'detection coverage. Watch for service account system:serviceaccount:default:compromised-sa ' +
+      '(short name compromised-sa) in cluster prod-us-east-1 accessing secrets such as ' +
+      'db-credentials, creating clusterrolebindings/escalation-binding toward cluster-admin, and ' +
+      'traffic from 192[.]0[.]2[.]60 (192.0.2.60). Related behaviors may include pod exec against ' +
+      'exec-pod and kube-system ConfigMap changes. Apply as monitoring guidance; the advisory does ' +
+      'not claim your cluster is under active compromise. Hunt ATT&CK T1552.007, T1078, and T1610 ' +
+      'in kubernetes.audit logs.',
+    historicArticles: [
+      {
+        title: 'Cluster audit review: compromised-sa secret reads in prod-us-east-1',
+        body:
+          'Audit review for cluster prod-us-east-1 where system:serviceaccount:default:compromised-sa ' +
+          '(compromised-sa) read db-credentials and created escalation-binding. Source IP ' +
+          '192[.]0[.]2[.]60 (192.0.2.60) also appeared near exec-pod activity. Hunt T1552.007, T1078, ' +
+          'and T1610 in kubernetes.audit.',
+      },
+      {
+        title: 'Service-account lateral movement patterns toward cluster-admin bindings',
+        body:
+          'Lateral movement patterns for system:serviceaccount:default:compromised-sa (compromised-sa) ' +
+          'creating escalation-binding toward cluster-admin in prod-us-east-1. Correlate secret access ' +
+          'to db-credentials, exec-pod, and 192[.]0[.]2[.]60 (192.0.2.60). Techniques T1552.007, T1078, ' +
+          'T1610 remain primary.',
+      },
+      {
+        title: 'Kubernetes secret theft advisory for db-credentials in shared namespaces',
+        body:
+          'Advisory on db-credentials theft via system:serviceaccount:default:compromised-sa ' +
+          '(compromised-sa) in prod-us-east-1. Monitor 192[.]0[.]2[.]60 (192.0.2.60), ' +
+          'escalation-binding creation, and exec-pod. Map detections to T1552.007, T1078, and T1610.',
+      },
+      {
+        title: 'Pod exec abuse notes tied to compromised-sa in prod-us-east-1',
+        body:
+          'Pod exec notes for exec-pod when driven by system:serviceaccount:default:compromised-sa ' +
+          '(compromised-sa) in prod-us-east-1. Related IOCs include 192[.]0[.]2[.]60 (192.0.2.60), ' +
+          'db-credentials access, and escalation-binding. Cover ATT&CK T1552.007, T1078, and T1610.',
+      },
+      {
+        title: 'RBAC escalation-binding detections for Kubernetes audit pipelines',
+        body:
+          'RBAC detections for escalation-binding in prod-us-east-1 involving ' +
+          'system:serviceaccount:default:compromised-sa (compromised-sa). Seed with IP ' +
+          '192[.]0[.]2[.]60 (192.0.2.60), db-credentials reads, and exec-pod. Techniques: T1552.007, ' +
+          'T1078, T1610.',
+      },
+      {
+        title: 'Container platform IOC pack: compromised-sa and 192.0.2.60 revisit',
+        body:
+          'IOC pack revisit for system:serviceaccount:default:compromised-sa (compromised-sa), ' +
+          '192[.]0[.]2[.]60 (192.0.2.60), prod-us-east-1, db-credentials, escalation-binding, and ' +
+          'exec-pod. Keep kubernetes.audit hunts on T1552.007, T1078, and T1610.',
+      },
+    ],
     joinIocs: [
       { type: 'ip', value: '192.0.2.60', defanged: '192[.]0[.]2[.]60' },
       // Full SA principal — short "compromised-sa" alone is narrative only (not term-matchable).
@@ -229,19 +450,73 @@ export const PACK_TI_SCENARIOS: Record<string, PackTiScenario> = {
     ],
     tags: ['threat-intel', 'pack:kubernetes', 'kubernetes', 'containers'],
     mitre: ['T1552.007', 'T1078', 'T1610'],
+    categories: ['cloud-security', 'malware'],
+    regions: ['north-america', 'europe'],
+    historicSourceAliases: {
+      emerging: 'Kubernetes cluster threat feed',
+    },
   },
   'github-actions': {
     packId: 'github-actions',
     sourceId: 'ti-rss-github-actions',
     name: 'GitHub supply-chain abuse feed',
-    title: 'GitHub org corp-example contractor account enables supply-chain abuse',
+    title: 'Recurring contractor IOCs in GitHub supply-chain reporting',
     body:
-      'Contractor account dev-contractor-42@corp.example in GitHub org corp-example ' +
-      '(IP 192[.]0[.]2[.]70 / 192.0.2.70) is making corp-example/payment-service public, creating ' +
-      'deploy keys (deploy_key.create), and inviting malicious-actor-x@external.example as org ' +
-      'admin. The same actor dismisses secret scanning alerts, bypasses branch protection, and ' +
-      'completes fork-triggered workflows while minting fine-grained PATs. Hunt ATT&CK T1567, ' +
-      'T1098, and T1195 in github.audit telemetry.',
+      'Background research note for situational awareness. Prior public reporting has mentioned ' +
+      'contractor-style accounts such as dev-contractor-42@corp.example (user dev-contractor-42) in ' +
+      'GitHub org corp-example, source IP 192[.]0[.]2[.]70 (192.0.2.70), and invitee ' +
+      'malicious-actor-x@external.example as illustrative indicators. Historical write-ups also ' +
+      'referenced making corp-example/payment-service public, deploy_key.create, secret-scanning ' +
+      'alert dismissals, and fine-grained PATs. No immediate incident response is requested; this ' +
+      'catalogs previously reported indicators for optional hunting. Related ATT&CK references: ' +
+      'T1567, T1098, and T1195 in github.audit telemetry.',
+    historicArticles: [
+      {
+        title: 'Supply-chain bulletin: contractor invite patterns in corp-example org',
+        body:
+          'Bulletin on contractor invites in org corp-example. Watch ' +
+          'dev-contractor-42@corp.example (dev-contractor-42), invitee malicious-actor-x@external.example, ' +
+          'and source IP 192[.]0[.]2[.]70 (192.0.2.70) near payment-service visibility changes and ' +
+          'deploy_key.create. Optional hunts: T1567, T1098, T1195.',
+      },
+      {
+        title: 'GitHub audit revisit: deploy_key.create around payment-service exposure',
+        body:
+          'Audit revisit for deploy_key.create when corp-example/payment-service exposure coincided ' +
+          'with dev-contractor-42@corp.example (dev-contractor-42) and malicious-actor-x@external.example ' +
+          'from 192[.]0[.]2[.]70 (192.0.2.70). Map github.audit to T1567, T1098, and T1195.',
+      },
+      {
+        title: 'PAT and secret-scanning dismissal patterns in contractor abuse reporting',
+        body:
+          'Reporting on fine-grained PATs and secret-scanning dismissals linked to ' +
+          'dev-contractor-42@corp.example (dev-contractor-42) in corp-example, IP ' +
+          '192[.]0[.]2[.]70 (192.0.2.70), and malicious-actor-x@external.example. payment-service and ' +
+          'deploy_key.create remain useful pivots for T1567, T1098, T1195.',
+      },
+      {
+        title: 'Org hardening note after public flip of corp-example/payment-service',
+        body:
+          'Hardening note after corp-example/payment-service was made public. Review activity from ' +
+          'dev-contractor-42@corp.example (dev-contractor-42), malicious-actor-x@external.example, and ' +
+          '192[.]0[.]2[.]70 (192.0.2.70), including deploy_key.create. Techniques T1567, T1098, T1195.',
+      },
+      {
+        title: 'External invitee tracking for malicious-actor-x across GitHub orgs',
+        body:
+          'Invitee tracking for malicious-actor-x@external.example alongside ' +
+          'dev-contractor-42@corp.example (dev-contractor-42) in corp-example. Correlate ' +
+          '192[.]0[.]2[.]70 (192.0.2.70), payment-service, and deploy_key.create. Hunt T1567, T1098, ' +
+          'and T1195 in github.audit.',
+      },
+      {
+        title: 'GitHub supply-chain IOC catalog refresh for optional hunting',
+        body:
+          'IOC catalog refresh: 192[.]0[.]2[.]70 (192.0.2.70), dev-contractor-42@corp.example, ' +
+          'dev-contractor-42, malicious-actor-x@external.example, corp-example, payment-service, and ' +
+          'deploy_key.create. Keep optional hunts on T1567, T1098, and T1195.',
+      },
+    ],
     joinIocs: [
       { type: 'ip', value: '192.0.2.70', defanged: '192[.]0[.]2[.]70' },
       { type: 'email', value: 'dev-contractor-42@corp.example' },
@@ -251,6 +526,11 @@ export const PACK_TI_SCENARIOS: Record<string, PackTiScenario> = {
     narrative: ['corp-example', 'payment-service', 'deploy_key.create', 'T1567', 'T1098', 'T1195'],
     tags: ['threat-intel', 'pack:github-actions', 'github', 'supply-chain'],
     mitre: ['T1567', 'T1098', 'T1195'],
+    categories: ['supply-chain', 'insider-threat'],
+    regions: ['north-america', 'europe'],
+    historicSourceAliases: {
+      emerging: 'GitHub Actions supply-chain watch',
+    },
   },
 };
 export const allThreatIntelSourceIds = (): string[] =>
@@ -278,8 +558,97 @@ const cdata = (value: string): string =>
 const timestampAt = (startMs: number, endMs: number, ratio: number): string =>
   new Date(Math.round(startMs + (endMs - startMs) * ratio)).toISOString();
 
-/** RSS items seeded per pack feed so hub period presets can compare current vs prior counts. */
-export const THREAT_INTEL_REPORTS_PER_PACK = 6;
+/**
+ * Current-only RSS items per pack feed. Kept to a single recent item so mustard
+ * `source_ingestion` demos real ingest once per pack without minting near-duplicate
+ * "today" cards (Hub history comes from `--threat-intel-reports`, not RSS).
+ */
+export const THREAT_INTEL_RSS_CURRENT_ITEMS_PER_PACK = 1;
+
+/**
+ * Default historic Hub reports per pack when `--threat-intel-reports` is set
+ * without `--threat-intel-report-count`. Spread across `--start-date`/`--end-date`.
+ */
+export const THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT = 12;
+
+/** @deprecated Prefer THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT / RSS current count. */
+export const THREAT_INTEL_REPORTS_PER_PACK = THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT;
+
+/** Place the single current RSS item just before endMs (pubDate is narrative-only; ingest uses now). */
+const RSS_CURRENT_OFFSET_MS = 15 * 60 * 1000;
+
+/**
+ * Trailing window reserved for real mustard workflow ingest. Historic
+ * `--threat-intel-reports` docs stop at `endMs - LIVE_WINDOW` so Last 24h can
+ * be filled by `source_ingestion` without colliding with mocks.
+ */
+export const THREAT_INTEL_LIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export const resolveHistoricThreatIntelWindow = ({
+  startMs,
+  endMs,
+  liveWindowMs = THREAT_INTEL_LIVE_WINDOW_MS,
+}: {
+  startMs: number;
+  endMs: number;
+  liveWindowMs?: number;
+}): { historicStartMs: number; historicEndMs: number } => {
+  const historicEndMs = endMs - liveWindowMs;
+  if (historicEndMs <= startMs) {
+    throw new Error(
+      `--threat-intel-reports needs a generate window wider than the ${Math.round(
+        liveWindowMs / (60 * 60 * 1000)
+      )}h live reserve (got start=${new Date(startMs).toISOString()} end=${new Date(
+        endMs
+      ).toISOString()}). Use e.g. --start-date 180d --end-date now.`
+    );
+  }
+  return { historicStartMs: startMs, historicEndMs };
+};
+
+const SEVERITY_CYCLE = [
+  { level: 'medium', score: 40 },
+  { level: 'high', score: 70 },
+  { level: 'critical', score: 90 },
+  { level: 'low', score: 20 },
+] as const;
+
+/**
+ * Severity for live-window twins (one per pack). Pack 0 is Critical so Last 24h
+ * shows variety after ingest dedup (mustard RSS adapter would otherwise write medium).
+ */
+export const LIVE_PACK_SEVERITY_CYCLE = [
+  { level: 'critical', score: 90 },
+  { level: 'high', score: 70 },
+  { level: 'medium', score: 40 },
+  { level: 'high', score: 70 },
+] as const;
+
+/**
+ * Severity for seeded Hub reports.
+ * - `historic`: newest slot Critical, then High, then cycle
+ * - `live`: per-pack Critical/High/Medium for the trailing 24h twins
+ */
+export const severityForSeededReport = ({
+  kind,
+  packIndex = 0,
+  itemIndex,
+  reportsPerPack,
+}: {
+  kind: 'historic' | 'live';
+  packIndex?: number;
+  itemIndex: number;
+  reportsPerPack: number;
+}): { level: string; score: number } => {
+  if (kind === 'live') {
+    return LIVE_PACK_SEVERITY_CYCLE[packIndex % LIVE_PACK_SEVERITY_CYCLE.length];
+  }
+  const fromEnd = reportsPerPack - 1 - itemIndex;
+  if (fromEnd === 0) return { level: 'critical', score: 90 };
+  if (fromEnd === 1) return { level: 'high', score: 70 };
+  if (fromEnd === 2) return { level: 'medium', score: 40 };
+  return SEVERITY_CYCLE[itemIndex % SEVERITY_CYCLE.length];
+};
 
 export interface PackRssReportItem {
   /** Stable suffix for RSS guid (`ti-report-<pack>-<itemKey>`). */
@@ -287,20 +656,74 @@ export interface PackRssReportItem {
   reportTimestamp: string;
 }
 
+export interface HistoricThreatReportDoc {
+  '@timestamp': string;
+  content_fingerprint: string;
+  space_id: string;
+  source: {
+    type: 'rss';
+    name: string;
+    url: string;
+    adapter_id: string;
+  };
+  content: {
+    title: string;
+    body_text: string;
+    language: 'en';
+  };
+  severity: { level: string; score: number };
+  extracted?: {
+    categories: string[];
+    ttps: { techniques: string[] };
+    iocs: Array<{ type: string; value: string; defanged?: string }>;
+    relevance: number;
+    detection_actionability: 'rule_candidate';
+  };
+  geography?: { regions: string[] };
+  lineage: {
+    ingested_at: string;
+    extracted_at?: string;
+    extraction_method: 'seeded' | 'pending';
+    source_doc_ref: { index: 'rss:feed'; id: string };
+  };
+  attribution?: {
+    environment_hits_total: number;
+    environment_hits: {
+      window: string;
+      computed_at: string;
+      layer_1_ioc_match: number;
+      layer_2_behavioral: number;
+    };
+  };
+}
+
 /**
- * Spread report pubDates across the generator window. Each pack gets a different phase
- * so aggregate counts differ between current and prior hub presets (24h / 7d / 30d / 90d).
+ * Mirror of mustard `adapters/fingerprint.buildFingerprint` so optional
+ * overlap with RSS current items can share the ingest dedup key.
+ */
+export const buildThreatIntelContentFingerprint = (
+  parts: ReadonlyArray<string | undefined | null>
+): string => {
+  const seed = parts.map((part) => (part ?? '').trim().normalize('NFKC')).join(':');
+  return createHash('sha256').update(seed).digest('hex');
+};
+
+/**
+ * Spread report timestamps across the generator window. Each pack gets a
+ * different phase so aggregate counts differ between Hub presets (24h / 7d /
+ * 30d / 90d) and their prior windows.
  */
 export const reportTimestampRatiosForPack = (
   packIndex: number,
   packCount: number,
-  reportsPerPack: number = THREAT_INTEL_REPORTS_PER_PACK
+  reportsPerPack: number = THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT
 ): number[] => {
   const ratios: number[] = [];
   for (let itemIndex = 0; itemIndex < reportsPerPack; itemIndex++) {
     const slot = (itemIndex + 1) / (reportsPerPack + 1);
     const packPhase = (packIndex / Math.max(packCount, 1)) * 0.45;
-    const wave = Math.sin((itemIndex / reportsPerPack) * Math.PI * 2 + packPhase) * 0.11;
+    const wave =
+      Math.sin((itemIndex / Math.max(reportsPerPack, 1)) * Math.PI * 2 + packPhase) * 0.11;
     ratios.push(Math.min(0.97, Math.max(0.03, slot + wave)));
   }
   return ratios.sort((a, b) => a - b);
@@ -312,12 +735,13 @@ export const reportTimestampsForWindow = (
   ratios: readonly number[]
 ): string[] => ratios.map((ratio) => timestampAt(startMs, endMs, ratio));
 
-export const buildPackRssReportItemsForScenario = ({
+/** Historic Hub report slots across the full generate window (not written into RSS). */
+export const buildPackHistoricReportItemsForScenario = ({
   packIndex,
   packCount,
   startMs,
   endMs,
-  reportsPerPack = THREAT_INTEL_REPORTS_PER_PACK,
+  reportsPerPack = THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT,
 }: {
   packIndex: number;
   packCount: number;
@@ -327,17 +751,48 @@ export const buildPackRssReportItemsForScenario = ({
 }): PackRssReportItem[] => {
   const ratios = reportTimestampRatiosForPack(packIndex, packCount, reportsPerPack);
   return reportTimestampsForWindow(startMs, endMs, ratios).map((reportTimestamp, itemIndex) => ({
-    itemKey: String(itemIndex + 1).padStart(2, '0'),
+    itemKey: `historic-${String(itemIndex + 1).padStart(2, '0')}`,
     reportTimestamp,
   }));
 };
+
+/**
+ * RSS-only items near `endMs` for mustard workflow demos. Guids are distinct
+ * from historic report refs so ingest does not collide with seeded history.
+ * Titles stay undated — dated title variants belong only on historic Hub docs.
+ */
+export const buildPackRssCurrentReportItems = ({
+  endMs,
+  itemsPerPack = THREAT_INTEL_RSS_CURRENT_ITEMS_PER_PACK,
+}: {
+  endMs: number;
+  itemsPerPack?: number;
+}): PackRssReportItem[] => {
+  const items: PackRssReportItem[] = [];
+  for (let itemIndex = 0; itemIndex < itemsPerPack; itemIndex++) {
+    const offsetMs = RSS_CURRENT_OFFSET_MS * (itemIndex + 1);
+    items.push({
+      itemKey: `current-${String(itemIndex + 1).padStart(2, '0')}`,
+      reportTimestamp: new Date(Math.max(0, endMs - offsetMs)).toISOString(),
+    });
+  }
+  return items;
+};
+
+/** @deprecated Use buildPackHistoricReportItemsForScenario or buildPackRssCurrentReportItems. */
+export const buildPackRssReportItemsForScenario = buildPackHistoricReportItemsForScenario;
 
 /**
  * Offline mock "upstream article" for Intelligence Hub's external link.
  * Becomes report `source.url` after mustard RSS ingestion. Requires mustard
  * `isBrowsableReportUrl` to allow `data:` (http/https alone hides the link).
  */
-export const buildPackArticleDataUrl = (scenario: PackTiScenario): string => {
+export const buildPackArticleDataUrl = (
+  scenario: PackTiScenario,
+  article?: Pick<PackTiHistoricArticle, 'title' | 'body'>
+): string => {
+  const title = article?.title ?? scenario.title;
+  const body = article?.body ?? scenario.body;
   const mitreLine = scenario.mitre.length
     ? `<p><strong>Techniques:</strong> ${htmlEscape(scenario.mitre.join(', '))}</p>`
     : '';
@@ -345,7 +800,7 @@ export const buildPackArticleDataUrl = (scenario: PackTiScenario): string => {
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>${htmlEscape(scenario.title)}</title>
+  <title>${htmlEscape(title)}</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 42rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; color: #1a1a1a; }
     .feed { color: #666; font-size: 0.875rem; margin-bottom: 0.5rem; }
@@ -355,8 +810,8 @@ export const buildPackArticleDataUrl = (scenario: PackTiScenario): string => {
 </head>
 <body>
   <p class="feed">${htmlEscape(scenario.name)}</p>
-  <h1>${htmlEscape(scenario.title)}</h1>
-  <p>${htmlEscape(scenario.body)}</p>
+  <h1>${htmlEscape(title)}</h1>
+  <p>${htmlEscape(body)}</p>
   ${mitreLine}
 </body>
 </html>`;
@@ -378,10 +833,11 @@ export const buildPackRssDataUrl = ({
   const description = `${scenario.body}${mitreLine}`;
   const articleLink = xmlEscape(buildPackArticleDataUrl(scenario));
   const itemsXml = reportItems
-    .map((item, index) => {
+    .map((item) => {
       const guid = `ti-report-${scenario.packId}-${item.itemKey}`;
-      const title =
-        index === 0 ? scenario.title : `${scenario.title} (${item.reportTimestamp.slice(0, 10)})`;
+      // Current RSS items always use the canonical title. Historic Hub docs
+      // rotate `historicArticles` instead of minting dated title duplicates.
+      const title = scenario.title;
       return `    <item>
       <title>${xmlEscape(title)}</title>
       <guid isPermaLink="false">${xmlEscape(guid)}</guid>
@@ -402,6 +858,109 @@ ${itemsXml}
 </rss>`;
 
   return `data:application/rss+xml;charset=utf-8,${encodeURIComponent(feedBody)}`;
+};
+
+export const buildHistoricThreatReportDoc = ({
+  scenario,
+  item,
+  itemIndex,
+  packIndex = 0,
+  reportsPerPack = THREAT_INTEL_HISTORIC_REPORTS_PER_PACK_DEFAULT,
+  spaceId,
+  feedUrl,
+  kind = 'historic',
+}: {
+  scenario: PackTiScenario;
+  item: PackRssReportItem;
+  itemIndex: number;
+  packIndex?: number;
+  reportsPerPack?: number;
+  spaceId: string;
+  feedUrl: string;
+  /** `live` = trailing-24h twin (pending enrich, varied severity). */
+  kind?: 'historic' | 'live';
+}): HistoricThreatReportDoc => {
+  const isLive = kind === 'live' || item.itemKey.startsWith('current-');
+  const historicVariant =
+    !isLive && scenario.historicArticles.length > 0
+      ? scenario.historicArticles[itemIndex % scenario.historicArticles.length]
+      : undefined;
+  const title = historicVariant?.title ?? scenario.title;
+  const articleBody = historicVariant?.body ?? scenario.body;
+  const guid = `ti-report-${scenario.packId}-${item.itemKey}`;
+  const articleUrl = buildPackArticleDataUrl(
+    scenario,
+    historicVariant ? { title, body: articleBody } : undefined
+  );
+  const severity = severityForSeededReport({
+    kind: isLive ? 'live' : 'historic',
+    packIndex,
+    itemIndex,
+    reportsPerPack: isLive ? Math.max(itemIndex + 1, 1) : reportsPerPack,
+  });
+  const mitreLine = scenario.mitre.length ? ` Techniques: ${scenario.mitre.join(', ')}.` : '';
+  const bodyText = `${articleBody}${mitreLine}`;
+  const sourceName = isLive
+    ? scenario.name
+    : resolveHistoricSourceName({ scenario, itemIndex, reportsPerPack });
+
+  const doc: HistoricThreatReportDoc = {
+    '@timestamp': item.reportTimestamp,
+    content_fingerprint: buildThreatIntelContentFingerprint([feedUrl, guid, title]),
+    space_id: spaceId,
+    source: {
+      type: 'rss',
+      name: sourceName,
+      url: articleUrl,
+      adapter_id: `rss:${scenario.sourceId}`,
+    },
+    content: {
+      title,
+      body_text: bodyText,
+      language: 'en',
+    },
+    severity: { level: severity.level, score: severity.score },
+    lineage: {
+      ingested_at: item.reportTimestamp,
+      extraction_method: isLive ? 'pending' : 'seeded',
+      source_doc_ref: { index: 'rss:feed', id: guid },
+    },
+  };
+
+  if (!isLive) {
+    const region = scenario.regions[itemIndex % scenario.regions.length];
+    const categories =
+      itemIndex % 2 === 0 ? scenario.categories : [...scenario.categories].reverse();
+    const envHitsTotal = itemIndex % 3 === 0 ? 4 + (itemIndex % 5) : 0;
+    doc.extracted = {
+      categories,
+      ttps: { techniques: [...scenario.mitre] },
+      iocs: scenario.joinIocs.map((ioc) => ({
+        type: ioc.type,
+        value: ioc.value,
+        ...(ioc.defanged ? { defanged: ioc.defanged } : {}),
+      })),
+      relevance: 0.72,
+      detection_actionability: 'rule_candidate',
+    };
+    doc.geography = { regions: [region] };
+    doc.lineage.extracted_at = item.reportTimestamp;
+    if (envHitsTotal > 0) {
+      const layer1 = Math.max(1, Math.floor(envHitsTotal * 0.6));
+      const layer2 = Math.max(0, envHitsTotal - layer1);
+      doc.attribution = {
+        environment_hits_total: envHitsTotal,
+        environment_hits: {
+          window: 'seeded',
+          computed_at: item.reportTimestamp,
+          layer_1_ioc_match: layer1,
+          layer_2_behavioral: layer2,
+        },
+      };
+    }
+  }
+
+  return doc;
 };
 
 const ensurePlainIndex = async ({
@@ -500,6 +1059,90 @@ export const cleanThreatIntelFixtures = async ({
   );
 };
 
+const seedHistoricThreatReports = async ({
+  esClient,
+  log,
+  scenarios,
+  startMs,
+  endMs,
+  spaceId,
+  reportsPerPack,
+}: {
+  esClient: Client;
+  log: ToolingLog;
+  scenarios: PackTiScenario[];
+  startMs: number;
+  endMs: number;
+  spaceId: string;
+  reportsPerPack: number;
+}): Promise<number> => {
+  const { historicStartMs, historicEndMs } = resolveHistoricThreatIntelWindow({ startMs, endMs });
+  const docs: HistoricThreatReportDoc[] = [];
+
+  for (let packIndex = 0; packIndex < scenarios.length; packIndex++) {
+    const scenario = scenarios[packIndex];
+    // Fingerprint feed URL matches the live RSS source (current-only items near endMs).
+    // Do not seed live-window report docs: Last 24h stays empty until real source_ingestion.
+    const currentItems = buildPackRssCurrentReportItems({ endMs });
+    const feedUrl = buildPackRssDataUrl({ scenario, reportItems: currentItems });
+    const historicItems = buildPackHistoricReportItemsForScenario({
+      packIndex,
+      packCount: scenarios.length,
+      startMs: historicStartMs,
+      endMs: historicEndMs,
+      reportsPerPack,
+    });
+    for (let itemIndex = 0; itemIndex < historicItems.length; itemIndex++) {
+      docs.push(
+        buildHistoricThreatReportDoc({
+          scenario,
+          item: historicItems[itemIndex],
+          itemIndex,
+          packIndex,
+          reportsPerPack,
+          spaceId,
+          feedUrl,
+          kind: 'historic',
+        })
+      );
+    }
+  }
+
+  if (docs.length === 0) return 0;
+
+  try {
+    const bulkBody = docs.flatMap((doc) => [
+      { create: { _index: THREAT_REPORTS_DATA_STREAM } },
+      doc,
+    ]);
+    const bulkResponse = await esClient.bulk({ refresh: true, body: bulkBody });
+    if (bulkResponse.errors) {
+      const firstError = bulkResponse.items.find((item) => item.create?.error)?.create?.error;
+      throw new Error(
+        `Historic threat-report bulk index had errors: ${
+          firstError?.reason ?? firstError?.type ?? 'unknown'
+        }`
+      );
+    }
+  } catch (e) {
+    const status = getStatusCode(e);
+    if (status === 404) {
+      throw new Error(
+        `Cannot seed historic threat reports: data stream ${THREAT_REPORTS_DATA_STREAM} does not exist. ` +
+          `Start mustard Kibana against this Elasticsearch first so the Hub index template is installed.`
+      );
+    }
+    throw e;
+  }
+
+  log.info(
+    `Seeded ${docs.length} historic threat report(s) into ${THREAT_REPORTS_DATA_STREAM} ` +
+      `across [${new Date(historicStartMs).toISOString()}, ${new Date(historicEndMs).toISOString()}] ` +
+      `(live window (${THREAT_INTEL_LIVE_WINDOW_MS / (60 * 60 * 1000)}h) left empty for real workflow ingest).`
+  );
+  return docs.length;
+};
+
 export const seedThreatIntelForPacks = async ({
   esClient,
   log,
@@ -507,6 +1150,7 @@ export const seedThreatIntelForPacks = async ({
   startMs,
   endMs,
   spaceId,
+  historicReportsPerPack,
 }: {
   esClient: Client;
   log: ToolingLog;
@@ -514,7 +1158,9 @@ export const seedThreatIntelForPacks = async ({
   startMs: number;
   endMs: number;
   spaceId: string;
-}): Promise<{ sourceCount: number; reportItemCount: number }> => {
+  /** When set, write enriched historic reports into `.kibana-threat-reports`. */
+  historicReportsPerPack?: number;
+}): Promise<{ sourceCount: number; reportItemCount: number; historicReportCount: number }> => {
   const resolved = resolveThreatIntelPackIds(packIds);
   const scenarios = resolved.map((id) => {
     const scenario = PACK_TI_SCENARIOS[id];
@@ -534,15 +1180,10 @@ export const seedThreatIntelForPacks = async ({
   const allTags = new Set<string>(['threat-intel']);
   let reportItemCount = 0;
 
-  for (let packIndex = 0; packIndex < scenarios.length; packIndex++) {
-    const scenario = scenarios[packIndex];
+  for (const scenario of scenarios) {
     for (const tag of scenario.tags) allTags.add(tag);
-    const reportItems = buildPackRssReportItemsForScenario({
-      packIndex,
-      packCount: scenarios.length,
-      startMs,
-      endMs,
-    });
+    // RSS stays current-only so workflow ingest does not replay the historic archive.
+    const reportItems = buildPackRssCurrentReportItems({ endMs });
     reportItemCount += reportItems.length;
     const url = buildPackRssDataUrl({ scenario, reportItems });
     await esClient.index({
@@ -580,14 +1221,34 @@ export const seedThreatIntelForPacks = async ({
     },
   });
 
+  let historicReportCount = 0;
+  if (historicReportsPerPack !== undefined) {
+    if (!Number.isFinite(historicReportsPerPack) || historicReportsPerPack < 1) {
+      throw new Error(
+        `Invalid historicReportsPerPack "${historicReportsPerPack}" (expected integer >= 1)`
+      );
+    }
+    historicReportCount = await seedHistoricThreatReports({
+      esClient,
+      log,
+      scenarios,
+      startMs,
+      endMs,
+      spaceId,
+      reportsPerPack: Math.floor(historicReportsPerPack),
+    });
+  }
+
   log.info(
-    `Seeded ${scenarios.length} threat-intel RSS source(s) (${reportItemCount} dated RSS item(s) ` +
-      `across [${new Date(startMs).toISOString()}, ${new Date(
-        endMs
-      ).toISOString()}]) and 1 digest ` +
-      `subscription. Environment telemetry is the Technology Watch pack indices (not logs-aws.local). ` +
-      `On mustard Kibana: run threat-intel.source_ingestion, then threat-intel.nl_extraction_behavioral.`
+    `Seeded ${scenarios.length} threat-intel RSS source(s) (${reportItemCount} current RSS item(s) ` +
+      `for workflow ingest) and 1 digest subscription` +
+      (historicReportCount > 0 ? `, plus ${historicReportCount} historic Hub report(s)` : '') +
+      `. Environment telemetry is the Technology Watch pack indices (not logs-aws.local). ` +
+      `On mustard Kibana: run threat-intel.source_ingestion to fill the live ${
+        THREAT_INTEL_LIVE_WINDOW_MS / (60 * 60 * 1000)
+      }h window with real reports; ` +
+      `Hub history comes from --threat-intel-reports (through end-date minus that live window).`
   );
 
-  return { sourceCount: scenarios.length, reportItemCount };
+  return { sourceCount: scenarios.length, reportItemCount, historicReportCount };
 };

--- a/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.ts
@@ -278,6 +278,60 @@ const cdata = (value: string): string =>
 const timestampAt = (startMs: number, endMs: number, ratio: number): string =>
   new Date(Math.round(startMs + (endMs - startMs) * ratio)).toISOString();
 
+/** RSS items seeded per pack feed so hub period presets can compare current vs prior counts. */
+export const THREAT_INTEL_REPORTS_PER_PACK = 6;
+
+export interface PackRssReportItem {
+  /** Stable suffix for RSS guid (`ti-report-<pack>-<itemKey>`). */
+  itemKey: string;
+  reportTimestamp: string;
+}
+
+/**
+ * Spread report pubDates across the generator window. Each pack gets a different phase
+ * so aggregate counts differ between current and prior hub presets (24h / 7d / 30d / 90d).
+ */
+export const reportTimestampRatiosForPack = (
+  packIndex: number,
+  packCount: number,
+  reportsPerPack: number = THREAT_INTEL_REPORTS_PER_PACK
+): number[] => {
+  const ratios: number[] = [];
+  for (let itemIndex = 0; itemIndex < reportsPerPack; itemIndex++) {
+    const slot = (itemIndex + 1) / (reportsPerPack + 1);
+    const packPhase = (packIndex / Math.max(packCount, 1)) * 0.45;
+    const wave = Math.sin((itemIndex / reportsPerPack) * Math.PI * 2 + packPhase) * 0.11;
+    ratios.push(Math.min(0.97, Math.max(0.03, slot + wave)));
+  }
+  return ratios.sort((a, b) => a - b);
+};
+
+export const reportTimestampsForWindow = (
+  startMs: number,
+  endMs: number,
+  ratios: readonly number[]
+): string[] => ratios.map((ratio) => timestampAt(startMs, endMs, ratio));
+
+export const buildPackRssReportItemsForScenario = ({
+  packIndex,
+  packCount,
+  startMs,
+  endMs,
+  reportsPerPack = THREAT_INTEL_REPORTS_PER_PACK,
+}: {
+  packIndex: number;
+  packCount: number;
+  startMs: number;
+  endMs: number;
+  reportsPerPack?: number;
+}): PackRssReportItem[] => {
+  const ratios = reportTimestampRatiosForPack(packIndex, packCount, reportsPerPack);
+  return reportTimestampsForWindow(startMs, endMs, ratios).map((reportTimestamp, itemIndex) => ({
+    itemKey: String(itemIndex + 1).padStart(2, '0'),
+    reportTimestamp,
+  }));
+};
+
 /**
  * Offline mock "upstream article" for Intelligence Hub's external link.
  * Becomes report `source.url` after mustard RSS ingestion. Requires mustard
@@ -312,28 +366,38 @@ export const buildPackArticleDataUrl = (scenario: PackTiScenario): string => {
 
 export const buildPackRssDataUrl = ({
   scenario,
-  reportTimestamp,
+  reportItems,
 }: {
   scenario: PackTiScenario;
-  reportTimestamp: string;
+  reportItems: PackRssReportItem[];
 }): string => {
-  const guid = `ti-report-${scenario.packId}`;
+  if (reportItems.length === 0) {
+    throw new Error('buildPackRssDataUrl requires at least one report item');
+  }
   const mitreLine = scenario.mitre.length ? ` Techniques: ${scenario.mitre.join(', ')}.` : '';
   const description = `${scenario.body}${mitreLine}`;
   const articleLink = xmlEscape(buildPackArticleDataUrl(scenario));
+  const itemsXml = reportItems
+    .map((item, index) => {
+      const guid = `ti-report-${scenario.packId}-${item.itemKey}`;
+      const title =
+        index === 0 ? scenario.title : `${scenario.title} (${item.reportTimestamp.slice(0, 10)})`;
+      return `    <item>
+      <title>${xmlEscape(title)}</title>
+      <guid isPermaLink="false">${xmlEscape(guid)}</guid>
+      <link>${articleLink}</link>
+      <pubDate>${new Date(item.reportTimestamp).toUTCString()}</pubDate>
+      <description>${cdata(description)}</description>
+    </item>`;
+    })
+    .join('\n');
   const feedBody = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
   <channel>
     <title>${xmlEscape(scenario.name)}</title>
     <link>${articleLink}</link>
     <language>en</language>
-    <item>
-      <title>${xmlEscape(scenario.title)}</title>
-      <guid isPermaLink="false">${xmlEscape(guid)}</guid>
-      <link>${articleLink}</link>
-      <pubDate>${new Date(reportTimestamp).toUTCString()}</pubDate>
-      <description>${cdata(description)}</description>
-    </item>
+${itemsXml}
   </channel>
 </rss>`;
 
@@ -450,7 +514,7 @@ export const seedThreatIntelForPacks = async ({
   startMs: number;
   endMs: number;
   spaceId: string;
-}): Promise<{ sourceCount: number }> => {
+}): Promise<{ sourceCount: number; reportItemCount: number }> => {
   const resolved = resolveThreatIntelPackIds(packIds);
   const scenarios = resolved.map((id) => {
     const scenario = PACK_TI_SCENARIOS[id];
@@ -466,12 +530,21 @@ export const seedThreatIntelForPacks = async ({
   await ensurePlainIndex({ esClient, index: THREAT_INTEL_SUBSCRIPTIONS_INDEX, log });
   await cleanThreatIntelFixtures({ esClient, log, packIds: resolved });
 
-  const reportTimestamp = timestampAt(startMs, endMs, 0.7);
+  const sourceTimestamp = new Date(endMs).toISOString();
   const allTags = new Set<string>(['threat-intel']);
+  let reportItemCount = 0;
 
-  for (const scenario of scenarios) {
+  for (let packIndex = 0; packIndex < scenarios.length; packIndex++) {
+    const scenario = scenarios[packIndex];
     for (const tag of scenario.tags) allTags.add(tag);
-    const url = buildPackRssDataUrl({ scenario, reportTimestamp });
+    const reportItems = buildPackRssReportItemsForScenario({
+      packIndex,
+      packCount: scenarios.length,
+      startMs,
+      endMs,
+    });
+    reportItemCount += reportItems.length;
+    const url = buildPackRssDataUrl({ scenario, reportItems });
     await esClient.index({
       index: THREAT_INTEL_SOURCES_INDEX,
       id: scenario.sourceId,
@@ -483,8 +556,8 @@ export const seedThreatIntelForPacks = async ({
         config: { url },
         tags: scenario.tags,
         space_id: spaceId,
-        created_at: reportTimestamp,
-        updated_at: reportTimestamp,
+        created_at: sourceTimestamp,
+        updated_at: sourceTimestamp,
       },
     });
   }
@@ -502,16 +575,19 @@ export const seedThreatIntelForPacks = async ({
       human_summary: 'Daily digest of medium+ severity reports tagged for Technology Watch packs.',
       template_id: 'threat-intel',
       space_id: spaceId,
-      created_at: reportTimestamp,
-      updated_at: reportTimestamp,
+      created_at: sourceTimestamp,
+      updated_at: sourceTimestamp,
     },
   });
 
   log.info(
-    `Seeded ${scenarios.length} threat-intel RSS source(s) and 1 digest subscription. ` +
-      `Environment telemetry is the Technology Watch pack indices (not logs-aws.local). ` +
+    `Seeded ${scenarios.length} threat-intel RSS source(s) (${reportItemCount} dated RSS item(s) ` +
+      `across [${new Date(startMs).toISOString()}, ${new Date(
+        endMs
+      ).toISOString()}]) and 1 digest ` +
+      `subscription. Environment telemetry is the Technology Watch pack indices (not logs-aws.local). ` +
       `On mustard Kibana: run threat-intel.source_ingestion, then threat-intel.nl_extraction_behavioral.`
   );
 
-  return { sourceCount: scenarios.length };
+  return { sourceCount: scenarios.length, reportItemCount };
 };


### PR DESCRIPTION
## Summary

The data generator `--threat-intel` path used one shared `pubDate` (0.7 through the window) for every pack RSS feed, so Intelligence Hub current vs prior period counts stayed flat on 24h/7d/30d/90d presets. Each pack feed now seeds six RSS items with `pubDate` spread across `--start-date` / `--end-date`, with a per-pack phase offset. Source/subscription metadata uses `end-date` for `created_at`; pack telemetry scaling is unchanged (still driven by `-n` and episodes).

## To test

1. From `x-pack/solutions/security/plugins/security_solution/scripts/data`:

```bash
yarn data:generate --clean -n 120 --episodes ep1 \
  --start-date 180d --end-date now \
  --packs okta,aws-iam,kubernetes,github-actions \
  --threat-intel \
  --alert-mode preview \
  --kibanaUrl http://127.0.0.1:5601/kbn
```

2. Run `node scripts/jest x-pack/solutions/security/plugins/security_solution/scripts/data/lib/threat_intel_fixtures.test.ts`.
3. On mustard Kibana, run `threat-intel.source_ingestion`, then confirm `.kibana-threat-reports` has multiple reports per `ti-rss-*` source with `@timestamp` / published dates in both halves of the 180d window.
4. In Intelligence Hub, flip 7d / 30d / 90d period presets and confirm current vs prior report counts can differ (not identical totals).

_PR developed with Cursor + Composer_

Made with [Cursor](https://cursor.com)