### PR TITLE
feat(context-engine): gate ki-automation-generation skill on valid AI Index definition

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
@@ -38,10 +38,10 @@ Tell the user Elasticsearch is starting up.
 
 ### Step 3: Register GCS Snapshot Repository
 
-Wait for Elasticsearch to become available by polling until the cluster health endpoint responds. Fail after 30 attempts (approximately 2.5 minutes):
+Wait for Elasticsearch to become available by polling until the cluster health endpoint responds. Fail after 30 attempts (approximately 2.5 minutes). Use `elastic:changeme` since `yarn es snapshot` starts a stateful cluster:
 
 ```bash
-MAX_RETRIES=30; COUNT=0; until curl -s -u elastic:changeme http://localhost:9200/_cluster/health | grep -q '"status"'; do COUNT=$((COUNT+1)); if [ "$COUNT" -ge "$MAX_RETRIES" ]; then echo "ERROR: Elasticsearch did not become available after $MAX_RETRIES attempts"; exit 1; fi; sleep 5; done
+MAX_RETRIES=30; COUNT=0; until curl -sk -u elastic:changeme http://localhost:9200/_cluster/health | grep -q '"status"'; do COUNT=$((COUNT+1)); if [ "$COUNT" -ge "$MAX_RETRIES" ]; then echo "ERROR: Elasticsearch did not become available after $MAX_RETRIES attempts"; exit 1; fi; sleep 5; done
 ```
 
 If the poll times out, show the error to the user and suggest checking the Elasticsearch background task output for startup errors.
@@ -53,7 +53,7 @@ Once ES is ready, register the GCS snapshot repository with these defaults:
 - **Base path**: `knowledge_base/snapshot_dt=2026-01-10`
 
 ```bash
-curl -s -u elastic:changeme -X PUT "http://localhost:9200/_snapshot/agent-builder-datasets" \
+curl -sk -u elastic:changeme -X PUT "http://localhost:9200/_snapshot/agent-builder-datasets" \
   -H "Content-Type: application/json" \
   -d '{
     "type": "gcs",
@@ -73,7 +73,7 @@ Tell the user the GCS snapshot repository has been registered.
 List available snapshots in the repository:
 
 ```bash
-curl -s -u elastic:changeme "http://localhost:9200/_snapshot/agent-builder-datasets/_all"
+curl -sk -u elastic:changeme "http://localhost:9200/_snapshot/agent-builder-datasets/_all"
 ```
 
 Parse the response and present each snapshot as an option using `AskUserQuestion`. For each snapshot, show:
@@ -87,7 +87,7 @@ Example options:
 Once the user selects a snapshot, restore it:
 
 ```bash
-curl -s -u elastic:changeme -X POST "http://localhost:9200/_snapshot/agent-builder-datasets/<snapshot_name>/_restore" \
+curl -sk -u elastic:changeme -X POST "http://localhost:9200/_snapshot/agent-builder-datasets/<snapshot_name>/_restore" \
   -H "Content-Type: application/json" \
   -d '{
     "indices": "*",
@@ -100,7 +100,7 @@ Verify the restore was accepted by checking the response contains `"accepted":tr
 To retry with conflicting indices closed:
 
 ```bash
-curl -s -u elastic:changeme -X POST "http://localhost:9200/<comma_separated_index_names>/_close"
+curl -sk -u elastic:changeme -X POST "http://localhost:9200/<comma_separated_index_names>/_close"
 ```
 
 Then re-run the restore command.
@@ -109,30 +109,43 @@ Tell the user the snapshot has been restored.
 
 ### Step 5: Launch Kibana
 
-Launch Kibana in the background using `run_in_background`:
+Launch Kibana in the background using `run_in_background`. This flow uses a stateful (non-serverless) ES snapshot, so launch stateful Kibana:
 
 ```bash
 yarn start --no-base-path
 ```
 
-Tell the user Kibana is starting up.
+Tell the user Kibana is starting up. Once Kibana is running, use `scripts/kibana_api_common.sh` to detect the working URL and credentials for subsequent steps:
 
-### Step 6: Confirm Phoenix Running
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/kibana_api_common.sh"
+# KIBANA_URL and KIBANA_AUTH are now set
+```
 
-Use `AskUserQuestion` to confirm Phoenix is running:
+### Step 6: Confirm Phoenix Running (optional)
 
-> Is Phoenix running and ready to receive traces?
+Use `AskUserQuestion` to ask whether the user wants Phoenix tracing:
+
+> Do you want to use Phoenix for trace collection?
 
 Options:
