### PR TITLE
chore(eslint): enforce `@elastic/eui/accessible-interactive-element' rule at the error level

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -477,6 +477,7 @@ module.exports = {
     '@elastic/eui/consistent-is-invalid-props': 'error',
     '@elastic/eui/tooltip-no-interactive-content': 'error',
     '@elastic/eui/require-table-caption': 'error',
+    '@elastic/eui/accessible-interactive-element': 'error',
   },
 
   overrides: [

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_tag_badge.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_tag_badge.tsx
@@ -61,7 +61,6 @@ export const RuleTagBadge = <T extends RuleTagBadgeOptions>(props: RuleTagBadgeP
         color="hollow"
         iconType="tag"
         iconSide="left"
-        tabIndex={-1}
         onClick={onClick}
         onClickAriaLabel="Tags"
       >

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_input/components/command_input_clear_history.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_input/components/command_input_clear_history.tsx
@@ -70,7 +70,6 @@ export const CommandInputClearHistory = memo(() => {
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty
             size="xs"
-            tabIndex={-1}
             onClick={handleClearInputHistory}
             disabled={showConfirmModal}
             data-test-subj={getTestId('clearInputHistoryButton')}

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/process_event_dot.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/process_event_dot.tsx
@@ -221,7 +221,7 @@ const UnstyledProcessEventDot = React.memo(
     /**
      * The `left` and `top` values represent the 'center' point of the process node.
      * Since the view has content to the left and above the 'center' point, offset the
-     * position to accomodate for that. This aligns the logical center of the process node
+     * position to accommodate for that. This aligns the logical center of the process node
      * with the correct position on the map.
      */
 
@@ -497,6 +497,7 @@ const UnstyledProcessEventDot = React.memo(
               zIndex: 45,
             }}
           >
+            {/* eslint-disable-next-line @elastic/eui/accessible-interactive-element */}
             <EuiButton
               iconSide={isNodeLoading ? 'right' : 'left'}
               isLoading={isNodeLoading}


### PR DESCRIPTION
## Summary

This PR enforces `@elastic/eui/no-unnamed-interactive-element` rule  at the `error` level in the shared `@kbn/eslint-config` configuration:

- **`@elastic/eui/accessible-interactive-element`** — Ensure interactive EUI components (like e.g. `EuiLink`, `EuiButton`, `EuiRadio`) remain accessible by prohibiting `tabIndex={-1}`, which removes them from keyboard navigation.

### Changes

- `packages/kbn-eslint-config/.eslintrc.js`