### PR TITLE
[Docs] Document securitySolution:excludeColdAndFrozenTiersInPrevalence advanced setting

### DIFF
--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2005,6 +2005,20 @@ groups:
           self: ga
           serverless: unavailable
 
+      - setting: "securitySolution:excludeColdAndFrozenTiersInPrevalence"
+        id: security-solution-exclude-cold-frozen-tiers-prevalence
+        description: |
+          Skips cold and frozen tiers in Prevalence queries when activated.
+        datatype: bool
+        default: false
+        applies_to:
+          stack: ga
+          ech: ga
+          ece: ga
+          eck: ga
+          self: ga
+          serverless: unavailable
+
       - setting: "securitySolution:enableGraphVisualization"
         id: security-solution-enable-graph-visualization
         description: |

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2012,7 +2012,7 @@ groups:
         datatype: bool
         default: false
         applies_to:
-          stack: ga
+          stack: ga 9.2
           ech: ga
           ece: ga
           eck: ga


### PR DESCRIPTION
## Summary

Adds the missing `securitySolution:excludeColdAndFrozenTiersInPrevalence` entry to the [Kibana advanced settings reference](https://www.elastic.co/docs/reference/kibana/advanced-settings) (`docs/reference/advanced-settings-space.yml`).

The setting was completely absent from the reference page, while its parallel sibling `securitySolution:excludeColdAndFrozenTiersInAnalyzer` was already documented. The new entry mirrors that sibling's format.

### Verification

- **Exposed:** The setting is registered unconditionally. It is defined in `getDefaultColdAndFrozenTiersSettings()` and spread into `securityUiSettings` (`x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts`), then registered via `uiSettings.register(...)`. It has no `readonly` or `technicalPreview` flag, so it is a normal, user-editable advanced setting.
- **Type / default:** `boolean`, default `false`, `requiresPageReload: true`.
- **Since when:** Introduced in #257011 (merged 2026-03-11). Release labels: **9.4.0**, backported to **8.19.13**, **9.2.7**, **9.3.2** — not to 9.0 or 9.1.

### `applies_to` reasoning

- `stack: ga 9.2` — on the 9.x line the setting first appears in **9.2** (backported to 9.2.7), and is not present in 9.0 or 9.1. Following this file's convention, only the `stack` key carries the version; the 8.19.13 maintenance backport is not reflected in the badge (see the `includedDataStreamNamespacesForRuleExecution` precedent).
- `serverless: unavailable` — the feature does not apply to serverless (no cold/frozen tiers there), per the implementation PR.

## Resolves

Closes elastic/docs-content#7452

---

> **AI-assisted draft** — please double-check the `applies_to` scoping before merging.