### PR TITLE
[kbn-evals] Improve weekly Slack summary format and trigger earlier

### DIFF
--- a/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
+++ b/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
@@ -54,7 +54,7 @@ spec:
           access_level: READ_ONLY
       schedules:
         Weekly build:
-          cronline: 0 0 * * 1 GMT
+          cronline: 0 20 * * 0 GMT
           message: Weekly LLM Evals (all suites, all models)
           branch: main
       tags:

--- a/x-pack/platform/packages/shared/kbn-evals/scripts/ci/build_weekly_slack_summary.js
+++ b/x-pack/platform/packages/shared/kbn-evals/scripts/ci/build_weekly_slack_summary.js
@@ -62,7 +62,7 @@ function renderSuiteLine(suite) {
   const rootCause = extractSuiteRootCauseLine(suite.triageBody);
   if (rootCause) {
     lines.push(`  ${rootCause}`);
-  } else if (!suite.triageBody) {
+  } else {
     lines.push(`  _(no triage)_`);
   }
 

--- a/x-pack/platform/packages/shared/kbn-evals/scripts/ci/build_weekly_slack_summary.js
+++ b/x-pack/platform/packages/shared/kbn-evals/scripts/ci/build_weekly_slack_summary.js
@@ -36,15 +36,7 @@ function renderChannelLink(suite) {
 }
 
 function renderSuiteLine(suite) {
-  const parts = [
-    `\`${suite.suiteId}\``,
-    (suite.failingProjects || []).map((project) => String(project)).join(', '),
-  ];
-
-  const rootCause = extractSuiteRootCauseLine(suite.triageBody);
-  if (rootCause) {
-    parts.push(rootCause);
-  }
+  const headerParts = [`*\`${suite.suiteId}\`*`];
 
   const links = [];
   if (suite.jobUrl) {
@@ -55,20 +47,26 @@ function renderSuiteLine(suite) {
     links.push(channelLink);
   }
   if (links.length > 0) {
-    parts.push(links.join(' · '));
+    headerParts.push(links.join(' · '));
   }
 
-  return `• ${parts.join(' — ')}`;
-}
+  const lines = [headerParts.join(' · ')];
 
-function renderOverviewLine(suite) {
-  const modelCount = Array.isArray(suite.failingProjects) ? suite.failingProjects.length : 0;
-  const parts = [`\`${suite.suiteId}\``, `${modelCount} model${modelCount === 1 ? '' : 's'}`];
-  const channelLink = renderChannelLink(suite);
-  if (channelLink) {
-    parts.push(channelLink);
+  const projects = Array.isArray(suite.failingProjects) ? suite.failingProjects : [];
+  if (projects.length > 3) {
+    lines.push(`  ${projects.length} models`);
+  } else if (projects.length > 0) {
+    lines.push(`  ${projects.map((p) => String(p)).join(', ')}`);
   }
-  return `• ${parts.join(' — ')}`;
+
+  const rootCause = extractSuiteRootCauseLine(suite.triageBody);
+  if (rootCause) {
+    lines.push(`  ${rootCause}`);
+  } else if (!suite.triageBody) {
+    lines.push(`  _(no triage)_`);
+  }
+
+  return lines.join('\n');
 }
 
 async function main() {
@@ -107,12 +105,7 @@ async function main() {
 
   lines.push('', '*Failed suites:*');
   for (const suite of suites) {
-    lines.push(renderOverviewLine(suite));
-  }
-
-  lines.push('', '*All failures:*');
-  for (const suite of suites) {
-    lines.push(renderSuiteLine(suite));
+    lines.push('', renderSuiteLine(suite));
   }
 
   lines.push(


### PR DESCRIPTION
Closes https://github.com/elastic/nightshift-program/issues/751

## Summary

Improves the weekly LLM evals workflow in two small ways:

1. Simplifies the weekly Slack summary by removing redundant information and making failures easier to scan.
2. Triggers the weekly run 4 hours earlier so results are ready by the start of the work week.

## Changes

### Weekly Slack summary

**Before** (two sections, 20 bullet points to read), example: https://elastic.slack.com/archives/C0A491YE5L4/p1784564046723179:

<details>
<summary>Expand example</summary>

```txt
  Buildkite  [6:14 PM]
  :broken_heart: Kibana / Evals / Weekly LLM Evals / main #66Failed Steps
  • LLM Evals: agent-builder / eis-anthropic-claude-4-6-opus
  • LLM Evals: agent-builder / eis-anthropic-claude-4-6-sonnet
  • LLM Evals: agent-builder / eis-google-gemini-3-0-flash
  • LLM Evals: agent-builder / eis-google-gemini-3-0-flash
  • LLM Evals: agent-builder / eis-google-gemini-3-1-pro
  • LLM Evals: agent-builder / eis-openai-gpt-5-4
  • LLM Evals: agent-builder / eis-openai-gpt-5-4
  • LLM Evals: agent-builder / eis-openai-gpt-oss-120b
  • LLM Evals: agent-builder / eis-openai-gpt-oss-120b
  • LLM Evals: agent-builder-dashboards / eis-google-gemini-3-0-flash
  • LLM Evals: agent-builder-dashboards / eis-google-gemini-3-1-pro
  • LLM Evals: streams / eis-anthropic-claude-4-6-sonnet
  • LLM Evals: streams / eis-google-gemini-3-0-flash
  • LLM Evals: streams / eis-google-gemini-3-1-pro
  • LLM Evals: streams / eis-openai-gpt-oss-120b
  • LLM Evals: significant-events / eis-anthropic-claude-4-6-opus
  • LLM Evals: significant-events / eis-anthropic-claude-4-6-opus
  • LLM Evals: significant-events / eis-anthropic-claude-4-6-opus
  • <h:rotating_light: Weekly LLM evals — 10 suites failed (23 model runs)
  :buildkite: Kibana / Evals / Weekly LLM Evals #66 · 2026-07-20

  Executive summary:
  - Overall: 3 suites likely retryable, 7 need a team to investigate.
  - Shared causes: 5 suites (agent-builder, endpoint, security-alert-analysis-workflow, security-alert-triage, streams) hit missing toolCallId in streaming chunks across multiple models; 2 suites (agent-builder-dashboards, significant-events) lack triage details; eis-google-gemini-3-1-pro fails across 5 suites with distinct causes.
  - Needs action: agent-builder — tool-calling behavior in multi-turn interactions; attack-discovery — no triage available; security-alerts-rag-regression — payload exceeds 413 limit; siem-readiness — missing required report sections; significant-events — no triage available; streams — inference service connection issues and pipeline suggestion failures.
  - Retry: agent-builder-dashboards, endpoint, security-alert-analysis-workflow, security-alert-triage.

  Failed suites:
  • agent-builder — 2 models — #agent-builder-alerts
  • agent-builder-dashboards — 2 models — private channel
  • attack-discovery — 2 models
  • endpoint — 1 model — #security-defend-workflows-tests
  • security-alert-analysis-workflow — 1 model — #security-generative-ai-evals
  • security-alert-triage — 2 models — #security-generative-ai-evals
  • security-alerts-rag-regression — 1 model — #security-generative-ai-evals
  • siem-readiness — 1 model — #siem-readiness
  • significant-events — 7 models — #significant-events-alerts
  • streams — 4 models — #observability-streams-dev

  All failures:
  • agent-builder — eis-openai-gpt-5-4, eis-openai-gpt-oss-120b — Error: expect(received).toBe(expected) // Object.is equality — job · #agent-builder-alerts
  • agent-builder-dashboards — eis-google-gemini-3-0-flash, eis-google-gemini-3-1-pro — Test timeout of 300000ms exceeded. — job · private channel
  • attack-discovery — eis-anthropic-claude-4-6-opus, eis-anthropic-claude-4-6-sonnet
  • endpoint — eis-openai-gpt-oss-120b — Tool call key is missing for index 0 in chunk — job · #security-defend-workflows-tests
  • security-alert-analysis-workflow — eis-openai-gpt-5-4 — Tool call key is missing for index 0 in chunk — job · #security-generative-ai-evals
  • security-alert-triage — eis-google-gemini-3-1-pro, eis-openai-gpt-5-4 — Tool call key is missing for index 0 in chunk — <httelastic/kibana · f2585d21

```

</details>

**After**
- Removed the redundant **Failed suites** overview section.
  - The information duplicated the **All failures** section while providing less detail.
- Reformatted failure reporting into a single per-suite multi-line block:
  - **Line 1:** Suite name + links
  - **Line 2:** Failing models
  - **Line 3:** Root cause
- Collapse model lists longer than 3 entries into `N models`.

<details>
<summary>Expand example</summary>

```txt
:rotating_light: *Weekly LLM evals* — 10 suites failed (23 model runs)
:buildkite: <build|Kibana / Evals / Weekly LLM Evals #66> · 2026-07-20

*Executive summary:*
- Overall: 3 suites likely retryable, 7 need a team to investigate.
- Shared causes: 5 suites (agent-builder, endpoint, security-alert-analysis-workflow, security-alert-triage, streams) hit missing toolCallId in streaming chunks across multiple models; 2 suites (agent-builder-dashboards, significant-events) lack triage details; eis-google-gemini-3-1-pro fails across 5 suites with distinct causes.
- Needs action: agent-builder — tool-calling behavior in multi-turn interactions; attack-discovery — no triage available; security-alerts-rag-regression — payload exceeds 413 limit; siem-readiness — missing required report sections; significant-events — no triage available; streams — inference service connection issues and pipeline suggestion failures.
- Retry: agent-builder-dashboards, endpoint, security-alert-analysis-workflow, security-alert-triage.

*Failed suites:*

*`agent-builder`* · <job> · #agent-builder-alerts
  eis-openai-gpt-5-4, eis-openai-gpt-oss-120b
  expect(received).toBe(expected) // Object.is equality

*`agent-builder-dashboards`* · <job> · #kibana-presentation-reminders
  eis-google-gemini-3-0-flash, eis-google-gemini-3-1-pro
  _(no triage)_

*`attack-discovery`* · <job>
  eis-anthropic-claude-4-6-opus, eis-anthropic-claude-4-6-sonnet
  _(no triage)_

*`endpoint`* · <job> · #security-defend-workflows-tests
  eis-openai-gpt-oss-120b
  Tool call key is missing for index 0 in chunk

*`security-alert-analysis-workflow`* · <job> · #security-generative-ai-evals
  eis-openai-gpt-5-4
  Tool call key is missing for index 0 in chunk

*`security-alert-triage`* · <job> · #security-generative-ai-evals
  eis-google-gemini-3-1-pro, eis-openai-gpt-5-4
  Tool call key is missing for index 0 in chunk

*`security-alerts-rag-regression`* · <job> · #security-generative-ai-evals
  eis-openai-gpt-oss-120b

*`siem-readiness`* · <job> · #siem-readiness
  eis-anthropic-claude-4-6-sonnet

*`significant-events`* · <job> · #significant-events-alerts
  7 models
  _(no triage)_

*`streams`* · <job> · #observability-streams-dev
  4 models

_Full per-suite triage posted to each team channel; see the build annotation for the complete detail._
```

</details>


### Weekly schedule

- Changed the weekly workflow trigger from **Monday 00:00 UTC** to **Sunday 20:00 UTC**

This allows the weekly evaluation results to be available at the beginning of the work week instead of continuing to run into Monday morning.


