### PR TITLE
[Cases] Gate legacy deprecation copy, dismiss templates banner, fix tour scroll

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -308,6 +308,7 @@ export const LOCAL_STORAGE_KEYS = {
   casesListBannerDismissed: 'cases.list.banner.dismissed.v1',
   caseDetailsTourSeen: 'cases.caseView.tour.seen.v1',
   templateEditorTourSeen: 'cases.templates.editor.tour.seen.v1',
+  templatesListInfoPanelDismissed: 'cases.templates.list.infoPanel.dismissed.v1',
   showLegacyCustomFields: 'cases.showLegacyCustomFields',
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields_deprecation_callout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields_deprecation_callout.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { type ReactNode } from 'react';
+import { EuiCallOut, EuiLink } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useCasesContext } from '../cases_context/use_cases_context';
+import {
+  useCasesFieldLibraryNavigation,
+  useConfigureCasesNavigation,
+} from '../../common/navigation';
+import * as i18n from './translations';
+import * as configureCasesI18n from '../configure_cases/translations';
+
+interface CustomFieldsDeprecationCalloutProps {
+  title?: ReactNode;
+}
+
+/**
+ * Warning callout shown above legacy custom fields when templates v2 is enabled.
+ * Users with settings permission get links to manage fields and disable the legacy
+ * section; users without settings permission get an administrator-contact message.
+ */
+export const CustomFieldsDeprecationCallout: React.FC<CustomFieldsDeprecationCalloutProps> = ({
+  title,
+}) => {
+  const { permissions } = useCasesContext();
+  const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
+  const { getConfigureCasesUrl } = useConfigureCasesNavigation();
+
+  return (
+    <EuiCallOut
+      announceOnMount
+      title={title}
+      color="warning"
+      iconType="warning"
+      size="s"
+      data-test-subj="legacy-custom-fields-deprecation-callout"
+    >
+      {permissions.settings ? (
+        <FormattedMessage
+          id="xpack.cases.caseFormFields.legacyCustomFieldsDeprecationBody"
+          defaultMessage='These custom fields are deprecated and have already been migrated to the new system, so you may see the same fields in both places. Manage them in {customFieldsLink}. To stop showing them here, disable "{switchLabel}" in {settingsLink}.'
+          values={{
+            customFieldsLink: (
+              <EuiLink
+                href={getCasesFieldLibraryUrl()}
+                data-test-subj="legacy-custom-fields-view-new-link"
+              >
+                {i18n.LEGACY_CUSTOM_FIELDS_VIEW_CUSTOM_FIELDS}
+              </EuiLink>
+            ),
+            switchLabel: configureCasesI18n.SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES,
+            settingsLink: (
+              <EuiLink
+                href={getConfigureCasesUrl()}
+                data-test-subj="legacy-custom-fields-view-settings-link"
+              >
+                {i18n.LEGACY_CUSTOM_FIELDS_VIEW_SETTINGS}
+              </EuiLink>
+            ),
+          }}
+        />
+      ) : (
+        <FormattedMessage
+          id="xpack.cases.caseFormFields.legacyCustomFieldsDeprecationBodyNoSettings"
+          defaultMessage="These custom fields are deprecated and have already been migrated to the new system, so you may see the same fields in both places. Contact your administrator to confirm the fields have been migrated, so that the legacy custom fields can be safely removed."
+        />
+      )}
+    </EuiCallOut>
+  );
+};
+CustomFieldsDeprecationCallout.displayName = 'CustomFieldsDeprecationCallout';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
 
-import { renderWithTestingProviders } from '../../common/mock';
+import { noCasesSettingsPermission, renderWithTestingProviders } from '../../common/mock';
 import { FormTestComponent } from '../../common/test_utils';
 import { customFieldsConfigurationMock } from '../../containers/mock';
 import { userProfiles } from '../../containers/user_profiles/api.mock';
