### PR TITLE
[Data Streams] Docs: hidden ≠ Elasticsearch system data streams

### DIFF
--- a/src/core/packages/data-streams/server/README.md
+++ b/src/core/packages/data-streams/server/README.md
@@ -10,6 +10,8 @@ Some additional benefits to using the core data streams service:
 - Core can coordinate updates to existing data streams a bit better i.e. avoid a flood of requests from multi Kibana clusters
 - Change detection data streams are easier to detect/keep track of via Core registrations
 
+**Hidden ≠ system.** Core registration creates Kibana-managed (usually hidden) data streams; it does **not** register an Elasticsearch system data stream. Privileged streams need a matching ES `SystemDataStreamDescriptor` so `GET _data_stream/<name>` reports `system: true`. See [`@kbn/data-streams` README — System data streams](../../../../platform/packages/private/kbn-data-streams/README.md#system-data-streams).
+
 ## Examples
 
 Please refer to [examples/data_streams_example/server/index.ts](../../../../../examples/data_streams_example/server/index.ts)

--- a/src/platform/packages/private/kbn-data-streams/README.md
+++ b/src/platform/packages/private/kbn-data-streams/README.md
@@ -128,7 +128,7 @@ Kibana **cannot** mark a stream as system. That requires a matching [`SystemData
 
 ### Why this matters
 
-Privileged Kibana streams that are **not** Elasticsearch system data streams have been readable across spaces (the class of bug behind [security-team#18291](https://github.com/elastic/security-team/issues/18291)). Treat any stream that holds privileged or cross-space-sensitive data as needing ES `system: true` — `hidden` alone is not enough.
+`@kbn/data-streams` are **not** system data streams by default. This means data is readable across spaces by default (leading to the class of bug behind [security-team#18291](https://github.com/elastic/security-team/issues/18291)). Treat any stream that holds privileged or cross-space-sensitive data as needing ES `system: true` — `hidden` alone is not enough.
 
 This package does **not** currently fail boot or roll back when Elasticsearch reports `system: false`. Developers must land the ES descriptor and verify the runtime flag themselves. Core is tracking stronger platform guidance / checks in [kibana-team#3797](https://github.com/elastic/kibana-team/issues/3797).
 

--- a/src/platform/packages/private/kbn-data-streams/README.md
+++ b/src/platform/packages/private/kbn-data-streams/README.md
@@ -115,6 +115,44 @@ All CRUD operations (`create`, `search`) accept an optional `space` parameter:
 
 Data streams can contain both space-bound and space-agnostic documents. The package does not handle RBAC; higher-level repositories should wrap these APIs for access control.
 
+## System data streams
+
+`@kbn/data-streams` (and Core `registerDataStream`) can create **hidden** data streams (`hidden` defaults to `true`). That is **not** the same as an Elasticsearch **system** data stream.
+
+| Flag | Who sets it | What it means |
+|------|-------------|----------------|
+| `hidden: true` | Kibana definition / index template | Stream and backing indices are hidden from normal listings |
+| `system: true` | Elasticsearch only | Stream is registered as a system data stream (security / restricted-index semantics, product origin, DLM treatment, etc.) |
+
+Kibana **cannot** mark a stream as system. That requires a matching [`SystemDataStreamDescriptor`](https://javadoc.io/doc/org.elasticsearch/elasticsearch/latest/org/elasticsearch/indices/SystemDataStreamDescriptor.html) in the Elasticsearch Kibana plugin (or equivalent ES registration). If you only call `registerDataStream` / `DataStreamClient.initialize` without that ES registration, `GET _data_stream/<name>` typically reports `system: false` even when the stream is hidden and named `.kibana_*` / `.workflows-*`.
+
+### Why this matters
+
+Privileged Kibana streams that are **not** Elasticsearch system data streams have been readable across spaces (the class of bug behind [security-team#18291](https://github.com/elastic/security-team/issues/18291)). Treat any stream that holds privileged or cross-space-sensitive data as needing ES `system: true` — `hidden` alone is not enough.
+
+This package does **not** currently fail boot or roll back when Elasticsearch reports `system: false`. Developers must land the ES descriptor and verify the runtime flag themselves. Core is tracking stronger platform guidance / checks in [kibana-team#3797](https://github.com/elastic/kibana-team/issues/3797).
+
+### Landing order
+
+Ship the Elasticsearch `SystemDataStreamDescriptor` **with or before** enabling Kibana writes for that stream. Examples:
+
+| Stream | ES registration |
+|--------|-----------------|
+| `.workflows-events`, `.workflows-execution-data-stream-logs` | [elastic/elasticsearch#145822](https://github.com/elastic/elasticsearch/pull/145822) |
+| `.kibana_change_history` | [elastic/elasticsearch#154113](https://github.com/elastic/elasticsearch/pull/154113) |
+
+### How to verify
+
+After Kibana has created the stream (local `yarn es snapshot` + Kibana boot, or a stack that includes the descriptor):
+
+```http
+GET _data_stream/<name>
+```
+
+Confirm `system: true` and `hidden: true` for privileged streams. There is no Elasticsearch API that lists all registered `SystemIndexDescriptor` / `SystemDataStreamDescriptor` patterns — those live in ES plugin code.
+
+When writing integration tests that touch system streams, use a client that sends `x-elastic-product-origin: kibana` (see [kibana#279803](https://github.com/elastic/kibana/pull/279803)).
+
 ## Mapping Validation
 
 When registering a data stream, the following reserved keys are automatically validated and will cause an error if found in your mappings:

--- a/x-pack/platform/packages/shared/kbn-change-history/README.md
+++ b/x-pack/platform/packages/shared/kbn-change-history/README.md
@@ -175,6 +175,8 @@ If a future consumer needs to filter or sort on any of these, add them back to t
 
 `.kibana_change_history` is enrolled in data stream lifecycle with `enabled: true` and no `data_retention`. Change history documents are kept indefinitely by default.
 
+This stream must be registered as an Elasticsearch **system** data stream (`system: true`), not only as a Kibana hidden stream. Kibana `registerDataStream` / `@kbn/data-streams` cannot set that flag — it comes from the ES [`SystemDataStreamDescriptor`](https://github.com/elastic/elasticsearch/pull/154113) ([security-team#18291](https://github.com/elastic/security-team/issues/18291)). See [`@kbn/data-streams` README — System data streams](../../../../../src/platform/packages/private/kbn-data-streams/README.md#system-data-streams). Verify with `GET _data_stream/.kibana_change_history`.
+
 Cluster admins can add retention later via **Stack Management → Index Management → Data Streams** on both stateful and serverless deployments.
 
 ### Dependencies


### PR DESCRIPTION
## Summary

- Document that Kibana `hidden` data streams are **not** Elasticsearch `system: true` streams. `@kbn/data-streams` / Core `registerDataStream` cannot set system status.
- Call out the privileged-stream pitfall (cross-space readability when not registered as an ES system data stream) and the required ES `SystemDataStreamDescriptor` landing order, with workflows / change-history examples.
- Point Core `dataStreams` and `@kbn/change-history` readers at that guidance; note runtime fail-closed validation is **not** in main yet.

Relates to [kibana-team#3797](https://github.com/elastic/kibana-team/issues/3797) and [security-team#18291](https://github.com/elastic/security-team/issues/18291).




