### PR TITLE
[Agent Builder] Prevent conversation overwrite via auto-create

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.test.ts
@@ -303,17 +303,37 @@ describe('ConversationClient', () => {
   });
 
   describe('exists', () => {
-    it('returns false when conversation access passes but agent use access fails', async () => {
-      agentRegistry.get.mockRejectedValue(createAgentNotFoundError({ agentId: 'agent-1' }));
+    it('returns true when the document exists, even when owned by another user and private', async () => {
       mockEsClient.search.mockResolvedValue({
         hits: {
           hits: [
             createConversationDocument({
               userId: 'other-user-id',
               username: 'other-user',
-              accessMode: ConversationAccessControlMode.Public,
+              accessMode: ConversationAccessControlMode.Private,
             }),
           ],
+        },
+      });
+
+      await expect(client.exists('conversation-1')).resolves.toBe(true);
+    });
+
+    it('returns true when the document exists but agent use access fails', async () => {
+      agentRegistry.get.mockRejectedValue(createAgentNotFoundError({ agentId: 'agent-1' }));
+      mockEsClient.search.mockResolvedValue({
+        hits: {
+          hits: [createConversationDocument()],
+        },
+      });
+
+      await expect(client.exists('conversation-1')).resolves.toBe(true);
+    });
+
+    it('returns false when no document exists', async () => {
+      mockEsClient.search.mockResolvedValue({
+        hits: {
+          hits: [],
         },
       });
 
@@ -326,23 +346,62 @@ describe('ConversationClient', () => {
 
       await expect(client.exists('conversation-1')).rejects.toBe(error);
     });
+  });
 
-    it('propagates agent registry failures that are not access denials', async () => {
-      const error = new Error('agent registry unavailable');
-      agentRegistry.get.mockRejectedValue(error);
+  describe('create', () => {
+    beforeEach(() => {
+      mockEsClient.index.mockResolvedValue({ result: 'created' });
       mockEsClient.search.mockResolvedValue({
         hits: {
-          hits: [
-            createConversationDocument({
-              userId: 'other-user-id',
-              username: 'other-user',
-              accessMode: ConversationAccessControlMode.Public,
-            }),
-          ],
+          hits: [createConversationDocument()],
         },
       });
+    });
 
-      await expect(client.exists('conversation-1')).rejects.toBe(error);
+    it('indexes with op_type create so existing conversations are never overwritten', async () => {
+      await client.create({
+        id: 'conversation-1',
+        title: 'Conversation 1',
+        agent_id: 'agent-1',
+        rounds: [],
+      });
+
+      expect(mockEsClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'conversation-1',
+          op_type: 'create',
+        })
+      );
+    });
+
+    it('throws a not found error when the id already exists', async () => {
+      const conflictError = Object.assign(new Error('version conflict'), { statusCode: 409 });
+      mockEsClient.index.mockRejectedValueOnce(conflictError);
+
+      await expect(
+        client.create({
+          id: 'conversation-1',
+          title: 'Conversation 1',
+          agent_id: 'agent-1',
+          rounds: [],
+        })
+      ).rejects.toMatchObject({
+        message: 'Conversation conversation-1 not found',
+      });
+    });
+
+    it('propagates non-conflict index failures', async () => {
+      const error = new Error('index unavailable');
+      mockEsClient.index.mockRejectedValueOnce(error);
+
+      await expect(
+        client.create({
+          id: 'conversation-1',
+          title: 'Conversation 1',
+          agent_id: 'agent-1',
+          rounds: [],
+        })
+      ).rejects.toBe(error);
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -138,16 +138,9 @@ class ConversationClientImpl implements ConversationClient {
   }
 
   async exists(conversationId: string): Promise<boolean> {
-    try {
-      await this.getDocumentWithAccess({ conversationId, access: 'converse' });
-      return true;
-    } catch (error) {
-      if (isConversationNotFoundError(error)) {
-        return false;
-      }
+    const document = await this._get(conversationId);
 
-      throw error;
-    }
+    return document !== undefined;
   }
 
   async getByOrigin(origin: ConversationOrigin): Promise<Conversation | undefined> {
@@ -193,10 +186,19 @@ class ConversationClientImpl implements ConversationClient {
       space: this.space,
     });
 
-    await this.storage.getClient().index({
-      id,
-      document: attributes,
-    });
+    try {
+      await this.storage.getClient().index({
+        id,
+        document: attributes,
+        op_type: 'create',
+      });
+    } catch (error) {
+      if (error?.statusCode === 409) {
+        throw createConversationNotFoundError({ conversationId: id });
+      }
+
+      throw error;
+    }
 
     return this.get(id);
   }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.test.ts
@@ -7,7 +7,11 @@
 
 import { of } from 'rxjs';
 import type { RoundCompleteEvent } from '@kbn/agent-builder-common';
-import { ChatEventType, ConversationAccessControlMode } from '@kbn/agent-builder-common';
+import {
+  ChatEventType,
+  ConversationAccessControlMode,
+  createConversationNotFoundError,
+} from '@kbn/agent-builder-common';
 import {
   createEmptyConversation,
   createRound,
@@ -126,6 +130,29 @@ describe('conversations utils', () => {
         });
 
         expect(result.operation).toBe('UPDATE');
+      });
+
+      it('throws not found instead of creating when autoCreateConversationWithId=true and the conversation exists but is not accessible', async () => {
+        // e.g. another user's private conversation with the same id: exists() reports
+        // physical existence, and the converse-gated get() denies access
+        const conversationClient = createConversationClientMock();
+        conversationClient.exists.mockResolvedValue(true);
+        conversationClient.get.mockRejectedValue(
+          createConversationNotFoundError({ conversationId: 'existing-conversation' })
+        );
+
+        await expect(
+          getConversation({
+            agentId: 'test-agent',
+            conversationId: 'existing-conversation',
+            autoCreateConversationWithId: true,
+            conversationClient,
+          })
+        ).rejects.toMatchObject({
+          message: 'Conversation existing-conversation not found',
+        });
+
+        expect(conversationClient.create).not.toHaveBeenCalled();
       });
 
       it('ignores access control when auto-created conversation already exists', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
@@ -118,19 +118,6 @@ export const updateConversation$ = ({
   );
 };
 
-/**
- * Check if a conversation exists
- */
-export const conversationExists = async ({
-  conversationId,
-  conversationClient,
-}: {
-  conversationId: string;
-  conversationClient: ConversationClient;
-}): Promise<boolean> => {
-  return conversationClient.exists(conversationId);
-};
-
 export type ConversationOperation = 'CREATE' | 'UPDATE';
 
 export type ConversationWithOperation = Conversation & { operation: ConversationOperation };
@@ -184,7 +171,8 @@ export const getConversation = async ({
   }
 
   // Case 3: Conversation ID specified and autoCreate is true - check if exists
-  const exists = await conversationExists({ conversationId, conversationClient });
+  const exists = await conversationClient.exists(conversationId);
+
   if (exists) {
     return {
       ...(await conversationClient.get(conversationId)),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/index.ts
@@ -11,7 +11,6 @@ export { handleCancellation } from './handle_cancellation';
 export { executeAgent$ } from './execute_agent';
 export {
   getConversation,
-  conversationExists,
   updateConversation$,
   createConversation$,
   placeholderConversation,

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts
@@ -738,6 +738,56 @@ apiTest.describe(
       }
     );
 
+    // ── auto-create IDOR ──────────────────────────────────────────────────────
+
+    apiTest(
+      'auto-create cannot overwrite or take over another user conversation',
+      async ({ apiClient }) => {
+        const agentId = `${ACCESS_CONTROL_TEST_PREFIX}-autocreate-agent-${testRunId.slice(0, 8)}`;
+        await createAgentAs(apiClient, alice, mockAgent(agentId, AgentAccessControlMode.Shared));
+
+        const aliceConversation = await createConversationAs({
+          apiClient,
+          user: alice,
+          agentId,
+          input: 'alice data',
+          title: 'Alice private conversation',
+        });
+        const conversationId = aliceConversation.conversation_id;
+
+        // converse auto-creates a conversation with the caller-supplied id, so Bob replaying
+        // Alice's id previously overwrote and took over her conversation. It must now be
+        // rejected before any create, with no LLM round (so no interceptor is set up).
+        const attempt = await apiClient.post(`${accessControlApiBase}/converse`, {
+          headers: headersFor(bob),
+          body: {
+            agent_id: agentId,
+            input: 'bob data',
+            connector_id: connectorId,
+            _execution_mode: 'local',
+            conversation_id: conversationId,
+          },
+          responseType: 'json',
+        });
+        expect(attempt).toHaveStatusCode(404);
+
+        const aliceView = await apiClient.get(
+          `${accessControlApiBase}/conversations/${encodeURIComponent(conversationId)}`,
+          { headers: headersFor(alice), responseType: 'json' }
+        );
+        expect(aliceView).toHaveStatusCode(200);
+        const conversation = aliceView.body as Conversation;
+        expect(conversation.user.username).toBe(alice.username);
+        expect(conversation.rounds).toHaveLength(1);
+
+        const bobView = await apiClient.get(
+          `${accessControlApiBase}/conversations/${encodeURIComponent(conversationId)}`,
+          { headers: headersFor(bob), responseType: 'json' }
+        );
+        expect(bobView).toHaveStatusCode(404);
+      }
+    );
+
     // ── route-level privileges ──────────────────────────────────────────────
 
     apiTest(


### PR DESCRIPTION
## Summary

Hardens conversation auto-create so that an existing conversation can no longer be replaced by a subsequent create.

- `create()` now indexes with `op_type: 'create'`, so it never overwrites an existing document; the resulting conflict is surfaced as a standard not-found error.
- `ConversationClient.exists()` now reflects document existence rather than caller access, so the auto-create path defers to the access-gated `get()` for ids that already exist.
- Removes the now-unused `conversationExists` wrapper.

Adds unit coverage (`client.test.ts`, `conversations.test.ts`) and an API test.


<!--ONMERGE {"backportTargets":["9.3","9.4","9.5"]} ONMERGE-->