@@ -435,6 +435,38 @@ describe('CaseFormFields', () => {
       expect(screen.getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
       expect(screen.getByTestId('legacy-custom-fields-view-settings-link')).toBeInTheDocument();
       expect(screen.getByTestId('legacy-custom-fields-divider')).toBeInTheDocument();
+    });
+
+    it('shows the administrator message in the deprecation callout when the user lacks settings permission', async () => {
+      jest
+        .spyOn(KibanaServices, 'getConfig')
+        .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+          typeof KibanaServices.getConfig
+        >);
+      localStorage.setItem('securitySolution.cases.showLegacyCustomFields', 'true');
+
+      renderWithTestingProviders(
+        <FormTestComponent formDefaultValue={formDefaultValue} onSubmit={onSubmit}>
+          <CaseFormFields
+            isLoading={false}
+            configurationCustomFields={customFieldsConfigurationMock}
+          />
+        </FormTestComponent>,
+        {
+          wrapperProps: { permissions: noCasesSettingsPermission() },
+        }
+      );
+
+      expect(
+        await screen.findByTestId('legacy-custom-fields-deprecation-callout')
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('legacy-custom-fields-view-new-link')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('legacy-custom-fields-view-settings-link')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/Contact your administrator to confirm the fields have been migrated/i)
+      ).toBeInTheDocument();
     });
 
     it('forces legacy custom fields visible when required fields lack defaults', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.test.tsx
@@ -432,8 +432,12 @@ describe('CaseFormFields', () => {
       expect(
         await screen.findByTestId('legacy-custom-fields-deprecation-callout')
       ).toBeInTheDocument();
-      expect(screen.getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
-      expect(screen.getByTestId('legacy-custom-fields-view-settings-link')).toBeInTheDocument();
+      // announceOnMount duplicates content into a live region with the same test subjects.
+      const content = screen.getByTestId('legacy-custom-fields-deprecation-callout__content');
+      expect(within(content).getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
+      expect(
+        within(content).getByTestId('legacy-custom-fields-view-settings-link')
+      ).toBeInTheDocument();
       expect(screen.getByTestId('legacy-custom-fields-divider')).toBeInTheDocument();
     });
 
@@ -460,12 +464,17 @@ describe('CaseFormFields', () => {
       expect(
         await screen.findByTestId('legacy-custom-fields-deprecation-callout')
       ).toBeInTheDocument();
-      expect(screen.queryByTestId('legacy-custom-fields-view-new-link')).not.toBeInTheDocument();
+      const content = screen.getByTestId('legacy-custom-fields-deprecation-callout__content');
       expect(
-        screen.queryByTestId('legacy-custom-fields-view-settings-link')
+        within(content).queryByTestId('legacy-custom-fields-view-new-link')
       ).not.toBeInTheDocument();
       expect(
-        screen.getByText(/Contact your administrator to confirm the fields have been migrated/i)
+        within(content).queryByTestId('legacy-custom-fields-view-settings-link')
+      ).not.toBeInTheDocument();
+      expect(
+        within(content).getByText(
+          /Contact your administrator to confirm the fields have been migrated/i
+        )
       ).toBeInTheDocument();
     });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
@@ -6,8 +6,7 @@
  */
 
 import React, { memo, useEffect } from 'react';
-import { EuiCallOut, EuiFlexGroup, EuiHorizontalRule, EuiLink } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiFlexGroup, EuiHorizontalRule } from '@elastic/eui';
 import { useFormContext } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { Title } from './title';
 import { Tags } from './tags';
@@ -21,12 +20,7 @@ import type { CasesConfigurationUI } from '../../containers/types';
 import { KibanaServices } from '../../common/lib/kibana';
 import { CreateCaseTemplateFields } from '../create/template_fields';
 import { useShowLegacyCustomFields } from '../../common/use_show_old_custom_fields';
-import {
-  useCasesFieldLibraryNavigation,
-  useConfigureCasesNavigation,
-} from '../../common/navigation';
-import * as i18n from './translations';
-import * as configureCasesI18n from '../configure_cases/translations';
+import { CustomFieldsDeprecationCallout } from './custom_fields_deprecation_callout';
 
 interface Props {
   isLoading: boolean;
@@ -46,8 +40,6 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
   const { caseAssignmentAuthorized } = useCasesFeatures();
   const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
   const { showLegacyCustomFields } = useShowLegacyCustomFields(configurationCustomFields);
-  const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
-  const { getConfigureCasesUrl } = useConfigureCasesNavigation();
   const { setFieldValue } = useFormContext();
 
   // When templates v2 is off, always show legacy custom fields (they are the only system).
@@ -64,39 +56,7 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
     }
   }, [isEditMode, showLegacyCustomFieldsInputs, setFieldValue]);
 
