### PR TITLE
[skill-path-checker] Detect stale file paths in Security Solution skill files

### DIFF
--- a/.buildkite/pipelines/scheduled/skill_path_check.yml
+++ b/.buildkite/pipelines/scheduled/skill_path_check.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: ':book: Check Skill Path Drift'
+    command: .buildkite/scripts/steps/checks/skill_path_check.sh
+    timeout_in_minutes: 15
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-2

--- a/.buildkite/scripts/steps/checks/post_skill_path_slack.ts
+++ b/.buildkite/scripts/steps/checks/post_skill_path_slack.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { readFileSync } from 'fs';
+import * as https from 'https';
+
+interface Finding {
+  file: string;
+  line: number;
+  token: string;
+}
+
+interface Report {
+  findings?: Finding[];
+}
+
+function parseArgs(argv: string[]): { reportPath: string; channel: string } {
+  const args = argv.slice(2);
+  let reportPath = '';
+  let channel = '';
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--report' && args[i + 1]) {
+      reportPath = args[++i];
+    } else if (args[i] === '--channel' && args[i + 1]) {
+      channel = args[++i];
+    }
+  }
+
+  return { reportPath, channel };
+}
+
+function postSlackMessage(token: string, channel: string, text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ channel, text });
+    const options: https.RequestOptions = {
+      hostname: 'slack.com',
+      path: '/api/chat.postMessage',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${token}`,
+        'Content-Length': Buffer.byteLength(body),
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          if (!parsed.ok) {
+            console.error(`Slack API error: ${parsed.error}`);
+          } else {
+            console.log('Slack message posted successfully');
+          }
+        } catch {
+          console.error('Failed to parse Slack API response');
+        }
+        resolve();
+      });
+    });
+
+    req.on('error', (err) => {
+      reject(err);
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+async function main() {
+  const { reportPath, channel } = parseArgs(process.argv);
+
+  if (!reportPath || !channel) {
+    console.error('Usage: post_skill_path_slack.ts --report <path> --channel <channel-id>');
+    process.exit(0);
+  }
+
+  const token = process.env.SKILL_PATH_SLACK_TOKEN;
+  if (!token) {
+    console.warn('Warning: SKILL_PATH_SLACK_TOKEN is not set — skipping Slack notification');
+    process.exit(0);
+  }
+
+  let report: Report;
+  try {
+    report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  } catch (err) {
+    console.error(`Failed to read report at ${reportPath}:`, err);
+    process.exit(0);
+  }
+
+  const findings: Finding[] = report.findings ?? [];
+  const count = findings.length;
+
+  if (count === 0) {
+    console.log('No findings in report — nothing to post');
+    process.exit(0);
+  }
+
+  const MAX_SHOWN = 20;
+  const shown = findings.slice(0, MAX_SHOWN);
+  const bullets = shown.map((f) => `• ${f.file}:${f.line} — \`${f.token}\``).join('\n');
+  const truncationNote = count > MAX_SHOWN ? `\nand ${count - MAX_SHOWN} more...` : '';
+
+  const buildUrl = process.env.BUILDKITE_BUILD_URL ?? '(local)';
+
+  const text = [
+    `:warning: Skill path drift detected — ${count} stale path(s) found`,
+    '',
+    'Files affected:',
+    bullets + truncationNote,
+    '',
+    'Run `node scripts/check_skill_paths` locally to reproduce.',
+    `Build: ${buildUrl}`,
+  ].join('\n');
+
+  try {
+    await postSlackMessage(token, channel, text);
+  } catch (err) {
+    console.error('Failed to post Slack message:', err);
+    // Safe-fail: exit 0 so CI stays green
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/.buildkite/scripts/steps/checks/skill_path_check.sh
+++ b/.buildkite/scripts/steps/checks/skill_path_check.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
+echo --- Skill Path Drift Check
+
+# Bootstrap (needed for ts-node / node with proper env)
+.buildkite/scripts/bootstrap.sh
+
+node scripts/check_skill_paths --json --out /tmp/skill_path_report.json
+
+# Count findings from the JSON report
+FINDING_COUNT=$(node -e "
+  const r = require('/tmp/skill_path_report.json');
+  process.stdout.write(String(r.findings ? r.findings.length : 0));
+")
+
+if [[ "$FINDING_COUNT" -gt 0 ]]; then
+  echo "Found $FINDING_COUNT stale path(s) in skill files"
+
+  # Buildkite annotation (visible in the build UI)
+  buildkite-agent annotate \
+    --context skill-path-drift \
+    --style warning \
+    "$(node -e "
+      const r = require('/tmp/skill_path_report.json');
+      const lines = r.findings.map(f => '- \`' + f.file + ':' + f.line + '\` — \`' + f.token + '\`');
+      process.stdout.write(':warning: **Stale skill paths detected**\n\n' + lines.join('\n'));
+    ")" || true
+
+  # Slack notification (only when channel is configured)
+  if [[ -n "${SKILL_PATH_SLACK_CHANNEL:-}" ]]; then
+    ts-node .buildkite/scripts/steps/checks/post_skill_path_slack.ts \
+      --report /tmp/skill_path_report.json \
+      --channel "$SKILL_PATH_SLACK_CHANNEL"
+  fi
+else
+  echo "No stale skill paths found"
+fi
+
+exit 0

--- a/scripts/check_skill_paths.js
+++ b/scripts/check_skill_paths.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+require('@kbn/setup-node-env');
+require('../src/dev/run_check_skill_paths');

--- a/src/dev/run_check_skill_paths.ts
+++ b/src/dev/run_check_skill_paths.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { writeFileSync } from 'fs';
+
+import globby from 'globby';
+
+import { REPO_ROOT } from '@kbn/repo-info';
+import { run } from '@kbn/dev-cli-runner';
+
+import { runSkillPathCheck } from './skill_paths/run_skill_path_check';
+
+run(
+  async ({ log, flagsReader }) => {
+    const quiet = flagsReader.boolean('quiet');
+    const writeJson = flagsReader.boolean('json');
+    const outPath = flagsReader.string('out') ?? 'skill_path_report.json';
+
+    const paths = await globby('x-pack/solutions/security/**/.agents/skills/**/*.md', {
+      cwd: REPO_ROOT,
+      onlyFiles: true,
+      gitignore: true,
+    });
+
+    const absolutePaths = paths.map((p) => `${REPO_ROOT}/${p}`);
+
+    const result = await runSkillPathCheck(absolutePaths, REPO_ROOT);
+
+    log.info(
+      `Checked ${result.checked} paths, found ${result.findings.length} stale, skipped ${result.skipped}`
+    );
+
+    if (!quiet) {
+      for (const finding of result.findings) {
+        log.info(`STALE: ${finding.file}:${finding.line} — ${finding.token}`);
+      }
+    }
+
+    if (writeJson) {
+      writeFileSync(outPath, JSON.stringify(result, null, 2));
+      log.info(`JSON report written to ${outPath}`);
+    }
+  },
+  {
+    flags: {
+      boolean: ['quiet', 'json'],
+      string: ['out'],
+      default: {
+        out: 'skill_path_report.json',
+      },
+      help: `
+        --quiet   Suppress per-finding log lines (summary is always printed).
+        --json    Write findings as JSON to the path given by --out.
+        --out     Output file path for --json (default: skill_path_report.json).
+      `,
+    },
+  }
+);

--- a/src/dev/skill_paths/extract_paths.test.ts
+++ b/src/dev/skill_paths/extract_paths.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { classifyToken } from './extract_paths';
+
+describe('classifyToken', () => {
+  describe('skip cases', () => {
+    it('skips placeholder with angle-bracket namespace', () => {
+      const result = classifyToken(
+        'test/scout/<namespace>/ui/',
+        'backtick',
+        '`test/scout/<namespace>/ui/`',
+        ''
+      );
+      expect(result.kind).toBe('skip');
+    });
+
+    it('skips glob with double-star', () => {
+      const result = classifyToken('public/**/*.test.ts', 'backtick', '`public/**/*.test.ts`', '');
+      expect(result.kind).toBe('skip');
+    });
+
+    it('skips module specifier starting with @', () => {
+      const result = classifyToken('@kbn/scout-security', 'backtick', '`@kbn/scout-security`', '');
+      expect(result.kind).toBe('skip');
+    });
+
+    it('skips absolute/route path starting with /', () => {
+      const result = classifyToken(
+        '/api/security/entity_store/',
+        'backtick',
+        '`/api/security/entity_store/`',
+        ''
+      );
+      expect(result.kind).toBe('skip');
+    });
+
+    it('skips filename-only token with no slash', () => {
+      const result = classifyToken(
+        'alerts_table.test.ts',
+        'backtick',
+        '`alerts_table.test.ts`',
+        ''
+      );
+      expect(result.kind).toBe('skip');
+    });
+
+    it('skips HTTPS URL', () => {
+      const result = classifyToken(
+        'https://example.com/foo',
+        'backtick',
+        '`https://example.com/foo`',
+        ''
+      );
+      expect(result.kind).toBe('skip');
+    });
+
+    it('skips token containing shell variable $', () => {
+      const result = classifyToken('$REPO_ROOT/scripts', 'backtick', '`$REPO_ROOT/scripts`', '');
+      expect(result.kind).toBe('skip');
+    });
+
+    it('skips token containing ellipsis ...', () => {
+      const result = classifyToken('test/scout/.../ui/', 'backtick', '`test/scout/.../ui/`', '');
+      expect(result.kind).toBe('skip');
+    });
+
+    it('honors the skill-path-ignore inline marker', () => {
+      const result = classifyToken(
+        'scripts/nonexistent.js',
+        'backtick',
+        '`scripts/nonexistent.js` <!-- skill-path-ignore -->',
+        ''
+      );
+      expect(result.kind).toBe('skip');
+    });
+
+    it('skips backtick token with slash but no recognised anchor (no-anchor)', () => {
+      const result = classifyToken(
+        'plugins/security_solution/public/',
+        'backtick',
+        '`plugins/security_solution/public/`',
+        '' // file content has NO skill-path-base comment
+      );
+      expect(result.kind).toBe('skip');
+      expect((result as { kind: 'skip'; reason: string }).reason).toBe('no-anchor');
+    });
+  });
+
+  describe('validate cases', () => {
+    it('validates a repo-root prefixed path (scripts/)', () => {
+      const result = classifyToken('scripts/scout.js', 'backtick', '`scripts/scout.js`', '');
+      expect(result.kind).toBe('validate');
+      if (result.kind === 'validate') {
+        expect(result.anchor).toBe('repo-root');
+        expect(result.token).toBe('scripts/scout.js');
+      }
+    });
+
+    it('validates a repo-root prefixed path (x-pack/)', () => {
+      const result = classifyToken(
+        'x-pack/solutions/security/',
+        'backtick',
+        '`x-pack/solutions/security/`',
+        ''
+      );
+      expect(result.kind).toBe('validate');
+      if (result.kind === 'validate') {
+        expect(result.anchor).toBe('repo-root');
+      }
+    });
+
+    it('validates a markdown link with anchor=file', () => {
+      const result = classifyToken(
+        'references/mode-generate.md',
+        'markdown-link',
+        '[foo](references/mode-generate.md)',
+        ''
+      );
+      expect(result.kind).toBe('validate');
+      if (result.kind === 'validate') {
+        expect(result.anchor).toBe('file');
+        expect(result.token).toBe('references/mode-generate.md');
+      }
+    });
+
+    it('validates a markdown link with fragment — strips fragment from token', () => {
+      const result = classifyToken(
+        '../SKILL.md#section',
+        'markdown-link',
+        '[foo](../SKILL.md#section)',
+        ''
+      );
+      expect(result.kind).toBe('validate');
+      if (result.kind === 'validate') {
+        expect(result.anchor).toBe('file');
+        expect(result.token).toBe('../SKILL.md');
+      }
+    });
+
+    it('validates a declared-base path when file has skill-path-base comment', () => {
+      const fileContent = '<!-- skill-path-base: x-pack/solutions/security -->\nsome content';
+      const result = classifyToken(
+        'plugins/security_solution/public/',
+        'backtick',
+        '`plugins/security_solution/public/`',
+        fileContent
+      );
+      expect(result.kind).toBe('validate');
+      if (result.kind === 'validate') {
+        expect(result.anchor).toBe('declared-base');
+        expect(result.token).toBe('plugins/security_solution/public/');
+        expect(result.declaredBase).toBe('x-pack/solutions/security');
+      }
+    });
+  });
+});

--- a/src/dev/skill_paths/extract_paths.test.ts
+++ b/src/dev/skill_paths/extract_paths.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { classifyToken } from './extract_paths';
+import { classifyToken, extractPaths } from './extract_paths';
 
 describe('classifyToken', () => {
   describe('skip cases', () => {
@@ -159,5 +159,68 @@ describe('classifyToken', () => {
         expect(result.declaredBase).toBe('x-pack/solutions/security');
       }
     });
+  });
+});
+
+describe('extractPaths', () => {
+  it('extracts backtick inline path from plain prose', () => {
+    const results = extractPaths('See `scripts/scout.js` for details.');
+    expect(results).toHaveLength(1);
+    expect(results[0].token).toBe('scripts/scout.js');
+    expect(results[0].line).toBe(1);
+    expect(results[0].tokenKind).toBe('backtick');
+  });
+
+  it('skips paths inside fenced code blocks', () => {
+    const content = [
+      'Some prose.',
+      '```bash',
+      'x-pack/solutions/security/something.ts',
+      '```',
+      'After fence.',
+    ].join('\n');
+    const results = extractPaths(content);
+    const fenceTokens = results.filter((r) => r.token.includes('security/something.ts'));
+    expect(fenceTokens).toHaveLength(0);
+  });
+
+  it('extracts markdown link target; classifyToken strips fragment and assigns anchor=file', () => {
+    const results = extractPaths('[link](references/mode-generate.md#section-name)');
+    expect(results).toHaveLength(1);
+    expect(results[0].tokenKind).toBe('markdown-link');
+    // raw token retains the fragment — classifyToken strips it
+    const classified = classifyToken(
+      results[0].token,
+      results[0].tokenKind,
+      results[0].rawLine,
+      ''
+    );
+    expect(classified.kind).toBe('validate');
+    if (classified.kind === 'validate') {
+      expect(classified.token).toBe('references/mode-generate.md');
+      expect(classified.anchor).toBe('file');
+    }
+  });
+
+  it('respects declared-base comment: classifyToken assigns anchor=declared-base', () => {
+    const content =
+      '<!-- skill-path-base: x-pack/solutions/security -->\n\nSee `plugins/security_solution/` for details.';
+    const results = extractPaths(content);
+    const token = results.find((r) => r.token === 'plugins/security_solution/');
+    expect(token).toBeDefined();
+    if (token) {
+      const classified = classifyToken(token.token, token.tokenKind, token.rawLine, content);
+      expect(classified.kind).toBe('validate');
+      if (classified.kind === 'validate') {
+        expect(classified.anchor).toBe('declared-base');
+      }
+    }
+  });
+
+  it('returns line numbers correctly — path on line 2 reports line=2', () => {
+    const content = 'No path here.\nSee `scripts/scout.js` here.';
+    const results = extractPaths(content);
+    expect(results).toHaveLength(1);
+    expect(results[0].line).toBe(2);
   });
 });

--- a/src/dev/skill_paths/extract_paths.test.ts
+++ b/src/dev/skill_paths/extract_paths.test.ts
@@ -91,6 +91,23 @@ describe('classifyToken', () => {
       expect(result.kind).toBe('skip');
       expect((result as { kind: 'skip'; reason: string }).reason).toBe('no-anchor');
     });
+
+    it('skips backtick token with a space (command string)', () => {
+      const result = classifyToken(
+        'node scripts/scout.js run-tests',
+        'backtick',
+        '`node scripts/scout.js run-tests`',
+        ''
+      );
+      expect(result.kind).toBe('skip');
+      expect((result as any).reason).toBe('contains-space');
+    });
+
+    it('skips declared-base token with fewer than 3 components', () => {
+      const content = '<!-- skill-path-base: x-pack/solutions/security -->';
+      const result = classifyToken('cypress/e2e/', 'backtick', '`cypress/e2e/`', content);
+      expect(result.kind).toBe('skip');
+    });
   });
 
   describe('validate cases', () => {
@@ -204,9 +221,9 @@ describe('extractPaths', () => {
 
   it('respects declared-base comment: classifyToken assigns anchor=declared-base', () => {
     const content =
-      '<!-- skill-path-base: x-pack/solutions/security -->\n\nSee `plugins/security_solution/` for details.';
+      '<!-- skill-path-base: x-pack/solutions/security -->\n\nSee `plugins/security_solution/public/` for details.';
     const results = extractPaths(content);
-    const token = results.find((r) => r.token === 'plugins/security_solution/');
+    const token = results.find((r) => r.token === 'plugins/security_solution/public/');
     expect(token).toBeDefined();
     if (token) {
       const classified = classifyToken(token.token, token.tokenKind, token.rawLine, content);

--- a/src/dev/skill_paths/extract_paths.ts
+++ b/src/dev/skill_paths/extract_paths.ts
@@ -7,8 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// TODO: implement
-
 export type TokenKind = 'backtick' | 'markdown-link';
 
 export type ClassifyResult =
@@ -27,17 +25,128 @@ export interface ExtractedToken {
   rawLine: string;
 }
 
-// Stub — always returns skip until implemented
+/** Repo-root prefixes: tokens starting with these are relative to the repo root. */
+const REPO_ROOT_PREFIXES = [
+  'x-pack/',
+  'src/',
+  'packages/',
+  'scripts/',
+  '.buildkite/',
+  '.agents/',
+  'docs/',
+  'config/',
+];
+
+/** Characters whose presence in a token forces a skip. */
+const SKIP_CHARS = ['<', '>', '*', '{', '}', '$'];
+
+/**
+ * Classify a single extracted token.
+ *
+ * @param token      - The raw token string (path or URL).
+ * @param tokenKind  - Whether this came from a backtick span or a markdown link.
+ * @param rawLine    - The full source line (used to detect the ignore marker).
+ * @param fileContent- The full markdown file content (used to detect skill-path-base).
+ */
 export function classifyToken(
-  _token: string,
-  _tokenKind: TokenKind,
-  _rawLine: string,
-  _fileContent: string
+  token: string,
+  tokenKind: TokenKind,
+  rawLine: string,
+  fileContent: string
 ): ClassifyResult {
-  return { kind: 'skip', reason: 'not-implemented' };
+  // Inline escape hatch — the whole line is intentionally excluded
+  if (rawLine.includes('<!-- skill-path-ignore -->')) {
+    return { kind: 'skip', reason: 'ignore-marker' };
+  }
+
+  // Skip tokens that contain template/glob/shell/braces characters
+  if (SKIP_CHARS.some((c) => token.includes(c))) {
+    return { kind: 'skip', reason: 'invalid-chars' };
+  }
+  if (token.includes('...')) {
+    return { kind: 'skip', reason: 'ellipsis' };
+  }
+
+  // Skip npm/yarn/package module specifiers
+  if (token.startsWith('@')) {
+    return { kind: 'skip', reason: 'module-specifier' };
+  }
+
+  // Skip absolute URLs
+  if (token.startsWith('http') || token.startsWith('mailto:')) {
+    return { kind: 'skip', reason: 'url' };
+  }
+
+  // Skip Kibana route bases / absolute FS paths
+  if (token.startsWith('/')) {
+    return { kind: 'skip', reason: 'absolute-path' };
+  }
+
+  // Markdown link tokens: always anchor relative to the containing file
+  if (tokenKind === 'markdown-link') {
+    const stripped = token.includes('#') ? token.split('#')[0] : token;
+    return { kind: 'validate', anchor: 'file', token: stripped };
+  }
+
+  // Backtick tokens: must contain a slash (otherwise it's a bare filename)
+  if (!token.includes('/')) {
+    return { kind: 'skip', reason: 'no-slash' };
+  }
+
+  // Backtick tokens that start with a known repo-root prefix
+  if (REPO_ROOT_PREFIXES.some((prefix) => token.startsWith(prefix))) {
+    return { kind: 'validate', anchor: 'repo-root', token };
+  }
+
+  // Backtick tokens in a file that declares a base path
+  const baseMatch = fileContent.match(/<!--\s*skill-path-base:\s*(\S+)\s*-->/);
+  if (baseMatch) {
+    return { kind: 'validate', anchor: 'declared-base', token, declaredBase: baseMatch[1] };
+  }
+
+  // No anchor could be determined — silently skip
+  return { kind: 'skip', reason: 'no-anchor' };
 }
 
-// Stub — returns empty array until implemented
-export function extractPaths(_fileContent: string): ExtractedToken[] {
-  return [];
+/**
+ * Extract all candidate path tokens from a markdown file, skipping fenced code blocks.
+ * Returns raw tokens; call {@link classifyToken} on each to classify.
+ */
+export function extractPaths(fileContent: string): ExtractedToken[] {
+  const lines = fileContent.split('\n');
+  const results: ExtractedToken[] = [];
+  let inFencedCode = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i];
+    const lineNum = i + 1;
+
+    // Toggle fenced-code state on ``` fence lines
+    if (rawLine.trimStart().startsWith('```')) {
+      inFencedCode = !inFencedCode;
+      continue;
+    }
+
+    if (inFencedCode) {
+      continue;
+    }
+
+    // Extract backtick inline-code spans that contain a slash
+    const backtickRe = /`([^`]+)`/g;
+    let m: RegExpExecArray | null;
+    while ((m = backtickRe.exec(rawLine)) !== null) {
+      const tok = m[1];
+      if (tok.includes('/')) {
+        results.push({ line: lineNum, token: tok, tokenKind: 'backtick', rawLine });
+      }
+    }
+
+    // Extract markdown link targets (including any #fragment)
+    const linkRe = /\]\(([^)]+)\)/g;
+    while ((m = linkRe.exec(rawLine)) !== null) {
+      results.push({ line: lineNum, token: m[1], tokenKind: 'markdown-link', rawLine });
+    }
+  }
+
+  return results;
 }

--- a/src/dev/skill_paths/extract_paths.ts
+++ b/src/dev/skill_paths/extract_paths.ts
@@ -93,14 +93,19 @@ export function classifyToken(
     return { kind: 'skip', reason: 'no-slash' };
   }
 
+  // Skip command strings — tokens with spaces cannot be filesystem paths
+  if (tokenKind === 'backtick' && token.includes(' ')) {
+    return { kind: 'skip', reason: 'contains-space' };
+  }
+
   // Backtick tokens that start with a known repo-root prefix
   if (REPO_ROOT_PREFIXES.some((prefix) => token.startsWith(prefix))) {
     return { kind: 'validate', anchor: 'repo-root', token };
   }
 
-  // Backtick tokens in a file that declares a base path
+  // Backtick tokens in a file that declares a base path (min 3 components to avoid naming-convention fragments)
   const baseMatch = fileContent.match(/<!--\s*skill-path-base:\s*(\S+)\s*-->/);
-  if (baseMatch) {
+  if (baseMatch && token.split('/').filter(Boolean).length >= 3) {
     return { kind: 'validate', anchor: 'declared-base', token, declaredBase: baseMatch[1] };
   }
 

--- a/src/dev/skill_paths/extract_paths.ts
+++ b/src/dev/skill_paths/extract_paths.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// TODO: implement
+
+export type TokenKind = 'backtick' | 'markdown-link';
+
+export type ClassifyResult =
+  | { kind: 'skip'; reason: string }
+  | {
+      kind: 'validate';
+      anchor: 'repo-root' | 'file' | 'declared-base';
+      token: string;
+      declaredBase?: string;
+    };
+
+export interface ExtractedToken {
+  line: number;
+  token: string;
+  tokenKind: TokenKind;
+  rawLine: string;
+}
+
+// Stub — always returns skip until implemented
+export function classifyToken(
+  _token: string,
+  _tokenKind: TokenKind,
+  _rawLine: string,
+  _fileContent: string
+): ClassifyResult {
+  return { kind: 'skip', reason: 'not-implemented' };
+}
+
+// Stub — returns empty array until implemented
+export function extractPaths(_fileContent: string): ExtractedToken[] {
+  return [];
+}

--- a/src/dev/skill_paths/jest.config.js
+++ b/src/dev/skill_paths/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../..',
+  roots: ['<rootDir>/src/dev/skill_paths'],
+};

--- a/src/dev/skill_paths/resolve_and_check.test.ts
+++ b/src/dev/skill_paths/resolve_and_check.test.ts
@@ -29,7 +29,7 @@ describe('resolveAndCheck', () => {
       repoRoot: REPO_ROOT,
     });
     expect(result.exists).toBe(true);
-    expect(result.resolvedPath).toBe(path.join(REPO_ROOT, 'scripts/scout.js'));
+    expect(result.resolvedPath).toBe(path.resolve(REPO_ROOT, 'scripts/scout.js'));
   });
 
   it('resolves a repo-root path that exists (src/dev/run_check_file_casing.ts)', () => {
@@ -40,7 +40,7 @@ describe('resolveAndCheck', () => {
       repoRoot: REPO_ROOT,
     });
     expect(result.exists).toBe(true);
-    expect(result.resolvedPath).toBe(path.join(REPO_ROOT, 'src/dev/run_check_file_casing.ts'));
+    expect(result.resolvedPath).toBe(path.resolve(REPO_ROOT, 'src/dev/run_check_file_casing.ts'));
   });
 
   it('resolves a repo-root path that does NOT exist', () => {
@@ -51,7 +51,7 @@ describe('resolveAndCheck', () => {
       repoRoot: REPO_ROOT,
     });
     expect(result.exists).toBe(false);
-    expect(result.resolvedPath).toBe(path.join(REPO_ROOT, 'scripts/scout_NONEXISTENT_9999.js'));
+    expect(result.resolvedPath).toBe(path.resolve(REPO_ROOT, 'scripts/scout_NONEXISTENT_9999.js'));
   });
 
   it('resolves a markdown-link token relative to the containing file directory', () => {
@@ -65,7 +65,7 @@ describe('resolveAndCheck', () => {
     });
     expect(result.exists).toBe(true);
     expect(result.resolvedPath).toBe(
-      path.join(path.dirname(SKILL_FILE), 'assets/page_object_template.md')
+      path.resolve(path.dirname(SKILL_FILE), 'assets/page_object_template.md')
     );
   });
 

--- a/src/dev/skill_paths/resolve_and_check.test.ts
+++ b/src/dev/skill_paths/resolve_and_check.test.ts
@@ -12,7 +12,7 @@ import { resolveAndCheck } from './resolve_and_check';
 
 // The worktree root serves as repoRoot for these tests.
 // It shares the same file tree as the main Kibana repo.
-const REPO_ROOT = path.resolve(__dirname, '../../../../');
+const REPO_ROOT = path.resolve(__dirname, '../../../');
 
 // Absolute path to a real skill file used for markdown-link anchor tests.
 const SKILL_FILE = path.join(
@@ -79,7 +79,7 @@ describe('resolveAndCheck', () => {
     });
     expect(result.exists).toBe(true);
     expect(result.resolvedPath).toBe(
-      path.join(REPO_ROOT, 'x-pack/solutions/security', 'plugins/security_solution/')
+      path.resolve(REPO_ROOT, 'x-pack/solutions/security', 'plugins/security_solution/')
     );
   });
 });

--- a/src/dev/skill_paths/resolve_and_check.test.ts
+++ b/src/dev/skill_paths/resolve_and_check.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as path from 'path';
+import { resolveAndCheck } from './resolve_and_check';
+
+// The worktree root serves as repoRoot for these tests.
+// It shares the same file tree as the main Kibana repo.
+const REPO_ROOT = path.resolve(__dirname, '../../../../');
+
+// Absolute path to a real skill file used for markdown-link anchor tests.
+const SKILL_FILE = path.join(
+  REPO_ROOT,
+  'x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration/SKILL.md'
+);
+
+describe('resolveAndCheck', () => {
+  it('resolves a repo-root path that exists (scripts/scout.js)', () => {
+    const result = resolveAndCheck({
+      token: 'scripts/scout.js',
+      anchor: 'repo-root',
+      containingFile: SKILL_FILE,
+      repoRoot: REPO_ROOT,
+    });
+    expect(result.exists).toBe(true);
+    expect(result.resolvedPath).toBe(path.join(REPO_ROOT, 'scripts/scout.js'));
+  });
+
+  it('resolves a repo-root path that exists (src/dev/run_check_file_casing.ts)', () => {
+    const result = resolveAndCheck({
+      token: 'src/dev/run_check_file_casing.ts',
+      anchor: 'repo-root',
+      containingFile: SKILL_FILE,
+      repoRoot: REPO_ROOT,
+    });
+    expect(result.exists).toBe(true);
+    expect(result.resolvedPath).toBe(path.join(REPO_ROOT, 'src/dev/run_check_file_casing.ts'));
+  });
+
+  it('resolves a repo-root path that does NOT exist', () => {
+    const result = resolveAndCheck({
+      token: 'scripts/scout_NONEXISTENT_9999.js',
+      anchor: 'repo-root',
+      containingFile: SKILL_FILE,
+      repoRoot: REPO_ROOT,
+    });
+    expect(result.exists).toBe(false);
+    expect(result.resolvedPath).toBe(path.join(REPO_ROOT, 'scripts/scout_NONEXISTENT_9999.js'));
+  });
+
+  it('resolves a markdown-link token relative to the containing file directory', () => {
+    // SKILL_FILE is in .../cypress-to-scout-migration/
+    // assets/page_object_template.md exists in that same directory
+    const result = resolveAndCheck({
+      token: 'assets/page_object_template.md',
+      anchor: 'file',
+      containingFile: SKILL_FILE,
+      repoRoot: REPO_ROOT,
+    });
+    expect(result.exists).toBe(true);
+    expect(result.resolvedPath).toBe(
+      path.join(path.dirname(SKILL_FILE), 'assets/page_object_template.md')
+    );
+  });
+
+  it('resolves a declared-base token under x-pack/solutions/security', () => {
+    const result = resolveAndCheck({
+      token: 'plugins/security_solution/',
+      anchor: 'declared-base',
+      containingFile: SKILL_FILE,
+      repoRoot: REPO_ROOT,
+      declaredBase: 'x-pack/solutions/security',
+    });
+    expect(result.exists).toBe(true);
+    expect(result.resolvedPath).toBe(
+      path.join(REPO_ROOT, 'x-pack/solutions/security', 'plugins/security_solution/')
+    );
+  });
+});

--- a/src/dev/skill_paths/resolve_and_check.ts
+++ b/src/dev/skill_paths/resolve_and_check.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// TODO: implement
+import { existsSync } from 'fs';
+import * as path from 'path';
 
 export interface ResolveOptions {
   token: string;
@@ -22,7 +23,29 @@ export interface ResolveResult {
   resolvedPath: string;
 }
 
-// Stub — always returns not-found until implemented
-export function resolveAndCheck(_options: ResolveOptions): ResolveResult {
-  return { exists: false, resolvedPath: '' };
+/**
+ * Resolve a token to an absolute path and check whether it exists on disk.
+ * Accepts files and directories (tokens ending in `/`).
+ */
+export function resolveAndCheck(options: ResolveOptions): ResolveResult {
+  const { token, anchor, containingFile, repoRoot, declaredBase } = options;
+
+  let resolvedPath: string;
+
+  switch (anchor) {
+    case 'repo-root':
+      resolvedPath = path.resolve(repoRoot, token);
+      break;
+    case 'file':
+      resolvedPath = path.resolve(path.dirname(containingFile), token);
+      break;
+    case 'declared-base':
+      if (!declaredBase) {
+        throw new Error(`anchor is 'declared-base' but no declaredBase was provided`);
+      }
+      resolvedPath = path.resolve(repoRoot, declaredBase, token);
+      break;
+  }
+
+  return { exists: existsSync(resolvedPath), resolvedPath };
 }

--- a/src/dev/skill_paths/resolve_and_check.ts
+++ b/src/dev/skill_paths/resolve_and_check.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// TODO: implement
+
+export interface ResolveOptions {
+  token: string;
+  anchor: 'repo-root' | 'file' | 'declared-base';
+  containingFile: string;
+  repoRoot: string;
+  declaredBase?: string;
+}
+
+export interface ResolveResult {
+  exists: boolean;
+  resolvedPath: string;
+}
+
+// Stub — always returns not-found until implemented
+export function resolveAndCheck(_options: ResolveOptions): ResolveResult {
+  return { exists: false, resolvedPath: '' };
+}

--- a/src/dev/skill_paths/run_skill_path_check.ts
+++ b/src/dev/skill_paths/run_skill_path_check.ts
@@ -7,25 +7,75 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// TODO: implement
+import { readFileSync } from 'fs';
+import * as path from 'path';
+
+import { classifyToken, extractPaths } from './extract_paths';
+import { resolveAndCheck } from './resolve_and_check';
 
 export interface SkillPathFinding {
+  /** Repo-relative path of the skill file containing the broken reference. */
   file: string;
+  /** 1-indexed line number of the token within that file. */
   line: number;
+  /** The path token as it appears in the source (fragment already stripped for links). */
   token: string;
+  /** The absolute path that was checked and found to be missing. */
   resolvedPath: string;
 }
 
 export interface SkillPathResult {
+  /** Tokens that resolved to a path that does not exist on disk. */
   findings: SkillPathFinding[];
+  /** Number of tokens that were validated (not skipped). */
   checked: number;
+  /** Number of tokens that were skipped (not validated). */
   skipped: number;
 }
 
-// Stub — returns empty result until implemented
+/**
+ * Scan a list of skill Markdown files for path tokens that no longer exist.
+ *
+ * @param skillFiles - Absolute paths to the Markdown files to check.
+ * @param repoRoot   - Absolute path to the repository root.
+ */
 export async function runSkillPathCheck(
-  _skillFiles: string[],
-  _repoRoot: string
+  skillFiles: string[],
+  repoRoot: string
 ): Promise<SkillPathResult> {
-  return { findings: [], checked: 0, skipped: 0 };
+  const findings: SkillPathFinding[] = [];
+  let checked = 0;
+  let skipped = 0;
+
+  for (const absPath of skillFiles) {
+    const content = readFileSync(absPath, 'utf8');
+    const tokens = extractPaths(content);
+
+    for (const { line, token, tokenKind, rawLine } of tokens) {
+      const classification = classifyToken(token, tokenKind, rawLine, content);
+
+      if (classification.kind === 'skip') {
+        skipped++;
+        continue;
+      }
+
+      // classification.kind === 'validate'
+      checked++;
+      const { anchor, token: resolvedToken, declaredBase } = classification;
+      const { exists, resolvedPath } = resolveAndCheck({
+        token: resolvedToken,
+        anchor,
+        containingFile: absPath,
+        repoRoot,
+        declaredBase,
+      });
+
+      if (!exists) {
+        const repoRelFile = path.relative(repoRoot, absPath);
+        findings.push({ file: repoRelFile, line, token: resolvedToken, resolvedPath });
+      }
+    }
+  }
+
+  return { findings, checked, skipped };
 }

--- a/src/dev/skill_paths/run_skill_path_check.ts
+++ b/src/dev/skill_paths/run_skill_path_check.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// TODO: implement
+
+export interface SkillPathFinding {
+  file: string;
+  line: number;
+  token: string;
+  resolvedPath: string;
+}
+
+export interface SkillPathResult {
+  findings: SkillPathFinding[];
+  checked: number;
+  skipped: number;
+}
+
+// Stub — returns empty result until implemented
+export async function runSkillPathCheck(
+  _skillFiles: string[],
+  _repoRoot: string
+): Promise<SkillPathResult> {
+  return { findings: [], checked: 0, skipped: 0 };
+}

--- a/src/platform/packages/shared/kbn-test/src/jest/setup/disallow_code_generation.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/setup/disallow_code_generation.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/*
+ * Disallow runtime code generation from strings in Jest tests.
+ *
+ * In production and dev mode, Kibana runs with the V8 flag
+ * --disallow-code-generation-from-strings, which causes eval() and
+ * new Function(string) to throw:
+ *
+ *   "Code generation from strings disallowed for this context"
+ *
+ * We cannot use that V8 flag for Jest because Jest's own dependencies
+ * (tmpl -> makeerror -> walker) call new Function() during startup.
+ * Instead, this setup file replaces eval and Function with versions that
+ * throw the same EvalError, scoped to the test sandbox only.
+ *
+ * Jest's own mock system (jest-mock) uses new Function() to create mock
+ * functions that preserve the original function's name. These calls are
+ * exempted by checking the call stack for known Jest internal callers.
+ *
+ * If your test is failing with this error, it means the code under test
+ * uses eval() or new Function() — which would also fail in production.
+ * Fix the underlying code rather than removing this restriction.
+ *
+ * See: packages/kbn-cli-dev-mode/src/using_server_process.ts  (dev flag)
+ *      src/dev/build/tasks/bin/scripts/kibana                  (prod flag)
+ *      src/platform/packages/shared/kbn-security-hardening/    (hardening package)
+ */
+
+const ERROR_MESSAGE = 'Code generation from strings disallowed for this context';
+
+// Zod v4 has a JIT compiler that uses new Function() for schema parsing.
+// Setting jitless on the backing store ensures Zod skips JIT regardless of
+// import order. Zod's own allowsEval probe is unreliable here because module
+// caching can cause it to run before our Function proxy is installed.
+global.__zod_globalConfig = Object.assign(global.__zod_globalConfig || {}, { jitless: true });
+
+const ALLOWED_CALLERS = [
+  // ESLint's ajv plugin uses new Function() for schema parsing. Dev-only, this is OK.
+  /eslint.*ajv/,
+  // i18n_eui_mapping.test.ts intentionally uses eval within its harness. Dev-only, this is OK.
+  /i18n_eui_mapping.*\.test/,
+  // Jest's own mock system (jest-mock) uses new Function() to create mock. Dev-only, this is OK.
+  /jest-mock/,
+  // Jest's own runtime uses new Function() for code generation. Dev-only, this is OK.
+  /jest-runtime/,
+  // Jest's own snapshot system uses new Function() for code generation. Dev-only, this is OK.
+  /jest-snapshot/,
+  // Jest's own environment uses new Function() for code generation. Dev-only, this is OK.
+  /jest-environment/,
+  // kbn-handlebars tests intentionally exercise the eval-based Handlebars compiler
+  // to verify parity with the safe AST-based replacement. The CSP probe
+  // (kbnUnsafeEvalTest) is blocked separately above, so this exception only
+  // affects the actual parity-test compilation calls.
+  /kbn-handlebars.*test/,
+  // hmr_client.test uses new Function() to load a browser bundle with injected globals;
+  // the bundle itself does not use code generation in production.
+  /kbn-rspack-optimizer.*hmr_client\.test/,
+];
+
+// @kbn/handlebars probes for CSP unsafe-eval support by calling
+// new Function('kbnUnsafeEvalTest', 'return true;'). In Jest the jest-runtime
+// allow-list entry would let this probe succeed (jest-runtime is in the stack
+// during module loading), causing handlebars to pick the eval-based compiler
+// that later fails. Blocking the probe explicitly makes the Jest environment
+// match browser CSP behavior, routing to the safe compileAST path.
+const CSP_PROBE_MARKER = 'kbnUnsafeEvalTest';
+
+function isCspProbe(args) {
+  return args.length > 0 && args[0] === CSP_PROBE_MARKER;
+}
+
+function isCallerAllowed() {
+  const stack = new Error().stack || '';
+  return ALLOWED_CALLERS.some((pattern) => pattern.test(stack));
+}
+
+// eslint-disable-next-line no-eval -- intentionally replacing eval to block code generation
+const OriginalEval = global.eval;
+
+// eslint-disable-next-line no-eval -- intentionally replacing eval to block code generation
+global.eval = function () {
+  if (isCallerAllowed()) {
+    return OriginalEval.apply(this, arguments);
+  }
+  throw new EvalError(ERROR_MESSAGE);
+};
+
+const OriginalFunction = global.Function;
+const FunctionProxy = new Proxy(OriginalFunction, {
+  apply(target, thisArg, args) {
+    if (!isCspProbe(args) && isCallerAllowed()) {
+      return Reflect.apply(target, thisArg, args);
+    }
+    throw new EvalError(ERROR_MESSAGE);
+  },
+  construct(target, args, newTarget) {
+    if (!isCspProbe(args) && isCallerAllowed()) {
+      return Reflect.construct(target, args, newTarget);
+    }
+    throw new EvalError(ERROR_MESSAGE);
+  },
+});
+
+Object.defineProperty(FunctionProxy, 'prototype', {
+  value: OriginalFunction.prototype,
+  writable: false,
+});
+
+global.Function = FunctionProxy;

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/security-test-directories.md
@@ -1,0 +1,240 @@
+<!-- skill-path-base: x-pack/solutions/security -->
+# Security Solution — Test Directories Reference
+
+This file maps Security Solution feature areas to their test directories, file naming conventions, and test types. Use it when building the test coverage catalog in Step 1 to locate existing tests for any feature area.
+
+---
+
+## Contents
+
+- [Repo-level skill locations](#repo-level-skill-locations)
+- [Test type overview](#test-type-overview)
+- [Feature area → test directory mapping](#feature-area--test-directory-mapping)
+  - [Detection Engine & Rules Management](#detection-engine--rules-management)
+  - [Alerts](#alerts)
+  - [Timelines & Timeline Templates](#timelines--timeline-templates)
+  - [Cases](#cases)
+  - [Entity Analytics](#entity-analytics-risk-engine-entity-store-entity-details)
+  - [Explore](#explore-hosts-network-users-overview)
+  - [Exceptions & Value Lists](#exceptions--value-lists)
+  - [AI Assistant / GenAI](#ai-assistant--genai-attack-discovery-conversations-knowledge-base)
+  - [AI4DSOC / Security AI Features](#ai4dsoc--security-ai-features)
+  - [SIEM Migrations](#siem-migrations)
+  - [Flyout / Expandable Flyout](#flyout--expandable-flyout)
+  - [Asset Inventory](#asset-inventory)
+  - [Cloud Security Posture](#cloud-security-posture-cspm--kspm--cdr)
+  - [Endpoint Security / EDR Workflows](#endpoint-security--edr-workflows)
+  - [Telemetry](#telemetry)
+  - [Investigations](#investigations-cross-feature-dashboards-data-view-threat-intelligence)
+  - [Notes](#notes)
+  - [Onboarding / Sourcerer / Common](#onboarding--sourcerer--common)
+- [File naming conventions](#file-naming-conventions)
+- [Notes for test coverage catalog](#notes-for-test-coverage-catalog)
+
+---
+
+## Repo-level skill locations
+
+| Skill | Path |
+|---|---|
+| Scout UI testing | `.agents/skills/scout-ui-testing/SKILL.md` |
+| Scout API testing | `.agents/skills/scout-api-testing/SKILL.md` |
+| FTR testing | `.agents/skills/ftr-testing/SKILL.md` |
+
+These skills describe test file conventions, runner commands, authentication patterns, and fixture extension rules. Read the relevant skill when generating or reviewing test scenarios that involve those test types.
+
+---
+
+## Test type overview
+
+| Type | File pattern | Runner |
+|---|---|---|
+| Unit | `*.test.ts` (co-located with source) | `yarn test:jest` |
+| Integration (Jest) | `*.test.ts` under `__tests__/` or adjacent; `jest.integration.config.js` | `yarn test:jest_integration` |
+| API integration (FTR) | `x-pack/solutions/security/test/security_solution_api_integration/` | `node scripts/functional_tests` |
+| Functional / E2E (FTR) | `x-pack/solutions/security/test/functional/` | `node scripts/functional_tests` |
+| Cypress E2E | `x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/**/*.cy.ts` | Cypress runner |
+| Scout API | `<plugin>/test/scout*/api/**/*.spec.ts` | `node scripts/scout.js run-tests` |
+| Scout UI | `<plugin>/test/scout*/ui/**/*.spec.ts` | `node scripts/scout.js run-tests` |
+
+---
+
+## Feature area → test directory mapping
+
+### Detection Engine & Rules Management
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/detection_engine/**/*.test.ts` |
+| Unit | `plugins/security_solution/public/detections/**/*.test.ts` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/detection_response/rule_management/` |
+| API integration | `test/security_solution_api_integration/test_suites/detections_response/detection_engine/` |
+| API integration | `test/security_solution_api_integration/test_suites/detections_response/rules_management/` |
+
+### Alerts
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/detections/**/*.test.ts` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/alerts/` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/` |
+
+### Timelines & Timeline Templates
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/timelines/**/*.test.ts` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/timelines/` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/timeline_templates/` |
+| API integration | `test/security_solution_api_integration/test_suites/investigation/timeline/` |
+
+### Cases
+
+| Test type | Directory |
+|---|---|
+| API integration | `test/cases_api_integration/` |
+| Cypress E2E | Covered under investigations area |
+
+### Entity Analytics (Risk Engine, Entity Store, Entity Details)
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/entity_analytics/**/*.test.ts` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/entity_analytics/` |
+| Cypress E2E (dashboards) | `test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/` |
+| Cypress E2E (hosts/watchlists) | `test/security_solution_cypress/cypress/e2e/entity_analytics/hosts/`, `watchlists/` |
+| API integration | `test/security_solution_api_integration/test_suites/entity_analytics/entity_details/` |
+| API integration | `test/security_solution_api_integration/test_suites/entity_analytics/entity_store/` |
+| API integration | `test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/` |
+| Scout API | `plugins/entity_store/test/scout/api/` |
+
+### Explore (Hosts, Network, Users, Overview)
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/explore/**/*.test.ts` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/explore/` |
+| API integration | `test/security_solution_api_integration/test_suites/explore/hosts/` |
+| API integration | `test/security_solution_api_integration/test_suites/explore/network/` |
+| API integration | `test/security_solution_api_integration/test_suites/explore/overview/` |
+| API integration | `test/security_solution_api_integration/test_suites/explore/users/` |
+
+### Exceptions & Value Lists
+
+| Test type | Directory |
+|---|---|
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/detection_response/rule_management/` |
+| API integration | `test/security_solution_api_integration/test_suites/lists_and_exception_lists/exception_lists_items/` |
+| API integration | `test/security_solution_api_integration/test_suites/lists_and_exception_lists/lists_items/` |
+| API integration | `test/security_solution_api_integration/test_suites/lists_and_exception_lists/authorization/` |
+
+### AI Assistant / GenAI (Attack Discovery, Conversations, Knowledge Base)
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/assistant/**/*.test.ts` |
+| Unit | `plugins/security_solution/public/attack_discovery/**/*.test.ts` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/ai_assistant/` |
+| API integration | `test/security_solution_api_integration/test_suites/genai/attack_discovery/` |
+| API integration | `test/security_solution_api_integration/test_suites/genai/conversations/` |
+| API integration | `test/security_solution_api_integration/test_suites/genai/knowledge_base/` |
+| API integration | `test/security_solution_api_integration/test_suites/genai/evaluations/` |
+| API integration | `test/security_solution_api_integration/test_suites/genai/startup/` |
+
+### AI4DSOC / Security AI Features
+
+| Test type | Directory |
+|---|---|
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/ai4dsoc/` |
+| API integration | `test/security_solution_api_integration/test_suites/ai4dsoc/` |
+
+### SIEM Migrations
+
+| Test type | Directory |
+|---|---|
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/siem_migrations/` |
+| API integration | `test/security_solution_api_integration/test_suites/siem_migrations/rules/` |
+
+### Flyout / Expandable Flyout
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/flyout/**/*.test.ts` |
+| Unit (package) | `packages/expandable-flyout/src/**/*.test.ts` |
+
+### Asset Inventory
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/asset_inventory/**/*.test.ts` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/asset_inventory/` |
+
+### Cloud Security Posture (CSPM / KSPM / CDR)
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/cloud_security_posture/public/**/*.test.ts` |
+| Functional (FTR) | `test/cloud_security_posture_functional/` |
+| API integration | `test/cloud_security_posture_api/` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/cloud_security_posture/` |
+
+### Endpoint Security / EDR Workflows
+
+| Test type | Directory |
+|---|---|
+| Functional (FTR) | `test/security_solution_endpoint/` |
+| Cypress E2E | `test/defend_workflows_cypress/` |
+| API integration | `test/security_solution_api_integration/test_suites/edr_workflows/` |
+
+### Telemetry
+
+| Test type | Directory |
+|---|---|
+| API integration | `test/security_solution_api_integration/test_suites/telemetry/` |
+| API integration | `test/security_solution_api_integration/test_suites/detections_response/telemetry/` |
+
+### Investigations (Cross-feature: dashboards, data view, threat intelligence)
+
+| Test type | Directory |
+|---|---|
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/dashboards/` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/data_view/` |
+| Cypress E2E | `test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/` |
+
+### Notes
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/notes/**/*.test.ts` |
+
+### Onboarding / Sourcerer / Common
+
+| Test type | Directory |
+|---|---|
+| Unit | `plugins/security_solution/public/onboarding/**/*.test.ts` |
+| Unit | `plugins/security_solution/public/sourcerer/**/*.test.ts` |
+| Unit | `plugins/security_solution/public/common/**/*.test.ts` |
+
+---
+
+## File naming conventions
+
+| Scenario | Convention | Example |
+|---|---|---|
+| Unit test | Co-located with source file | `alerts_table.tsx` → `alerts_table.test.ts` |
+| Jest integration test | Adjacent or in `__tests__/` | `my_hook.test.ts` with `jest.integration.config.js` |
+| Cypress spec | `*.cy.ts` inside `cypress/e2e/` | `rule_creation.cy.ts` |
+| Scout UI spec | `*.spec.ts` inside `test/scout*/ui/` | `alerts_page.spec.ts` |
+| Scout API spec | `*.spec.ts` inside `test/scout*/api/` | `rules_api.spec.ts` |
+| FTR API integration test | `*.ts` inside `test_suites/` | `create_rules.ts` |
+
+---
+
+## Notes for test coverage catalog
+
+- When reading PR diffs, look for changed files matching any of the paths above to find associated tests.
+- Unit tests are always the first coverage signal — check for `*.test.ts` files adjacent to any modified source file before assuming there is no coverage.
+- Cypress tests are the legacy E2E layer. Scout is the current standard — new E2E and API tests should use Scout.
+- FTR API integration tests under `security_solution_api_integration/` remain the primary API test layer for Security Solution until Scout coverage reaches parity.
+- The `entity_store` plugin has its own Scout API scaffold at `plugins/entity_store/test/scout/api/`.


### PR DESCRIPTION
## Summary

- Adds a conservative skill-path staleness detector that tokenizes Security Solution `.agents/skills/**/*.md` files, classifies path-like tokens (skip-if-uncertain to avoid false positives), and reports paths that no longer exist in the repo.
- Adds CLI entry (`scripts/check_skill_paths.js`) and a Buildkite scheduled pipeline (`.buildkite/pipelines/scheduled/skill_path_check.yml`) that runs weekly and posts findings to a central Slack channel.
- Seeds `<!-- skill-path-base: x-pack/solutions/security -->` on `security-test-directories.md` so its solution-relative Scout paths are covered by the declared-base anchor.

**Motivation:** PR #275087 reorganised Scout test namespaces without touching skill files — nobody noticed until manual discovery triggered #280060. This detector closes that gap for future reorganisations.

## Architecture

```
src/dev/skill_paths/
  extract_paths.ts        # tokeniser + conservative classifier (9 skip rules, 3 anchor types)
  resolve_and_check.ts    # anchor resolution + fs.existsSync
  run_skill_path_check.ts # orchestrator (glob → classify → resolve → findings)
  *.test.ts               # 27 tests (TDD: RED→GREEN)

src/dev/run_check_skill_paths.ts   # @kbn/dev-cli-runner entry, exits 0 always
scripts/check_skill_paths.js       # two-line shim

.buildkite/pipelines/scheduled/skill_path_check.yml
.buildkite/scripts/steps/checks/skill_path_check.sh
.buildkite/scripts/steps/checks/post_skill_path_slack.ts
```

The classifier is deliberately conservative (precision > recall): it only validates tokens it can resolve with certainty, and silently skips everything else. On the current clean tree: **0 false positives, 3 true positives** (pre-existing stale refs in `bug-validator/` — known, flagged for follow-up).

## Manual ops (needed before first run)

- [ ] Register a weekly Buildkite schedule in the UI pointing at `.buildkite/pipelines/scheduled/skill_path_check.yml`
- [ ] Provision `SKILL_PATH_SLACK_TOKEN` (bot token) in Vault / CI env
- [ ] Set `SKILL_PATH_SLACK_CHANNEL` (channel ID) in the pipeline or step env

## Test plan

- [ ] `node --experimental-vm-modules node_modules/.bin/jest --config src/dev/skill_paths/jest.config.js --no-coverage` — 27 tests pass
- [ ] `node scripts/check_skill_paths --json` against clean tree — reports 0 false positives (confirmed locally)
- [ ] Breaking a known path in a skill file confirms the detector reports that finding with correct file + line

## Known issues / follow-ups

- [ ] 3 pre-existing stale refs in `bug-validator/` (`x-pack/test/security_solution_api_integration/` moved; `x-pack/platform/plugins/shared/response-ops/` non-existent) — will fire on first scheduled run; fix in follow-up
- [ ] 3-component declared-base guard skips top-level `test/*` entries in `security-test-directories.md` (highest-risk reorg-drift category)
- [ ] `runSkillPathCheck` declared `async` but uses only synchronous `readFileSync`
- [ ] No request timeout on Slack HTTPS post

🤖 Generated with [Claude Code](https://claude.com/claude-code)