### PR TITLE
[9.4] [Discover] Do not apply unit formatters to a histogram field (#279776)

### DIFF
--- a/src/platform/plugins/shared/data_views/common/data_views/data_view.test.ts
+++ b/src/platform/plugins/shared/data_views/common/data_views/data_view.test.ts
@@ -481,6 +481,19 @@ describe('IndexPattern', () => {
         })
       );
     });
+
+    test('should derive a scalar formatter from defaultFormatter', () => {
+      expect(
+        indexPattern.getFormatterForField({
+          name: 'durationSeconds',
+          type: 'number',
+          esTypes: ['long'],
+          searchable: true,
+          aggregatable: true,
+          defaultFormatter: 's',
+        })
+      ).toBeInstanceOf(MockFieldFormatter);
+    });
   });
 
   describe('toSpec', () => {

--- a/src/platform/plugins/shared/field_formats/common/converters/duration.test.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/duration.test.ts
@@ -9,6 +9,7 @@
 
 import { DurationFormat } from './duration';
 import { HTML_CONTEXT_TYPE } from '../content_types';
+import { asPrettyString } from '../utils';
 
 describe('Duration Format', () => {
   test('handles missing values in html context', () => {
@@ -25,6 +26,16 @@ describe('Duration Format', () => {
     expect(duration.convert(undefined, HTML_CONTEXT_TYPE)).toBe(
       '<span class="ffString__emptyValue">(null)</span>'
     );
+  });
+
+  test('renders object values (e.g. histogram fields) as JSON instead of NaN', () => {
+    const formatter = new DurationFormat(
+      { inputFormat: 'seconds', outputFormat: 'humanize' },
+      jest.fn()
+    );
+    const histogramValue = { scale: 20, sum: 0.000825416, min: 0.000825416, max: 0.000825416 };
+
+    expect(formatter.convert(histogramValue)).toBe(asPrettyString(histogramValue));
   });
 
   testCase({

--- a/src/platform/plugins/shared/field_formats/common/converters/duration.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/duration.ts
@@ -20,6 +20,7 @@ import {
   DURATION_INPUT_FORMATS,
   DURATION_OUTPUT_FORMATS,
 } from '../constants/duration_formats';
+import { asPrettyString } from '../utils';
 
 const ratioToSeconds: Record<string, number> = {
   picoseconds: 0.000000000001,
@@ -67,10 +68,16 @@ export class DurationFormat extends FieldFormat {
     };
   }
 
-  textConvert: TextContextTypeConvert = (val: number) => {
+  textConvert: TextContextTypeConvert = (val) => {
     const missing = this.checkForMissingValueText(val);
     if (missing) {
       return missing;
+    }
+
+    // Some fields like histogram have object values that cannot be represented as a duration,
+    // so render them as-is.
+    if (typeof val === 'object') {
+      return asPrettyString(val);
     }
 
     const inputFormat = this.param('inputFormat');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Discover] Do not apply unit formatters to a histogram field (#279776)](https://github.com/elastic/kibana/pull/279776)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastian Delle Donne","email":"sebastian.delledonne@elastic.co"},"sourceCommit":{"committedDate":"2026-07-22T12:36:43Z","message":"[Discover] Do not apply unit formatters to a histogram field (#279776)\n\n- Closes https://github.com/elastic/kibana/issues/275513\n## Summary\nThe Otel SDK posts the `otel.sdk.metric_reader.collection.duration`\nmetric with meta unit as seconds.\nDue to that, the formatter was trying to transform the JSON value of an\nexponential histogram into a number.\n```json\n\"metrics.otel.sdk.metric_reader.collection.duration\" : {\n      \"exponential_histogram\" : {\n        \"type\" : \"exponential_histogram\",\n        \"metadata_field\" : false,\n        \"searchable\" : false,\n        \"aggregatable\" : true,\n        \"inference\" : false,\n        \"time_series_metric\" : \"histogram\",\n        \"meta\" : {\n          \"unit\" : [\n            \"s\"\n          ]\n        }\n      }\n    }\n```\n\nThe fix consists in checking if the value is an object before trying to\nconvert it into a number, this is the same approach taken for numbers ->\nhttps://github.com/elastic/kibana/pull/231481\n\n### Alternatives considered\nConsidered a more top level fix in\n[here](https://github.com/elastic/kibana/pull/279776/changes/5228e2e2f52a3b5154d025f1c7299b94b3a50b5e),\nthat directly avoids to apply unit formatters to field types like\nHISTOGRAM, but it requires to list the affected field types, so it makes\nit more fragile when new types are added.\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2aa708d0ac5b54e77f03eacaa1ffb697e4fd381a","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","Team:DataDiscovery","backport:version","v9.5.0","v9.4.4","v9.6.0"],"title":"[Discover] Do not apply unit formatters to a histogram field","number":279776,"url":"https://github.com/elastic/kibana/pull/279776","mergeCommit":{"message":"[Discover] Do not apply unit formatters to a histogram field (#279776)\n\n- Closes https://github.com/elastic/kibana/issues/275513\n## Summary\nThe Otel SDK posts the `otel.sdk.metric_reader.collection.duration`\nmetric with meta unit as seconds.\nDue to that, the formatter was trying to transform the JSON value of an\nexponential histogram into a number.\n```json\n\"metrics.otel.sdk.metric_reader.collection.duration\" : {\n      \"exponential_histogram\" : {\n        \"type\" : \"exponential_histogram\",\n        \"metadata_field\" : false,\n        \"searchable\" : false,\n        \"aggregatable\" : true,\n        \"inference\" : false,\n        \"time_series_metric\" : \"histogram\",\n        \"meta\" : {\n          \"unit\" : [\n            \"s\"\n          ]\n        }\n      }\n    }\n```\n\nThe fix consists in checking if the value is an object before trying to\nconvert it into a number, this is the same approach taken for numbers ->\nhttps://github.com/elastic/kibana/pull/231481\n\n### Alternatives considered\nConsidered a more top level fix in\n[here](https://github.com/elastic/kibana/pull/279776/changes/5228e2e2f52a3b5154d025f1c7299b94b3a50b5e),\nthat directly avoids to apply unit formatters to field types like\nHISTOGRAM, but it requires to list the affected field types, so it makes\nit more fragile when new types are added.\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2aa708d0ac5b54e77f03eacaa1ffb697e4fd381a"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/280127","number":280127,"state":"OPEN"},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279776","number":279776,"mergeCommit":{"message":"[Discover] Do not apply unit formatters to a histogram field (#279776)\n\n- Closes https://github.com/elastic/kibana/issues/275513\n## Summary\nThe Otel SDK posts the `otel.sdk.metric_reader.collection.duration`\nmetric with meta unit as seconds.\nDue to that, the formatter was trying to transform the JSON value of an\nexponential histogram into a number.\n```json\n\"metrics.otel.sdk.metric_reader.collection.duration\" : {\n      \"exponential_histogram\" : {\n        \"type\" : \"exponential_histogram\",\n        \"metadata_field\" : false,\n        \"searchable\" : false,\n        \"aggregatable\" : true,\n        \"inference\" : false,\n        \"time_series_metric\" : \"histogram\",\n        \"meta\" : {\n          \"unit\" : [\n            \"s\"\n          ]\n        }\n      }\n    }\n```\n\nThe fix consists in checking if the value is an object before trying to\nconvert it into a number, this is the same approach taken for numbers ->\nhttps://github.com/elastic/kibana/pull/231481\n\n### Alternatives considered\nConsidered a more top level fix in\n[here](https://github.com/elastic/kibana/pull/279776/changes/5228e2e2f52a3b5154d025f1c7299b94b3a50b5e),\nthat directly avoids to apply unit formatters to field types like\nHISTOGRAM, but it requires to list the affected field types, so it makes\nit more fragile when new types are added.\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2aa708d0ac5b54e77f03eacaa1ffb697e4fd381a"}}]}] BACKPORT-->