### PR TITLE
Notify owning team Slack channel when a flaky-fix PR is ready for review

### DIFF
--- a/.github/workflows/notify-flaky-fix-ready.yml
+++ b/.github/workflows/notify-flaky-fix-ready.yml
@@ -1,0 +1,30 @@
+name: Notify on flaky-fix PR ready for review
+
+on:
+  pull_request_target:
+    types: [ready_for_review]
+
+jobs:
+  notify_slack:
+    name: Notify owning team Slack channel
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'flaky-test-fixer')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kibana-operations
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: 'elastic/kibana-operations'
+          ref: main
+          path: ./kibana-operations
+          token: ${{secrets.KIBANAMACHINE_TOKEN}}
+          persist-credentials: false
+
+      - name: Notify owning team Slack channel
+        working-directory: ./kibana-operations/triage
+        env:
+          GITHUB_TOKEN: ${{secrets.KIBANAMACHINE_TOKEN}}
+          SLACK_TOKEN: ${{secrets.SLACK_TOKEN_FAILED_TEST_NOTIFIER}}
+        run: |
+          npm ci --omit=dev
+          node flaky-fix-ready ${{github.event.pull_request.number}} || true


### PR DESCRIPTION
## Summary

- Adds a workflow that posts to the owning team's Slack channel when a [Flaky Test Fixer](https://github.com/elastic/kibana/blob/main/.github/workflows/flaky-test-fixer.md) PR is marked **ready for review**, so teams learn about AI-generated fixes for their flaky tests without watching GitHub.
- Trigger: `pull_request_target: ready_for_review` on PRs labeled `flaky-test-fixer`. The fixer opens its PRs as drafts and the [Flaky Fix Verifier](https://github.com/elastic/kibana/blob/main/.github/workflows/flaky-fix-verifier.md) un-drafts them on a terminal verdict using the `kibanamachine` PAT, so this event fires for every verified fix (and also when a human un-drafts one manually).
- Mirrors [alert-failed-test.yml](https://github.com/elastic/kibana/blob/main/.github/workflows/alert-failed-test.yml): checks out `elastic/kibana-operations` and runs the new `triage/flaky-fix-ready.js`, which resolves owning teams from the PR's changed files via CODEOWNERS and posts the PR link, the `flaky-fix-check:*` verification verdict, and the linked `failed-test` issue to each team's channel. Reuses the existing `SLACK_TOKEN_FAILED_TEST_NOTIFIER` and `KIBANAMACHINE_TOKEN` secrets — no new secrets needed.

> [!IMPORTANT]
> Depends on elastic/kibana-operations#628, which adds the `flaky-fix-ready` script. That PR must merge first.

## Test plan

- [ ] Merge elastic/kibana-operations#628
- [ ] Dry-run the script against a recent fixer PR (`DEBUG=1 node flaky-fix-ready <pr-number>`)
- [ ] After merge, confirm the workflow fires and posts when the next fixer PR is marked ready for review

Made with [Cursor](https://cursor.com)