### PR TITLE
[Webhook connector] Fix OpenAPI docs for OAuth2 client credentials and additional HTTP methods

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -133045,8 +133045,9 @@ components:
       enum:
         - webhook-authentication-basic
         - webhook-authentication-ssl
+        - webhook-oauth2-client-credentials
       description: |
-        The type of authentication to use: basic, SSL, or none.
+        The type of authentication to use: basic, SSL, OAuth2 client credentials, or none.
     ca:
       title: Certificate authority
       type: string
@@ -133080,12 +133081,25 @@ components:
       description: Defines properties for connectors when type is `.webhook`.
       type: object
       properties:
+        accessTokenUrl:
+          type: string
+          description: |
+            The URL used to request an OAuth2 access token. If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
+        additionalFields:
+          type: string
+          nullable: true
+          description: |
+            Additional fields, encoded as a JSON object, sent as part of the OAuth2 access token request body.
         authType:
           $ref: '#/components/schemas/auth_type'
         ca:
           $ref: '#/components/schemas/ca'
         certType:
           $ref: '#/components/schemas/cert_type'
+        clientId:
+          type: string
+          description: |
+            The client identifier for OAuth2 authentication. If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
         hasAuth:
           $ref: '#/components/schemas/has_auth'
         headers:
@@ -133098,8 +133112,15 @@ components:
           enum:
             - post
             - put
+            - patch
+            - get
+            - delete
           description: |
-            The HTTP request method, either `post` or `put`.
+            The HTTP request method: `post`, `put`, `patch`, `get`, or `delete`.
+        scope:
+          type: string
+          description: |
+            The scope requested when acquiring the OAuth2 access token.
         url:
           type: string
           description: |
@@ -133472,6 +133493,10 @@ components:
       description: Defines secrets for connectors when type is `.webhook`.
       type: object
       properties:
+        clientSecret:
+          type: string
+          description: |
+            The client secret for OAuth2 authentication. If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
         crt:
           $ref: '#/components/schemas/crt'
         key:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -146559,8 +146559,9 @@ components:
       enum:
         - webhook-authentication-basic
         - webhook-authentication-ssl
+        - webhook-oauth2-client-credentials
       description: |
-        The type of authentication to use: basic, SSL, or none.
+        The type of authentication to use: basic, SSL, OAuth2 client credentials, or none.
     ca:
       title: Certificate authority
       type: string
@@ -146594,12 +146595,25 @@ components:
       description: Defines properties for connectors when type is `.webhook`.
       type: object
       properties:
+        accessTokenUrl:
+          type: string
+          description: |
+            The URL used to request an OAuth2 access token. If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
+        additionalFields:
+          type: string
+          nullable: true
+          description: |
+            Additional fields, encoded as a JSON object, sent as part of the OAuth2 access token request body.
         authType:
           $ref: '#/components/schemas/auth_type'
         ca:
           $ref: '#/components/schemas/ca'
         certType:
           $ref: '#/components/schemas/cert_type'
+        clientId:
+          type: string
+          description: |
+            The client identifier for OAuth2 authentication. If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
         hasAuth:
           $ref: '#/components/schemas/has_auth'
         headers:
@@ -146612,8 +146626,15 @@ components:
           enum:
             - post
             - put
+            - patch
+            - get
+            - delete
           description: |
-            The HTTP request method, either `post` or `put`.
+            The HTTP request method: `post`, `put`, `patch`, `get`, or `delete`.
+        scope:
+          type: string
+          description: |
+            The scope requested when acquiring the OAuth2 access token.
         url:
           type: string
           description: |
@@ -146986,6 +147007,10 @@ components:
       description: Defines secrets for connectors when type is `.webhook`.
       type: object
       properties:
+        clientSecret:
+          type: string
+          description: |
+            The client secret for OAuth2 authentication. If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
         crt:
           $ref: '#/components/schemas/crt'
         key:

--- a/x-pack/platform/plugins/shared/actions/docs/openapi/components/schemas/auth_type.yaml
+++ b/x-pack/platform/plugins/shared/actions/docs/openapi/components/schemas/auth_type.yaml
@@ -4,5 +4,6 @@ nullable: true
 enum:
   - webhook-authentication-basic
   - webhook-authentication-ssl
+  - webhook-oauth2-client-credentials
 description: >
-  The type of authentication to use: basic, SSL, or none.
+  The type of authentication to use: basic, SSL, OAuth2 client credentials, or none.

--- a/x-pack/platform/plugins/shared/actions/docs/openapi/components/schemas/webhook_config.yaml
+++ b/x-pack/platform/plugins/shared/actions/docs/openapi/components/schemas/webhook_config.yaml
@@ -2,12 +2,27 @@ title: Connector request properties for a Webhook connector
 description: Defines properties for connectors when type is `.webhook`.
 type: object
 properties:
