### PR TITLE
[Entity Analytics] Fix Host Risk sub tab now shows data

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.test.tsx
@@ -13,8 +13,10 @@ import { useUiSetting } from '../../../common/lib/kibana';
 import { RiskDetailsTabBody } from '.';
 import { EntityType } from '../../../../common/search_strategy';
 import { useRiskScore } from '../../api/hooks/use_risk_score';
+import { useEntityRiskScores } from '../../api/hooks/use_entity_risk_scores';
 
 jest.mock('../../api/hooks/use_risk_score');
+jest.mock('../../api/hooks/use_entity_risk_scores');
 jest.mock('../../../common/containers/query_toggle');
 jest.mock('../../../common/lib/kibana');
 
@@ -27,29 +29,38 @@ describe.each([EntityType.host, EntityType.user])('Risk Tab Body entityType: %s'
     riskEntity,
   };
 
+  const riskScoreState = {
+    loading: false,
+    inspect: {
+      dsl: [],
+      response: [],
+    },
+    isInspected: false,
+    totalCount: 0,
+    data: [],
+    refetch: jest.fn(),
+    hasEngineBeenInstalled: true,
+  };
+
   const mockUseRiskScore = useRiskScore as jest.Mock;
+  const mockUseEntityRiskScores = useEntityRiskScores as jest.Mock;
   const mockUseQueryToggle = useQueryToggle as jest.Mock;
   const mockUseUiSetting = useUiSetting as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseRiskScore.mockReturnValue({
-      loading: false,
-      inspect: {
-        dsl: [],
-        response: [],
-      },
-      isInspected: false,
-      totalCount: 0,
+    mockUseRiskScore.mockReturnValue(riskScoreState);
+    mockUseEntityRiskScores.mockReturnValue({
+      base: riskScoreState,
+      resolution: { state: riskScoreState, hasResolutionGroup: false, resolutionTargetEntityId: undefined },
       refetch: jest.fn(),
-      hasEngineBeenInstalled: true,
     });
     mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: jest.fn() });
     mockUseUiSetting.mockReturnValue(false);
   });
 
