### PR TITLE
Fix serverless alerting rule test isolation

### DIFF
--- a/x-pack/platform/test/serverless/api_integration/test_suites/alerting/rules.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/alerting/rules.ts
@@ -22,14 +22,15 @@ export default function ({ getService }: FtrProviderContext) {
   let roleAdmin: RoleCredentials;
   let internalReqHeader: InternalRequestHeader;
 
-  // Failing: See https://github.com/elastic/kibana/issues/251764
-  describe.skip('Alerting rules', function () {
+  describe('Alerting rules', function () {
     // Timeout of 360000ms exceeded
     this.tags(['failsOnMKI']);
     const RULE_TYPE_ID = '.es-query';
-    const ALERT_ACTION_INDEX = 'alert-action-es-query';
+    const alertActionIndexPrefix = 'alert-action-es-query';
     let connectorId: string;
     let ruleId: string;
+    let alertActionIndex: string;
+    let testIndex = 0;
 
     before(async () => {
       roleAdmin = await svlUserManager.createM2mApiKeyWithRoleScope('admin');
@@ -37,6 +38,10 @@ export default function ({ getService }: FtrProviderContext) {
     });
     after(async () => {
       await svlUserManager.invalidateM2mApiKeyWithRoleScope(roleAdmin);
+    });
+
+    beforeEach(() => {
+      alertActionIndex = `${alertActionIndexPrefix}-${testIndex++}`;
     });
 
     afterEach(async () => {
@@ -47,7 +52,7 @@ export default function ({ getService }: FtrProviderContext) {
         conflicts: 'proceed',
         query: { term: { 'kibana.alert.rule.consumer': 'alerts' } },
       });
-      await esDeleteAllIndices([ALERT_ACTION_INDEX]);
+      await esDeleteAllIndices([alertActionIndex]);
     });
 
     it('should schedule task, run rule and schedule actions when appropriate', async () => {
@@ -56,7 +61,7 @@ export default function ({ getService }: FtrProviderContext) {
       const createdConnector = await alertingApi.helpers.createIndexConnector({
         roleAuthc: roleAdmin,
         name: 'Index Connector: Alerting API test',
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
       });
       connectorId = createdConnector.id;
 
@@ -108,7 +113,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Wait for the action to index a document before disabling the alert and waiting for tasks to finish
       const resp = await alertingApi.helpers.waitForDocumentInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
         retryOptions: {
           retryCount: 12,
@@ -154,7 +159,7 @@ export default function ({ getService }: FtrProviderContext) {
       const createdConnector = await alertingApi.helpers.createIndexConnector({
         roleAuthc: roleAdmin,
         name: 'Index Connector: Alerting API test',
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
       });
       connectorId = createdConnector.id;
 
@@ -206,7 +211,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Wait for the action to index a document before disabling the alert and waiting for tasks to finish
       const resp = await alertingApi.helpers.waitForDocumentInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
         retryOptions: { retryDelay: 800, retryCount: 10 },
       });
@@ -248,7 +253,7 @@ export default function ({ getService }: FtrProviderContext) {
       // make sure alert info passed to executor is correct
       const resp2 = await alertingApi.helpers.waitForDocumentInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
         num: 2,
       });
@@ -327,7 +332,7 @@ export default function ({ getService }: FtrProviderContext) {
       const createdConnector = await alertingApi.helpers.createIndexConnector({
         roleAuthc: roleAdmin,
         name: 'Index Connector: Alerting API test',
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
       });
       connectorId = createdConnector.id;
 
@@ -396,7 +401,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Ensure actions only executed once
       const resp = await alertingApi.helpers.waitForDocumentInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
       });
       expect(resp.hits.hits.length).to.be(1);
@@ -408,7 +413,7 @@ export default function ({ getService }: FtrProviderContext) {
       const createdConnector = await alertingApi.helpers.createIndexConnector({
         roleAuthc: roleAdmin,
         name: 'Index Connector: Alerting API test',
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
       });
       connectorId = createdConnector.id;
 
@@ -481,7 +486,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Ensure actions only executed once
       const resp = await alertingApi.helpers.waitForDocumentInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
       });
       expect(resp.hits.hits.length).to.be(1);
@@ -493,7 +498,7 @@ export default function ({ getService }: FtrProviderContext) {
       const createdConnector = await alertingApi.helpers.createIndexConnector({
         roleAuthc: roleAdmin,
         name: 'Index Connector: Alerting API test',
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
       });
       connectorId = createdConnector.id;
 
@@ -571,7 +576,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Wait for the action to index a document
       const resp = await alertingApi.helpers.waiting.waitForDocumentInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
       });
       expect(resp.hits.hits.length).to.be(1);
@@ -631,7 +636,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Ensure only 2 actions are executed
       const resp2 = await alertingApi.helpers.waitForDocumentInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
         num: 2,
       });
@@ -640,12 +645,12 @@ export default function ({ getService }: FtrProviderContext) {
 
     it(`shouldn't schedule actions when alert is muted`, async () => {
       const testStart = new Date();
-      await alertingApi.helpers.waiting.createIndex({ esClient, indexName: ALERT_ACTION_INDEX });
+      await alertingApi.helpers.waiting.createIndex({ esClient, indexName: alertActionIndex });
 
       const createdConnector = await alertingApi.helpers.createIndexConnector({
         roleAuthc: roleAdmin,
         name: 'Index Connector: Alerting API test',
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
       });
       connectorId = createdConnector.id;
 
@@ -729,7 +734,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Should not have executed any action
       const resp2 = await alertingApi.helpers.waiting.getDocumentsInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
       });
       expect(resp2.hits.hits.length).to.be(0);
@@ -737,12 +742,12 @@ export default function ({ getService }: FtrProviderContext) {
 
     it(`shouldn't schedule actions when alert instance is muted`, async () => {
       const testStart = new Date();
-      await alertingApi.helpers.waiting.createIndex({ esClient, indexName: ALERT_ACTION_INDEX });
+      await alertingApi.helpers.waiting.createIndex({ esClient, indexName: alertActionIndex });
 
       const createdConnector = await alertingApi.helpers.createIndexConnector({
         roleAuthc: roleAdmin,
         name: 'Index Connector: Alerting API test',
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
       });
       connectorId = createdConnector.id;
 
@@ -827,7 +832,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Should not have executed any action
       const resp2 = await alertingApi.helpers.waiting.getDocumentsInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
       });
       expect(resp2.hits.hits.length).to.be(0);
@@ -837,7 +842,7 @@ export default function ({ getService }: FtrProviderContext) {
       const createdConnector = await alertingApi.helpers.createIndexConnector({
         roleAuthc: roleAdmin,
         name: 'Index Connector: Alerting API test',
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
       });
       connectorId = createdConnector.id;
 
@@ -911,7 +916,7 @@ export default function ({ getService }: FtrProviderContext) {
       // Should have one document indexed by the action
       const resp = await alertingApi.helpers.waitForDocumentInIndex({
         esClient,
-        indexName: ALERT_ACTION_INDEX,
+        indexName: alertActionIndex,
         ruleId,
       });
       expect(resp.hits.hits.length).to.be(1);

--- a/x-pack/platform/test/serverless/api_integration/test_suites/alerting/rules.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/alerting/rules.ts
@@ -26,7 +26,7 @@ export default function ({ getService }: FtrProviderContext) {
     // Timeout of 360000ms exceeded
     this.tags(['failsOnMKI']);
     const RULE_TYPE_ID = '.es-query';
-    const alertActionIndexPrefix = 'alert-action-es-query';
+    const ALERT_ACTION_INDEX = 'alert-action-es-query';
     let connectorId: string;
     let ruleId: string;
     let alertActionIndex: string;
@@ -41,7 +41,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     beforeEach(() => {
-      alertActionIndex = `${alertActionIndexPrefix}-${testIndex++}`;
+      alertActionIndex = `${ALERT_ACTION_INDEX}-${testIndex++}`;
     });
 
     afterEach(async () => {


### PR DESCRIPTION
## Summary
- Restore the serverless alerting rules suite by assigning each test a distinct index connector target.
- Prevent pending action tasks from a prior test from recreating or deleting the next test's shared index, which caused missing-index, missing-`date`-mapping, and document-count failures.

## Root cause
All tests used `alert-action-es-query`, then deleted it in `afterEach` while alerting and action tasks could still run. A delayed task could recreate that index with dynamic mappings, or a following test could delete it before another test's wait completed.

Closes #251764
