### PR TITLE
feat(fleet/epm): add allow_outdated_version flag for IaC pinned package installs

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/epm/handlers.ts
@@ -498,6 +498,7 @@ export const installPackageFromRegistryHandler: FleetRequestHandler<
     esClient,
     spaceId,
     force: request.body?.force,
+    allowOutdatedVersion: request.body?.allow_outdated_version,
     ignoreConstraints: request.body?.ignore_constraints,
     prerelease: request.query?.prerelease,
     request,
@@ -636,6 +637,7 @@ export const bulkInstallPackagesFromRegistryHandler: FleetRequestHandler<
     spaceId,
     prerelease: request.query.prerelease,
     force: request.body.force,
+    allowOutdatedVersion: request.body.allow_outdated_version,
     request,
   });
   const payload = bulkInstalledResponses.map(bulkInstallServiceResponseToHttpEntry);

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/bulk_install_packages.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/bulk_install_packages.ts
@@ -30,6 +30,7 @@ interface BulkInstallPackagesParams {
   >;
   esClient: ElasticsearchClient;
   force?: boolean;
+  allowOutdatedVersion?: boolean;
   spaceId: string;
   preferredSource?: 'registry' | 'bundled';
   prerelease?: boolean;
@@ -43,6 +44,7 @@ export async function bulkInstallPackages({
   esClient,
   spaceId,
   force,
+  allowOutdatedVersion,
   prerelease,
   request,
   skipIfInstalled,
@@ -145,6 +147,7 @@ export async function bulkInstallPackages({
         installSource: 'registry',
         spaceId,
         force,
+        allowOutdatedVersion,
         prerelease: prerelease || ('prerelease' in pkgKeyProps && pkgKeyProps.prerelease),
         request,
         skipDataStreamRollover: pkgKeyProps.skipDataStreamRollover,

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
@@ -213,6 +213,59 @@ describe('install', () => {
       });
     });
 
+    it('should bypass out-of-date check when allow_outdated_version is true', async () => {
+      jest.spyOn(licenseService, 'hasAtLeast').mockReturnValue(true);
+
+      const response = await installPackage({
+        spaceId: DEFAULT_SPACE_ID,
+        installSource: 'registry',
+        pkgkey: 'apache-1.1.0',
+        savedObjectsClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        allowOutdatedVersion: true,
+      });
+
+      // Should reach the state machine (i.e. not fail with out-of-date error)
+      expect(response.error).toBeUndefined();
+      expect(response.status).toEqual('installed');
+    });
+
+    it('should still reject out-of-date version without allow_outdated_version', async () => {
+      const response = await installPackage({
+        spaceId: DEFAULT_SPACE_ID,
+        installSource: 'registry',
+        pkgkey: 'apache-1.1.0',
+        savedObjectsClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+      });
+
+      expect(response.error).toBeDefined();
+      expect(response.error!.message).toEqual(
+        'apache-1.1.0 is out-of-date and cannot be installed or updated'
+      );
+    });
+
+    it('should not bypass agentless guard when allow_outdated_version is true but not force', async () => {
+      jest.spyOn(licenseService, 'hasAtLeast').mockReturnValue(true);
+      jest.mocked(isAgentlessEnabled).mockReturnValueOnce(false);
+      jest.mocked(isOnlyAgentlessIntegration).mockReturnValueOnce(true);
+
+      const response = await installPackage({
+        spaceId: DEFAULT_SPACE_ID,
+        installSource: 'registry',
+        // use the latest version so the out-of-date check is not the blocking issue
+        pkgkey: 'test_package',
+        savedObjectsClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        allowOutdatedVersion: true,
+      });
+
+      expect(response.error).toBeDefined();
+      expect(response.error!.message).toEqual(
+        'test_package contains agentless policy templates, agentless is not available on this deployment'
+      );
+    });
+
     it('should send telemetry on install failure, license error', async () => {
       jest.spyOn(licenseService, 'hasAtLeast').mockReturnValue(false);
       await installPackage({

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -408,6 +408,7 @@ interface InstallRegistryPackageParams {
   esClient: ElasticsearchClient;
   spaceId: string;
   force?: boolean;
+  allowOutdatedVersion?: boolean;
   neverIgnoreVerificationError?: boolean;
   ignoreConstraints?: boolean;
   prerelease?: boolean;
@@ -496,6 +497,7 @@ async function installPackageFromRegistry({
   spaceId,
   request,
   force = false,
+  allowOutdatedVersion = false,
   ignoreConstraints = false,
   neverIgnoreVerificationError = false,
   prerelease = false,
@@ -560,9 +562,9 @@ async function installPackageFromRegistry({
     telemetryEvent.discoveryDatasets = packageInfo.discovery?.datasets;
     telemetryEvent.automaticInstall = automaticInstall;
 
-    // let the user install if using the force flag or needing to reinstall or install a previous version due to failed update
+    // let the user install if using the force flag, allow_outdated_version flag, or needing to reinstall or install a previous version due to failed update
     const installOutOfDateVersionOk =
-      force || ['reinstall', 'reupdate', 'rollback'].includes(installType);
+      force || allowOutdatedVersion || ['reinstall', 'reupdate', 'rollback'].includes(installType);
 
     // if the requested version is out-of-date of the latest package version, check if we allow it
     // if we don't allow it, return an error
@@ -574,7 +576,11 @@ async function installPackageFromRegistry({
       }
       logger.debug(
         `${pkgkey} is out-of-date, installing anyway due to ${
-          force ? 'force flag' : `install type ${installType}`
+          force
+            ? 'force flag'
+            : allowOutdatedVersion
+            ? 'allow_outdated_version flag'
+            : `install type ${installType}`
         }`
       );
     }
@@ -1020,6 +1026,7 @@ export async function installPackage(args: InstallPackageParams): Promise<Instal
     const {
       pkgkey,
       force,
+      allowOutdatedVersion,
       ignoreConstraints,
       spaceId,
       neverIgnoreVerificationError,
@@ -1067,6 +1074,7 @@ export async function installPackage(args: InstallPackageParams): Promise<Instal
       esClient,
       spaceId,
       force,
+      allowOutdatedVersion,
       neverIgnoreVerificationError,
       ignoreConstraints,
       prerelease,

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
@@ -1007,8 +1007,21 @@ export const InstallPackageFromRegistryRequestSchema = {
   body: schema.nullable(
     schema.object(
       {
-        force: schema.boolean({ defaultValue: false }),
+        force: schema.boolean({
+          defaultValue: false,
+          meta: {
+            description:
+              'When true, bypass the already-installed short-circuit, allow unverified packages, restart stuck installs, and skip dependency compatibility checks. Broad recovery-oriented flag — prefer allow_outdated_version for IaC pinned-version installs.',
+          },
+        }),
         ignore_constraints: schema.boolean({ defaultValue: false }),
+        allow_outdated_version: schema.boolean({
+          defaultValue: false,
+          meta: {
+            description:
+              'When true, allow installing a specific package version that is older than the latest available registry version. Unlike force, this bypasses only the out-of-date version check and does not enable reinstall, unverified-package, deployment-mode bypass, or dependency-skip behavior. Intended for IaC workflows that pin a vetted package version.',
+          },
+        }),
       },
       { meta: { id: 'install_package_from_registry_request' } }
     )
@@ -1060,7 +1073,20 @@ export const BulkInstallPackagesFromRegistryRequestSchema = {
         ]),
         { minSize: 1, maxSize: 1000 }
       ),
-      force: schema.boolean({ defaultValue: false }),
+      force: schema.boolean({
+        defaultValue: false,
+        meta: {
+          description:
+            'When true, bypass the already-installed short-circuit and restart stuck installs. Broad recovery-oriented flag — prefer allow_outdated_version for IaC pinned-version installs.',
+        },
+      }),
+      allow_outdated_version: schema.boolean({
+        defaultValue: false,
+        meta: {
+          description:
+            'When true, allow installing a specific package version that is older than the latest available registry version. Unlike force, this bypasses only the out-of-date version check and does not enable reinstall or dependency-skip behavior. Intended for IaC workflows that pin a vetted package version.',
+        },
+      }),
     },
     { meta: { id: 'bulk_install_packages_from_registry_request' } }
   ),

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/bulk_install.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/bulk_install.ts
@@ -87,5 +87,47 @@ export default function (providerContext: FtrProviderContext) {
         'multiple_versions-0.1.0 is out-of-date and cannot be installed or updated'
       );
     });
+
+    it('should install an older version if allow_outdated_version is true', async () => {
+      const response = await supertest
+        .post(`/api/fleet/epm/packages/_bulk?prerelease=true`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          packages: [{ name: pkgName, version: pkgOlderVersion }],
+          allow_outdated_version: true,
+        })
+        .expect(200);
+
+      expect(response.body.items.length).equal(1);
+      expect(response.body.items[0].version).equal(pkgOlderVersion);
+
+      await uninstallPackage(pkgName, pkgOlderVersion);
+    });
+
+    it('should return already_installed when re-installing same version with allow_outdated_version but not force', async () => {
+      // First install the older version
+      await supertest
+        .post(`/api/fleet/epm/packages/_bulk?prerelease=true`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          packages: [{ name: pkgName, version: pkgOlderVersion }],
+          allow_outdated_version: true,
+        })
+        .expect(200);
+
+      // Re-POST the same version — should return already_installed, not trigger a reinstall
+      const response = await supertest
+        .post(`/api/fleet/epm/packages/_bulk?prerelease=true`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          packages: [{ name: pkgName, version: pkgOlderVersion }],
+          allow_outdated_version: true,
+        })
+        .expect(200);
+
+      expect(response.body.items[0].result?.status).equal('already_installed');
+
+      await uninstallPackage(pkgName, pkgOlderVersion);
+    });
   });
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/install_update.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/install_update.ts
@@ -73,6 +73,13 @@ export default function (providerContext: FtrProviderContext) {
         .send({ force: true })
         .expect(200);
     });
+    it('should return 200 if trying to install an out-of-date package with allow_outdated_version', async function () {
+      await supertest
+        .post(`/api/fleet/epm/packages/multiple_versions/0.1.0`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ allow_outdated_version: true })
+        .expect(200);
+    });
     it('should return 200 if trying to reinstall an out-of-date package', async function () {
       await supertest
         .post(`/api/fleet/epm/packages/multiple_versions/0.1.0`)


### PR DESCRIPTION
## Summary

Closes #275183

Adds a narrow `allow_outdated_version` boolean flag to the EPM registry install endpoints. When `true`, it lets callers install a specific package version that is older than the latest published registry version — without enabling the broad destructive/recovery semantics of `force`.

**Motivation:** IaC systems (Terraform, CI pipelines) need deterministic installs. A vetted, pinned package version can become undeployable simply because a newer version was published between validation and `apply`. `force` is the only current escape hatch, but it also triggers reinstall of Kibana saved objects and transforms, allows unverified packages, and bypasses the agentless deployment-mode guard — all undesirable in steady-state CI.

## What changed

### New flag: `allow_outdated_version` (default: `false`)

Available on:
- `POST /api/fleet/epm/packages/{pkgName}/{pkgVersion}`
- `POST /api/fleet/epm/packages/_bulk`

**Bypasses only:** the `semverLt(pkgVersion, latestPackage.version)` / `PackageOutdatedError` check.

**Does NOT bypass:**
- Package signature verification
- Dependency compatibility checks
- Agentless deployment-mode guard
- Already-installed short-circuit (re-installing the same version still returns `already_installed`, not a forced reinstall)
- Concurrency / stuck-install handling

## Test plan

- [x] Unit tests in `install.test.ts`:
  - `allow_outdated_version: true` bypasses the out-of-date check and reaches the state machine
  - Without the flag, out-of-date install still fails (existing behaviour preserved)
  - `allow_outdated_version: true` does NOT bypass the agentless guard (scope is narrow)
- [x] API integration tests in `install_update.ts` and `bulk_install.ts`:
  - Single endpoint: `allow_outdated_version: true` returns 200 for an older version
  - Bulk endpoint: older version installs; re-installing same version returns `already_installed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)