-  it('calls with correct arguments for each entity', () => {
+  it('reads from the risk-score index by entity name when entity store V2 is off', () => {
     render(
       <TestProviders>
         <RiskDetailsTabBody {...defaultProps} />
@@ -71,25 +82,30 @@ describe.each([EntityType.host, EntityType.user])('Risk Tab Body entityType: %s'
     });
   });
 
-  it('uses entityId as filter when entityStoreV2 is enabled', () => {
-    mockUseUiSetting.mockReturnValueOnce(true);
+  it('reads from the entity store by entityId when entity store V2 is on', () => {
+    mockUseUiSetting.mockReturnValue(true);
     render(
       <TestProviders>
         <RiskDetailsTabBody {...defaultProps} entityId="entity-123" />
       </TestProviders>
     );
-    expect(mockUseRiskScore).toBeCalledWith(
-      expect.objectContaining({
-        filterQuery: {
-          terms: {
-            [`${riskEntity}.name`]: ['entity-123'],
-          },
-        },
-      })
-    );
+    expect(mockUseEntityRiskScores).toBeCalledWith(riskEntity, 'entity-123');
+    // The legacy read is skipped in V2.
+    expect(mockUseRiskScore.mock.calls[0][0].skip).toEqual(true);
   });
 
-  it("doesn't skip when toggleStatus is true", () => {
+  it('skips the entity store read when the contributors toggle is off in V2', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseQueryToggle.mockReturnValue({ toggleStatus: false, setToggleStatus: jest.fn() });
+    render(
+      <TestProviders>
+        <RiskDetailsTabBody {...defaultProps} entityId="entity-123" />
+      </TestProviders>
+    );
+    expect(mockUseEntityRiskScores).toBeCalledWith(riskEntity, undefined);
+  });
+
+  it("doesn't skip the legacy read when toggleStatus is true", () => {
     render(
       <TestProviders>
         <RiskDetailsTabBody {...defaultProps} />
@@ -98,7 +114,7 @@ describe.each([EntityType.host, EntityType.user])('Risk Tab Body entityType: %s'
     expect(mockUseRiskScore.mock.calls[0][0].skip).toEqual(false);
   });
 
-  it('skips when toggleStatus is false', () => {
+  it('skips the legacy read when toggleStatus is false', () => {
     mockUseQueryToggle.mockReturnValue({ toggleStatus: false, setToggleStatus: jest.fn() });
 
     render(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.test.tsx
@@ -53,7 +53,11 @@ describe.each([EntityType.host, EntityType.user])('Risk Tab Body entityType: %s'
     mockUseRiskScore.mockReturnValue(riskScoreState);
     mockUseEntityRiskScores.mockReturnValue({
       base: riskScoreState,
-      resolution: { state: riskScoreState, hasResolutionGroup: false, resolutionTargetEntityId: undefined },
+      resolution: {
+        state: riskScoreState,
+        hasResolutionGroup: false,
+        resolutionTargetEntityId: undefined,
+      },
       refetch: jest.fn(),
     });
     mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: jest.fn() });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.tsx
@@ -24,6 +24,7 @@ import type { UsersComponentsQueryProps } from '../../../explore/users/pages/nav
 import type { HostsComponentsQueryProps } from '../../../explore/hosts/pages/navigation/types';
 import { HostRiskScoreQueryId, UserRiskScoreQueryId } from '../../common/utils';
 import { useRiskScore } from '../../api/hooks/use_risk_score';
+import { useEntityRiskScores } from '../../api/hooks/use_entity_risk_scores';
 import { useMissingRiskEnginePrivileges } from '../../hooks/use_missing_risk_engine_privileges';
 import { RiskEnginePrivilegesCallOut } from '../risk_engine_privileges_callout';
 import { RiskScoresNoDataDetected } from '../risk_score_no_data_detected';
@@ -67,21 +68,33 @@ const RiskDetailsTabBodyComponent: React.FC<
   const { toggleStatus: contributorsToggleStatus, setToggleStatus: setContributorsToggleStatus } =
     useQueryToggle(`${queryId} contributors`);
 
-  const filterQuery = useMemo(() => {
-    if (entityStoreV2Enabled && entityId != null) {
-      return buildEntityNameFilter(riskEntity, [entityId]);
-    }
+  // Legacy (non-V2) read: query the risk-score index by entity name within the page's
+  // time range. In V2 the documents are keyed by EUID and stamped with the calculation
+  // time, so this query does not match them. The V2 read below is used instead.
+  const filterQuery = useMemo(
+    () => (entityName ? buildEntityNameFilter(riskEntity, [entityName]) : {}),
+    [entityName, riskEntity]
+  );
 
-    return entityName ? buildEntityNameFilter(riskEntity, [entityName]) : {};
-  }, [entityStoreV2Enabled, entityId, entityName, riskEntity]);
-
-  const { data, loading, refetch, inspect, hasEngineBeenInstalled } = useRiskScore({
+  const legacyRiskScore = useRiskScore({
     filterQuery,
     onlyLatest: false,
     riskEntity,
-    skip: !contributorsToggleStatus,
+    skip: entityStoreV2Enabled || !contributorsToggleStatus,
     timerange,
   });
+
+  // V2 read: same path the entity flyout uses. Filters by `<entity>.risk.id_value` (the
+  // EUID) and returns full records including `risk.inputs`, which the contributors panel
+  // needs. Passing `undefined` as the id skips the query (when V2 is off or toggled shut).
+  const { base: entityStoreRiskScore } = useEntityRiskScores(
+    riskEntity,
+    entityStoreV2Enabled && contributorsToggleStatus ? entityId : undefined
+  );
+
+  const { data, loading, refetch, inspect, hasEngineBeenInstalled } = entityStoreV2Enabled
+    ? entityStoreRiskScore
+    : legacyRiskScore;
 
   useQueryInspector({
     queryId,


### PR DESCRIPTION
## Summary

The shared `RiskDetailsTabBody` component never read the V2path. It was still using `useRiskScore` with a `host.name` filter and a global time-range constraint - neither of which match V2 risk documents.

The entity flyout already reads V2 risk data correctly via `useEntityRiskScores`, which filters by `<entity>.risk.id_value` (the EUID) with no time-range. This fix applies the same pattern to `RiskDetailsTabBody`.

Fixes #278266
Tested locally


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->