### PR TITLE
[9.5] [Entity Analytics][Bugfix] Risk score inspect not working from entity preview (#278949)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.tsx
@@ -94,6 +94,15 @@ import { entityAttachmentQueryClient } from '../attachment_types/entity_attachme
 
 const AGENT_BUILDER_ENTITY_CARD_SCOPE = 'agent-builder-entity-card';
 
+/**
+ * Namespaced Inspect query ids for the Agent Builder entity Preview canvas.
+ * Must not collide with the Security entity flyout ids — both share one Redux store, and the
+ * flyout's `useQueryInspector` cleanup `deleteQuery` would otherwise disable Preview Inspect.
+ */
+const AGENT_BUILDER_HOST_PANEL_RISK_SCORE_QUERY_ID = `agentBuilder${HOST_PANEL_RISK_SCORE_QUERY_ID}`;
+const AGENT_BUILDER_USER_PANEL_RISK_SCORE_QUERY_ID = `agentBuilder${USER_PANEL_RISK_SCORE_QUERY_ID}`;
+const AGENT_BUILDER_SERVICE_PANEL_RISK_SCORE_QUERY_ID = `agentBuilder${SERVICE_PANEL_RISK_SCORE_QUERY_ID}`;
+
 const FIRST_RECORD_PAGINATION = {
   cursorStart: 0,
   querySize: 1,
@@ -361,7 +370,7 @@ const HostEntityFlyoutOverviewCanvas: React.FC<{
     deleteQuery,
     inspect: hasEntityStoreRecord ? entityFromStoreResult?.inspect ?? null : inspect,
     loading: hasEntityStoreRecord ? entityFromStoreResult?.isLoading ?? false : loading,
-    queryId: HOST_PANEL_RISK_SCORE_QUERY_ID,
+    queryId: AGENT_BUILDER_HOST_PANEL_RISK_SCORE_QUERY_ID,
     refetch: hasEntityStoreRecord ? entityFromStoreResult?.refetch ?? (() => {}) : refetch,
     setQuery,
   });
@@ -487,6 +496,7 @@ const HostEntityFlyoutOverviewCanvas: React.FC<{
             skipRiskAndCriticality={noEntityInStore}
             entityStoreEntityId={entityStoreEntityId}
             prefetchedResolutionRisk={prefetchedResolutionRisk}
+            riskScoreQueryId={AGENT_BUILDER_HOST_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </FlyoutBody>
@@ -698,7 +708,7 @@ const UserEntityFlyoutOverviewCanvas: React.FC<{
     deleteQuery,
     inspect: useEntityStoreInspectForRisk ? entityFromStoreResult?.inspect ?? null : inspect,
     loading: useEntityStoreInspectForRisk ? entityFromStoreResult?.isLoading ?? false : loading,
-    queryId: USER_PANEL_RISK_SCORE_QUERY_ID,
+    queryId: AGENT_BUILDER_USER_PANEL_RISK_SCORE_QUERY_ID,
     refetch: useEntityStoreInspectForRisk
       ? entityFromStoreResult?.refetch ?? (() => {})
       : riskScoreState.refetch,
@@ -830,6 +840,7 @@ const UserEntityFlyoutOverviewCanvas: React.FC<{
             skipRiskAndCriticality={noEntityInStore}
             entityStoreEntityId={entityStoreEntityId}
             prefetchedResolutionRisk={prefetchedResolutionRisk}
+            riskScoreQueryId={AGENT_BUILDER_USER_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </FlyoutBody>
@@ -1037,7 +1048,7 @@ const ServiceEntityFlyoutOverviewCanvas: React.FC<{
     deleteQuery,
     inspect,
     loading,
-    queryId: SERVICE_PANEL_RISK_SCORE_QUERY_ID,
+    queryId: AGENT_BUILDER_SERVICE_PANEL_RISK_SCORE_QUERY_ID,
     refetch: riskScoreState.refetch,
     setQuery,
   });
@@ -1120,6 +1131,7 @@ const ServiceEntityFlyoutOverviewCanvas: React.FC<{
             isPreviewMode={isPreviewMode}
             entityStoreEntityId={entityStoreEntityId}
             prefetchedResolutionRisk={prefetchedResolutionRisk}
+            riskScoreQueryId={AGENT_BUILDER_SERVICE_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/security_redux_embedded_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/security_redux_embedded_provider.tsx
@@ -6,11 +6,14 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { createMemoryHistory } from 'history';
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
+import { Router } from '@kbn/shared-ux-router';
 import { NavigationProvider } from '@kbn/security-solution-navigation';
 import type { SecurityAppStore } from '../../common/store/types';
 import { KibanaContextProvider } from '../../common/lib/kibana/kibana_react';
@@ -33,6 +36,29 @@ export interface SecurityReduxEmbeddedProviderProps {
   resolveCanvasContext: () => Promise<SecurityCanvasEmbeddedBundle>;
   children: React.ReactNode;
 }
+
+const useHasRouterContext = (): boolean => {
+  try {
+    useLocation();
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Reuse a host Router when present and mount an in-memory Router for surfaces with none (chrome embeddable)
+ */
+const EmbeddedRouter: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const hasRouterContext = useHasRouterContext();
+  const [fallbackHistory] = useState(() => createMemoryHistory());
+
+  if (hasRouterContext) {
+    return <>{children}</>;
+  }
+
+  return <Router history={fallbackHistory}>{children}</Router>;
+};
 
 /**
  * Agent Builder attachment Canvas renders outside Security's `ReduxStoreProvider` and outside the
@@ -89,19 +115,21 @@ export const SecurityReduxEmbeddedProvider: React.FC<SecurityReduxEmbeddedProvid
         ...bundle.kibanaServices,
       }}
     >
-      <CellActionsProvider
-        getTriggerCompatibleActions={bundle.kibanaServices.uiActions.getTriggerCompatibleActions}
-      >
-        <NavigationProvider core={bundle.kibanaServices}>
-          <Provider store={bundle.store}>
-            <UpsellingProvider upsellingService={bundle.kibanaServices.upselling}>
-              <CaseProvider>
-                <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
-              </CaseProvider>
-            </UpsellingProvider>
-          </Provider>
-        </NavigationProvider>
-      </CellActionsProvider>
+      <EmbeddedRouter>
+        <CellActionsProvider
+          getTriggerCompatibleActions={bundle.kibanaServices.uiActions.getTriggerCompatibleActions}
+        >
+          <NavigationProvider core={bundle.kibanaServices}>
+            <Provider store={bundle.store}>
+              <UpsellingProvider upsellingService={bundle.kibanaServices.upselling}>
+                <CaseProvider>
+                  <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
+                </CaseProvider>
+              </UpsellingProvider>
+            </Provider>
+          </NavigationProvider>
+        </CellActionsProvider>
+      </EmbeddedRouter>
     </KibanaContextProvider>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -319,6 +319,7 @@ export const HostPanel = memo(function HostPanel({
             refetchEntityRecord={entityFromStoreResult.refetch}
             skipRiskAndCriticality={noEntityInStore}
             entityStoreEntityId={entityStoreEntityId}
+            riskScoreQueryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.test.tsx
@@ -50,6 +50,7 @@ const defaultProps = {
   openDetailsPanel: () => {},
   isPreviewMode: false,
   entityStoreEntityId: 'service:nginx@okta',
+  riskScoreQueryId: 'servicePanelRiskScoreQuery',
 };
 
 describe('ServicePanelContent — resolution license gating', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
@@ -15,7 +15,6 @@ import { FlyoutRiskSummary } from '../../../entity_analytics/components/risk_sum
 import type { RiskScoreState } from '../../../entity_analytics/api/hooks/use_risk_score';
 import type { EntityRiskScoresState } from '../../../entity_analytics/api/hooks/use_entity_risk_scores';
 import { EntityType } from '../../../../common/entity_analytics/types';
-import { SERVICE_PANEL_RISK_SCORE_QUERY_ID } from '.';
 import { ObservedEntity } from '../../../flyout_v2/entity/shared/components/observed_entity';
 import type { ObservedEntityData } from '../../../flyout_v2/entity/shared/components/observed_entity/types';
 import { useObservedServiceItems } from './hooks/use_observed_service_items';
@@ -51,6 +50,11 @@ interface ServicePanelContentProps {
     entityId: string;
     entityName: string | undefined;
   }) => void;
+  /**
+   * Inspect query id for {@link FlyoutRiskSummary}. Callers must pass a stable id that matches
+   * their `useQueryInspector` registration
+   */
+  riskScoreQueryId: string;
 }
 
 export const ServicePanelContent = ({
@@ -69,6 +73,7 @@ export const ServicePanelContent = ({
   entityStoreEntityId,
   prefetchedResolutionRisk,
   onShowEntity,
+  riskScoreQueryId,
 }: ServicePanelContentProps) => {
   const observedFields = useObservedServiceItems(observedService);
   const hasEntityResolutionLicense = useHasEntityResolutionLicense();
@@ -87,7 +92,7 @@ export const ServicePanelContent = ({
             riskScoreData={riskScoreState}
             entityRiskScores={entityRiskScores}
             recalculatingScore={recalculatingScore}
-            queryId={SERVICE_PANEL_RISK_SCORE_QUERY_ID}
+            queryId={riskScoreQueryId}
             openDetailsPanel={openDetailsPanel}
             isPreviewMode={isPreviewMode}
             entityType={EntityType.service}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -225,6 +225,7 @@ export const ServicePanel = memo(function ServicePanel({
             openDetailsPanel={openDetailsPanel}
             isPreviewMode={isPreviewMode}
             entityStoreEntityId={entityStoreEntityId}
+            riskScoreQueryId={SERVICE_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -329,6 +329,7 @@ export const UserPanel = memo(function UserPanel({
             refetchEntityRecord={entityFromStoreResult.refetch}
             skipRiskAndCriticality={noEntityInStore}
             entityStoreEntityId={entityStoreEntityId}
+            riskScoreQueryId={USER_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/content.test.tsx
@@ -65,6 +65,7 @@ const defaultProps = {
   openDetailsPanel: () => {},
   isPreviewMode: false,
   entityStoreEntityId: 'host:host-1@okta',
+  riskScoreQueryId: 'HostPanelRiskScoreQuery',
 };
 
 describe('Content — resolution license gating', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/content.tsx
@@ -20,7 +20,7 @@ import { FlyoutRiskSummary } from '../../../../entity_analytics/components/risk_
 import type { RiskScoreState } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import type { EntityRiskScoresState } from '../../../../entity_analytics/api/hooks/use_entity_risk_scores';
 import { EntityIdentifierFields, EntityType } from '../../../../../common/entity_analytics/types';
-import { HOST_PANEL_OBSERVED_HOST_QUERY_ID, HOST_PANEL_RISK_SCORE_QUERY_ID } from './constants';
+import { HOST_PANEL_OBSERVED_HOST_QUERY_ID } from './constants';
 import type { EntityDetailsPath } from '../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
 import type { IdentityFields } from '../../../../flyout/document_details/shared/utils';
 import type { ObservedEntityData } from '../../shared/components/observed_entity/types';
@@ -83,6 +83,11 @@ export interface ContentProps {
     entityId: string;
     entityName: string | undefined;
   }) => void;
+  /**
+   * Inspect query id for {@link FlyoutRiskSummary}. Callers must pass a stable id that matches
+   * their `useQueryInspector` registration
+   */
+  riskScoreQueryId: string;
 }
 
 /**
@@ -107,6 +112,7 @@ export const Content = ({
   enableGraphAndResolutionNavigation = true,
   hideHeaderIcons = false,
   onShowEntity,
+  riskScoreQueryId,
 }: ContentProps) => {
   const hasEntityResolutionLicense = useHasEntityResolutionLicense();
   const isAnomalyDetailsEnabled = useIsExperimentalFeatureEnabled('entityAnalyticsAnomalyDetails');
@@ -143,7 +149,7 @@ export const Content = ({
               riskScoreData={riskScoreState}
               entityRiskScores={entityRiskScores}
               recalculatingScore={recalculatingScore}
-              queryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
+              queryId={riskScoreQueryId}
               openDetailsPanel={openDetailsPanel}
               isPreviewMode={isPreviewMode}
               entityId={entityRecord?.entity?.id}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
@@ -445,6 +445,7 @@ export const Host: FC<HostProps> = memo(function Host({
             entityStoreEntityId={entityStoreEntityId}
             onShowEntity={onShowRelatedEntityFromResolution}
             hideHeaderIcons
+            riskScoreQueryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </EuiFlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
@@ -314,6 +314,7 @@ export const Service: FC<ServiceProps> = memo(function Service({
             isPreviewMode={false}
             entityStoreEntityId={entityStoreEntityId}
             onShowEntity={onShowRelatedEntityFromResolution}
+            riskScoreQueryId={SERVICE_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/content.tsx
@@ -20,7 +20,7 @@ import { FlyoutRiskSummary } from '../../../../entity_analytics/components/risk_
 import type { RiskScoreState } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import type { EntityRiskScoresState } from '../../../../entity_analytics/api/hooks/use_entity_risk_scores';
 import { EntityIdentifierFields, EntityType } from '../../../../../common/entity_analytics/types';
-import { USER_PANEL_OBSERVED_USER_QUERY_ID, USER_PANEL_RISK_SCORE_QUERY_ID } from './constants';
+import { USER_PANEL_OBSERVED_USER_QUERY_ID } from './constants';
 import type { EntityDetailsPath } from '../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
 import type { IdentityFields } from '../../../../flyout/document_details/shared/utils';
 import type { ObservedEntityData } from '../../shared/components/observed_entity/types';
@@ -86,6 +86,11 @@ export interface ContentProps {
     entityId: string;
     entityName: string | undefined;
   }) => void;
+  /**
+   * Inspect query id for {@link FlyoutRiskSummary}. Callers must pass a stable id that matches
+   * their `useQueryInspector` registration
+   */
+  riskScoreQueryId: string;
 }
 
 /**
@@ -110,6 +115,7 @@ export const Content = ({
   enableGraphAndResolutionNavigation = true,
   hideHeaderIcons = false,
   onShowEntity,
+  riskScoreQueryId,
 }: ContentProps) => {
   const hasEntityResolutionLicense = useHasEntityResolutionLicense();
   const isAnomalyDetailsEnabled = useIsExperimentalFeatureEnabled('entityAnalyticsAnomalyDetails');
@@ -145,7 +151,7 @@ export const Content = ({
               riskScoreData={riskScoreState}
               entityRiskScores={entityRiskScores}
               recalculatingScore={recalculatingScore}
-              queryId={USER_PANEL_RISK_SCORE_QUERY_ID}
+              queryId={riskScoreQueryId}
               openDetailsPanel={openDetailsPanel}
               isPreviewMode={isPreviewMode}
               entityId={entityRecord?.entity?.id}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
@@ -465,6 +465,7 @@ export const User: FC<UserProps> = memo(function User({
             entityStoreEntityId={entityStoreEntityId}
             onShowEntity={onShowRelatedEntityFromResolution}
             hideHeaderIcons
+            riskScoreQueryId={USER_PANEL_RISK_SCORE_QUERY_ID}
           />
         )}
       </EuiFlyoutBody>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Entity Analytics][Bugfix] Risk score inspect not working from entity preview (#278949)](https://github.com/elastic/kibana/pull/278949)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"tcalopes","email":"tatiana.lopes@elastic.co"},"sourceCommit":{"committedDate":"2026-07-20T14:56:13Z","message":"[Entity Analytics][Bugfix] Risk score inspect not working from entity preview (#278949)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/278006\n\n**Issues:**\n\n1. Clicking _Inspect_ on Risk Score in the Agent Builder entity\nattachment Preview showed **Couldn't render this attachment** when the\npreview was opened from the side chat\n2. While testing I also noticed that from the entity attachment: open\nthe Preview → click on `Open in Entity Analytics` from the attachment →\nclose the entity flyout → Risk Score Inspect in Preview is now disabled\n\n**Fixes:**\n\n1. Add an `EmbeddedRouter` to `SecurityReduxEmbeddedProvider` that\nreuses a host Router when present and if not uses `createMemoryHistory`\nto create a `Router`, so `useLocation` (used inside `ModalInspectQuery`)\nworks\n2. Preview and the Entity Analytics flyout were both registering Risk\nScore Inspect under the same Redux id. Closing the flyout cleared that\nregistration, so Inspect in Preview stayed disabled. Preview now uses\nits own Inspect ids so the flyout can’t wipe them.\n\n## How to test\n\n1. Start Elasticsearch with EIS enabled (to use Agent Builder).\n2. Load some data. I used the `risk-score-v2` command from\n[security-documents-generator](https://github.com/elastic/security-documents-generator):\n  ```\n  yarn start risk-score-v2\n  ```\n4. Ask about information about an entity with risk score in the Agent\nBuilder chat\n5. Click _Preview_ on the entity attachment\n6. On the Risk Score table, click _Inspect_ — the Inspect modal should\nopen (no _Couldn't render this attachment_)\n7. From the entity attachment, click `Open in Entity Analytics`, close\nthe entity flyout, return to Preview — Inspect button should still be\nenabled\n8. From `app/agent_builder`, open a conversation with an entity\nattachment, click _Preview_ — Preview should render normally and Inspect\nshould still work\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/dfb27d31-fc6b-4742-9105-320300dc6f4c\n\n### After\n\n\nhttps://github.com/user-attachments/assets/1cbd778c-929a-4bd1-87c4-f31c1675a4b5","sha":"129d345e2bfdffa8b8c2a016320f12a357017534","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:Entity Analytics","backport:version","v9.5.0","v9.6.0"],"title":"[Entity Analytics][Bugfix] Risk score inspect not working from entity preview","number":278949,"url":"https://github.com/elastic/kibana/pull/278949","mergeCommit":{"message":"[Entity Analytics][Bugfix] Risk score inspect not working from entity preview (#278949)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/278006\n\n**Issues:**\n\n1. Clicking _Inspect_ on Risk Score in the Agent Builder entity\nattachment Preview showed **Couldn't render this attachment** when the\npreview was opened from the side chat\n2. While testing I also noticed that from the entity attachment: open\nthe Preview → click on `Open in Entity Analytics` from the attachment →\nclose the entity flyout → Risk Score Inspect in Preview is now disabled\n\n**Fixes:**\n\n1. Add an `EmbeddedRouter` to `SecurityReduxEmbeddedProvider` that\nreuses a host Router when present and if not uses `createMemoryHistory`\nto create a `Router`, so `useLocation` (used inside `ModalInspectQuery`)\nworks\n2. Preview and the Entity Analytics flyout were both registering Risk\nScore Inspect under the same Redux id. Closing the flyout cleared that\nregistration, so Inspect in Preview stayed disabled. Preview now uses\nits own Inspect ids so the flyout can’t wipe them.\n\n## How to test\n\n1. Start Elasticsearch with EIS enabled (to use Agent Builder).\n2. Load some data. I used the `risk-score-v2` command from\n[security-documents-generator](https://github.com/elastic/security-documents-generator):\n  ```\n  yarn start risk-score-v2\n  ```\n4. Ask about information about an entity with risk score in the Agent\nBuilder chat\n5. Click _Preview_ on the entity attachment\n6. On the Risk Score table, click _Inspect_ — the Inspect modal should\nopen (no _Couldn't render this attachment_)\n7. From the entity attachment, click `Open in Entity Analytics`, close\nthe entity flyout, return to Preview — Inspect button should still be\nenabled\n8. From `app/agent_builder`, open a conversation with an entity\nattachment, click _Preview_ — Preview should render normally and Inspect\nshould still work\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/dfb27d31-fc6b-4742-9105-320300dc6f4c\n\n### After\n\n\nhttps://github.com/user-attachments/assets/1cbd778c-929a-4bd1-87c4-f31c1675a4b5","sha":"129d345e2bfdffa8b8c2a016320f12a357017534"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278949","number":278949,"mergeCommit":{"message":"[Entity Analytics][Bugfix] Risk score inspect not working from entity preview (#278949)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/278006\n\n**Issues:**\n\n1. Clicking _Inspect_ on Risk Score in the Agent Builder entity\nattachment Preview showed **Couldn't render this attachment** when the\npreview was opened from the side chat\n2. While testing I also noticed that from the entity attachment: open\nthe Preview → click on `Open in Entity Analytics` from the attachment →\nclose the entity flyout → Risk Score Inspect in Preview is now disabled\n\n**Fixes:**\n\n1. Add an `EmbeddedRouter` to `SecurityReduxEmbeddedProvider` that\nreuses a host Router when present and if not uses `createMemoryHistory`\nto create a `Router`, so `useLocation` (used inside `ModalInspectQuery`)\nworks\n2. Preview and the Entity Analytics flyout were both registering Risk\nScore Inspect under the same Redux id. Closing the flyout cleared that\nregistration, so Inspect in Preview stayed disabled. Preview now uses\nits own Inspect ids so the flyout can’t wipe them.\n\n## How to test\n\n1. Start Elasticsearch with EIS enabled (to use Agent Builder).\n2. Load some data. I used the `risk-score-v2` command from\n[security-documents-generator](https://github.com/elastic/security-documents-generator):\n  ```\n  yarn start risk-score-v2\n  ```\n4. Ask about information about an entity with risk score in the Agent\nBuilder chat\n5. Click _Preview_ on the entity attachment\n6. On the Risk Score table, click _Inspect_ — the Inspect modal should\nopen (no _Couldn't render this attachment_)\n7. From the entity attachment, click `Open in Entity Analytics`, close\nthe entity flyout, return to Preview — Inspect button should still be\nenabled\n8. From `app/agent_builder`, open a conversation with an entity\nattachment, click _Preview_ — Preview should render normally and Inspect\nshould still work\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/dfb27d31-fc6b-4742-9105-320300dc6f4c\n\n### After\n\n\nhttps://github.com/user-attachments/assets/1cbd778c-929a-4bd1-87c4-f31c1675a4b5","sha":"129d345e2bfdffa8b8c2a016320f12a357017534"}}]}] BACKPORT-->