### PR TITLE
Make app menu item order optional

### DIFF
--- a/src/core/packages/chrome/app-menu/app_menu.mdx
+++ b/src/core/packages/chrome/app-menu/app_menu.mdx
@@ -19,7 +19,7 @@ It offers a structured and organized way to present navigation options and actio
 
 The `AppMenuConfig` object accepts:
 
-- **`items`** — menu items displayed in the app menu bar. Items beyond the limit overflow into a "More" popover.
+- **`items`** — menu items displayed in ascending `order`. The optional `order` defaults to `0`, and items with the same order retain their array order. Items beyond the limit overflow into a "More" popover.
 - **`primaryActionItem`** — a primary action button placed as the rightmost item. Can be a simple button (with `run`), a button with a popover (with `items`), or a split button (with `run` and `splitButtonProps`).
 - **`switch`** — an optional `AppMenuSwitch` rendered to the left of the menu items. Only one switch is available per app menu.
 

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -220,9 +220,10 @@ export type AppMenuItemCommon = AppMenuButtonItem | AppMenuItemWithPopover | App
 
 type AppMenuItemTypeBase = AppMenuItemCommon & {
   /**
-   * Order of the item in the menu. Lower numbers appear first.
+   * Order of the item in the menu. Lower numbers appear first. Defaults to 0.
+   * Items with the same order preserve their array order.
    */
-  order: number;
+  order?: number;
   /**
    * Adds a separator line above or below the item when rendered inside a popover menu.
    * Ignored for top-level, non-popover items.

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
@@ -239,13 +239,14 @@ describe('utils', () => {
 
     it('should return all items as displayed when under limit', () => {
       const items = [
-        { id: '1', label: 'Item 1', run: jest.fn(), iconType: 'gear' as const, order: 1 },
-        { id: '2', label: 'Item 2', run: jest.fn(), iconType: 'gear' as const, order: 2 },
+        { id: '1', label: 'Item 1', run: jest.fn(), iconType: 'gear' as const },
+        { id: '2', label: 'Item 2', run: jest.fn(), iconType: 'gear' as const },
       ];
 
       const result = getAppMenuItems({ config: { items } });
 
       expect(result.displayedItems).toHaveLength(2);
+      expect(result.displayedItems.map((item) => item.id)).toEqual(['1', '2']);
       expect(result.overflowItems).toHaveLength(0);
       expect(result.shouldOverflow).toBe(false);
     });
@@ -262,6 +263,18 @@ describe('utils', () => {
       expect(result.displayedItems[0].id).toBe('1');
       expect(result.displayedItems[1].id).toBe('2');
       expect(result.displayedItems[2].id).toBe('3');
+    });
+
+    it('should use zero as the default order', () => {
+      const items = [
+        { id: 'last', label: 'Last', run: jest.fn(), iconType: 'gear' as const, order: 1 },
+        { id: 'default', label: 'Default', run: jest.fn(), iconType: 'gear' as const },
+        { id: 'first', label: 'First', run: jest.fn(), iconType: 'gear' as const, order: -1 },
+      ];
+
+      const result = getAppMenuItems({ config: { items } });
+
+      expect(result.displayedItems.map((item) => item.id)).toEqual(['first', 'default', 'last']);
     });
 
     it('should split items into displayed and overflow when exceeding limit', () => {
@@ -595,8 +608,8 @@ describe('utils', () => {
 
     it('should create single panel for flat items', () => {
       const items: AppMenuPopoverItem[] = [
-        { id: '1', label: 'Item 1', run: jest.fn(), order: 1 },
-        { id: '2', label: 'Item 2', run: jest.fn(), order: 2 },
+        { id: '1', label: 'Item 1', run: jest.fn() },
+        { id: '2', label: 'Item 2', run: jest.fn() },
       ];
 
       const panels = getPopoverPanels({ items });
@@ -604,6 +617,7 @@ describe('utils', () => {
       expect(panels).toHaveLength(1);
       expect(panels[0].id).toBe(0);
       expect(panels[0].items).toHaveLength(2);
+      expect(panels[0].items?.map((item) => item.key)).toEqual(['1', '2']);
     });
 
     it('should create nested panels for items with sub-items', () => {

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -36,8 +36,8 @@ import type {
 import { APP_MENU_ITEM_LIMIT, DEFAULT_POPOVER_WIDTH } from './constants';
 import { APP_MENU_TEST_SUBJECTS, getAppMenuItemTestSubj } from './test_subjects';
 
-const sortByOrder = <T extends { order: number }>(items: T[]): T[] =>
-  [...items].sort((a, b) => a.order - b.order);
+const sortByOrder = <T extends { order?: number }>(items: T[]): T[] =>
+  [...items].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 
 /**
  * Calculate how many items can be displayed.
@@ -397,7 +397,7 @@ export const getPopoverPanels = ({
   }) => {
     const panelItems: EuiContextMenuPanelItemDescriptor[] = [];
 
-    const sortedItems = [...itemsToProcess].sort((a, b) => a.order - b.order);
+    const sortedItems = sortByOrder(itemsToProcess);
 
     sortedItems.forEach((item) => {
       if (item.separator === 'above') {

--- a/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/types.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/types.ts
@@ -85,15 +85,23 @@ type DiscoverAppMenuActionOrSubmenu =
 type WithDiscoverAppMenuAction<BaseItem> = Omit<BaseItem, 'run' | 'items'> &
   DiscoverAppMenuActionOrSubmenu;
 
+type WithDiscoverAppMenuOrder<BaseItem> = Omit<BaseItem, 'order'> & {
+  order: number;
+};
+
 /**
  * Discover-specific popover item with typed run action and nested items
  */
-export type DiscoverAppMenuPopoverItem = WithDiscoverAppMenuAction<AppMenuPopoverItem>;
+export type DiscoverAppMenuPopoverItem = WithDiscoverAppMenuAction<
+  WithDiscoverAppMenuOrder<AppMenuPopoverItem>
+>;
 
 /**
  * Discover-specific menu item type with typed run action and items
  */
-export type DiscoverAppMenuItemType = WithDiscoverAppMenuAction<AppMenuItemType>;
+export type DiscoverAppMenuItemType = WithDiscoverAppMenuAction<
+  WithDiscoverAppMenuOrder<AppMenuItemType>
+>;
 
 /**
  * Discover-specific primary action item with typed run action

--- a/src/platform/plugins/shared/discover/public/application/main/components/chrome_app_header/chrome_app_header.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chrome_app_header/chrome_app_header.tsx
@@ -60,7 +60,7 @@ export const ChromeAppHeader = ({ menu, tabsBar, hasTabs = false }: ChromeAppHea
           return {
             ...item,
             overflow,
-            order: newSessionItem.order + 0.5,
+            order: (newSessionItem.order ?? 0) + 0.5,
           } as AppMenuItemType;
         }
 


### PR DESCRIPTION
Chrome Next polish.

## Summary

App menu items no longer need to set `order` when array order is sufficient. Explicit ordering remains available for menus assembled from multiple sources.

An omitted `order` is treated as `0`. Negative values sort before unordered items, while positive values sort after them. Items with `order: 0` and items without `order` stay in their relative array order. The same rules apply independently to nested popover items and static items.