### PR TITLE
[8.19][Canvas] Document createTable rowCount maximum

### DIFF
--- a/docs/canvas/canvas-function-reference.asciidoc
+++ b/docs/canvas/canvas-function-reference.asciidoc
@@ -671,7 +671,7 @@ This creates a table based on the results of two `essql` queries, joined into on
 
 |`rowCount`
 |`number`
-|The number of empty rows to add to the table, to be assigned a value later
+|The number of empty rows to add to the table, to be assigned a value later. Must be an integer between 0 and 10,000.
 
 Default: `1`
 |===


### PR DESCRIPTION
## Summary

Documents the `createTable` expression function's newly enforced `rowCount` range in the 8.19 Canvas function reference. The `rowCount` argument must be an integer between 0 and 10,000; values outside that range are rejected. This is the 8.19 (AsciiDoc) companion to the V3 docs update in elastic/docs-content#7491.

The validation shipped in 8.19.19 (kibana PR #276502). It was also backported to 9.3.8, 9.4.4, and 9.5.0, which are covered by the docs-content change.

- **`docs/canvas/canvas-function-reference.asciidoc`**: Add the valid range to the `rowCount` argument description, preserving the existing default of `1`.

## Notes for reviewer / labels needed

- Docs-only backport to the 8.19 branch. Please add `release_note:skip` and the appropriate `v8.19.x` version label on merge.

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review for factual accuracy before merging.