### PR TITLE
[9.4] Bound key strings in ui-settings and user-storage routes (#279726)

### DIFF
--- a/src/core/packages/ui-settings/server-internal/src/routes/delete.ts
+++ b/src/core/packages/ui-settings/server-internal/src/routes/delete.ts
@@ -18,7 +18,7 @@ import type { InternalUiSettingsRequestHandlerContext } from '../internal_types'
 
 const validate = {
   params: schema.object({
-    key: schema.string(),
+    key: schema.string({ minLength: 1, maxLength: 1024 }),
   }),
 };
 

--- a/src/core/packages/ui-settings/server-internal/src/routes/internal/delete.ts
+++ b/src/core/packages/ui-settings/server-internal/src/routes/internal/delete.ts
@@ -18,7 +18,7 @@ import type { InternalUiSettingsRequestHandlerContext } from '../../internal_typ
 
 const validate = {
   params: schema.object({
-    key: schema.string(),
+    key: schema.string({ minLength: 1, maxLength: 1024 }),
   }),
 };
 

--- a/src/core/packages/ui-settings/server-internal/src/routes/internal/set.ts
+++ b/src/core/packages/ui-settings/server-internal/src/routes/internal/set.ts
@@ -19,7 +19,7 @@ import { CannotOverrideError } from '../../ui_settings_errors';
 
 const validate = {
   params: schema.object({
-    key: schema.string(),
+    key: schema.string({ minLength: 1, maxLength: 1024 }),
   }),
   body: schema.object({
     value: schema.any(),

--- a/src/core/packages/ui-settings/server-internal/src/routes/internal/validate.ts
+++ b/src/core/packages/ui-settings/server-internal/src/routes/internal/validate.ts
@@ -63,7 +63,7 @@ export function registerInternalValidateRoute(router: InternalUiSettingsRouter) 
       },
       validate: {
         params: schema.object({
-          key: schema.string(),
+          key: schema.string({ minLength: 1, maxLength: 1024 }),
         }),
         body: schema.object({
           value: schema.any(),

--- a/src/core/packages/ui-settings/server-internal/src/routes/set.ts
+++ b/src/core/packages/ui-settings/server-internal/src/routes/set.ts
@@ -19,7 +19,7 @@ import { CannotOverrideError } from '../ui_settings_errors';
 
 const validate = {
   params: schema.object({
-    key: schema.string(),
+    key: schema.string({ minLength: 1, maxLength: 1024 }),
   }),
   body: schema.object({
     value: schema.any(),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Bound key strings in ui-settings and user-storage routes (#279726)](https://github.com/elastic/kibana/pull/279726)

**Note:** the `user-storage` change from the original PR is intentionally excluded here — the `@kbn/core-user-storage-server-internal` package was introduced in 9.5, so it does not exist on this branch. Only the `ui-settings` route key bounds are backported.

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Anton Dosov","email":"anton.dosov@elastic.co"},"sourceCommit":{"committedDate":"2026-07-21T11:15:08Z","message":"Bound key strings in ui-settings and user-storage routes (#279726)\n\nPart of https://github.com/elastic/kibana-team/issues/3691\n\n## Summary\n\nAdds an upper length bound to unbounded route param/key strings flagged\nby CodeQL rule `js/kibana/unbounded-string-in-schema`. This is DoS\nhardening, not a fix for an exploitable vuln.\n\n- ui-settings routes (`set`, internal `set`, `delete`, internal\n`delete`, internal `validate`): `key` -> `{ minLength: 1, maxLength:\n1024 }` (1024 accommodates namespaced setting keys).\n- user-storage routes (get/put/delete): `key` -> `z.string().max(1024)`.","sha":"ba3092edc076d3d409481a9880c388d3e9fbc979","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:all-open","v9.6.0"],"title":"Bound key strings in ui-settings and user-storage routes","number":279726,"url":"https://github.com/elastic/kibana/pull/279726","mergeCommit":{"message":"Bound key strings in ui-settings and user-storage routes (#279726)\n\nPart of https://github.com/elastic/kibana-team/issues/3691\n\n## Summary\n\nAdds an upper length bound to unbounded route param/key strings flagged\nby CodeQL rule `js/kibana/unbounded-string-in-schema`. This is DoS\nhardening, not a fix for an exploitable vuln.\n\n- ui-settings routes (`set`, internal `set`, `delete`, internal\n`delete`, internal `validate`): `key` -> `{ minLength: 1, maxLength:\n1024 }` (1024 accommodates namespaced setting keys).\n- user-storage routes (get/put/delete): `key` -> `z.string().max(1024)`.","sha":"ba3092edc076d3d409481a9880c388d3e9fbc979"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279726","number":279726,"mergeCommit":{"message":"Bound key strings in ui-settings and user-storage routes (#279726)\n\nPart of https://github.com/elastic/kibana-team/issues/3691\n\n## Summary\n\nAdds an upper length bound to unbounded route param/key strings flagged\nby CodeQL rule `js/kibana/unbounded-string-in-schema`. This is DoS\nhardening, not a fix for an exploitable vuln.\n\n- ui-settings routes (`set`, internal `set`, `delete`, internal\n`delete`, internal `validate`): `key` -> `{ minLength: 1, maxLength:\n1024 }` (1024 accommodates namespaced setting keys).\n- user-storage routes (get/put/delete): `key` -> `z.string().max(1024)`.","sha":"ba3092edc076d3d409481a9880c388d3e9fbc979"}}]}] BACKPORT-->
