### PR TITLE
[9.5] [Security Solution][Flyout v2] Fix prevalence entity resolution and attack document rendering (#279957)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/utils/is_attack_document.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/utils/is_attack_document.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { isAttackDocument } from './is_attack_document';
+
+const createHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
+  ({
+    id: '1',
+    raw: { _id: '1', _index: 'test', _source: {} },
+    flattened,
+    isAnchor: false,
+  } as DataTableRecord);
+
+describe('isAttackDocument', () => {
+  it('returns true for a scheduled attack discovery alert', () => {
+    expect(
+      isAttackDocument(
+        createHit({
+          'event.kind': 'signal',
+          'kibana.alert.rule.rule_type_id': 'attack-discovery',
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('returns true for an ad-hoc attack discovery alert', () => {
+    expect(
+      isAttackDocument(
+        createHit({
+          'event.kind': 'signal',
+          'kibana.alert.rule.rule_type_id': 'attack_discovery_ad_hoc_rule_type_id',
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('returns false for a regular detection alert (signal, non-attack rule type)', () => {
+    expect(
+      isAttackDocument(
+        createHit({
+          'event.kind': 'signal',
+          'kibana.alert.rule.rule_type_id': 'siem.queryRule',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when the attack rule type id is present but event.kind is not signal', () => {
+    expect(
+      isAttackDocument(
+        createHit({
+          'event.kind': 'event',
+          'kibana.alert.rule.rule_type_id': 'attack-discovery',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('returns false for a plain event document', () => {
+    expect(isAttackDocument(createHit({ 'event.kind': 'event' }))).toBe(false);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/utils/is_attack_document.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/utils/is_attack_document.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
+import { ALERT_RULE_TYPE_ID, EVENT_KIND } from '@kbn/rule-data-utils';
+import {
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+} from '@kbn/elastic-assistant-common';
+import { EventKind } from '../../document/main/constants/event_kinds';
+
+/**
+ * Returns `true` when the given hit is an attack discovery document. Detection is based on the
+ * alert's rule type id (scheduled or ad-hoc attack-discovery rule type) alongside `event.kind:
+ * signal`, rather than the presence of a display field like the attack title: attack discoveries
+ * are persisted as alerts, so this is the same signal the rest of the platform uses (mirrors
+ * Discover's `isAttackDocument`) and won't misfire on a missing title.
+ */
+export const isAttackDocument = (hit: DataTableRecord): boolean => {
+  const eventKind = getFieldValue(hit, EVENT_KIND) as string | undefined;
+  const ruleTypeId = getFieldValue(hit, ALERT_RULE_TYPE_ID) as string | undefined;
+
+  return (
+    eventKind === EventKind.signal &&
+    (ruleTypeId === ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID ||
+      ruleTypeId === ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID)
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.test.tsx
@@ -39,12 +39,22 @@ const eventHit = createHit({
   'host.name': 'host-1',
 });
 
+const attackHit = createHit({
+  'event.kind': 'signal',
+  'kibana.alert.rule.rule_type_id': 'attack-discovery',
+  'kibana.alert.attack_discovery.title': 'My Attack',
+});
+
 describe('useDocumentFlyoutTitle', () => {
   const openDocumentFlyoutFromIndexAsChild = jest.fn();
+  const openAttackFlyoutAsChild = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useFlyoutApi as jest.Mock).mockReturnValue({ openDocumentFlyoutFromIndexAsChild });
+    (useFlyoutApi as jest.Mock).mockReturnValue({
+      openDocumentFlyoutFromIndexAsChild,
+      openAttackFlyoutAsChild,
+    });
   });
 
   it('derives label and warning icon for alerts', () => {
@@ -61,7 +71,14 @@ describe('useDocumentFlyoutTitle', () => {
     expect(result.current.iconType).toBe('analyzeEvent');
   });
 
-  it('opens the source document as a child flyout via openDocumentFlyoutFromIndexAsChild (so it is URL-persisted and reports telemetry)', () => {
+  it('derives the attack name and bolt icon for attack documents', () => {
+    const { result } = renderHook(() => useDocumentFlyoutTitle({ hit: attackHit }));
+
+    expect(result.current.label).toBe('My Attack');
+    expect(result.current.iconType).toBe('bolt');
+  });
+
+  it('opens a regular document as a child flyout via openDocumentFlyoutFromIndexAsChild', () => {
     const { result } = renderHook(() => useDocumentFlyoutTitle({ hit: alertHit }));
 
     act(() => {
@@ -76,6 +93,26 @@ describe('useDocumentFlyoutTitle', () => {
         origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
       })
     );
+    expect(openAttackFlyoutAsChild).not.toHaveBeenCalled();
+  });
+
+  it('opens an attack document via openAttackFlyoutAsChild (attack indices are not in the default data view)', () => {
+    const { result } = renderHook(() => useDocumentFlyoutTitle({ hit: attackHit }));
+
+    act(() => {
+      result.current.onTitleClick();
+    });
+
+    expect(openAttackFlyoutAsChild).toHaveBeenCalledTimes(1);
+    expect(openAttackFlyoutAsChild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attackId: '1',
+        indexName: 'test',
+        attackTitle: 'My Attack',
+        origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
+      })
+    );
+    expect(openDocumentFlyoutFromIndexAsChild).not.toHaveBeenCalled();
   });
 
   it('returns badge and timestamp nodes derived from the hit', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
@@ -17,6 +17,9 @@ import {
 } from '../../document/main/utils/get_header_title';
 import type { CellActionRenderer } from '../components/cell_actions';
 import { noopCellActionRenderer } from '../components/cell_actions';
+import { getAttackTitleValue } from '../../attack/utils/get_attack_title';
+import { isAttackDocument } from '../../attack/utils/is_attack_document';
+import { ATTACK_TITLE, formatFlyoutTitle } from '../constants/flyout_titles';
 import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
 import { DocumentSeverity } from '../../document/main/components/severity';
 import { Timestamp } from '../components/timestamp';
@@ -32,11 +35,14 @@ export interface UseDocumentFlyoutTitleOptions {
 }
 
 export interface DocumentFlyoutTitleResult {
-  /** Document title derived from the hit. */
+  /** Document title derived from the hit (the attack name for attack documents). */
   label: string;
-  /** Icon type: `'warning'` for alerts, `'analyzeEvent'` for other documents. */
+  /**
+   * Icon type: `'bolt'` for attack documents, `'warning'` for alerts, `'analyzeEvent'` for other
+   * documents.
+   */
   iconType: string;
-  /** Opens the source document as a child flyout. */
+  /** Opens the source document as a child flyout (the attack flyout for attack documents). */
   onTitleClick: () => void;
   /** Severity badge for the document. */
   badge: React.ReactNode;
@@ -52,32 +58,63 @@ export const useDocumentFlyoutTitle = ({
   renderCellActions = noopCellActionRenderer,
   onAlertUpdated = noop,
 }: UseDocumentFlyoutTitleOptions): DocumentFlyoutTitleResult => {
-  const { openDocumentFlyoutFromIndexAsChild } = useFlyoutApi();
+  const { openDocumentFlyoutFromIndexAsChild, openAttackFlyoutAsChild } = useFlyoutApi();
+
+  // Attack discovery documents are persisted as alerts (event.kind: signal), so detect them by
+  // rule type id first — they'd otherwise match the generic alert branch below.
+  const isAttack = useMemo(() => isAttackDocument(hit), [hit]);
+  const attackTitle = useMemo(() => getAttackTitleValue(hit), [hit]);
 
   const isAlert = useMemo(
     () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
     [hit]
   );
 
-  const label = useMemo(() => getDocumentTitle(hit), [hit]);
-  const sessionTitle = useMemo(() => getDocumentHistoryTitle(hit), [hit]);
-  const iconType = isAlert ? 'warning' : 'analyzeEvent';
+  const label = useMemo(
+    () => (isAttack ? attackTitle ?? ATTACK_TITLE : getDocumentTitle(hit)),
+    [attackTitle, hit, isAttack]
+  );
+  const sessionTitle = useMemo(
+    () => (isAttack ? formatFlyoutTitle(ATTACK_TITLE, attackTitle) : getDocumentHistoryTitle(hit)),
+    [attackTitle, hit, isAttack]
+  );
+  const iconType = isAttack ? 'bolt' : isAlert ? 'warning' : 'analyzeEvent';
 
-  // Open the source document as a child flyout. Route through the shared
-  // `openDocumentFlyoutFromIndexAsChild` API rather than calling `overlays.openSystemFlyout`
-  // directly, so the child descriptor is written to the flyoutV2 URL param (via the API's
-  // internal writeOnOpen('inherit')). Opening it directly here bypassed the URL writer, so the
-  // child was not restored on refresh — only the parent tool flyout reopened.
+  // Open the source document as a child flyout. Route through the flyout API rather than calling
+  // `overlays.openSystemFlyout` directly so the child descriptor is written to the flyoutV2 URL
+  // param (via the API's internal writeOnOpen('inherit')) and restored on refresh.
+  // Attack documents live in alert-specific indices not covered by the default data view, so they
+  // must be opened with openAttackFlyoutAsChild (which fetches via useTimelineEventsDetails against
+  // the specific index). openDocumentFlyoutFromIndexAsChild uses useEsDocSearch against the default
+  // data view and returns NotFound for attack documents.
   const onTitleClick = useCallback(() => {
-    openDocumentFlyoutFromIndexAsChild({
-      documentId: hit.raw._id ?? '',
-      indexName: (hit.raw._index as string) ?? '',
-      renderCellActions,
-      onAlertUpdated,
-      title: sessionTitle,
-      origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
-    });
-  }, [openDocumentFlyoutFromIndexAsChild, hit, renderCellActions, onAlertUpdated, sessionTitle]);
+    if (isAttack) {
+      openAttackFlyoutAsChild({
+        attackId: hit.raw._id ?? '',
+        indexName: (hit.raw._index as string) ?? '',
+        attackTitle: attackTitle ?? undefined,
+        origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
+      });
+    } else {
+      openDocumentFlyoutFromIndexAsChild({
+        documentId: hit.raw._id ?? '',
+        indexName: (hit.raw._index as string) ?? '',
+        renderCellActions,
+        onAlertUpdated,
+        title: sessionTitle,
+        origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
+      });
+    }
+  }, [
+    isAttack,
+    openAttackFlyoutAsChild,
+    openDocumentFlyoutFromIndexAsChild,
+    hit,
+    attackTitle,
+    renderCellActions,
+    onAlertUpdated,
+    sessionTitle,
+  ]);
 
   const badge = <DocumentSeverity hit={hit} />;
   const timestamp = <Timestamp hit={hit} size="xs" />;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Security Solution][Flyout v2] Fix prevalence entity resolution and attack document rendering (#279957)](https://github.com/elastic/kibana/pull/279957)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-22T02:09:13Z","message":"[Security Solution][Flyout v2] Fix prevalence entity resolution and attack document rendering (#279957)\n\n## Summary\n\nThree flyout v2 bug fixes:\n\n- **Prevalence entity resolution** — the Prevalence section pulled the\nobserved host/username instead of the entity store version, inconsistent\nwith Highlighted Fields. `InsightsSection` now passes the source `hit`\nto `OpenFlyoutLink`, which resolves host/user links to the entity store\n(matching Highlighted Fields).\n- **Attack flyout header title** — the tools flyout header showed a\nwrong/placeholder title for attack discovery documents (reproduced in\nboth Discover and the Correlations tool). Attack documents are now\ndetected via the attack-discovery rule type id and render the attack\nname with a bolt icon.\n- **Attack document rendering** — attack documents opened as an\nalert-type child instead of the native attack view. Clicking the header\ntitle now opens the attack flyout (`AttackFlyoutWrapper`) for attack\ndocuments rather than the raw alert document.\n\nA new `isAttackDocument` util detects attack discoveries by `event.kind:\nsignal` + the scheduled/ad-hoc attack-discovery rule type id (mirrors\nDiscover), rather than relying on the presence of a display field.\n\nTo exercise manually, enable `securitySolution:enableNewFlyout` in\nAdvanced Settings.\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"94c413a3156ef48bee139ca58b997c2f4b1271b6","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","backport:version","v9.5.0","OneDiscover","v9.6.0"],"title":"[Security Solution][Flyout v2] Fix prevalence entity resolution and attack document rendering","number":279957,"url":"https://github.com/elastic/kibana/pull/279957","mergeCommit":{"message":"[Security Solution][Flyout v2] Fix prevalence entity resolution and attack document rendering (#279957)\n\n## Summary\n\nThree flyout v2 bug fixes:\n\n- **Prevalence entity resolution** — the Prevalence section pulled the\nobserved host/username instead of the entity store version, inconsistent\nwith Highlighted Fields. `InsightsSection` now passes the source `hit`\nto `OpenFlyoutLink`, which resolves host/user links to the entity store\n(matching Highlighted Fields).\n- **Attack flyout header title** — the tools flyout header showed a\nwrong/placeholder title for attack discovery documents (reproduced in\nboth Discover and the Correlations tool). Attack documents are now\ndetected via the attack-discovery rule type id and render the attack\nname with a bolt icon.\n- **Attack document rendering** — attack documents opened as an\nalert-type child instead of the native attack view. Clicking the header\ntitle now opens the attack flyout (`AttackFlyoutWrapper`) for attack\ndocuments rather than the raw alert document.\n\nA new `isAttackDocument` util detects attack discoveries by `event.kind:\nsignal` + the scheduled/ad-hoc attack-discovery rule type id (mirrors\nDiscover), rather than relying on the presence of a display field.\n\nTo exercise manually, enable `securitySolution:enableNewFlyout` in\nAdvanced Settings.\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"94c413a3156ef48bee139ca58b997c2f4b1271b6"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279957","number":279957,"mergeCommit":{"message":"[Security Solution][Flyout v2] Fix prevalence entity resolution and attack document rendering (#279957)\n\n## Summary\n\nThree flyout v2 bug fixes:\n\n- **Prevalence entity resolution** — the Prevalence section pulled the\nobserved host/username instead of the entity store version, inconsistent\nwith Highlighted Fields. `InsightsSection` now passes the source `hit`\nto `OpenFlyoutLink`, which resolves host/user links to the entity store\n(matching Highlighted Fields).\n- **Attack flyout header title** — the tools flyout header showed a\nwrong/placeholder title for attack discovery documents (reproduced in\nboth Discover and the Correlations tool). Attack documents are now\ndetected via the attack-discovery rule type id and render the attack\nname with a bolt icon.\n- **Attack document rendering** — attack documents opened as an\nalert-type child instead of the native attack view. Clicking the header\ntitle now opens the attack flyout (`AttackFlyoutWrapper`) for attack\ndocuments rather than the raw alert document.\n\nA new `isAttackDocument` util detects attack discoveries by `event.kind:\nsignal` + the scheduled/ad-hoc attack-discovery rule type id (mirrors\nDiscover), rather than relying on the presence of a display field.\n\nTo exercise manually, enable `securitySolution:enableNewFlyout` in\nAdvanced Settings.\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"94c413a3156ef48bee139ca58b997c2f4b1271b6"}}]}] BACKPORT-->