### PR TITLE
[Discover] fix delete Dataview flyout relationships link

### DIFF
--- a/src/platform/plugins/shared/data_view_management/moon.yml
+++ b/src/platform/plugins/shared/data_view_management/moon.yml
@@ -62,6 +62,7 @@ dependsOn:
   - '@kbn/cps'
   - '@kbn/discover-utils'
   - '@kbn/scout'
+  - '@kbn/core-http-browser-mocks'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.test.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.test.tsx
@@ -7,15 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/public';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import {
   DeleteModalContent,
   relationshipCalloutText,
   spacesWarningText,
 } from './delete_data_view_flyout_content';
 import type { RemoveDataViewProps } from '../edit_index_pattern';
+import { mockManagementPlugin } from '../../mocks';
 
 const mockViews: RemoveDataViewProps[] = [
   {
@@ -53,100 +57,71 @@ describe('DeleteModalContent', () => {
     setReviewedItems = jest.fn();
   });
 
-  it('renders warning callout when no relationships', () => {
+  const renderContent = (
+    overrides: Partial<React.ComponentProps<typeof DeleteModalContent>> = {},
+    context = mockManagementPlugin.createIndexPatternManagmentContext()
+  ) =>
     render(
       <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={{ '1': [], '2': [] }}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
+        <KibanaContextProvider services={context}>
+          <DeleteModalContent
+            views={mockViews}
+            hasSpaces={true}
+            relationships={mockRelationships}
+            reviewedItems={reviewedItems}
+            setReviewedItems={setReviewedItems}
+            {...overrides}
+          />
+        </KibanaContextProvider>
       </IntlProvider>
     );
-    expect(screen.getByText(spacesWarningText)).toBeInTheDocument();
-    expect(screen.getByText(/Successfully deleted 2 data views/i)).toBeInTheDocument();
+
+  it('renders warning callout when no relationships', () => {
+    renderContent({ relationships: { '1': [], '2': [] } });
+    expect(screen.getByText(spacesWarningText)).toBeVisible();
+    expect(screen.getByText(/Successfully deleted 2 data views/i)).toBeVisible();
   });
 
   it('renders danger callout when relationships exist', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
-    );
-    expect(screen.getByText(relationshipCalloutText)).toBeInTheDocument();
+    renderContent();
+    expect(screen.getByText(relationshipCalloutText)).toBeVisible();
   });
 
   it('renders table with data view names and spaces', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
-    );
-    expect(screen.getByText('Data View 1')).toBeInTheDocument();
-    expect(screen.getByText('Data View 2')).toBeInTheDocument();
-    expect(screen.getByText('all')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
+    renderContent();
+    expect(screen.getByText('Data View 1')).toBeVisible();
+    expect(screen.getByText('Data View 2')).toBeVisible();
+    expect(screen.getByText('all')).toBeVisible();
+    expect(screen.getByText('1')).toBeVisible();
   });
 
   it('shows "Review" button for views with relationships', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
-    );
+    renderContent();
     expect(screen.getAllByText('Review').length).toBe(1);
   });
 
-  it('expands relationship details when "Review" is clicked', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
-    );
-    const reviewBtn = screen.getByRole('button', { name: /Expand/i });
-    fireEvent.click(reviewBtn);
-    expect(screen.getByText('Dashboard 1')).toBeInTheDocument();
+  it('expands relationship details when "Review" is clicked', async () => {
+    renderContent();
+    await userEvent.click(screen.getByRole('button', { name: /Expand/i }));
+    expect(screen.getByText('Dashboard 1')).toBeVisible();
     expect(setReviewedItems).toHaveBeenCalled();
   });
 
-  it('renders without spaces column if hasSpaces is false', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={false}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
+  it('renders related object links with the current space basePath', async () => {
+    const context = mockManagementPlugin.createIndexPatternManagmentContext();
+    context.http = httpServiceMock.createStartContract({ basePath: '/s/space-a' });
+
+    renderContent({}, context);
+    await userEvent.click(screen.getByRole('button', { name: /Expand/i }));
+
+    expect(screen.getByText('Dashboard 1').closest('a')).toHaveAttribute(
+      'href',
+      '/s/space-a/app/dashboards#/view/rel-1'
     );
+  });
+
+  it('renders without spaces column if hasSpaces is false', () => {
+    renderContent({ hasSpaces: false });
     expect(screen.queryByText('Spaces')).not.toBeInTheDocument();
   });
 });

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
@@ -24,8 +24,10 @@ import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/p
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useState, type ReactNode } from 'react';
 import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { RemoveDataViewProps } from '../edit_index_pattern';
 import { MAX_DISPLAYED_RELATIONSHIPS } from '../../constants';
+import type { IndexPatternManagmentContext } from '../../types';
 
 const all = i18n.translate('indexPatternManagement.dataViewTable.spaceCountAll', {
   defaultMessage: 'all',
@@ -84,6 +86,8 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
   reviewedItems,
   setReviewedItems,
 }) => {
+  const { http } = useKibana<IndexPatternManagmentContext>().services;
+
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<Record<string, ReactNode>>(
     {}
   );
@@ -103,7 +107,7 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
           }),
           render: (meta: SavedObjectRelation['meta']) => {
             return meta.inAppUrl ? (
-              <EuiLink target="_blank" href={meta.inAppUrl.path}>
+              <EuiLink target="_blank" href={http.basePath.prepend(meta.inAppUrl.path)}>
                 {meta.title}
               </EuiLink>
             ) : (

--- a/src/platform/plugins/shared/data_view_management/tsconfig.json
+++ b/src/platform/plugins/shared/data_view_management/tsconfig.json
@@ -54,6 +54,7 @@
     "@kbn/cps",
     "@kbn/discover-utils",
     "@kbn/scout",
+    "@kbn/core-http-browser-mocks",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/274785
## Summary
DataView relationship links were not built correctly within spaces and lead to a 404 page.

**Steps to reproduce**
- Create a custom Kibana Space (e.g. space-a) and ensure it has access to Stack Management → Data Views.
- In space-a, create or share a Data View that is used by at least one saved object in that space (e.g. a saved search or dashboard).
- Navigate to Stack Management → Data Views while in space-a (URL should include /s/space-a/).
- Open the Data View and confirm on the Relationships tab that related objects link correctly (hover a link — URL includes /s/space-a/).
- Initiate deletion of the Data View (from the detail page or the list page).
- In the Delete Data View flyout, expand Review for the Data View and hover a related object link.

### After fix
<img width="1713" height="871" alt="dataview2" src="https://github.com/user-attachments/assets/88b6cc14-06c2-4bce-a3cc-ef83ac797a7a" />


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->