-- **Yes** — Continue
-- **Not yet** — Wait for the user to start Phoenix, then ask again
+- **Yes, Phoenix is running** — Set `KBN_EVALS_EXECUTOR=phoenix` in the final command
+- **No, use inline executor** — Set `KBN_EVALS_EXECUTOR=inline` (no Phoenix needed; traces won't be exported)
+
+If Phoenix: ask the user to confirm it's ready before continuing.
 
 ### Step 7: Launch EDOT
 
-Launch the EDOT collector in the background using `run_in_background`:
+Launch the EDOT collector in the background using `run_in_background`. Use the ES credentials detected by `kibana_api_common.sh`:
 
 ```bash
-ELASTICSEARCH_HOST=http://localhost:9200 ELASTICSEARCH_USERNAME=elastic ELASTICSEARCH_PASSWORD=changeme node scripts/edot_collector.js
+ES_USER="${KIBANA_AUTH%%:*}"
+ES_PASS="${KIBANA_AUTH#*:}"
+ELASTICSEARCH_HOST=http://localhost:9200 \
+ELASTICSEARCH_USERNAME="$ES_USER" \
+ELASTICSEARCH_PASSWORD="$ES_PASS" \
+node scripts/edot_collector.js
 ```
 
 Tell the user EDOT is starting up.
@@ -180,13 +193,16 @@ Using the collected values and the following defaults, output the exact command 
 - **RAG_EVAL_K**: `10,20,30,40`
 - **EVALUATION_REPETITIONS**: `1`
 
+Use `KIBANA_AUTH` detected in Step 5 for `TRACING_ES_URL` (format: `http://<user>:<pass>@localhost:9200`).
+Use the executor chosen in Step 6 (`phoenix` or `inline`).
+
 Display a summary and the command:
 
 > **Stack is ready!**
 >
 > - Elasticsearch: running (snapshot with GCS credentials)
-> - Kibana: running (no base path)
-> - Phoenix: confirmed running
+> - Kibana: `<KIBANA_URL>` (`<KIBANA_AUTH username>`)
+> - Executor: `<phoenix|inline>`
 > - EDOT: running
 >
 > **Important:** Make sure Cloud Connected Mode (CCM) is enabled in Kibana before running the evaluation. Go to **Stack Management > Cloud Connected Mode** in the Kibana UI and enable it if it is not already active.
@@ -194,10 +210,10 @@ Display a summary and the command:
 > **Run the following command in a separate terminal to start the evaluation:**
 >
 > ```bash
-> TRACING_ES_URL=http://elastic:changeme@localhost:9200 \
+> TRACING_ES_URL=http://<ES_USER>:<ES_PASS>@localhost:9200 \
 > SELECTED_EVALUATORS="<value>" \
 > RAG_EVAL_K=<value> \
-> KBN_EVALS_EXECUTOR=phoenix \
+> KBN_EVALS_EXECUTOR=<phoenix|inline> \
 > EVALUATION_CONNECTOR_ID=<value> \
 > DATASET_NAME="<value>" \
 > EVALUATION_REPETITIONS=<value> \
@@ -242,7 +258,8 @@ Tell the user:
 ## Important Notes
 
 - **Background processes**: ES, Kibana, and EDOT are launched with `run_in_background`. Their task IDs are tracked by the session so `stop` can kill them.
-- **Hard-coded values**: `TRACING_ES_URL`, `KBN_EVALS_EXECUTOR`, and `KBN_EVALS_SKIP_CONNECTOR_SETUP` are not configurable — they are set for the local dev stack.
+- **`KBN_EVALS_EXECUTOR`**: Set to `phoenix` if the user confirmed Phoenix is running, otherwise `inline`. With `inline`, traces are not exported and `ExpectedSkillInvocation` evaluators return `null`.
+- **ES credentials**: Always derived from `KIBANA_AUTH` (detected via `kibana_api_common.sh`). The `yarn es snapshot` flow starts a stateful cluster with `elastic:changeme`; do not hard-code this.
 - **Always use `node scripts/playwright test`** — never use `npx playwright test`.
 - **Playwright config**: Always uses `x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/playwright.config.ts`.
 - **Test spec**: Always runs `evals/external/external_dataset.spec.ts`.

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/run-agent-builder-skill-eval/SKILL.md
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/run-agent-builder-skill-eval/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: run-agent-builder-skill-eval
+description: Run a behavioral eval spec for a specific agent-builder skill against a locally-running Kibana/ES stack. Handles prereq checks, Scout file creation, and runs the suite.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+argument-hint: [spec-path-or-grep-pattern]
+---
+
+# Run Agent Builder Skill Eval
+
+This skill runs a behavioral evaluation spec (or subset of specs) from the `agent-builder` suite against your locally-running Kibana and Elasticsearch. It assumes you manage your own stack — it does **not** launch ES or Kibana.
+
+Use this when you've written or modified a skill spec under `evals/platform/` or `evals/external/` and want to verify it locally before pushing to CI.
+
+---
+
+## What "passing" means
+
+Behavioral eval tests pass or fail on **exception only** — a test passes if it runs without throwing. Score output (Factuality, Groundedness, Relevance, etc.) is observability data for trending, not a gate. CODE evaluators (e.g. `ExpectedSkillInvocation`, `RequiredTermsInResponse`) are binary 0/1 and can gate CI via trace-based assertions, but they don't fail the Playwright test by default either.
+
+This means: a test showing `Factuality: 0.0` still "passes" from the framework's perspective. Low scores are a signal to investigate, not an automatic failure.
+
+**Trace-based evaluator noise:** The `evaluate_dataset` fixture wires up trace-based evaluators (Latency, Input Tokens, Output Tokens, Cached Tokens, Skill Invoked) for every spec in the suite, including behavioral skill specs. Without a running EDOT collector, these query the OTEL tracing index, find nothing, and retry 5 times with exponential backoff — adding minutes of overhead per test. The run command in Step 4 includes `SELECTED_EVALUATORS` to skip these by default. If you need them, run with `--profile dev-vault` and a full EDOT stack.
+
+---
+
+## Step 1: Check prerequisites
+
+### 1a: Verify ES and Kibana are running
+
+Source `scripts/kibana_api_common.sh` to auto-detect Kibana:
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/kibana_api_common.sh"
+echo "Kibana: $KIBANA_URL ($KIBANA_AUTH)"
+```
+
+If detection fails, tell the user:
+
+> Kibana doesn't appear to be running. Please start your stack first:
+> - ES: `yarn serverless-es` (or `yarn es snapshot --eis` for snapshot data)
+> - Kibana: `yarn serverless-es` in a separate terminal (or `yarn start --no-base-path` for stateful)
+>
+> Then re-run this skill.
+
+Do NOT attempt to start ES or Kibana. Stop here if they're not running.
+
+Derive ES connection from KIBANA_AUTH (same username/password). For serverless:
+- ES host: `http://localhost:9200` (try `https://` if `http://` fails)
+- ES auth: same as `KIBANA_AUTH`
+
+Verify ES is up:
+
+```bash
+ES_USER="${KIBANA_AUTH%%:*}"
+ES_PASS="${KIBANA_AUTH#*:}"
+curl -sk -u "$ES_USER:$ES_PASS" http://localhost:9200/_cluster/health | grep -q '"status"' \
+  && echo "ES OK" || curl -sk -u "$ES_USER:$ES_PASS" https://localhost:9200/_cluster/health | grep -q '"status"' \
+  && echo "ES OK (https)" || echo "ES not reachable"
+```
+
+### 1b: Verify `xpack.evals.enabled: true` in `kibana.dev.yml`
+
+```bash
+grep -q 'xpack.evals.enabled: true' "$REPO_ROOT/config/kibana.dev.yml" \
+  && echo "evals enabled" || echo "MISSING"
+```
+
+If missing, tell the user to add it and restart Kibana:
+
+```yaml
+xpack.evals.enabled: true
+```
+
+### 1b-ii: Detect ES scheme
+
+Note whether ES is on HTTP or HTTPS — you'll need this in Step 1d. Use whichever scheme succeeded in the health check above.
+
+### 1c: Verify at least one connector is configured
+
+Check `config/kibana.dev.yml` for `xpack.actions.preconfigured`. If the section is absent or empty, tell the user:
+
+> No preconfigured connectors found in `config/kibana.dev.yml`. Add at least one under `xpack.actions.preconfigured`. Example for Opus 4.6 via EIS:
+>
+> ```yaml
+> xpack.actions.preconfigured:
+>   Anthropic-Claude-Opus-4-6:
+>     name: Anthropic Claude Opus 4.6
+>     actionTypeId: .inference
+>     exposeConfig: true
+>     config:
+>       provider: 'elastic'
+>       taskType: 'chat_completion'
+>       inferenceId: '.anthropic-claude-4.6-opus-chat_completion'
+>       providerConfig:
+>         model_id: 'anthropic-claude-4.6-opus'
+> ```
+>
+> Then restart Kibana.
+
+### 1d: Check and fix `config.local.json`
+
+Step 4 will output a command using `--profile local` (required for non-interactive runs). The first time `node scripts/evals start --profile local` runs, it auto-generates `config.local.json` — but it hardcodes `elastic:changeme` and `http://` regardless of your actual stack credentials and ES scheme.
+
+Check the file:
+
+```bash
+cat "$REPO_ROOT/x-pack/platform/packages/shared/kbn-evals/scripts/vault/config.local.json" 2>/dev/null || echo "missing (will be generated on first run)"
+```
+
+If it exists, verify:
+- `evaluationsEs.url` and `tracingEs.url` use the correct username and scheme (e.g. `https://elastic_serverless:changeme@localhost:9200` for serverless with HTTPS ES, or `http://elastic:changeme@localhost:9200` for stateful)
+- `evaluationsKbn.url` is `http://<user>:<pass>@localhost:5601` — **no path suffix** (a `/dev` suffix causes the KbnClient to resolve all internal routes under `/dev/internal/...`, producing 404s that look like the evals plugin is disabled)
+
+If the file is missing or has wrong values, fix it before running. The file is gitignored and safe to edit directly.
+
+---
+
+## Step 2: Ensure Scout files exist
+
+The eval framework requires two files that are normally written by `scout start-server`. Create them if missing.
+
+### 2a: `.scout/servers/local.json`
+
+Check if it exists:
+
+```bash
+ls "$REPO_ROOT/.scout/servers/local.json" 2>/dev/null && echo "exists" || echo "missing"
+```
+
+If missing, create it. Derive `kibana` host from `KIBANA_URL`. For ES host, use whichever scheme succeeded in Step 1b-ii (`http://` or `https://`). Use `serverless: true` when running in serverless mode (i.e. when `KIBANA_AUTH` is `elastic_serverless:changeme`), `false` otherwise.
+
+```json
+{
+  "serverless": true,
+  "isCloud": false,
+  "uiam": false,
+  "license": "trial",
+  "projectType": "security",
+  "productTier": "complete",
+  "cloudUsersFilePath": "<REPO_ROOT>/.ftr/role_users.json",
+  "hosts": {
+    "kibana": "<KIBANA_URL>",
+    "elasticsearch": "<http-or-https>://localhost:9200"
+  },
+  "auth": {
+    "username": "<ES_USER>",
+    "password": "<ES_PASS>"
+  }
+}
+```
+
+**Important:** `cloudUsersFilePath` must be the absolute path, not `~`.
+
+### 2b: `.ftr/role_users.json`
+
+Check if it exists:
+
+```bash
+ls "$REPO_ROOT/.ftr/role_users.json" 2>/dev/null && echo "exists" || echo "missing"
+```
+
+If missing, create it (this file is read lazily for SAML auth only — minimal content is fine):
+
+```json
+{ "admin": { "email": "admin@example.com", "password": "changeme" } }
+```
+
+---
+
+## Step 3: Collect eval parameters
+
+### 3a: Determine which spec(s) to run
+
+If `$ARGUMENTS` is non-empty, use it as a `--grep` filter. Otherwise, ask:
+
+> Which spec(s) do you want to run?
+
+Options:
+- **All agent-builder specs** — run the entire suite (no grep filter)
+- **ki-automation-generation** — `--grep "ki.automation.generation"`
+- **Enter a grep pattern** — (other)
+
+### 3b: Discover available connectors
+
+Read `config/kibana.dev.yml` and parse `xpack.actions.preconfigured` connector IDs and names.
+
+### 3c: Select the model connector to evaluate
+
+Ask:
+
+> Which connector/model should be evaluated?
+
+Options: one per discovered connector, using `<id> (<name>)` as the label.
+
+### 3d: Select the judge connector
+
+Ask:
+
+> Which connector should be used as the LLM judge?
+
+Options: one per discovered connector. Default to the same connector as the model (judge and model can be the same).
+
+---
+
+## Step 4: Run the evals
+
+Tell the user:
+
+> **Prerequisites verified. Stack is ready. Running evals now...**
+>
+> - Kibana: `<KIBANA_URL>` (`<KIBANA_AUTH username>`)
+> - Evals plugin: enabled
+> - Scout files: present
+
+Then run the command directly using the Bash tool (do not ask the user to run it). Substitute actual values; omit `--grep` if no filter was selected:
+
+```bash
+cd <REPO_ROOT> && \
+KBN_EVALS_SKIP_CONNECTOR_SETUP=true \
+SELECTED_EVALUATORS="Factuality,Groundedness,Relevance,RequiredTermsInResponse,ExpectedSkillInvocation,ExpectedToolCalled" \
+EVALUATION_CONNECTOR_ID=<judge_connector_id> \
+node scripts/evals start \
+  --suite agent-builder \
+  --skip-server \
+  --profile local \
+  --model <model_connector_id> \
+  [--grep "<pattern>"]
+```
+
+This command runs for several minutes. Use a Bash timeout of at least 600000ms (10 minutes). When it completes, summarize the results table (dataset names and scores).
+
+**`SELECTED_EVALUATORS` is set explicitly** to skip the trace-based evaluators (Latency, Input Tokens, Output Tokens, Cached Tokens, Skill Invoked). Without this, those evaluators query the OTEL tracing index, fail to find data (since there's no EDOT collector running), and retry 5 times with exponential backoff — adding minutes of overhead per test. Remove `SELECTED_EVALUATORS` only if you have a full EDOT/tracing stack running (e.g. `--profile dev-vault`).
+
+**`--profile` is required** — `node scripts/evals start` errors in non-interactive mode without it. Use `--profile local` for local runs against your own stack. Use `--profile dev-vault` to ship results to the golden cluster (requires `vault login --method oidc`).
+
+Then add this note:
+
+> **Reminder:** Score output (Factuality, Groundedness, etc.) is observability data — tests pass/fail on exception only. A score of 0 does not fail the test; it's a signal to investigate.
+
+---
+
+## Important notes
+
+- **Do not launch ES or Kibana** — this skill assumes the user's stack is already running.
+- **Do not use `node scripts/playwright test` directly** — use `node scripts/evals start` with `--skip-server` instead; it handles connector discovery and EDOT correctly.
+- **`KBN_EVALS_SKIP_CONNECTOR_SETUP=true`** — required when using preconfigured connectors from `kibana.dev.yml` to skip the connector creation/teardown lifecycle.
+- **Scout files are not idempotent** — `scout start-server` overwrites `.scout/servers/local.json`. If the user restarts Scout, these files may need to be recreated.
+- **Serverless vs stateful**: serverless uses `elastic_serverless:changeme`; stateful uses `elastic:changeme`. The `kibana_api_common.sh` auto-detects which is running.

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/platform/context_engine/ki_automation_generation.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/platform/context_engine/ki_automation_generation.spec.ts
@@ -110,7 +110,7 @@ evaluate.describe(
           dataset: {
             name: 'ki-automation-generation: valid AI Index provided',
             description:
-              'Skill must pass Phase 0 and proceed to Phase 1 discovery when a valid AiIndexHttpItem is in the conversation.',
+              'Skill must pass Phase 0 and attempt Phase 1 discovery when a valid AiIndexHttpItem is in the conversation. The source index may not exist in the eval cluster, so the agent may report that the index was not found and ask how to proceed — that is acceptable as long as it attempted get_index_mapping and did not ask the user to provide an AI Index definition.',
             examples: [
               {
                 input: {
@@ -118,7 +118,7 @@ evaluate.describe(
                 },
                 output: {
                   expected:
-                    'The agent validates the AI Index, proceeds to Phase 1 (calls get_index_mapping for raw-cases-all), and moves toward strategy suggestion. It does not ask the user to provide an AI Index.',
+                    'The agent validates the AI Index and proceeds to Phase 1 discovery. It calls get_index_mapping for raw-cases-all (the index parsed from the sources[] ES|QL query). If the index does not exist, it informs the user and asks how to proceed (e.g. ingest data first or point to a different index). It does NOT ask the user to provide an AI Index definition.',
                 },
                 metadata: {
                   expectedSkill: 'ki-automation-generation',

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/platform/context_engine/ki_automation_generation.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/platform/context_engine/ki_automation_generation.spec.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-// x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/platform/context_engine/ki_automation_generation.spec.ts
-
 import { tags } from '@kbn/scout';
 import { evaluate as base } from '../../../src/evaluate';
 import { createEvaluateDataset } from '../../../src/evaluate_dataset';

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/platform/context_engine/ki_automation_generation.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/platform/context_engine/ki_automation_generation.spec.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/platform/context_engine/ki_automation_generation.spec.ts
+
+import { tags } from '@kbn/scout';
+import { evaluate as base } from '../../../src/evaluate';
+import { createEvaluateDataset } from '../../../src/evaluate_dataset';
+import type { EvaluateDataset } from '../../../src/evaluate_dataset';
+
+// A minimal but fully valid AiIndexHttpItem for the "valid AI Index" scenario.
+// Using a real-looking dest and a simple ES|QL source so Phase 1 discovery
+// has something concrete to work with.
+const VALID_AI_INDEX_JSON = JSON.stringify({
+  id: 'eval-test-support-cases',
+  name: 'Support Cases',
+  description: 'AI Index for support case lookups by case number, status, and priority.',
+  dest: {
+    type: 'index',
+    value: 'ai-index-idx-support-cases',
+  },
+  sources: [
+    {
+      type: 'esql',
+      value: 'FROM raw-cases-all | LIMIT 1000',
+    },
+  ],
+  automations: [],
+  date_created: '2026-07-21T00:00:00.000Z',
+  date_modified: '2026-07-21T00:00:00.000Z',
+});
+
+const evaluate = base.extend<{ evaluateDataset: EvaluateDataset }, {}>({
+  evaluateDataset: [
+    ({ chatClient, evaluators, executorClient, traceEsClient, log }, use) => {
+      use(
+        createEvaluateDataset({
+          chatClient,
+          evaluators,
+          executorClient,
+          traceEsClient,
+          log,
+        })
+      );
+    },
+    { scope: 'test' },
+  ],
+});
+
+evaluate.describe(
+  'ki-automation-generation skill — AI Index gate',
+  { tag: tags.serverless.security.complete },
+  () => {
+    evaluate('requests AI Index definition when none is provided', async ({ evaluateDataset }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'ki-automation-generation: no AI Index provided',
+          description:
+            'Skill must block at Phase 0 and request an AI Index definition when none is in the conversation.',
+          examples: [
+            {
+              input: {
+                question: 'Help me set up the Context Engine.',
+              },
+              output: {
+                expected:
+                  'The agent loads the ki-automation-generation skill and responds by asking the user to provide an AI Index definition. It does not call list_indices or get_index_mapping.',
+              },
+              metadata: {
+                expectedSkill: 'ki-automation-generation',
+                requiredTerms: ['AI Index'],
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    evaluate('rejects invalid AI Index definition', async ({ evaluateDataset }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'ki-automation-generation: invalid AI Index provided',
+          description:
+            'Skill must reject a non-JSON or structurally invalid AI Index and explain what is wrong.',
+          examples: [
+            {
+              input: {
+                question: "My AI index is 'foobar'. Please set up the Context Engine using it.",
+              },
+              output: {
+                expected:
+                  "The agent explains that 'foobar' is not a valid AI Index definition and describes what a valid one looks like. It does not proceed to discovery or workflow generation.",
+              },
+              metadata: {
+                expectedSkill: 'ki-automation-generation',
+                requiredTerms: ['AI Index'],
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    evaluate(
+      'proceeds to discovery when valid AI Index is provided',
+      async ({ evaluateDataset }) => {
+        await evaluateDataset({
+          dataset: {
+            name: 'ki-automation-generation: valid AI Index provided',
+            description:
+              'Skill must pass Phase 0 and proceed to Phase 1 discovery when a valid AiIndexHttpItem is in the conversation.',
+            examples: [
+              {
+                input: {
+                  question: `Here is my AI Index definition:\n\n${VALID_AI_INDEX_JSON}\n\nPlease set up the Context Engine for it.`,
+                },
+                output: {
+                  expected:
+                    'The agent validates the AI Index, proceeds to Phase 1 (calls get_index_mapping for raw-cases-all), and moves toward strategy suggestion. It does not ask the user to provide an AI Index.',
+                },
+                metadata: {
+                  expectedSkill: 'ki-automation-generation',
+                },
+              },
+            ],
+          },
+        });
+      }
+    );
+  }
+);

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_selection/benchmark_dataset.csv
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_selection/benchmark_dataset.csv
@@ -166,3 +166,9 @@ dashboard-management,platform,Create a dashboard using kibana_sample_data_logs w
 visualization-creation,platform,Create a bar chart showing the distribution of response codes in kibana_sample_data_logs.,direct,visualization-creation,source=dashboard_management_spec (negative test — loaded as viz-without-dashboard case)
 dashboard-management,platform,Help me write an ES|QL query to find slow transactions,distractor,threat-hunting,source=dashboard_management_spec; corrected from empty — ES|QL query authoring for performance investigation maps to threat-hunting not dashboard; tests dashboard precision
 dashboard-management,platform,What fields are available in the logs-* index?,distractor,streams-management,source=dashboard_management_spec; corrected from empty — field/schema discovery for logs-* maps to streams-management not dashboard; tests dashboard precision
+ki-automation-generation,platform,Set up the Context Engine for my Elasticsearch data,direct,ki-automation-generation,
+ki-automation-generation,platform,Generate Knowledge Indicators from my support case index,direct,ki-automation-generation,
+ki-automation-generation,platform,I want AI agents to be able to answer questions about my data — help me set that up,indirect,ki-automation-generation,
+ki-automation-generation,platform,Create KIs so agents can query my customer records without scanning the raw index,indirect,ki-automation-generation,
+ki-automation-generation,platform,Add a knowledge indicator to track weekly login volume for admin accounts,distractor,knowledge-indicators-management,AMBIGUOUS: creating a single KI manually vs bulk KI generation via workflow
+ki-automation-generation,platform,Run the KI identification task on the logs.ecs stream to find monitoring patterns,distractor,ki-identification-management,AMBIGUOUS: automated KI discovery vs context engine setup

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_selection/benchmark_dataset.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_selection/benchmark_dataset.ts
@@ -98,6 +98,7 @@ const bySkill = (skillId: string): BenchmarkExample[] =>
 
 export const DASHBOARD_MANAGEMENT_EXAMPLES = bySkill('dashboard-management');
 export const GRAPH_CREATION_EXAMPLES = bySkill('graph-creation');
+export const KI_AUTOMATION_GENERATION_EXAMPLES = bySkill('ki-automation-generation');
 export const SKILL_AUTHORING_EXAMPLES = bySkill('skill-authoring');
 export const VISUALIZATION_CREATION_EXAMPLES = bySkill('visualization-creation');
 

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_selection/skill_selection_benchmark.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_selection/skill_selection_benchmark.spec.ts
@@ -19,6 +19,7 @@ import {
   FIND_RULES_EXAMPLES,
   FIND_SECURITY_ML_JOBS_EXAMPLES,
   GRAPH_CREATION_EXAMPLES,
+  KI_AUTOMATION_GENERATION_EXAMPLES,
   KI_IDENTIFICATION_MANAGEMENT_EXAMPLES,
   KNOWLEDGE_INDICATORS_MANAGEMENT_EXAMPLES,
   OBSERVABILITY_INVESTIGATION_EXAMPLES,
@@ -120,6 +121,13 @@ evaluate.describe(
       await evaluateBenchmark({
         skillId: 'dashboard-management',
         examples: DASHBOARD_MANAGEMENT_EXAMPLES,
+      });
+    });
+
+    evaluate('ki-automation-generation routing', async ({ evaluateBenchmark }) => {
+      await evaluateBenchmark({
+        skillId: 'ki-automation-generation',
+        examples: KI_AUTOMATION_GENERATION_EXAMPLES,
       });
     });
   }

--- a/x-pack/platform/plugins/shared/agent_builder_platform/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/kibana.jsonc
@@ -13,6 +13,7 @@
       "actions",
       "agentBuilder",
       "agentBuilderSml",
+      "contextEngine",
       "share",
       "triggersActionsUi"
     ],

--- a/x-pack/platform/plugins/shared/agent_builder_platform/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/moon.yml
@@ -47,6 +47,7 @@ dependsOn:
   - '@kbn/logging-mocks'
   - '@kbn/triggers-actions-ui-plugin'
   - '@kbn/agent-builder-plugin'
+  - '@kbn/context-engine-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation.skill.md.text
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation.skill.md.text
@@ -37,7 +37,7 @@ Apply these when deciding what KIs to generate and what each one should contain.
    wrong answers. For those, provide an access pattern that reads live data.
 
 3. **Access patterns must be grounded and validated.** Build every query from the index's real
-   mapping and sample documents — never invented field names. 
+   mapping and sample documents — never invented field names.
 
 4. **The Context Engine is more like a cache than a database.** Avoid generating KIs for the entire corpus
    eagerly. Prefer data views. Best practice is to apply a filter before starting: a time window (e.g. last 90 days), a status
@@ -125,8 +125,6 @@ resource attached to this skill. It must have at minimum:
 - `name` (string)
 - `dest` object with `type` (`"data_stream"` or `"index"`) and `value` (string)
 - `sources` array of objects each with `type: "esql"` and `value` (string)
-- `automations` array of objects each with `type: "workflow"` and `value` (string)
-- `date_created` and `date_modified` (strings)
 
 **If no AI Index definition is present:**
 
@@ -151,7 +149,7 @@ Explain what a valid definition looks like. Do not proceed until a valid one is 
 Extract and hold these values for the rest of the conversation:
 - `dest.value` — the target index/data stream where KIs will be written
 - `dest.type` — whether it is a data stream or index
-- `sources[]` — the declared data sources (ES|QL queries or future connector sources)
+- `sources[]` — the declared data sources
 - `name` and `description` — the AI Index's stated purpose
 
 Proceed to Phase 1.
@@ -160,23 +158,22 @@ Proceed to Phase 1.
 
 Using the validated AI Index definition, gather context about the declared sources:
 
-1. Parse the index or data stream names referenced in each `sources[]` entry whose `type` is
-   `"esql"`. Extract them from the `FROM` clause of each ES|QL query (e.g.
-   `FROM my-index-* | WHERE ...` → `my-index-*`).
-2. Call `platform.core.get_index_mapping` for each of those index/data stream names.
-3. Call `platform.workflows.get_connectors` to list configured connectors. (Connector source
-   types will appear in `sources[]` as the API matures — handle them here when present.)
+1. For each `sources[]` entry, attempt to extract out where the data comes from. For example,
+   if `type` is `"esql"`,  extract them from the `value` the `FROM` clause of each ES|QL query (e.g.
+  `FROM my-index-* | WHERE ...` → `my-index-*`).
+2. For each source, attempt to understand the schema of that source.
+   For example, for an index/datastream name or pattern, Call `platform.core.get_index_mapping`.
 
 Do **not** call `platform.core.list_indices` to broadly explore all indices. The AI Index
 already declares which sources matter.
 
 Do **not** ask the user what data sources they care about — the AI Index already answers that.
 
-After gathering mappings, proceed directly to Phase 2.
+After gathering an understanding of each source's schema, proceed directly to Phase 2.
 
 ### Phase 2 — Suggest strategies
 
-Based on the declared sources (from `sources[]`), their mappings, and the AI Index's
+Based on the declared sources (from `sources[]`), their schemas, and the AI Index's
 `name` and `description`, propose a coherent set of KI generation strategies that serves the
 AI Index's stated purpose as a whole.
 

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation.skill.md.text
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation.skill.md.text
@@ -114,31 +114,92 @@ A reference workflow YAML for the Index Metadata strategy is available in the
 
 Follow these phases in order. Do not skip ahead.
 
+### Phase 0 — Validate AI Index
+
+Before calling any tool or asking any question, check whether the conversation contains a valid
+AI Index definition.
+
+A valid AI Index definition is a JSON object that matches the schema in the `ai-index-schema`
+resource attached to this skill. It must have at minimum:
+- `id` (string)
+- `name` (string)
+- `dest` object with `type` (`"data_stream"` or `"index"`) and `value` (string)
+- `sources` array of objects each with `type: "esql"` and `value` (string)
+- `automations` array of objects each with `type: "workflow"` and `value` (string)
+- `date_created` and `date_modified` (strings)
+
+**If no AI Index definition is present:**
+
+Respond with:
+
+> "To set up the Context Engine, I need an AI Index definition. An AI Index defines the destination
+> index, data sources, and automations for the Context Engine. You can create one using the
+> Context Engine UI or the AI Index API (`PUT /api/context_engine/ai_index/{id}`), then paste the
+> full JSON definition here and I'll get started."
+
+Do not call any tools. Do not proceed.
+
+**If something is provided but it is not a valid AI Index definition:**
+
+Compare the provided value against the `ai-index-schema` resource. Identify specifically what is
+missing or wrong (e.g. "The `dest` field is missing", "The `sources` array is empty",
+"`foobar` is not a valid AI Index definition — it is not a JSON object with the required fields").
+Explain what a valid definition looks like. Do not proceed until a valid one is provided.
+
+**If a valid AI Index definition is provided:**
+
+Extract and hold these values for the rest of the conversation:
+- `dest.value` — the target index/data stream where KIs will be written
+- `dest.type` — whether it is a data stream or index
+- `sources[]` — the declared data sources (ES|QL queries or future connector sources)
+- `name` and `description` — the AI Index's stated purpose
+
+Proceed to Phase 1.
+
 ### Phase 1 — Discover
 
-Before asking the user anything, silently gather context:
+Using the validated AI Index definition, gather context about the declared sources:
 
-1. Call `platform.core.list_indices` to list Elasticsearch indices.
-2. Call `platform.core.get_index_mapping` on 3–5 of the most interesting indices
-   (skip system indices starting with `.`).
-3. Call `platform.workflows.get_connectors` to list configured connectors.
+1. Parse the index or data stream names referenced in each `sources[]` entry whose `type` is
+   `"esql"`. Extract them from the `FROM` clause of each ES|QL query (e.g.
+   `FROM my-index-* | WHERE ...` → `my-index-*`).
+2. Call `platform.core.get_index_mapping` for each of those index/data stream names.
+3. Call `platform.workflows.get_connectors` to list configured connectors. (Connector source
+   types will appear in `sources[]` as the API matures — handle them here when present.)
 
-Then ask the user one focused question:
+Do **not** call `platform.core.list_indices` to broadly explore all indices. The AI Index
+already declares which sources matter.
 
-> "I can see your environment. Before I suggest how to set up the Context Engine, can you tell
-> me a bit about your use case — what kinds of questions do you want AI agents to answer, and
-> which data sources do you think matter most?"
+Do **not** ask the user what data sources they care about — the AI Index already answers that.
 
-Wait for their answer before continuing.
+After gathering mappings, proceed directly to Phase 2.
 
-### Phase 2 — Suggest sources and strategies
+### Phase 2 — Suggest strategies
 
-Based on indices, connectors, and the user's goal, present per-source recommendations. Example:
+Based on the declared sources (from `sources[]`), their mappings, and the AI Index's
+`name` and `description`, propose a coherent set of KI generation strategies that serves the
+AI Index's stated purpose as a whole.
 
-> **`customer_support_tickets`** — Support case records with status, priority, description.
-> Recommended: **Bottom-Up** — agents will want to retrieve specific case facts.
+A single AI Index may warrant one strategy spanning all sources, or several complementary
+strategies — let the data and stated purpose guide the choice. For example:
 
-Ask the user to confirm which sources to include and whether to adjust any strategy.
+- A support-ticket AI Index with one `sources[]` ES|QL entry → single Bottom-Up strategy
+- A mixed AI Index with multiple sources (logs + a case system) → Index Metadata for all sources
+  plus Selective/Outlier for the log stream
+
+Present your recommendation like this:
+
+> **Sources declared in the AI Index:**
+> - `my-cases-index` (from ES|QL source): support case records with status, priority, description
+>
+> **Recommended strategy:** **Bottom-Up** — each case becomes one KI; agents retrieve specific
+> case facts by case number or status.
+>
+> **Target index:** `<dest.value>` (from the AI Index `dest` field)
+>
+> Does this look right? Would you like to adjust the strategy before I draft the workflow?
+
+Wait for confirmation before proceeding to Phase 3.
 
 ### Phase 3 — Agree on a corpus filter
 

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation_skill.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation_skill.test.ts
@@ -52,6 +52,7 @@ describe('kiAutomationGenerationSkill', () => {
     const properties = schema.properties as Record<string, unknown>;
     expect(properties).toBeDefined();
     expect(properties).toHaveProperty('id');
+    expect(properties).toHaveProperty('name');
     expect(properties).toHaveProperty('dest');
     expect(properties).toHaveProperty('sources');
     expect(properties).toHaveProperty('automations');

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation_skill.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation_skill.test.ts
@@ -30,12 +30,33 @@ describe('kiAutomationGenerationSkill', () => {
     expect(kiAutomationGenerationSkill.content.length).toBeGreaterThan(0);
   });
 
-  it('has exactly one referencedContent entry for the index-selection reference workflow', () => {
-    expect(kiAutomationGenerationSkill.referencedContent).toHaveLength(1);
+  it('has exactly two referencedContent entries', () => {
+    expect(kiAutomationGenerationSkill.referencedContent).toHaveLength(2);
+  });
+
+  it('first referencedContent entry is the index-selection reference workflow', () => {
     const ref = kiAutomationGenerationSkill.referencedContent![0];
     expect(ref.name).toBe('index-selection-reference-workflow');
     expect(ref.relativePath).toBe('.');
     expect(ref.content.length).toBeGreaterThan(0);
+  });
+
+  it('second referencedContent entry is the AI Index JSON Schema with required fields', () => {
+    const ref = kiAutomationGenerationSkill.referencedContent![1];
+    expect(ref.name).toBe('ai-index-schema');
+    expect(ref.relativePath).toBe('.');
+
+    const schema = JSON.parse(ref.content) as Record<string, unknown>;
+    expect(schema.type).toBe('object');
+
+    const properties = schema.properties as Record<string, unknown>;
+    expect(properties).toBeDefined();
+    expect(properties).toHaveProperty('id');
+    expect(properties).toHaveProperty('dest');
+    expect(properties).toHaveProperty('sources');
+    expect(properties).toHaveProperty('automations');
+    expect(properties).toHaveProperty('date_created');
+    expect(properties).toHaveProperty('date_modified');
   });
 
   it('binds all required registry tools including getConnectors', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation_skill.ts
@@ -8,6 +8,7 @@
 import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
 import { platformCoreTools } from '@kbn/agent-builder-common/tools';
 import { internalNamespaces } from '@kbn/agent-builder-common/base/namespaces';
+import { getAiIndexJsonSchema } from '@kbn/context-engine-plugin/common/http_api/ai_index_schema';
 import content from './ki_automation_generation.skill.md.text';
 import indexSelectionReferenceYaml from './index_selection_reference.yaml.text';
 
@@ -24,6 +25,11 @@ export const kiAutomationGenerationSkill = defineSkillType({
       name: 'index-selection-reference-workflow',
       relativePath: '.',
       content: indexSelectionReferenceYaml,
+    },
+    {
+      name: 'ai-index-schema',
+      relativePath: '.',
+      content: JSON.stringify(getAiIndexJsonSchema(), null, 2),
     },
   ],
   getRegistryTools: () => [

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/ki_automation_generation/ki_automation_generation_skill.ts
@@ -37,7 +37,7 @@ export const kiAutomationGenerationSkill = defineSkillType({
     platformCoreTools.executeWorkflow,
     platformCoreTools.generateEsql,
     platformCoreTools.executeEsql,
-    platformCoreTools.listIndices,
+    platformCoreTools.listIndices, // available for edge-case handling; Phase 1 uses get_index_mapping instead
     platformCoreTools.getIndexMapping,
     platformCoreTools.getWorkflowExecutionStatus,
     `${internalNamespaces.workflows}.validate_workflow`,

--- a/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
@@ -36,5 +36,6 @@
     "@kbn/logging-mocks",
     "@kbn/triggers-actions-ui-plugin",
     "@kbn/agent-builder-plugin",
+    "@kbn/context-engine-plugin",
   ]
 }

--- a/x-pack/platform/plugins/shared/context_engine/common/http_api/ai_index_schema.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/http_api/ai_index_schema.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+
+const aiIndexTypeSchema = z.enum(['data_stream', 'index']);
+
+const aiIndexDestSchema = z.object({
+  type: aiIndexTypeSchema,
+  value: z.string(),
+});
+
+const aiIndexSourceSchema = z.object({
+  type: z.literal('esql'),
+  value: z.string(),
+});
+
+const aiIndexAutomationSchema = z.object({
+  type: z.literal('workflow'),
+  value: z.string(),
+});
+
+export const aiIndexHttpItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  dest: aiIndexDestSchema,
+  automations: z.array(aiIndexAutomationSchema),
+  sources: z.array(aiIndexSourceSchema),
+  date_created: z.string(),
+  date_modified: z.string(),
+});
+
+export const getAiIndexJsonSchema = (): object =>
+  z.toJSONSchema(aiIndexHttpItemSchema, { reused: 'inline' });

--- a/x-pack/platform/plugins/shared/context_engine/common/http_api/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/http_api/ai_indices.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+import type { z } from '@kbn/zod/v4';
+import type { aiIndexHttpItemSchema } from './ai_index_schema';
+
 /**
  * The type of backing store an AI index is attached to. `index` covers a
  * concrete index name or an index pattern (e.g. `foo`, `foo,bar`, `foo*`).
@@ -15,36 +18,22 @@ export interface AiIndexDest {
   type: AiIndexType;
   value: string;
 }
-
 export type AiIndexSourceType = 'esql';
-
 export interface AiIndexSource {
   type: AiIndexSourceType;
   value: string;
 }
-
 export type AiIndexAutomationType = 'workflow';
-
 export interface AiIndexAutomation {
   type: AiIndexAutomationType;
   value: string;
 }
 
-export interface AiIndexProperties {
-  name: string;
-  description?: string;
-  dest: AiIndexDest;
-  automations: AiIndexAutomation[];
-  sources: AiIndexSource[];
-}
-
-export interface AiIndexHttpItem extends AiIndexProperties {
-  id: string;
-  date_created: string;
-  date_modified: string;
-}
-
+export type AiIndexHttpItem = z.infer<typeof aiIndexHttpItemSchema>;
 export type GetAiIndexResponse = AiIndexHttpItem;
+
+/** Properties used when creating or updating an AI index (excludes server-set fields). */
+export type AiIndexProperties = Omit<AiIndexHttpItem, 'id' | 'date_created' | 'date_modified'>;
 
 export interface ListAiIndexResponse {
   ai_indices: AiIndexHttpItem[];

--- a/x-pack/platform/plugins/shared/context_engine/moon.yml
+++ b/x-pack/platform/plugins/shared/context_engine/moon.yml
@@ -38,6 +38,7 @@ dependsOn:
   - '@kbn/try-in-console'
   - '@kbn/share-plugin'
   - '@kbn/console-plugin'
+  - '@kbn/zod'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
@@ -9,7 +9,6 @@ import { schema } from '@kbn/config-schema';
 import type { IRouter, KibanaResponseFactory, RequestHandler } from '@kbn/core/server';
 import type { RouteSecurity } from '@kbn/core-http-server';
 import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
-import type { z } from '@kbn/zod/v4';
 import {
   AI_INDEX_API_VERSION,
   MAX_AI_INDEX_AUTOMATION_LENGTH,
@@ -24,9 +23,9 @@ import {
   aiIndexByIdPath,
   aiIndexPath,
 } from '../../common/constants';
-import type { aiIndexHttpItemSchema } from '../../common/http_api/ai_index_schema';
 import type {
   DeleteAiIndexResponse,
+  GetAiIndexResponse,
   ListAiIndexResponse,
   PutAiIndexResponse,
 } from '../../common/http_api/ai_indices';
@@ -202,9 +201,7 @@ export const registerAiIndexRoutes = ({
       },
       withContextEngineFeatureFlag(async (ctx, request, response) => {
         try {
-          const body: z.infer<typeof aiIndexHttpItemSchema> = await getAiIndexService().get(
-            request.params.aiIndexId
-          );
+          const body: GetAiIndexResponse = await getAiIndexService().get(request.params.aiIndexId);
           return response.ok({ body });
         } catch (error) {
           return handleAiIndexError(error, response);

--- a/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
@@ -9,6 +9,7 @@ import { schema } from '@kbn/config-schema';
 import type { IRouter, KibanaResponseFactory, RequestHandler } from '@kbn/core/server';
 import type { RouteSecurity } from '@kbn/core-http-server';
 import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
+import type { z } from '@kbn/zod/v4';
 import {
   AI_INDEX_API_VERSION,
   MAX_AI_INDEX_AUTOMATION_LENGTH,
@@ -23,9 +24,9 @@ import {
   aiIndexByIdPath,
   aiIndexPath,
 } from '../../common/constants';
+import type { aiIndexHttpItemSchema } from '../../common/http_api/ai_index_schema';
 import type {
   DeleteAiIndexResponse,
-  GetAiIndexResponse,
   ListAiIndexResponse,
   PutAiIndexResponse,
 } from '../../common/http_api/ai_indices';
@@ -201,7 +202,9 @@ export const registerAiIndexRoutes = ({
       },
       withContextEngineFeatureFlag(async (ctx, request, response) => {
         try {
-          const body: GetAiIndexResponse = await getAiIndexService().get(request.params.aiIndexId);
+          const body: z.infer<typeof aiIndexHttpItemSchema> = await getAiIndexService().get(
+            request.params.aiIndexId
+          );
           return response.ok({ body });
         } catch (error) {
           return handleAiIndexError(error, response);

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -33,5 +33,6 @@
     "@kbn/try-in-console",
     "@kbn/share-plugin",
     "@kbn/console-plugin"
+    "@kbn/zod"
   ]
 }

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -28,6 +28,7 @@
     "@kbn/shared-ux-page-kibana-template",
     "@kbn/i18n-react",
     "@kbn/kibana-react-plugin",
+<<<<<<< HEAD
     "@kbn/esql",
     "@kbn/es-query",
     "@kbn/try-in-console",

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -32,7 +32,7 @@
     "@kbn/es-query",
     "@kbn/try-in-console",
     "@kbn/share-plugin",
-    "@kbn/console-plugin"
+    "@kbn/console-plugin",
     "@kbn/zod"
   ]
 }

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -28,7 +28,6 @@
     "@kbn/shared-ux-page-kibana-template",
     "@kbn/i18n-react",
     "@kbn/kibana-react-plugin",
-<<<<<<< HEAD
     "@kbn/esql",
     "@kbn/es-query",
     "@kbn/try-in-console",


### PR DESCRIPTION
## Summary

Builds on #278149 (ki-automation-generation skill v1) and #277316 (AI Index API).

- **Derives `AiIndexHttpItem` from a Zod v4 schema** (`context_engine/common/http_api/ai_index_schema.ts`) and exposes a `getAiIndexJsonSchema()` helper that produces a JSON Schema object at runtime. This gives us a single source of truth: the Zod schema drives both the TypeScript type (via `z.infer`) and the JSON Schema embedded in the skill.
- **GET route return type** is now compiler-enforced against the Zod schema (`z.infer<typeof aiIndexHttpItemSchema>`), so any drift between the route and the schema is a type error.
- **AI Index JSON Schema injected into the skill** as a `referencedContent` entry, alongside the existing index-selection reference workflow. The LLM uses it to validate user-supplied AI Index definitions without any server-side tool call.
- **Phase 0 gate added to `ki_automation_generation.skill.md`**: validates the AI Index in the conversation before any tool calls. Three branches: no definition → ask; structurally invalid → explain; valid → extract and proceed.
- **Phase 1 rewritten** to be AI Index–driven: parses `FROM` clauses from `sources[]` ES|QL queries to determine which index mappings to fetch, and sources connector info from `get_connectors` — no open-ended user questions. `list_indices` is still registered but explicitly noted as an edge-case fallback.
- **Phase 2 rewritten** to derive the output target from `dest.value` and suggest a strategy that may span one or all sources.
- **Unit tests** assert both `referencedContent` entries and required JSON Schema fields.
- **Behavioral evals** cover the three Phase 0 branches (no AI Index, invalid AI Index, valid AI Index).
- **Skill selection benchmark** extended with 6 new rows for `ki-automation-generation`.

## Implementation notes

`zod-to-json-schema@3.25.0` has type declarations that reference `zod/v3`, causing a TS2345 error when passed a Zod v4 schema. Used Zod v4's built-in `z.toJSONSchema(schema, { reused: 'inline' })` instead — equivalent to `$refStrategy: 'none'` and avoids the package's silent empty-schema behavior with v4 inputs.

## Test plan

- [ ] `node scripts/jest x-pack/platform/plugins/shared/agent_builder_platform --no-coverage` — all 8 unit tests pass
- [ ] Type check: `node scripts/type_check --project x-pack/platform/plugins/shared/context_engine/tsconfig.json`
- [ ] Type check: `node scripts/type_check --project x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json`
- [ ] Behavioral evals (require running Agent Builder stack): `evals/platform/context_engine/ki_automation_generation.spec.ts`
- [ ] Skill selection benchmark: `evals/skill_selection/skill_selection_benchmark.spec.ts`

## Screenshots
<img width="903" height="379" alt="Screenshot 2026-07-22 at 10 05 03 AM" src="https://github.com/user-attachments/assets/f8ec0e4e-1081-4eb3-a23d-8a0d1143089c" />

<img width="852" height="548" alt="Screenshot 2026-07-22 at 10 05 22 AM" src="https://github.com/user-attachments/assets/638781a1-3910-4670-9ff0-95d7e84ee733" />

<img width="709" height="633" alt="Screenshot 2026-07-22 at 10 23 40 AM" src="https://github.com/user-attachments/assets/10f6cef6-6d0e-4b4c-9d98-21c6b0b6a271" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)