### PR TITLE
[Fleet] Exclude agentless policies from policy selector in enrollment token tab

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/new_enrollment_key_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/new_enrollment_key_modal.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act } from '@testing-library/react';
+
+import { createFleetTestRendererMock } from '../mock';
+import type { AgentPolicy } from '../types';
+
+import { NewEnrollmentTokenModal } from './new_enrollment_key_modal';
+
+jest.mock('../hooks', () => ({
+  ...jest.requireActual('../hooks'),
+  useStartServices: jest.fn().mockReturnValue({
+    notifications: {
+      toasts: {
+        addSuccess: jest.fn(),
+        addError: jest.fn(),
+      },
+    },
+  }),
+  sendCreateEnrollmentAPIKey: jest.fn().mockResolvedValue({ data: { item: {} } }),
+}));
+
+const MOCK_POLICIES = [
+  { id: 'normal-policy', name: 'Normal Policy', revision: 1 },
+  { id: 'managed-policy', name: 'Managed Policy', revision: 1, is_managed: true },
+  { id: 'agentless-policy', name: 'Agentless Policy', revision: 1, supports_agentless: true },
+] as AgentPolicy[];
+
+describe('NewEnrollmentTokenModal', () => {
+  it('excludes managed and agentless policies from the policy selector', async () => {
+    const testRenderer = createFleetTestRendererMock();
+
+    // Add a second normal policy so the dropdown actually shows items when opened
+    const policies = [
+      ...MOCK_POLICIES,
+      { id: 'normal-policy-2', name: 'Normal Policy 2', revision: 1 },
+    ] as AgentPolicy[];
+
+    const results = testRenderer.render(
+      <NewEnrollmentTokenModal agentPolicies={policies} onClose={jest.fn()} />
+    );
+
+    // Open the combobox dropdown to see the remaining non-selected options
+    await act(async () => {
+      results.getByTestId('comboBoxToggleListButton').click();
+    });
+
+    // "Normal Policy 2" should be available (Normal Policy 1 is auto-selected so not in the list)
+    expect(results.getByText('Normal Policy 2')).toBeInTheDocument();
+    // Managed and agentless policies should never appear
+    expect(results.queryByText('Managed Policy')).toBeNull();
+    expect(results.queryByText('Agentless Policy')).toBeNull();
+  });
+
+  it('renders with no options when all policies are managed or agentless', () => {
+    const testRenderer = createFleetTestRendererMock();
+    const policiesAllExcluded = [
+      { id: 'managed-policy', name: 'Managed Policy', revision: 1, is_managed: true },
+      { id: 'agentless-policy', name: 'Agentless Policy', revision: 1, supports_agentless: true },
+    ] as AgentPolicy[];
+
+    const results = testRenderer.render(
+      <NewEnrollmentTokenModal agentPolicies={policiesAllExcluded} onClose={jest.fn()} />
+    );
+
+    expect(results.getByTestId('createEnrollmentTokenSelectField')).toBeInTheDocument();
+    // The combobox should be empty — no pre-selected value
+    expect(results.queryByText('Managed Policy')).toBeNull();
+    expect(results.queryByText('Agentless Policy')).toBeNull();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/components/new_enrollment_key_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/new_enrollment_key_modal.tsx
@@ -88,7 +88,7 @@ export const NewEnrollmentTokenModal: React.FunctionComponent<Props> = ({
 
   const selectPolicyOptions = useMemo(() => {
     return agentPolicies
-      .filter((agentPolicy) => !agentPolicy.is_managed)
+      .filter((agentPolicy) => !agentPolicy.is_managed && !agentPolicy.supports_agentless)
       .map((agentPolicy) => ({
         key: agentPolicy.id,
         label: agentPolicy.name,


### PR DESCRIPTION
Fixes #273056.

## Summary
Agentless policies were showing up in the policy selector when creating an enrollment token from the Fleet Enrollment tab. Since enrollment tokens only apply to agent-based policies, selecting an agentless policy would silently fail to create a token.

The fix adds a supports_agentless check to the policy filter in NewEnrollmentTokenModal, matching the pattern already used in the sibling enrollment token list page and the agent enrollment flyout.

### Testing
Repro steps (before fix):

- Set up Kibana with at least one agentless integration installed.
- Go to Fleet > Enrollment tokens tab.
- Click Create enrollment token.
- Open the Policy dropdown: agentless policies don't appear. Only agent-based policies are listed.

### Checklist
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks — this is a purely additive UI filter change with no API or data model impact.




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->