-  const deprecationNotice = isTemplatesV2Enabled ? (
-    <EuiCallOut
-      announceOnMount
-      color="warning"
-      iconType="warning"
-      size="s"
-      data-test-subj="legacy-custom-fields-deprecation-callout"
-    >
-      <FormattedMessage
-        id="xpack.cases.caseFormFields.legacyCustomFieldsDeprecationBody"
-        defaultMessage='These custom fields are deprecated and have already been migrated to the new system, so you may see the same fields in both places. Manage them in {customFieldsLink}. To stop showing them here, disable "{switchLabel}" in {settingsLink}.'
-        values={{
-          customFieldsLink: (
-            <EuiLink
-              href={getCasesFieldLibraryUrl()}
-              data-test-subj="legacy-custom-fields-view-new-link"
-            >
-              {i18n.LEGACY_CUSTOM_FIELDS_VIEW_CUSTOM_FIELDS}
-            </EuiLink>
-          ),
-          switchLabel: configureCasesI18n.SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES,
-          settingsLink: (
-            <EuiLink
-              href={getConfigureCasesUrl()}
-              data-test-subj="legacy-custom-fields-view-settings-link"
-            >
-              {i18n.LEGACY_CUSTOM_FIELDS_VIEW_SETTINGS}
-            </EuiLink>
-          ),
-        }}
-      />
-    </EuiCallOut>
-  ) : undefined;
+  const deprecationNotice = isTemplatesV2Enabled ? <CustomFieldsDeprecationCallout /> : undefined;
 
   return (
     <EuiFlexGroup data-test-subj="case-form-fields" direction="column" gutterSize="none">

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.test.tsx
@@ -18,7 +18,11 @@ import {
   customFieldsMock,
   getCaseUsersMockResponse,
 } from '../../../../../containers/mock';
-import { noUpdateCasesPermissions, renderWithTestingProviders } from '../../../../../common/mock';
+import {
+  noUpdateCasesPermissions,
+  noCasesSettingsPermission,
+  renderWithTestingProviders,
+} from '../../../../../common/mock';
 import { CaseViewSidebar } from './case_view_sidebar';
 import type { CaseUI } from '../../../../../../common';
 import { CaseSeverity, ConnectorTypes } from '../../../../../../common/types/domain';
@@ -390,6 +394,67 @@ describe('CaseViewSidebar (redesign)', () => {
       'aria-expanded',
       'false'
     );
+  });
+
+  it('shows settings and custom fields links in the deprecation callout when the user has settings permission', async () => {
+    jest
+      .spyOn(KibanaServices, 'getConfig')
+      .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+        typeof KibanaServices.getConfig
+      >);
+    localStorage.setItem('securitySolution.cases.showLegacyCustomFields', 'true');
+    (useGetCaseConfiguration as jest.Mock).mockReturnValue({
+      data: {
+        customFields: [customFieldsConfigurationMock[1]],
+        observableTypes: [],
+      },
+    });
+
+    renderWithTestingProviders(
+      <CaseViewSidebar caseData={{ ...caseData, customFields: [customFieldsMock[1]] }} />
+    );
+
+    // Accordion is closed by default; open it to reveal the callout.
+    await userEvent.click(screen.getByTestId('case-view-sidebar-legacy-custom-fields-toggle'));
+
+    expect(
+      await screen.findByTestId('legacy-custom-fields-deprecation-callout')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
+    expect(screen.getByTestId('legacy-custom-fields-view-settings-link')).toBeInTheDocument();
+  });
+
+  it('shows the administrator message in the deprecation callout when the user lacks settings permission', async () => {
+    jest
+      .spyOn(KibanaServices, 'getConfig')
+      .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+        typeof KibanaServices.getConfig
+      >);
+    localStorage.setItem('securitySolution.cases.showLegacyCustomFields', 'true');
+    (useGetCaseConfiguration as jest.Mock).mockReturnValue({
+      data: {
+        customFields: [customFieldsConfigurationMock[1]],
+        observableTypes: [],
+      },
+    });
+
+    renderWithTestingProviders(
+      <CaseViewSidebar caseData={{ ...caseData, customFields: [customFieldsMock[1]] }} />,
+      {
+        wrapperProps: { permissions: noCasesSettingsPermission() },
+      }
+    );
+
+    await userEvent.click(screen.getByTestId('case-view-sidebar-legacy-custom-fields-toggle'));
+
+    expect(
+      await screen.findByTestId('legacy-custom-fields-deprecation-callout')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-custom-fields-view-new-link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-custom-fields-view-settings-link')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Contact your administrator to confirm the fields have been migrated/i)
+    ).toBeInTheDocument();
   });
 
   it('should show the category correctly', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.test.tsx
@@ -417,11 +417,12 @@ describe('CaseViewSidebar (redesign)', () => {
     // Accordion is closed by default; open it to reveal the callout.
     await userEvent.click(screen.getByTestId('case-view-sidebar-legacy-custom-fields-toggle'));
 
+    // announceOnMount duplicates callout content into a live region with the same test subjects.
+    const content = await screen.findByTestId('legacy-custom-fields-deprecation-callout__content');
+    expect(within(content).getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
     expect(
-      await screen.findByTestId('legacy-custom-fields-deprecation-callout')
+      within(content).getByTestId('legacy-custom-fields-view-settings-link')
     ).toBeInTheDocument();
-    expect(screen.getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
-    expect(screen.getByTestId('legacy-custom-fields-view-settings-link')).toBeInTheDocument();
   });
 
   it('shows the administrator message in the deprecation callout when the user lacks settings permission', async () => {
@@ -447,13 +448,17 @@ describe('CaseViewSidebar (redesign)', () => {
 
     await userEvent.click(screen.getByTestId('case-view-sidebar-legacy-custom-fields-toggle'));
 
+    const content = await screen.findByTestId('legacy-custom-fields-deprecation-callout__content');
     expect(
-      await screen.findByTestId('legacy-custom-fields-deprecation-callout')
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId('legacy-custom-fields-view-new-link')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('legacy-custom-fields-view-settings-link')).not.toBeInTheDocument();
+      within(content).queryByTestId('legacy-custom-fields-view-new-link')
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Contact your administrator to confirm the fields have been migrated/i)
+      within(content).queryByTestId('legacy-custom-fields-view-settings-link')
+    ).not.toBeInTheDocument();
+    expect(
+      within(content).getByText(
+        /Contact your administrator to confirm the fields have been migrated/i
+      )
     ).toBeInTheDocument();
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
@@ -6,10 +6,8 @@
  */
 
 import {
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLink,
   EuiPanel,
   EuiScreenReaderOnly,
   EuiSpacer,
@@ -18,7 +16,6 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useMemo } from 'react';
 import type { CaseUI } from '../../../../../../common';
 import type { CaseConnector } from '../../../../../../common/types/domain';
@@ -44,10 +41,7 @@ import { useGetSupportedActionConnectors } from '../../../../../containers/confi
 import { useGetTemplate } from '../../../../templates_v2/hooks/use_get_template';
 import { KibanaServices } from '../../../../../common/lib/kibana';
 import { useShowLegacyCustomFields } from '../../../../../common/use_show_old_custom_fields';
-import {
-  useCasesFieldLibraryNavigation,
-  useConfigureCasesNavigation,
-} from '../../../../../common/navigation';
+import { CustomFieldsDeprecationCallout } from '../../../../case_form_fields/custom_fields_deprecation_callout';
 import * as configureCasesI18n from '../../../../configure_cases/translations';
 
 export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
@@ -66,8 +60,6 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
   const { showLegacyCustomFields } = useShowLegacyCustomFields(
     casesConfiguration?.customFields ?? []
   );
-  const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
-  const { getConfigureCasesUrl } = useConfigureCasesNavigation();
 
   const { data: templateData } = useGetTemplate(caseData.template?.id, caseData.template?.version, {
     includeDeleted: true,
@@ -155,38 +147,7 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
             >
               {isTemplatesV2Enabled ? (
                 <>
-                  <EuiCallOut
-                    announceOnMount
-                    title={redesignI18n.LEGACY_CUSTOM_FIELDS_TITLE}
-                    color="warning"
-                    iconType="warning"
-                    size="s"
-                    data-test-subj="legacy-custom-fields-deprecation-callout"
-                  >
-                    <FormattedMessage
-                      id="xpack.cases.casesRedesign.details.legacyCustomFieldsDisclaimerBody"
-                      defaultMessage='These custom fields are deprecated and have already been migrated to the new system, so you may see the same fields in both places. Manage them in {customFieldsLink}. To stop showing them here, disable "{switchLabel}" in {settingsLink}.'
-                      values={{
-                        customFieldsLink: (
-                          <EuiLink
-                            href={getCasesFieldLibraryUrl()}
-                            data-test-subj="legacy-custom-fields-view-new-link"
-                          >
-                            {redesignI18n.LEGACY_CUSTOM_FIELDS_VIEW_CUSTOM_FIELDS}
-                          </EuiLink>
-                        ),
-                        switchLabel: configureCasesI18n.SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES,
-                        settingsLink: (
-                          <EuiLink
-                            href={getConfigureCasesUrl()}
-                            data-test-subj="legacy-custom-fields-view-settings-link"
-                          >
-                            {redesignI18n.LEGACY_CUSTOM_FIELDS_VIEW_SETTINGS}
-                          </EuiLink>
-                        ),
-                      }}
-                    />
-                  </EuiCallOut>
+                  <CustomFieldsDeprecationCallout title={redesignI18n.LEGACY_CUSTOM_FIELDS_TITLE} />
                   <EuiSpacer size="m" />
                 </>
               ) : null}

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
@@ -176,17 +176,3 @@ export const LEGACY_CUSTOM_FIELDS_TITLE = i18n.translate(
     defaultMessage: 'Legacy custom fields',
   }
 );
-
-export const LEGACY_CUSTOM_FIELDS_VIEW_CUSTOM_FIELDS = i18n.translate(
-  'xpack.cases.casesRedesign.details.legacyCustomFieldsViewCustomFields',
-  {
-    defaultMessage: 'custom fields',
-  }
-);
-
-export const LEGACY_CUSTOM_FIELDS_VIEW_SETTINGS = i18n.translate(
-  'xpack.cases.casesRedesign.details.legacyCustomFieldsViewSettings',
-  {
-    defaultMessage: 'settings',
-  }
-);

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_info_panel.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_info_panel.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { TemplatesInfoPanel } from './templates_info_panel';
 import { renderWithTestingProviders } from '../../../common/mock';
@@ -51,5 +52,26 @@ describe('TemplatesInfoPanel', () => {
     renderWithTestingProviders(<TemplatesInfoPanel />);
 
     expect(await screen.findByTestId('templates-info-panel-illustration')).toBeInTheDocument();
+  });
+
+  it('does not render the dismiss button when onDismiss is not provided', () => {
+    renderWithTestingProviders(<TemplatesInfoPanel />);
+
+    expect(screen.queryByTestId('templates-info-panel-dismiss')).not.toBeInTheDocument();
+  });
+
+  it('calls onDismiss when the dismiss button is clicked', async () => {
+    const onDismiss = jest.fn();
+    renderWithTestingProviders(<TemplatesInfoPanel onDismiss={onDismiss} />);
+
+    await userEvent.click(await screen.findByTestId('templates-info-panel-dismiss'));
+
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('renders the start tour button when onStartTour is provided', async () => {
+    renderWithTestingProviders(<TemplatesInfoPanel onStartTour={jest.fn()} />);
+
+    expect(await screen.findByTestId('templates-info-panel-start-tour')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_info_panel.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_info_panel.tsx
@@ -15,7 +15,9 @@ import {
   EuiText,
   EuiLink,
   EuiButton,
+  EuiButtonIcon,
   EuiSpacer,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -27,9 +29,11 @@ import { START_TOUR } from '../tour/translations';
 interface Props {
   /** When provided, renders a "Start tour" button that launches the templates guided tour. */
   onStartTour?: () => void;
+  /** When provided, renders a dismiss button that hides the panel. */
+  onDismiss?: () => void;
 }
 
-const TemplatesInfoPanelComponent: React.FC<Props> = ({ onStartTour }) => {
+const TemplatesInfoPanelComponent: React.FC<Props> = ({ onStartTour, onDismiss }) => {
   const { euiTheme } = useEuiTheme();
   const { docLinks } = useKibana().services;
 
@@ -39,11 +43,28 @@ const TemplatesInfoPanelComponent: React.FC<Props> = ({ onStartTour }) => {
       hasBorder={false}
       data-test-subj="templates-info-panel"
       css={css`
+        position: relative;
         background-color: ${euiTheme.colors.backgroundBaseSubdued};
         border-radius: ${euiTheme.size.s};
         padding: ${euiTheme.size.base};
       `}
     >
+      {onDismiss ? (
+        <EuiToolTip content={i18n.TEMPLATES_INFO_PANEL_DISMISS} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="cross"
+            color="text"
+            aria-label={i18n.TEMPLATES_INFO_PANEL_DISMISS}
+            onClick={onDismiss}
+            data-test-subj="templates-info-panel-dismiss"
+            css={css`
+              position: absolute;
+              top: ${euiTheme.size.s};
+              right: ${euiTheme.size.s};
+            `}
+          />
+        </EuiToolTip>
+      ) : null}
       <EuiFlexGroup alignItems="center" gutterSize="l" responsive={false}>
         <EuiFlexItem grow={false}>
           <EuiImage

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/all_templates_page.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/all_templates_page.test.tsx
@@ -159,6 +159,22 @@ describe('AllTemplatesPage', () => {
     });
   });
 
+  it('hides the info panel when dismissed', async () => {
+    const queryClient = createTestQueryClient();
+
+    renderWithTestingProviders(<AllTemplatesPage />, {
+      wrapperProps: { queryClient },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('templates-info-panel')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId('templates-info-panel-dismiss'));
+
+    expect(screen.queryByTestId('templates-info-panel')).not.toBeInTheDocument();
+  });
+
   it('renders the table filters', async () => {
     const queryClient = createTestQueryClient();
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/all_templates_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/all_templates_page.tsx
@@ -37,6 +37,8 @@ import { GuidedTour } from '../../tour/guided_tour';
 import { TEMPLATES_TOUR_STEPS } from '../tour/tour_steps_config';
 import { TEMPLATES_TOUR_STEP_TEST_ID } from '../tour/constants';
 import { useKibana } from '../../../common/lib/kibana';
+import { useNewFeatureSeen } from '../../../common/use_new_feature_seen';
+import { LOCAL_STORAGE_KEYS } from '../../../../common/constants';
 
 export const AllTemplatesPage: React.FC = () => {
   useCasesTemplatesBreadcrumbs();
@@ -48,6 +50,9 @@ export const AllTemplatesPage: React.FC = () => {
   const { getCasesFieldLibraryUrl, navigateToCasesFieldLibrary } = useCasesFieldLibraryNavigation();
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   const [isTourActive, setIsTourActive] = useState(false);
+  const { isNew: showInfoPanel, markSeen: dismissInfoPanel } = useNewFeatureSeen(
+    LOCAL_STORAGE_KEYS.templatesListInfoPanelDismissed
+  );
 
   const startTour = useCallback(() => setIsTourActive(true), []);
   const finishTour = useCallback(() => setIsTourActive(false), []);
@@ -173,7 +178,9 @@ export const AllTemplatesPage: React.FC = () => {
         testIdPrefix={TEMPLATES_TOUR_STEP_TEST_ID}
       />
       <CasesPageBody>
-        <TemplatesInfoPanel onStartTour={startTour} />
+        {showInfoPanel ? (
+          <TemplatesInfoPanel onStartTour={startTour} onDismiss={dismissInfoPanel} />
+        ) : null}
         <TemplatesTableFilters
           queryParams={queryParams}
           onQueryParamsChange={setQueryParams}

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/translations.ts
@@ -688,6 +688,13 @@ export const TEMPLATES_INFO_DESCRIPTION = i18n.translate('xpack.cases.templates.
     'Create templates with custom set of fields, that can automatically populate values in new cases.',
 });
 
+export const TEMPLATES_INFO_PANEL_DISMISS = i18n.translate(
+  'xpack.cases.templates.infoPanelDismiss',
+  {
+    defaultMessage: 'Dismiss',
+  }
+);
+
 export const LEARN_MORE = i18n.translate('xpack.cases.templates.learnMore', {
   defaultMessage: 'Learn more',
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/tour/guided_tour.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/tour/guided_tour.test.tsx
@@ -27,6 +27,13 @@ const STEPS: CasesTourStep[] = [
 const Anchor = () => <button type="button" data-test-subj="anchor-a" aria-label="anchor" />;
 
 describe('GuidedTour', () => {
+  const scrollIntoViewMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+  });
+
   it('renders nothing when inactive', () => {
     renderWithTestingProviders(
       <>
@@ -55,5 +62,27 @@ describe('GuidedTour', () => {
     );
 
     expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('scrolls the active step anchor into view when the tour is active', () => {
+    renderWithTestingProviders(
+      <>
+        <Anchor />
+        <GuidedTour steps={STEPS} isActive onFinish={jest.fn()} testIdPrefix="test-tour" />
+      </>
+    );
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+  });
+
+  it('does not scroll when the tour is inactive', () => {
+    renderWithTestingProviders(
+      <>
+        <Anchor />
+        <GuidedTour steps={STEPS} isActive={false} onFinish={jest.fn()} testIdPrefix="test-tour" />
+      </>
+    );
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/tour/guided_tour.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/tour/guided_tour.tsx
@@ -89,9 +89,11 @@ const GuidedTourComponent: React.FC<GuidedTourProps> = ({
     if (!isActive || !currentStepConfig || !isCurrentAnchorMounted) {
       return;
     }
-    document
-      .querySelector(currentStepConfig.anchor)
-      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    const anchorEl = document.querySelector(currentStepConfig.anchor);
+    // jsdom does not implement scrollIntoView; guard so tours used in unit tests do not crash.
+    if (anchorEl && typeof anchorEl.scrollIntoView === 'function') {
+      anchorEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
   }, [isActive, currentStepConfig, isCurrentAnchorMounted]);
 
   if (!isActive || !currentStepConfig || !isCurrentAnchorMounted) {

--- a/x-pack/platform/plugins/shared/cases/public/components/tour/guided_tour.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/tour/guided_tour.tsx
@@ -82,6 +82,18 @@ const GuidedTourComponent: React.FC<GuidedTourProps> = ({
   // Only mount `EuiTourStep` once the current step's anchor is in the DOM. EuiTourStep resolves
   // its anchor a tick after mount; rendering before the anchor exists produces an unanchored
   // popover that never recovers.
+  //
+  // Scroll the active step's anchor into view so the tour doesn't open off-screen (e.g. the
+  // attach button at the bottom of a long case activity thread).
+  useEffect(() => {
+    if (!isActive || !currentStepConfig || !isCurrentAnchorMounted) {
+      return;
+    }
+    document
+      .querySelector(currentStepConfig.anchor)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [isActive, currentStepConfig, isCurrentAnchorMounted]);
+
   if (!isActive || !currentStepConfig || !isCurrentAnchorMounted) {
     return null;
   }


### PR DESCRIPTION
## What & Why
Gates the legacy custom-fields deprecation callout on Create Case and Case Details behind `permissions.settings` (admins keep links; others get an administrator-contact message). Makes the templates list info panel dismissible, and scrolls guided-tour anchors into view so the case-details tour doesn’t open off-screen on long threads.

## How to Test
1. Enable templates v2 and show legacy custom fields; open Create Case / Case Details as a user with settings permission — confirm callout links to custom fields and settings.
2. As a user **without** the Case settings sub-feature (`cases_settings: false`; not Cases All), with legacy fields visible (admin enabled the switch on this browser, or set `localStorage` `*.cases.showLegacyCustomFields` to `true`) — confirm callout has no links and shows the administrator-contact message. Settings should be missing from the Cases menu.
3. On Templates list, dismiss the info panel; reload and confirm it stays hidden.
4. Open Case Details with many comments while the details tour is unseen — confirm the first tour step scrolls the attach button into view.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->