### PR TITLE
[Docs][8.19] Document securitySolution:excludeColdAndFrozenTiersInPrevalence advanced setting

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -554,6 +554,9 @@ privilege check warnings in rules for CCS indices.
 [[securitysolution-enablenewsfeed]]`securitySolution:enableNewsFeed`:: Enables
 the security news feed on the Security *Overview* page.
 
+[[security-solution-exclude-cold-frozen-tiers-prevalence]]`securitySolution:excludeColdAndFrozenTiersInPrevalence`::
+Skips cold and frozen tiers in Prevalence queries when activated. Off by default.
+
 [[securitysolution-ipreputationlinks]]`securitySolution:ipReputationLinks`::
 A JSON array containing links for verifying the reputation of an IP address. The
 links are displayed on {security-guide}/network-page-overview.html[IP detail]


### PR DESCRIPTION
## Summary

Documents the `securitySolution:excludeColdAndFrozenTiersInPrevalence` advanced setting in the 8.19 AsciiDoc reference (`docs/management/advanced-options.asciidoc`).

This is the 8.19 counterpart to the V3/`main` change in #280090. On the `8.19` branch the advanced-settings reference is still the legacy AsciiDoc (the V3 `advanced-settings-space.yml` does not exist there), so the `main` PR does not reach 8.19 readers.

### Why this belongs in 8.19

- The setting was backported to **8.19.13** (implementation PR elastic/kibana#257011) and is present in the 8.19 `security_solution` `ui_settings.ts`, registered unconditionally with no `readonly`/`technicalPreview` flag.
- Adding a missing advanced setting to the 8.19 AsciiDoc is an established, recent pattern (for example #248658, #243993, #238144).

### Note / possible follow-up

The Security Solution list in this file is also missing the parallel twin `securitySolution:excludeColdAndFrozenTiersInAnalyzer` (present in 8.19 since long before). This PR is scoped to the prevalence setting from elastic/docs-content#7452; the analyzer setting could be added in a follow-up if desired.

## Related

Related to elastic/docs-content#7452 and #280090 (main / V3).

---

> **AI-assisted draft** — please review before merging.