### PR TITLE
[DateRangePicker] Fix rounding units for `roundRelativeTime` setting (disabled by default)

### DIFF
--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
@@ -70,10 +70,8 @@ export const UNIT_SHORT_TO_FULL_MAP: Record<string, string> = {
 /**
  * Maps each date-math offset unit to the unit used for rounding (`/X` suffix).
  *
- * Each unit rounds to the next finer meaningful unit so bounds snap to clean
- * boundaries without noticeably extending the window (rounding `now-1h` to
- * `/h` could stretch it to almost two hours; `/m` keeps it at ~1h). Units of
- * a day and above all normalise to `/d`.
+ * Minutes up to a week round to the next finer unit.
+ * Seconds and milliseconds round to `/s`, while months and years normalise to `/d`.
  */
 export const ROUND_UNIT_MAP: Record<string, string> = {
   ms: 's',

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
@@ -70,15 +70,17 @@ export const UNIT_SHORT_TO_FULL_MAP: Record<string, string> = {
 /**
  * Maps each date-math offset unit to the unit used for rounding (`/X` suffix).
  *
- * Sub-day units promote one step up (`ms→s`, `s→m`, `m→h`), except `h→h`
- * which keeps the hour boundary. Day-and-above units all normalise to `/d`.
+ * Each unit rounds to the next finer meaningful unit so bounds snap to clean
+ * boundaries without noticeably extending the window (rounding `now-1h` to
+ * `/h` could stretch it to almost two hours; `/m` keeps it at ~1h). Units of
+ * a day and above all normalise to `/d`.
  */
 export const ROUND_UNIT_MAP: Record<string, string> = {
   ms: 's',
-  s: 'm',
-  m: 'm',
-  h: 'h',
-  d: 'd',
+  s: 's',
+  m: 's',
+  h: 'm',
+  d: 'h',
   w: 'd',
   M: 'd',
   y: 'd',

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<DateRangePickerProps> = {
     onChange: action('onChange'),
     onInputChange: action('onInputChange'),
     onSettingsChange: action('onSettingsChange'),
-    settings: { roundRelativeTime: true, timePrecision: 's' },
+    settings: { roundRelativeTime: false, timePrecision: 's' },
   },
   argTypes: {
     locale: {
@@ -132,7 +132,7 @@ export const AutoRefresh: Story = {
   args: {
     defaultValue: 'last 15 minutes',
     settings: {
-      roundRelativeTime: true,
+      roundRelativeTime: false,
       timePrecision: 's',
       autoRefresh: {
         isEnabled: true,

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_context.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_context.tsx
@@ -182,7 +182,7 @@ export function DateRangePickerProvider({
   onInputChange,
   width = 'auto',
   calendarOptions,
-  settings = { roundRelativeTime: true },
+  settings = { roundRelativeTime: false },
   onSettingsChange,
   timeZone,
   onRefresh,

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_control.test.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_control.test.tsx
@@ -689,7 +689,7 @@ describe('DateRangePickerControl', () => {
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ start: 'now-15m/m', end: 'now' })
+        expect.objectContaining({ start: 'now-15m/s', end: 'now' })
       );
       await waitForPopoverClose();
     });

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/moon.yml
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/moon.yml
@@ -19,7 +19,6 @@ project:
 dependsOn:
   - '@kbn/i18n'
   - '@kbn/test-jest-helpers'
-  - '@kbn/i18n-react'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/settings_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/settings_panel.tsx
@@ -9,8 +9,7 @@
 
 import React, { useCallback } from 'react';
 
-import { EuiFlexGroup, EuiSwitch, EuiButtonGroup, EuiText, EuiBadge } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiFlexGroup, EuiSwitch, EuiButtonGroup, EuiText } from '@elastic/eui';
 
 import type { TimePrecision } from '../types';
 
@@ -21,7 +20,6 @@ import {
   PanelBodySection,
   PanelBodySectionInfo,
   SubPanelHeading,
-  PanelFooter,
 } from '../date_range_picker_panel_ui';
 import { AutoRefresh } from '../settings/auto_refresh';
 import { useDateRangePickerContext } from '../date_range_picker_context';
@@ -118,15 +116,6 @@ export function SettingsPanel() {
           </EuiFlexGroup>
         </PanelBodySection>
       </PanelBody>
-      <PanelFooter>
-        <EuiBadge aria-label="Tech preview" color="hollow" iconType="flask" />
-        <EuiText size="xs" color="subdued" component="p">
-          <FormattedMessage
-            id="sharedUXPackages.dateRangePicker.settingsPanel.technicalPreviewNotice"
-            defaultMessage="This time picker is in a technical preview."
-          />
-        </EuiText>
-      </PanelFooter>
     </PanelContainer>
   );
 }

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
@@ -520,13 +520,12 @@ describe('textToTimeRange', () => {
   describe('roundRelativeTime', () => {
     const opts = (round: boolean) => ({ roundRelativeTime: round });
 
-    describe('true — adds rounding', () => {
+    describe('true — adds rounding one unit finer than the offset unit', () => {
       it.each([
-        ['last 7 days', 'now-7d/d', 'now'],
         ['last 2 weeks', 'now-2w/d', 'now'],
         ['last 3 months', 'now-3M/d', 'now'],
         ['last 1 year', 'now-1y/d', 'now'],
-      ])('natural duration (day+) "%s" → start=%s', (text, start, end) => {
+      ])('natural duration (week+) "%s" → start=%s', (text, start, end) => {
         const range = textToTimeRange(text, opts(true));
 
         expect(range.start).toBe(start);
@@ -535,11 +534,12 @@ describe('textToTimeRange', () => {
       });
 
       it.each([
-        ['last 30 minutes', 'now-30m/m', 'now'],
-        ['last 3 hours', 'now-3h/h', 'now'],
-        ['last 10 seconds', 'now-10s/m', 'now'],
+        ['last 7 days', 'now-7d/h', 'now'],
+        ['last 3 hours', 'now-3h/m', 'now'],
+        ['last 30 minutes', 'now-30m/s', 'now'],
+        ['last 10 seconds', 'now-10s/s', 'now'],
         ['last 500 milliseconds', 'now-500ms/s', 'now'],
-      ])('natural duration (sub-day) "%s" → start=%s', (text, start, end) => {
+      ])('natural duration (sub-week) "%s" → start=%s', (text, start, end) => {
         const range = textToTimeRange(text, opts(true));
 
         expect(range.start).toBe(start);
@@ -548,10 +548,10 @@ describe('textToTimeRange', () => {
       });
 
       it.each([
-        ['-7d', 'now-7d/d'],
-        ['7d', 'now-7d/d'],
-        ['30m', 'now-30m/m'],
-        ['3h', 'now-3h/h'],
+        ['-7d', 'now-7d/h'],
+        ['7d', 'now-7d/h'],
+        ['30m', 'now-30m/s'],
+        ['3h', 'now-3h/m'],
         ['500ms', 'now-500ms/s'],
       ])('shorthand "%s" → start=%s', (text, start) => {
         const range = textToTimeRange(text, opts(true));
@@ -562,9 +562,9 @@ describe('textToTimeRange', () => {
       });
 
       it.each([
-        ['now-30m to now', 'now-30m/m', 'now'],
-        ['-7d to now', 'now-7d/d', 'now'],
-        ['now-3h to now-1h', 'now-3h/h', 'now-1h'],
+        ['now-30m to now', 'now-30m/s', 'now'],
+        ['-7d to now', 'now-7d/h', 'now'],
+        ['now-3h to now-1h', 'now-3h/m', 'now-1h/m'],
       ])('delimiter-split "%s" → start=%s end=%s', (text, start, end) => {
         const range = textToTimeRange(text, opts(true));
 
@@ -583,11 +583,40 @@ describe('textToTimeRange', () => {
         expect(range.start).toBe(start);
       });
 
-      it('rounds future start in delimiter-split path', () => {
+      it('rounds future start and end in delimiter-split path', () => {
         const range = textToTimeRange('now+3d to now+7d', opts(true));
 
-        expect(range.start).toBe('now+3d/d');
-        expect(range.end).toBe('now+7d');
+        expect(range.start).toBe('now+3d/h');
+        expect(range.end).toBe('now+7d/h');
+      });
+
+      it('rounds future natural duration end (start is bare "now")', () => {
+        const range = textToTimeRange('next 7 days', opts(true));
+
+        expect(range.start).toBe('now');
+        expect(range.end).toBe('now+7d/h');
+      });
+
+      it('rounds both bounds based on their own offset units', () => {
+        const range = textToTimeRange('now-7d to now-1d', opts(true));
+
+        expect(range.start).toBe('now-7d/h');
+        expect(range.end).toBe('now-1d/h');
+      });
+
+      it('rounds bounds independently when their units differ', () => {
+        const range = textToTimeRange('now-1h to now-30m', opts(true));
+
+        expect(range.start).toBe('now-1h/m');
+        expect(range.end).toBe('now-30m/s');
+      });
+
+      it('applies rounding to preset matches (bare "now" end stays as-is)', () => {
+        const presets = [{ label: 'Last 15 Minutes', start: 'now-15m', end: 'now' }];
+        const range = textToTimeRange('Last 15 Minutes', { presets, roundRelativeTime: true });
+
+        expect(range.start).toBe('now-15m/s');
+        expect(range.end).toBe('now');
       });
     });
 
@@ -596,14 +625,7 @@ describe('textToTimeRange', () => {
         const range = textToTimeRange('+7d', opts(true));
 
         expect(range.start).toBe('now');
-        expect(range.end).toBe('now+7d');
-      });
-
-      it('does not round future natural duration start', () => {
-        const range = textToTimeRange('next 7 days', opts(true));
-
-        expect(range.start).toBe('now');
-        expect(range.end).toBe('now+7d');
+        expect(range.end).toBe('now+7d/h');
       });
 
       it('does not affect named ranges', () => {
@@ -612,33 +634,34 @@ describe('textToTimeRange', () => {
         expect(range.start).toBe('now/d');
         expect(range.end).toBe('now/d');
       });
-
-      it('applies rounding to preset matches', () => {
-        const presets = [{ label: 'Last 15 Minutes', start: 'now-15m', end: 'now' }];
-        const range = textToTimeRange('Last 15 Minutes', { presets, roundRelativeTime: true });
-
-        expect(range.start).toBe('now-15m/m');
-        expect(range.end).toBe('now');
-      });
-
-      it('never modifies end', () => {
-        const range = textToTimeRange('now-7d to now-1d', opts(true));
-
-        expect(range.end).toBe('now-1d');
-      });
     });
 
-    describe('false — strips rounding', () => {
-      it('removes existing rounding suffix', () => {
+    describe('false — preserves input (does not add or strip rounding)', () => {
+      it('preserves an existing rounding suffix on shorthand input', () => {
         const range = textToTimeRange('-7d/d', opts(false));
 
-        expect(range.start).toBe('now-7d');
+        expect(range.start).toBe('now-7d/d');
       });
 
       it('is a no-op when no rounding is present', () => {
         const range = textToTimeRange('-7d', opts(false));
 
         expect(range.start).toBe('now-7d');
+      });
+
+      it('preserves rounding baked into a preset on both bounds', () => {
+        const presets = [{ label: 'Last 24 hours', start: 'now-24h/h', end: 'now' }];
+        const range = textToTimeRange('Last 24 hours', { ...opts(false), presets });
+
+        expect(range.start).toBe('now-24h/h');
+        expect(range.end).toBe('now');
+      });
+
+      it('preserves user-typed rounding on both sides of a range', () => {
+        const range = textToTimeRange('-1h/h to now-30m/m', opts(false));
+
+        expect(range.start).toBe('now-1h/h');
+        expect(range.end).toBe('now-30m/m');
       });
     });
 

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
@@ -166,8 +166,9 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
   // (1) Preset label match
   const preset = matchPreset(trimmed, presets);
   if (preset) {
-    const roundedStart = applyStartBoundRounding(preset.start, roundRelativeTime);
-    return buildRange(text, roundedStart, preset.end, formats, true);
+    const roundedStart = applyRelativeRounding(preset.start, roundRelativeTime);
+    const roundedEnd = applyRelativeRounding(preset.end, roundRelativeTime);
+    return buildRange(text, roundedStart, roundedEnd, formats, true);
   }
 
   // (2) Named range ("today", "yesterday", "this week", ...) or alias ("td", "yd", "tmr")
@@ -181,8 +182,9 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
   // (3) Natural duration ("last 7 minutes", "next 3 days")
   const duration = matchNaturalDuration(trimmed, compiled);
   if (duration) {
-    const roundedStart = applyStartBoundRounding(duration.start, roundRelativeTime);
-    return buildRange(text, roundedStart, duration.end, formats, true);
+    const roundedStart = applyRelativeRounding(duration.start, roundRelativeTime);
+    const roundedEnd = applyRelativeRounding(duration.end, roundRelativeTime);
+    return buildRange(text, roundedStart, roundedEnd, formats, true);
   }
 
   // (4) Try splitting on delimiters (extra + locale grammar + universal dash).
@@ -205,8 +207,9 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
         formats
       );
       if (startDateString && endDateString) {
-        const roundedStart = applyStartBoundRounding(startDateString, roundRelativeTime);
-        return buildRange(text, roundedStart, endDateString, formats, false);
+        const roundedStart = applyRelativeRounding(startDateString, roundRelativeTime);
+        const roundedEnd = applyRelativeRounding(endDateString, roundRelativeTime);
+        return buildRange(text, roundedStart, roundedEnd, formats, false);
       }
     }
   }
@@ -216,9 +219,10 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
   if (!dateString) return buildInvalidRange(text);
 
   if (dateString.startsWith('now+')) {
-    return buildRange(text, 'now', dateString, formats, false);
+    const roundedEnd = applyRelativeRounding(dateString, roundRelativeTime);
+    return buildRange(text, 'now', roundedEnd, formats, false);
   }
-  const roundedStart = applyStartBoundRounding(dateString, roundRelativeTime);
+  const roundedStart = applyRelativeRounding(dateString, roundRelativeTime);
   return buildRange(text, roundedStart, 'now', formats, false);
 }
 
@@ -252,35 +256,31 @@ function dateStringToOffset(dateString: DateString): DateOffset | null {
 }
 
 /**
- * Applies or strips the rounding suffix on a relative datemath `start` string.
+ * Applies the rounding suffix on a relative datemath bound (`start` or `end`)
+ * when `roundRelativeTime` is `true`.
  *
  * - `true` — keeps existing rounding; when absent, appends `/{roundUnit}`
- *   inferred from the offset unit via {@link ROUND_UNIT_MAP}.
- * - `false` — removes any trailing rounding suffix.
- * - `undefined` — returns the string unchanged.
+ *   inferred from the bound's own offset unit via {@link ROUND_UNIT_MAP}.
+ * - `false` / `undefined` — returns the string unchanged (preserves any
+ *   rounding the user or a preset provided).
  *
  * Bare `'now'` and non-relative strings are always returned as-is.
  */
-function applyStartBoundRounding(
-  start: DateString,
+function applyRelativeRounding(
+  bound: DateString,
   roundRelativeTime: boolean | undefined
 ): DateString {
-  if (roundRelativeTime === undefined) return start;
-  if (start === 'now' || !start.includes('now')) return start;
+  if (!roundRelativeTime) return bound;
+  if (bound === 'now' || !bound.includes('now')) return bound;
 
-  const offset = dateStringToOffset(start);
-  if (!offset) return start;
-
-  if (roundRelativeTime === false) {
-    return start.replace(/\/[smhdwMy]$/, '');
-  }
-
-  if (offset.roundTo) return start;
+  const offset = dateStringToOffset(bound);
+  if (!offset) return bound;
+  if (offset.roundTo) return bound;
 
   const roundUnit = ROUND_UNIT_MAP[offset.unit];
-  if (!roundUnit) return start;
+  if (!roundUnit) return bound;
 
-  return `${start}/${roundUnit}`;
+  return `${bound}/${roundUnit}`;
 }
 
 /**

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parser_corpus.test.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parser_corpus.test.ts
@@ -436,20 +436,31 @@ describe('parser corpus: textToTimeRange (English)', () => {
       {
         input: 'last 7 minutes',
         options: { roundRelativeTime: true },
-        note: 'true infers rounding from the offset unit (m → /m)',
-        expected: { start: 'now-7m/m', end: 'now', startOffset: offset(-7, 'm', 'm') },
+        note: 'true infers rounding one unit finer than the offset unit (m → /s)',
+        expected: { start: 'now-7m/s', end: 'now', startOffset: offset(-7, 'm', 's') },
       },
       {
         input: 'last 7 days',
         options: { roundRelativeTime: true },
-        note: 'day-and-above rounds to /d',
-        expected: { start: 'now-7d/d', end: 'now', startOffset: offset(-7, 'd', 'd') },
+        note: 'days round to /h; week-and-above rounds to /d',
+        expected: { start: 'now-7d/h', end: 'now', startOffset: offset(-7, 'd', 'h') },
+      },
+      {
+        input: 'now-7d/d to now-1d/d',
+        options: { roundRelativeTime: true },
+        note: 'true rounds both bounds, each by its own offset unit (existing rounding kept)',
+        expected: {
+          start: 'now-7d/d',
+          end: 'now-1d/d',
+          startOffset: offset(-7, 'd', 'd'),
+          endOffset: offset(-1, 'd', 'd'),
+        },
       },
       {
         input: 'now-7d/d',
         options: { roundRelativeTime: false },
-        note: 'false strips an existing rounding suffix from the start bound',
-        expected: { start: 'now-7d', end: 'now', startOffset: offset(-7, 'd') },
+        note: 'false preserves an existing rounding suffix',
+        expected: { start: 'now-7d/d', end: 'now', startOffset: offset(-7, 'd', 'd') },
       },
     ]);
   });
@@ -533,8 +544,8 @@ describe('parser corpus: prettifyValue (English)', () => {
     runPrettify([
       {
         input: 'now-7d/d to now',
-        note: 'past range ending at now → start shorthand, rounding stripped from start',
-        expected: '-7d',
+        note: 'past range ending at now → start shorthand, rounding preserved',
+        expected: '-7d/d',
       },
       {
         input: 'now to now+1d',
@@ -543,8 +554,8 @@ describe('parser corpus: prettifyValue (English)', () => {
       },
       {
         input: 'now-30d/d to now-7d/d',
-        note: 'two offsets → start strips rounding, end keeps it',
-        expected: '-30d to -7d/d',
+        note: 'two offsets → both keep their rounding',
+        expected: '-30d/d to -7d/d',
       },
       {
         input: 'now-7d',

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/prettify_value.test.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/prettify_value.test.ts
@@ -14,16 +14,16 @@ import { prettifyValue } from './prettify_value';
 
 describe('prettifyValue', () => {
   describe('relative to now — collapses "to now"', () => {
-    it('simplifies "now-7d/d to now" to "-7d"', () => {
-      expect(prettifyValue('now-7d/d to now')).toBe('-7d');
+    it('simplifies "now-7d/d to now" to "-7d/d"', () => {
+      expect(prettifyValue('now-7d/d to now')).toBe('-7d/d');
     });
 
     it('simplifies "now-15m to now" to "-15m"', () => {
       expect(prettifyValue('now-15m to now')).toBe('-15m');
     });
 
-    it('simplifies "now-1h/h to now" to "-1h"', () => {
-      expect(prettifyValue('now-1h/h to now')).toBe('-1h');
+    it('simplifies "now-1h/h to now" to "-1h/h"', () => {
+      expect(prettifyValue('now-1h/h to now')).toBe('-1h/h');
     });
 
     it('simplifies "now to now+1d" to "+1d"', () => {
@@ -36,8 +36,8 @@ describe('prettifyValue', () => {
   });
 
   describe('both bounds relative — keeps delimiter', () => {
-    it('strips rounding only from start: "now-30d/d to now-7d/d" to "-30d to -7d/d"', () => {
-      expect(prettifyValue('now-30d/d to now-7d/d')).toBe('-30d to -7d/d');
+    it('preserves rounding on both bounds: "now-30d/d to now-7d/d" to "-30d/d to -7d/d"', () => {
+      expect(prettifyValue('now-30d/d to now-7d/d')).toBe('-30d/d to -7d/d');
     });
 
     it('simplifies "now-1y to now-1M" to "-1y to -1M"', () => {
@@ -48,7 +48,7 @@ describe('prettifyValue', () => {
   describe('mixed relative and absolute', () => {
     it('prettifies the relative start, formats absolute end', () => {
       expect(prettifyValue('now-1d/d to 2025-06-15T00:00:00Z')).toBe(
-        `-1d to ${moment('2025-06-15T00:00:00Z').format(DEFAULT_DATE_FORMAT)}`
+        `-1d/d to ${moment('2025-06-15T00:00:00Z').format(DEFAULT_DATE_FORMAT)}`
       );
     });
 
@@ -119,8 +119,8 @@ describe('prettifyValue', () => {
   });
 
   describe('single dateMath expression (no delimiter)', () => {
-    it('simplifies "now-7d/d" to "-7d"', () => {
-      expect(prettifyValue('now-7d/d')).toBe('-7d');
+    it('simplifies "now-7d/d" to "-7d/d"', () => {
+      expect(prettifyValue('now-7d/d')).toBe('-7d/d');
     });
 
     it('simplifies "now+1h" to "+1h"', () => {
@@ -148,15 +148,15 @@ describe('prettifyValue', () => {
 
   describe('alternative delimiters', () => {
     it('handles "until" delimiter', () => {
-      expect(prettifyValue('now-7d/d until now')).toBe('-7d');
+      expect(prettifyValue('now-7d/d until now')).toBe('-7d/d');
     });
 
     it('handles dash delimiter', () => {
-      expect(prettifyValue('now-7d/d - now')).toBe('-7d');
+      expect(prettifyValue('now-7d/d - now')).toBe('-7d/d');
     });
 
     it('handles extra consumer delimiter', () => {
-      expect(prettifyValue('now-7d/d through now', { extraDelimiter: 'through' })).toBe('-7d');
+      expect(prettifyValue('now-7d/d through now', { extraDelimiter: 'through' })).toBe('-7d/d');
     });
   });
 
@@ -185,7 +185,7 @@ describe('prettifyValue', () => {
     });
 
     it('falls through to normal prettify when no preset matches', () => {
-      expect(prettifyValue('now-3d/d to now', { presets })).toBe('-3d');
+      expect(prettifyValue('now-3d/d to now', { presets })).toBe('-3d/d');
     });
 
     it('ignores display-form preset labels (non natural-language) and prettifies the bounds', () => {
@@ -205,7 +205,7 @@ describe('prettifyValue', () => {
     });
 
     it('works without presets (no options)', () => {
-      expect(prettifyValue('now-7d/d to now')).toBe('-7d');
+      expect(prettifyValue('now-7d/d to now')).toBe('-7d/d');
     });
   });
 });

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/prettify_value.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/prettify_value.ts
@@ -20,15 +20,14 @@ import { textToTimeRange } from './parse_text';
  * Simplifies a dateMath value string into a compact shorthand suitable for
  * display in the input field.
  *
- * - `now-7d/d to now`          → `-7d`
+ * - `now-7d/d to now`          → `-7d/d`
  * - `now to now+1d`            → `+1d`
- * - `now-30d/d to now-7d/d`    → `-30d to -7d/d`
+ * - `now-30d/d to now-7d/d`    → `-30d/d to -7d/d`
  * - `now/w to now`             → `now/w to now` (now + rounding only → unchanged)
  * - Natural language ("last 3 weeks") and absolute dates pass through unchanged.
  *
- * Rounding is only stripped from the **start** bound (the end bound keeps its
- * rounding intact) because start-bound rounding is controlled by the
- * `roundRelativeTime` setting.
+ * Rounding suffixes are always preserved: rounding policy belongs to the
+ * parser (the `roundRelativeTime` setting), not to this display layer.
  */
 
 // Matches a dateMath relative expression with an offset: optional "now", sign, digits, unit, optional rounding.
@@ -68,24 +67,12 @@ const prettifyAbsoluteDate = (bound: string, precision: TimePrecision = 'ms'): s
 };
 
 /**
- * Strips the `now` prefix and rounding suffix from a dateMath offset bound.
- * Returns `null` if the bound is not a relative offset expression
- * (bare `now`, `now/w`, absolute dates, natural language all return null).
+ * Strips the `now` prefix from a dateMath offset bound, preserving any
+ * rounding suffix. Returns `null` if the bound is not a relative offset
+ * expression (bare `now`, `now/w`, absolute dates, natural language all
+ * return null).
  */
-const prettifyStartBound = (bound: string): string | null => {
-  const match = bound.match(DATEMATH_OFFSET_RE);
-  if (!match) return null;
-
-  // first two values omitted on purpose
-  const [, , sign, count, unit] = match;
-  return `${sign}${count}${unit}`;
-};
-
-/**
- * Strips only the `now` prefix from a dateMath offset bound, keeping rounding.
- * Returns `null` if the bound is not a relative offset expression.
- */
-const prettifyEndBound = (bound: string): string | null => {
+const prettifyRelativeBound = (bound: string): string | null => {
   const match = bound.match(DATEMATH_OFFSET_RE);
   if (!match) return null;
 
@@ -154,8 +141,8 @@ export const prettifyValue = (value: string, options?: PrettifyValueOptions): st
         if (presetLabel) return presetLabel;
       }
 
-      const prettyStart = prettifyStartBound(start);
-      const prettyEnd = prettifyEndBound(end);
+      const prettyStart = prettifyRelativeBound(start);
+      const prettyEnd = prettifyRelativeBound(end);
 
       // Both bounds are "now" (with or without rounding) — format any absolute dates
       if (!prettyStart && !prettyEnd) {
@@ -182,9 +169,9 @@ export const prettifyValue = (value: string, options?: PrettifyValueOptions): st
     }
   }
 
-  // No delimiter found — try prettifying as a single dateMath expression (start-bound rules)
+  // No delimiter found — try prettifying as a single dateMath expression
   if (trimmed === 'now') return trimmed;
-  const prettySingle = prettifyStartBound(trimmed);
+  const prettySingle = prettifyRelativeBound(trimmed);
   if (prettySingle) return prettySingle;
 
   // Try formatting as an absolute ISO date

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/tsconfig.json
@@ -19,6 +19,5 @@
   "kbn_references": [
     "@kbn/i18n",
     "@kbn/test-jest-helpers",
-    "@kbn/i18n-react",
   ]
 }

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
@@ -75,13 +75,13 @@ export interface TimeRangeTransformOptions {
    */
   dateFormat?: string;
   /**
-   * Controls rounding of the start bound for relative time ranges.
-   * Only affects relative `start` bounds (strings containing `now`);
-   * future ranges where start is bare `now` are unaffected.
-   * - `true`: keep existing rounding; if absent, infer it from the offset
-   *   unit (`/d` for day-and-above, next-unit-up for sub-day units).
-   * - `false`: strip any rounding suffix.
-   * - `undefined`: leave the start string as-is.
+   * Controls rounding of relative time range bounds (strings containing
+   * `now`); bare `now` bounds are unaffected.
+   * - `true`: keep existing rounding; if absent, infer it for each bound
+   *   from its own offset unit (`/d` for week-and-above, next finer unit
+   *   otherwise).
+   * - `false` / `undefined`: leave the bounds as-is, preserving any
+   *   rounding the user or a preset provided.
    * @default undefined
    */
   roundRelativeTime?: boolean;
@@ -129,9 +129,9 @@ export type TimePrecision = 's' | 'ms' | 'none';
 /** User-facing settings exposed by the date range picker settings panel. */
 export interface DateRangePickerSettings {
   /**
-   * When true, relative time ranges round to the nearest full unit
-   * (e.g. minute, hour, day).
-   * @default true
+   * When true, relative time range bounds round to a full unit one step
+   * finer than their offset unit (e.g. `now-1h` → `now-1h/m`).
+   * @default false
    */
   roundRelativeTime: boolean;
   /**

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -361,7 +361,7 @@ export const QueryBarTopRow = React.memo(
     const [isQueryInputFocused, setIsQueryInputFocused] = useState(false);
     const [dateRangePickerSettings, setDateRangePickerSettings] = useState<DateRangePickerSettings>(
       {
-        roundRelativeTime: true,
+        roundRelativeTime: false,
         timePrecision: 'none',
       }
     );

--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -8317,7 +8317,6 @@
     "sharedUXPackages.dateRangePicker.settingsPanel.heading": "Einstellungen",
     "sharedUXPackages.dateRangePicker.settingsPanel.relativeTimeRangeHeading": "Relativer Zeitbereich",
     "sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeLabel": "Runde relative Zeitbereiche",
-    "sharedUXPackages.dateRangePicker.settingsPanel.technicalPreviewNotice": "Diese Zeitauswahl befindet sich in einer technischen Vorschau.",
     "sharedUXPackages.dateRangePicker.settingsPanel.timeFormatDescription": "Die Zeitzone wurde von Ihrem Administrator auf {timeZoneLabel} eingestellt. Das gilt für alle Nutzer in diesem Bereich.",
     "sharedUXPackages.dateRangePicker.settingsPanel.timeFormatHeading": "Zeitformat und Zeitzone",
     "sharedUXPackages.dateRangePicker.settingsPanel.timePrecisionLabel": "Zeitgenauigkeit",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -8318,7 +8318,6 @@
     "sharedUXPackages.dateRangePicker.settingsPanel.heading": "Paramètres",
     "sharedUXPackages.dateRangePicker.settingsPanel.relativeTimeRangeHeading": "Période relative",
     "sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeLabel": "Arrondir les plages horaires relatives",
-    "sharedUXPackages.dateRangePicker.settingsPanel.technicalPreviewNotice": "Ce sélecteur d'heure est en version d'évaluation technique.",
     "sharedUXPackages.dateRangePicker.settingsPanel.timeFormatDescription": "Le fuseau horaire est réglé sur {timeZoneLabel} par votre administrateur. Cela s'applique à tous les utilisateurs de l'espace.",
     "sharedUXPackages.dateRangePicker.settingsPanel.timeFormatHeading": "Format horaire et fuseau horaire",
     "sharedUXPackages.dateRangePicker.settingsPanel.timePrecisionLabel": "Précision temporelle",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -8345,7 +8345,6 @@
     "sharedUXPackages.dateRangePicker.settingsPanel.heading": "設定",
     "sharedUXPackages.dateRangePicker.settingsPanel.relativeTimeRangeHeading": "相対的時間範囲",
     "sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeLabel": "相対的時間範囲を四捨五入",
-    "sharedUXPackages.dateRangePicker.settingsPanel.technicalPreviewNotice": "このタイムピッカーはテクニカルプレビュー段階です。",
     "sharedUXPackages.dateRangePicker.settingsPanel.timeFormatDescription": "タイムゾーンは管理者によって{timeZoneLabel}に設定されています。これはスペース内のすべてのユーザーに適用されます。",
     "sharedUXPackages.dateRangePicker.settingsPanel.timeFormatHeading": "時間形式とタイムゾーン",
     "sharedUXPackages.dateRangePicker.settingsPanel.timePrecisionLabel": "時間精度",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -8342,7 +8342,6 @@
     "sharedUXPackages.dateRangePicker.settingsPanel.heading": "设置",
     "sharedUXPackages.dateRangePicker.settingsPanel.relativeTimeRangeHeading": "相对时间范围",
     "sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeLabel": "取整相对时间范围",
-    "sharedUXPackages.dateRangePicker.settingsPanel.technicalPreviewNotice": "此时间选择器目前为技术预览版。",
     "sharedUXPackages.dateRangePicker.settingsPanel.timeFormatDescription": "时区由管理员设置为 {timeZoneLabel}。适用于此空间内的所有用户。",
     "sharedUXPackages.dateRangePicker.settingsPanel.timeFormatHeading": "时间格式和时区",
     "sharedUXPackages.dateRangePicker.settingsPanel.timePrecisionLabel": "时间精度",


### PR DESCRIPTION
## Summary

Closes elastic/eui-private#681. Supersedes #269531 (rebuilt on current `main` after the LocaleGrammar parser refactors).

Changes the `roundRelativeTime` behavior in `@kbn/date-range-picker`:

- **`false` (new default):** the parser never strips or adds rounding — user-typed or preset-provided suffixes (e.g. `now-1h/h`) are preserved as-is on both bounds
- **`true`:** rounding is applied to **both** start and end bounds, each inferred from its own offset unit (previously start only)
- **`undefined`:** no-op (unchanged)
- **`ROUND_UNIT_MAP` rounds one unit finer than the offset unit** (`h → /m`, `d → /h`, `m`/`s`/`ms` → `/s`; `w`/`M`/`y` → `/d` unchanged), so opted-in rounding snaps to clean boundaries without nearly doubling the window (`now-1h/h` could stretch "last hour" to almost two hours; `now-1h/m` keeps it at ~1h)
- `prettifyValue` (display layer) no longer strips rounding — rounding policy belongs to the parser setting, not the formatter. Its two bound-prettify helpers became identical and were unified into `prettifyRelativeBound`

~~The Unified Search query bar currently passes an explicit `roundRelativeTime: true`, so its behavior only changes to both-bounds/finer-units rounding until the companion PR for elastic/eui-private#721 flips it to `false` (kept separate to scope PRs by code owner).~~

## Test plan

- [x] `node scripts/jest --config=src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/jest.config.js` — 741 tests green

### For reviewer

- [x] Manual: disable enable "Round relative time ranges" in the picker settings, type `now-1h/h to now/h`, submit, re-focus input → both sides keep rounding
- [x] Manual: enable "Round relative time ranges" in the picker settings, type `now-7d to now-1d`, submit → both become `now-7d/h` / `now-1d/h` (in Storybook the input value remains `now-7d to now-1d` but the resolved range is rounded as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Release note

Relative time ranges, for example "last 15 minutes", are no longer rounded by default in the time range selector in Discover and Dashboards. You can enable automatic rounding of relative ranges again in the time range selector settings.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->