### PR TITLE
[Data Streams] Validate privileged streams are elasticsearch system data streams

### DIFF
--- a/examples/data_streams_example/server/index.ts
+++ b/examples/data_streams_example/server/index.ts
@@ -26,6 +26,7 @@ const dataStreamMappings = {
 const dataStream: DataStreamDefinition<typeof dataStreamMappings> = {
   name: '.kibana-my-data-stream',
   version: 1,
+  requiresSystemDataStream: false,
   template: {
     mappings: dataStreamMappings,
   },

--- a/src/core/packages/data-streams/server-internal/src/service.ts
+++ b/src/core/packages/data-streams/server-internal/src/service.ts
@@ -94,8 +94,11 @@ export class DataStreamsService implements CoreService<DataStreamsSetup, DataStr
 
     const allDataStreamNames = Array.from(this.dataStreamDefinitions.keys());
     for (const dataStreamName of allDataStreamNames) {
+      const definition = this.dataStreamDefinitions.get(dataStreamName);
+      // Privileged streams create+assert on startup; others only install the template.
+      const eagerCreation = Boolean(definition?.requiresSystemDataStream);
       setupPromises.push(
-        limit(() => this.initializeDataStream(dataStreamName, elasticsearchClient, true))
+        limit(() => this.initializeDataStream(dataStreamName, elasticsearchClient, !eagerCreation))
       );
     }
 

--- a/src/platform/packages/private/kbn-data-streams/README.md
+++ b/src/platform/packages/private/kbn-data-streams/README.md
@@ -115,6 +115,26 @@ All CRUD operations (`create`, `search`) accept an optional `space` parameter:
 
 Data streams can contain both space-bound and space-agnostic documents. The package does not handle RBAC; higher-level repositories should wrap these APIs for access control.
 
+## System data streams
+
+`@kbn/data-streams` can create **hidden** data streams (`hidden` defaults to `true`). It **cannot** register a stream as a system data stream — that requires a matching [`SystemDataStreamDescriptor`](https://javadoc.io/doc/org.elasticsearch/elasticsearch/latest/org/elasticsearch/indices/SystemDataStreamDescriptor.html) in Elasticsearch.
+
+`requiresSystemDataStream` **defaults to `true`**. After setup, if the data stream already exists, initialization re-reads it via `GET _data_stream/<name>` and **fails closed** unless Elasticsearch reports `system: true`. Opt out only when a stream is intentionally non-system:
+
+```typescript
+const definition: DataStreamDefinition<typeof mappings> = {
+  name: '.my-non-system-stream',
+  version: 1,
+  hidden: true,
+  requiresSystemDataStream: false, // explicit opt-out
+  template: { mappings },
+};
+```
+
+When the stream does not exist yet (lazy creation), verification is skipped until a later initialize sees the stream.
+
+Use `GET _data_stream/<name>` to inspect runtime `system` / `hidden` flags. There is no Elasticsearch API that lists all registered `SystemIndexDescriptor` / `SystemDataStreamDescriptor` patterns — those live in ES plugin code.
+
 ## Mapping Validation
 
 When registering a data stream, the following reserved keys are automatically validated and will cause an error if found in your mappings:

--- a/src/platform/packages/private/kbn-data-streams/README.md
+++ b/src/platform/packages/private/kbn-data-streams/README.md
@@ -119,19 +119,45 @@ Data streams can contain both space-bound and space-agnostic documents. The pack
 
 `@kbn/data-streams` can create **hidden** data streams (`hidden` defaults to `true`). It **cannot** register a stream as a system data stream — that requires a matching [`SystemDataStreamDescriptor`](https://javadoc.io/doc/org.elasticsearch/elasticsearch/latest/org/elasticsearch/indices/SystemDataStreamDescriptor.html) in Elasticsearch.
 
-`requiresSystemDataStream` **defaults to `true`**. After setup, if the data stream already exists, initialization re-reads it via `GET _data_stream/<name>` and **fails closed** unless Elasticsearch reports `system: true`. Opt out only when a stream is intentionally non-system:
+`requiresSystemDataStream` is **required** on every `DataStreamDefinition` (`true` or `false`). Set `false` for intentional non-system streams; set `true` for privileged streams that must be ES system data streams.
+
+When `true`, after setup initialization re-reads `GET _data_stream/<name>`:
+
+- **Created in this initialize call** and `system !== true` → **fail closed** (throw) and **roll back** the stream (+ template if created this call).
+- **Already existed** in the environment and `system !== true` → **warn and continue** so leftover non-system streams do not crash Kibana boot (recreate after ES registration).
 
 ```typescript
 const definition: DataStreamDefinition<typeof mappings> = {
   name: '.my-non-system-stream',
   version: 1,
   hidden: true,
-  requiresSystemDataStream: false, // explicit opt-out
+  requiresSystemDataStream: false,
+  template: { mappings },
+};
+
+const privileged: DataStreamDefinition<typeof mappings> = {
+  name: '.kibana_change_history',
+  version: 1,
+  requiresSystemDataStream: true,
   template: { mappings },
 };
 ```
 
-When the stream does not exist yet (lazy creation), verification is skipped until a later initialize sees the stream.
+### Privileged streams (`requiresSystemDataStream: true`)
+
+- Use `DataStreamClient.initialize({ lazyCreation: false })` (or core `initializeClient`) so create and assert share one boot path — this is the only supported boot path for privileged streams when the stream does not exist yet.
+- Core `registerDataStream` eager-inits privileged streams; others stay lazy.
+- Privileged + `lazyCreation: true` or `initializeTemplate` (stream absent) **throws** via a shared refuse helper.
+- Create-this-call + assert failure rolls back stream **and** template created in that call. Pre-existing non-system → warn only. Transient `GET _data_stream` errors do **not** trigger rollback.
+
+### Landing order
+
+Ship the Elasticsearch `SystemDataStreamDescriptor` **with or before** enabling Kibana writes for that stream, you can find examples in:
+
+| Stream | ES registration |
+|--------|-----------------|
+| `.workflows-events`, `.workflows-execution-data-stream-logs` | [elastic/elasticsearch#145822](https://github.com/elastic/elasticsearch/pull/145822) |
+| `.kibana_change_history` | [elastic/elasticsearch#154113](https://github.com/elastic/elasticsearch/pull/154113) ([security-team#18291](https://github.com/elastic/security-team/issues/18291)) |
 
 Use `GET _data_stream/<name>` to inspect runtime `system` / `hidden` flags. There is no Elasticsearch API that lists all registered `SystemIndexDescriptor` / `SystemDataStreamDescriptor` patterns — those live in ES plugin code.
 

--- a/src/platform/packages/private/kbn-data-streams/src/__fixtures__/full_client_example.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/__fixtures__/full_client_example.ts
@@ -37,6 +37,7 @@ const dataStreamDefinition: DataStreamDefinition<typeof dataStreamMapping, FullD
   {
     name: 'test-data-stream',
     version: 1,
+    requiresSystemDataStream: false,
     template: {
       mappings: dataStreamMapping,
     },

--- a/src/platform/packages/private/kbn-data-streams/src/__fixtures__/simple_client_example.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/__fixtures__/simple_client_example.ts
@@ -28,6 +28,7 @@ const dataStreamMapping = {
 const dataStreamDefinition: DataStreamDefinition<typeof dataStreamMapping> = {
   name: 'test-data-stream',
   version: 1,
+  requiresSystemDataStream: false,
   template: {
     mappings: dataStreamMapping,
   },

--- a/src/platform/packages/private/kbn-data-streams/src/client.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/client.ts
@@ -25,6 +25,7 @@ import { initialize } from './initialize';
 import { initializeIndexTemplate } from './initialize/index_template';
 import { initializeDataStream } from './initialize/data_stream';
 import { getExistingDataStream, getExistingIndexTemplate } from './initialize/exists_checks';
+import { assertSystemDataStream } from './initialize/assert_system_data_stream';
 import { validateClientArgs } from './validate_client_args';
 import {
   generateSpacePrefixedId,
@@ -133,6 +134,12 @@ export class DataStreamClient<
       existingIndexTemplate,
       skipCreation: true,
     });
+
+    // Template-only setup cannot create a system stream; if one already exists, verify it
+    // (requiresSystemDataStream defaults to true; explicit false opts out).
+    if (dataStream.requiresSystemDataStream !== false && existingDataStream) {
+      await assertSystemDataStream({ logger, dataStream, elasticsearchClient });
+    }
   }
 
   /**

--- a/src/platform/packages/private/kbn-data-streams/src/client.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/client.ts
@@ -25,7 +25,10 @@ import { initialize } from './initialize';
 import { initializeIndexTemplate } from './initialize/index_template';
 import { initializeDataStream } from './initialize/data_stream';
 import { getExistingDataStream, getExistingIndexTemplate } from './initialize/exists_checks';
-import { assertSystemDataStream } from './initialize/assert_system_data_stream';
+import {
+  assertSystemDataStream,
+  rejectDeferredPrivilegedSetup,
+} from './initialize/assert_system_data_stream';
 import { validateClientArgs } from './validate_client_args';
 import {
   generateSpacePrefixedId,
@@ -91,6 +94,10 @@ export class DataStreamClient<
    * mapping changes are applied to the current write index — same contract as
    * {@link DataStreamClient.initialize}, minus the data stream creation step.
    *
+   * Not valid for privileged streams (`requiresSystemDataStream: true`) when the data stream
+   * does not exist yet — call {@link DataStreamClient.initialize} with `lazyCreation: false`
+   * instead so create and system assert share one boot path.
+   *
    * Use {@link DataStreamClient.fromDefinition} to obtain a client at runtime.
    *
    * @remark Idempotent: subsequent calls with the same definition are no-ops; calls with a higher
@@ -114,6 +121,10 @@ export class DataStreamClient<
       getExistingIndexTemplate(elasticsearchClient, dataStream.name, logger),
     ]);
 
+    if (!existingDataStream) {
+      rejectDeferredPrivilegedSetup(dataStream, 'initializeTemplate');
+    }
+
     await initializeIndexTemplate({
       logger,
       dataStream,
@@ -135,11 +146,12 @@ export class DataStreamClient<
       skipCreation: true,
     });
 
-    // Template-only setup cannot create a system stream; if one already exists, verify it
-    // (requiresSystemDataStream defaults to true; explicit false opts out).
-    if (dataStream.requiresSystemDataStream !== false && existingDataStream) {
-      await assertSystemDataStream({ logger, dataStream, elasticsearchClient });
-    }
+    await assertSystemDataStream({
+      logger,
+      dataStream,
+      elasticsearchClient,
+      failClosed: false,
+    });
   }
 
   /**

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/assert_system_data_stream.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/assert_system_data_stream.test.ts
@@ -14,7 +14,7 @@ import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { errors as EsErrors } from '@elastic/elasticsearch';
 import { mappings, type MappingsDefinition } from '@kbn/es-mappings';
 import type { DataStreamDefinition } from '../types';
-import { assertSystemDataStream } from './assert_system_data_stream';
+import { assertSystemDataStream, SystemDataStreamAssertError } from './assert_system_data_stream';
 
 describe('assertSystemDataStream', () => {
   let logger: Logger;
@@ -31,6 +31,7 @@ describe('assertSystemDataStream', () => {
   ): DataStreamDefinition<typeof testMappings> => ({
     name: '.kibana_change_history',
     version: 1,
+    requiresSystemDataStream: true,
     template: { mappings: testMappings },
     ...overrides,
   });
@@ -53,17 +54,18 @@ describe('assertSystemDataStream', () => {
     jest.clearAllMocks();
   });
 
-  it('is a no-op when requiresSystemDataStream is explicitly false', async () => {
+  it('is a no-op when requiresSystemDataStream is false', async () => {
     await assertSystemDataStream({
       logger,
       elasticsearchClient,
       dataStream: createDefinition({ requiresSystemDataStream: false }),
+      failClosed: true,
     });
 
     expect(elasticsearchClient.indices.getDataStream).not.toHaveBeenCalled();
   });
 
-  it('skips verification when the data stream does not exist yet (lazy creation)', async () => {
+  it('skips verification when the data stream does not exist yet', async () => {
     (elasticsearchClient.indices.getDataStream as jest.Mock).mockRejectedValue(notFoundError());
 
     await expect(
@@ -71,11 +73,12 @@ describe('assertSystemDataStream', () => {
         logger,
         elasticsearchClient,
         dataStream: createDefinition(),
+        failClosed: true,
       })
     ).resolves.toBeUndefined();
   });
 
-  it('succeeds when Elasticsearch reports system: true (default requires system)', async () => {
+  it('succeeds when Elasticsearch reports system: true', async () => {
     (elasticsearchClient.indices.getDataStream as jest.Mock).mockResolvedValue({
       data_streams: [{ name: '.kibana_change_history', system: true, hidden: true }],
     });
@@ -85,11 +88,12 @@ describe('assertSystemDataStream', () => {
         logger,
         elasticsearchClient,
         dataStream: createDefinition(),
+        failClosed: true,
       })
     ).resolves.toBeUndefined();
   });
 
-  it('throws when Elasticsearch reports system: false', async () => {
+  it('throws when failClosed and Elasticsearch reports system: false', async () => {
     (elasticsearchClient.indices.getDataStream as jest.Mock).mockResolvedValue({
       data_streams: [{ name: '.kibana_change_history', system: false, hidden: true }],
     });
@@ -99,11 +103,12 @@ describe('assertSystemDataStream', () => {
         logger,
         elasticsearchClient,
         dataStream: createDefinition(),
+        failClosed: true,
       })
-    ).rejects.toThrow(/system: false/);
+    ).rejects.toBeInstanceOf(SystemDataStreamAssertError);
   });
 
-  it('throws when Elasticsearch omits the system flag', async () => {
+  it('throws when failClosed and Elasticsearch omits the system flag', async () => {
     (elasticsearchClient.indices.getDataStream as jest.Mock).mockResolvedValue({
       data_streams: [{ name: '.kibana_change_history', hidden: true }],
     });
@@ -112,8 +117,26 @@ describe('assertSystemDataStream', () => {
       assertSystemDataStream({
         logger,
         elasticsearchClient,
-        dataStream: createDefinition({ requiresSystemDataStream: true }),
+        dataStream: createDefinition(),
+        failClosed: true,
       })
-    ).rejects.toThrow(/system: undefined/);
+    ).rejects.toBeInstanceOf(SystemDataStreamAssertError);
+  });
+
+  it('warns and continues when not failClosed and Elasticsearch reports system: false', async () => {
+    (elasticsearchClient.indices.getDataStream as jest.Mock).mockResolvedValue({
+      data_streams: [{ name: '.kibana_change_history', system: false, hidden: true }],
+    });
+
+    await expect(
+      assertSystemDataStream({
+        logger,
+        elasticsearchClient,
+        dataStream: createDefinition(),
+        failClosed: false,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/system: false/));
   });
 });

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/assert_system_data_stream.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/assert_system_data_stream.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/logging';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import { mappings, type MappingsDefinition } from '@kbn/es-mappings';
+import type { DataStreamDefinition } from '../types';
+import { assertSystemDataStream } from './assert_system_data_stream';
+
+describe('assertSystemDataStream', () => {
+  let logger: Logger;
+  let elasticsearchClient: jest.Mocked<ElasticsearchClient>;
+
+  const testMappings = {
+    properties: {
+      '@timestamp': mappings.date(),
+    },
+  } satisfies MappingsDefinition;
+
+  const createDefinition = (
+    overrides: Partial<DataStreamDefinition<typeof testMappings>> = {}
+  ): DataStreamDefinition<typeof testMappings> => ({
+    name: '.kibana_change_history',
+    version: 1,
+    template: { mappings: testMappings },
+    ...overrides,
+  });
+
+  const notFoundError = () =>
+    new EsErrors.ResponseError({
+      statusCode: 404,
+      body: { error: { type: 'resource_not_found_exception' } },
+      warnings: [],
+      headers: {},
+      meta: {} as never,
+    });
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    elasticsearchClient = elasticsearchClientMock.createInternalClient();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is a no-op when requiresSystemDataStream is explicitly false', async () => {
+    await assertSystemDataStream({
+      logger,
+      elasticsearchClient,
+      dataStream: createDefinition({ requiresSystemDataStream: false }),
+    });
+
+    expect(elasticsearchClient.indices.getDataStream).not.toHaveBeenCalled();
+  });
+
+  it('skips verification when the data stream does not exist yet (lazy creation)', async () => {
+    (elasticsearchClient.indices.getDataStream as jest.Mock).mockRejectedValue(notFoundError());
+
+    await expect(
+      assertSystemDataStream({
+        logger,
+        elasticsearchClient,
+        dataStream: createDefinition(),
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('succeeds when Elasticsearch reports system: true (default requires system)', async () => {
+    (elasticsearchClient.indices.getDataStream as jest.Mock).mockResolvedValue({
+      data_streams: [{ name: '.kibana_change_history', system: true, hidden: true }],
+    });
+
+    await expect(
+      assertSystemDataStream({
+        logger,
+        elasticsearchClient,
+        dataStream: createDefinition(),
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws when Elasticsearch reports system: false', async () => {
+    (elasticsearchClient.indices.getDataStream as jest.Mock).mockResolvedValue({
+      data_streams: [{ name: '.kibana_change_history', system: false, hidden: true }],
+    });
+
+    await expect(
+      assertSystemDataStream({
+        logger,
+        elasticsearchClient,
+        dataStream: createDefinition(),
+      })
+    ).rejects.toThrow(/system: false/);
+  });
+
+  it('throws when Elasticsearch omits the system flag', async () => {
+    (elasticsearchClient.indices.getDataStream as jest.Mock).mockResolvedValue({
+      data_streams: [{ name: '.kibana_change_history', hidden: true }],
+    });
+
+    await expect(
+      assertSystemDataStream({
+        logger,
+        elasticsearchClient,
+        dataStream: createDefinition({ requiresSystemDataStream: true }),
+      })
+    ).rejects.toThrow(/system: undefined/);
+  });
+});

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/assert_system_data_stream.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/assert_system_data_stream.ts
@@ -13,48 +13,78 @@ import type { AnyDataStreamDefinition } from '../types';
 import { getExistingDataStream } from './exists_checks';
 
 /**
- * Fail closed when a definition requires a system data stream (the default) but Elasticsearch
- * has created it as a non-system stream (`system` !== true).
- *
- * Hidden is not sufficient for privilege hardening; only a SystemDataStreamDescriptor makes
- * ES treat the stream as system. Opt out with `requiresSystemDataStream: false`.
- *
- * When the stream does not exist yet (lazy creation), verification is skipped.
+ * Thrown when fail-closed assert finds `system` !== true (used to scope rollback).
+ * Transient GET failures must not use this type.
+ */
+export class SystemDataStreamAssertError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SystemDataStreamAssertError';
+    Object.setPrototypeOf(this, SystemDataStreamAssertError.prototype);
+  }
+}
+
+const DEFERRED_SETUP_TIP: Record<'lazyCreation' | 'initializeTemplate', string> = {
+  lazyCreation: 'Use lazyCreation: false so create and assert share one boot path.',
+  initializeTemplate:
+    'Use DataStreamClient.initialize({ lazyCreation: false }) (or core initializeClient) instead.',
+};
+
+/**
+ * Throws when a privileged stream would defer create+assert (lazy / template-only).
+ */
+export function rejectDeferredPrivilegedSetup(
+  dataStream: AnyDataStreamDefinition,
+  reason: 'lazyCreation' | 'initializeTemplate'
+): void {
+  if (!dataStream.requiresSystemDataStream) {
+    return;
+  }
+
+  throw new Error(
+    `Data stream "${dataStream.name}" requires a system data stream and cannot defer creation (${reason}). ` +
+      DEFERRED_SETUP_TIP[reason]
+  );
+}
+
+/**
+ * Re-reads GET _data_stream and checks `system: true` when requiresSystemDataStream.
+ * @param failClosed - throw (create-this-call); otherwise warn and continue (pre-existing).
  */
 export async function assertSystemDataStream({
   logger,
   dataStream,
   elasticsearchClient,
+  failClosed,
 }: {
   logger: Logger;
   dataStream: AnyDataStreamDefinition;
   elasticsearchClient: ElasticsearchClient;
+  failClosed: boolean;
 }): Promise<void> {
-  // Default is true: only an explicit false opts out.
-  if (dataStream.requiresSystemDataStream === false) {
+  if (!dataStream.requiresSystemDataStream) {
     return;
   }
 
-  const existing = await getExistingDataStream(elasticsearchClient, dataStream.name, logger);
+  const resolved = await getExistingDataStream(elasticsearchClient, dataStream.name, logger);
 
-  if (!existing) {
-    logger.debug(
-      `Skipping system data stream verification for "${dataStream.name}": data stream does not exist yet.`
-    );
+  if (!resolved) {
     return;
   }
 
-  if (existing.system !== true) {
-    throw new Error(
-      `Data stream "${dataStream.name}" requires a system data stream (requiresSystemDataStream defaults to true), ` +
-        `but Elasticsearch reports system: ${String(existing.system)}. ` +
-        `Hidden data streams are not privilege-hardened. Register a SystemDataStreamDescriptor for this name in ` +
-        `Elasticsearch (e.g. KibanaPlugin), or set requiresSystemDataStream: false if this stream is intentionally ` +
-        `non-system. See https://github.com/elastic/security-team/issues/18291`
-    );
+  if (resolved.system === true) {
+    return;
   }
 
-  logger.debug(
-    `Verified data stream "${dataStream.name}" is registered as a system data stream (system: true).`
-  );
+  const message =
+    `Data stream "${dataStream.name}" requires system: true (requiresSystemDataStream), ` +
+    `but Elasticsearch reports system: ${String(resolved.system)}. ` +
+    `Register a SystemDataStreamDescriptor in Elasticsearch, or set requiresSystemDataStream: false. ` +
+    `See https://github.com/elastic/security-team/issues/18291`;
+
+  if (failClosed) {
+    throw new SystemDataStreamAssertError(message);
+  }
+
+  logger.warn(`${message} Stream already existed; continuing. Recreate after ES registration.`);
 }

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/assert_system_data_stream.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/assert_system_data_stream.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
+import type { AnyDataStreamDefinition } from '../types';
+import { getExistingDataStream } from './exists_checks';
+
+/**
+ * Fail closed when a definition requires a system data stream (the default) but Elasticsearch
+ * has created it as a non-system stream (`system` !== true).
+ *
+ * Hidden is not sufficient for privilege hardening; only a SystemDataStreamDescriptor makes
+ * ES treat the stream as system. Opt out with `requiresSystemDataStream: false`.
+ *
+ * When the stream does not exist yet (lazy creation), verification is skipped.
+ */
+export async function assertSystemDataStream({
+  logger,
+  dataStream,
+  elasticsearchClient,
+}: {
+  logger: Logger;
+  dataStream: AnyDataStreamDefinition;
+  elasticsearchClient: ElasticsearchClient;
+}): Promise<void> {
+  // Default is true: only an explicit false opts out.
+  if (dataStream.requiresSystemDataStream === false) {
+    return;
+  }
+
+  const existing = await getExistingDataStream(elasticsearchClient, dataStream.name, logger);
+
+  if (!existing) {
+    logger.debug(
+      `Skipping system data stream verification for "${dataStream.name}": data stream does not exist yet.`
+    );
+    return;
+  }
+
+  if (existing.system !== true) {
+    throw new Error(
+      `Data stream "${dataStream.name}" requires a system data stream (requiresSystemDataStream defaults to true), ` +
+        `but Elasticsearch reports system: ${String(existing.system)}. ` +
+        `Hidden data streams are not privilege-hardened. Register a SystemDataStreamDescriptor for this name in ` +
+        `Elasticsearch (e.g. KibanaPlugin), or set requiresSystemDataStream: false if this stream is intentionally ` +
+        `non-system. See https://github.com/elastic/security-team/issues/18291`
+    );
+  }
+
+  logger.debug(
+    `Verified data stream "${dataStream.name}" is registered as a system data stream (system: true).`
+  );
+}

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/data_stream.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/data_stream.test.ts
@@ -47,6 +47,7 @@ describe('initializeDataStream', () => {
     const dataStream: DataStreamDefinition<typeof testMappings> = {
       name: 'test-data-stream',
       version: 2,
+      requiresSystemDataStream: false,
       template: {
         mappings: testMappings,
         lifecycle: newLifecycle,

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/defaults.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/defaults.test.ts
@@ -186,6 +186,7 @@ describe('applyDefaults', () => {
       const result = applyDefaults(dataStream);
 
       expect(result.hidden).toBe(true);
+      expect(result.requiresSystemDataStream).toBe(true);
       expect(result.template?.priority).toBe(100);
       expect(result.template?._meta?.managed).toBe(true);
       expect(result.template?._meta?.userAgent).toBe('@kbn/data-streams');

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/defaults.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/defaults.test.ts
@@ -17,6 +17,7 @@ describe('applyDefaults', () => {
   ): DataStreamDefinition<MappingsDefinition> => ({
     name: 'test-data-stream',
     version: 1,
+    requiresSystemDataStream: false,
     template: {
       mappings: {
         properties: {
@@ -182,11 +183,23 @@ describe('applyDefaults', () => {
     });
 
     it('should apply defaults', () => {
-      const dataStream = createTestDataStream();
+      const dataStream: DataStreamDefinition<MappingsDefinition> = {
+        name: 'test-data-stream',
+        version: 1,
+        requiresSystemDataStream: false,
+        template: {
+          mappings: {
+            properties: {
+              '@timestamp': mappings.date(),
+              field: mappings.keyword(),
+            },
+          },
+        },
+      };
       const result = applyDefaults(dataStream);
 
       expect(result.hidden).toBe(true);
-      expect(result.requiresSystemDataStream).toBe(true);
+      expect(result.requiresSystemDataStream).toBe(false);
       expect(result.template?.priority).toBe(100);
       expect(result.template?._meta?.managed).toBe(true);
       expect(result.template?._meta?.userAgent).toBe('@kbn/data-streams');
@@ -200,6 +213,7 @@ describe('applyDefaults', () => {
       const dataStream: DataStreamDefinition<MappingsDefinition> = {
         name: 'test-data-stream',
         version: 1,
+        requiresSystemDataStream: false,
         template: {},
       };
 
@@ -215,6 +229,7 @@ describe('applyDefaults', () => {
       const dataStream: DataStreamDefinition<MappingsDefinition> = {
         name: 'test-data-stream',
         version: 1,
+        requiresSystemDataStream: false,
         template: {
           priority: 200,
         },

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/defaults.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/defaults.ts
@@ -62,6 +62,7 @@ export function applyDefaults(def: AnyDataStreamDefinition): AnyDataStreamDefini
 
   const defaultDataStreamDefinition: Partial<DataStreamDefinition<any, any>> = {
     hidden: true,
+    requiresSystemDataStream: true,
     template: {
       priority: 100,
       _meta: {

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/defaults.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/defaults.ts
@@ -62,7 +62,6 @@ export function applyDefaults(def: AnyDataStreamDefinition): AnyDataStreamDefini
 
   const defaultDataStreamDefinition: Partial<DataStreamDefinition<any, any>> = {
     hidden: true,
-    requiresSystemDataStream: true,
     template: {
       priority: 100,
       _meta: {

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/index.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/index.test.ts
@@ -7,15 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License v 1".
- */
-
 import type { Logger } from '@kbn/logging';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
@@ -657,34 +648,81 @@ describe('initialize - versioning logic', () => {
   });
 
   describe('requiresSystemDataStream', () => {
-    it('throws after create when Elasticsearch reports system: false (default)', async () => {
+    const notFoundError = () =>
+      new EsErrors.ResponseError({
+        statusCode: 404,
+        body: { error: { type: 'resource_not_found_exception' } },
+        warnings: [],
+        headers: {},
+        meta: {} as never,
+      });
+
+    it('throws after create when Elasticsearch reports system: false and rolls back stream + template', async () => {
       const dataStream = {
         ...createTestDataStream(1),
-        requiresSystemDataStream: undefined,
+        requiresSystemDataStream: true,
       };
 
       (elasticsearchClient.indices.getIndexTemplate as jest.Mock).mockRejectedValueOnce(
-        new EsErrors.ResponseError({
-          statusCode: 404,
-          body: { error: { type: 'resource_not_found_exception' } },
-          warnings: [],
-          headers: {},
-          meta: {} as never,
-        })
+        notFoundError()
       );
       (elasticsearchClient.indices.getDataStream as jest.Mock)
+        // pre-create lookup
+        .mockRejectedValueOnce(notFoundError())
+        // assert after create
+        .mockResolvedValueOnce({
+          data_streams: [{ name: dataStream.name, system: false, hidden: true }],
+        });
+      (elasticsearchClient.indices.putIndexTemplate as jest.Mock).mockResolvedValueOnce({
+        acknowledged: true,
+      });
+      (elasticsearchClient.indices.createDataStream as jest.Mock).mockResolvedValueOnce({
+        acknowledged: true,
+      });
+      (elasticsearchClient.indices.deleteDataStream as jest.Mock).mockResolvedValueOnce({
+        acknowledged: true,
+      });
+      (elasticsearchClient.indices.deleteIndexTemplate as jest.Mock).mockResolvedValueOnce({
+        acknowledged: true,
+      });
+
+      await expect(
+        initialize({
+          logger,
+          elasticsearchClient,
+          dataStream,
+          lazyCreation: false,
+        })
+      ).rejects.toThrow(/system: false/);
+
+      expect(elasticsearchClient.indices.deleteDataStream).toHaveBeenCalledWith({
+        name: dataStream.name,
+      });
+      expect(elasticsearchClient.indices.deleteIndexTemplate).toHaveBeenCalledWith({
+        name: dataStream.name,
+      });
+    });
+
+    it('does not roll back when post-create GET _data_stream fails with a transient error', async () => {
+      const dataStream = {
+        ...createTestDataStream(1),
+        requiresSystemDataStream: true,
+      };
+
+      (elasticsearchClient.indices.getIndexTemplate as jest.Mock).mockRejectedValueOnce(
+        notFoundError()
+      );
+      (elasticsearchClient.indices.getDataStream as jest.Mock)
+        .mockRejectedValueOnce(notFoundError())
         .mockRejectedValueOnce(
           new EsErrors.ResponseError({
-            statusCode: 404,
-            body: { error: { type: 'resource_not_found_exception' } },
+            statusCode: 500,
+            body: { error: { type: 'internal_server_error' } },
             warnings: [],
             headers: {},
             meta: {} as never,
           })
-        )
-        .mockResolvedValueOnce({
-          data_streams: [{ name: dataStream.name, system: false, hidden: true }],
-        });
+        );
       (elasticsearchClient.indices.putIndexTemplate as jest.Mock).mockResolvedValueOnce({
         acknowledged: true,
       });
@@ -699,7 +737,10 @@ describe('initialize - versioning logic', () => {
           dataStream,
           lazyCreation: false,
         })
-      ).rejects.toThrow(/system: false/);
+      ).rejects.toMatchObject({ statusCode: 500 });
+
+      expect(elasticsearchClient.indices.deleteDataStream).not.toHaveBeenCalled();
+      expect(elasticsearchClient.indices.deleteIndexTemplate).not.toHaveBeenCalled();
     });
 
     it('succeeds when Elasticsearch reports system: true', async () => {
@@ -709,24 +750,10 @@ describe('initialize - versioning logic', () => {
       };
 
       (elasticsearchClient.indices.getIndexTemplate as jest.Mock).mockRejectedValueOnce(
-        new EsErrors.ResponseError({
-          statusCode: 404,
-          body: { error: { type: 'resource_not_found_exception' } },
-          warnings: [],
-          headers: {},
-          meta: {} as never,
-        })
+        notFoundError()
       );
       (elasticsearchClient.indices.getDataStream as jest.Mock)
-        .mockRejectedValueOnce(
-          new EsErrors.ResponseError({
-            statusCode: 404,
-            body: { error: { type: 'resource_not_found_exception' } },
-            warnings: [],
-            headers: {},
-            meta: {} as never,
-          })
-        )
+        .mockRejectedValueOnce(notFoundError())
         .mockResolvedValueOnce({
           data_streams: [{ name: dataStream.name, system: true, hidden: true }],
         });
@@ -745,6 +772,76 @@ describe('initialize - versioning logic', () => {
           lazyCreation: false,
         })
       ).resolves.toEqual({ dataStreamReady: true });
+
+      expect(elasticsearchClient.indices.deleteDataStream).not.toHaveBeenCalled();
+    });
+
+    it('rejects privileged lazyCreation when the stream does not exist yet', async () => {
+      const dataStream = {
+        ...createTestDataStream(1),
+        requiresSystemDataStream: true,
+      };
+
+      (elasticsearchClient.indices.getIndexTemplate as jest.Mock).mockRejectedValueOnce(
+        notFoundError()
+      );
+      (elasticsearchClient.indices.getDataStream as jest.Mock).mockRejectedValueOnce(
+        notFoundError()
+      );
+
+      await expect(
+        initialize({
+          logger,
+          elasticsearchClient,
+          dataStream,
+          lazyCreation: true,
+        })
+      ).rejects.toThrow(/cannot defer creation \(lazyCreation\)/);
+
+      expect(elasticsearchClient.indices.putIndexTemplate).not.toHaveBeenCalled();
+      expect(elasticsearchClient.indices.createDataStream).not.toHaveBeenCalled();
+      expect(elasticsearchClient.indices.deleteDataStream).not.toHaveBeenCalled();
+    });
+
+    it('warns and continues for a pre-existing non-system stream (no rollback, no throw)', async () => {
+      const dataStream = {
+        ...createTestDataStream(1),
+        requiresSystemDataStream: true,
+      };
+
+      (elasticsearchClient.indices.getIndexTemplate as jest.Mock).mockResolvedValueOnce({
+        index_templates: [
+          {
+            name: dataStream.name,
+            index_template: {
+              index_patterns: [dataStream.name],
+              data_stream: {},
+              _meta: { managed: true, userAgent: '@kbn/data-streams', version: 1 },
+              template: { mappings: { properties: {} } },
+            },
+          },
+        ],
+      });
+      const existingNonSystem = {
+        data_streams: [{ name: dataStream.name, system: false, hidden: true }],
+      };
+      (elasticsearchClient.indices.getDataStream as jest.Mock)
+        // pre-create lookup
+        .mockResolvedValueOnce(existingNonSystem)
+        // assert re-GET
+        .mockResolvedValueOnce(existingNonSystem);
+
+      await expect(
+        initialize({
+          logger,
+          elasticsearchClient,
+          dataStream,
+          lazyCreation: false,
+        })
+      ).resolves.toEqual({ dataStreamReady: true });
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/system: false/));
+      expect(elasticsearchClient.indices.deleteDataStream).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/index.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/index.test.ts
@@ -39,6 +39,7 @@ describe('initialize - versioning logic', () => {
   const createTestDataStream = (version: number): DataStreamDefinition<typeof testMappings> => ({
     name: 'test-data-stream',
     version,
+    requiresSystemDataStream: false,
     template: {
       mappings: testMappings,
     },
@@ -652,6 +653,98 @@ describe('initialize - versioning logic', () => {
       expect(createCall?.template?.lifecycle).toEqual({
         data_retention: '30d',
       });
+    });
+  });
+
+  describe('requiresSystemDataStream', () => {
+    it('throws after create when Elasticsearch reports system: false (default)', async () => {
+      const dataStream = {
+        ...createTestDataStream(1),
+        requiresSystemDataStream: undefined,
+      };
+
+      (elasticsearchClient.indices.getIndexTemplate as jest.Mock).mockRejectedValueOnce(
+        new EsErrors.ResponseError({
+          statusCode: 404,
+          body: { error: { type: 'resource_not_found_exception' } },
+          warnings: [],
+          headers: {},
+          meta: {} as never,
+        })
+      );
+      (elasticsearchClient.indices.getDataStream as jest.Mock)
+        .mockRejectedValueOnce(
+          new EsErrors.ResponseError({
+            statusCode: 404,
+            body: { error: { type: 'resource_not_found_exception' } },
+            warnings: [],
+            headers: {},
+            meta: {} as never,
+          })
+        )
+        .mockResolvedValueOnce({
+          data_streams: [{ name: dataStream.name, system: false, hidden: true }],
+        });
+      (elasticsearchClient.indices.putIndexTemplate as jest.Mock).mockResolvedValueOnce({
+        acknowledged: true,
+      });
+      (elasticsearchClient.indices.createDataStream as jest.Mock).mockResolvedValueOnce({
+        acknowledged: true,
+      });
+
+      await expect(
+        initialize({
+          logger,
+          elasticsearchClient,
+          dataStream,
+          lazyCreation: false,
+        })
+      ).rejects.toThrow(/system: false/);
+    });
+
+    it('succeeds when Elasticsearch reports system: true', async () => {
+      const dataStream = {
+        ...createTestDataStream(1),
+        requiresSystemDataStream: true,
+      };
+
+      (elasticsearchClient.indices.getIndexTemplate as jest.Mock).mockRejectedValueOnce(
+        new EsErrors.ResponseError({
+          statusCode: 404,
+          body: { error: { type: 'resource_not_found_exception' } },
+          warnings: [],
+          headers: {},
+          meta: {} as never,
+        })
+      );
+      (elasticsearchClient.indices.getDataStream as jest.Mock)
+        .mockRejectedValueOnce(
+          new EsErrors.ResponseError({
+            statusCode: 404,
+            body: { error: { type: 'resource_not_found_exception' } },
+            warnings: [],
+            headers: {},
+            meta: {} as never,
+          })
+        )
+        .mockResolvedValueOnce({
+          data_streams: [{ name: dataStream.name, system: true, hidden: true }],
+        });
+      (elasticsearchClient.indices.putIndexTemplate as jest.Mock).mockResolvedValueOnce({
+        acknowledged: true,
+      });
+      (elasticsearchClient.indices.createDataStream as jest.Mock).mockResolvedValueOnce({
+        acknowledged: true,
+      });
+
+      await expect(
+        initialize({
+          logger,
+          elasticsearchClient,
+          dataStream,
+          lazyCreation: false,
+        })
+      ).resolves.toEqual({ dataStreamReady: true });
     });
   });
 });

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/index.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/index.ts
@@ -13,6 +13,7 @@ import type { AnyDataStreamDefinition } from '../types';
 import { initializeDataStream } from './data_stream';
 import { initializeIndexTemplate } from './index_template';
 import { getExistingDataStream, getExistingIndexTemplate } from './exists_checks';
+import { assertSystemDataStream } from './assert_system_data_stream';
 
 /**
  * https://www.elastic.co/docs/manage-data/data-store/data-streams/set-up-data-stream
@@ -69,6 +70,11 @@ export async function initialize({
     existingIndexTemplate,
     skipCreation: !createDataStreamIfDoesntExist,
   });
+
+  // Fail closed when a privileged stream is missing its ES SystemDataStreamDescriptor.
+  // Callers that set requiresSystemDataStream should use lazyCreation: false so the stream
+  // exists and can be verified (assert throws if the stream is absent or system !== true).
+  await assertSystemDataStream({ logger, dataStream, elasticsearchClient });
 
   return {
     dataStreamReady: indexTemplateReady && dataStreamReady,

--- a/src/platform/packages/private/kbn-data-streams/src/initialize/index.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/initialize/index.ts
@@ -13,7 +13,42 @@ import type { AnyDataStreamDefinition } from '../types';
 import { initializeDataStream } from './data_stream';
 import { initializeIndexTemplate } from './index_template';
 import { getExistingDataStream, getExistingIndexTemplate } from './exists_checks';
-import { assertSystemDataStream } from './assert_system_data_stream';
+import {
+  assertSystemDataStream,
+  rejectDeferredPrivilegedSetup,
+  SystemDataStreamAssertError,
+} from './assert_system_data_stream';
+
+const rollbackAfterFailedSystemAssert = async ({
+  logger,
+  elasticsearchClient,
+  dataStreamName,
+  deleteIndexTemplate,
+}: {
+  logger: Logger;
+  elasticsearchClient: ElasticsearchClient;
+  dataStreamName: string;
+  deleteIndexTemplate: boolean;
+}): Promise<void> => {
+  const tryRollback = async (label: string, fn: () => Promise<unknown>): Promise<void> => {
+    try {
+      await fn();
+      logger.warn(`Rolled back ${label} "${dataStreamName}" after system assert failure`);
+    } catch (deleteError) {
+      logger.error(`Failed to roll back ${label} "${dataStreamName}": ${deleteError}`);
+    }
+  };
+
+  await tryRollback('data stream', () =>
+    elasticsearchClient.indices.deleteDataStream({ name: dataStreamName })
+  );
+
+  if (deleteIndexTemplate) {
+    await tryRollback('index template', () =>
+      elasticsearchClient.indices.deleteIndexTemplate({ name: dataStreamName })
+    );
+  }
+};
 
 /**
  * https://www.elastic.co/docs/manage-data/data-store/data-streams/set-up-data-stream
@@ -53,6 +88,12 @@ export async function initialize({
   const createIndexTemplateIfDoesntExist = existingDataStream ? true : !lazyCreation;
   // create the data stream only if not lazy.
   const createDataStreamIfDoesntExist = !lazyCreation;
+  const createdDataStreamThisCall = !existingDataStream && createDataStreamIfDoesntExist;
+  const createdIndexTemplateThisCall = !existingIndexTemplate && createIndexTemplateIfDoesntExist;
+
+  if (lazyCreation && !existingDataStream) {
+    rejectDeferredPrivilegedSetup(dataStream, 'lazyCreation');
+  }
 
   const { uptoDate: indexTemplateReady } = await initializeIndexTemplate({
     logger,
@@ -71,10 +112,25 @@ export async function initialize({
     skipCreation: !createDataStreamIfDoesntExist,
   });
 
-  // Fail closed when a privileged stream is missing its ES SystemDataStreamDescriptor.
-  // Callers that set requiresSystemDataStream should use lazyCreation: false so the stream
-  // exists and can be verified (assert throws if the stream is absent or system !== true).
-  await assertSystemDataStream({ logger, dataStream, elasticsearchClient });
+  try {
+    await assertSystemDataStream({
+      logger,
+      dataStream,
+      elasticsearchClient,
+      failClosed: createdDataStreamThisCall,
+    });
+  } catch (error) {
+    // Only roll back on the invariant failure — not on transient GET/network errors.
+    if (createdDataStreamThisCall && error instanceof SystemDataStreamAssertError) {
+      await rollbackAfterFailedSystemAssert({
+        logger,
+        elasticsearchClient,
+        dataStreamName: dataStream.name,
+        deleteIndexTemplate: createdIndexTemplateThisCall,
+      });
+    }
+    throw error;
+  }
 
   return {
     dataStreamReady: indexTemplateReady && dataStreamReady,

--- a/src/platform/packages/private/kbn-data-streams/src/integration_tests/client.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/integration_tests/client.test.ts
@@ -32,6 +32,7 @@ describe('DataStreamClient', () => {
   const testDataStream: DataStreamDefinition<MappingsDefinition> = {
     name: 'test-data-stream',
     version: 1,
+    requiresSystemDataStream: false,
     template: {
       mappings: myTestDocMappings,
     },
@@ -143,6 +144,7 @@ describe('DataStreamClient', () => {
     const lifecycleTestDataStream: DataStreamDefinition<MappingsDefinition> = {
       name: 'lifecycle-test-data-stream',
       version: 1,
+      requiresSystemDataStream: false,
       template: {
         mappings: myTestDocMappings,
         lifecycle: {
@@ -853,6 +855,7 @@ describe('DataStreamClient', () => {
     const lifecycleVersionedDataStreamV1: DataStreamDefinition<MappingsDefinition> = {
       name: 'lifecycle-versioned-test-data-stream',
       version: 1,
+      requiresSystemDataStream: false,
       template: {
         mappings: myTestDocMappings,
         lifecycle: {
@@ -876,6 +879,7 @@ describe('DataStreamClient', () => {
     const lifecycleAddedDataStreamV1: DataStreamDefinition<MappingsDefinition> = {
       name: 'lifecycle-added-test-data-stream',
       version: 1,
+      requiresSystemDataStream: false,
       template: {
         mappings: myTestDocMappings,
       },
@@ -1215,6 +1219,7 @@ describe('DataStreamClient', () => {
       const lifecycleOnCreateDataStream: DataStreamDefinition<MappingsDefinition> = {
         name: 'lifecycle-on-create-test-data-stream',
         version: 1,
+      requiresSystemDataStream: false,
         template: {
           mappings: myTestDocMappings,
           lifecycle: {

--- a/src/platform/packages/private/kbn-data-streams/src/integration_tests/client.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/integration_tests/client.test.ts
@@ -868,6 +868,7 @@ describe('DataStreamClient', () => {
     const lifecycleVersionedDataStreamV2: DataStreamDefinition<MappingsDefinition> = {
       ...lifecycleVersionedDataStreamV1,
       version: 2,
+      requiresSystemDataStream: false,
       template: {
         ...lifecycleVersionedDataStreamV1.template,
         lifecycle: {
@@ -889,6 +890,7 @@ describe('DataStreamClient', () => {
     const lifecycleAddedDataStreamV2: DataStreamDefinition<MappingsDefinition> = {
       ...lifecycleAddedDataStreamV1,
       version: 2,
+      requiresSystemDataStream: false,
       template: {
         ...lifecycleAddedDataStreamV1.template,
         lifecycle: {
@@ -1048,6 +1050,7 @@ describe('DataStreamClient', () => {
       const nextDefinition: DataStreamDefinition<typeof nextMappings> = {
         ...testDataStream,
         version: 2,
+        requiresSystemDataStream: false,
         template: {
           mappings: nextMappings,
         },
@@ -1219,7 +1222,7 @@ describe('DataStreamClient', () => {
       const lifecycleOnCreateDataStream: DataStreamDefinition<MappingsDefinition> = {
         name: 'lifecycle-on-create-test-data-stream',
         version: 1,
-      requiresSystemDataStream: false,
+        requiresSystemDataStream: false,
         template: {
           mappings: myTestDocMappings,
           lifecycle: {
@@ -1298,6 +1301,7 @@ describe('DataStreamClient', () => {
       const lifecycleRemovedDefinition: DataStreamDefinition<MappingsDefinition> = {
         ...lifecycleVersionedDataStreamV1,
         version: 2,
+        requiresSystemDataStream: false,
         template: {
           mappings: myTestDocMappings,
         },

--- a/src/platform/packages/private/kbn-data-streams/src/integration_tests/initialize.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/integration_tests/initialize.test.ts
@@ -53,6 +53,7 @@ describe('Data streams initialize function', () => {
   const testDataStream: DataStreamDefinition<typeof myTestDocMappings, MyTestDoc> = {
     name: 'test-data-stream',
     version: 1,
+    requiresSystemDataStream: false,
     template: {
       mappings: myTestDocMappings,
     },
@@ -136,6 +137,44 @@ describe('Data streams initialize function', () => {
         data_streams: [dataStreamUpdated],
       } = await esClient.indices.getDataStream({ name: testDataStream.name });
       expect(dataStreamUpdated.generation).toEqual(1);
+    });
+
+    it('fails closed by default when Elasticsearch reports system: false', async () => {
+      const esClient = esServer.getClient();
+      const privilegedStream: DataStreamDefinition<typeof myTestDocMappings, MyTestDoc> = {
+        ...testDataStream,
+        name: 'test-requires-system-data-stream',
+        // omit requiresSystemDataStream — default is true
+        requiresSystemDataStream: undefined,
+      };
+
+      await esClient.indices
+        .deleteDataStream({ name: privilegedStream.name })
+        .catch(() => undefined);
+      await esClient.indices
+        .deleteIndexTemplate({ name: privilegedStream.name })
+        .catch(() => undefined);
+
+      await expect(
+        initialize({
+          logger,
+          elasticsearchClient: esClient,
+          dataStream: privilegedStream,
+          lazyCreation: false,
+        })
+      ).rejects.toThrow(/requires a system data stream[\s\S]*system: false/);
+
+      // Stream was created as a normal hidden stream; the assert fails after creation.
+      const {
+        data_streams: [created],
+      } = await esClient.indices.getDataStream({ name: privilegedStream.name });
+      expect(created.hidden).toBe(true);
+      expect(created.system).not.toBe(true);
+
+      await esClient.indices.deleteDataStream({ name: privilegedStream.name }).catch(() => undefined);
+      await esClient.indices
+        .deleteIndexTemplate({ name: privilegedStream.name })
+        .catch(() => undefined);
     });
 
     it('Updates the index template and the data stream if they exist and the version is different', async () => {

--- a/src/platform/packages/private/kbn-data-streams/src/integration_tests/initialize.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/integration_tests/initialize.test.ts
@@ -139,13 +139,12 @@ describe('Data streams initialize function', () => {
       expect(dataStreamUpdated.generation).toEqual(1);
     });
 
-    it('fails closed by default when Elasticsearch reports system: false', async () => {
+    it('fails closed when Elasticsearch reports system: false and rolls back the stream', async () => {
       const esClient = esServer.getClient();
       const privilegedStream: DataStreamDefinition<typeof myTestDocMappings, MyTestDoc> = {
         ...testDataStream,
         name: 'test-requires-system-data-stream',
-        // omit requiresSystemDataStream — default is true
-        requiresSystemDataStream: undefined,
+        requiresSystemDataStream: true,
       };
 
       await esClient.indices
@@ -162,16 +161,129 @@ describe('Data streams initialize function', () => {
           dataStream: privilegedStream,
           lazyCreation: false,
         })
-      ).rejects.toThrow(/requires a system data stream[\s\S]*system: false/);
+      ).rejects.toThrow(/requires system: true[\s\S]*system: false/);
 
-      // Stream was created as a normal hidden stream; the assert fails after creation.
+      // Create-then-fail must not leave an unprotected stream or template behind.
+      await expect(
+        esClient.indices.getDataStream({ name: privilegedStream.name })
+      ).rejects.toThrow();
+      await expect(
+        esClient.indices.getIndexTemplate({ name: privilegedStream.name })
+      ).rejects.toThrow();
+    });
+
+    it('rejects privileged initializeTemplate when the stream does not exist yet', async () => {
+      const esClient = esServer.getClient();
+      const privilegedStream: DataStreamDefinition<typeof myTestDocMappings, MyTestDoc> = {
+        ...testDataStream,
+        name: 'test-requires-system-template-only',
+        requiresSystemDataStream: true,
+      };
+
+      await esClient.indices
+        .deleteDataStream({ name: privilegedStream.name })
+        .catch(() => undefined);
+      await esClient.indices
+        .deleteIndexTemplate({ name: privilegedStream.name })
+        .catch(() => undefined);
+
+      await expect(
+        DataStreamClient.initializeTemplate({
+          logger,
+          elasticsearchClient: esClient,
+          dataStream: privilegedStream,
+        })
+      ).rejects.toThrow(/cannot defer creation \(initializeTemplate\)/);
+
+      await expect(
+        esClient.indices.getIndexTemplate({ name: privilegedStream.name })
+      ).rejects.toThrow();
+    });
+
+    it('rejects privileged lazyCreation when the stream does not exist yet', async () => {
+      const esClient = esServer.getClient();
+      const privilegedStream: DataStreamDefinition<typeof myTestDocMappings, MyTestDoc> = {
+        ...testDataStream,
+        name: 'test-requires-system-lazy',
+        requiresSystemDataStream: true,
+      };
+
+      await esClient.indices
+        .deleteDataStream({ name: privilegedStream.name })
+        .catch(() => undefined);
+      await esClient.indices
+        .deleteIndexTemplate({ name: privilegedStream.name })
+        .catch(() => undefined);
+
+      await expect(
+        initialize({
+          logger,
+          elasticsearchClient: esClient,
+          dataStream: privilegedStream,
+          lazyCreation: true,
+        })
+      ).rejects.toThrow(/cannot defer creation \(lazyCreation\)/);
+
+      await expect(
+        esClient.indices.getDataStream({ name: privilegedStream.name })
+      ).rejects.toThrow();
+      await expect(
+        esClient.indices.getIndexTemplate({ name: privilegedStream.name })
+      ).rejects.toThrow();
+    });
+
+    it('warns and continues on a later initialize after a non-system stream was created', async () => {
+      const esClient = esServer.getClient();
+      const privilegedStream: DataStreamDefinition<typeof myTestDocMappings, MyTestDoc> = {
+        ...testDataStream,
+        name: 'test-requires-system-deferred',
+        requiresSystemDataStream: true,
+      };
+      const nonSystemCreate: DataStreamDefinition<typeof myTestDocMappings, MyTestDoc> = {
+        ...privilegedStream,
+        requiresSystemDataStream: false,
+      };
+
+      await esClient.indices
+        .deleteDataStream({ name: privilegedStream.name })
+        .catch(() => undefined);
+      await esClient.indices
+        .deleteIndexTemplate({ name: privilegedStream.name })
+        .catch(() => undefined);
+
+      // Simulate first write / non-privileged create leaving a non-system stream.
+      await initialize({
+        logger,
+        elasticsearchClient: esClient,
+        dataStream: nonSystemCreate,
+        lazyCreation: false,
+      });
+
       const {
         data_streams: [created],
       } = await esClient.indices.getDataStream({ name: privilegedStream.name });
-      expect(created.hidden).toBe(true);
       expect(created.system).not.toBe(true);
 
-      await esClient.indices.deleteDataStream({ name: privilegedStream.name }).catch(() => undefined);
+      // Later privileged initialize must not crash boot or delete the leftover stream.
+      await expect(
+        initialize({
+          logger,
+          elasticsearchClient: esClient,
+          dataStream: privilegedStream,
+          lazyCreation: false,
+        })
+      ).resolves.toEqual({ dataStreamReady: true });
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/system: false/));
+
+      const {
+        data_streams: [stillPresent],
+      } = await esClient.indices.getDataStream({ name: privilegedStream.name });
+      expect(stillPresent.name).toBe(privilegedStream.name);
+
+      await esClient.indices
+        .deleteDataStream({ name: privilegedStream.name })
+        .catch(() => undefined);
       await esClient.indices
         .deleteIndexTemplate({ name: privilegedStream.name })
         .catch(() => undefined);

--- a/src/platform/packages/private/kbn-data-streams/src/types/definition.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/types/definition.ts
@@ -33,6 +33,23 @@ export interface DataStreamDefinition<
   hidden?: boolean;
 
   /**
+   * When true (the default), initialization fails if the data stream already exists and
+   * Elasticsearch reports `system` as anything other than `true`.
+   *
+   * Kibana cannot register a system data stream via the create/template APIs. That requires
+   * a matching `SystemDataStreamDescriptor` in Elasticsearch (for example in the Kibana
+   * plugin). Opt out explicitly with `requiresSystemDataStream: false` only when the stream
+   * is intentionally non-system; otherwise a missing ES registration fails closed.
+   *
+   * When the stream does not exist yet (e.g. lazy creation), verification is skipped until
+   * a later initialize sees the stream.
+   *
+   * @default true
+   * @see https://github.com/elastic/security-team/issues/18291
+   */
+  requiresSystemDataStream?: boolean;
+
+  /**
    * @remark Must be **incremented** in order to release a new version of the template definition.
    * @remark Must be greater than 0
    */

--- a/src/platform/packages/private/kbn-data-streams/src/types/definition.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/types/definition.ts
@@ -33,21 +33,11 @@ export interface DataStreamDefinition<
   hidden?: boolean;
 
   /**
-   * When true (the default), initialization fails if the data stream already exists and
-   * Elasticsearch reports `system` as anything other than `true`.
-   *
-   * Kibana cannot register a system data stream via the create/template APIs. That requires
-   * a matching `SystemDataStreamDescriptor` in Elasticsearch (for example in the Kibana
-   * plugin). Opt out explicitly with `requiresSystemDataStream: false` only when the stream
-   * is intentionally non-system; otherwise a missing ES registration fails closed.
-   *
-   * When the stream does not exist yet (e.g. lazy creation), verification is skipped until
-   * a later initialize sees the stream.
-   *
-   * @default true
-   * @see https://github.com/elastic/security-team/issues/18291
+   * When true, verify ES reports `system: true` after setup.
+   * Create-this-call failures throw (initialize may roll back); pre-existing non-system warns.
+   * @see README "System data streams"
    */
-  requiresSystemDataStream?: boolean;
+  requiresSystemDataStream: boolean;
 
   /**
    * @remark Must be **incremented** in order to release a new version of the template definition.

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/data_stream.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/data_stream.ts
@@ -18,7 +18,7 @@ export const initializeLogsRepositoryDataStream = (coreDataStreams: DataStreamsS
   return coreDataStreams.registerDataStream({
     name: WORKFLOWS_EXECUTION_LOGS_DATA_STREAM,
     version: 3,
-    // Registered as SystemDataStreamDescriptor in Elasticsearch (see elastic/elasticsearch#145822).
+    requiresSystemDataStream: true,
     template: {
       mappings: logsRepositoryMappings,
     },

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/data_stream.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/data_stream.ts
@@ -18,6 +18,7 @@ export const initializeLogsRepositoryDataStream = (coreDataStreams: DataStreamsS
   return coreDataStreams.registerDataStream({
     name: WORKFLOWS_EXECUTION_LOGS_DATA_STREAM,
     version: 3,
+    // Registered as SystemDataStreamDescriptor in Elasticsearch (see elastic/elasticsearch#145822).
     template: {
       mappings: logsRepositoryMappings,
     },

--- a/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/event_logs/trigger_events_data_stream.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/event_logs/trigger_events_data_stream.ts
@@ -18,7 +18,7 @@ export const initializeTriggerEventsDataStream = (coreDataStreams: DataStreamsSe
   coreDataStreams.registerDataStream({
     name: WORKFLOWS_EVENTS_DATA_STREAM,
     version: 3,
-    // Registered as SystemDataStreamDescriptor in Elasticsearch (see elastic/elasticsearch#145822).
+    requiresSystemDataStream: true,
     template: {
       mappings: triggerEventsMappings,
       settings: {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/event_logs/trigger_events_data_stream.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/event_logs/trigger_events_data_stream.ts
@@ -18,6 +18,7 @@ export const initializeTriggerEventsDataStream = (coreDataStreams: DataStreamsSe
   coreDataStreams.registerDataStream({
     name: WORKFLOWS_EVENTS_DATA_STREAM,
     version: 3,
+    // Registered as SystemDataStreamDescriptor in Elasticsearch (see elastic/elasticsearch#145822).
     template: {
       mappings: triggerEventsMappings,
       settings: {

--- a/x-pack/platform/packages/shared/kbn-change-history/README.md
+++ b/x-pack/platform/packages/shared/kbn-change-history/README.md
@@ -175,6 +175,8 @@ If a future consumer needs to filter or sort on any of these, add them back to t
 
 `.kibana_change_history` is enrolled in data stream lifecycle with `enabled: true` and no `data_retention`. Change history documents are kept indefinitely by default.
 
+Initialization sets `requiresSystemDataStream: true` and uses `lazyCreation: false`. Create-this-call fails closed unless Elasticsearch reports `system: true` (and rolls back a non-system stream). A pre-existing non-system stream warns and continues so leftover env state does not block boot.
+
 Cluster admins can add retention later via **Stack Management → Index Management → Data Streams** on both stateful and serverless deployments.
 
 ### Dependencies

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
@@ -49,6 +49,7 @@ describe('ChangeHistoryClient.initialize', () => {
       expect.objectContaining({
         dataStream: expect.objectContaining({
           version: 3,
+          requiresSystemDataStream: true,
           template: expect.objectContaining({
             mappings: expect.any(Object),
             lifecycle: { enabled: true },

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
@@ -111,6 +111,7 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
         name: DATA_STREAM_NAME,
         version: 3,
         hidden: true,
+        requiresSystemDataStream: true,
         template: {
           priority: 100,
           mappings: changeHistoryMappings.v1,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.ts
@@ -31,8 +31,8 @@ export class DatastreamInitializer implements IResourceInitializer {
     const dataStreamDefinition: DataStreamDefinition<typeof this.resourceDefinition.mappings> = {
       name: this.resourceDefinition.dataStreamName,
       hidden: true,
-      requiresSystemDataStream: false,
       version: this.resourceDefinition.version,
+      requiresSystemDataStream: false,
       template: {
         aliases: {},
         priority: INDEX_TEMPLATE_PRIORITY,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.ts
@@ -31,6 +31,7 @@ export class DatastreamInitializer implements IResourceInitializer {
     const dataStreamDefinition: DataStreamDefinition<typeof this.resourceDefinition.mappings> = {
       name: this.resourceDefinition.dataStreamName,
       hidden: true,
+      requiresSystemDataStream: false,
       version: this.resourceDefinition.version,
       template: {
         aliases: {},

--- a/x-pack/platform/plugins/shared/evals/server/storage/scores_index_template.ts
+++ b/x-pack/platform/plugins/shared/evals/server/storage/scores_index_template.ts
@@ -99,6 +99,7 @@ export const evaluationsDataStreamDefinition: DataStreamDefinition<MappingsDefin
   name: EvaluationIndices.SCORES,
   version: 1,
   hidden: true,
+  requiresSystemDataStream: false,
   template: {
     lifecycle: {
       data_retention: '90d',

--- a/x-pack/platform/plugins/shared/evals/server/storage/scores_index_template.ts
+++ b/x-pack/platform/plugins/shared/evals/server/storage/scores_index_template.ts
@@ -98,8 +98,8 @@ const evaluationsDataStreamMappings = {
 export const evaluationsDataStreamDefinition: DataStreamDefinition<MappingsDefinition> = {
   name: EvaluationIndices.SCORES,
   version: 1,
-  hidden: true,
   requiresSystemDataStream: false,
+  hidden: true,
   template: {
     lifecycle: {
       data_retention: '90d',

--- a/x-pack/platform/plugins/shared/notification_center/server/data_stream/notification_data_stream.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/data_stream/notification_data_stream.ts
@@ -40,8 +40,8 @@ export const notificationDataStreamDefinition = {
   name: NOTIFICATION_DATA_STREAM_NAME,
   // bump on any mapping or lifecycle change
   version: 1,
-  hidden: true,
   requiresSystemDataStream: false,
+  hidden: true,
   template: {
     priority: 500,
     lifecycle: {

--- a/x-pack/platform/plugins/shared/notification_center/server/data_stream/notification_data_stream.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/data_stream/notification_data_stream.ts
@@ -41,6 +41,7 @@ export const notificationDataStreamDefinition = {
   // bump on any mapping or lifecycle change
   version: 1,
   hidden: true,
+  requiresSystemDataStream: false,
   template: {
     priority: 500,
     lifecycle: {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/knowledge_indicators/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/knowledge_indicators/data_stream.ts
@@ -167,6 +167,7 @@ export const knowledgeIndicatorsDataStream: DataStreamDefinition<
   name: KNOWLEDGE_INDICATORS_DATA_STREAM,
   version: 2,
   hidden: true,
+  requiresSystemDataStream: false,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/knowledge_indicators/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/knowledge_indicators/data_stream.ts
@@ -166,8 +166,8 @@ export const knowledgeIndicatorsDataStream: DataStreamDefinition<
 > = {
   name: KNOWLEDGE_INDICATORS_DATA_STREAM,
   version: 2,
-  hidden: true,
   requiresSystemDataStream: false,
+  hidden: true,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/detections/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/detections/data_stream.ts
@@ -34,8 +34,8 @@ export const detectionsDataStream: DataStreamDefinition<
 > = {
   name: DETECTIONS_DATA_STREAM,
   version: 7,
-  hidden: true,
   requiresSystemDataStream: false,
+  hidden: true,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/detections/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/detections/data_stream.ts
@@ -35,6 +35,7 @@ export const detectionsDataStream: DataStreamDefinition<
   name: DETECTIONS_DATA_STREAM,
   version: 7,
   hidden: true,
+  requiresSystemDataStream: false,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/discoveries/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/discoveries/data_stream.ts
@@ -42,6 +42,7 @@ export const discoveriesDataStream: DataStreamDefinition<
   name: DISCOVERIES_DATA_STREAM,
   version: 4,
   hidden: true,
+  requiresSystemDataStream: false,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/discoveries/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/discoveries/data_stream.ts
@@ -41,8 +41,8 @@ export const discoveriesDataStream: DataStreamDefinition<
 > = {
   name: DISCOVERIES_DATA_STREAM,
   version: 4,
-  hidden: true,
   requiresSystemDataStream: false,
+  hidden: true,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/events/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/events/data_stream.ts
@@ -33,6 +33,7 @@ export const eventsDataStream: DataStreamDefinition<typeof eventsMappings, Store
   name: EVENTS_DATA_STREAM,
   version: 6,
   hidden: true,
+  requiresSystemDataStream: false,
   template: {
     priority: 500,
     mappings: eventsMappings,

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/events/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/events/data_stream.ts
@@ -32,8 +32,8 @@ export type { SignificantEvent };
 export const eventsDataStream: DataStreamDefinition<typeof eventsMappings, StoredEvent> = {
   name: EVENTS_DATA_STREAM,
   version: 6,
-  hidden: true,
   requiresSystemDataStream: false,
+  hidden: true,
   template: {
     priority: 500,
     mappings: eventsMappings,

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/data_stream.ts
@@ -42,6 +42,7 @@ export const memoriesDataStream: DataStreamDefinition<typeof memoriesMappings, S
   name: MEMORIES_DATA_STREAM,
   version: 2,
   hidden: true,
+  requiresSystemDataStream: false,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/data_stream.ts
@@ -41,8 +41,8 @@ export type StoredMemoryPage = GetFieldsOf<typeof memoriesMappings>;
 export const memoriesDataStream: DataStreamDefinition<typeof memoriesMappings, StoredMemoryPage> = {
   name: MEMORIES_DATA_STREAM,
   version: 2,
-  hidden: true,
   requiresSystemDataStream: false,
+  hidden: true,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/history_data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/history_data_stream.ts
@@ -36,6 +36,7 @@ export const memoryHistoryDataStream: DataStreamDefinition<
   name: memoryHistoryDataStreamName,
   version: 1,
   hidden: true,
+  requiresSystemDataStream: false,
   template: {
     priority: 500,
     lifecycle: { data_retention: '180d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/history_data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/history_data_stream.ts
@@ -35,8 +35,8 @@ export const memoryHistoryDataStream: DataStreamDefinition<
 > = {
   name: memoryHistoryDataStreamName,
   version: 1,
-  hidden: true,
   requiresSystemDataStream: false,
+  hidden: true,
   template: {
     priority: 500,
     lifecycle: { data_retention: '180d' },


### PR DESCRIPTION
## Summary

Prevents a repeat of system hidden data streams that are **not** registered as elasticsearch system data streams (`system: false`) and are readable across spaces.

- Add required `requiresSystemDataStream: boolean` on `DataStreamDefinition` (no default in `applyDefaults`).
- After setup, re-read `GET _data_stream/<name>`:
  - **Created this call** + `system !== true` → fail closed, roll back stream (+ template if created this call).
  - **Pre-existing** + `system !== true` → warn and continue (do not crash boot on leftovers).
- Refuse privileged deferred setup (`lazyCreation: true` / `initializeTemplate` when the stream is absent).
- Core `registerDataStream` eager-inits privileged streams; others stay lazy.
- Opt in: workflows execution logs/events + change-history (`true`). Other adopters set `false`.

Relates to [security-team#18291](https://github.com/elastic/security-team/issues/18291).
