### PR TITLE
[skills] Update Scout namespace paths after security_solution test reorganisation (#275087)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
@@ -89,14 +89,16 @@ All paths relative to this skill's directory.
 
 ## Scaffold shortcut
 
-Use the general skill's scaffold with Security Solution defaults:
+Use the general skill's scaffold with Security Solution defaults. Security Solution tests are organised into namespace sub-directories, so pass the correct `<namespace>` for the feature area being migrated (e.g. `timelines`, `entity_analytics`, `flyout`, `reports`, `workflows`, `agent_builder`):
 
 ```bash
 bash .agents/skills/cypress-to-scout-migration/scripts/scaffold_scout_spec.sh \
   --name <spec_name> --domain <domain_path> \
-  --plugin-test-dir x-pack/solutions/security/plugins/security_solution/test/scout/ui \
+  --plugin-test-dir x-pack/solutions/security/plugins/security_solution/test/scout/<namespace>/ui \
   --type parallel --scout-package @kbn/scout-security
 ```
+
+If the namespace directory does not yet exist, create it first with `node scripts/scout.js generate --path x-pack/solutions/security/plugins/security_solution --type ui` and move / rename the generated scaffold into the correct namespace sub-directory, or create the structure manually following an existing namespace (e.g. `test/scout/timelines/ui/`).
 
 ## Security Solution tags
 
@@ -180,7 +182,7 @@ After migration, run the `scout-best-practices-reviewer` skill against the new t
 
 ## Ownership notes
 
-- **Timeline UI** lives in the `security_solution` plugin (`public/timelines/`), not the `timelines` plugin. The `timelines` plugin only contains server-side saved object definitions and APIs. Scout tests for timeline UI belong in `security_solution/test/scout/`.
+- **Timeline UI** lives in the `security_solution` plugin (`public/timelines/`), not the `timelines` plugin. The `timelines` plugin only contains server-side saved object definitions and APIs. Scout tests for timeline UI belong in `security_solution/test/scout/timelines/ui/`.
 - **Timeline `deleteAll()`** must delete both timelines and templates — they share the same API but require separate fetch calls filtered by `timeline_type`.
 
 ## Skill improvement

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
@@ -87,6 +87,44 @@ When in doubt: if the Cypress test primarily calls `cy.request()` for setup and 
 
 All paths relative to this skill's directory.
 
+## Namespace selection — where does the test belong?
+
+Before scaffolding, decide which namespace the migrated test belongs in.
+
+### Add to an existing namespace when:
+
+- The feature under test lives inside a source directory already represented by a namespace (e.g., anything under `public/entity_analytics/` → `test/scout/entity_analytics/`)
+- The CODEOWNERS for the new file match an existing namespace
+
+Existing namespaces and their source scope:
+
+| Namespace | Source scope |
+|-----------|-------------|
+| `entity_analytics` | `public/entity_analytics/` |
+| `flyout` | `public/flyout/` |
+| `timelines` | `public/timelines/` |
+| `agent_builder` | `public/agent_builder/` |
+| `reports` | `public/reports/` |
+| `workflows` | `public/workflows/` |
+
+### Create a new namespace when:
+
+- The feature source lives in a top-level directory under `public/` not in the table above (e.g., `public/asset_inventory/` → namespace `asset_inventory`)
+- The tests will be owned by a different team than any existing namespace (different CODEOWNERS line)
+- There are 3 or more test specs — single tests do not justify a new Playwright config
+
+### How to create a new namespace:
+
+1. Name it after the top-level source directory (`public/<area>/` → namespace `<area>`)
+2. Copy the directory structure from an existing namespace: `test/scout/timelines/ui/` is a minimal reference
+3. Add a CODEOWNERS entry for `x-pack/solutions/security/plugins/security_solution/test/scout/<area>/`
+4. Add the namespace to the namespace table in `security-test-directories.md` (in this skill set)
+5. Register the new config in CI: update `.buildkite/scout_ci_config.yml` (look for `security_solution` entries)
+
+> **Do not** create a namespace for a sub-component of an existing feature area — add those tests to the parent namespace (e.g., a new risk-score view → `entity_analytics`, not a new `risk_score` namespace).
+
+---
+
 ## Scaffold shortcut
 
 Use the general skill's scaffold with Security Solution defaults. Security Solution tests are organised into namespace sub-directories, so pass the correct `<namespace>` for the feature area being migrated (e.g. `timelines`, `entity_analytics`, `flyout`, `reports`, `workflows`, `agent_builder`):

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
@@ -103,7 +103,7 @@ Existing namespaces and their source scope:
 | `agent_builder` | `public/agent_builder/` | no |
 | `entity_analytics` | `public/entity_analytics/` | yes |
 | `exceptions` | `public/exceptions/` | no |
-| `flyout` | `public/flyout/` (including `flyout_v2`) | no |
+| `flyout` | `public/flyout/` (and `public/flyout_v2/`, a v2 rewrite of the same feature area in a separate top-level dir; tests should land in this namespace) | no |
 | `reports` | `public/reports/` | no |
 | `timelines` | `public/timelines/` | no |
 | `workflows` | `public/workflows/` | no |
@@ -112,7 +112,7 @@ Existing namespaces and their source scope:
 
 ### Create a new namespace when:
 
-- The feature source lives in a top-level directory under `public/` **not covered** by any row above (e.g., `public/asset_inventory/` → new namespace `asset_inventory`). Sub-directories of an existing scope (e.g. `public/flyout_v2/`) belong in the parent namespace, not a new one. For server-only features with no `public/` counterpart, use the directory name under `server/lib/` as the namespace anchor (e.g., `server/lib/machine_learning/` → namespace `machine_learning`). ⚠️ Exception: `server/lib/timeline` (singular) maps to the existing `timelines` namespace — do not create a new `timeline` namespace.
+- The feature source lives in a top-level directory under `public/` **not covered** by any row above (e.g., `public/asset_inventory/` → new namespace `asset_inventory`). Separate v2/v3 rewrites of an existing feature area (e.g. `public/flyout_v2/`) belong in the parent namespace, not a new one. For server-only features with no `public/` counterpart, use the directory name under `server/lib/` as the namespace anchor (e.g., `server/lib/machine_learning/` → namespace `machine_learning`). ⚠️ Exception: `server/lib/timeline` (singular) maps to the existing `timelines` namespace — do not create a new `timeline` namespace.
 - There are **3 or more test specs** — single tests do not justify a new Playwright config with its own fixtures tree.
 
 A different owning team reinforces the decision but is not required on its own.
@@ -120,7 +120,7 @@ A different owning team reinforces the decision but is not required on its own.
 ### How to create a new namespace (3 required steps):
 
 1. **Create the directory structure.** Run `node scripts/scout generate --path x-pack/solutions/security/plugins/security_solution --type ui --namespace <name>` (use `--type api` or `--type both` if API tests are also needed). This scaffolds `test/scout/<name>/{ui,api}/` with the correct config files.
-2. **Generate and commit the config manifest.** Run `node scripts/scout.js update-test-config-manifests` from the repo root. This writes `.meta/(ui|api)/*.json` under the namespace dir. Without it, CI discovery and selective testing will not see the new config. Commit the generated file.
+2. **Generate and commit the config manifest.** Run `node scripts/scout update-test-config-manifests` from the repo root. This writes `.meta/(ui|api)/*.json` under the namespace dir. Without it, CI discovery and selective testing will not see the new config. Commit the generated file.
 3. **Add a CODEOWNERS entry.** Add `/x-pack/solutions/security/plugins/security_solution/test/scout/<namespace>/ @elastic/<team>` to `.github/CODEOWNERS`. If omitted, ownership falls through to the umbrella entry `@elastic/security-engineering-productivity` — easy to forget (the `exceptions` namespace currently has no dedicated entry for this reason).
 
 > **No `.buildkite/scout_ci_config.yml` edit is needed.** The `security_solution` plugin is already registered in the `enabled` plugins list in that file. CI auto-discovers all `playwright.config.ts` files within registered plugins — only entries under `excluded_configs` are skipped. New namespace configs are picked up automatically.
@@ -162,7 +162,6 @@ Available Security serverless tiers:
 | Role | Method | Use |
 |------|--------|-----|
 | Platform engineer | `browserAuth.loginAsPlatformEngineer()` | Default for most tests — standard CRUD privileges |
-| Privileged user | `browserAuth.loginAsPrivilegedUser()` | Editor role in serverless security projects |
 | T1 analyst | `browserAuth.loginAsT1Analyst()` | Read-only analyst (RBAC testing) |
 | Any security role | `browserAuth.loginAsSecurityRole('role_name')` | Generic — works for any role in `roles.yml` |
 | Custom role | `browserAuth.loginWithCustomRole(roleDescriptor)` | Ad-hoc RBAC testing with inline descriptors |

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
@@ -108,16 +108,18 @@ Existing namespaces and their source scope:
 | `timelines` | `public/timelines/` | no |
 | `workflows` | `public/workflows/` | no |
 
+> The source scope column shows the UI (`public/`) anchor. API tests for a feature belong in the **same namespace** as its UI tests — the namespace tracks the feature area, not the code layer (e.g., entity analytics API tests live in `entity_analytics/api/` alongside the UI tests).
+
 ### Create a new namespace when:
 
-- The feature source lives in a top-level directory under `public/` **not covered** by any row above (e.g., `public/asset_inventory/` → new namespace `asset_inventory`). Sub-directories of an existing scope (e.g. `public/flyout_v2/`) belong in the parent namespace, not a new one.
+- The feature source lives in a top-level directory under `public/` **not covered** by any row above (e.g., `public/asset_inventory/` → new namespace `asset_inventory`). Sub-directories of an existing scope (e.g. `public/flyout_v2/`) belong in the parent namespace, not a new one. For server-only features with no `public/` counterpart, use the directory name under `server/lib/` as the namespace anchor (e.g., `server/lib/machine_learning/` → namespace `machine_learning`). ⚠️ Exception: `server/lib/timeline` (singular) maps to the existing `timelines` namespace — do not create a new `timeline` namespace.
 - There are **3 or more test specs** — single tests do not justify a new Playwright config with its own fixtures tree.
 
 A different owning team reinforces the decision but is not required on its own.
 
 ### How to create a new namespace (3 required steps):
 
-1. **Create the directory structure.** Copy from `test/scout/timelines/ui/` (UI-only reference) or `test/scout/entity_analytics/` (UI + API reference; also has a `common/` dir for shared fixtures). Each namespace needs its own `parallel.playwright.config.ts` (or `playwright.config.ts`), `fixtures/index.ts`, and specs.
+1. **Create the directory structure.** Run `node scripts/scout generate --path x-pack/solutions/security/plugins/security_solution --type ui --namespace <name>` (use `--type api` or `--type both` if API tests are also needed). This scaffolds `test/scout/<name>/{ui,api}/` with the correct config files.
 2. **Generate and commit the config manifest.** Run `node scripts/scout.js update-test-config-manifests` from the repo root. This writes `.meta/(ui|api)/*.json` under the namespace dir. Without it, CI discovery and selective testing will not see the new config. Commit the generated file.
 3. **Add a CODEOWNERS entry.** Add `/x-pack/solutions/security/plugins/security_solution/test/scout/<namespace>/ @elastic/<team>` to `.github/CODEOWNERS`. If omitted, ownership falls through to the umbrella entry `@elastic/security-engineering-productivity` — easy to forget (the `exceptions` namespace currently has no dedicated entry for this reason).
 
@@ -140,7 +142,6 @@ bash .agents/skills/cypress-to-scout-migration/scripts/scaffold_scout_spec.sh \
   --type parallel --scout-package @kbn/scout-security
 ```
 
-If the namespace directory does not yet exist, create it first with `node scripts/scout.js generate --path x-pack/solutions/security/plugins/security_solution --type ui` and move / rename the generated scaffold into the correct namespace sub-directory, or create the structure manually following an existing namespace (e.g. `test/scout/timelines/ui/`).
 
 ## Security Solution tags
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
@@ -117,11 +117,11 @@ A different owning team reinforces the decision but is not required on its own.
 
 ### How to create a new namespace (3 required steps):
 
-1. **Create the directory structure.** Copy from `test/scout/timelines/ui/` (UI-only reference) or `test/scout/entity_analytics/` (UI + API reference). Each namespace needs its own `parallel.playwright.config.ts` (or `playwright.config.ts`), `fixtures/index.ts`, and specs.
-2. **Generate and commit the config manifest.** Run `node scripts/scout update-test-config-manifests` from the repo root. This writes `.meta/(ui|api)/*.json` under the namespace dir. Without it, CI discovery and selective testing will not see the new config. Commit the generated file.
+1. **Create the directory structure.** Copy from `test/scout/timelines/ui/` (UI-only reference) or `test/scout/entity_analytics/` (UI + API reference; also has a `common/` dir for shared fixtures). Each namespace needs its own `parallel.playwright.config.ts` (or `playwright.config.ts`), `fixtures/index.ts`, and specs.
+2. **Generate and commit the config manifest.** Run `node scripts/scout.js update-test-config-manifests` from the repo root. This writes `.meta/(ui|api)/*.json` under the namespace dir. Without it, CI discovery and selective testing will not see the new config. Commit the generated file.
 3. **Add a CODEOWNERS entry.** Add `/x-pack/solutions/security/plugins/security_solution/test/scout/<namespace>/ @elastic/<team>` to `.github/CODEOWNERS`. If omitted, ownership falls through to the umbrella entry `@elastic/security-engineering-productivity` — easy to forget (the `exceptions` namespace currently has no dedicated entry for this reason).
 
-> **No `.buildkite/scout_ci_config.yml` edit is needed.** The `security_solution` plugin is already registered; new namespace configs are discovered automatically by glob.
+> **No `.buildkite/scout_ci_config.yml` edit is needed.** The `security_solution` plugin is already registered in the `enabled` plugins list in that file. CI auto-discovers all `playwright.config.ts` files within registered plugins — only entries under `excluded_configs` are skipped. New namespace configs are picked up automatically.
 
 **Then:** add the namespace to the source-scope table in `security-test-directories.md` (in this skill set) and the namespace table in `scout-best-practices-reviewer`.
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md
@@ -90,36 +90,40 @@ All paths relative to this skill's directory.
 ## Namespace selection — where does the test belong?
 
 Before scaffolding, decide which namespace the migrated test belongs in.
+**Primary rule: namespaces track feature areas**, not teams — one team commonly owns several namespaces (e.g. `@elastic/security-threat-hunting` owns `agent_builder`, `flyout`, `timelines`, and `workflows`).
 
 ### Add to an existing namespace when:
 
-- The feature under test lives inside a source directory already represented by a namespace (e.g., anything under `public/entity_analytics/` → `test/scout/entity_analytics/`)
-- The CODEOWNERS for the new file match an existing namespace
+The feature under test lives inside a source directory already covered by an existing namespace (see table below). A different owning team is a secondary / reinforcing signal, not a primary criterion.
 
 Existing namespaces and their source scope:
 
-| Namespace | Source scope |
-|-----------|-------------|
-| `entity_analytics` | `public/entity_analytics/` |
-| `flyout` | `public/flyout/` |
-| `timelines` | `public/timelines/` |
-| `agent_builder` | `public/agent_builder/` |
-| `reports` | `public/reports/` |
-| `workflows` | `public/workflows/` |
+| Namespace | Source scope | `api/`? |
+|-----------|-------------|---------|
+| `agent_builder` | `public/agent_builder/` | no |
+| `entity_analytics` | `public/entity_analytics/` | yes |
+| `exceptions` | `public/exceptions/` | no |
+| `flyout` | `public/flyout/` (including `flyout_v2`) | no |
+| `reports` | `public/reports/` | no |
+| `timelines` | `public/timelines/` | no |
+| `workflows` | `public/workflows/` | no |
 
 ### Create a new namespace when:
 
-- The feature source lives in a top-level directory under `public/` not in the table above (e.g., `public/asset_inventory/` → namespace `asset_inventory`)
-- The tests will be owned by a different team than any existing namespace (different CODEOWNERS line)
-- There are 3 or more test specs — single tests do not justify a new Playwright config
+- The feature source lives in a top-level directory under `public/` **not covered** by any row above (e.g., `public/asset_inventory/` → new namespace `asset_inventory`). Sub-directories of an existing scope (e.g. `public/flyout_v2/`) belong in the parent namespace, not a new one.
+- There are **3 or more test specs** — single tests do not justify a new Playwright config with its own fixtures tree.
 
-### How to create a new namespace:
+A different owning team reinforces the decision but is not required on its own.
 
-1. Name it after the top-level source directory (`public/<area>/` → namespace `<area>`)
-2. Copy the directory structure from an existing namespace: `test/scout/timelines/ui/` is a minimal reference
-3. Add a CODEOWNERS entry for `x-pack/solutions/security/plugins/security_solution/test/scout/<area>/`
-4. Add the namespace to the namespace table in `security-test-directories.md` (in this skill set)
-5. Register the new config in CI: update `.buildkite/scout_ci_config.yml` (look for `security_solution` entries)
+### How to create a new namespace (3 required steps):
+
+1. **Create the directory structure.** Copy from `test/scout/timelines/ui/` (UI-only reference) or `test/scout/entity_analytics/` (UI + API reference). Each namespace needs its own `parallel.playwright.config.ts` (or `playwright.config.ts`), `fixtures/index.ts`, and specs.
+2. **Generate and commit the config manifest.** Run `node scripts/scout update-test-config-manifests` from the repo root. This writes `.meta/(ui|api)/*.json` under the namespace dir. Without it, CI discovery and selective testing will not see the new config. Commit the generated file.
+3. **Add a CODEOWNERS entry.** Add `/x-pack/solutions/security/plugins/security_solution/test/scout/<namespace>/ @elastic/<team>` to `.github/CODEOWNERS`. If omitted, ownership falls through to the umbrella entry `@elastic/security-engineering-productivity` — easy to forget (the `exceptions` namespace currently has no dedicated entry for this reason).
+
+> **No `.buildkite/scout_ci_config.yml` edit is needed.** The `security_solution` plugin is already registered; new namespace configs are discovered automatically by glob.
+
+**Then:** add the namespace to the source-scope table in `security-test-directories.md` (in this skill set) and the namespace table in `scout-best-practices-reviewer`.
 
 > **Do not** create a namespace for a sub-component of an existing feature area — add those tests to the parent namespace (e.g., a new risk-score view → `entity_analytics`, not a new `risk_score` namespace).
 
@@ -127,7 +131,7 @@ Existing namespaces and their source scope:
 
 ## Scaffold shortcut
 
-Use the general skill's scaffold with Security Solution defaults. Security Solution tests are organised into namespace sub-directories, so pass the correct `<namespace>` for the feature area being migrated (e.g. `timelines`, `entity_analytics`, `flyout`, `reports`, `workflows`, `agent_builder`):
+Use the general skill's scaffold with Security Solution defaults. Security Solution tests are organised into namespace sub-directories, so pass the correct `<namespace>` for the feature area being migrated (e.g. `timelines`, `entity_analytics`, `exceptions`, `flyout`, `reports`, `workflows`, `agent_builder`):
 
 ```bash
 bash .agents/skills/cypress-to-scout-migration/scripts/scaffold_scout_spec.sh \

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md
@@ -75,9 +75,21 @@ If a new API service is added, verify it:
 
 ### Test placement
 
-- Timeline UI tests belong in `security_solution/test/scout/` — the `timelines` plugin only has server-side saved object definitions and APIs
-- Parallel specs go in `test/scout/ui/parallel_tests/<domain>/`
-- Sequential specs go in `test/scout/ui/tests/<domain>/`
+Security Solution Scout tests use a namespace sub-directory structure. Each feature area has its own directory under `test/scout/`:
+
+| Namespace | Path |
+|-----------|------|
+| `entity_analytics` | `test/scout/entity_analytics/{ui,api}/` |
+| `flyout` | `test/scout/flyout/ui/` |
+| `timelines` | `test/scout/timelines/ui/` |
+| `agent_builder` | `test/scout/agent_builder/ui/` |
+| `reports` | `test/scout/reports/ui/` |
+| `workflows` | `test/scout/workflows/ui/` |
+
+- Timeline UI tests belong in `security_solution/test/scout/timelines/ui/` — the `timelines` plugin only has server-side saved object definitions and APIs
+- Parallel specs go in `test/scout/<namespace>/ui/parallel_tests/`
+- Sequential specs go in `test/scout/<namespace>/ui/tests/`
+- Root-level `test/scout/ui/` or `test/scout/api/` no longer exist in `security_solution`; a structural guard in kbn-scout enforces that root-level and namespace-based layouts cannot coexist
 
 ## Migration parity (Security-specific additions)
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md
@@ -90,6 +90,7 @@ Security Solution Scout tests use a namespace sub-directory structure. Each feat
 - Parallel specs go in `test/scout/<namespace>/ui/parallel_tests/`
 - Sequential specs go in `test/scout/<namespace>/ui/tests/`
 - Root-level `test/scout/ui/` or `test/scout/api/` no longer exist in `security_solution`; a structural guard in kbn-scout enforces that root-level and namespace-based layouts cannot coexist
+- If a test is placed in a namespace that doesn't match its source scope (e.g., a flyout test landed in `entity_analytics/`), flag it — see the **Namespace selection** section of `security-cypress-to-scout-migration` for the source-scope table and creation criteria
 
 ## Migration parity (Security-specific additions)
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md
@@ -79,17 +79,18 @@ Security Solution Scout tests use a namespace sub-directory structure. Each feat
 
 | Namespace | Path |
 |-----------|------|
-| `entity_analytics` | `test/scout/entity_analytics/{ui,api}/` |
-| `flyout` | `test/scout/flyout/ui/` |
-| `timelines` | `test/scout/timelines/ui/` |
 | `agent_builder` | `test/scout/agent_builder/ui/` |
+| `entity_analytics` | `test/scout/entity_analytics/{ui,api}/` |
+| `exceptions` | `test/scout/exceptions/ui/` |
+| `flyout` | `test/scout/flyout/ui/` |
 | `reports` | `test/scout/reports/ui/` |
+| `timelines` | `test/scout/timelines/ui/` |
 | `workflows` | `test/scout/workflows/ui/` |
 
 - Timeline UI tests belong in `security_solution/test/scout/timelines/ui/` — the `timelines` plugin only has server-side saved object definitions and APIs
 - Parallel specs go in `test/scout/<namespace>/ui/parallel_tests/`
 - Sequential specs go in `test/scout/<namespace>/ui/tests/`
-- Root-level `test/scout/ui/` or `test/scout/api/` no longer exist in `security_solution`; a structural guard in kbn-scout enforces that root-level and namespace-based layouts cannot coexist
+- Root-level `test/scout/ui/` contains only `.scout/reports` output, not test specs; `test/scout/api/` does not exist — all test specs live under namespace sub-dirs
 - If a test is placed in a namespace that doesn't match its source scope (e.g., a flyout test landed in `entity_analytics/`), flag it — see the **Namespace selection** section of `security-cypress-to-scout-migration` for the source-scope table and creation criteria
 
 ## Migration parity (Security-specific additions)

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md
@@ -90,7 +90,7 @@ Security Solution Scout tests use a namespace sub-directory structure. Each feat
 - Timeline UI tests belong in `security_solution/test/scout/timelines/ui/` — the `timelines` plugin only has server-side saved object definitions and APIs
 - Parallel specs go in `test/scout/<namespace>/ui/parallel_tests/`
 - Sequential specs go in `test/scout/<namespace>/ui/tests/`
-- Root-level `test/scout/ui/` contains only `.scout/reports` output, not test specs; `test/scout/api/` does not exist — all test specs live under namespace sub-dirs
+- There is no root-level `test/scout/ui/` or `test/scout/api/` in `security_solution` — all test specs live under namespace sub-dirs
 - If a test is placed in a namespace that doesn't match its source scope (e.g., a flyout test landed in `entity_analytics/`), flag it — see the **Namespace selection** section of `security-cypress-to-scout-migration` for the source-scope table and creation criteria
 
 ## Migration parity (Security-specific additions)

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
@@ -27,6 +27,9 @@ This file maps Security Solution feature areas to their test directories, file n
   - [Investigations](#investigations-cross-feature-dashboards-data-view-threat-intelligence)
   - [Notes](#notes)
   - [Onboarding / Sourcerer / Common](#onboarding--sourcerer--common)
+  - [Agent Builder](#agent-builder)
+  - [Reports (AI Value Report)](#reports-ai-value-report)
+  - [Workflows](#workflows)
 - [File naming conventions](#file-naming-conventions)
 - [Notes for test coverage catalog](#notes-for-test-coverage-catalog)
 
@@ -53,8 +56,22 @@ These skills describe test file conventions, runner commands, authentication pat
 | API integration (FTR) | `x-pack/solutions/security/test/security_solution_api_integration/` | `node scripts/functional_tests` |
 | Functional / E2E (FTR) | `x-pack/solutions/security/test/functional/` | `node scripts/functional_tests` |
 | Cypress E2E | `x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/**/*.cy.ts` | Cypress runner |
-| Scout API | `<plugin>/test/scout*/api/**/*.spec.ts` | `node scripts/scout.js run-tests` |
-| Scout UI | `<plugin>/test/scout*/ui/**/*.spec.ts` | `node scripts/scout.js run-tests` |
+| Scout API | `<plugin>/test/scout/<namespace>/api/**/*.spec.ts` | `node scripts/scout.js run-tests` |
+| Scout UI | `<plugin>/test/scout/<namespace>/ui/**/*.spec.ts` | `node scripts/scout.js run-tests` |
+
+> **Security Solution Scout namespace structure.** Scout tests for `security_solution` are organised into feature-area sub-directories under `test/scout/`:
+>
+> ```
+> test/scout/
+>   agent_builder/ui/
+>   entity_analytics/ui/  entity_analytics/api/
+>   flyout/ui/
+>   reports/ui/
+>   timelines/ui/
+>   workflows/ui/
+> ```
+>
+> Each namespace has its own `parallel.playwright.config.ts` and `fixtures/` tree. Use `test/scout/<namespace>/ui/` (or `api/`) in place of the generic `test/scout*/ui/` glob when working with Security Solution tests. A structural guard in kbn-scout enforces this: root-level `test/scout/{ui,api}/` and namespace dirs cannot coexist in the same plugin.
 
 ---
 
@@ -87,6 +104,7 @@ These skills describe test file conventions, runner commands, authentication pat
 | Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/timelines/` |
 | Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/timeline_templates/` |
 | API integration | `test/security_solution_api_integration/test_suites/investigation/timeline/` |
+| Scout UI | `plugins/security_solution/test/scout/timelines/ui/` |
 
 ### Cases
 
@@ -106,7 +124,9 @@ These skills describe test file conventions, runner commands, authentication pat
 | API integration | `test/security_solution_api_integration/test_suites/entity_analytics/entity_details/` |
 | API integration | `test/security_solution_api_integration/test_suites/entity_analytics/entity_store/` |
 | API integration | `test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/` |
-| Scout API | `plugins/entity_store/test/scout/api/` |
+| Scout UI | `plugins/security_solution/test/scout/entity_analytics/ui/` |
+| Scout API | `plugins/security_solution/test/scout/entity_analytics/api/` |
+| Scout API (entity_store pkg) | `plugins/entity_store/test/scout/api/` |
 
 ### Explore (Hosts, Network, Users, Overview)
 
@@ -161,6 +181,7 @@ These skills describe test file conventions, runner commands, authentication pat
 |---|---|
 | Unit | `plugins/security_solution/public/flyout/**/*.test.ts` |
 | Unit (package) | `packages/expandable-flyout/src/**/*.test.ts` |
+| Scout UI | `plugins/security_solution/test/scout/flyout/ui/` |
 
 ### Asset Inventory
 
@@ -215,6 +236,24 @@ These skills describe test file conventions, runner commands, authentication pat
 | Unit | `plugins/security_solution/public/sourcerer/**/*.test.ts` |
 | Unit | `plugins/security_solution/public/common/**/*.test.ts` |
 
+### Agent Builder
+
+| Test type | Directory |
+|---|---|
+| Scout UI | `plugins/security_solution/test/scout/agent_builder/ui/` |
+
+### Reports (AI Value Report)
+
+| Test type | Directory |
+|---|---|
+| Scout UI | `plugins/security_solution/test/scout/reports/ui/` |
+
+### Workflows
+
+| Test type | Directory |
+|---|---|
+| Scout UI | `plugins/security_solution/test/scout/workflows/ui/` |
+
 ---
 
 ## File naming conventions
@@ -224,8 +263,8 @@ These skills describe test file conventions, runner commands, authentication pat
 | Unit test | Co-located with source file | `alerts_table.tsx` → `alerts_table.test.ts` |
 | Jest integration test | Adjacent or in `__tests__/` | `my_hook.test.ts` with `jest.integration.config.js` |
 | Cypress spec | `*.cy.ts` inside `cypress/e2e/` | `rule_creation.cy.ts` |
-| Scout UI spec | `*.spec.ts` inside `test/scout*/ui/` | `alerts_page.spec.ts` |
-| Scout API spec | `*.spec.ts` inside `test/scout*/api/` | `rules_api.spec.ts` |
+| Scout UI spec | `*.spec.ts` inside `test/scout/<namespace>/ui/` | `alerts_page.spec.ts` |
+| Scout API spec | `*.spec.ts` inside `test/scout/<namespace>/api/` | `rules_api.spec.ts` |
 | FTR API integration test | `*.ts` inside `test_suites/` | `create_rules.ts` |
 
 ---

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
@@ -72,6 +72,8 @@ These skills describe test file conventions, runner commands, authentication pat
 > ```
 >
 > Each namespace has its own `parallel.playwright.config.ts` and `fixtures/` tree. Use `test/scout/<namespace>/ui/` (or `api/`) in place of the generic `test/scout*/ui/` glob when working with Security Solution tests. A structural guard in kbn-scout enforces this: root-level `test/scout/{ui,api}/` and namespace dirs cannot coexist in the same plugin.
+>
+> **Adding tests for a new feature area?** Namespaces map 1-to-1 with top-level source directories under `public/`. If the feature source lives in a directory not already represented (e.g., `public/asset_inventory/`), a new namespace is needed. If it lives inside an existing namespace's scope, add to that namespace. See the **Namespace selection** section in `security-cypress-to-scout-migration` for the full decision table and creation steps.
 
 ---
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
@@ -65,15 +65,16 @@ These skills describe test file conventions, runner commands, authentication pat
 > test/scout/
 >   agent_builder/ui/
 >   entity_analytics/ui/  entity_analytics/api/
+>   exceptions/ui/
 >   flyout/ui/
 >   reports/ui/
 >   timelines/ui/
 >   workflows/ui/
 > ```
 >
-> Each namespace has its own `parallel.playwright.config.ts` and `fixtures/` tree. Use `test/scout/<namespace>/ui/` (or `api/`) in place of the generic `test/scout*/ui/` glob when working with Security Solution tests. A structural guard in kbn-scout enforces this: root-level `test/scout/{ui,api}/` and namespace dirs cannot coexist in the same plugin.
+> Each namespace has its own `parallel.playwright.config.ts` and `fixtures/` tree. Use `test/scout/<namespace>/ui/` (or `api/`) in place of the generic `test/scout*/ui/` glob when working with Security Solution tests. A root-level `test/scout/ui/` directory exists but holds only `.scout/reports` output — all test specs live under namespace sub-dirs.
 >
-> **Adding tests for a new feature area?** Namespaces map 1-to-1 with top-level source directories under `public/`. If the feature source lives in a directory not already represented (e.g., `public/asset_inventory/`), a new namespace is needed. If it lives inside an existing namespace's scope, add to that namespace. See the **Namespace selection** section in `security-cypress-to-scout-migration` for the full decision table and creation steps.
+> **Adding tests for a new feature area?** Namespaces track feature areas and roughly correspond to top-level source directories under `public/` (e.g., `public/asset_inventory/` has no namespace yet and would need one). Sub-directories of an existing source scope belong in the parent namespace. See the **Namespace selection** section in `security-cypress-to-scout-migration` for the full decision table and creation steps (3 required: create scope, commit manifest, add CODEOWNERS).
 
 ---
 
@@ -149,6 +150,7 @@ These skills describe test file conventions, runner commands, authentication pat
 | API integration | `test/security_solution_api_integration/test_suites/lists_and_exception_lists/exception_lists_items/` |
 | API integration | `test/security_solution_api_integration/test_suites/lists_and_exception_lists/lists_items/` |
 | API integration | `test/security_solution_api_integration/test_suites/lists_and_exception_lists/authorization/` |
+| Scout UI | `plugins/security_solution/test/scout/exceptions/ui/` |
 
 ### AI Assistant / GenAI (Attack Discovery, Conversations, Knowledge Base)
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
@@ -56,8 +56,8 @@ These skills describe test file conventions, runner commands, authentication pat
 | API integration (FTR) | `x-pack/solutions/security/test/security_solution_api_integration/` | `node scripts/functional_tests` |
 | Functional / E2E (FTR) | `x-pack/solutions/security/test/functional/` | `node scripts/functional_tests` |
 | Cypress E2E | `x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/**/*.cy.ts` | Cypress runner |
-| Scout API | `<plugin>/test/scout/<namespace>/api/**/*.spec.ts` | `node scripts/scout.js run-tests` |
-| Scout UI | `<plugin>/test/scout/<namespace>/ui/**/*.spec.ts` | `node scripts/scout.js run-tests` |
+| Scout API | `<plugin>/test/scout*/api/**/*.spec.ts` | `node scripts/scout.js run-tests` |
+| Scout UI | `<plugin>/test/scout*/ui/**/*.spec.ts` | `node scripts/scout.js run-tests` |
 
 > **Security Solution Scout namespace structure.** Scout tests for `security_solution` are organised into feature-area sub-directories under `test/scout/`:
 >
@@ -72,9 +72,7 @@ These skills describe test file conventions, runner commands, authentication pat
 >   workflows/ui/
 > ```
 >
-> Each namespace has its own `parallel.playwright.config.ts` and `fixtures/` tree. Use `test/scout/<namespace>/ui/` (or `api/`) in place of the generic `test/scout*/ui/` glob when working with Security Solution tests. A root-level `test/scout/ui/` directory exists but holds only `.scout/reports` output — all test specs live under namespace sub-dirs.
->
-> **Adding tests for a new feature area?** Namespaces track feature areas and roughly correspond to top-level source directories under `public/` (e.g., `public/asset_inventory/` has no namespace yet and would need one). Sub-directories of an existing source scope belong in the parent namespace. See the **Namespace selection** section in `security-cypress-to-scout-migration` for the full decision table and creation steps (3 required: create scope, commit manifest, add CODEOWNERS).
+> Each namespace has its own `parallel.playwright.config.ts` and `fixtures/` tree. When searching for Security Solution Scout tests, use the specific feature-area paths in the tables below rather than the generic glob above.
 
 ---
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
@@ -59,21 +59,6 @@ These skills describe test file conventions, runner commands, authentication pat
 | Scout API | `<plugin>/test/scout*/api/**/*.spec.ts` | `node scripts/scout.js run-tests` |
 | Scout UI | `<plugin>/test/scout*/ui/**/*.spec.ts` | `node scripts/scout.js run-tests` |
 
-> **Security Solution Scout namespace structure.** Scout tests for `security_solution` are organised into feature-area sub-directories under `test/scout/`:
->
-> ```
-> test/scout/
->   agent_builder/ui/
->   entity_analytics/ui/  entity_analytics/api/
->   exceptions/ui/
->   flyout/ui/
->   reports/ui/
->   timelines/ui/
->   workflows/ui/
-> ```
->
-> Each namespace has its own `parallel.playwright.config.ts` and `fixtures/` tree. When searching for Security Solution Scout tests, use the specific feature-area paths in the tables below rather than the generic glob above.
-
 ---
 
 ## Feature area → test directory mapping

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
@@ -235,6 +235,8 @@ These skills describe test file conventions, runner commands, authentication pat
 |---|---|
 | Scout UI | `plugins/security_solution/test/scout/reports/ui/` |
 
+> Note: there is also a separate `test/scout_ai_value_report/` directory (a sibling of `test/scout/`, outside the namespace structure) owned by the same team. That path uses an older naming convention and is distinct from the `reports` namespace above.
+
 ### Workflows
 
 | Test type | Directory |


### PR DESCRIPTION
## Summary

Three Security Solution skills became stale after #275087 reorganised Scout tests into namespace sub-directories (`test/scout/<namespace>/{ui,api}/`). This PR updates them.

Changes were fact-checked against the live repo (directory structure, CODEOWNERS, CI config) before finalising.

### `cypress-to-scout-migration/SKILL.md`

- Fix hardcoded scaffold path (`test/scout/ui` → `test/scout/<namespace>/ui`).
- Add a **Namespace selection** section: feature-area-first decision rule, source-scope table (namespace → `public/<area>/`, including `api/?` column), corrected 3-step creation checklist:
  1. Create the namespace scope (copy from `timelines/` or `entity_analytics/`).
  2. Generate + commit the config manifest (`node scripts/scout update-test-config-manifests`).
  3. Add a CODEOWNERS entry — easy to forget; the `exceptions` namespace has none today as proof.
  - Explicitly notes **no `.buildkite/scout_ci_config.yml` edit needed** (plugin-level registration, glob-based discovery).
- Fix the timeline ownership note to `test/scout/timelines/ui/`.

### `scout-best-practices-reviewer/SKILL.md`

- Add missing `exceptions` namespace to the placement table.
- Fix stale test placement paths (`test/scout/ui/parallel_tests/` → `test/scout/<namespace>/ui/parallel_tests/`).
- Fix inaccurate "root-level `ui/` no longer exists" claim: `test/scout/ui/` exists but holds only `.scout/reports` output — no test specs.
- Add cross-reference to the migration skill's Namespace selection section for wrong-placement flags.

### `test-plan-generator/references/security-test-directories.md`

- Add Scout UI rows for `entity_analytics`, `timelines`, `flyout`, `exceptions` (tests exist, were undocumented).
- Add Scout UI + API rows for `entity_analytics` from the `security_solution` plugin (previously only the `entity_store` package row existed).
- Add new feature-area sections for `agent_builder`, `reports`, `workflows`.
- Update file naming conventions Scout rows to the namespace path pattern.

## Out of scope — pending investigation

**How to keep skills up to date as the codebase evolves.** This PR was triggered by manual discovery that skills had gone stale after #275087 merged. There is currently no mechanism to detect or prevent this. Worth exploring: a lightweight CI check (or PR checklist item) that validates paths referenced in skill files still exist in the repo.

## Test plan

- [ ] Namespace paths in all three files match `ls x-pack/solutions/security/plugins/security_solution/test/scout/`
- [ ] No reference to editing `.buildkite/scout_ci_config.yml` for a new namespace
- [ ] `exceptions` namespace present in `cypress-to-scout-migration`, `scout-best-practices-reviewer`, and `security-test-directories.md`
- [ ] Manifest step (`node scripts/scout update-test-config-manifests`) present in the creation checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)