### PR TITLE
[Security Solution][Cypress] Unskip Inspect Explore pages - Network page test (#199563)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect/inspect_button.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect/inspect_button.cy.ts
@@ -24,9 +24,14 @@ import { mockRiskEngineEnabled } from '../../../tasks/entity_analytics';
 
 const DATA_VIEW = 'auditbeat-*';
 
-// FLAKY: https://github.com/elastic/kibana/issues/199563
-// FLAKY: https://github.com/elastic/kibana/issues/178367
-describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => {
+// The Hosts and Users pages in this suite are still individually flaky/skipped for reasons
+// tracked by their own issues below. Their root cause has not been verified as fixed, so they
+// stay skipped here. Do not remove these without separately verifying and closing those issues.
+// FLAKY (Hosts page): https://github.com/elastic/kibana/issues/178367
+// FLAKY (Users page): https://github.com/elastic/kibana/issues/199583
+const SKIPPED_PAGES = ['Hosts', 'Users'];
+
+describe('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     // illegal_argument_exception: unknown setting [index.lifecycle.name]
     cy.task('esArchiverLoad', { archiveName: 'risk_scores_new' });
@@ -44,7 +49,7 @@ describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => 
     /**
      * Group all tests of a page into one "it" call to improve speed
      */
-    it(`inspect ${pageName} page`, () => {
+    const testBody = () => {
       visitWithTimeRange(url, {
         visitOptions: {
           onLoad: () => {
@@ -79,6 +84,16 @@ describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => 
 
         closesModal();
       });
-    });
+    };
+
+    // NOTE: the CI spec load-balancer statically parses this file for literal `it`/`it.skip`
+    // calls, so this must stay an if/else rather than a `const itFn = cond ? it.skip : it`
+    // (a dynamic reference isn't recognized and would cause the whole file to be treated as
+    // fully skipped and excluded from CI runs).
+    if (SKIPPED_PAGES.includes(pageName)) {
+      it.skip(`inspect ${pageName} page`, testBody);
+    } else {
+      it(`inspect ${pageName} page`, testBody);
+    }
   });
 });


### PR DESCRIPTION
Fixes #199563

## Summary

**Problem:** `Inspect Explore pages inspect Network page` in `inspect_button.cy.ts` was timing out after 300s waiting for `[data-test-subj="sourcerer-trigger"]`, which never appeared. It was statically skipped (via a top-level `describe.skip`) in March 2025.

**Root cause:** The failure originated from `selectDataView(DATA_VIEW)` (in the test's `onLoad` hook), which called into `tasks/sourcerer.ts`'s `openSourcerer`/`selectDataView`, clicking a now-defunct `sourcerer-trigger" UI element. That code path no longer exists: commit [c30b6a6f4e9b](https://github.com/elastic/kibana/commit/c30b6a6f4e9b) ("[Security Solution] turn on newDataViewPickerEnabled feature flag", #234101) removed the `selectDataView(DATA_VIEW)` call from this test entirely, and `tasks/sourcerer.ts` has since been deleted from the suite. The test now provisions its data view via a direct API call (`postDataView`) instead of driving the old sourcerer UI — the index pattern assertion still passes because Security Solution's default data view pattern (`INCLUDE_INDEX_PATTERN` in `common/constants.ts`) already contains `auditbeat-*` as a substring, so no manual data-view selection was ever strictly required for this assertion to pass. The original 300s timeout is therefore structurally impossible to hit anymore.

I checked for duplicate/lower-layer coverage per the epic's redundancy guidance before unskipping: there are Jest unit tests for the Inspect modal component (`public/common/components/inspect/modal.test.tsx`), but those use fully synthetic request/response props and don't exercise any real page, embeddable, or Lens/table wiring. This Cypress test's actual value is verifying that ~14 real KPI/Lens embeddables and tables on the live Network page each wire up their inspect button to the correct index pattern — genuine E2E/integration coverage not duplicated elsewhere. So I kept it as a Cypress E2E test rather than deleting or migrating it.

**What I actually fixed:**
- Removed `describe.skip` (was skipping all 3 pages: Hosts, Network, Users) and replaced it with a plain `describe`.
- Added a small `SKIPPED_PAGES` allow-list so only the `inspect Network page` case (this issue's scope) now runs; `inspect Hosts page` (#178367) and `inspect Users page` (#199583) remain individually skipped via `it.skip`, since those are tracked by separate issues and out of scope here. Note: the CI spec load-balancer (`scripts/run_cypress/utils.ts`) statically parses the file for literal `it`/`it.skip` calls to decide whether a spec has any runnable tests, so the per-page skip is implemented as a literal `if/else` between `it(...)` and `it.skip(...)` (a `const itFn = cond ? it.skip : it` indirection is invisible to that parser and would cause the whole file to be treated as fully skipped and excluded from CI).
- No production code changes — this is a test-only change.

**Risk:** Low. Test-only change; only the `inspect Network page` case starts running again, and it does not touch any shared setup used by the still-skipped Hosts/Users cases beyond removing the top-level `.skip`.

## Repro & Verification

- Confirmed via `git log`/`git show` that the exact code (`tasks/sourcerer.ts`, the `selectDataView` call site at the line number cited in the CI stack trace) was deleted by commit c30b6a6f4e9b — the original failure mode cannot occur anymore.
- Ran `yarn cypress:ess --spec './cypress/e2e/explore/inspect/inspect_button.cy.ts'` locally (ESS, real ES+Kibana via FTR). The machine was under very heavy concurrent load from other agents/processes during this session (sustained load average 25-46, multiple other Docker ES clusters and Kibana FTR stacks running in parallel), and both my run and Cypress's own automatic in-place retry hit an unrelated whole-app crash (Kibana's generic core `FatalErrorsService` "Elastic did not load properly" screen, triggered by a null-dereference `TypeError` during React bootstrap) before the test's own inspect logic ever ran — this is Kibana core's top-level uncaught-exception boundary, unrelated to the Network page or inspect feature, and consistent with resource-starvation-induced chunk-loading races rather than a product regression. I'm flagging this candidly rather than claiming a clean local pass. `node scripts/type_check.js` against `cypress/tsconfig.json` and `prettier --check` both pass on the changed file.
- Given the strong static evidence (exact line-for-line match between the original CI stack trace and the deleted code), I'm confident in this fix, but a maintainer re-run of CI (or a local re-run on a quieter machine) would be good extra confirmation.

Made with Cursor

Made with [Cursor](https://cursor.com)