### PR TITLE
[Security Solution][Query POC] Entity Analytics - Add execution context identifiers to Entity Analytics home page queries

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/entity_maintainers.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/entity_maintainers.test.ts
@@ -65,6 +65,9 @@ function createMockDeps() {
         asScoped: () => ({ asCurrentUser: mockEsClient }),
       },
     },
+    executionContext: {
+      withContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+    },
   };
   const plugins = {
     licensing: {

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/index.ts
@@ -111,34 +111,42 @@ export function registerEntityMaintainerTask({
             description,
             timeout: effectiveTimeout,
             createTaskRunner: ({ taskInstance, abortController, fakeRequest }) => ({
-              run: async () => {
-                const status = taskInstance.state;
+              run: async () =>
+                coreStart.executionContext.withContext(
+                  {
+                    type: 'security_solution',
+                    name: 'entity_analytics-entity_maintainers_task',
+                    id: taskInstance.id,
+                  },
+                  async () => {
+                    const status = taskInstance.state;
 
-                if (!fakeRequest) {
-                  logger.error(`No fake request found, skipping run`);
-                  return { state: status };
-                }
+                    if (!fakeRequest) {
+                      logger.error(`No fake request found, skipping run`);
+                      return { state: status };
+                    }
 
-                const result = await executeMaintainerRun({
-                  status,
-                  request: fakeRequest,
-                  taskId: taskInstance.id,
-                  taskAbortController: abortController,
-                  id,
-                  run,
-                  setup,
-                  initialState,
-                  effectiveMinLicense,
-                  type,
-                  coreStart,
-                  licensing: plugins.licensing,
-                  workflowsExtensions: plugins.workflowsExtensions,
-                  analytics,
-                  logger,
-                });
+                    const result = await executeMaintainerRun({
+                      status,
+                      request: fakeRequest,
+                      taskId: taskInstance.id,
+                      taskAbortController: abortController,
+                      id,
+                      run,
+                      setup,
+                      initialState,
+                      effectiveMinLicense,
+                      type,
+                      coreStart,
+                      licensing: plugins.licensing,
+                      workflowsExtensions: plugins.workflowsExtensions,
+                      analytics,
+                      logger,
+                    });
 
-                return result ?? { state: status };
-              },
+                    return result ?? { state: status };
+                  }
+                ),
             }),
           },
         });

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.ts
@@ -154,27 +154,37 @@ export function registerExtractEntityTasks({
           title: config.title,
           timeout: config.timeout,
           createTaskRunner: ({ taskInstance, abortController, fakeRequest, executionUuid }) => ({
-            run: () =>
-              wrapTaskRun({
-                spanName: 'entityStore.task.extract_entity.run',
-                namespace: taskInstance.state.namespace,
-                attributes: {
-                  'entity_store.task.id': taskInstance.id,
-                  'entity_store.task.type': taskType,
-                  'entity_store.entity.type': type,
+            run: async () => {
+              const [coreStart] = await core.getStartServices();
+              return coreStart.executionContext.withContext(
+                {
+                  type: 'security_solution',
+                  name: 'entity_analytics-entity_store_extract_task',
+                  id: taskInstance.id,
                 },
-                run: () =>
-                  runTask({
-                    taskInstance,
-                    abortController,
-                    executionUuid,
-                    logger: logger.get(taskInstance.id),
-                    core,
-                    entityType: type,
-                    fakeRequest,
-                    isServerless,
-                  }),
-              }),
+                () =>
+                  wrapTaskRun({
+                    spanName: 'entityStore.task.extract_entity.run',
+                    namespace: taskInstance.state.namespace,
+                    attributes: {
+                      'entity_store.task.id': taskInstance.id,
+                      'entity_store.task.type': taskType,
+                      'entity_store.entity.type': type,
+                    },
+                    run: () =>
+                      runTask({
+                        taskInstance,
+                        abortController,
+                        executionUuid,
+                        logger: logger.get(taskInstance.id),
+                        core,
+                        entityType: type,
+                        fakeRequest,
+                        isServerless,
+                      }),
+                  })
+              );
+            },
           }),
         },
       });

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
@@ -97,23 +97,33 @@ export function registerHistorySnapshotTask({
         },
       },
       createTaskRunner: ({ taskInstance, abortController, fakeRequest }) => ({
-        run: () =>
-          wrapTaskRun({
-            spanName: 'entityStore.task.history_snapshot.run',
-            namespace: taskInstance.state.namespace,
-            attributes: {
-              'entity_store.task.id': taskInstance.id,
-              'entity_store.task.type': taskType,
+        run: async () => {
+          const [coreStart] = await core.getStartServices();
+          return coreStart.executionContext.withContext(
+            {
+              type: 'security_solution',
+              name: 'entity_analytics-entity_store_history_snapshot_task',
+              id: taskInstance.id,
             },
-            run: () =>
-              runHistorySnapshotTask({
-                taskInstance,
-                abortController,
-                fakeRequest,
-                core,
-                logger,
-              }),
-          }),
+            () =>
+              wrapTaskRun({
+                spanName: 'entityStore.task.history_snapshot.run',
+                namespace: taskInstance.state.namespace,
+                attributes: {
+                  'entity_store.task.id': taskInstance.id,
+                  'entity_store.task.type': taskType,
+                },
+                run: () =>
+                  runHistorySnapshotTask({
+                    taskInstance,
+                    abortController,
+                    fakeRequest,
+                    core,
+                    logger,
+                  }),
+              })
+          );
+        },
       }),
     },
   });

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.test.ts
@@ -149,7 +149,13 @@ describe('status report task — usage, resolution state & metadata telemetry', 
     const taskManager = {
       registerTaskDefinitions: jest.fn(),
     } as unknown as TaskManagerSetupContract;
-    const core = { analytics: { reportEvent } } as unknown as EntityStoreCoreSetup;
+    const executionContextMock = {
+      withContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+    };
+    const core = {
+      analytics: { reportEvent },
+      getStartServices: jest.fn().mockResolvedValue([{ executionContext: executionContextMock }]),
+    } as unknown as EntityStoreCoreSetup;
 
     registerStatusReportTask({ taskManager, logger, core });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.ts
@@ -246,24 +246,34 @@ export function registerStatusReportTask({
         title: config.title,
         timeout: config.timeout,
         createTaskRunner: ({ taskInstance, fakeRequest, abortController, executionUuid }) => ({
-          run: () =>
-            wrapTaskRun({
-              spanName: 'entityStore.task.status_report.run',
-              namespace: taskInstance.state.namespace,
-              attributes: {
-                'entity_store.task.id': taskInstance.id,
+          run: async () => {
+            const [coreStart] = await core.getStartServices();
+            return coreStart.executionContext.withContext(
+              {
+                type: 'security_solution',
+                name: 'entity_analytics-entity_store_status_report_task',
+                id: taskInstance.id,
               },
-              run: () =>
-                runTask({
-                  taskInstance,
-                  fakeRequest,
-                  abortController,
-                  executionUuid,
-                  logger: logger.get(taskInstance.id),
-                  core,
-                  telemetryReporter,
-                }),
-            }),
+              () =>
+                wrapTaskRun({
+                  spanName: 'entityStore.task.status_report.run',
+                  namespace: taskInstance.state.namespace,
+                  attributes: {
+                    'entity_store.task.id': taskInstance.id,
+                  },
+                  run: () =>
+                    runTask({
+                      taskInstance,
+                      fakeRequest,
+                      abortController,
+                      executionUuid,
+                      logger: logger.get(taskInstance.id),
+                      core,
+                      telemetryReporter,
+                    }),
+                })
+            );
+          },
         }),
       },
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/use_search_strategy/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/use_search_strategy/index.test.ts
@@ -311,5 +311,20 @@ describe('useSearchStrategy', () => {
       expect(mockEndTracking).toBeCalledTimes(1);
       expect(mockEndTracking).toBeCalledWith('aborted');
     });
+
+    it('forwards a caller-supplied executionContext to data.search.search', () => {
+      const executionContext = {
+        child: { type: 'security_solution', name: 'test-page', id: 'test-panel' },
+      };
+      const { result } = renderHook(() =>
+        useSearch<FactoryQueryTypes>(factoryQueryType, executionContext)
+      );
+      result.current({ request, abortSignal: new AbortController().signal }).subscribe();
+
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ executionContext })
+      );
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/use_search_strategy/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/use_search_strategy/index.tsx
@@ -11,6 +11,7 @@ import type { Observable } from 'rxjs';
 import { useObservable } from '@kbn/securitysolution-hook-utils';
 import { isRunningResponse } from '@kbn/data-plugin/public';
 import { AbortError } from '@kbn/kibana-utils-plugin/common';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import * as i18n from './translations';
 
 import type {
@@ -44,10 +45,20 @@ const EMPTY_INSPECT = {
 };
 
 export const useSearch = <QueryType extends FactoryQueryTypes>(
-  factoryQueryType: QueryType
+  factoryQueryType: QueryType,
+  executionContext?: KibanaExecutionContext
 ): UseSearchFunction<QueryType> => {
   const { data } = useKibana().services;
   const { startTracking } = useTrackHttpRequest();
+
+  // Hold the latest executionContext in a ref so re-renders that pass a fresh
+  // literal (e.g. `executionContext: buildExecutionContext(...)` inline) don't
+  // change the `search` callback identity, which would cascade into
+  // `useObservable`'s `start` and cause a re-subscribe → refetch loop.
+  // The values here are pure trace labels; there's no correctness cost to
+  // reading them at invocation time rather than closing over them.
+  const executionContextRef = useRef(executionContext);
+  executionContextRef.current = executionContext;
 
   const search = useCallback<UseSearchFunction<QueryType>>(
     ({ abortSignal, request }) => {
@@ -59,7 +70,11 @@ export const useSearch = <QueryType extends FactoryQueryTypes>(
       return data.search
         .search<StrategyRequestInputType<QueryType>, StrategyResponseType<QueryType>>(
           { ...request, factoryQueryType } as StrategyRequestInputType<QueryType>,
-          { strategy: 'securitySolutionSearchStrategy', abortSignal }
+          {
+            strategy: 'securitySolutionSearchStrategy',
+            abortSignal,
+            executionContext: executionContextRef.current,
+          }
         )
         .pipe(
           filter((response) => !isRunningResponse(response)),
@@ -84,6 +99,7 @@ export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
   errorMessage,
   abort = false,
   showErrorToast = true,
+  executionContext,
 }: {
   factoryQueryType: QueryType;
   /**
@@ -102,12 +118,18 @@ export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
    * Show error toast when error occurs on search complete
    */
   showErrorToast?: boolean;
+  /**
+   * Optional Kibana execution context forwarded to the underlying data.search.search call so
+   * slow logs and APM traces can attribute the query to the calling page/panel. Callers
+   * typically pass `{ child: { type: 'security_solution', name: '<page>', id: '<panel>' } }`.
+   */
+  executionContext?: KibanaExecutionContext;
 }) => {
   const abortCtrl = useRef(new AbortController());
   const refetch = useRef<inputsModel.Refetch>(noop);
   const { addError } = useAppToasts();
 
-  const search = useSearch(factoryQueryType);
+  const search = useSearch(factoryQueryType, executionContext);
 
   const { start, error, result, loading } = useObservable<
     [UseSearchFunctionParams<QueryType>],

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/api.ts
@@ -46,6 +46,7 @@ import { resolvePathVariables } from '../../../../common/utils/resolve_path_vari
 export const fetchQueryAlerts = async <Hit, Aggregations>({
   query,
   signal,
+  context,
 }: QueryAlerts): Promise<AlertSearchResponse<Hit, Aggregations>> => {
   return KibanaServices.get().http.fetch<AlertSearchResponse<Hit, Aggregations>>(
     DETECTION_ENGINE_QUERY_SIGNALS_URL,
@@ -54,6 +55,7 @@ export const fetchQueryAlerts = async <Hit, Aggregations>({
       method: 'POST',
       body: JSON.stringify(query),
       signal,
+      context,
     }
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { AlertClosingReason } from '../../../../../common/types';
 import type { Status } from '../../../../../common/api/detection_engine';
 import type { RuntimeFieldType } from '../../../../../common/api/detection_engine/signals/set_signal_status/set_signals_status_route.gen';
@@ -14,6 +15,7 @@ export interface BasicSignals {
 }
 export interface QueryAlerts extends BasicSignals {
   query: object;
+  context?: KibanaExecutionContext;
 }
 
 export interface AlertsResponse {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_query.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_query.tsx
@@ -8,6 +8,7 @@
 import { isEmpty } from 'lodash';
 import type { Dispatch, SetStateAction } from 'react';
 import { useMemo, useEffect, useState } from 'react';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type {
   fetchQueryAttacks,
   fetchQueryUnifiedAlerts,
@@ -45,6 +46,8 @@ export interface AlertsQueryParams {
    * The query name is used for performance monitoring with APM
    */
   queryName: AlertsQueryName;
+  /** Execution context forwarded to ES as x-opaque-id for tracing */
+  executionContext?: KibanaExecutionContext;
 }
 
 /**
@@ -84,6 +87,7 @@ export const useQueryAlerts = <Hit, Aggs>({
   indexName,
   skip,
   queryName,
+  executionContext,
 }: AlertsQueryParams): ReturnQueryAlerts<Hit, Aggs> => {
   const [query, setQuery] = useState(initialQuery);
   const [alerts, setAlerts] = useState<
@@ -110,6 +114,7 @@ export const useQueryAlerts = <Hit, Aggs>({
         const alertResponse = await fetchAlerts<Hit, Aggs>({
           query,
           signal: abortCtrl.signal,
+          context: executionContext,
         });
 
         if (isSubscribed) {
@@ -154,7 +159,7 @@ export const useQueryAlerts = <Hit, Aggs>({
       isSubscribed = false;
       abortCtrl.abort();
     };
-  }, [query, indexName, skip, fetchAlerts]);
+  }, [query, indexName, skip, fetchAlerts, executionContext]);
 
   return { loading, ...alerts };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
@@ -6,6 +6,7 @@
  */
 
 import { useMemo } from 'react';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common';
 import {
   API_VERSIONS as ENTITY_STORE_API_VERSIONS,
@@ -182,15 +183,18 @@ export const useEntityAnalyticsRoutes = () => {
     const fetchRiskScorePreview = ({
       signal,
       params,
+      context,
     }: {
       signal?: AbortSignal;
       params: RiskScoresPreviewRequest;
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<RiskScoresPreviewResponse>(RISK_SCORE_PREVIEW_URL, {
         version: '1',
         method: 'POST',
         body: JSON.stringify(params),
         signal,
+        context,
       });
 
     /**
@@ -198,10 +202,12 @@ export const useEntityAnalyticsRoutes = () => {
      */
     const fetchRiskScoreHistory = ({
       signal,
+      context,
       params,
     }: {
       signal?: AbortSignal;
       params: FetchRiskScoreHistoryParams;
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<RiskScoreHistoryResponse>(RISK_SCORE_HISTORY_URL, {
         version: API_VERSIONS.public.v1,
@@ -215,6 +221,7 @@ export const useEntityAnalyticsRoutes = () => {
           include_contributions: params.includeContributions,
         },
         signal,
+        context,
       });
 
     /**
@@ -247,9 +254,11 @@ export const useEntityAnalyticsRoutes = () => {
     const fetchEntitiesListV2 = ({
       signal,
       params,
+      context,
     }: {
       signal?: AbortSignal;
       params: FetchEntitiesListParams;
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<ListEntitiesResponse>(ENTITY_STORE_ROUTES.public.CRUD_GET, {
         version: ENTITY_STORE_API_VERSIONS.public.v1,
@@ -263,12 +272,19 @@ export const useEntityAnalyticsRoutes = () => {
           filterQuery: params.filterQuery,
         },
         signal,
+        context,
       });
 
     /**
      * Fetches risks engine status
      */
-    const fetchRiskEngineStatus = async ({ signal }: { signal?: AbortSignal }) => {
+    const fetchRiskEngineStatus = async ({
+      signal,
+      context,
+    }: {
+      signal?: AbortSignal;
+      context?: KibanaExecutionContext;
+    }) => {
       if (isMaintainerRiskScoreV2Enabled) {
         const riskScoreMaintainer = await fetchRiskScoreMaintainer();
         const riskEngineStatus = !riskScoreMaintainer
@@ -301,6 +317,7 @@ export const useEntityAnalyticsRoutes = () => {
         version: '1',
         method: 'GET',
         signal,
+        context,
       });
     };
 
@@ -467,6 +484,7 @@ export const useEntityAnalyticsRoutes = () => {
     const searchPrivMonIndices = async (params: {
       query: string | undefined;
       signal?: AbortSignal;
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<SearchPrivilegesIndicesResponse>(PRIVMON_INDICES_URL, {
         version: API_VERSIONS.public.v1,
@@ -475,6 +493,7 @@ export const useEntityAnalyticsRoutes = () => {
           searchQuery: params.query,
         },
         signal: params.signal,
+        context: params.context,
       });
 
     /**
@@ -570,12 +589,15 @@ export const useEntityAnalyticsRoutes = () => {
      * Get asset criticality
      */
     const fetchAssetCriticality = async (
-      params: Pick<AssetCriticality, 'idField' | 'idValue'>
+      params: Pick<AssetCriticality, 'idField' | 'idValue'> & {
+        context?: KibanaExecutionContext;
+      }
     ): Promise<AssetCriticalityRecord> => {
       return http.fetch<AssetCriticalityRecord>(ASSET_CRITICALITY_PUBLIC_URL, {
         version: API_VERSIONS.public.v1,
         method: 'GET',
         query: { id_value: params.idValue, id_field: params.idField },
+        context: params.context,
       });
     };
 
@@ -585,6 +607,7 @@ export const useEntityAnalyticsRoutes = () => {
     const fetchAssetCriticalityList = async (params: {
       idField: string;
       idValues: string[];
+      context?: KibanaExecutionContext;
     }): Promise<FindAssetCriticalityRecordsResponse> => {
       const wrapWithQuotes = (each: string) => `"${each}"`;
       const kueryValues = `${params.idValues.map(wrapWithQuotes).join(' OR ')}`;
@@ -596,12 +619,14 @@ export const useEntityAnalyticsRoutes = () => {
         query: {
           kuery,
         },
+        context: params.context,
       });
     };
 
     const uploadAssetCriticalityFile = async (
       fileContent: string,
-      fileName: string
+      fileName: string,
+      context?: KibanaExecutionContext
     ): Promise<UploadAssetCriticalityRecordsResponse> => {
       const file = new File([new Blob([fileContent])], fileName, {
         type: 'text/csv',
@@ -619,6 +644,7 @@ export const useEntityAnalyticsRoutes = () => {
               'Content-Type': undefined, // Lets the browser set the appropriate content type
             },
             body,
+            context,
           }
         );
 
@@ -651,6 +677,7 @@ export const useEntityAnalyticsRoutes = () => {
             'Content-Type': undefined, // Lets the browser set the appropriate content type
           },
           body,
+          context,
         }
       );
     };
@@ -658,11 +685,18 @@ export const useEntityAnalyticsRoutes = () => {
     /**
      * List all data source for privilege monitoring engine
      */
-    const listPrivMonMonitoredIndices = async ({ signal }: { signal?: AbortSignal }) =>
+    const listPrivMonMonitoredIndices = async ({
+      signal,
+      context,
+    }: {
+      signal?: AbortSignal;
+      context?: KibanaExecutionContext;
+    }) =>
       http.fetch<ListEntitySourcesResponse>(MONITORING_ENTITY_LIST_SOURCES_URL, {
         version: API_VERSIONS.public.v1,
         method: 'GET',
         signal,
+        context,
         query: {
           type: 'index',
           managed: false,
@@ -672,7 +706,8 @@ export const useEntityAnalyticsRoutes = () => {
 
     const uploadPrivilegedUserMonitoringFile = async (
       fileContent: string,
-      fileName: string
+      fileName: string,
+      context?: KibanaExecutionContext
     ): Promise<PrivmonBulkUploadUsersCSVResponse> => {
       const file = new File([new Blob([fileContent])], fileName, {
         type: 'text/csv',
@@ -687,6 +722,7 @@ export const useEntityAnalyticsRoutes = () => {
           'Content-Type': undefined, // Lets the browser set the appropriate content type
         },
         body,
+        context,
       });
     };
 
@@ -696,10 +732,13 @@ export const useEntityAnalyticsRoutes = () => {
         method: 'POST',
       });
 
-    const fetchPrivilegeMonitoringEngineStatus = (): Promise<PrivMonHealthResponse> =>
+    const fetchPrivilegeMonitoringEngineStatus = (
+      context?: KibanaExecutionContext
+    ): Promise<PrivMonHealthResponse> =>
       http.fetch<PrivMonHealthResponse>(PRIVMON_HEALTH_URL, {
         version: API_VERSIONS.public.v1,
         method: 'GET',
+        context,
       });
 
     const fetchPrivilegeMonitoringPrivileges = (): Promise<PrivMonPrivilegesResponse> =>
@@ -742,7 +781,11 @@ export const useEntityAnalyticsRoutes = () => {
         body: JSON.stringify(params),
       });
 
-    const fetchEntityDetailsHighlights = (
+    const fetchEntityDetailsHighlights = ({
+      params,
+      signal,
+      context,
+    }: {
       params: {
         entityType: string;
         entityIdentifier: string;
@@ -750,23 +793,30 @@ export const useEntityAnalyticsRoutes = () => {
         from: number;
         to: number;
         connectorId: string;
-      },
-      signal?: AbortSignal
-    ): Promise<EntityDetailsHighlightsResponse> =>
+      };
+      signal?: AbortSignal;
+      context?: KibanaExecutionContext;
+    }): Promise<EntityDetailsHighlightsResponse> =>
       http.fetch(ENTITY_DETAILS_HIGHLIGHT_INTERNAL_URL, {
         version: API_VERSIONS.internal.v1,
         method: 'POST',
         body: JSON.stringify(params),
         signal,
+        context,
       });
 
-    const saveEntityAiSummary = (
-      params: SaveEntityAiSummaryParams
-    ): Promise<{ created: boolean }> =>
+    const saveEntityAiSummary = ({
+      params,
+      context,
+    }: {
+      params: SaveEntityAiSummaryParams;
+      context?: KibanaExecutionContext;
+    }): Promise<{ created: boolean }> =>
       http.fetch(ENTITY_DETAILS_AI_SUMMARY_INTERNAL_URL, {
         version: API_VERSIONS.internal.v1,
         method: 'POST',
         body: JSON.stringify(params),
+        context,
       });
 
     /**
@@ -774,57 +824,82 @@ export const useEntityAnalyticsRoutes = () => {
      * `canRead: false` in the response means the user lacks metadata read access
      * and the caller should fall back to on-demand generation.
      */
-    const fetchPersistedAiSummary = (
-      params: { entityType: string; entityIdentifier: string },
-      signal?: AbortSignal
-    ): Promise<GetPersistedAiSummaryResponse> =>
+    const fetchPersistedAiSummary = ({
+      params,
+      signal,
+      context,
+    }: {
+      params: { entityType: string; entityIdentifier: string };
+      signal?: AbortSignal;
+      context?: KibanaExecutionContext;
+    }): Promise<GetPersistedAiSummaryResponse> =>
       http.fetch(ENTITY_DETAILS_AI_SUMMARY_INTERNAL_URL, {
         version: API_VERSIONS.internal.v1,
         method: 'GET',
         query: { entityId: params.entityIdentifier, entityType: params.entityType },
         signal,
+        context,
       });
 
     /**
      * List all watchlists
      */
-    const fetchWatchlists = async ({ signal }: { signal?: AbortSignal } = {}) =>
+    const fetchWatchlists = async ({
+      signal,
+      context,
+    }: { signal?: AbortSignal; context?: KibanaExecutionContext } = {}) =>
       http.fetch<ListWatchlistsResponse>(`${WATCHLISTS_URL}/list`, {
         version: API_VERSIONS.public.v1,
         method: 'GET',
         signal,
+        context,
       });
 
-    const getWatchlist = async (params: { id: string; signal?: AbortSignal }) =>
+    const getWatchlist = async (params: {
+      id: string;
+      signal?: AbortSignal;
+      context?: KibanaExecutionContext;
+    }) =>
       http.fetch<GetWatchlistResponse>(`${WATCHLISTS_URL}/${params.id}`, {
         version: API_VERSIONS.public.v1,
         method: 'GET',
         signal: params.signal,
+        context: params.context,
       });
 
-    const createWatchlist = async (params: CreateWatchlistRequestBodyInput) =>
+    const createWatchlist = async (
+      params: CreateWatchlistRequestBodyInput,
+      context?: KibanaExecutionContext
+    ) =>
       http.fetch<CreateWatchlistResponse>(WATCHLISTS_URL, {
         version: API_VERSIONS.public.v1,
         method: 'POST',
         body: JSON.stringify(params),
+        context,
       });
 
-    const updateWatchlist = async (params: { id: string; body: UpdateWatchlistRequestBodyInput }) =>
+    const updateWatchlist = async (
+      params: { id: string; body: UpdateWatchlistRequestBodyInput },
+      context?: KibanaExecutionContext
+    ) =>
       http.fetch<UpdateWatchlistResponse>(`${WATCHLISTS_URL}/${params.id}`, {
         version: API_VERSIONS.public.v1,
         method: 'PUT',
         body: JSON.stringify(params.body),
+        context,
       });
 
-    const deleteWatchlist = async (params: { id: string }) =>
+    const deleteWatchlist = async (params: { id: string }, context?: KibanaExecutionContext) =>
       http.fetch<{ deleted: true }>(`${WATCHLISTS_URL}/${params.id}`, {
         version: API_VERSIONS.public.v1,
         method: 'DELETE',
+        context,
       });
 
     const listWatchlistEntitySources = async (params: {
       watchlistId: string;
       signal?: AbortSignal;
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<ListWatchlistEntitySourcesResponse>(
         `${WATCHLISTS_URL}/${params.watchlistId}/entity_source/list`,
@@ -832,6 +907,7 @@ export const useEntityAnalyticsRoutes = () => {
           version: API_VERSIONS.public.v1,
           method: 'GET',
           signal: params.signal,
+          context: params.context,
         }
       );
 
@@ -906,6 +982,7 @@ export const useEntityAnalyticsRoutes = () => {
     const fetchLeads = ({
       signal,
       params,
+      context,
     }: {
       signal?: AbortSignal;
       params?: {
@@ -915,33 +992,45 @@ export const useEntityAnalyticsRoutes = () => {
         sortOrder?: 'asc' | 'desc';
         status?: 'active' | 'dismissed' | 'expired';
       };
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<FindLeadsResponse>(GET_LEADS_URL, {
         version: API_VERSIONS.internal.v1,
         method: 'GET',
         query: params,
         signal,
+        context,
       });
 
-    const fetchLeadGenerationStatus = ({ signal }: { signal?: AbortSignal }) =>
+    const fetchLeadGenerationStatus = ({
+      signal,
+      context,
+    }: {
+      signal?: AbortSignal;
+      context?: KibanaExecutionContext;
+    }) =>
       http.fetch<LeadGenerationStatus>(LEAD_GENERATION_STATUS_URL, {
         version: API_VERSIONS.internal.v1,
         method: 'GET',
         signal,
+        context,
       });
 
     const generateLeads = ({
       signal,
       params,
+      context,
     }: {
       signal?: AbortSignal;
       params: { connectorId: string; maxLeads?: number };
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<GenerateLeadsResponse>(GENERATE_LEADS_URL, {
         version: API_VERSIONS.internal.v1,
         method: 'POST',
         body: JSON.stringify(params),
         signal,
+        context,
       });
 
     const dismissLead = ({ signal, id }: { signal?: AbortSignal; id: string }) =>
@@ -995,11 +1084,13 @@ export const useEntityAnalyticsRoutes = () => {
       entityId,
       body,
       signal,
+      context,
     }: {
       entityType: string;
       entityId: string;
       body?: AnomalySummaryRequestBody;
       signal?: AbortSignal;
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<AnomalySummaryResponse>(
         ENTITY_ANOMALY_SUMMARY_INTERNAL_URL.replace(
@@ -1011,6 +1102,7 @@ export const useEntityAnalyticsRoutes = () => {
           method: 'POST',
           body: JSON.stringify(body ?? {}),
           signal,
+          context,
         }
       );
 
@@ -1019,11 +1111,13 @@ export const useEntityAnalyticsRoutes = () => {
       entityId,
       body,
       signal,
+      context,
     }: {
       entityType: string;
       entityId: string;
       body?: AnomalyOverviewRequestBody;
       signal?: AbortSignal;
+      context?: KibanaExecutionContext;
     }) =>
       http.fetch<AnomalyOverviewResponse>(
         ENTITY_ANOMALY_OVERVIEW_INTERNAL_URL.replace(
@@ -1035,6 +1129,7 @@ export const useEntityAnalyticsRoutes = () => {
           method: 'POST',
           body: JSON.stringify(body ?? {}),
           signal,
+          context,
         }
       );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/entity_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/entity_store.ts
@@ -6,6 +6,7 @@
  */
 import { useMemo } from 'react';
 import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/public';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type {
   GetEntityStoreStatusResponse,
   InitEntityStoreResponse,
@@ -44,43 +45,48 @@ export const useEntityStoreRoutes = () => {
       }
     };
 
-    const getEntityStoreStatus = async (withComponents = false) =>
+    const getEntityStoreStatus = async (withComponents = false, context?: KibanaExecutionContext) =>
       http.fetch<GetEntityStoreStatusResponse>(ENTITY_STORE_ROUTES.public.STATUS, {
         method: 'GET',
         version: API_VERSIONS.public.v1,
         query: { include_components: withComponents },
+        context,
       });
 
-    const installEntityStore = async () => {
+    const installEntityStore = async (context?: KibanaExecutionContext) => {
       await tryInstallPrebuiltWatchlistsWithToast();
       return http.fetch<InitEntityStoreResponse>(ENTITY_STORE_ROUTES.public.INSTALL, {
         method: 'POST',
         version: API_VERSIONS.public.v1,
         body: JSON.stringify({}),
+        context,
       });
     };
 
-    const startEntityStore = async () => {
+    const startEntityStore = async (context?: KibanaExecutionContext) => {
       await tryInstallPrebuiltWatchlistsWithToast();
       return http.fetch<StartEntityEngineResponse>(ENTITY_STORE_ROUTES.public.START, {
         method: 'PUT',
         version: API_VERSIONS.public.v1,
         body: JSON.stringify({}),
+        context,
       });
     };
 
-    const stopEntityStore = async () =>
+    const stopEntityStore = async (context?: KibanaExecutionContext) =>
       http.fetch<StopEntityEngineResponse>(ENTITY_STORE_ROUTES.public.STOP, {
         method: 'PUT',
         version: API_VERSIONS.public.v1,
         body: JSON.stringify({}),
+        context,
       });
 
-    const deleteEntityStore = async () =>
+    const deleteEntityStore = async (context?: KibanaExecutionContext) =>
       http.fetch(ENTITY_STORE_ROUTES.public.UNINSTALL, {
         method: 'POST',
         version: API_VERSIONS.public.v1,
         body: JSON.stringify({}),
+        context,
       });
 
     return {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_overview.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import React from 'react';
+import { useAnomalyOverview } from './use_anomaly_overview';
+import { useEntityAnalyticsRoutes } from '../api';
+
+jest.mock('../api');
+
+const mockFetchAnomalyOverview = jest.fn();
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    {children}
+  </QueryClientProvider>
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useEntityAnalyticsRoutes as jest.Mock).mockReturnValue({
+    fetchAnomalyOverview: mockFetchAnomalyOverview,
+  });
+  mockFetchAnomalyOverview.mockResolvedValue({});
+});
+
+describe('useAnomalyOverview', () => {
+  it('forwards a caller-supplied executionContext to fetchAnomalyOverview', async () => {
+    const executionContext = {
+      child: {
+        type: 'security_solution',
+        name: 'entity_analytics-entity_details_flyout',
+        id: 'anomaly_overview',
+      },
+    };
+
+    renderHook(
+      () => useAnomalyOverview({ entityId: 'host-1', entityType: 'host', executionContext }),
+      { wrapper: TestWrapper }
+    );
+
+    await waitFor(() =>
+      expect(mockFetchAnomalyOverview).toHaveBeenCalledWith(
+        expect.objectContaining({ context: executionContext })
+      )
+    );
+  });
+
+  it('omits context when the caller does not supply executionContext', async () => {
+    renderHook(() => useAnomalyOverview({ entityId: 'host-1', entityType: 'host' }), {
+      wrapper: TestWrapper,
+    });
+
+    await waitFor(() => expect(mockFetchAnomalyOverview).toHaveBeenCalled());
+    const [callArg] = mockFetchAnomalyOverview.mock.calls[0];
+    expect(callArg.context).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_overview.test.tsx
@@ -33,7 +33,7 @@ describe('useAnomalyOverview', () => {
     const executionContext = {
       child: {
         type: 'security_solution',
-        name: 'entity_analytics-entity_details_flyout',
+        name: 'entity_analytics:entity_details_flyout',
         id: 'anomaly_overview',
       },
     };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_overview.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_overview.ts
@@ -6,6 +6,7 @@
  */
 
 import { useQuery } from '@kbn/react-query';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { AnomalyScoreRange } from '../../../../common/api/entity_analytics';
 import { useEntityAnalyticsRoutes } from '../api';
 
@@ -19,6 +20,11 @@ interface UseAnomalyOverviewParams {
   threatTactics?: string[];
   scoreRanges?: AnomalyScoreRange[];
   enabled?: boolean;
+  /**
+   * Optional Kibana execution context forwarded to the anomaly-overview fetch so slow logs and
+   * APM traces can attribute the query to the calling page/panel.
+   */
+  executionContext?: KibanaExecutionContext;
 }
 
 export const useAnomalyOverview = ({
@@ -29,6 +35,7 @@ export const useAnomalyOverview = ({
   threatTactics,
   scoreRanges,
   enabled = true,
+  executionContext,
 }: UseAnomalyOverviewParams) => {
   const { fetchAnomalyOverview } = useEntityAnalyticsRoutes();
 
@@ -43,7 +50,8 @@ export const useAnomalyOverview = ({
 
   return useQuery(
     [...ANOMALY_OVERVIEW_QUERY_KEY, entityType, entityId, from, to, threatTactics, scoreRanges],
-    ({ signal }) => fetchAnomalyOverview({ entityType, entityId, body, signal }),
+    ({ signal }) =>
+      fetchAnomalyOverview({ entityType, entityId, body, signal, context: executionContext }),
     {
       enabled: enabled && !!entityId,
       keepPreviousData: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_summary.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_summary.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import React from 'react';
+import { useAnomalySummary } from './use_anomaly_summary';
+import { useEntityAnalyticsRoutes } from '../api';
+
+jest.mock('../api');
+
+const mockFetchAnomalySummary = jest.fn();
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    {children}
+  </QueryClientProvider>
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useEntityAnalyticsRoutes as jest.Mock).mockReturnValue({
+    fetchAnomalySummary: mockFetchAnomalySummary,
+  });
+  mockFetchAnomalySummary.mockResolvedValue({});
+});
+
+describe('useAnomalySummary', () => {
+  it('forwards a caller-supplied executionContext to fetchAnomalySummary', async () => {
+    const executionContext = {
+      child: {
+        type: 'security_solution',
+        name: 'entity_analytics-entity_details_flyout',
+        id: 'anomaly_summary',
+      },
+    };
+
+    renderHook(
+      () => useAnomalySummary({ entityId: 'host-1', entityType: 'host', executionContext }),
+      { wrapper: TestWrapper }
+    );
+
+    await waitFor(() =>
+      expect(mockFetchAnomalySummary).toHaveBeenCalledWith(
+        expect.objectContaining({ context: executionContext })
+      )
+    );
+  });
+
+  it('omits context when the caller does not supply executionContext', async () => {
+    renderHook(() => useAnomalySummary({ entityId: 'host-1', entityType: 'host' }), {
+      wrapper: TestWrapper,
+    });
+
+    await waitFor(() => expect(mockFetchAnomalySummary).toHaveBeenCalled());
+    const [callArg] = mockFetchAnomalySummary.mock.calls[0];
+    expect(callArg.context).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_summary.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_summary.test.tsx
@@ -33,7 +33,7 @@ describe('useAnomalySummary', () => {
     const executionContext = {
       child: {
         type: 'security_solution',
-        name: 'entity_analytics-entity_details_flyout',
+        name: 'entity_analytics:entity_details_flyout',
         id: 'anomaly_summary',
       },
     };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_summary.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_summary.ts
@@ -6,6 +6,7 @@
  */
 
 import { useQuery } from '@kbn/react-query';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type {
   AnomalySummaryRequestBody,
   GetAnomalySummaryRequestBodyInput,
@@ -19,6 +20,11 @@ interface UseAnomalySummaryParams {
   entityType: string;
   body?: GetAnomalySummaryRequestBodyInput;
   enabled?: boolean;
+  /**
+   * Optional Kibana execution context forwarded to the anomaly-summary fetch so slow logs and
+   * APM traces can attribute the query to the calling page/panel.
+   */
+  executionContext?: KibanaExecutionContext;
 }
 
 const DEFAULT_BODY: Required<Pick<AnomalySummaryRequestBody, 'page' | 'page_size' | 'sort'>> = {
@@ -32,6 +38,7 @@ export const useAnomalySummary = ({
   entityType,
   body,
   enabled = true,
+  executionContext,
 }: UseAnomalySummaryParams) => {
   const { fetchAnomalySummary } = useEntityAnalyticsRoutes();
 
@@ -39,7 +46,14 @@ export const useAnomalySummary = ({
 
   return useQuery(
     [...ANOMALY_SUMMARY_QUERY_KEY, entityType, entityId, resolvedBody],
-    ({ signal }) => fetchAnomalySummary({ entityType, entityId, body: resolvedBody, signal }),
+    ({ signal }) =>
+      fetchAnomalySummary({
+        entityType,
+        entityId,
+        body: resolvedBody,
+        signal,
+        context: executionContext,
+      }),
     {
       enabled: enabled && !!entityId,
       keepPreviousData: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_risk_scores.ts
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useMemo } from 'react';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import { useRiskScore, type RiskScoreState } from './use_risk_score';
 import { useResolutionGroup } from '../../components/entity_resolution/hooks/use_resolution_group';
@@ -32,8 +33,16 @@ export interface EntityRiskScoresState<T extends EntityType> {
  */
 export const useEntityRiskScores = <T extends EntityType>(
   entityType: T,
-  entityId: string | undefined
+  entityId: string | undefined,
+  options?: {
+    /**
+     * Optional Kibana execution context forwarded to both the base and resolution risk-score
+     * queries so slow logs and APM traces can attribute the queries to the calling page/panel.
+     */
+    executionContext?: KibanaExecutionContext;
+  }
 ): EntityRiskScoresState<T> => {
+  const executionContext = options?.executionContext;
   const baseFilterQuery = useMemo(
     () =>
       entityId
@@ -52,6 +61,7 @@ export const useEntityRiskScores = <T extends EntityType>(
     onlyLatest: false,
     pagination: FIRST_RECORD_PAGINATION,
     skip: !entityId,
+    executionContext,
   });
 
   const { data: resolutionGroup } = useResolutionGroup(entityId ?? '', {
@@ -83,6 +93,7 @@ export const useEntityRiskScores = <T extends EntityType>(
     onlyLatest: false,
     pagination: FIRST_RECORD_PAGINATION,
     skip: !shouldFetchResolution,
+    executionContext,
   });
 
   const refetch = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_store_risk_score.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_store_risk_score.tsx
@@ -55,6 +55,7 @@ export function useEntityStoreRiskScore({
   skip = false,
   pagination,
   riskEntity,
+  executionContext,
 }: UseEntityStoreRiskScoreParams):
   | RiskScoreState<EntityType.host>
   | RiskScoreState<EntityType.user> {
@@ -137,6 +138,7 @@ export function useEntityStoreRiskScore({
           sortField,
           sortOrder,
         },
+        context: executionContext,
       }),
     enabled: queryEnabled,
     cacheTime: 0,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_store_risk_score_kpi.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_store_risk_score_kpi.tsx
@@ -50,6 +50,7 @@ export const useEntityStoreRiskScoreKpi = ({
   skip,
   riskEntity,
   timerange,
+  executionContext,
 }: UseRiskScoreKpiProps) => {
   const { addError } = useAppToasts();
   const { fetchEntitiesListV2 } = useEntityAnalyticsRoutes();
@@ -139,6 +140,7 @@ export const useEntityStoreRiskScoreKpi = ({
             sortField,
             sortOrder: 'asc',
           },
+          context: executionContext,
         });
 
         total = res.total;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_get_watchlists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_get_watchlists.ts
@@ -7,12 +7,17 @@
 
 import { useQuery } from '@kbn/react-query';
 import { useEntityAnalyticsRoutes } from '../api';
+import { buildExecutionContext } from '../../common';
 
 export const useGetWatchlists = () => {
   const { fetchWatchlists } = useEntityAnalyticsRoutes();
 
   return useQuery({
     queryKey: ['GET', 'WATCHLISTS'],
-    queryFn: ({ signal }) => fetchWatchlists({ signal }),
+    queryFn: ({ signal }) =>
+      fetchWatchlists({
+        signal,
+        context: buildExecutionContext('entity_analytics-watchlists', 'watchlists_list'),
+      }),
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_get_watchlists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_get_watchlists.ts
@@ -17,7 +17,7 @@ export const useGetWatchlists = () => {
     queryFn: ({ signal }) =>
       fetchWatchlists({
         signal,
-        context: buildExecutionContext('entity_analytics-watchlists', 'watchlists_list'),
+        context: buildExecutionContext('entity_analytics:watchlists', 'watchlists_list'),
       }),
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_preview_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_preview_risk_scores.ts
@@ -8,6 +8,7 @@ import { useQuery } from '@kbn/react-query';
 import dateMath from '@kbn/datemath';
 import type { RiskScoresPreviewRequest } from '../../../../common/api/entity_analytics/risk_engine/preview_route.gen';
 import { useEntityAnalyticsRoutes } from '../api';
+import { buildExecutionContext } from '../../common';
 
 export type UseRiskScorePreviewParams = Omit<RiskScoresPreviewRequest, 'data_view_id'> & {
   data_view_id?: RiskScoresPreviewRequest['data_view_id'];
@@ -72,7 +73,14 @@ export const useRiskScorePreview = ({
         params.filters = filters;
       }
 
-      const response = await fetchRiskScorePreview({ signal, params });
+      const response = await fetchRiskScorePreview({
+        signal,
+        params,
+        context: buildExecutionContext(
+          'entity_analytics-risk_score_management',
+          'risk_score_preview'
+        ),
+      });
 
       return response;
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_preview_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_preview_risk_scores.ts
@@ -77,7 +77,7 @@ export const useRiskScorePreview = ({
         signal,
         params,
         context: buildExecutionContext(
-          'entity_analytics-risk_score_management',
+          'entity_analytics:risk_score_management',
           'risk_score_preview'
         ),
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_engine_status.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_engine_status.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import React from 'react';
+import { useRiskEngineStatus } from './use_risk_engine_status';
+import { useEntityAnalyticsRoutes } from '../api';
+
+jest.mock('../api');
+
+const mockFetchRiskEngineStatus = jest.fn();
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    {children}
+  </QueryClientProvider>
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useEntityAnalyticsRoutes as jest.Mock).mockReturnValue({
+    fetchRiskEngineStatus: mockFetchRiskEngineStatus,
+  });
+  mockFetchRiskEngineStatus.mockResolvedValue({ risk_engine_status: 'ENABLED' });
+});
+
+describe('useRiskEngineStatus', () => {
+  it('forwards a caller-supplied executionContext to fetchRiskEngineStatus', async () => {
+    const executionContext = {
+      child: {
+        type: 'security_solution',
+        name: 'entity_analytics-risk_score_management',
+        id: 'risk_engine_status',
+      },
+    };
+
+    renderHook(() => useRiskEngineStatus({}, { executionContext }), {
+      wrapper: TestWrapper,
+    });
+
+    await waitFor(() =>
+      expect(mockFetchRiskEngineStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ context: executionContext })
+      )
+    );
+  });
+
+  it('omits context when no executionContext option is supplied', async () => {
+    renderHook(() => useRiskEngineStatus(), { wrapper: TestWrapper });
+
+    await waitFor(() => expect(mockFetchRiskEngineStatus).toHaveBeenCalled());
+    const [callArg] = mockFetchRiskEngineStatus.mock.calls[0];
+    expect(callArg.context).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_engine_status.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_engine_status.test.tsx
@@ -33,7 +33,7 @@ describe('useRiskEngineStatus', () => {
     const executionContext = {
       child: {
         type: 'security_solution',
-        name: 'entity_analytics-risk_score_management',
+        name: 'entity_analytics:risk_score_management',
         id: 'risk_engine_status',
       },
     };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_engine_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_engine_status.ts
@@ -9,6 +9,7 @@ import { useQuery, useQueryClient } from '@kbn/react-query';
 import { useCallback } from 'react';
 import moment from 'moment';
 import { i18n } from '@kbn/i18n';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { RiskEngineStatusResponse } from '../../../../common/api/entity_analytics/risk_engine/engine_status_route.gen';
 import { useEntityAnalyticsRoutes } from '../api';
 const FETCH_RISK_ENGINE_STATUS = ['GET', 'FETCH_RISK_ENGINE_STATUS'];
@@ -41,12 +42,21 @@ export const useRiskEngineStatus = (
   queryOptions: Pick<
     UseQueryOptions<unknown, unknown, RiskEngineStatusResponse, string[]>,
     'refetchInterval' | 'structuralSharing'
-  > = {}
+  > = {},
+  {
+    executionContext,
+  }: {
+    /**
+     * Optional Kibana execution context forwarded to the risk-engine-status fetch so slow logs
+     * and APM traces can attribute the query to the calling page/panel.
+     */
+    executionContext?: KibanaExecutionContext;
+  } = {}
 ) => {
   const { fetchRiskEngineStatus } = useEntityAnalyticsRoutes();
   return useQuery(
     FETCH_RISK_ENGINE_STATUS,
-    async ({ signal }) => fetchRiskEngineStatus({ signal }),
+    async ({ signal }) => fetchRiskEngineStatus({ signal, context: executionContext }),
     queryOptions
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score.test.tsx
@@ -208,7 +208,7 @@ describe.each([EntityType.host, EntityType.user])('useRiskScore entityType: %s',
   test('forwards executionContext to useSearchStrategy', () => {
     mockRiskEngineStatus('ENABLED');
     const executionContext = {
-      child: { type: 'security_solution', name: 'explore-hosts_page', id: 'hosts_risk_score' },
+      child: { type: 'security_solution', name: 'entity_analytics:explore-hosts_page', id: 'hosts_risk_score' },
     };
 
     renderHook(() => useRiskScore({ riskEntity, executionContext }), {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score.test.tsx
@@ -204,4 +204,19 @@ describe.each([EntityType.host, EntityType.user])('useRiskScore entityType: %s',
       });
     });
   });
+
+  test('forwards executionContext to useSearchStrategy', () => {
+    mockRiskEngineStatus('ENABLED');
+    const executionContext = {
+      child: { type: 'security_solution', name: 'explore-hosts_page', id: 'hosts_risk_score' },
+    };
+
+    renderHook(() => useRiskScore({ riskEntity, executionContext }), {
+      wrapper: TestProviders,
+    });
+
+    expect(mockUseSearchStrategy).toHaveBeenCalledWith(
+      expect.objectContaining({ executionContext })
+    );
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score.tsx
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import { EntityRiskQueries } from '../../../../common/api/search_strategy';
 import { useLicense } from '../../../common/hooks/use_license';
 import { createFilter } from '../../../common/containers/helpers';
@@ -52,6 +53,11 @@ export interface UseRiskScoreParams {
   skip?: boolean;
   sort?: RiskScoreSortField;
   timerange?: { to: string; from: string };
+  /**
+   * Optional Kibana execution context forwarded to the underlying search strategy so slow logs
+   * and APM traces can attribute the query to the calling page/panel.
+   */
+  executionContext?: KibanaExecutionContext;
 }
 
 interface UseRiskScore<T> extends UseRiskScoreParams {
@@ -72,6 +78,7 @@ export const useRiskScore = <T extends EntityType>({
   pagination,
   riskEntity,
   includeAlertsCount = false,
+  executionContext,
 }: UseRiskScore<T>): RiskScoreState<T> => {
   const defaultIndex = useGetDefaultRiskIndex(onlyLatest);
   const {
@@ -99,6 +106,7 @@ export const useRiskScore = <T extends EntityType>({
     initialResult,
     abort: skip,
     showErrorToast: false,
+    executionContext,
   });
 
   const refetchAll = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score_history.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score_history.ts
@@ -11,6 +11,7 @@ import { useErrorToast } from '../../../common/hooks/use_error_toast';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useEntityAnalyticsRoutes } from '../api';
 import type { FetchRiskScoreHistoryParams } from '../api';
+import { buildExecutionContext } from '../../common';
 
 export interface UseRiskScoreHistoryParams extends Omit<FetchRiskScoreHistoryParams, 'entityId'> {
   entityId: string | undefined;
@@ -53,6 +54,10 @@ export const useRiskScoreHistory = ({
       return fetchRiskScoreHistory({
         signal,
         params: { entityType, entityId, from, to, scoreType, includeContributions },
+        context: buildExecutionContext(
+          'entity_analytics-risk_score_management',
+          'risk_score_history'
+        ),
       });
     },
     enabled,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score_history.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score_history.ts
@@ -55,7 +55,7 @@ export const useRiskScoreHistory = ({
         signal,
         params: { entityType, entityId, from, to, scoreType, includeContributions },
         context: buildExecutionContext(
-          'entity_analytics-risk_score_management',
+          'entity_analytics:risk_score_management',
           'risk_score_history'
         ),
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score_kpi.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_score_kpi.tsx
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import { EntityRiskQueries } from '../../../../common/api/search_strategy';
 import type { EntityType } from '../../../../common/search_strategy';
 import { RiskSeverity, EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
@@ -36,6 +37,11 @@ export interface UseRiskScoreKpiProps {
   skip?: boolean;
   riskEntity: EntityType | EntityType[];
   timerange?: { to: string; from: string };
+  /**
+   * Optional Kibana execution context forwarded to the underlying search strategy so slow logs
+   * and APM traces can attribute the query to the calling page/panel.
+   */
+  executionContext?: KibanaExecutionContext;
 }
 
 export const useRiskScoreKpi = ({
@@ -43,6 +49,7 @@ export const useRiskScoreKpi = ({
   skip,
   riskEntity,
   timerange,
+  executionContext,
 }: UseRiskScoreKpiProps): RiskScoreKpi => {
   const { addError } = useAppToasts();
   const defaultIndex = useGetDefaultRiskIndex();
@@ -60,6 +67,7 @@ export const useRiskScoreKpi = ({
       },
       abort: skip,
       showErrorToast: false,
+      executionContext,
     });
 
   const isModuleDisabled = !!error && isIndexNotFoundError(error);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/execution_context.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/execution_context.test.ts
@@ -9,18 +9,18 @@ import { buildExecutionContext } from './execution_context';
 
 describe('buildExecutionContext', () => {
   it('returns a child execution context tagged as security_solution', () => {
-    expect(buildExecutionContext('entity_analytics-home_page', 'entities_table')).toEqual({
+    expect(buildExecutionContext('entity_analytics:home_page', 'entities_table')).toEqual({
       child: {
         type: 'security_solution',
-        name: 'entity_analytics-home_page',
+        name: 'entity_analytics:home_page',
         id: 'entities_table',
       },
     });
   });
 
   it('preserves the name and id verbatim so trace labels match the caller', () => {
-    const ctx = buildExecutionContext('explore-hosts_page', 'hosts_all');
-    expect(ctx.child.name).toBe('explore-hosts_page');
+    const ctx = buildExecutionContext('entity_analytics:explore-hosts_page', 'hosts_all');
+    expect(ctx.child.name).toBe('entity_analytics:explore-hosts_page');
     expect(ctx.child.id).toBe('hosts_all');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/execution_context.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/execution_context.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildExecutionContext } from './execution_context';
+
+describe('buildExecutionContext', () => {
+  it('returns a child execution context tagged as security_solution', () => {
+    expect(buildExecutionContext('entity_analytics-home_page', 'entities_table')).toEqual({
+      child: {
+        type: 'security_solution',
+        name: 'entity_analytics-home_page',
+        id: 'entities_table',
+      },
+    });
+  });
+
+  it('preserves the name and id verbatim so trace labels match the caller', () => {
+    const ctx = buildExecutionContext('explore-hosts_page', 'hosts_all');
+    expect(ctx.child.name).toBe('explore-hosts_page');
+    expect(ctx.child.id).toBe('hosts_all');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/execution_context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/execution_context.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
+
+const EXECUTION_CONTEXT_TYPE = 'security_solution';
+
+/**
+ * Builds the `child` slice of a Kibana execution context for a query issued
+ * from a Security Solution / Entity Analytics UI surface. The parent app
+ * context (`type: 'application'`, `name: <appId>`, `page: <pathname>`) is
+ * merged in automatically by core when the search or http.fetch call
+ * executes, so callers only supply the child descriptor.
+ *
+ * @param name Logical page or feature the query belongs to (e.g. `entity_analytics-home_page`).
+ * @param id   Panel or query token within the page (e.g. `entities_table`).
+ */
+export const buildExecutionContext = (
+  name: string,
+  id: string
+): { child: KibanaExecutionContext } => ({
+  child: {
+    type: EXECUTION_CONTEXT_TYPE,
+    name,
+    id,
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+export { buildExecutionContext } from './execution_context';
 export { userHasRiskEngineReadPermissions } from './user_has_risk_engine_read_permissions';
 export type { SnakeToCamelCase } from './utils';
 export {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/use_asset_criticality.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/use_asset_criticality.test.ts
@@ -14,12 +14,17 @@ import {
   renderWrappedHook,
 } from '../../../management/hooks/test_utils';
 import type { Entity } from './use_asset_criticality';
-import { useAssetCriticalityPrivileges, useAssetCriticalityData } from './use_asset_criticality';
+import {
+  useAssetCriticalityPrivileges,
+  useAssetCriticalityData,
+  useAssetCriticalityFetchList,
+} from './use_asset_criticality';
 import { ENTITY_STORE_ENTITIES_LIST } from '../entity_store/hooks/use_entities_list_query';
 
 const mockFetchAssetCriticalityPrivileges = jest.fn().mockResolvedValue({});
 const mockFetchEntityStoreV2Privileges = jest.fn().mockResolvedValue({});
 const mockFetchAssetCriticality = jest.fn().mockResolvedValue({});
+const mockFetchAssetCriticalityList = jest.fn().mockResolvedValue({});
 const mockDeleteAssetCriticality = jest.fn().mockResolvedValue({});
 const mockCreateAssetCriticality = jest.fn().mockResolvedValue({});
 jest.mock('../../api/api', () => ({
@@ -27,6 +32,7 @@ jest.mock('../../api/api', () => ({
     fetchAssetCriticalityPrivileges: mockFetchAssetCriticalityPrivileges,
     fetchEntityStoreV2Privileges: mockFetchEntityStoreV2Privileges,
     fetchAssetCriticality: mockFetchAssetCriticality,
+    fetchAssetCriticalityList: mockFetchAssetCriticalityList,
     deleteAssetCriticality: mockDeleteAssetCriticality,
     createAssetCriticality: mockCreateAssetCriticality,
   }),
@@ -101,6 +107,27 @@ describe('useAssetCriticality', () => {
       expect(mockCreateAssetCriticality).toHaveBeenCalled();
     });
 
+    it('forwards a caller-supplied executionContext to fetchAssetCriticality', async () => {
+      mockFetchEntityStoreV2Privileges.mockResolvedValue({ has_all_required: true });
+      mockFetchAssetCriticality.mockResolvedValue({});
+      const entity: Entity = { name: 'test_entity_name', type: EntityType.host };
+      const executionContext = {
+        child: {
+          type: 'security_solution',
+          name: 'entity_analytics-asset_criticality',
+          id: 'asset_criticality_get',
+        },
+      };
+
+      await renderWrappedHook(() => useAssetCriticalityData({ entity, executionContext }));
+
+      await waitFor(() =>
+        expect(mockFetchAssetCriticality).toHaveBeenCalledWith(
+          expect.objectContaining({ context: executionContext })
+        )
+      );
+    });
+
     it('invalidates the entity store entities list query on a successful mutation', async () => {
       mockFetchAssetCriticalityPrivileges.mockResolvedValue({ has_all_required: true });
       mockCreateAssetCriticality.mockResolvedValue({});
@@ -124,6 +151,33 @@ describe('useAssetCriticality', () => {
       );
 
       invalidateQueriesSpy.mockRestore();
+    });
+  });
+
+  describe('useAssetCriticalityFetchList', () => {
+    it('forwards a caller-supplied executionContext to fetchAssetCriticalityList', async () => {
+      mockFetchAssetCriticalityList.mockResolvedValue({ records: [], total: 0 });
+      const executionContext = {
+        child: {
+          type: 'security_solution',
+          name: 'entity_analytics-asset_criticality',
+          id: 'asset_criticality_list',
+        },
+      };
+
+      await renderQuery(
+        () =>
+          useAssetCriticalityFetchList({
+            idField: 'host.name',
+            idValues: ['web01'],
+            executionContext,
+          }),
+        'isSuccess'
+      );
+
+      expect(mockFetchAssetCriticalityList).toHaveBeenCalledWith(
+        expect.objectContaining({ context: executionContext })
+      );
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/use_asset_criticality.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/use_asset_criticality.test.ts
@@ -114,7 +114,7 @@ describe('useAssetCriticality', () => {
       const executionContext = {
         child: {
           type: 'security_solution',
-          name: 'entity_analytics-asset_criticality',
+          name: 'entity_analytics:asset_criticality',
           id: 'asset_criticality_get',
         },
       };
@@ -160,7 +160,7 @@ describe('useAssetCriticality', () => {
       const executionContext = {
         child: {
           type: 'security_solution',
-          name: 'entity_analytics-asset_criticality',
+          name: 'entity_analytics:asset_criticality',
           id: 'asset_criticality_list',
         },
       };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/use_asset_criticality.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/use_asset_criticality.ts
@@ -7,6 +7,7 @@
 
 import type { UseMutationResult, UseQueryResult } from '@kbn/react-query';
 import { useMutation, useQuery, useQueryClient } from '@kbn/react-query';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { SecurityAppError } from '@kbn/securitysolution-t-grid';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import { EntityTypeToIdentifierField } from '../../../../common/entity_analytics/types';
@@ -52,15 +53,21 @@ export const useAssetCriticalityFetchList = ({
   idField,
   idValues,
   skip = false,
+  executionContext,
 }: {
   idField: string;
   idValues: string[];
   skip?: boolean;
+  /**
+   * Optional Kibana execution context forwarded to the asset-criticality list fetch so slow logs
+   * and APM traces can attribute the query to the calling page/panel.
+   */
+  executionContext?: KibanaExecutionContext;
 }) => {
   const { fetchAssetCriticalityList } = useEntityAnalyticsRoutes();
   return useQuery<FindAssetCriticalityRecordsResponse>({
     queryKey: [ASSET_CRITICALITY_LIST_KEY],
-    queryFn: () => fetchAssetCriticalityList({ idField, idValues }),
+    queryFn: () => fetchAssetCriticalityList({ idField, idValues, context: executionContext }),
     enabled: !skip && idValues.length > 0,
   });
 };
@@ -69,10 +76,17 @@ export const useAssetCriticalityData = ({
   entity,
   enabled = true,
   onChange,
+  executionContext,
 }: {
   entity: Entity;
   enabled?: boolean;
   onChange?: () => void;
+  /**
+   * Optional Kibana execution context forwarded to the asset-criticality GET so slow logs and
+   * APM traces can attribute the query to the calling page/panel. Only tags the read query; the
+   * create/delete mutation is left per-page for callers to instrument.
+   */
+  executionContext?: KibanaExecutionContext;
 }): State => {
   const QC = useQueryClient();
   const QUERY_KEY = [ASSET_CRITICALITY_KEY, entity.name];
@@ -86,6 +100,7 @@ export const useAssetCriticalityData = ({
       fetchAssetCriticality({
         idField: EntityTypeToIdentifierField[entity.type],
         idValue: entity.name,
+        context: executionContext,
       }),
     retry: (failureCount, error) => error.body.statusCode === 404 && failureCount > 0,
     enabled,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/asset_criticality_file_uploader.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/asset_criticality_file_uploader.tsx
@@ -14,6 +14,7 @@ import { INITIAL_STATE, reducer } from './reducer';
 import { isFilePickerStep, isResultStep, isValidationStep } from './helpers';
 import { AssetCriticalityResultStep } from './components/result_step';
 import { useEntityAnalyticsRoutes } from '../../api/api';
+import { buildExecutionContext } from '../../common';
 import { useFileValidation, useNavigationSteps } from './hooks';
 import type { OnCompleteParams } from './types';
 import { EntityEventTypes } from '../../../common/lib/telemetry';
@@ -105,7 +106,11 @@ export const AssetCriticalityFileUploader: React.FC = () => {
       try {
         const result = await uploadAssetCriticalityFile(
           state.validatedFile.validLines.text,
-          state.validatedFile.name
+          state.validatedFile.name,
+          buildExecutionContext(
+            'entity_analytics-asset_criticality',
+            'asset_criticality_bulk_upload'
+          )
         );
 
         dispatch({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/asset_criticality_file_uploader.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/asset_criticality_file_uploader.tsx
@@ -108,7 +108,7 @@ export const AssetCriticalityFileUploader: React.FC = () => {
           state.validatedFile.validLines.text,
           state.validatedFile.name,
           buildExecutionContext(
-            'entity_analytics-asset_criticality',
+            'entity_analytics:asset_criticality',
             'asset_criticality_bulk_upload'
           )
         );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
@@ -136,7 +136,7 @@ const EntityAnalyticsRiskScoresComponent = <T extends EntityType>({
     filterQuery,
     timerange,
     executionContext: useMemo(
-      () => buildExecutionContext('entity_analytics-home_page', `risk_score_panel_${riskEntity}`),
+      () => buildExecutionContext('entity_analytics:home_page', `risk_score_panel_${riskEntity}`),
       [riskEntity]
     ),
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
@@ -36,6 +36,7 @@ import { getRiskEntityTranslation } from './translations';
 import { useKibana } from '../../../common/lib/kibana';
 import { useGlobalFilterQuery } from '../../../common/hooks/use_global_filter_query';
 import { useEntityAnalyticsRiskScorePanelData } from './use_entity_analytics_risk_score_panel_data';
+import { buildExecutionContext } from '../../common';
 import { RiskEnginePrivilegesCallOut } from '../risk_engine_privileges_callout';
 import { useMissingRiskEnginePrivileges } from '../../hooks/use_missing_risk_engine_privileges';
 import { EntityEventTypes } from '../../../common/lib/telemetry';
@@ -134,6 +135,10 @@ const EntityAnalyticsRiskScoresComponent = <T extends EntityType>({
     toggleStatus,
     filterQuery,
     timerange,
+    executionContext: useMemo(
+      () => buildExecutionContext('entity_analytics-home_page', `risk_score_panel_${riskEntity}`),
+      [riskEntity]
+    ),
   });
 
   useQueryInspector({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/use_entity_analytics_risk_score_panel_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/use_entity_analytics_risk_score_panel_data.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { EntityRiskScore } from '../../../../common/search_strategy';
 import { EntityType } from '../../../../common/entity_analytics/types';
 import type { ESQuery } from '../../../../common/typed_json';
@@ -18,11 +19,17 @@ export const useEntityAnalyticsRiskScorePanelData = <T extends EntityType>({
   toggleStatus,
   filterQuery,
   timerange,
+  executionContext,
 }: {
   riskEntity: T;
   toggleStatus: boolean;
   filterQuery?: ESQuery | string;
   timerange: { from: string; to: string };
+  /**
+   * Optional Kibana execution context forwarded to all four underlying risk-score hooks so slow
+   * logs and APM traces can attribute each query to the calling page/panel.
+   */
+  executionContext?: KibanaExecutionContext;
 }) => {
   // Entity store v2 only carries risk for host/user; service/generic risk
   // continues to flow through the legacy risk-score search strategy.
@@ -33,6 +40,7 @@ export const useEntityAnalyticsRiskScorePanelData = <T extends EntityType>({
     skip: !toggleStatus || isHostOrUserRiskEntity,
     timerange,
     riskEntity,
+    executionContext,
   });
 
   const entityStoreKpi = useEntityStoreRiskScoreKpi({
@@ -40,6 +48,7 @@ export const useEntityAnalyticsRiskScorePanelData = <T extends EntityType>({
     skip: !toggleStatus || !isHostOrUserRiskEntity,
     timerange,
     riskEntity,
+    executionContext,
   });
 
   const kpi = isHostOrUserRiskEntity ? entityStoreKpi : legacyKpi;
@@ -54,6 +63,7 @@ export const useEntityAnalyticsRiskScorePanelData = <T extends EntityType>({
     timerange,
     riskEntity,
     includeAlertsCount: true,
+    executionContext,
   });
 
   const entityStoreRiskScore = useEntityStoreRiskScore({
@@ -65,6 +75,7 @@ export const useEntityAnalyticsRiskScorePanelData = <T extends EntityType>({
     },
     timerange,
     riskEntity: riskEntity as EntityType.host,
+    executionContext,
   });
 
   const riskScore = isHostOrUserRiskEntity ? entityStoreRiskScore : legacyRiskScore;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_entity_details_highlights.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_entity_details_highlights.test.tsx
@@ -123,12 +123,15 @@ describe('useFetchEntityDetailsHighlights', () => {
     });
 
     expect(mockFetchEntityDetailsHighlights).toHaveBeenCalledWith({
-      entityType: 'user',
-      entityIdentifier: 'test-user',
-      anonymizationFields: mockProps.anonymizationFields,
-      from: expect.any(Number),
-      to: expect.any(Number),
-      connectorId: 'test-connector-id',
+      params: {
+        entityType: 'user',
+        entityIdentifier: 'test-user',
+        anonymizationFields: mockProps.anonymizationFields,
+        from: expect.any(Number),
+        to: expect.any(Number),
+        connectorId: 'test-connector-id',
+      },
+      context: expect.objectContaining({ child: expect.anything() }),
     });
 
     expect(mockInferenceOutput).toHaveBeenCalledWith({
@@ -288,21 +291,24 @@ describe('useFetchEntityDetailsHighlights', () => {
       });
 
       expect(mockSaveEntityAiSummary).toHaveBeenCalledWith({
-        entityId: 'test-user',
-        entityType: 'user',
-        summary: {
-          highlights: mockSuccessfulInferenceOutput.output.highlights,
-          recommended_actions: mockSuccessfulInferenceOutput.output.recommended_actions,
-          generated_at: expect.any(Number),
-          staleness: {
-            enabled_signals: ['risk_score'],
-            snapshot: { risk_score: 55 },
+        params: {
+          entityId: 'test-user',
+          entityType: 'user',
+          summary: {
+            highlights: mockSuccessfulInferenceOutput.output.highlights,
+            recommended_actions: mockSuccessfulInferenceOutput.output.recommended_actions,
+            generated_at: expect.any(Number),
+            staleness: {
+              enabled_signals: ['risk_score'],
+              snapshot: { risk_score: 55 },
+            },
+          },
+          modelOutputCounts: {
+            highlights: 1,
+            recommendedActions: 2,
           },
         },
-        modelOutputCounts: {
-          highlights: 1,
-          recommendedActions: 2,
-        },
+        context: expect.objectContaining({ child: expect.anything() }),
       });
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_entity_details_highlights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_entity_details_highlights.ts
@@ -27,11 +27,11 @@ import { getAnonymizedEntityIdentifier } from '../utils/helpers';
 import type { EntityHighlightsResponse } from '../types';
 
 const HIGHLIGHTS_CONTEXT = buildExecutionContext(
-  'entity_analytics-entity_details_flyout',
+  'entity_analytics:entity_details_flyout',
   'entity_details_highlights'
 );
 const AI_SUMMARY_SAVE_CONTEXT = buildExecutionContext(
-  'entity_analytics-entity_details_flyout',
+  'entity_analytics:entity_details_flyout',
   'entity_details_ai_summary_save'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_entity_details_highlights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_entity_details_highlights.ts
@@ -22,8 +22,18 @@ import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { useCurrentUser } from '../../../../common/lib/kibana';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
+import { buildExecutionContext } from '../../../common';
 import { getAnonymizedEntityIdentifier } from '../utils/helpers';
 import type { EntityHighlightsResponse } from '../types';
+
+const HIGHLIGHTS_CONTEXT = buildExecutionContext(
+  'entity_analytics-entity_details_flyout',
+  'entity_details_highlights'
+);
+const AI_SUMMARY_SAVE_CONTEXT = buildExecutionContext(
+  'entity_analytics-entity_details_flyout',
+  'entity_details_ai_summary_save'
+);
 
 const entityHighlightsSchema = {
   type: 'object',
@@ -166,12 +176,15 @@ export const useFetchEntityDetailsHighlights = ({
       const toDate = Date.now();
       const fromDate = toDate - ENTITY_ANOMALY_DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
       const { summary, replacements, prompt } = await fetchEntityDetailsHighlights({
-        entityType,
-        entityIdentifier,
-        anonymizationFields,
-        from: fromDate,
-        to: toDate,
-        connectorId,
+        params: {
+          entityType,
+          entityIdentifier,
+          anonymizationFields,
+          from: fromDate,
+          to: toDate,
+          connectorId,
+        },
+        context: HIGHLIGHTS_CONTEXT,
       }).catch((e: Error) => {
         const caughtError = e instanceof Error ? e : new Error(String(e));
         addError(caughtError, {
@@ -232,20 +245,23 @@ export const useFetchEntityDetailsHighlights = ({
       if (persistSummary) {
         // Persist to entity store — fire-and-forget, don't block UI on this
         saveEntityAiSummary({
-          entityId: entityIdentifier,
-          entityType,
-          summary: {
-            highlights,
-            recommended_actions: recommendedActions,
-            generated_at: generatedAt,
-            staleness: buildEntitySummaryStaleness({
-              riskScoreNorm: entitySnapshot?.riskScoreNorm ?? null,
-            }),
+          params: {
+            entityId: entityIdentifier,
+            entityType,
+            summary: {
+              highlights,
+              recommended_actions: recommendedActions,
+              generated_at: generatedAt,
+              staleness: buildEntitySummaryStaleness({
+                riskScoreNorm: entitySnapshot?.riskScoreNorm ?? null,
+              }),
+            },
+            modelOutputCounts: {
+              highlights: modelHighlightsCount,
+              recommendedActions: modelRecommendedActionsCount,
+            },
           },
-          modelOutputCounts: {
-            highlights: modelHighlightsCount,
-            recommendedActions: modelRecommendedActionsCount,
-          },
+          context: AI_SUMMARY_SAVE_CONTEXT,
         })
           .then(() => {
             // Keep `generationBaseline` as the staleness-suppression source for this session.

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_persisted_ai_summary.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_persisted_ai_summary.test.tsx
@@ -48,10 +48,11 @@ describe('useFetchPersistedAiSummary', () => {
       expect(result.current.summary).toEqual(persisted.summary);
       expect(result.current.canRead).toBe(true);
     });
-    expect(fetchPersistedAiSummary).toHaveBeenCalledWith(
-      { entityType: 'user', entityIdentifier: 'user:alice' },
-      expect.any(AbortSignal)
-    );
+    expect(fetchPersistedAiSummary).toHaveBeenCalledWith({
+      params: { entityType: 'user', entityIdentifier: 'user:alice' },
+      signal: expect.any(AbortSignal),
+      context: expect.objectContaining({ child: expect.anything() }),
+    });
   });
 
   it('exposes canRead: false with a null summary when the user lacks metadata read access', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_persisted_ai_summary.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_persisted_ai_summary.ts
@@ -9,6 +9,12 @@ import { useMemo } from 'react';
 import { useQuery } from '@kbn/react-query';
 import type { PersistedEntityAiSummary } from '@kbn/entity-store/common';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
+import { buildExecutionContext } from '../../../common';
+
+const PERSISTED_AI_SUMMARY_CONTEXT = buildExecutionContext(
+  'entity_analytics-entity_details_flyout',
+  'entity_details_ai_summary_get'
+);
 
 export const PERSISTED_AI_SUMMARY_QUERY_KEY = 'PERSISTED_AI_SUMMARY';
 
@@ -43,7 +49,12 @@ export const useFetchPersistedAiSummary = ({
 
   const { data, isLoading, isFetching, refetch } = useQuery({
     queryKey: [PERSISTED_AI_SUMMARY_QUERY_KEY, entityType, entityIdentifier],
-    queryFn: ({ signal }) => fetchPersistedAiSummary({ entityType, entityIdentifier }, signal),
+    queryFn: ({ signal }) =>
+      fetchPersistedAiSummary({
+        params: { entityType, entityIdentifier },
+        signal,
+        context: PERSISTED_AI_SUMMARY_CONTEXT,
+      }),
     enabled: !skip && Boolean(entityIdentifier),
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_persisted_ai_summary.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_fetch_persisted_ai_summary.ts
@@ -12,7 +12,7 @@ import { useEntityAnalyticsRoutes } from '../../../api/api';
 import { buildExecutionContext } from '../../../common';
 
 const PERSISTED_AI_SUMMARY_CONTEXT = buildExecutionContext(
-  'entity_analytics-entity_details_flyout',
+  'entity_analytics:entity_details_flyout',
   'entity_details_ai_summary_get'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
@@ -35,7 +35,7 @@ import type { CriticalityLevel } from '../../../../../../common/entity_analytics
 import { getWatchlistName } from '../../../../../../common/entity_analytics/watchlists/constants';
 import { useGlobalTime } from '../../../../../common/containers/use_global_time';
 import { useQueryInspector } from '../../../../../common/components/page/manage_query';
-import { formatRiskScore } from '../../../../common';
+import { buildExecutionContext, formatRiskScore } from '../../../../common';
 import type {
   InputAlert,
   UseRiskContributingAlertsResult,
@@ -378,7 +378,14 @@ const RiskInputsTabContent = <T extends EntityType>({
     setQuery,
   });
 
-  const alerts = useRiskContributingAlerts<T>({ riskScore: activeRiskScore, entityType });
+  const alerts = useRiskContributingAlerts<T>({
+    riskScore: activeRiskScore,
+    entityType,
+    executionContext: buildExecutionContext(
+      'entity_analytics-entity_details_flyout',
+      'risk_inputs_alerts'
+    ),
+  });
 
   const entityNameByEuid = useMemo(() => {
     const map = new Map<string, string>();

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_link_entities.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_link_entities.test.ts
@@ -50,11 +50,14 @@ describe('useLinkEntities', () => {
     });
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/security/entity_store/resolution/link', {
-        version: '2023-10-31',
-        method: 'POST',
-        body: JSON.stringify({ target_id: 'target-1', entity_ids: ['alias-1'] }),
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/security/entity_store/resolution/link',
+        expect.objectContaining({
+          version: '2023-10-31',
+          method: 'POST',
+          body: JSON.stringify({ target_id: 'target-1', entity_ids: ['alias-1'] }),
+        })
+      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_link_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_link_entities.ts
@@ -11,6 +11,7 @@ import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/public';
 import { API_VERSIONS } from '../../../../../common/entity_analytics/constants';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
+import { buildExecutionContext } from '../../../common';
 import {
   ENTITY_RESOLVED_TOAST,
   ENTITY_RESOLVED_TOAST_TEXT,
@@ -44,6 +45,7 @@ export const useLinkEntities = (options?: UseLinkEntitiesOptions) => {
         version: API_VERSIONS.public.v1,
         method: 'POST',
         body: JSON.stringify(params),
+        context: buildExecutionContext('entity_analytics-entity_resolution', 'resolution_link'),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [RESOLUTION_GROUP_QUERY_KEY] });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_link_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_link_entities.ts
@@ -45,7 +45,7 @@ export const useLinkEntities = (options?: UseLinkEntitiesOptions) => {
         version: API_VERSIONS.public.v1,
         method: 'POST',
         body: JSON.stringify(params),
-        context: buildExecutionContext('entity_analytics-entity_resolution', 'resolution_link'),
+        context: buildExecutionContext('entity_analytics:entity_resolution', 'resolution_link'),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [RESOLUTION_GROUP_QUERY_KEY] });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_resolution_group.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_resolution_group.test.ts
@@ -45,11 +45,14 @@ describe('useResolutionGroup', () => {
     });
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(RESOLUTION_GROUP_ROUTE, {
-        version: '2023-10-31',
-        method: 'GET',
-        query: { entity_id: 'target-1' },
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        RESOLUTION_GROUP_ROUTE,
+        expect.objectContaining({
+          version: '2023-10-31',
+          method: 'GET',
+          query: { entity_id: 'target-1' },
+        })
+      );
       expect(result.current.data).toEqual(mockGroup);
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_resolution_group.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_resolution_group.ts
@@ -10,6 +10,7 @@ import type { IHttpFetchError } from '@kbn/core/public';
 import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/public';
 import { API_VERSIONS } from '../../../../../common/entity_analytics/constants';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
+import { buildExecutionContext } from '../../../common';
 
 export const RESOLUTION_GROUP_ROUTE = ENTITY_STORE_ROUTES.public.RESOLUTION_GROUP;
 export const RESOLUTION_GROUP_QUERY_KEY = 'resolution-group';
@@ -34,6 +35,7 @@ export const useResolutionGroup = (entityId: string, options?: UseResolutionGrou
         version: API_VERSIONS.public.v1,
         method: 'GET',
         query: { entity_id: entityId },
+        context: buildExecutionContext('entity_analytics-entity_resolution', 'resolution_group'),
       }),
     enabled: options?.enabled !== false && !!entityId,
     refetchOnWindowFocus: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_resolution_group.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_resolution_group.ts
@@ -35,7 +35,7 @@ export const useResolutionGroup = (entityId: string, options?: UseResolutionGrou
         version: API_VERSIONS.public.v1,
         method: 'GET',
         query: { entity_id: entityId },
-        context: buildExecutionContext('entity_analytics-entity_resolution', 'resolution_group'),
+        context: buildExecutionContext('entity_analytics:entity_resolution', 'resolution_group'),
       }),
     enabled: options?.enabled !== false && !!entityId,
     refetchOnWindowFocus: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_unlink_entities.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_unlink_entities.test.ts
@@ -50,11 +50,14 @@ describe('useUnlinkEntities', () => {
     });
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/security/entity_store/resolution/unlink', {
-        version: '2023-10-31',
-        method: 'POST',
-        body: JSON.stringify({ entity_ids: ['alias-1'] }),
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/security/entity_store/resolution/unlink',
+        expect.objectContaining({
+          version: '2023-10-31',
+          method: 'POST',
+          body: JSON.stringify({ entity_ids: ['alias-1'] }),
+        })
+      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_unlink_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_unlink_entities.ts
@@ -11,6 +11,7 @@ import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/public';
 import { API_VERSIONS } from '../../../../../common/entity_analytics/constants';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
+import { buildExecutionContext } from '../../../common';
 import {
   ENTITY_REMOVED_TOAST,
   ENTITY_REMOVED_TOAST_TEXT,
@@ -38,6 +39,7 @@ export const useUnlinkEntities = () => {
         version: API_VERSIONS.public.v1,
         method: 'POST',
         body: JSON.stringify(params),
+        context: buildExecutionContext('entity_analytics-entity_resolution', 'resolution_unlink'),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [RESOLUTION_GROUP_QUERY_KEY] });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_unlink_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_unlink_entities.ts
@@ -39,7 +39,7 @@ export const useUnlinkEntities = () => {
         version: API_VERSIONS.public.v1,
         method: 'POST',
         body: JSON.stringify(params),
-        context: buildExecutionContext('entity_analytics-entity_resolution', 'resolution_unlink'),
+        context: buildExecutionContext('entity_analytics:entity_resolution', 'resolution_unlink'),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [RESOLUTION_GROUP_QUERY_KEY] });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.tsx
@@ -82,7 +82,7 @@ export const EntitiesList: React.FC = () => {
         },
       }),
       executionContext: buildExecutionContext(
-        'entity_analytics-entity_store_management',
+        'entity_analytics:entity_store_management',
         'entities_list'
       ),
     }),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.tsx
@@ -23,6 +23,7 @@ import { EntitySourceFilter } from './components/entity_source_filter';
 import { useEntitiesListFilters } from './hooks/use_entities_list_filters';
 import { AssetCriticalityFilter } from '../asset_criticality/asset_criticality_filter';
 import { useEntitiesListQuery } from './hooks/use_entities_list_query';
+import { buildExecutionContext } from '../../common';
 import { ENTITIES_LIST_TABLE_ID, rowItems } from './constants';
 import { useEntitiesListColumns } from './hooks/use_entities_list_columns';
 import type { EntitySourceTag } from './types';
@@ -80,6 +81,10 @@ export const EntitiesList: React.FC = () => {
           filter,
         },
       }),
+      executionContext: buildExecutionContext(
+        'entity_analytics-entity_store_management',
+        'entities_list'
+      ),
     }),
     [entityTypes, activePage, limit, sorting.field, sorting.direction, querySkip, filter]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_query.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_query.test.tsx
@@ -57,8 +57,37 @@ describe('useEntitiesListQuery', () => {
           sortOrder: 'desc',
         },
         signal: expect.any(AbortSignal),
+        context: undefined,
       });
       expect(result.current.data).toEqual(v2Response);
+    });
+  });
+
+  it('forwards a caller-supplied executionContext to fetchEntitiesListV2', async () => {
+    const executionContext = {
+      child: {
+        type: 'security_solution',
+        name: 'entity_analytics-entity_store_management',
+        id: 'entities_list',
+      },
+    };
+    const searchParams = {
+      entityTypes: ['host'] as EntityType[],
+      page: 1,
+      perPage: 20,
+      sortField: '@timestamp',
+      sortOrder: 'desc' as const,
+    };
+    fetchEntitiesListV2Mock.mockResolvedValueOnce({ records: [] });
+
+    renderHook(() => useEntitiesListQuery({ ...searchParams, skip: false, executionContext }), {
+      wrapper: TestWrapper,
+    });
+
+    await waitFor(() => {
+      expect(fetchEntitiesListV2Mock).toHaveBeenCalledWith(
+        expect.objectContaining({ context: executionContext })
+      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_query.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_query.test.tsx
@@ -67,7 +67,7 @@ describe('useEntitiesListQuery', () => {
     const executionContext = {
       child: {
         type: 'security_solution',
-        name: 'entity_analytics-entity_store_management',
+        name: 'entity_analytics:entity_store_management',
         id: 'entities_list',
       },
     };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_query.ts
@@ -7,6 +7,7 @@
 
 import { useQuery } from '@kbn/react-query';
 import type { IHttpFetchError } from '@kbn/core/public';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { EntityType as EntityStoreEntityType } from '@kbn/entity-store/public';
 import type { ListEntitiesResponse } from '@kbn/entity-store/common';
 import type { FetchEntitiesListParams } from '../../../api/api';
@@ -16,10 +17,17 @@ export const ENTITY_STORE_ENTITIES_LIST = 'ENTITY_STORE_ENTITIES_LIST';
 
 interface UseEntitiesListParams extends FetchEntitiesListParams {
   skip: boolean;
+  /**
+   * Optional Kibana execution context. Forwarded to `fetchEntitiesListV2` so slow logs and APM
+   * traces can attribute the query to the caller's page/panel. Callers typically pass a
+   * `{ child: { type: 'security_solution', name: '<page>', id: '<panel>' } }` descriptor built via
+   * `buildExecutionContext(...)`.
+   */
+  executionContext?: KibanaExecutionContext;
 }
 
 export const useEntitiesListQuery = (params: UseEntitiesListParams) => {
-  const { skip, ...fetchParams } = params;
+  const { skip, executionContext, ...fetchParams } = params;
   const { fetchEntitiesListV2 } = useEntityAnalyticsRoutes();
 
   return useQuery<ListEntitiesResponse | null, IHttpFetchError>({
@@ -33,6 +41,7 @@ export const useEntitiesListQuery = (params: UseEntitiesListParams) => {
           page: fetchParams.page ?? 1,
           perPage: fetchParams.perPage ?? 20,
         },
+        context: executionContext,
       }),
     cacheTime: 0,
     enabled: !skip,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
@@ -11,7 +11,10 @@ import type { IHttpFetchError } from '@kbn/core-http-browser';
 import type { GetEntityStoreStatusResponse } from '@kbn/entity-store/common';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { useEntityStoreRoutes } from '../../../api/entity_store';
+import { buildExecutionContext } from '../../../common';
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
+
+const ENTITY_STORE_MANAGEMENT_PAGE = 'entity_analytics-entity_store_management';
 
 const ENTITY_STORE_STATUS = ['GET', 'ENTITY_STORE_STATUS'];
 
@@ -30,7 +33,11 @@ export const useEntityStoreStatus = (opts: Options = {}) => {
 
   return useQuery<GetEntityStoreStatusResponse, IHttpFetchError>({
     queryKey: [...ENTITY_STORE_STATUS, opts.withComponents],
-    queryFn: () => getEntityStoreStatus(opts.withComponents),
+    queryFn: () =>
+      getEntityStoreStatus(
+        opts.withComponents,
+        buildExecutionContext(ENTITY_STORE_MANAGEMENT_PAGE, 'entity_store_status')
+      ),
     enabled: opts.enabled !== false,
     structuralSharing: opts.structuralSharing,
     refetchInterval:
@@ -60,7 +67,9 @@ export const useInstallEntityStoreMutation = () => {
         timestamp: new Date().toISOString(),
         action: 'start',
       });
-      return installEntityStore();
+      return installEntityStore(
+        buildExecutionContext(ENTITY_STORE_MANAGEMENT_PAGE, 'entity_store_install')
+      );
     },
     {
       mutationKey: INSTALL_ENTITY_STORE_KEY,
@@ -81,7 +90,9 @@ export const useStartEntityStoreMutation = () => {
         timestamp: new Date().toISOString(),
         action: 'start',
       });
-      return startEntityStore();
+      return startEntityStore(
+        buildExecutionContext(ENTITY_STORE_MANAGEMENT_PAGE, 'entity_store_start')
+      );
     },
     {
       mutationKey: START_ENTITY_STORE_KEY,
@@ -102,7 +113,9 @@ export const useStopEntityStoreMutation = () => {
         timestamp: new Date().toISOString(),
         action: 'stop',
       });
-      return stopEntityStore();
+      return stopEntityStore(
+        buildExecutionContext(ENTITY_STORE_MANAGEMENT_PAGE, 'entity_store_stop')
+      );
     },
     {
       mutationKey: STOP_ENTITY_STORE_KEY,
@@ -116,11 +129,15 @@ export const useDeleteEntityStoreMutation = ({ onSuccess }: { onSuccess?: () => 
   const queryClient = useQueryClient();
   const { deleteEntityStore } = useEntityStoreRoutes();
 
-  return useMutation(() => deleteEntityStore(), {
-    mutationKey: DELETE_ENTITY_STORE_KEY,
-    onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: ENTITY_STORE_STATUS });
-      onSuccess?.();
-    },
-  });
+  return useMutation(
+    () =>
+      deleteEntityStore(buildExecutionContext(ENTITY_STORE_MANAGEMENT_PAGE, 'entity_store_delete')),
+    {
+      mutationKey: DELETE_ENTITY_STORE_KEY,
+      onSuccess: () => {
+        queryClient.refetchQueries({ queryKey: ENTITY_STORE_STATUS });
+        onSuccess?.();
+      },
+    }
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
@@ -14,7 +14,7 @@ import { useEntityStoreRoutes } from '../../../api/entity_store';
 import { buildExecutionContext } from '../../../common';
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
 
-const ENTITY_STORE_MANAGEMENT_PAGE = 'entity_analytics-entity_store_management';
+const ENTITY_STORE_MANAGEMENT_PAGE = 'entity_analytics:entity_store_management';
 
 const ENTITY_STORE_STATUS = ['GET', 'ENTITY_STORE_STATUS'];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
@@ -130,9 +130,11 @@ export const useFetchGroupedData = ({
           },
           {
             executionContext: {
-              type: 'security_solution',
-              name: 'entity_analytics-home_page',
-              id: 'entities_table_grouped',
+              child: {
+                type: 'security_solution',
+                name: 'entity_analytics-home_page',
+                id: 'entities_table_grouped',
+              },
             },
           }
         )
@@ -184,9 +186,11 @@ export const useFetchTargetMetadata = (entityIds: string[]): TargetMetadataMap =
           },
           {
             executionContext: {
-              type: 'security_solution',
-              name: 'entity_analytics-home_page',
-              id: 'entities_table_target_metadata',
+              child: {
+                type: 'security_solution',
+                name: 'entity_analytics-home_page',
+                id: 'entities_table_target_metadata',
+              },
             },
           }
         )

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
@@ -124,9 +124,18 @@ export const useFetchGroupedData = ({
         searchService.search<
           {},
           IKibanaSearchResponse<SearchResponse<{}, EntitiesRootGroupingAggregation>>
-        >({
-          params: getGroupedEntitiesQuery(query, indexPattern),
-        })
+        >(
+          {
+            params: getGroupedEntitiesQuery(query, indexPattern),
+          },
+          {
+            executionContext: {
+              type: 'security_solution',
+              name: 'entity_analytics-home_page',
+              id: 'entities_table_grouped',
+            },
+          }
+        )
       );
 
       if (!aggregations) throw new Error('Failed to aggregate by, missing resource id');
@@ -151,27 +160,36 @@ export const useFetchTargetMetadata = (entityIds: string[]): TargetMetadataMap =
       const {
         rawResponse: { hits },
       } = await lastValueFrom(
-        searchService.search<{}, IKibanaSearchResponse<SearchResponse>>({
-          params: {
-            index: indexPattern,
-            project_routing: '_alias:_origin',
-            ignore_unavailable: true,
-            size: entityIds.length,
-            _source: [
-              ENTITY_FIELDS.ENTITY_ID,
-              ENTITY_FIELDS.ENTITY_NAME,
-              ENTITY_FIELDS.ENTITY_TYPE,
-              ENTITY_FIELDS.ENTITY_RISK,
-              ENTITY_FIELDS.RESOLUTION_RISK_SCORE,
-            ],
-            query: {
-              bool: {
-                filter: [{ terms: { [ENTITY_FIELDS.ENTITY_ID]: entityIds } }],
-                must_not: [{ exists: { field: ENTITY_FIELDS.RESOLVED_TO } }],
+        searchService.search<{}, IKibanaSearchResponse<SearchResponse>>(
+          {
+            params: {
+              index: indexPattern,
+              project_routing: '_alias:_origin',
+              ignore_unavailable: true,
+              size: entityIds.length,
+              _source: [
+                ENTITY_FIELDS.ENTITY_ID,
+                ENTITY_FIELDS.ENTITY_NAME,
+                ENTITY_FIELDS.ENTITY_TYPE,
+                ENTITY_FIELDS.ENTITY_RISK,
+                ENTITY_FIELDS.RESOLUTION_RISK_SCORE,
+              ],
+              query: {
+                bool: {
+                  filter: [{ terms: { [ENTITY_FIELDS.ENTITY_ID]: entityIds } }],
+                  must_not: [{ exists: { field: ENTITY_FIELDS.RESOLVED_TO } }],
+                },
               },
             },
           },
-        })
+          {
+            executionContext: {
+              type: 'security_solution',
+              name: 'entity_analytics-home_page',
+              id: 'entities_table_target_metadata',
+            },
+          }
+        )
       );
 
       return parseTargetMetadataHits(hits.hits);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
@@ -14,6 +14,7 @@ import { showErrorToast } from '@kbn/cloud-security-posture';
 import { useContext, useMemo } from 'react';
 import type { EntityType } from '../../../../../../common/entity_analytics/types';
 import { useKibana } from '../../../../../common/lib/kibana';
+import { buildExecutionContext } from '../../../../common';
 import {
   ENTITY_FIELDS,
   QUERY_KEY_GROUPING_DATA,
@@ -129,13 +130,10 @@ export const useFetchGroupedData = ({
             params: getGroupedEntitiesQuery(query, indexPattern),
           },
           {
-            executionContext: {
-              child: {
-                type: 'security_solution',
-                name: 'entity_analytics-home_page',
-                id: 'entities_table_grouped',
-              },
-            },
+            executionContext: buildExecutionContext(
+              'entity_analytics-home_page',
+              'entities_table_grouped'
+            ),
           }
         )
       );
@@ -185,13 +183,10 @@ export const useFetchTargetMetadata = (entityIds: string[]): TargetMetadataMap =
             },
           },
           {
-            executionContext: {
-              child: {
-                type: 'security_solution',
-                name: 'entity_analytics-home_page',
-                id: 'entities_table_target_metadata',
-              },
-            },
+            executionContext: buildExecutionContext(
+              'entity_analytics-home_page',
+              'entities_table_target_metadata'
+            ),
           }
         )
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
@@ -131,7 +131,7 @@ export const useFetchGroupedData = ({
           },
           {
             executionContext: buildExecutionContext(
-              'entity_analytics-home_page',
+              'entity_analytics:home_page',
               'entities_table_grouped'
             ),
           }
@@ -184,7 +184,7 @@ export const useFetchTargetMetadata = (entityIds: string[]): TargetMetadataMap =
           },
           {
             executionContext: buildExecutionContext(
-              'entity_analytics-home_page',
+              'entity_analytics:home_page',
               'entities_table_target_metadata'
             ),
           }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
@@ -16,6 +16,7 @@ import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-ty
 import type { BaseEsQuery } from '@kbn/cloud-security-posture';
 import { useContext, useMemo } from 'react';
 import { useKibana } from '../../../../../common/lib/kibana';
+import { buildExecutionContext } from '../../../../common';
 import {
   ENTITY_FIELDS,
   ENTITY_TYPE_FILTER,
@@ -105,13 +106,7 @@ export function useFetchGridData(options: UseEntitiesOptions) {
             params: queryParams as LatestEntitiesRequest['params'],
           },
           {
-            executionContext: {
-              child: {
-                type: 'security_solution',
-                name: 'entity_analytics-home_page',
-                id: 'entities_table',
-              },
-            },
+            executionContext: buildExecutionContext('entity_analytics-home_page', 'entities_table'),
           }
         )
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
@@ -100,9 +100,18 @@ export function useFetchGridData(options: UseEntitiesOptions) {
         rawResponse,
         rawResponse: { hits },
       } = await lastValueFrom(
-        data.search.search<LatestEntitiesRequest, LatestEntitiesResponse>({
-          params: queryParams as LatestEntitiesRequest['params'],
-        })
+        data.search.search<LatestEntitiesRequest, LatestEntitiesResponse>(
+          {
+            params: queryParams as LatestEntitiesRequest['params'],
+          },
+          {
+            executionContext: {
+              type: 'security_solution',
+              name: 'entity_analytics-home_page',
+              id: 'entities_table',
+            },
+          }
+        )
       );
 
       return {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
@@ -106,9 +106,11 @@ export function useFetchGridData(options: UseEntitiesOptions) {
           },
           {
             executionContext: {
-              type: 'security_solution',
-              name: 'entity_analytics-home_page',
-              id: 'entities_table',
+              child: {
+                type: 'security_solution',
+                name: 'entity_analytics-home_page',
+                id: 'entities_table',
+              },
             },
           }
         )

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
@@ -106,7 +106,7 @@ export function useFetchGridData(options: UseEntitiesOptions) {
             params: queryParams as LatestEntitiesRequest['params'],
           },
           {
-            executionContext: buildExecutionContext('entity_analytics-home_page', 'entities_table'),
+            executionContext: buildExecutionContext('entity_analytics:home_page', 'entities_table'),
           }
         )
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
@@ -133,9 +133,11 @@ export const EntityAlertsCell: React.FC<{
           // hasn't supplied one.
           signal: signal ?? new AbortController().signal,
           context: {
-            type: 'security_solution',
-            name: 'entity_analytics-home_page',
-            id: 'entity_alerts_cell',
+            child: {
+              type: 'security_solution',
+              name: 'entity_analytics-home_page',
+              id: 'entity_alerts_cell',
+            },
           },
         });
         endTracking('success');

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
@@ -132,6 +132,11 @@ export const EntityAlertsCell: React.FC<{
           // to a fresh controller so the call type-checks when react-query
           // hasn't supplied one.
           signal: signal ?? new AbortController().signal,
+          context: {
+            type: 'security_solution',
+            name: 'entity_analytics-home_page',
+            id: 'entity_alerts_cell',
+          },
         });
         endTracking('success');
         return response;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
@@ -133,7 +133,7 @@ export const EntityAlertsCell: React.FC<{
           // to a fresh controller so the call type-checks when react-query
           // hasn't supplied one.
           signal: signal ?? new AbortController().signal,
-          context: buildExecutionContext('entity_analytics-home_page', 'entity_alerts_cell'),
+          context: buildExecutionContext('entity_analytics:home_page', 'entity_alerts_cell'),
         });
         endTracking('success');
         return response;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
@@ -45,6 +45,7 @@ import {
   parseAlertsData,
 } from '../../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
 import { getFormattedAlertStats } from '../../../flyout_v2/document/main/components/alert_count_insight';
+import { buildExecutionContext } from '../../common';
 
 const QUERY_KEY_ENTITY_ALERTS_BY_STATUS = 'entity-analytics-alerts-by-status';
 
@@ -132,13 +133,7 @@ export const EntityAlertsCell: React.FC<{
           // to a fresh controller so the call type-checks when react-query
           // hasn't supplied one.
           signal: signal ?? new AbortController().signal,
-          context: {
-            child: {
-              type: 'security_solution',
-              name: 'entity_analytics-home_page',
-              id: 'entity_alerts_cell',
-            },
-          },
+          context: buildExecutionContext('entity_analytics-home_page', 'entity_alerts_cell'),
         });
         endTracking('success');
         return response;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/pad_chart/hooks/pad_query_hooks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/pad_chart/hooks/pad_query_hooks.tsx
@@ -14,6 +14,7 @@ import { useEsqlGlobalFilterQuery } from '../../../../../../../common/hooks/esql
 import { esqlResponseToRecords } from '../../../../../../../common/utils/esql';
 import { useKibana } from '../../../../../../../common/lib/kibana';
 import { useErrorToast } from '../../../../../../../common/hooks/use_error_toast';
+import { buildExecutionContext } from '../../../../../../common';
 import type { AnomalyBand } from '../../../../../recent_anomalies';
 import {
   usePadAnomalyDataEsqlSource,
@@ -59,6 +60,10 @@ const usePrivilegedAccessDetectionTopUsersQuery = (params: {
             search,
             signal,
             filter: filterQuery,
+            executionContext: buildExecutionContext(
+              'entity_analytics-privileged_user_monitoring',
+              'pad_chart_top_users'
+            ),
           })
         )?.response
       );
@@ -109,6 +114,10 @@ export const usePrivilegedAccessDetectionAnomaliesQuery = (params: {
             search,
             signal,
             filter: filterQuery,
+            executionContext: buildExecutionContext(
+              'entity_analytics-privileged_user_monitoring',
+              'pad_chart_anomalies'
+            ),
           })
         ).response
       ).map((eachRawRecord) => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/pad_chart/hooks/pad_query_hooks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/pad_chart/hooks/pad_query_hooks.tsx
@@ -61,7 +61,7 @@ const usePrivilegedAccessDetectionTopUsersQuery = (params: {
             signal,
             filter: filterQuery,
             executionContext: buildExecutionContext(
-              'entity_analytics-privileged_user_monitoring',
+              'entity_analytics:privileged_user_monitoring',
               'pad_chart_top_users'
             ),
           })
@@ -115,7 +115,7 @@ export const usePrivilegedAccessDetectionAnomaliesQuery = (params: {
             signal,
             filter: filterQuery,
             executionContext: buildExecutionContext(
-              'entity_analytics-privileged_user_monitoring',
+              'entity_analytics:privileged_user_monitoring',
               'pad_chart_anomalies'
             ),
           })

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/hooks.ts
@@ -20,7 +20,19 @@ import { getPrivilegedMonitorUsersIndex } from '../../../../../../common/entity_
 import type { CriticalityLevelWithUnassigned } from '../../../../../../common/entity_analytics/asset_criticality/types';
 import type { EntityRiskScore } from '../../../../../../common/search_strategy';
 import { useKibana } from '../../../../../common/lib/kibana';
+import { buildExecutionContext } from '../../../../common';
 import { DEFAULT_PAGE_SIZE } from '.';
+
+const PUM_PAGE = 'entity_analytics-privileged_user_monitoring';
+const PRIVILEGED_USERS_TABLE_CONTEXT = buildExecutionContext(PUM_PAGE, 'privileged_users_table');
+const PRIVILEGED_USERS_RISK_SCORE_CONTEXT = buildExecutionContext(
+  PUM_PAGE,
+  'privileged_users_risk_score'
+);
+const PRIVILEGED_USERS_ASSET_CRITICALITY_CONTEXT = buildExecutionContext(
+  PUM_PAGE,
+  'privileged_users_asset_criticality'
+);
 
 interface RiskScoresByUserName {
   [key: string]: EntityRiskScore<EntityType.user>;
@@ -56,6 +68,7 @@ export const usePrivilegedUsersTableData = (
         esqlQuery: privilegedUsersTableQuery,
         search: data.search.search,
         filter: filterQueryWithoutTimerange,
+        executionContext: PRIVILEGED_USERS_TABLE_CONTEXT,
       });
     },
   });
@@ -81,6 +94,7 @@ export const usePrivilegedUsersTableData = (
       querySize: records.length,
     },
     skip: nameFilterQuery === undefined || records.length === 0,
+    executionContext: PRIVILEGED_USERS_RISK_SCORE_CONTEXT,
   });
 
   const riskScores = riskScoreData && riskScoreData.length > 0 ? riskScoreData : [];
@@ -96,6 +110,7 @@ export const usePrivilegedUsersTableData = (
     idField: 'user.name',
     idValues: records.map((user) => user['user.name']),
     skip: !toggleStatus || records.length === 0,
+    executionContext: PRIVILEGED_USERS_ASSET_CRITICALITY_CONTEXT,
   });
   const assetCriticalityRecords =
     assetCriticalityData && assetCriticalityData.records.length > 0

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/hooks.ts
@@ -23,7 +23,7 @@ import { useKibana } from '../../../../../common/lib/kibana';
 import { buildExecutionContext } from '../../../../common';
 import { DEFAULT_PAGE_SIZE } from '.';
 
-const PUM_PAGE = 'entity_analytics-privileged_user_monitoring';
+const PUM_PAGE = 'entity_analytics:privileged_user_monitoring';
 const PRIVILEGED_USERS_TABLE_CONTEXT = buildExecutionContext(PUM_PAGE, 'privileged_users_table');
 const PRIVILEGED_USERS_RISK_SCORE_CONTEXT = buildExecutionContext(
   PUM_PAGE,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/hooks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/hooks.tsx
@@ -18,6 +18,7 @@ import { useErrorToast } from '../../../../../common/hooks/use_error_toast';
 import { useEsqlGlobalFilterQuery } from '../../../../../common/hooks/esql/use_esql_global_filter';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useGetDefaultRiskIndex } from '../../../../hooks/use_get_default_risk_index';
+import { buildExecutionContext } from '../../../../common';
 import type { RiskLevelsTableItem, RiskLevelsPrivilegedUsersQueryResult } from './types';
 import { RiskScoreLevel } from '../../../severity/common';
 import type { RiskSeverity } from '../../../../../../common/search_strategy';
@@ -64,6 +65,10 @@ export const useRiskLevelsPrivilegedUserQuery = ({
         search: data.search.search,
         signal,
         filter: filterQuery,
+        executionContext: buildExecutionContext(
+          'entity_analytics-privileged_user_monitoring',
+          'pum_risk_level_panel'
+        ),
       }),
     {
       keepPreviousData: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/hooks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/hooks.tsx
@@ -66,7 +66,7 @@ export const useRiskLevelsPrivilegedUserQuery = ({
         signal,
         filter: filterQuery,
         executionContext: buildExecutionContext(
-          'entity_analytics-privileged_user_monitoring',
+          'entity_analytics:privileged_user_monitoring',
           'pum_risk_level_panel'
         ),
       }),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/hooks/manage_data_sources_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/hooks/manage_data_sources_query_hooks.ts
@@ -33,7 +33,7 @@ export const useGetLatestCSVPrivilegedUserUploadQuery = (namespace: string) => {
             search,
             signal,
             executionContext: buildExecutionContext(
-              'entity_analytics-privileged_user_monitoring',
+              'entity_analytics:privileged_user_monitoring',
               'pum_data_sources_latest_csv'
             ),
           })

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/hooks/manage_data_sources_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/hooks/manage_data_sources_query_hooks.ts
@@ -10,6 +10,7 @@ import { getESQLResults } from '@kbn/esql-utils';
 import { getPrivilegedMonitorUsersIndex } from '../../../../../common/entity_analytics/privileged_user_monitoring/utils';
 import { esqlResponseToRecords } from '../../../../common/utils/esql';
 import { useKibana } from '../../../../common/lib/kibana';
+import { buildExecutionContext } from '../../../common';
 
 const getLatestCSVPrivilegedUserUploadQuery = (namespace: string) => {
   return `FROM ${getPrivilegedMonitorUsersIndex(namespace)}
@@ -31,6 +32,10 @@ export const useGetLatestCSVPrivilegedUserUploadQuery = (namespace: string) => {
             esqlQuery: getLatestCSVPrivilegedUserUploadQuery(namespace),
             search,
             signal,
+            executionContext: buildExecutionContext(
+              'entity_analytics-privileged_user_monitoring',
+              'pum_data_sources_latest_csv'
+            ),
           })
         )?.response
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/hooks.ts
@@ -15,6 +15,7 @@ import { useGlobalTime } from '../../../../../common/containers/use_global_time'
 import { useQueryInspector } from '../../../../../common/components/page/manage_query';
 import { esqlResponseToRecords } from '../../../../../common/utils/esql';
 import { useKibana } from '../../../../../common/lib/kibana';
+import { buildExecutionContext } from '../../../../common';
 import type { EsqlQueryOrInvalidFields } from '../../../privileged_user_monitoring/queries/helpers';
 
 export const DASHBOARD_TABLE_QUERY_ID = 'privmonDashboardTableQueryId';
@@ -45,6 +46,10 @@ export const useDashboardTableQuery = <TableItemType extends Record<string, stri
         search: data.search.search,
         signal,
         filter: filterQuery,
+        executionContext: buildExecutionContext(
+          'entity_analytics-privileged_user_monitoring',
+          'pum_onboarding_dashboard_panel'
+        ),
       });
     },
     {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/hooks.ts
@@ -47,7 +47,7 @@ export const useDashboardTableQuery = <TableItemType extends Record<string, stri
         signal,
         filter: filterQuery,
         executionContext: buildExecutionContext(
-          'entity_analytics-privileged_user_monitoring',
+          'entity_analytics:privileged_user_monitoring',
           'pum_onboarding_dashboard_panel'
         ),
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_monitored_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_monitored_indices.ts
@@ -17,7 +17,7 @@ export const useFetchMonitoredIndices = () => {
       listPrivMonMonitoredIndices({
         signal,
         context: buildExecutionContext(
-          'entity_analytics-privileged_user_monitoring',
+          'entity_analytics:privileged_user_monitoring',
           'pum_monitored_indices_list'
         ),
       }),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_monitored_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_monitored_indices.ts
@@ -7,12 +7,20 @@
 
 import { useQuery } from '@kbn/react-query';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
+import { buildExecutionContext } from '../../../common';
 
 export const useFetchMonitoredIndices = () => {
   const { listPrivMonMonitoredIndices } = useEntityAnalyticsRoutes();
   return useQuery(
     ['POST', 'LIST_PRIVILEGED_USER_MONITORED_INDICES'],
-    ({ signal }) => listPrivMonMonitoredIndices({ signal }),
+    ({ signal }) =>
+      listPrivMonMonitoredIndices({
+        signal,
+        context: buildExecutionContext(
+          'entity_analytics-privileged_user_monitoring',
+          'pum_monitored_indices_list'
+        ),
+      }),
     {
       keepPreviousData: true,
       refetchOnWindowFocus: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_privileged_user_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_privileged_user_indices.ts
@@ -18,7 +18,7 @@ export const useFetchPrivilegedUserIndices = (query: string | undefined) => {
         signal,
         query,
         context: buildExecutionContext(
-          'entity_analytics-privileged_user_monitoring',
+          'entity_analytics:privileged_user_monitoring',
           'pum_indices_search'
         ),
       }),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_privileged_user_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_privileged_user_indices.ts
@@ -7,12 +7,21 @@
 
 import { useQuery } from '@kbn/react-query';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
+import { buildExecutionContext } from '../../../common';
 
 export const useFetchPrivilegedUserIndices = (query: string | undefined) => {
   const { searchPrivMonIndices } = useEntityAnalyticsRoutes();
   return useQuery(
     ['POST', 'SEARCH_PRIVILEGED_USER_MONITORING_INDICES', query],
-    ({ signal }) => searchPrivMonIndices({ signal, query }),
+    ({ signal }) =>
+      searchPrivMonIndices({
+        signal,
+        query,
+        context: buildExecutionContext(
+          'entity_analytics-privileged_user_monitoring',
+          'pum_indices_search'
+        ),
+      }),
     {
       keepPreviousData: true,
       cacheTime: 0, // Do not cache the data because it is used by an autocomplete query

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -15,6 +15,7 @@ import { ML_ANOMALIES_INDEX } from '../../../../../common/constants';
 import type { ESBoolQuery } from '../../../../../common/typed_json';
 import { useGlobalFilterQuery } from '../../../../common/hooks/use_global_filter_query';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
+import { buildExecutionContext } from '../../../common';
 import { esqlResponseToRecords } from '../../../../common/utils/esql';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useErrorToast } from '../../../../common/hooks/use_error_toast';
@@ -112,13 +113,10 @@ const useFilteredEntityIds = (spaceId?: string): FilteredEntityIds => {
         search,
         signal,
         filter: filterQuery,
-        executionContext: {
-          child: {
-            type: 'security_solution',
-            name: 'entity_analytics-home_page',
-            id: 'anomalies_entity_filter',
-          },
-        },
+        executionContext: buildExecutionContext(
+          'entity_analytics-home_page',
+          'anomalies_entity_filter'
+        ),
       });
       return esqlResponseToRecords<{ 'entity.id': string }>(esqlResult?.response)
         .map((record) => record['entity.id'])
@@ -213,13 +211,7 @@ const useRecentAnomaliesTopRowsQuery = (params: {
         search,
         signal,
         timeRange,
-        executionContext: {
-          child: {
-            type: 'security_solution',
-            name: 'entity_analytics-home_page',
-            id: 'anomalies_top_rows',
-          },
-        },
+        executionContext: buildExecutionContext('entity_analytics-home_page', 'anomalies_top_rows'),
       });
       return {
         records: esqlResponseToRecords<Record<string, string>>(esqlResult?.response),
@@ -314,13 +306,7 @@ export const useRecentAnomaliesQuery = (params: {
         search,
         signal,
         timeRange,
-        executionContext: {
-          child: {
-            type: 'security_solution',
-            name: 'entity_analytics-home_page',
-            id: 'anomalies_heatmap',
-          },
-        },
+        executionContext: buildExecutionContext('entity_analytics-home_page', 'anomalies_heatmap'),
       });
       const anomalyRecords = esqlResponseToRecords<Record<string, string | number>>(
         esqlResult.response

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -113,9 +113,11 @@ const useFilteredEntityIds = (spaceId?: string): FilteredEntityIds => {
         signal,
         filter: filterQuery,
         executionContext: {
-          type: 'security_solution',
-          name: 'entity_analytics-home_page',
-          id: 'anomalies_entity_filter',
+          child: {
+            type: 'security_solution',
+            name: 'entity_analytics-home_page',
+            id: 'anomalies_entity_filter',
+          },
         },
       });
       return esqlResponseToRecords<{ 'entity.id': string }>(esqlResult?.response)
@@ -212,9 +214,11 @@ const useRecentAnomaliesTopRowsQuery = (params: {
         signal,
         timeRange,
         executionContext: {
-          type: 'security_solution',
-          name: 'entity_analytics-home_page',
-          id: 'anomalies_top_rows',
+          child: {
+            type: 'security_solution',
+            name: 'entity_analytics-home_page',
+            id: 'anomalies_top_rows',
+          },
         },
       });
       return {
@@ -311,9 +315,11 @@ export const useRecentAnomaliesQuery = (params: {
         signal,
         timeRange,
         executionContext: {
-          type: 'security_solution',
-          name: 'entity_analytics-home_page',
-          id: 'anomalies_heatmap',
+          child: {
+            type: 'security_solution',
+            name: 'entity_analytics-home_page',
+            id: 'anomalies_heatmap',
+          },
         },
       });
       const anomalyRecords = esqlResponseToRecords<Record<string, string | number>>(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -114,7 +114,7 @@ const useFilteredEntityIds = (spaceId?: string): FilteredEntityIds => {
         signal,
         filter: filterQuery,
         executionContext: buildExecutionContext(
-          'entity_analytics-home_page',
+          'entity_analytics:home_page',
           'anomalies_entity_filter'
         ),
       });
@@ -211,7 +211,7 @@ const useRecentAnomaliesTopRowsQuery = (params: {
         search,
         signal,
         timeRange,
-        executionContext: buildExecutionContext('entity_analytics-home_page', 'anomalies_top_rows'),
+        executionContext: buildExecutionContext('entity_analytics:home_page', 'anomalies_top_rows'),
       });
       return {
         records: esqlResponseToRecords<Record<string, string>>(esqlResult?.response),
@@ -306,7 +306,7 @@ export const useRecentAnomaliesQuery = (params: {
         search,
         signal,
         timeRange,
-        executionContext: buildExecutionContext('entity_analytics-home_page', 'anomalies_heatmap'),
+        executionContext: buildExecutionContext('entity_analytics:home_page', 'anomalies_heatmap'),
       });
       const anomalyRecords = esqlResponseToRecords<Record<string, string | number>>(
         esqlResult.response

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -112,6 +112,11 @@ const useFilteredEntityIds = (spaceId?: string): FilteredEntityIds => {
         search,
         signal,
         filter: filterQuery,
+        executionContext: {
+          type: 'security_solution',
+          name: 'entity_analytics-home_page',
+          id: 'anomalies_entity_filter',
+        },
       });
       return esqlResponseToRecords<{ 'entity.id': string }>(esqlResult?.response)
         .map((record) => record['entity.id'])
@@ -206,6 +211,11 @@ const useRecentAnomaliesTopRowsQuery = (params: {
         search,
         signal,
         timeRange,
+        executionContext: {
+          type: 'security_solution',
+          name: 'entity_analytics-home_page',
+          id: 'anomalies_top_rows',
+        },
       });
       return {
         records: esqlResponseToRecords<Record<string, string>>(esqlResult?.response),
@@ -300,6 +310,11 @@ export const useRecentAnomaliesQuery = (params: {
         search,
         signal,
         timeRange,
+        executionContext: {
+          type: 'security_solution',
+          name: 'entity_analytics-home_page',
+          id: 'anomalies_heatmap',
+        },
       });
       const anomalyRecords = esqlResponseToRecords<Record<string, string | number>>(
         esqlResult.response

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.test.ts
@@ -87,16 +87,18 @@ describe('useHuntingLeads', () => {
       await capturedQueryFn?.({ signal: mockSignal });
     });
 
-    expect(mockFetchLeads).toHaveBeenCalledWith({
-      signal: mockSignal,
-      params: {
-        page: 1,
-        perPage: 20,
-        sortField: 'priority',
-        sortOrder: 'desc',
-        status: 'active',
-      },
-    });
+    expect(mockFetchLeads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: mockSignal,
+        params: {
+          page: 1,
+          perPage: 20,
+          sortField: 'priority',
+          sortOrder: 'desc',
+          status: 'active',
+        },
+      })
+    );
   });
 
   it('returns empty leads array when data is undefined', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.ts
@@ -11,10 +11,13 @@ import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useKibana } from '../../../../common/lib/kibana';
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
+import { buildExecutionContext } from '../../../common';
 import { useLeadGenerationPrivileges } from '../../../api/hooks/use_lead_generation_privileges';
 import { fromApiLead } from './types';
 import * as i18n from './translations';
 import { MAX_RECENT_LEADS } from './utils';
+
+const LEADS_PAGE = 'entity_analytics-threat_hunting_leads';
 
 const HUNTING_LEADS_QUERY_KEY = 'hunting-leads';
 const LEAD_SCHEDULE_QUERY_KEY = 'lead-generation-status';
@@ -134,7 +137,12 @@ export const useHuntingLeads = (
     refetch,
   } = useQuery({
     queryKey: [HUNTING_LEADS_QUERY_KEY],
-    queryFn: ({ signal }) => fetchLeads({ signal, ...FETCH_LEADS_PARAMS }),
+    queryFn: ({ signal }) =>
+      fetchLeads({
+        signal,
+        ...FETCH_LEADS_PARAMS,
+        context: buildExecutionContext(LEADS_PAGE, 'leads_list'),
+      }),
     enabled: isEnabled,
     onError: (error: Error) => {
       if (isPermissionDenied(error)) {
@@ -187,7 +195,11 @@ export const useHuntingLeads = (
       const { signal } = abortCtrl.current;
 
       telemetry.reportEvent(EntityEventTypes.LeadGenerationGenerateClicked, {});
-      const { executionUuid } = await generateLeadsApi({ params: { connectorId }, signal });
+      const { executionUuid } = await generateLeadsApi({
+        params: { connectorId },
+        signal,
+        context: buildExecutionContext(LEADS_PAGE, 'leads_generate'),
+      });
       writeInFlightGeneration(spaceId, { executionUuid, startedAt: Date.now() });
       return pollForCompletion(executionUuid, signal);
     },
@@ -213,7 +225,11 @@ export const useHuntingLeads = (
 
   const { data: statusData, isLoading: isStatusLoading } = useQuery({
     queryKey: [LEAD_SCHEDULE_QUERY_KEY],
-    queryFn: ({ signal }) => fetchLeadGenerationStatus({ signal }),
+    queryFn: ({ signal }) =>
+      fetchLeadGenerationStatus({
+        signal,
+        context: buildExecutionContext(LEADS_PAGE, 'leads_generation_status'),
+      }),
     enabled: isEnabled,
     onError: (error: Error) => {
       if (isPermissionDenied(error)) {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.ts
@@ -17,7 +17,7 @@ import { fromApiLead } from './types';
 import * as i18n from './translations';
 import { MAX_RECENT_LEADS } from './utils';
 
-const LEADS_PAGE = 'entity_analytics-threat_hunting_leads';
+const LEADS_PAGE = 'entity_analytics:threat_hunting_leads';
 
 const HUNTING_LEADS_QUERY_KEY = 'hunting-leads';
 const LEAD_SCHEDULE_QUERY_KEY = 'lead-generation-status';

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_risk_score_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_risk_score_tab_body.tsx
@@ -35,9 +35,9 @@ import { RiskEnginePrivilegesCallOut } from './risk_engine_privileges_callout';
 import { useUpsellingComponent } from '../../common/hooks/use_upselling';
 import { RiskScoresNoDataDetected } from './risk_score_no_data_detected';
 
-const USERS_RISK_TAB_CONTEXT = buildExecutionContext('explore-users_page', 'users_risk_score');
+const USERS_RISK_TAB_CONTEXT = buildExecutionContext('entity_analytics:explore-users_page', 'users_risk_score');
 const USERS_RISK_TAB_KPI_CONTEXT = buildExecutionContext(
-  'explore-users_page',
+  'entity_analytics:explore-users_page',
   'users_risk_score_kpi'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_risk_score_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_risk_score_tab_body.tsx
@@ -19,6 +19,7 @@ import { useRiskScoreKpi } from '../api/hooks/use_risk_score_kpi';
 import { useRiskScore } from '../api/hooks/use_risk_score';
 import { useEntityStoreRiskScoreKpi } from '../api/hooks/use_entity_store_risk_score_kpi';
 import { useEntityStoreRiskScore } from '../api/hooks/use_entity_store_risk_score';
+import { buildExecutionContext } from '../common';
 import { useUiSetting } from '../../common/lib/kibana';
 import { UserRiskScoreQueryId } from '../common/utils';
 import { EnableRiskScore } from './enable_risk_score';
@@ -33,6 +34,12 @@ import { useMissingRiskEnginePrivileges } from '../hooks/use_missing_risk_engine
 import { RiskEnginePrivilegesCallOut } from './risk_engine_privileges_callout';
 import { useUpsellingComponent } from '../../common/hooks/use_upselling';
 import { RiskScoresNoDataDetected } from './risk_score_no_data_detected';
+
+const USERS_RISK_TAB_CONTEXT = buildExecutionContext('explore-users_page', 'users_risk_score');
+const USERS_RISK_TAB_KPI_CONTEXT = buildExecutionContext(
+  'explore-users_page',
+  'users_risk_score_kpi'
+);
 
 const UserRiskScoreTableManage = manageQuery(UserRiskScoreTable);
 
@@ -58,6 +65,7 @@ const useUserRiskScoreTabData = ({
     skip: querySkip || entityStoreV2Enabled,
     sort,
     timerange,
+    executionContext: USERS_RISK_TAB_CONTEXT,
   });
 
   const entityStoreRiskScore = useEntityStoreRiskScore({
@@ -67,6 +75,7 @@ const useUserRiskScoreTabData = ({
     skip: querySkip || !entityStoreV2Enabled,
     sort,
     timerange,
+    executionContext: USERS_RISK_TAB_CONTEXT,
   });
 
   const risk = entityStoreV2Enabled ? entityStoreRiskScore : legacyRiskScore;
@@ -75,12 +84,14 @@ const useUserRiskScoreTabData = ({
     filterQuery,
     skip: querySkip || entityStoreV2Enabled,
     riskEntity: EntityType.user,
+    executionContext: USERS_RISK_TAB_KPI_CONTEXT,
   });
 
   const entityStoreKpi = useEntityStoreRiskScoreKpi({
     filterQuery,
     skip: querySkip || !entityStoreV2Enabled,
     riskEntity: EntityType.user,
+    executionContext: USERS_RISK_TAB_KPI_CONTEXT,
   });
 
   const kpi = entityStoreV2Enabled ? entityStoreKpi : legacyKpi;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
@@ -92,9 +92,11 @@ export const useRiskLevelsEsqlQuery = ({
             strategy: 'esql_async',
             projectRouting: '_alias:_origin',
             executionContext: {
-              type: 'security_solution',
-              name: 'entity_analytics-home_page',
-              id: 'risk_level_panel',
+              child: {
+                type: 'security_solution',
+                name: 'entity_analytics-home_page',
+                id: 'risk_level_panel',
+              },
             },
           }
         )

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
@@ -14,6 +14,7 @@ import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
 import { useErrorToast } from '../../../../../common/hooks/use_error_toast';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useEsqlGlobalFilterQuery } from '../../../../../common/hooks/esql/use_esql_global_filter';
+import { buildExecutionContext } from '../../../../common';
 import { useGlobalFilterQuery } from '../../../../../common/hooks/use_global_filter_query';
 import { esqlResponseToRecords } from '../../../../../common/utils/esql';
 import { useRiskEngineStatus } from '../../../../api/hooks/use_risk_engine_status';
@@ -91,13 +92,10 @@ export const useRiskLevelsEsqlQuery = ({
             abortSignal: signal,
             strategy: 'esql_async',
             projectRouting: '_alias:_origin',
-            executionContext: {
-              child: {
-                type: 'security_solution',
-                name: 'entity_analytics-home_page',
-                id: 'risk_level_panel',
-              },
-            },
+            executionContext: buildExecutionContext(
+              'entity_analytics-home_page',
+              'risk_level_panel'
+            ),
           }
         )
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
@@ -91,6 +91,11 @@ export const useRiskLevelsEsqlQuery = ({
             abortSignal: signal,
             strategy: 'esql_async',
             projectRouting: '_alias:_origin',
+            executionContext: {
+              type: 'security_solution',
+              name: 'entity_analytics-home_page',
+              id: 'risk_level_panel',
+            },
           }
         )
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
@@ -93,7 +93,7 @@ export const useRiskLevelsEsqlQuery = ({
             strategy: 'esql_async',
             projectRouting: '_alias:_origin',
             executionContext: buildExecutionContext(
-              'entity_analytics-home_page',
+              'entity_analytics:home_page',
               'risk_level_panel'
             ),
           }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/watchlists_management_table/hooks/use_delete_watchlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/watchlists_management_table/hooks/use_delete_watchlist.ts
@@ -20,7 +20,7 @@ export const useDeleteWatchlist = (spaceId: string) => {
     mutationFn: (id: string) =>
       deleteWatchlist(
         { id },
-        buildExecutionContext('entity_analytics-watchlists', 'watchlist_delete')
+        buildExecutionContext('entity_analytics:watchlists', 'watchlist_delete')
       ),
     onSuccess: async () => {
       addSuccess(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/watchlists_management_table/hooks/use_delete_watchlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/watchlists_management_table/hooks/use_delete_watchlist.ts
@@ -9,6 +9,7 @@ import { useMutation, useQueryClient } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
 import { useAppToasts } from '../../../../../../common/hooks/use_app_toasts';
 import { useEntityAnalyticsRoutes } from '../../../../../api/api';
+import { buildExecutionContext } from '../../../../../common';
 
 export const useDeleteWatchlist = (spaceId: string) => {
   const queryClient = useQueryClient();
@@ -16,7 +17,11 @@ export const useDeleteWatchlist = (spaceId: string) => {
   const { deleteWatchlist } = useEntityAnalyticsRoutes();
 
   return useMutation({
-    mutationFn: (id: string) => deleteWatchlist({ id }),
+    mutationFn: (id: string) =>
+      deleteWatchlist(
+        { id },
+        buildExecutionContext('entity_analytics-watchlists', 'watchlist_delete')
+      ),
     onSuccess: async () => {
       addSuccess(
         i18n.translate(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/watchlists_management_table/hooks/use_watchlists_table_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/watchlists_management_table/hooks/use_watchlists_table_data.ts
@@ -9,7 +9,10 @@ import { useQuery } from '@kbn/react-query';
 import { WATCHLISTS_URL } from '../../../../../../../common/entity_analytics/watchlists/constants';
 import type { MonitoringEntitySource } from '../../../../../../../common/api/entity_analytics/watchlists/data_source/common.gen';
 import { useEntityAnalyticsRoutes } from '../../../../../api/api';
+import { buildExecutionContext } from '../../../../../common';
 import type { WatchlistTableItemType } from '../types';
+
+const WATCHLISTS_PAGE = 'entity_analytics-watchlists';
 
 /**
  * Derives a human-readable source label from an entity source.
@@ -46,7 +49,11 @@ export const useWatchlistsTableData = (
   } = useQuery({
     queryKey: ['watchlists-management-table', spaceId],
     enabled: toggleStatus,
-    queryFn: ({ signal }) => fetchWatchlists({ signal }),
+    queryFn: ({ signal }) =>
+      fetchWatchlists({
+        signal,
+        context: buildExecutionContext(WATCHLISTS_PAGE, 'watchlists_management_table_list'),
+      }),
   });
 
   // Fetch entity sources for every watchlist that has entitySourceIds
@@ -66,6 +73,7 @@ export const useWatchlistsTableData = (
             const { sources } = await listWatchlistEntitySources({
               watchlistId: watchlist.id,
               signal,
+              context: buildExecutionContext(WATCHLISTS_PAGE, 'watchlists_entity_sources_list'),
             });
 
             const labels = sources

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/watchlists_management_table/hooks/use_watchlists_table_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/watchlists_management_table/hooks/use_watchlists_table_data.ts
@@ -12,7 +12,7 @@ import { useEntityAnalyticsRoutes } from '../../../../../api/api';
 import { buildExecutionContext } from '../../../../../common';
 import type { WatchlistTableItemType } from '../types';
 
-const WATCHLISTS_PAGE = 'entity_analytics-watchlists';
+const WATCHLISTS_PAGE = 'entity_analytics:watchlists';
 
 /**
  * Derives a human-readable source label from an entity source.

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/hooks/use_privileged_monitoring_health.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/hooks/use_privileged_monitoring_health.tsx
@@ -12,7 +12,7 @@ import { useEntityAnalyticsRoutes } from '../api/api';
 import { buildExecutionContext } from '../common';
 
 const PUM_HEALTH_CONTEXT = buildExecutionContext(
-  'entity_analytics-privileged_user_monitoring',
+  'entity_analytics:privileged_user_monitoring',
   'pum_health'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/hooks/use_privileged_monitoring_health.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/hooks/use_privileged_monitoring_health.tsx
@@ -9,6 +9,12 @@ import { useQuery } from '@kbn/react-query';
 import type { SecurityAppError } from '@kbn/securitysolution-t-grid';
 import type { PrivMonHealthResponse } from '../../../common/api/entity_analytics';
 import { useEntityAnalyticsRoutes } from '../api/api';
+import { buildExecutionContext } from '../common';
+
+const PUM_HEALTH_CONTEXT = buildExecutionContext(
+  'entity_analytics-privileged_user_monitoring',
+  'pum_health'
+);
 
 /**
  * Helper function to compute user statistics from health data
@@ -38,7 +44,7 @@ export const usePrivilegedMonitoringHealth = (options?: UsePrivilegedMonitoringH
 
   const { data, isLoading, isError, error } = useQuery<PrivMonHealthResponse, SecurityAppError>({
     queryKey: ['GET', 'PRIVILEGED_MONITORING_HEALTH'],
-    queryFn: fetchPrivilegeMonitoringEngineStatus,
+    queryFn: () => fetchPrivilegeMonitoringEngineStatus(PUM_HEALTH_CONTEXT),
     retry: 0,
     enabled: options?.enabled,
     refetchInterval: 30000, // Refresh every 30 seconds to keep user count current
@@ -65,9 +71,10 @@ export const usePrivilegedMonitoringEngineStatus = () => {
 
 // Hook specifically for user limit functionality
 export const useUserLimitStatus = (options?: UsePrivilegedMonitoringHealthOptions) => {
+  const { fetchPrivilegeMonitoringEngineStatus } = useEntityAnalyticsRoutes();
   const { data, isLoading, isError, error } = useQuery<PrivMonHealthResponse, SecurityAppError>({
     queryKey: ['GET', 'PRIVILEGED_MONITORING_HEALTH'],
-    queryFn: useEntityAnalyticsRoutes().fetchPrivilegeMonitoringEngineStatus,
+    queryFn: () => fetchPrivilegeMonitoringEngineStatus(PUM_HEALTH_CONTEXT),
     retry: 0,
     enabled: options?.enabled,
     refetchInterval: 30000,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/hooks/use_risk_contributing_alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/hooks/use_risk_contributing_alerts.ts
@@ -7,6 +7,7 @@
 
 import { useEffect } from 'react';
 import type { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 
 import type { EntityType } from '../../../common/entity_analytics/types';
 import type { RiskScoreInput } from '../../../common/api/entity_analytics/common';
@@ -19,6 +20,8 @@ import type { EntityRiskScore } from '../../../common/search_strategy/security_s
 interface UseRiskContributingAlerts<T extends EntityType> {
   entityType: T;
   riskScore: EntityRiskScore<T> | undefined;
+  /** Execution context forwarded to ES as x-opaque-id for tracing */
+  executionContext?: KibanaExecutionContext;
 }
 
 interface AlertData {
@@ -51,12 +54,14 @@ export interface UseRiskContributingAlertsResult {
 export const useRiskContributingAlerts = <T extends EntityType>({
   riskScore,
   entityType,
+  executionContext,
 }: UseRiskContributingAlerts<T>): UseRiskContributingAlertsResult => {
   const { hasAlertsRead } = useAlertsPrivileges();
   const { loading, data, setQuery } = useQueryAlerts<AlertHit, unknown>({
     query: {},
     queryName: ALERTS_QUERY_NAMES.BY_ID,
     skip: !hasAlertsRead,
+    executionContext,
   });
 
   const inputs = getInputs(riskScore, entityType);

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_host_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_host_table.tsx
@@ -34,7 +34,7 @@ const TABLE_QUERY_ID = 'authenticationsHostsTableQuery';
 const tableType = hostsModel.HostsTableType.authentications;
 
 const HOSTS_AUTHENTICATIONS_CONTEXT = buildExecutionContext(
-  'explore-hosts_page',
+  'entity_analytics:explore-hosts_page',
   'authentications'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_host_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_host_table.tsx
@@ -21,6 +21,7 @@ import {
   rowItems,
 } from './helpers';
 import { useAuthentications } from '../../containers/authentications';
+import { buildExecutionContext } from '../../../entity_analytics/common';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
 import type { HostsComponentsQueryProps } from '../../hosts/pages/navigation/types';
 import { hostsActions, hostsModel, hostsSelectors } from '../../hosts/store';
@@ -31,6 +32,11 @@ import { AuthStackByField } from '../../../../common/search_strategy';
 const TABLE_QUERY_ID = 'authenticationsHostsTableQuery';
 
 const tableType = hostsModel.HostsTableType.authentications;
+
+const HOSTS_AUTHENTICATIONS_CONTEXT = buildExecutionContext(
+  'explore-hosts_page',
+  'authentications'
+);
 
 const AuthenticationsHostTableComponent: React.FC<HostsComponentsQueryProps> = ({
   endDate,
@@ -101,6 +107,7 @@ const AuthenticationsHostTableComponent: React.FC<HostsComponentsQueryProps> = (
     stackByField: AuthStackByField.userName,
     activePage,
     limit,
+    executionContext: HOSTS_AUTHENTICATIONS_CONTEXT,
   });
 
   const columns =

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_user_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_user_table.tsx
@@ -22,6 +22,7 @@ import {
   rowItems,
 } from './helpers';
 import { useAuthentications } from '../../containers/authentications';
+import { buildExecutionContext } from '../../../entity_analytics/common';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
 import { useQueryToggle } from '../../../common/containers/query_toggle';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
@@ -29,6 +30,11 @@ import { usersActions, usersModel, usersSelectors } from '../../users/store';
 import type { AuthenticationsUserTableProps } from './types';
 
 const TABLE_QUERY_ID = 'authenticationsUsersTableQuery';
+
+const USERS_AUTHENTICATIONS_CONTEXT = buildExecutionContext(
+  'explore-users_page',
+  'authentications'
+);
 
 const AuthenticationsUserTableComponent: React.FC<AuthenticationsUserTableProps> = ({
   endDate,
@@ -98,6 +104,7 @@ const AuthenticationsUserTableComponent: React.FC<AuthenticationsUserTableProps>
     activePage,
     limit,
     stackByField: userName ? AuthStackByField.hostName : AuthStackByField.userName,
+    executionContext: USERS_AUTHENTICATIONS_CONTEXT,
   });
 
   const columns = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_user_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_user_table.tsx
@@ -32,7 +32,7 @@ import type { AuthenticationsUserTableProps } from './types';
 const TABLE_QUERY_ID = 'authenticationsUsersTableQuery';
 
 const USERS_AUTHENTICATIONS_CONTEXT = buildExecutionContext(
-  'explore-users_page',
+  'entity_analytics:explore-users_page',
   'authentications'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/containers/authentications/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/containers/authentications/index.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import deepEqual from 'fast-deep-equal';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 
 import type { UserAuthenticationsRequestOptionsInput } from '../../../../common/api/search_strategy';
 import type {
@@ -45,6 +46,11 @@ interface UseAuthentications {
   skip: boolean;
   stackByField: AuthStackByField;
   startDate: string;
+  /**
+   * Optional Kibana execution context forwarded to the underlying search strategy so slow logs
+   * and APM traces can attribute the query to the calling page (hosts vs users).
+   */
+  executionContext?: KibanaExecutionContext;
 }
 
 export const useAuthentications = ({
@@ -56,6 +62,7 @@ export const useAuthentications = ({
   skip,
   stackByField,
   startDate,
+  executionContext,
 }: UseAuthentications): [boolean, AuthenticationArgs] => {
   const [authenticationsRequest, setAuthenticationsRequest] =
     useState<UserAuthenticationsRequestOptionsInput | null>(null);
@@ -95,6 +102,7 @@ export const useAuthentications = ({
     },
     errorMessage: i18n.FAIL_AUTHENTICATIONS,
     abort: skip,
+    executionContext,
   });
 
   const authenticationsResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.tsx
@@ -17,7 +17,10 @@ import * as i18n from './translations';
 import type { InspectResponse } from '../../../../../types';
 import { useSearchStrategy } from '../../../../../common/containers/use_search_strategy';
 import { useUiSetting } from '../../../../../common/lib/kibana';
+import { buildExecutionContext } from '../../../../../entity_analytics/common';
 import type { EntityStoreRecord } from '../../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
+
+const HOST_DETAILS_CONTEXT = buildExecutionContext('explore-hosts_page', 'host_details');
 
 export const ID = 'hostsDetailsQuery';
 
@@ -114,6 +117,7 @@ export const useHostDetails = ({
     },
     errorMessage: i18n.FAIL_HOST_OVERVIEW,
     abort: shouldSkip,
+    executionContext: HOST_DETAILS_CONTEXT,
   });
 
   const hostDetailsResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.tsx
@@ -20,7 +20,7 @@ import { useUiSetting } from '../../../../../common/lib/kibana';
 import { buildExecutionContext } from '../../../../../entity_analytics/common';
 import type { EntityStoreRecord } from '../../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
 
-const HOST_DETAILS_CONTEXT = buildExecutionContext('explore-hosts_page', 'host_details');
+const HOST_DETAILS_CONTEXT = buildExecutionContext('entity_analytics:explore-hosts_page', 'host_details');
 
 export const ID = 'hostsDetailsQuery';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/index.tsx
@@ -20,8 +20,11 @@ import type { ESTermQuery } from '../../../../../common/typed_json';
 
 import * as i18n from './translations';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import type { HostsArgs } from './hosts_table_query_types';
 import { HOSTS_ALL_TABLE_QUERY_ID } from './hosts_table_query_types';
+
+const HOSTS_ALL_CONTEXT = buildExecutionContext('explore-hosts_page', 'hosts_all');
 
 export const ID = HOSTS_ALL_TABLE_QUERY_ID;
 
@@ -86,6 +89,7 @@ export const useAllHost = ({
     },
     errorMessage: i18n.FAIL_ALL_HOST,
     abort: skip,
+    executionContext: HOSTS_ALL_CONTEXT,
   });
 
   const hostsResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/index.tsx
@@ -24,7 +24,7 @@ import { buildExecutionContext } from '../../../../entity_analytics/common';
 import type { HostsArgs } from './hosts_table_query_types';
 import { HOSTS_ALL_TABLE_QUERY_ID } from './hosts_table_query_types';
 
-const HOSTS_ALL_CONTEXT = buildExecutionContext('explore-hosts_page', 'hosts_all');
+const HOSTS_ALL_CONTEXT = buildExecutionContext('entity_analytics:explore-hosts_page', 'hosts_all');
 
 export const ID = HOSTS_ALL_TABLE_QUERY_ID;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/use_all_entity_store_hosts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/use_all_entity_store_hosts.ts
@@ -22,6 +22,7 @@ import { useErrorToast } from '../../../../common/hooks/use_error_toast';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import type { inputsModel, State } from '../../../../common/store';
 import { useEntityAnalyticsRoutes } from '../../../../entity_analytics/api/api';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import { getLimitedPaginationTotalCount } from '../../../components/paginated_table/helpers';
 import type { hostsModel } from '../../store';
 import { hostsSelectors } from '../../store';
@@ -30,6 +31,11 @@ import { HOSTS_ALL_TABLE_QUERY_ID } from './hosts_table_query_types';
 import * as i18n from './translations';
 
 const ENTITY_STORE_HOSTS_LIST_QUERY_KEY = 'ENTITY_STORE_HOSTS_LIST';
+
+const HOSTS_ENTITY_STORE_LIST_CONTEXT = buildExecutionContext(
+  'explore-hosts_page',
+  'hosts_entity_store_list'
+);
 
 const isHostEntityRecord = (
   record: ListEntitiesResponse['records'][number]
@@ -171,6 +177,7 @@ export const useAllEntityStoreHosts = (
           sortField: sortFieldForApi,
           sortOrder: direction,
         },
+        context: HOSTS_ENTITY_STORE_LIST_CONTEXT,
       }),
     enabled: !skip,
     cacheTime: 0,

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/use_all_entity_store_hosts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/use_all_entity_store_hosts.ts
@@ -33,7 +33,7 @@ import * as i18n from './translations';
 const ENTITY_STORE_HOSTS_LIST_QUERY_KEY = 'ENTITY_STORE_HOSTS_LIST';
 
 const HOSTS_ENTITY_STORE_LIST_CONTEXT = buildExecutionContext(
-  'explore-hosts_page',
+  'entity_analytics:explore-hosts_page',
   'hosts_entity_store_list'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/uncommon_processes/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/uncommon_processes/index.tsx
@@ -30,7 +30,7 @@ import { useSearchStrategy } from '../../../../common/containers/use_search_stra
 import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 const UNCOMMON_PROCESSES_CONTEXT = buildExecutionContext(
-  'explore-hosts_page',
+  'entity_analytics:explore-hosts_page',
   'uncommon_processes'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/uncommon_processes/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/uncommon_processes/index.tsx
@@ -27,6 +27,12 @@ import type { ESTermQuery } from '../../../../../common/typed_json';
 import type { InspectResponse } from '../../../../types';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
+
+const UNCOMMON_PROCESSES_CONTEXT = buildExecutionContext(
+  'explore-hosts_page',
+  'uncommon_processes'
+);
 
 export const ID = 'hostsUncommonProcessesQuery';
 
@@ -103,6 +109,7 @@ export const useUncommonProcesses = ({
     },
     errorMessage: i18n.FAIL_UNCOMMON_PROCESSES,
     abort: skip,
+    executionContext: UNCOMMON_PROCESSES_CONTEXT,
   });
 
   const uncommonProcessesResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/navigation/host_risk_score_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/navigation/host_risk_score_tab_body.tsx
@@ -18,6 +18,7 @@ import { useRiskScoreKpi } from '../../../../entity_analytics/api/hooks/use_risk
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useEntityStoreRiskScoreKpi } from '../../../../entity_analytics/api/hooks/use_entity_store_risk_score_kpi';
 import { useEntityStoreRiskScore } from '../../../../entity_analytics/api/hooks/use_entity_store_risk_score';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import { useUiSetting } from '../../../../common/lib/kibana';
 import { EnableRiskScore } from '../../../../entity_analytics/components/enable_risk_score';
 import { manageQuery } from '../../../../common/components/page/manage_query';
@@ -32,6 +33,12 @@ import {
   type RiskScoreSortField,
 } from '../../../../../common/search_strategy';
 import type { HostsComponentsQueryProps } from './types';
+
+const HOSTS_RISK_TAB_CONTEXT = buildExecutionContext('explore-hosts_page', 'hosts_risk_score');
+const HOSTS_RISK_TAB_KPI_CONTEXT = buildExecutionContext(
+  'explore-hosts_page',
+  'hosts_risk_score_kpi'
+);
 
 const HostRiskScoreTableManage = manageQuery(HostRiskScoreTable);
 
@@ -57,6 +64,7 @@ const useHostRiskScoreTabData = ({
     skip: querySkip || entityStoreV2Enabled,
     sort,
     timerange,
+    executionContext: HOSTS_RISK_TAB_CONTEXT,
   });
 
   const entityStoreRiskScore = useEntityStoreRiskScore({
@@ -66,6 +74,7 @@ const useHostRiskScoreTabData = ({
     skip: querySkip || !entityStoreV2Enabled,
     sort,
     timerange,
+    executionContext: HOSTS_RISK_TAB_CONTEXT,
   });
 
   const risk = entityStoreV2Enabled ? entityStoreRiskScore : legacyRiskScore;
@@ -74,12 +83,14 @@ const useHostRiskScoreTabData = ({
     filterQuery,
     skip: querySkip || entityStoreV2Enabled,
     riskEntity: EntityType.host,
+    executionContext: HOSTS_RISK_TAB_KPI_CONTEXT,
   });
 
   const entityStoreKpi = useEntityStoreRiskScoreKpi({
     filterQuery,
     skip: querySkip || !entityStoreV2Enabled,
     riskEntity: EntityType.host,
+    executionContext: HOSTS_RISK_TAB_KPI_CONTEXT,
   });
 
   const kpi = entityStoreV2Enabled ? entityStoreKpi : legacyKpi;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/navigation/host_risk_score_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/navigation/host_risk_score_tab_body.tsx
@@ -34,9 +34,9 @@ import {
 } from '../../../../../common/search_strategy';
 import type { HostsComponentsQueryProps } from './types';
 
-const HOSTS_RISK_TAB_CONTEXT = buildExecutionContext('explore-hosts_page', 'hosts_risk_score');
+const HOSTS_RISK_TAB_CONTEXT = buildExecutionContext('entity_analytics:explore-hosts_page', 'hosts_risk_score');
 const HOSTS_RISK_TAB_KPI_CONTEXT = buildExecutionContext(
-  'explore-hosts_page',
+  'entity_analytics:explore-hosts_page',
   'hosts_risk_score_kpi'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/details/index.tsx
@@ -16,8 +16,11 @@ import * as i18n from './translations';
 import type { InspectResponse } from '../../../../types';
 
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkDetailsQuery';
+
+const NETWORK_DETAILS_CONTEXT = buildExecutionContext('explore-network_page', 'network_details');
 
 export interface NetworkDetailsArgs {
   id: string;
@@ -55,6 +58,7 @@ export const useNetworkDetails = ({
     },
     errorMessage: i18n.ERROR_NETWORK_DETAILS,
     abort: skip,
+    executionContext: NETWORK_DETAILS_CONTEXT,
   });
 
   const networkDetailsResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/details/index.tsx
@@ -20,7 +20,7 @@ import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkDetailsQuery';
 
-const NETWORK_DETAILS_CONTEXT = buildExecutionContext('explore-network_page', 'network_details');
+const NETWORK_DETAILS_CONTEXT = buildExecutionContext('entity_analytics:explore-network_page', 'network_details');
 
 export interface NetworkDetailsArgs {
   id: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_dns/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_dns/index.tsx
@@ -24,7 +24,7 @@ import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkDnsQuery';
 
-const NETWORK_DNS_CONTEXT = buildExecutionContext('explore-network_page', 'network_dns');
+const NETWORK_DNS_CONTEXT = buildExecutionContext('entity_analytics:explore-network_page', 'network_dns');
 
 export interface NetworkDnsResponse {
   id: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_dns/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_dns/index.tsx
@@ -20,8 +20,11 @@ import { NetworkQueries } from '../../../../../common/search_strategy';
 import * as i18n from './translations';
 import type { InspectResponse } from '../../../../types';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkDnsQuery';
+
+const NETWORK_DNS_CONTEXT = buildExecutionContext('explore-network_page', 'network_dns');
 
 export interface NetworkDnsResponse {
   id: string;
@@ -94,6 +97,7 @@ export const useNetworkDns = ({
     },
     errorMessage: i18n.ERROR_NETWORK_DNS,
     abort: skip,
+    executionContext: NETWORK_DNS_CONTEXT,
   });
 
   const networkDnsResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_http/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_http/index.tsx
@@ -26,8 +26,11 @@ import * as i18n from './translations';
 import type { InspectResponse } from '../../../../types';
 
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkHttpQuery';
+
+const NETWORK_HTTP_CONTEXT = buildExecutionContext('explore-network_page', 'network_http');
 
 export interface NetworkHttpArgs {
   id: string;
@@ -104,6 +107,7 @@ export const useNetworkHttp = ({
     },
     errorMessage: i18n.FAIL_NETWORK_HTTP,
     abort: skip,
+    executionContext: NETWORK_HTTP_CONTEXT,
   });
 
   const networkHttpResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_http/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_http/index.tsx
@@ -30,7 +30,7 @@ import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkHttpQuery';
 
-const NETWORK_HTTP_CONTEXT = buildExecutionContext('explore-network_page', 'network_http');
+const NETWORK_HTTP_CONTEXT = buildExecutionContext('entity_analytics:explore-network_page', 'network_http');
 
 export interface NetworkHttpArgs {
   id: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_top_countries/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_top_countries/index.tsx
@@ -30,7 +30,7 @@ import { buildExecutionContext } from '../../../../entity_analytics/common';
 export const ID = 'networkTopCountriesQuery';
 
 const NETWORK_TOP_COUNTRIES_CONTEXT = buildExecutionContext(
-  'explore-network_page',
+  'entity_analytics:explore-network_page',
   'network_top_countries'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_top_countries/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_top_countries/index.tsx
@@ -25,8 +25,14 @@ import { NetworkQueries } from '../../../../../common/search_strategy';
 import type { InspectResponse } from '../../../../types';
 import * as i18n from './translations';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkTopCountriesQuery';
+
+const NETWORK_TOP_COUNTRIES_CONTEXT = buildExecutionContext(
+  'explore-network_page',
+  'network_top_countries'
+);
 
 export interface NetworkTopCountriesArgs {
   id: string;
@@ -105,6 +111,7 @@ export const useNetworkTopCountries = ({
     },
     errorMessage: i18n.FAIL_NETWORK_TOP_COUNTRIES,
     abort: skip,
+    executionContext: NETWORK_TOP_COUNTRIES_CONTEXT,
   });
 
   const networkTopCountriesResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_top_n_flow/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_top_n_flow/index.tsx
@@ -24,8 +24,18 @@ import { NetworkQueries } from '../../../../../common/search_strategy';
 import type { InspectResponse } from '../../../../types';
 import * as i18n from './translations';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkTopNFlowQuery';
+
+const NETWORK_TOP_N_FLOW_CONTEXT = buildExecutionContext(
+  'explore-network_page',
+  'network_top_n_flow'
+);
+const NETWORK_TOP_N_FLOW_COUNT_CONTEXT = buildExecutionContext(
+  'explore-network_page',
+  'network_top_n_flow_count'
+);
 
 export interface NetworkTopNFlowArgs {
   id: string;
@@ -94,6 +104,7 @@ export const useNetworkTopNFlow = ({
     initialResult: { edges: [] },
     errorMessage: i18n.FAIL_NETWORK_TOP_N_FLOW,
     abort: skip,
+    executionContext: NETWORK_TOP_N_FLOW_CONTEXT,
   });
 
   const {
@@ -107,6 +118,7 @@ export const useNetworkTopNFlow = ({
     initialResult: { totalCount: -1 },
     errorMessage: i18n.FAIL_NETWORK_TOP_N_FLOW,
     abort: skip,
+    executionContext: NETWORK_TOP_N_FLOW_COUNT_CONTEXT,
   });
 
   const isLoading = isLoadingData || isLoadingTotalCount;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_top_n_flow/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/network_top_n_flow/index.tsx
@@ -29,11 +29,11 @@ import { buildExecutionContext } from '../../../../entity_analytics/common';
 export const ID = 'networkTopNFlowQuery';
 
 const NETWORK_TOP_N_FLOW_CONTEXT = buildExecutionContext(
-  'explore-network_page',
+  'entity_analytics:explore-network_page',
   'network_top_n_flow'
 );
 const NETWORK_TOP_N_FLOW_COUNT_CONTEXT = buildExecutionContext(
-  'explore-network_page',
+  'entity_analytics:explore-network_page',
   'network_top_n_flow_count'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/tls/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/tls/index.tsx
@@ -29,7 +29,7 @@ import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkTlsQuery';
 
-const NETWORK_TLS_CONTEXT = buildExecutionContext('explore-network_page', 'network_tls');
+const NETWORK_TLS_CONTEXT = buildExecutionContext('entity_analytics:explore-network_page', 'network_tls');
 
 export interface NetworkTlsArgs {
   id: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/tls/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/tls/index.tsx
@@ -25,8 +25,11 @@ import type {
   PageInfoPaginated,
 } from '../../../../../common/search_strategy';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkTlsQuery';
+
+const NETWORK_TLS_CONTEXT = buildExecutionContext('explore-network_page', 'network_tls');
 
 export interface NetworkTlsArgs {
   id: string;
@@ -104,6 +107,7 @@ export const useNetworkTls = ({
     },
     errorMessage: i18n.FAIL_NETWORK_TLS,
     abort: skip,
+    executionContext: NETWORK_TLS_CONTEXT,
   });
 
   const networkTlsResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/users/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/users/index.tsx
@@ -26,8 +26,11 @@ import * as i18n from './translations';
 import type { InspectResponse } from '../../../../types';
 import type { PageInfoPaginated } from '../../../../../common/search_strategy';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkUsersQuery';
+
+const NETWORK_USERS_CONTEXT = buildExecutionContext('explore-network_page', 'network_users');
 
 export interface NetworkUsersArgs {
   id: string;
@@ -103,6 +106,7 @@ export const useNetworkUsers = ({
     },
     errorMessage: i18n.FAIL_NETWORK_USERS,
     abort: skip,
+    executionContext: NETWORK_USERS_CONTEXT,
   });
 
   const networkUsersResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/users/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/containers/users/index.tsx
@@ -30,7 +30,7 @@ import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 export const ID = 'networkUsersQuery';
 
-const NETWORK_USERS_CONTEXT = buildExecutionContext('explore-network_page', 'network_users');
+const NETWORK_USERS_CONTEXT = buildExecutionContext('entity_analytics:explore-network_page', 'network_users');
 
 export interface NetworkUsersArgs {
   id: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.tsx
@@ -19,7 +19,7 @@ import { buildExecutionContext } from '../../../../../entity_analytics/common';
 import { useUiSetting } from '../../../../../common/lib/kibana';
 import type { EntityStoreRecord } from '../../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
 
-const OBSERVED_USER_CONTEXT = buildExecutionContext('explore-users_page', 'user_details_observed');
+const OBSERVED_USER_CONTEXT = buildExecutionContext('entity_analytics:explore-users_page', 'user_details_observed');
 
 export const OBSERVED_USER_QUERY_ID = 'observedUsersDetailsQuery';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.tsx
@@ -15,8 +15,11 @@ import { UsersQueries } from '../../../../../../common/search_strategy/security_
 import type { UserItem } from '../../../../../../common/search_strategy/security_solution/users/common';
 import { NOT_EVENT_KIND_ASSET_FILTER } from '../../../../../../common/search_strategy/security_solution/users/common';
 import { useSearchStrategy } from '../../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../../entity_analytics/common';
 import { useUiSetting } from '../../../../../common/lib/kibana';
 import type { EntityStoreRecord } from '../../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
+
+const OBSERVED_USER_CONTEXT = buildExecutionContext('explore-users_page', 'user_details_observed');
 
 export const OBSERVED_USER_QUERY_ID = 'observedUsersDetailsQuery';
 
@@ -112,6 +115,7 @@ export const useObservedUserDetails = ({
     },
     errorMessage: i18n.FAIL_USER_DETAILS,
     abort: shouldSkip,
+    executionContext: OBSERVED_USER_CONTEXT,
   });
 
   const userDetailsResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/use_all_entity_store_users.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/use_all_entity_store_users.ts
@@ -20,6 +20,7 @@ import { useErrorToast } from '../../../../common/hooks/use_error_toast';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import type { inputsModel, State } from '../../../../common/store';
 import { useEntityAnalyticsRoutes } from '../../../../entity_analytics/api/api';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import { getLimitedPaginationTotalCount } from '../../../components/paginated_table/helpers';
 import { usersSelectors } from '../../store';
 import type { InspectResponse } from '../../../../types';
@@ -28,6 +29,11 @@ import { USERS_ALL_TABLE_QUERY_ID } from './users_table_query_types';
 import * as i18n from './translations';
 
 const ENTITY_STORE_USERS_LIST_QUERY_KEY = 'ENTITY_STORE_USERS_LIST';
+
+const USERS_ENTITY_STORE_LIST_CONTEXT = buildExecutionContext(
+  'explore-users_page',
+  'users_entity_store_list'
+);
 
 export const mapUserEntityRecordToUser = (record: Entity): User | null => {
   if ('user' in record && record.user != null) {
@@ -162,6 +168,7 @@ export const useAllEntityStoreUsers = (
           sortField: sortFieldForApi,
           sortOrder: direction,
         },
+        context: USERS_ENTITY_STORE_LIST_CONTEXT,
       }),
     enabled: !skip,
     cacheTime: 0,

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/use_all_entity_store_users.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/use_all_entity_store_users.ts
@@ -31,7 +31,7 @@ import * as i18n from './translations';
 const ENTITY_STORE_USERS_LIST_QUERY_KEY = 'ENTITY_STORE_USERS_LIST';
 
 const USERS_ENTITY_STORE_LIST_CONTEXT = buildExecutionContext(
-  'explore-users_page',
+  'entity_analytics:explore-users_page',
   'users_entity_store_list'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/all_users_query_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/all_users_query_tab_body.tsx
@@ -28,7 +28,7 @@ const UsersTableManage = manageQuery(UsersTable);
 
 const QUERY_ID = 'UsersTable';
 
-const USERS_ALL_CONTEXT = buildExecutionContext('explore-users_page', 'users_all');
+const USERS_ALL_CONTEXT = buildExecutionContext('entity_analytics:explore-users_page', 'users_all');
 
 export const AllUsersQueryTabBody = ({
   endDate,

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/all_users_query_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/all_users_query_tab_body.tsx
@@ -14,6 +14,7 @@ import type { UsersComponentsQueryProps } from './types';
 import { manageQuery } from '../../../../common/components/page/manage_query';
 import { UsersTable } from '../../components/all_users';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import { UsersQueries } from '../../../../../common/search_strategy/security_solution/users';
 import * as i18n from './translations';
 import { generateTablePaginationOptions } from '../../../components/paginated_table/helpers';
@@ -26,6 +27,8 @@ import { useAllEntityStoreUsers } from '../../containers/users/use_all_entity_st
 const UsersTableManage = manageQuery(UsersTable);
 
 const QUERY_ID = 'UsersTable';
+
+const USERS_ALL_CONTEXT = buildExecutionContext('explore-users_page', 'users_all');
 
 export const AllUsersQueryTabBody = ({
   endDate,
@@ -73,6 +76,7 @@ export const AllUsersQueryTabBody = ({
     },
     errorMessage: i18n.ERROR_FETCHING_USERS_DATA,
     abort: querySkip || entityStoreV2Enabled,
+    executionContext: USERS_ALL_CONTEXT,
   });
 
   const [entityStoreLoading, entityStoreUsersArgs] = useAllEntityStoreUsers({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_get_generic_entity.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_get_generic_entity.test.ts
@@ -87,7 +87,8 @@ describe('fetchGenericEntity', () => {
 
       await fetchGenericEntity(mockDataService, { entityDocId });
 
-      expect(mockDataService.search.search).toHaveBeenCalledWith({
+      expect(mockDataService.search.search).toHaveBeenCalledWith(
+        expect.objectContaining({
         params: {
           index: ASSET_INVENTORY_INDEX_PATTERN,
           query: {
@@ -104,7 +105,9 @@ describe('fetchGenericEntity', () => {
           },
           fields: ['*'],
         },
-      });
+      }),
+        expect.objectContaining({ executionContext: expect.anything() })
+      );
     });
 
     it('should build bool query with entity.id term when only entityId is provided', async () => {
@@ -112,7 +115,8 @@ describe('fetchGenericEntity', () => {
 
       await fetchGenericEntity(mockDataService, { entityId });
 
-      expect(mockDataService.search.search).toHaveBeenCalledWith({
+      expect(mockDataService.search.search).toHaveBeenCalledWith(
+        expect.objectContaining({
         params: {
           index: ASSET_INVENTORY_INDEX_PATTERN,
           query: {
@@ -129,7 +133,9 @@ describe('fetchGenericEntity', () => {
           },
           fields: ['*'],
         },
-      });
+      }),
+        expect.objectContaining({ executionContext: expect.anything() })
+      );
     });
 
     it('should build OR query with both _id and entity.id terms when both are provided', async () => {
@@ -138,7 +144,8 @@ describe('fetchGenericEntity', () => {
 
       await fetchGenericEntity(mockDataService, { entityDocId, entityId });
 
-      expect(mockDataService.search.search).toHaveBeenCalledWith({
+      expect(mockDataService.search.search).toHaveBeenCalledWith(
+        expect.objectContaining({
         params: {
           index: ASSET_INVENTORY_INDEX_PATTERN,
           query: {
@@ -160,7 +167,9 @@ describe('fetchGenericEntity', () => {
           },
           fields: ['*'],
         },
-      });
+      }),
+        expect.objectContaining({ executionContext: expect.anything() })
+      );
     });
 
     it('should handle whitespace-only entityDocId as valid', async () => {
@@ -168,7 +177,8 @@ describe('fetchGenericEntity', () => {
 
       await fetchGenericEntity(mockDataService, { entityDocId });
 
-      expect(mockDataService.search.search).toHaveBeenCalledWith({
+      expect(mockDataService.search.search).toHaveBeenCalledWith(
+        expect.objectContaining({
         params: {
           index: ASSET_INVENTORY_INDEX_PATTERN,
           query: {
@@ -185,7 +195,9 @@ describe('fetchGenericEntity', () => {
           },
           fields: ['*'],
         },
-      });
+      }),
+        expect.objectContaining({ executionContext: expect.anything() })
+      );
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_get_generic_entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_get_generic_entity.ts
@@ -54,7 +54,7 @@ export const fetchGenericEntity = async (
       },
       {
         executionContext: buildExecutionContext(
-          'entity_details_flyout-generic_right',
+          'entity_analytics:entity_details_flyout-generic_right',
           'generic_entity_search'
         ),
       }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_get_generic_entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_get_generic_entity.ts
@@ -13,6 +13,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { ASSET_INVENTORY_INDEX_PATTERN } from '../../../../asset_inventory/constants';
 import type { GenericEntityRecord } from '../../../../asset_inventory/types/generic_entity_record';
 import { useKibana } from '../../../../common/lib/kibana';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 
 type GenericEntityRequest = IKibanaSearchRequest<estypes.SearchRequest>;
 type GenericEntityResponse = IKibanaSearchResponse<estypes.SearchResponse<GenericEntityRecord>>;
@@ -38,18 +39,26 @@ export const fetchGenericEntity = async (
   }
 
   return lastValueFrom(
-    dataService.search.search<GenericEntityRequest, GenericEntityResponse>({
-      params: {
-        index: ASSET_INVENTORY_INDEX_PATTERN,
-        query: {
-          bool: {
-            should: shouldClauses,
-            minimum_should_match: 1,
+    dataService.search.search<GenericEntityRequest, GenericEntityResponse>(
+      {
+        params: {
+          index: ASSET_INVENTORY_INDEX_PATTERN,
+          query: {
+            bool: {
+              should: shouldClauses,
+              minimum_should_match: 1,
+            },
           },
+          fields: ['*'],
         },
-        fields: ['*'],
       },
-    })
+      {
+        executionContext: buildExecutionContext(
+          'entity_details_flyout-generic_right',
+          'generic_entity_search'
+        ),
+      }
+    )
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -37,6 +37,7 @@ import {
   getRiskFromEntityRecord,
 } from '../shared/entity_store_risk_utils';
 import { useEntityFromStore, type EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
+import { buildExecutionContext } from '../../../entity_analytics/common';
 import type { CriticalityLevelWithUnassigned } from '../../../../common/entity_analytics/asset_criticality/types';
 import { ENABLE_ASSET_INVENTORY_SETTING } from '../../../../common/constants';
 import {
@@ -77,6 +78,11 @@ export interface HostPanelExpandableFlyoutProps extends FlyoutPanelProps {
 
 export const HostPreviewPanelKey: HostPanelExpandableFlyoutProps['key'] = 'host-preview-panel';
 
+const HOST_ENTITY_FROM_STORE_CONTEXT = buildExecutionContext(
+  'entity_details_flyout-host_right',
+  'entity_from_store'
+);
+
 const FIRST_RECORD_PAGINATION = {
   cursorStart: 0,
   querySize: 1,
@@ -105,6 +111,7 @@ export const HostPanel = memo(function HostPanel({
     identityFields: hostStoreIdentityFields,
     entityType: 'host',
     skip: isInitializing,
+    executionContext: HOST_ENTITY_FROM_STORE_CONTEXT,
   });
 
   const documentEntityIdentifiers = useMemo<IdentityFields>(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -79,7 +79,7 @@ export interface HostPanelExpandableFlyoutProps extends FlyoutPanelProps {
 export const HostPreviewPanelKey: HostPanelExpandableFlyoutProps['key'] = 'host-preview-panel';
 
 const HOST_ENTITY_FROM_STORE_CONTEXT = buildExecutionContext(
-  'entity_details_flyout-host_right',
+  'entity_analytics:entity_details_flyout-host_right',
   'entity_from_store'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/observed_service_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/observed_service_details.tsx
@@ -16,7 +16,7 @@ import type { ServiceItem } from '../../../../../common/search_strategy/security
 import { OBSERVED_SERVICE_QUERY_ID } from '../content';
 
 const OBSERVED_SERVICE_DETAILS_CONTEXT = buildExecutionContext(
-  'entity_details_flyout-service_right',
+  'entity_analytics:entity_details_flyout-service_right',
   'service_observed_details'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/observed_service_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/hooks/observed_service_details.tsx
@@ -8,11 +8,17 @@
 import { useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import type { inputsModel } from '../../../../common/store';
 import type { InspectResponse } from '../../../../types';
 import { ServicesQueries } from '../../../../../common/search_strategy/security_solution/services';
 import type { ServiceItem } from '../../../../../common/search_strategy/security_solution/services/common';
 import { OBSERVED_SERVICE_QUERY_ID } from '../content';
+
+const OBSERVED_SERVICE_DETAILS_CONTEXT = buildExecutionContext(
+  'entity_details_flyout-service_right',
+  'service_observed_details'
+);
 
 export interface ServiceDetailsArgs {
   id: string;
@@ -55,6 +61,7 @@ export const useObservedServiceDetails = ({
       defaultMessage: `Failed to run search on service details`,
     }),
     abort: skip,
+    executionContext: OBSERVED_SERVICE_DETAILS_CONTEXT,
   });
 
   const serviceDetailsResponse = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -57,11 +57,11 @@ const FIRST_RECORD_PAGINATION = {
 };
 
 const SERVICE_ENTITY_FROM_STORE_CONTEXT = buildExecutionContext(
-  'entity_details_flyout-service_right',
+  'entity_analytics:entity_details_flyout-service_right',
   'entity_from_store'
 );
 const SERVICE_RISK_SCORE_CONTEXT = buildExecutionContext(
-  'entity_details_flyout-service_right',
+  'entity_analytics:entity_details_flyout-service_right',
   'service_risk_score'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -29,6 +29,7 @@ import type { IdentityFields } from '../../document_details/shared/utils';
 import { EntityDetailsLeftPanelTab } from '../shared/components/left_panel/left_panel_header';
 import { useNavigateToServiceDetails } from './hooks/use_navigate_to_service_details';
 import { useEntityFromStore } from '../shared/hooks/use_entity_from_store';
+import { buildExecutionContext } from '../../../entity_analytics/common';
 import { getRiskFromEntityRecord } from '../shared/entity_store_risk_utils';
 import { FlyoutBody } from '../../shared/components/flyout_body';
 import { useEntityPanelTabs, TABLE_TAB_ID } from '../shared/hooks/use_entity_panel_tabs';
@@ -55,6 +56,15 @@ const FIRST_RECORD_PAGINATION = {
   querySize: 1,
 };
 
+const SERVICE_ENTITY_FROM_STORE_CONTEXT = buildExecutionContext(
+  'entity_details_flyout-service_right',
+  'entity_from_store'
+);
+const SERVICE_RISK_SCORE_CONTEXT = buildExecutionContext(
+  'entity_details_flyout-service_right',
+  'service_risk_score'
+);
+
 export const ServicePanel = memo(function ServicePanel({
   contextID,
   scopeId,
@@ -72,6 +82,7 @@ export const ServicePanel = memo(function ServicePanel({
     identityFields: serviceStoreIdentityFields,
     entityType: 'service',
     skip: false,
+    executionContext: SERVICE_ENTITY_FROM_STORE_CONTEXT,
   });
 
   const euidApi = useEntityStoreEuidApi();
@@ -94,6 +105,7 @@ export const ServicePanel = memo(function ServicePanel({
     onlyLatest: false,
     pagination: FIRST_RECORD_PAGINATION,
     skip: true,
+    executionContext: SERVICE_RISK_SCORE_CONTEXT,
   });
 
   const { inspect, loading, data: serviceRisk } = riskScoreState;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_entity_from_store.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_entity_from_store.test.ts
@@ -85,7 +85,7 @@ describe('useEntityFromStore', () => {
       const executionContext = {
         child: {
           type: 'security_solution',
-          name: 'entity_details_flyout-host_right',
+          name: 'entity_analytics:entity_details_flyout-host_right',
           id: 'entity_from_store',
         },
       };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_entity_from_store.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_entity_from_store.test.ts
@@ -79,4 +79,49 @@ describe('useEntityFromStore', () => {
       expect(hasHostIdExclusion).toBe(false);
     });
   });
+
+  describe('executionContext propagation', () => {
+    it('forwards the caller-supplied executionContext to fetchEntitiesListV2', async () => {
+      const executionContext = {
+        child: {
+          type: 'security_solution',
+          name: 'entity_details_flyout-host_right',
+          id: 'entity_from_store',
+        },
+      };
+
+      renderHook(
+        () =>
+          useEntityFromStore({
+            identityFields: { 'host.name': 'web01' },
+            entityType: 'host',
+            skip: false,
+            executionContext,
+          }),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(() => expect(mockFetchEntitiesListV2).toHaveBeenCalled());
+
+      const [callArg] = mockFetchEntitiesListV2.mock.calls[0];
+      expect(callArg.context).toEqual(executionContext);
+    });
+
+    it('omits context when the caller does not supply executionContext', async () => {
+      renderHook(
+        () =>
+          useEntityFromStore({
+            identityFields: { 'host.name': 'web01' },
+            entityType: 'host',
+            skip: false,
+          }),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(() => expect(mockFetchEntitiesListV2).toHaveBeenCalled());
+
+      const [callArg] = mockFetchEntitiesListV2.mock.calls[0];
+      expect(callArg.context).toBeUndefined();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_entity_from_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_entity_from_store.ts
@@ -8,6 +8,7 @@
 import { useMemo } from 'react';
 import { useQuery, type QueryClient } from '@kbn/react-query';
 import type { IHttpFetchError } from '@kbn/core/public';
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
 import type { EntityType, SearchEntitiesFromEntityStoreResponse } from '@kbn/entity-store/public';
 import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import type {
@@ -123,6 +124,13 @@ export interface UseEntityFromStoreParams {
   identityFields?: Record<string, string> | null;
   entityType?: string;
   skip: boolean;
+  /**
+   * Optional Kibana execution context forwarded to the entity-store search so slow logs and APM
+   * can attribute the query back to the calling page/panel. Callers typically pass a
+   * `{ child: { type: 'security_solution', name: '<page>', id: '<panel>' } }` descriptor built via
+   * `buildExecutionContext(...)`.
+   */
+  executionContext?: KibanaExecutionContext;
 }
 
 export type EntityStoreRecord = HostEntity | UserEntity | ServiceEntity;
@@ -149,7 +157,7 @@ export interface EntityFromStoreResult<T> {
 export function useEntityFromStore(
   params: UseEntityFromStoreParams
 ): EntityFromStoreResult<HostItem | UserItem> {
-  const { entityId, identityFields, entityType, skip } = params;
+  const { entityId, identityFields, entityType, skip, executionContext } = params;
   const euidApi = useEntityStoreEuidApi();
   const { fetchEntitiesListV2 } = useEntityAnalyticsRoutes();
 
@@ -247,6 +255,7 @@ export function useEntityFromStore(
           // The AI summary is loaded separately from the metadata datastream via
           // useFetchPersistedAiSummary, not from the entity store record.
         },
+        context: executionContext,
       });
     },
     enabled: !skip && (Boolean(entityId) || Boolean(storeFilter)),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_managed_user.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_managed_user.ts
@@ -9,9 +9,15 @@ import { useMemo } from 'react';
 import type { ManagedUserHits } from '../../../../../common/search_strategy/security_solution/users/managed_details';
 import { UsersQueries } from '../../../../../common/api/search_strategy';
 import { useSearchStrategy } from '../../../../common/containers/use_search_strategy';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
 import { MANAGED_USER_QUERY_ID } from '../constants';
+
+const MANAGED_USER_CONTEXT = buildExecutionContext(
+  'entity_details_flyout-user_right',
+  'user_managed_details'
+);
 import * as i18n from '../translations';
 
 export interface ManagedUserData {
@@ -31,6 +37,7 @@ export const useManagedUser = (): ManagedUserData => {
       users: {},
     },
     errorMessage: i18n.FAIL_MANAGED_USER,
+    executionContext: MANAGED_USER_CONTEXT,
   });
 
   useQueryInspector({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_managed_user.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_managed_user.ts
@@ -15,7 +15,7 @@ import { useQueryInspector } from '../../../../common/components/page/manage_que
 import { MANAGED_USER_QUERY_ID } from '../constants';
 
 const MANAGED_USER_CONTEXT = buildExecutionContext(
-  'entity_details_flyout-user_right',
+  'entity_analytics:entity_details_flyout-user_right',
   'user_managed_details'
 );
 import * as i18n from '../translations';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -37,6 +37,7 @@ import { useNavigateToUserDetails } from './hooks/use_navigate_to_user_details';
 import { EntityType } from '../../../../common/entity_analytics/types';
 import { useObservedUser } from '../../../flyout_v2/entity/user/main/hooks/use_observed_user';
 import { useEntityFromStore, type EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
+import { buildExecutionContext } from '../../../entity_analytics/common';
 import type { CriticalityLevelWithUnassigned } from '../../../../common/entity_analytics/asset_criticality/types';
 import {
   buildRiskScoreStateFromEntityRecord,
@@ -85,6 +86,15 @@ const FIRST_RECORD_PAGINATION = {
   querySize: 1,
 };
 
+const USER_ENTITY_FROM_STORE_CONTEXT = buildExecutionContext(
+  'entity_details_flyout-user_right',
+  'entity_from_store'
+);
+const USER_RISK_SCORE_CONTEXT = buildExecutionContext(
+  'entity_details_flyout-user_right',
+  'user_risk_score'
+);
+
 export const UserPanel = memo(function UserPanel({
   contextID,
   scopeId,
@@ -110,6 +120,7 @@ export const UserPanel = memo(function UserPanel({
     identityFields: userStoreIdentityFields,
     entityType: 'user',
     skip: isInitializing,
+    executionContext: USER_ENTITY_FROM_STORE_CONTEXT,
   });
 
   const documentEntityIdentifiers = useMemo<IdentityFields>(() => {
@@ -137,6 +148,7 @@ export const UserPanel = memo(function UserPanel({
     onlyLatest: false,
     pagination: FIRST_RECORD_PAGINATION,
     skip: !!observedUser?.entityRecord,
+    executionContext: USER_RISK_SCORE_CONTEXT,
   });
 
   const { inspect, loading } = riskScoreState;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -87,11 +87,11 @@ const FIRST_RECORD_PAGINATION = {
 };
 
 const USER_ENTITY_FROM_STORE_CONTEXT = buildExecutionContext(
-  'entity_details_flyout-user_right',
+  'entity_analytics:entity_details_flyout-user_right',
   'entity_from_store'
 );
 const USER_RISK_SCORE_CONTEXT = buildExecutionContext(
-  'entity_details_flyout-user_right',
+  'entity_analytics:entity_details_flyout-user_right',
   'user_risk_score'
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_create_watchlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_create_watchlist.ts
@@ -10,6 +10,7 @@ import { useMutation, useQueryClient } from '@kbn/react-query';
 import type { CreateWatchlistRequestBodyInput } from '../../../../../common/api/entity_analytics/watchlists/management/create.gen';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useEntityAnalyticsRoutes } from '../../../../entity_analytics/api/api';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import { getApiErrorMessage } from '../utils';
 
 export interface UseCreateWatchlistOptions {
@@ -30,7 +31,11 @@ export const useCreateWatchlist = ({
   const { createWatchlist } = useEntityAnalyticsRoutes();
 
   return useMutation({
-    mutationFn: () => createWatchlist(watchlist),
+    mutationFn: () =>
+      createWatchlist(
+        watchlist,
+        buildExecutionContext('entity_analytics-watchlists', 'watchlist_create')
+      ),
     onSuccess: async () => {
       toasts.addSuccess({
         title: i18n.translate(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_create_watchlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_create_watchlist.ts
@@ -34,7 +34,7 @@ export const useCreateWatchlist = ({
     mutationFn: () =>
       createWatchlist(
         watchlist,
-        buildExecutionContext('entity_analytics-watchlists', 'watchlist_create')
+        buildExecutionContext('entity_analytics:watchlists', 'watchlist_create')
       ),
     onSuccess: async () => {
       toasts.addSuccess({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_update_watchlist.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_update_watchlist.test.ts
@@ -95,10 +95,10 @@ describe('useUpdateWatchlist', () => {
       await result.current.mutateAsync();
     });
 
-    expect(mockUpdateWatchlist).toHaveBeenCalledWith({
-      id: 'wl-1',
-      body: baseOpts.watchlist,
-    });
+    expect(mockUpdateWatchlist).toHaveBeenCalledWith(
+      { id: 'wl-1', body: baseOpts.watchlist },
+      expect.objectContaining({ child: expect.anything() })
+    );
   });
 
   it('creates a new entity source when no existing ID is found', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_update_watchlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_update_watchlist.ts
@@ -10,6 +10,7 @@ import { useMutation, useQueryClient } from '@kbn/react-query';
 import type { CreateWatchlistRequestBodyInput } from '../../../../../common/api/entity_analytics/watchlists/management/create.gen';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useEntityAnalyticsRoutes } from '../../../../entity_analytics/api/api';
+import { buildExecutionContext } from '../../../../entity_analytics/common';
 import { getApiErrorMessage } from '../utils';
 import type { SourceType } from './rule_based_source_helpers';
 
@@ -101,7 +102,10 @@ export const useUpdateWatchlist = ({
       }
 
       // Update the watchlist metadata only after entity sources have succeeded
-      const updatedWatchlist = await updateWatchlist({ id: watchlistId, body: watchlist });
+      const updatedWatchlist = await updateWatchlist(
+        { id: watchlistId, body: watchlist },
+        buildExecutionContext('entity_analytics-watchlists', 'watchlist_update')
+      );
 
       return updatedWatchlist;
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_update_watchlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_update_watchlist.ts
@@ -104,7 +104,7 @@ export const useUpdateWatchlist = ({
       // Update the watchlist metadata only after entity sources have succeeded
       const updatedWatchlist = await updateWatchlist(
         { id: watchlistId, body: watchlist },
-        buildExecutionContext('entity_analytics-watchlists', 'watchlist_update')
+        buildExecutionContext('entity_analytics:watchlists', 'watchlist_update')
       );
 
       return updatedWatchlist;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/schedule_ecs_compliancy_migration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/schedule_ecs_compliancy_migration.test.ts
@@ -35,6 +35,9 @@ const getStartServices = jest.fn().mockResolvedValue([
     elasticsearch: {
       client: elasticsearchServiceMock.createClusterClient(),
     },
+    executionContext: {
+      withContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+    },
   },
   { taskManager: mockTaskManagerStart },
 ]);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/schedule_ecs_compliancy_migration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/schedule_ecs_compliancy_migration.ts
@@ -77,7 +77,7 @@ export const createMigrationTask =
         return coreStart.executionContext.withContext(
           {
             type: 'security_solution',
-            name: 'entity_analytics-asset_criticality_ecs_migration',
+            name: 'entity_analytics:asset_criticality_ecs_migration',
             id: TASK_ID,
           },
           async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/schedule_ecs_compliancy_migration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/schedule_ecs_compliancy_migration.ts
@@ -74,21 +74,30 @@ export const createMigrationTask =
     return {
       run: async () => {
         const [coreStart] = await getStartServices();
-        const esClient = coreStart.elasticsearch.client.asInternalUser;
-        const migrationClient = new AssetCriticalityMigrationClient({
-          esClient,
-          logger,
-          auditLogger,
-        });
+        return coreStart.executionContext.withContext(
+          {
+            type: 'security_solution',
+            name: 'entity_analytics-asset_criticality_ecs_migration',
+            id: TASK_ID,
+          },
+          async () => {
+            const esClient = coreStart.elasticsearch.client.asInternalUser;
+            const migrationClient = new AssetCriticalityMigrationClient({
+              esClient,
+              logger,
+              auditLogger,
+            });
 
-        const response = await migrationClient.migrateEcsData(abortController.signal);
-        const failures = response.failures?.map((failure) => failure.cause);
-        const hasFailures = failures && failures?.length > 0;
+            const response = await migrationClient.migrateEcsData(abortController.signal);
+            const failures = response.failures?.map((failure) => failure.cause);
+            const hasFailures = failures && failures?.length > 0;
 
-        logger.info(
-          `Task "${TASK_TYPE}" finished. Updated documents: ${response.updated}, failures: ${
-            hasFailures ? failures.join('\n') : 0
-          }`
+            logger.info(
+              `Task "${TASK_TYPE}" finished. Updated documents: ${response.updated}, failures: ${
+                hasFailures ? failures.join('\n') : 0
+              }`
+            );
+          }
         );
       },
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/tasks/lead_generation_task.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/tasks/lead_generation_task.test.ts
@@ -211,7 +211,10 @@ describe('Lead Generation Task', () => {
     } as unknown as ConcreteTaskInstance;
 
     // Re-created in each beforeEach so clearAllMocks() doesn't wipe return values
-    let mockCore: { elasticsearch: { client: { asScoped: jest.Mock } } };
+    let mockCore: {
+      elasticsearch: { client: { asScoped: jest.Mock } };
+      executionContext: { withContext: <T>(ctx: unknown, fn: () => T) => T };
+    };
     let mockStartPlugins: { entityStore: { createCRUDClient: jest.Mock }; inference: object };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let capturedCreateTaskRunner: any;
@@ -224,6 +227,9 @@ describe('Lead Generation Task', () => {
           client: {
             asScoped: jest.fn().mockReturnValue({ asCurrentUser: {} }),
           },
+        },
+        executionContext: {
+          withContext: <T>(_ctx: unknown, fn: () => T) => fn(),
         },
       };
       mockStartPlugins = {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/tasks/lead_generation_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/tasks/lead_generation_task.ts
@@ -132,7 +132,7 @@ const createLeadGenerationTaskRunnerFactory =
         return core.executionContext.withContext(
           {
             type: 'security_solution',
-            name: 'entity_analytics-lead_generation_task',
+            name: 'entity_analytics:lead_generation_task',
             id: taskInstance.id,
           },
           () =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/tasks/lead_generation_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/tasks/lead_generation_task.ts
@@ -129,16 +129,24 @@ const createLeadGenerationTaskRunnerFactory =
     return {
       run: async () => {
         const [core, startPlugins] = await deps.getStartServices();
-        return runLeadGenerationTask({
-          isCancelled,
-          logger: deps.logger,
-          taskInstance,
-          fakeRequest,
-          core,
-          startPlugins,
-          kibanaVersion: deps.kibanaVersion,
-          ml: deps.ml,
-        });
+        return core.executionContext.withContext(
+          {
+            type: 'security_solution',
+            name: 'entity_analytics-lead_generation_task',
+            id: taskInstance.id,
+          },
+          () =>
+            runLeadGenerationTask({
+              isCancelled,
+              logger: deps.logger,
+              taskInstance,
+              fakeRequest,
+              core,
+              startPlugins,
+              kibanaVersion: deps.kibanaVersion,
+              ml: deps.ml,
+            })
+        );
       },
       cancel: async () => {
         cancelled = true;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/asset_criticality_copy_timestamp_to_event_ingested.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/asset_criticality_copy_timestamp_to_event_ingested.ts
@@ -66,25 +66,34 @@ export const createMigrationTask =
     return {
       run: async () => {
         const [coreStart] = await getStartServices();
-        const esClient = coreStart.elasticsearch.client.asInternalUser;
-        const assetCrticalityClient = new AssetCriticalityMigrationClient({
-          esClient,
-          logger,
-          auditLogger,
-        });
+        return coreStart.executionContext.withContext(
+          {
+            type: 'security_solution',
+            name: 'entity_analytics-asset_criticality_migration',
+            id: TASK_ID,
+          },
+          async () => {
+            const esClient = coreStart.elasticsearch.client.asInternalUser;
+            const assetCrticalityClient = new AssetCriticalityMigrationClient({
+              esClient,
+              logger,
+              auditLogger,
+            });
 
-        const assetCriticalityResponse =
-          await assetCrticalityClient.copyTimestampToEventIngestedForAssetCriticality(
-            abortController.signal
-          );
+            const assetCriticalityResponse =
+              await assetCrticalityClient.copyTimestampToEventIngestedForAssetCriticality(
+                abortController.signal
+              );
 
-        const failures = assetCriticalityResponse.failures?.map((failure) => failure.cause);
-        const hasFailures = failures && failures?.length > 0;
+            const failures = assetCriticalityResponse.failures?.map((failure) => failure.cause);
+            const hasFailures = failures && failures?.length > 0;
 
-        logger.info(
-          `Task "${TASK_TYPE}" finished. Updated documents: ${
-            assetCriticalityResponse.updated
-          }, failures: ${hasFailures ? failures.join('\n') : 0}`
+            logger.info(
+              `Task "${TASK_TYPE}" finished. Updated documents: ${
+                assetCriticalityResponse.updated
+              }, failures: ${hasFailures ? failures.join('\n') : 0}`
+            );
+          }
         );
       },
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/asset_criticality_copy_timestamp_to_event_ingested.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/asset_criticality_copy_timestamp_to_event_ingested.ts
@@ -69,7 +69,7 @@ export const createMigrationTask =
         return coreStart.executionContext.withContext(
           {
             type: 'security_solution',
-            name: 'entity_analytics-asset_criticality_migration',
+            name: 'entity_analytics:asset_criticality_migration',
             id: TASK_ID,
           },
           async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/risk_score_copy_timestamp_to_event_ingested.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/risk_score_copy_timestamp_to_event_ingested.ts
@@ -67,27 +67,40 @@ export const createMigrationTask =
     return {
       run: async () => {
         const [coreStart] = await getStartServices();
-        const esClient = coreStart.elasticsearch.client.asInternalUser;
-        const soClient = buildScopedInternalSavedObjectsClientUnsafe({ coreStart, namespace: '*' });
+        return coreStart.executionContext.withContext(
+          {
+            type: 'security_solution',
+            name: 'entity_analytics-risk_score_migration',
+            id: TASK_ID,
+          },
+          async () => {
+            const esClient = coreStart.elasticsearch.client.asInternalUser;
+            const soClient = buildScopedInternalSavedObjectsClientUnsafe({
+              coreStart,
+              namespace: '*',
+            });
 
-        const riskScoreClient = new RiskScoreDataClient({
-          esClient,
-          logger,
-          auditLogger,
-          namespace: '*',
-          soClient,
-          kibanaVersion: '*',
-        });
-        const riskScoreResponse = await riskScoreClient.copyTimestampToEventIngestedForRiskScore(
-          abortController.signal
-        );
-        const failures = riskScoreResponse.failures?.map((failure) => failure.cause);
-        const hasFailures = failures && failures?.length > 0;
+            const riskScoreClient = new RiskScoreDataClient({
+              esClient,
+              logger,
+              auditLogger,
+              namespace: '*',
+              soClient,
+              kibanaVersion: '*',
+            });
+            const riskScoreResponse =
+              await riskScoreClient.copyTimestampToEventIngestedForRiskScore(
+                abortController.signal
+              );
+            const failures = riskScoreResponse.failures?.map((failure) => failure.cause);
+            const hasFailures = failures && failures?.length > 0;
 
-        logger.info(
-          `Task "${TASK_TYPE}" finished. Updated documents: ${
-            riskScoreResponse.updated
-          }, failures: ${hasFailures ? failures.join('\n') : 0}`
+            logger.info(
+              `Task "${TASK_TYPE}" finished. Updated documents: ${
+                riskScoreResponse.updated
+              }, failures: ${hasFailures ? failures.join('\n') : 0}`
+            );
+          }
         );
       },
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/risk_score_copy_timestamp_to_event_ingested.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/risk_score_copy_timestamp_to_event_ingested.ts
@@ -70,7 +70,7 @@ export const createMigrationTask =
         return coreStart.executionContext.withContext(
           {
             type: 'security_solution',
-            name: 'entity_analytics-risk_score_migration',
+            name: 'entity_analytics:risk_score_migration',
             id: TASK_ID,
           },
           async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/tasks/privilege_monitoring_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/tasks/privilege_monitoring_task.ts
@@ -165,7 +165,7 @@ const createPrivilegeMonitoringTaskRunnerFactory =
         return core.executionContext.withContext(
           {
             type: 'security_solution',
-            name: 'entity_analytics-privilege_monitoring_task',
+            name: 'entity_analytics:privilege_monitoring_task',
             id: taskInstance.id,
           },
           () =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/tasks/privilege_monitoring_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/tasks/privilege_monitoring_task.ts
@@ -162,16 +162,24 @@ const createPrivilegeMonitoringTaskRunnerFactory =
       run: async () => {
         const [core] = await deps.getStartServices();
         const config = deps.config;
-        return runPrivilegeMonitoringTask({
-          isCancelled,
-          logger: deps.logger,
-          telemetry: deps.telemetry,
-          taskInstance,
-          experimentalFeatures: deps.experimentalFeatures,
-          core,
-          config,
-          getPrivilegedUserMonitoringDataClient: deps.getPrivilegedUserMonitoringDataClient,
-        });
+        return core.executionContext.withContext(
+          {
+            type: 'security_solution',
+            name: 'entity_analytics-privilege_monitoring_task',
+            id: taskInstance.id,
+          },
+          () =>
+            runPrivilegeMonitoringTask({
+              isCancelled,
+              logger: deps.logger,
+              telemetry: deps.telemetry,
+              taskInstance,
+              experimentalFeatures: deps.experimentalFeatures,
+              core,
+              config,
+              getPrivilegedUserMonitoringDataClient: deps.getPrivilegedUserMonitoringDataClient,
+            })
+        );
       },
       cancel: async () => {
         cancelled = true;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.ts
@@ -445,7 +445,7 @@ const createTaskRunnerFactory =
         return coreStart.executionContext.withContext(
           {
             type: 'security_solution',
-            name: 'entity_analytics-risk_scoring_task',
+            name: 'entity_analytics:risk_scoring_task',
             id: taskInstance.id,
           },
           () =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.ts
@@ -134,6 +134,7 @@ export const registerRiskScoringTask = ({
       createTaskRunner: createTaskRunnerFactory({
         logger,
         getRiskScoreService,
+        getStartServices,
         telemetry,
         entityAnalyticsConfig,
         experimentalFeatures,
@@ -423,12 +424,14 @@ const createTaskRunnerFactory =
   ({
     logger,
     getRiskScoreService,
+    getStartServices,
     telemetry,
     entityAnalyticsConfig,
     experimentalFeatures,
   }: {
     logger: Logger;
     getRiskScoreService: GetRiskScoreService;
+    getStartServices: EntityAnalyticsRoutesDeps['getStartServices'];
     telemetry: AnalyticsServiceSetup;
     entityAnalyticsConfig: EntityAnalyticsConfig;
     experimentalFeatures: ExperimentalFeatures;
@@ -437,16 +440,26 @@ const createTaskRunnerFactory =
     let cancelled = false;
     const isCancelled = () => cancelled;
     return {
-      run: async () =>
-        runTask({
-          getRiskScoreService,
-          isCancelled,
-          logger,
-          taskInstance,
-          telemetry,
-          entityAnalyticsConfig,
-          experimentalFeatures,
-        }),
+      run: async () => {
+        const [coreStart] = await getStartServices();
+        return coreStart.executionContext.withContext(
+          {
+            type: 'security_solution',
+            name: 'entity_analytics-risk_scoring_task',
+            id: taskInstance.id,
+          },
+          () =>
+            runTask({
+              getRiskScoreService,
+              isCancelled,
+              logger,
+              taskInstance,
+              telemetry,
+              entityAnalyticsConfig,
+              experimentalFeatures,
+            })
+        );
+      },
       cancel: async () => {
         cancelled = true;
       },


### PR DESCRIPTION
## Summary

Every Elasticsearch query originating from the Entity Analytics home page now carries an execution context that is traceable via the `x-opaque-id` header. This enables identifying which specific UI component triggered each query, formatted as:

```
{requestId};kibana:security_solution:entity_analytics-home_page:{component_name}
```

### Changes

**7 files modified** across the `security_solution` plugin:

| File | Change |
|------|--------|
| `watchlists/.../use_risk_levels_esql_query.ts` | Added `executionContext` to `data.search.search` options (`risk_level_panel`) |
| `entities_table/.../use_fetch_grid_data.ts` | Added `executionContext` to `data.search.search` options (`entities_table`) |
| `entities_table/.../use_fetch_grouped_data.ts` | Added `executionContext` to both `searchService.search` calls (`entities_table_grouped`, `entities_table_target_metadata`) |
| `detections/.../alerts/types.ts` | Extended `QueryAlerts` interface with optional `context` field |
| `detections/.../alerts/api.ts` | Extended `fetchQueryAlerts` to forward `context` to `http.fetch` |
| `entity_alerts_cell.tsx` | Passed execution context to `fetchQueryAlerts` (`entity_alerts_cell`) |
| `recent_anomalies/.../recent_anomalies_query_hooks.ts` | Added `executionContext` to all 3 `getESQLResults` calls (`anomalies_entity_filter`, `anomalies_top_rows`, `anomalies_heatmap`) |

### Component identifiers

| `x-opaque-id` id | Component |
|---|---|
| `risk_level_panel` | DynamicRiskLevelPanel |
| `entities_table` | EntitiesDataTable |
| `entities_table_grouped` | EntitiesTableSection (grouped mode) |
| `entities_table_target_metadata` | EntitiesTableSection (resolution groups) |
| `entity_alerts_cell` | EntityAlertsCell |
| `anomalies_entity_filter` | useFilteredEntityIds |
| `anomalies_top_rows` | useRecentAnomaliesTopRowsQuery |
| `anomalies_heatmap` | useRecentAnomaliesQuery |

### How it works

Kibana's Execution Context Service propagates `type`, `name`, and `id` fields from the browser through the `x-kbn-context` header to the server, which serializes them into the `x-opaque-id` header on every ES request. This PR leverages existing support for `executionContext` in `data.search.search()`, `getESQLResults()`, and `http.fetch()` -- no framework changes were needed.

### Verification

Inspect `x-kbn-context` request headers in browser DevTools, or check ES slow logs / `GET _tasks?detailed=true` for the `x-opaque-id` field.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




