### PR TITLE
[Significant Events] Fix knowledge indicator keyword score types

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/lib/knowledge_indicators/knowledge_indicator_client/indicator_searcher.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/knowledge_indicators/knowledge_indicator_client/indicator_searcher.ts
@@ -74,7 +74,7 @@ const combineKeywordClauses = (clauses: KeywordClause[]): KeywordExpressions => 
   const score = clauses
     .map(
       ({ condition: clause, boost }) =>
-        `CASE(${BasicPrettyPrinter.expression(clause)}, ${boost}, 0.0)`
+        `CASE(${BasicPrettyPrinter.expression(clause)}, ${boost.toFixed(1)}, 0.0)`
     )
     .join(' + ');
 

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/knowledge_indicators/knowledge_indicator_client/knowledge_indicator_client.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/knowledge_indicators/knowledge_indicator_client/knowledge_indicator_client.test.ts
@@ -648,8 +648,8 @@ describe('KnowledgeIndicatorClient.findIndicators search', () => {
     expect(query).not.toContain('query.esql');
     expect(query).not.toContain('query.features.id');
     expect(query).toContain('EVAL _score = CASE');
-    expect(query).toContain('CASE(TO_LOWER(title) LIKE "*checkout*", 3, 0.0)');
-    expect(query).toContain('CASE(TO_LOWER(description) LIKE "*checkout*", 2, 0.0)');
+    expect(query).toContain('CASE(TO_LOWER(title) LIKE "*checkout*", 3.0, 0.0)');
+    expect(query).toContain('CASE(TO_LOWER(description) LIKE "*checkout*", 2.0, 0.0)');
   });
 
   it('uses only query fields when type is [query]', async () => {
@@ -686,9 +686,24 @@ describe('KnowledgeIndicatorClient.findIndicators search', () => {
     const { query } = rankRequest(rankEsql);
     // Substring form: join the multivalue then apply the shared `*<query>*` pattern.
     expect(query).toContain('MV_CONCAT(TO_LOWER(tags), " ") LIKE "*client*"');
-    expect(query).toContain('CASE(MV_CONCAT(TO_LOWER(tags), " ") LIKE "*client*", 1, 0.0)');
+    expect(query).toContain('CASE(MV_CONCAT(TO_LOWER(tags), " ") LIKE "*client*", 1.0, 0.0)');
     // The exact-element form must be gone.
     expect(query).not.toContain('MV_CONTAINS');
+  });
+
+  it('uses double keyword scores in hybrid search', async () => {
+    const { client, runEsql, rankEsql } = makeClientWithRanker();
+    runEsql.mockResolvedValueOnce({ hits: [createFeatureDoc()] });
+
+    await client.findIndicators(STREAM, 'checkout service', {
+      types: [KI_TYPE_FEATURE],
+      searchMode: 'hybrid',
+    });
+
+    const { query } = rankRequest(rankEsql);
+    expect(query).toContain('FUSE RRF');
+    expect(query).toContain('CASE(TO_LOWER(title) LIKE "*checkout service*", 3.0, 0.0)');
+    expect(query).toContain('CASE(TO_LOWER(description) LIKE "*checkout service*", 2.0, 0.0)');
   });
 
   it('normalizes and thresholds semantic scores in ES|QL', async () => {


### PR DESCRIPTION
Closes elastic/nightshift-program#740

## Summary
- emit knowledge indicator keyword boosts as double ES|QL literals so `CASE` branches share a type
- keep hybrid keyword `_score` compatible with the semantic branch's double score
- add regression coverage for keyword and hybrid query generation

Made with [Cursor](https://cursor.com)