+  accessTokenUrl:
+    type: string
+    description: >
+      The URL used to request an OAuth2 access token.
+      If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
+  additionalFields:
+    type: string
+    nullable: true
+    description: >
+      Additional fields, encoded as a JSON object, sent as part of the OAuth2 access token request body.
   authType:
     $ref: 'auth_type.yaml'
   ca:
     $ref: 'ca.yaml'
   certType:
     $ref: 'cert_type.yaml'
+  clientId:
+    type: string
+    description: >
+      The client identifier for OAuth2 authentication.
+      If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
   hasAuth:
     $ref: 'has_auth.yaml'
   headers:
@@ -20,8 +35,15 @@ properties:
     enum:
       - post
       - put
+      - patch
+      - get
+      - delete
     description: >
-      The HTTP request method, either `post` or `put`.
+      The HTTP request method: `post`, `put`, `patch`, `get`, or `delete`.
+  scope:
+    type: string
+    description: >
+      The scope requested when acquiring the OAuth2 access token.
   url:
     type: string
     description: >

--- a/x-pack/platform/plugins/shared/actions/docs/openapi/components/schemas/webhook_secrets.yaml
+++ b/x-pack/platform/plugins/shared/actions/docs/openapi/components/schemas/webhook_secrets.yaml
@@ -2,6 +2,11 @@ title: Connector secrets properties for a Webhook connector
 description: Defines secrets for connectors when type is `.webhook`.
 type: object
 properties:
+  clientSecret:
+    type: string
+    description: >
+      The client secret for OAuth2 authentication.
+      If `hasAuth` is set to `true` and `authType` is `webhook-oauth2-client-credentials`, this property is required.
   crt:
     $ref: 'crt.yaml'
   key:


### PR DESCRIPTION
## Summary

The `.webhook` connector's hand-authored OpenAPI docs (`webhook_config.yaml`, `auth_type.yaml`, `webhook_secrets.yaml`) had drifted out of sync with the connector's actual Zod validation schema (`@kbn/connector-schemas`). Three features shipped to the runtime schema over the last ~10 months were never reflected in the docs:

- #218442 added OAuth2 client credentials auth (`accessTokenUrl`, `clientId`, `scope`, `additionalFields`, `clientSecret`)
- #238072 added `patch`/`get`/`delete` to the allowed `method` values (previously only `post`/`put`)
- #276324 added `webhook-oauth2-password` to the shared `AuthType` enum — but only wired password-grant support into the `.http` connector; `.webhook`'s own `validateOAuth2()` explicitly rejects that authType at runtime

This PR brings the OpenAPI docs back in sync with the runtime schema:

- `auth_type.yaml`: added `webhook-oauth2-client-credentials` to the enum. `webhook-oauth2-password` is **intentionally omitted** — documenting it for `.webhook` would describe a value that gets rejected with a validation error if actually used, since password-grant is only supported by the `.http` connector (which has no OpenAPI docs).
- `webhook_config.yaml`: added `accessTokenUrl`, `clientId`, `scope`, `additionalFields`; expanded `method`'s enum to `post`/`put`/`patch`/`get`/`delete`.
- `webhook_secrets.yaml`: added `clientSecret`, which was missing entirely (not just stale) — without it, the OAuth2 config fields above would be undiscoverable/unusable via the published spec.

This is blocking a clean fix in the community Terraform provider, whose generated Go client is produced directly from `oas_docs/output/kibana.yaml` (elastic/terraform-provider-elasticstack#3773).

No changes to `oas_docs/output/kibana.yaml` / `kibana.serverless.yaml` are included — those are regenerated and auto-committed by CI (`capture_oas_snapshot` + `final_merge` steps in `on_merge.yml`), which requires a live-captured OAS snapshot that isn't available to reproduce accurately outside CI.

Fixes #280000

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md) — N/A, docs-only YAML, no UI text
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials — this PR *is* the documentation fix
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios — N/A, static OpenAPI schema fragments, no test coverage exists for the doc content itself
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker) — N/A, no config keys changed
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations. — additive only (new optional properties/enum values documented to match already-shipped, already-accepted runtime behavior); no breaking change
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed — N/A, no tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) — `release_note:skip` applied (docs-only fix, no user-facing behavior change)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels. — `backport:skip` applied; docs describe current `main` behavior only

### Identify risks

None. This only changes hand-authored OpenAPI documentation fragments (`.yaml` schema descriptions) to match already-shipped, already-accepted runtime validation behavior. No runtime code, no config, no test changes.

- [x] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
