### PR TITLE
Bound unbounded strings in content-management, home, feedback, and intercepts route schemas

### DIFF
--- a/src/platform/packages/shared/content-management/access_control/access_control_server/src/register_access_control.ts
+++ b/src/platform/packages/shared/content-management/access_control/access_control_server/src/register_access_control.ts
@@ -24,7 +24,7 @@ export const registerAccessControl = async ({
       validate: {
         request: {
           params: schema.object({
-            contentTypeId: schema.string(),
+            contentTypeId: schema.string({ minLength: 1, maxLength: 256 }),
           }),
         },
         response: {
@@ -89,8 +89,8 @@ export const registerAccessControl = async ({
           body: schema.object({
             objects: schema.arrayOf(
               schema.object({
-                type: schema.string(),
-                id: schema.string(),
+                type: schema.string({ minLength: 1, maxLength: 256 }),
+                id: schema.string({ minLength: 1, maxLength: 256 }),
               }),
               { maxSize: 100 }
             ),
@@ -107,12 +107,12 @@ export const registerAccessControl = async ({
                 // codeql[js/kibana/unbounded-array-in-schema] output schema — server controls the response size
                 results: schema.arrayOf(
                   schema.object({
-                    type: schema.string(),
-                    id: schema.string(),
+                    type: schema.string({ minLength: 1, maxLength: 256 }),
+                    id: schema.string({ minLength: 1, maxLength: 256 }),
                     success: schema.boolean(),
                     error: schema.maybe(
                       schema.object({
-                        message: schema.string(),
+                        message: schema.string({ maxLength: 2048 }),
                         statusCode: schema.number(),
                       })
                     ),

--- a/src/platform/packages/shared/content-management/access_control/access_control_server/src/register_access_control.ts
+++ b/src/platform/packages/shared/content-management/access_control/access_control_server/src/register_access_control.ts
@@ -107,12 +107,15 @@ export const registerAccessControl = async ({
                 // codeql[js/kibana/unbounded-array-in-schema] output schema — server controls the response size
                 results: schema.arrayOf(
                   schema.object({
-                    type: schema.string({ minLength: 1, maxLength: 256 }),
-                    id: schema.string({ minLength: 1, maxLength: 256 }),
+                    // codeql[js/kibana/unbounded-string-in-schema] output schema — server controls the response size
+                    type: schema.string(),
+                    // codeql[js/kibana/unbounded-string-in-schema] output schema — server controls the response size
+                    id: schema.string(),
                     success: schema.boolean(),
                     error: schema.maybe(
                       schema.object({
-                        message: schema.string({ maxLength: 2048 }),
+                        // codeql[js/kibana/unbounded-string-in-schema] output schema — server controls the response size
+                        message: schema.string(),
                         statusCode: schema.number(),
                       })
                     ),

--- a/src/platform/packages/shared/content-management/content_insights/content_insights_server/src/register.ts
+++ b/src/platform/packages/shared/content-management/content_insights/content_insights_server/src/register.ts
@@ -81,7 +81,7 @@ export const registerContentInsights = (
   const router = http.createRouter();
   const validate = {
     params: schema.object({
-      id: schema.string(),
+      id: schema.string({ minLength: 1, maxLength: 256 }),
       eventType: schema.literal('viewed'),
     }),
   };

--- a/src/platform/packages/shared/content-management/favorites/favorites_server/src/favorites_routes.ts
+++ b/src/platform/packages/shared/content-management/favorites/favorites_server/src/favorites_routes.ts
@@ -41,6 +41,8 @@ export function registerFavoritesRoutes({
   favoritesRegistry: FavoritesRegistry;
 }) {
   const typeSchema = schema.string({
+    minLength: 1,
+    maxLength: 256,
     validate: (type) => {
       if (!favoritesRegistry.hasType(type)) {
         return `Unknown favorite type: ${type}`;
@@ -75,7 +77,7 @@ export function registerFavoritesRoutes({
       path: '/internal/content_management/favorites/{type}/{id}/favorite',
       validate: {
         params: schema.object({
-          id: schema.string(),
+          id: schema.string({ minLength: 1, maxLength: 256 }),
           type: typeSchema,
         }),
         body: schema.maybe(
@@ -145,7 +147,7 @@ export function registerFavoritesRoutes({
       path: '/internal/content_management/favorites/{type}/{id}/unfavorite',
       validate: {
         params: schema.object({
-          id: schema.string(),
+          id: schema.string({ minLength: 1, maxLength: 256 }),
           type: typeSchema,
         }),
       },

--- a/src/platform/plugins/shared/home/server/routes/fetch_es_hits_status.ts
+++ b/src/platform/plugins/shared/home/server/routes/fetch_es_hits_status.ts
@@ -22,8 +22,8 @@ export const registerHitsStatusRoute = (router: IRouter) => {
       },
       validate: {
         body: schema.object({
-          index: schema.string(),
-          query: schema.recordOf(schema.string(), schema.any()),
+          index: schema.string({ minLength: 1, maxLength: 1024 }),
+          query: schema.recordOf(schema.string({ maxLength: 1024 }), schema.any()),
         }),
       },
     },

--- a/src/platform/plugins/shared/home/server/services/sample_data/routes/install.ts
+++ b/src/platform/plugins/shared/home/server/services/sample_data/routes/install.ts
@@ -34,9 +34,9 @@ export function createInstallRoute(
         },
       },
       validate: {
-        params: schema.object({ id: schema.string() }),
+        params: schema.object({ id: schema.string({ minLength: 1, maxLength: 256 }) }),
         // TODO validate now as date
-        query: schema.object({ now: schema.maybe(schema.string()) }),
+        query: schema.object({ now: schema.maybe(schema.string({ maxLength: 64 })) }),
       },
     },
     async (context, req, res) => {

--- a/src/platform/plugins/shared/home/server/services/sample_data/routes/uninstall.ts
+++ b/src/platform/plugins/shared/home/server/services/sample_data/routes/uninstall.ts
@@ -34,7 +34,7 @@ export function createUninstallRoute(
         },
       },
       validate: {
-        params: schema.object({ id: schema.string() }),
+        params: schema.object({ id: schema.string({ minLength: 1, maxLength: 256 }) }),
       },
     },
     async (context, request, response) => {

--- a/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
+++ b/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
@@ -12,7 +12,7 @@ import { FEEDBACK_SUBMITTED_EVENT_TYPE } from '../src';
 const feedbackQuestionSchema = schema.object({
   id: schema.string({ minLength: 1, maxLength: 256 }),
   question: schema.string({ maxLength: 1024 }),
-  answer: schema.string({ maxLength: 4096 }),
+  answer: schema.string({ maxLength: 16384 }),
 });
 
 const feedbackBodySchema = schema.object({

--- a/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
+++ b/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
@@ -10,20 +10,20 @@ import type { IRouter, AnalyticsServiceSetup } from '@kbn/core/server';
 import { FEEDBACK_SUBMITTED_EVENT_TYPE } from '../src';
 
 const feedbackQuestionSchema = schema.object({
-  id: schema.string(),
-  question: schema.string(),
-  answer: schema.string(),
+  id: schema.string({ minLength: 1, maxLength: 256 }),
+  question: schema.string({ maxLength: 1024 }),
+  answer: schema.string({ maxLength: 4096 }),
 });
 
 const feedbackBodySchema = schema.object({
-  app_id: schema.string(),
-  user_email: schema.maybe(schema.string()),
-  solution: schema.string(),
+  app_id: schema.string({ minLength: 1, maxLength: 256 }),
+  user_email: schema.maybe(schema.string({ maxLength: 256 })),
+  solution: schema.string({ maxLength: 256 }),
   csat_score: schema.maybe(schema.number()),
   questions: schema.maybe(schema.arrayOf(feedbackQuestionSchema, { maxSize: 2 })),
-  organization_id: schema.maybe(schema.string()),
+  organization_id: schema.maybe(schema.string({ maxLength: 256 })),
   allow_email_contact: schema.boolean(),
-  url: schema.string(),
+  url: schema.string({ maxLength: 2048 }),
 });
 
 export function registerSendFeedbackRoute(router: IRouter, analytics: AnalyticsServiceSetup) {

--- a/x-pack/platform/plugins/private/intercepts/server/orchestrator.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/orchestrator.ts
@@ -110,7 +110,7 @@ export class InterceptsTriggerOrchestrator {
         path: TRIGGER_INFO_API_ROUTE,
         validate: {
           body: schema.object({
-            triggerId: schema.string(),
+            triggerId: schema.string({ minLength: 1, maxLength: 256 }),
           }),
         },
         security: {

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_user_interaction.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_user_interaction.ts
@@ -33,7 +33,7 @@ export class InterceptUserInteractionService {
         path: TRIGGER_USER_INTERACTION_METADATA_API_ROUTE,
         validate: {
           params: schema.object({
-            triggerId: schema.string(),
+            triggerId: schema.string({ minLength: 1, maxLength: 256 }),
           }),
         },
         security: {
@@ -65,7 +65,7 @@ export class InterceptUserInteractionService {
         path: TRIGGER_USER_INTERACTION_METADATA_API_ROUTE,
         validate: {
           params: schema.object({
-            triggerId: schema.string(),
+            triggerId: schema.string({ minLength: 1, maxLength: 256 }),
           }),
           body: schema.object({
             lastInteractedInterceptId: schema.number(),


### PR DESCRIPTION
Part of https://github.com/elastic/kibana-team/issues/3691

## Summary

Adds upper length bounds (`maxLength`) to `schema.string()` fields in several route **request** schemas that previously had no ceiling. Cheap DoS-hardening against oversized inputs, flagged by CodeQL rule `js/kibana/unbounded-string-in-schema`.

Only request (input) schemas are bounded. Response (output) schema strings are left unbounded — the server controls response size — with inline `codeql[js/kibana/unbounded-string-in-schema]` suppression comments.

content-management:
- favorites: `id` and `type` (256)
- content_insights: `id` (256)
- access_control: request `contentTypeId` and `objects` `type`/`id` (256); `results` response schema left unbounded with suppression comments

home:
- sample_data install: `id` (256), `now` (64); uninstall: `id` (256)
- hits_status: `index` (1024), `query` record key (1024)

feedback:
- send_feedback: ids/email/solution (256), `url` (2048), `question` (1024), `answer` (16k)

intercepts:
- trigger routes: `triggerId` (256)


<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->