### PR TITLE
[9.5] [Dashboard][a11y] Restore focus across panel workflows (#278559)

### DIFF
--- a/examples/embeddable_examples/public/react_embeddables/saved_book/create_saved_book_action.tsx
+++ b/examples/embeddable_examples/public/react_embeddables/saved_book/create_saved_book_action.tsx
@@ -26,7 +26,7 @@ export const createSavedBookAction = (core: CoreStart) => {
     isCompatible: async ({ embeddable }: EmbeddableApiContext) => {
       return apiCanAddNewPanel(embeddable);
     },
-    execute: async ({ embeddable }: EmbeddableApiContext) => {
+    execute: async ({ embeddable, returnFocus }: EmbeddableApiContext) => {
       if (!apiCanAddNewPanel(embeddable)) throw new IncompatibleActionError();
       const newBookStateManager = initializeStateManager<BookState>(
         defaultBookState,
@@ -35,6 +35,7 @@ export const createSavedBookAction = (core: CoreStart) => {
       openLazyFlyout({
         core,
         parentApi: parent,
+        returnFocus,
         loadContent: async ({ closeFlyout }) => {
           const { getSavedBookEditor } = await import('./saved_book_editor');
           return getSavedBookEditor({

--- a/src/platform/packages/shared/presentation/presentation_publishing/embeddable_api_context.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/embeddable_api_context.ts
@@ -13,6 +13,8 @@ export interface EmbeddableApiContext {
    * to reflect the fact that this context could contain any api.
    */
   embeddable: unknown;
+  /** Returns focus to the control that opened the action, when available. */
+  returnFocus?: () => void;
 }
 
 export const isEmbeddableApiContext = (context: unknown): context is EmbeddableApiContext =>

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.test.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.test.tsx
@@ -32,7 +32,6 @@ const props = {
   flyoutProps: {
     'data-test-subj': 'lazyFlyoutTest',
   },
-  triggerId: 'testTrigger',
 };
 
 describe('openLazyFlyout', () => {
@@ -178,14 +177,38 @@ describe('openLazyFlyout', () => {
       }).not.toThrow();
     });
 
-    it('returns focus to the triggerId element when provided', () => {
+    it('uses the provided return focus callback', () => {
       const trigger = document.createElement('button');
-      trigger.id = 'myTrigger';
       document.body.appendChild(trigger);
 
-      openLazyFlyout({ core, loadContent, flyoutProps: { triggerId: 'myTrigger' } });
+      openLazyFlyout({
+        core,
+        loadContent,
+        returnFocus: () => trigger.focus(),
+      });
 
       getOnClose()();
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it('defers return focus until the next animation frame', () => {
+      const trigger = document.createElement('button');
+      trigger.id = 'myTrigger';
+      trigger.disabled = true;
+      document.body.appendChild(trigger);
+
+      openLazyFlyout({
+        core,
+        loadContent,
+        returnFocus: () => trigger.focus(),
+      });
+
+      getOnClose()();
+      expect(document.activeElement).not.toBe(trigger);
+
+      trigger.disabled = false;
       jest.runAllTimers();
 
       expect(document.activeElement).toBe(trigger);

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
@@ -26,8 +26,11 @@ interface LoadContentArgs {
 interface OpenLazyFlyoutParams {
   core: CoreStart;
   parentApi?: unknown;
+  returnFocus?: () => void;
   loadContent: (args: LoadContentArgs) => Promise<JSX.Element | null | void>;
-  flyoutProps?: Partial<OverlayFlyoutOpenOptions> & { triggerId?: string; focusedPanelId?: string };
+  flyoutProps?: Partial<OverlayFlyoutOpenOptions> & {
+    focusedPanelId?: string;
+  };
 }
 
 // Re-query by id so focus survives a re-render that replaced the node; fall back to the
@@ -61,8 +64,8 @@ const resolveAttachedElement = (el: HTMLElement | null): HTMLElement | null => {
  * @returns A handle to the opened flyout (`OverlayRef`).
  */
 export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
-  const { core, parentApi, loadContent, flyoutProps: allFlyoutProps } = params;
-  const { focusedPanelId, triggerId, ...flyoutProps } = allFlyoutProps ?? {};
+  const { core, parentApi, returnFocus, loadContent, flyoutProps: allFlyoutProps } = params;
+  const { focusedPanelId, ...flyoutProps } = allFlyoutProps ?? {};
 
   const ariaLabelledBy = flyoutProps?.['aria-labelledby'] ?? htmlId();
   const overlayTracker = tracksOverlays(parentApi) ? parentApi : undefined;
@@ -75,12 +78,10 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
       ? document.activeElement
       : null;
 
-  const getTriggerElement = () => {
-    // Priority: explicit triggerId → the element that had focus (re-queried by id to
-    // survive a re-render) → the panel's "..." toggle (for context-menu actions whose
-    // menu item is gone by the time an async flyout opens).
-    const byTriggerId = triggerId ? document.getElementById(triggerId) : null;
-    if (byTriggerId) return byTriggerId;
+  const resolveReturnFocusTarget = () => {
+    // Priority: the element that had focus (re-queried by id to survive a re-render) →
+    // the panel's "..." toggle (for context-menu actions whose menu item is gone by the
+    // time an async flyout opens).
     const byFocusedElement = resolveAttachedElement(previouslyFocusedElement);
     if (byFocusedElement) return byFocusedElement;
     return focusedPanelId
@@ -88,12 +89,22 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
       : null;
   };
 
+  const restoreFocus = () => {
+    window.requestAnimationFrame(() => {
+      if (returnFocus) {
+        setTimeout(returnFocus);
+        return;
+      }
+      focusFirstFocusable(resolveReturnFocusTarget);
+    });
+  };
+
   const onClose = () => {
     overlayTracker?.clearOverlays();
     flyoutRef?.close();
     // Resolve lazily: closing can re-render the panel, so the trigger is looked up after
     // that render (inside focusFirstFocusable's deferred callback).
-    focusFirstFocusable(getTriggerElement);
+    restoreFocus();
   };
 
   const flyoutRef = core.overlays.openFlyout(

--- a/src/platform/plugins/private/image_embeddable/public/actions/create_image_action.test.ts
+++ b/src/platform/plugins/private/image_embeddable/public/actions/create_image_action.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EmbeddableApiContext } from '@kbn/presentation-publishing';
+import { openLazyFlyout } from '@kbn/presentation-util';
+import { createImageAction } from './create_image_action';
+
+jest.mock('@kbn/presentation-util', () => ({
+  openLazyFlyout: jest.fn(),
+}));
+
+jest.mock('../services/kibana_services', () => ({
+  coreServices: {},
+}));
+
+describe('createImageAction', () => {
+  it('returns focus to Add when the image editor closes', async () => {
+    const returnFocus = jest.fn();
+    await createImageAction.execute({
+      embeddable: { addNewPanel: jest.fn() },
+      returnFocus,
+    } as unknown as EmbeddableApiContext);
+
+    expect(openLazyFlyout).toHaveBeenCalledWith(expect.objectContaining({ returnFocus }));
+  });
+});

--- a/src/platform/plugins/private/image_embeddable/public/actions/create_image_action.ts
+++ b/src/platform/plugins/private/image_embeddable/public/actions/create_image_action.ts
@@ -24,12 +24,13 @@ export const createImageAction: ActionDefinition<EmbeddableApiContext> = {
   getIconType: () => 'image',
   order: 20,
   isCompatible: async ({ embeddable: parentApi }) => apiCanAddNewPanel(parentApi),
-  execute: async ({ embeddable: parentApi }) => {
+  execute: async ({ embeddable: parentApi, returnFocus }) => {
     if (!apiCanAddNewPanel(parentApi)) throw new IncompatibleActionError();
 
     openLazyFlyout({
       core: coreServices,
       parentApi,
+      returnFocus,
       loadContent: async ({ closeFlyout, ariaLabelledBy }) => {
         const { getImageEditor } = await import('../components/image_editor/get_image_editor');
         return await getImageEditor({

--- a/src/platform/plugins/private/links/public/actions/add_links_panel_action.ts
+++ b/src/platform/plugins/private/links/public/actions/add_links_panel_action.ts
@@ -37,12 +37,13 @@ export const addLinksPanelAction: ActionDefinition<EmbeddableApiContext> = {
   getIconType: () => APP_ICON,
   order: 10,
   isCompatible: async ({ embeddable }) => isParentApiCompatible(embeddable),
-  execute: async ({ embeddable }) => {
+  execute: async ({ embeddable, returnFocus }) => {
     if (!isParentApiCompatible(embeddable)) throw new IncompatibleActionError();
 
     openLazyFlyout({
       core: coreServices,
       parentApi: embeddable,
+      returnFocus,
       loadContent: async ({ closeFlyout }) => {
         return getEditorFlyout({
           parentDashboard: embeddable,

--- a/src/platform/plugins/shared/controls/public/actions/create_data_control_panel_action.tsx
+++ b/src/platform/plugins/shared/controls/public/actions/create_data_control_panel_action.tsx
@@ -33,7 +33,7 @@ export const createDataControlPanelAction = (): ActionDefinition<EmbeddableApiCo
   grouping: [ADD_PANEL_CONTROL_GROUP],
   getIconType: () => 'controls',
   isCompatible: async ({ embeddable }) => apiCanAddNewPanel(embeddable),
-  execute: async ({ embeddable }) => {
+  execute: async ({ embeddable, returnFocus }) => {
     if (!apiCanAddNewPanel(embeddable)) throw new IncompatibleActionError();
     const defaultDataViewId = apiHasEditorConfig(embeddable)
       ? embeddable.getEditorConfig()?.defaultDataViewId
@@ -53,6 +53,7 @@ export const createDataControlPanelAction = (): ActionDefinition<EmbeddableApiCo
         values_source: ControlValuesSource.FIELD,
       },
       parentApi: embeddable,
+      returnFocus,
       setLastUsedDataViewId: (dataViewId) => {
         lastUsedDataViewId = dataViewId;
       },

--- a/src/platform/plugins/shared/controls/public/actions/create_esql_control_action.tsx
+++ b/src/platform/plugins/shared/controls/public/actions/create_esql_control_action.tsx
@@ -36,7 +36,7 @@ export const createESQLControlAction = (): ActionDefinition<EmbeddableApiContext
   grouping: [ADD_PANEL_CONTROL_GROUP],
   getIconType: () => 'controls',
   isCompatible: async ({ embeddable }) => apiCanAddNewPanel(embeddable),
-  execute: async ({ embeddable }) => {
+  execute: async ({ embeddable, returnFocus }) => {
     if (!apiCanAddNewPanel(embeddable)) throw new IncompatibleActionError();
     const variablesInParent = apiPublishesESQLVariables(embeddable)
       ? embeddable.esqlVariables$.value
@@ -64,6 +64,7 @@ export const createESQLControlAction = (): ActionDefinition<EmbeddableApiContext
           );
         },
         triggerSource: ControlTriggerSource.ADD_CONTROL_BTN,
+        returnFocus,
       });
     } catch (e) {
       // eslint-disable-next-line no-console

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/open_data_control_editor.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/open_data_control_editor.tsx
@@ -19,6 +19,7 @@ import { coreServices } from '../../services/kibana_services';
 export interface OpenDataControlEditorParams<State extends DataControlState = DataControlState> {
   initialState: Partial<State>;
   parentApi: unknown;
+  returnFocus?: () => void;
   setLastUsedDataViewId?: (dataViewId: string) => void;
   // these props are only provided when the control already exists and is being edited
   controlId?: string;
@@ -41,6 +42,7 @@ export const openDataControlEditor = <State extends DataControlState = DataContr
   const {
     initialState,
     parentApi,
+    returnFocus,
     setLastUsedDataViewId,
     controlId,
     controlType,
@@ -92,6 +94,7 @@ export const openDataControlEditor = <State extends DataControlState = DataContr
   openLazyFlyout({
     core: coreServices,
     parentApi,
+    returnFocus,
     loadContent: async ({ closeFlyout }) => {
       const { DataControlEditor } = await import('./editor/data_control_editor');
       return (
@@ -115,7 +118,6 @@ export const openDataControlEditor = <State extends DataControlState = DataContr
       );
     },
     flyoutProps: {
-      triggerId: 'dashboard-controls-menu-button',
       focusedPanelId: controlId,
     },
   });

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_panel_button/components/add_panel_flyout.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_panel_button/components/add_panel_flyout.tsx
@@ -43,13 +43,22 @@ const TAB_NEW_ID = 'new' as const;
 const TAB_LIBRARY_ID = 'library' as const;
 type FlyoutTab = typeof TAB_NEW_ID | typeof TAB_LIBRARY_ID;
 
-function NewPanelContent({ dashboardApi }: { dashboardApi: DashboardApi }) {
+function NewPanelContent({
+  dashboardApi,
+  returnFocus,
+}: {
+  dashboardApi: DashboardApi;
+  returnFocus?: () => void;
+}) {
   const {
     groups,
     loading: isLoadingGroups,
     error: loadGroupsError,
-  } = useMenuItemGroups({ dashboardApi });
-  const { featuredItems, loading: isLoadingFeaturedItems } = useFeaturedItems({ dashboardApi });
+  } = useMenuItemGroups({ dashboardApi, returnFocus });
+  const { featuredItems, loading: isLoadingFeaturedItems } = useFeaturedItems({
+    dashboardApi,
+    returnFocus,
+  });
 
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [filteredGroups, setFilteredGroups] = useState<MenuItemGroup[]>([]);
@@ -208,10 +217,12 @@ function LibraryContent({ dashboardApi }: { dashboardApi: DashboardApi }) {
 export function AddPanelFlyout({
   dashboardApi,
   ariaLabelledBy,
+  returnFocus,
   initialTab = TAB_NEW_ID,
 }: {
   dashboardApi: DashboardApi;
   ariaLabelledBy: string;
+  returnFocus?: () => void;
   initialTab?: FlyoutTab;
 }) {
   const [selectedTab, setSelectedTab] = useState<FlyoutTab>(initialTab);
@@ -253,7 +264,7 @@ export function AddPanelFlyout({
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         {selectedTab === TAB_NEW_ID ? (
-          <NewPanelContent dashboardApi={dashboardApi} />
+          <NewPanelContent dashboardApi={dashboardApi} returnFocus={returnFocus} />
         ) : (
           <LibraryContent dashboardApi={dashboardApi} />
         )}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_panel_button/use_featured_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_panel_button/use_featured_items.tsx
@@ -16,8 +16,10 @@ import { getMenuItems } from './use_menu_item_groups';
 
 export const useFeaturedItems = ({
   dashboardApi,
+  returnFocus,
 }: {
   dashboardApi: DashboardApi;
+  returnFocus?: () => void;
 }): { featuredItems: MenuItem[]; loading: boolean } => {
   const [featuredItems, setFeaturedItems] = useState<MenuItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -31,6 +33,7 @@ export const useFeaturedItems = ({
       trigger: {
         id: FEATURED_ADD_PANEL_TRIGGER,
       },
+      returnFocus,
     };
 
     uiActionsService
@@ -51,7 +54,7 @@ export const useFeaturedItems = ({
     return () => {
       canceled = true;
     };
-  }, [dashboardApi]);
+  }, [dashboardApi, returnFocus]);
 
   return { loading, featuredItems };
 };

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_panel_button/use_menu_item_groups.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_panel_button/use_menu_item_groups.test.tsx
@@ -29,6 +29,42 @@ jest.mock('../../../services/kibana_services', () => {
 });
 
 describe('useMenuItemGroups', () => {
+  test('opens the selected panel editor without waiting for Add to be enabled', async () => {
+    const execute = jest.fn();
+    const returnFocus = jest.fn();
+    mockGetTriggerCompatibleActions.mockResolvedValueOnce([
+      {
+        id: 'mockAddPanelAction',
+        type: '',
+        order: 10,
+        grouping: [
+          {
+            id: 'visualizations',
+            order: 1000,
+            getDisplayName: () => 'Visualizations',
+          },
+        ],
+        getDisplayName: () => 'mockAddPanelAction',
+        getIconType: () => 'empty',
+        execute,
+        isCompatible: async () => true,
+      },
+    ]);
+    const api = {
+      ...buildMockDashboardApi().api,
+      openOverlay: () => {},
+      clearOverlays: jest.fn(),
+    };
+    const { result } = renderHook(() => useMenuItemGroups({ dashboardApi: api, returnFocus }));
+    await waitFor(() => expect(result.current.groups).toBeDefined());
+
+    result.current.groups?.[0].items[0].onClick({
+      currentTarget: document.createElement('button'),
+    } as unknown as React.MouseEvent);
+
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ returnFocus }));
+  });
+
   test('gets sorted groups + items from ADD_PANEL_TRIGGER actions', async () => {
     mockGetTriggerCompatibleActions.mockResolvedValueOnce([
       {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_panel_button/use_menu_item_groups.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_panel_button/use_menu_item_groups.tsx
@@ -22,15 +22,18 @@ import type { MenuItemGroup } from './types';
 
 export const useMenuItemGroups = ({
   dashboardApi,
+  returnFocus,
 }: {
   dashboardApi: DashboardApi;
+  returnFocus?: () => void;
 }): { groups: MenuItemGroup[] | undefined; loading: boolean; error: Error | undefined } => {
   const context = useMemo(
     () => ({
       embeddable: dashboardApi,
       trigger: triggers[ADD_PANEL_TRIGGER],
+      returnFocus,
     }),
-    [dashboardApi]
+    [dashboardApi, returnFocus]
   );
 
   const [groups, setGroups] = useState<MenuItemGroup[] | undefined>();
@@ -65,23 +68,25 @@ async function getActionGroups(
   const groups: Record<string, { group: PresentableGroup; actions: Action[] }> = {};
   const disabledStateChangesSubjects: Array<Observable<void> | undefined> = [];
 
-  (
-    await uiActionsService.getTriggerCompatibleActions(ADD_PANEL_TRIGGER, { embeddable: api })
-  ).forEach((action) => {
-    const actionGroups = Array.isArray(action.grouping) ? action.grouping : [ADD_PANEL_OTHER_GROUP];
-    if (action.getDisabledStateChangesSubject) {
-      disabledStateChangesSubjects.push(action.getDisabledStateChangesSubject(context));
-    }
-    actionGroups.forEach((group) => {
-      if (!groups[group.id]) {
-        groups[group.id] = {
-          group,
-          actions: [],
-        };
+  (await uiActionsService.getTriggerCompatibleActions(ADD_PANEL_TRIGGER, context)).forEach(
+    (action) => {
+      const actionGroups = Array.isArray(action.grouping)
+        ? action.grouping
+        : [ADD_PANEL_OTHER_GROUP];
+      if (action.getDisabledStateChangesSubject) {
+        disabledStateChangesSubjects.push(action.getDisabledStateChangesSubject(context));
       }
-      groups[group.id].actions.push(action);
-    });
-  });
+      actionGroups.forEach((group) => {
+        if (!groups[group.id]) {
+          groups[group.id] = {
+            group,
+            actions: [],
+          };
+        }
+        groups[group.id].actions.push(action);
+      });
+    }
+  );
 
   return {
     groups,
@@ -102,7 +107,6 @@ export function getMenuItems(
         name: actionName,
         icon: action.getIconType?.(context) ?? 'empty',
         onClick: (event: React.MouseEvent) => {
-          dashboardApi.clearOverlays();
           if (event.currentTarget instanceof HTMLAnchorElement) {
             if (
               !event.defaultPrevented && // onClick prevented default
@@ -113,6 +117,7 @@ export function getMenuItems(
               event.preventDefault();
             }
           }
+          dashboardApi.clearOverlays();
           action.execute(context);
         },
         'data-test-subj': `create-action-${actionName}`,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.test.tsx
@@ -11,12 +11,18 @@ import { renderHook, waitFor } from '@testing-library/react';
 
 import type { AppMenuPopoverItem } from '@kbn/core-chrome-app-menu-components';
 import type { ShareActionIntents } from '@kbn/share-plugin/public/types';
+import { openLazyFlyout } from '@kbn/presentation-util';
 
 import { dashboardContextWrapper } from '../../mocks';
 import { coreServices, shareService } from '../../services/kibana_services';
 import { useDashboardMenuItems } from './use_dashboard_menu_items';
 import { BehaviorSubject } from 'rxjs';
 import type { DashboardApi } from '../../dashboard_api/types';
+
+jest.mock('@kbn/presentation-util', () => ({
+  ...jest.requireActual('@kbn/presentation-util'),
+  openLazyFlyout: jest.fn(),
+}));
 
 describe('useDashboardMenuItems', () => {
   beforeEach(() => {
@@ -25,6 +31,35 @@ describe('useDashboardMenuItems', () => {
     jest
       .mocked(shareService!.availableIntegrations)
       .mockImplementation(() => [] as ShareActionIntents[]);
+  });
+
+  describe('Add panel', () => {
+    test('returns focus to the Add button when the flyout closes', () => {
+      const returnFocus = jest.fn();
+      const { result } = renderHook(
+        () =>
+          useDashboardMenuItems({
+            isLabsShown: false,
+            setIsLabsShown: jest.fn(),
+            maybeRedirect: jest.fn(),
+          }),
+        {
+          wrapper: dashboardContextWrapper({}),
+        }
+      );
+
+      result.current.editModeTopNavConfig.items
+        ?.find(({ id }) => id === 'add')
+        ?.run?.({
+          triggerElement: document.createElement('button'),
+          returnFocus,
+        });
+
+      const [{ returnFocus: restoreFocus }] = jest.mocked(openLazyFlyout).mock.calls[0];
+      restoreFocus?.();
+
+      expect(returnFocus).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Export', () => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -20,6 +20,7 @@ import type {
   AppMenuConfig,
   AppMenuItemType,
   AppMenuPrimaryActionItem,
+  AppMenuRunActionParams,
 } from '@kbn/core-chrome-app-menu-components';
 import { useDashboardExportItems } from './share/use_dashboard_export_items';
 import { getAccessControlClient } from '../../services/access_control_service';
@@ -158,21 +159,30 @@ export const useDashboardMenuItems = ({
     }
   }, [quickSaveDashboard, dashboardInteractiveSave, lastSavedId]);
 
-  const openAddPanelFlyout = useCallback(() => {
-    openLazyFlyout({
-      core: coreServices,
-      parentApi: dashboardApi,
-      loadContent: async ({ closeFlyout, ariaLabelledBy }) => {
-        const { AddPanelFlyout } = await import('./add_panel_button/components/add_panel_flyout');
+  const openAddPanelFlyout = useCallback(
+    (params?: AppMenuRunActionParams) => {
+      openLazyFlyout({
+        core: coreServices,
+        parentApi: dashboardApi,
+        returnFocus: params?.returnFocus,
+        loadContent: async ({ closeFlyout, ariaLabelledBy }) => {
+          const { AddPanelFlyout } = await import('./add_panel_button/components/add_panel_flyout');
 
-        return <AddPanelFlyout dashboardApi={dashboardApi} ariaLabelledBy={ariaLabelledBy} />;
-      },
-      flyoutProps: {
-        'data-test-subj': 'dashboardAddPanel',
-        triggerId: 'dashboardAddTopNavButton',
-      },
-    });
-  }, [dashboardApi]);
+          return (
+            <AddPanelFlyout
+              dashboardApi={dashboardApi}
+              ariaLabelledBy={ariaLabelledBy}
+              returnFocus={params?.returnFocus}
+            />
+          );
+        },
+        flyoutProps: {
+          'data-test-subj': 'dashboardAddPanel',
+        },
+      });
+    },
+    [dashboardApi]
+  );
 
   const shareOptions = useShareOptions();
 
@@ -357,7 +367,7 @@ export const useDashboardMenuItems = ({
         testId: 'dashboardSettingsButton',
         disableButton: disableTopNav,
         htmlId: 'dashboardSettingsButton',
-        run: () => openSettingsFlyout(dashboardApi),
+        run: (params) => openSettingsFlyout(dashboardApi, params?.returnFocus),
       } as AppMenuItemType,
 
       // Action items

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/settings/open_settings_flyout.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/settings/open_settings_flyout.tsx
@@ -14,10 +14,11 @@ import type { DashboardApi } from '../../dashboard_api/types';
 import { DashboardContext } from '../../dashboard_api/use_dashboard_api';
 import { coreServices } from '../../services/kibana_services';
 
-export function openSettingsFlyout(dashboardApi: DashboardApi) {
+export function openSettingsFlyout(dashboardApi: DashboardApi, returnFocus?: () => void) {
   openLazyFlyout({
     core: coreServices,
     parentApi: dashboardApi,
+    returnFocus,
     loadContent: async ({ closeFlyout, ariaLabelledBy }) => {
       const { DashboardSettingsFlyout } = await import('./settings_flyout');
       return (
@@ -28,7 +29,6 @@ export function openSettingsFlyout(dashboardApi: DashboardApi) {
     },
     flyoutProps: {
       'data-test-subj': 'dashboardSettingsFlyout',
-      triggerId: 'dashboardSettingsButton',
     },
   });
 }

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.test.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.test.ts
@@ -42,6 +42,7 @@ describe('CreateESQLControlAction', () => {
     onCancelControl: jest.fn(),
     parentApi: {},
     triggerSource: ControlTriggerSource.QUESTION_MARK,
+    returnFocus: jest.fn(),
   };
 
   beforeEach(() => {
@@ -93,12 +94,12 @@ describe('CreateESQLControlAction', () => {
       expect(mockOpenLazyFlyout).toHaveBeenCalledWith({
         core: mockCore,
         parentApi: {},
+        returnFocus: mockContext.returnFocus,
         loadContent: expect.any(Function),
         flyoutProps: {
           'data-test-subj': 'create_esql_control_flyout',
           isResizable: true,
           maxWidth: 800,
-          triggerId: 'dashboard-controls-menu-button',
           onClose: expect.any(Function),
         },
       });

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
@@ -49,6 +49,7 @@ interface Context {
   parentApi?: unknown;
   triggerSource?: ControlTriggerSource;
   controlId?: string;
+  returnFocus?: () => void;
 }
 
 export class CreateESQLControlAction implements Action<Context> {
@@ -87,6 +88,7 @@ export class CreateESQLControlAction implements Action<Context> {
     parentApi,
     triggerSource,
     controlId,
+    returnFocus,
   }: Context) {
     if (!isActionCompatible(this.core, variableType)) {
       throw new IncompatibleActionError();
@@ -115,6 +117,7 @@ export class CreateESQLControlAction implements Action<Context> {
     openLazyFlyout({
       core: this.core,
       parentApi,
+      returnFocus,
       loadContent: async ({ closeFlyout, ariaLabelledBy }) => {
         const { loadESQLControlFlyout } = await import('./esql_control_helpers');
         return await loadESQLControlFlyout({
@@ -140,7 +143,6 @@ export class CreateESQLControlAction implements Action<Context> {
         focusedPanelId: controlId,
         isResizable: true,
         maxWidth: 800,
-        triggerId: 'dashboard-controls-menu-button',
         // When `onCancelControl` is present (i.e. flyout opened from the ES|QL editor),
         // use the local onClose as the onClose handler to ensure proper nested flyout closing behavior.
         // In other scenarios (opened directly from the dashboard), we keep the default close behavior.

--- a/src/platform/plugins/shared/inspector/public/types.ts
+++ b/src/platform/plugins/shared/inspector/public/types.ts
@@ -61,7 +61,9 @@ export interface InspectorViewDescription {
 export interface InspectorOptions {
   title?: string;
   options?: unknown;
-  flyoutProps?: Partial<OverlayFlyoutOpenOptions> & { triggerId?: string; focusedPanelId?: string };
+  flyoutProps?: Partial<OverlayFlyoutOpenOptions> & {
+    focusedPanelId?: string;
+  };
 }
 
 export type InspectorSession = OverlayRef;

--- a/src/platform/plugins/shared/ui_actions/public/actions/action.ts
+++ b/src/platform/plugins/shared/ui_actions/public/actions/action.ts
@@ -25,6 +25,10 @@ export interface ActionExecutionMeta {
    * The event that caused the action to execute (e.g., mouse click, keyboard event)
    */
   event?: React.MouseEvent;
+  /**
+   * Returns focus to the control that opened the action.
+   */
+  returnFocus?: () => void;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_change_point_chart.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_change_point_chart.tsx
@@ -62,6 +62,7 @@ export function createAddChangePointChartAction(
       openLazyFlyout({
         core: coreStart,
         parentApi: context.embeddable,
+        returnFocus: context.returnFocus,
         flyoutProps: {
           'data-test-subj': 'aiopsChangePointChartEmbeddableInitializer',
           'aria-labelledby': 'changePointConfig',

--- a/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_log_rate_analysis_actions.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_log_rate_analysis_actions.tsx
@@ -54,6 +54,7 @@ export function createAddLogRateAnalysisEmbeddableAction(
       openLazyFlyout({
         core: coreStart,
         parentApi: context.embeddable,
+        returnFocus: context.returnFocus,
         flyoutProps: {
           hideCloseButton: true,
           focusedPanelId: context.embeddable.uuid,

--- a/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_pattern_analysis_action.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_pattern_analysis_action.tsx
@@ -54,6 +54,7 @@ export function createAddPatternAnalysisEmbeddableAction(
       openLazyFlyout({
         core: coreStart,
         parentApi: context.embeddable,
+        returnFocus: context.returnFocus,
         flyoutProps: {
           hideCloseButton: true,
           focusedPanelId: context.embeddable.uuid,

--- a/x-pack/platform/plugins/shared/embeddable_alerts_table/public/actions/add_alerts_table_action.tsx
+++ b/x-pack/platform/plugins/shared/embeddable_alerts_table/public/actions/add_alerts_table_action.tsx
@@ -39,12 +39,13 @@ export const getAddAlertsTableAction = (
       const hasAccessToAnyRuleTypes = await checkRuleTypesPermissions(http);
       return apiIsPresentationContainer(embeddable) && hasAccessToAnyRuleTypes;
     },
-    execute: async ({ embeddable }) => {
+    execute: async ({ embeddable, returnFocus }) => {
       if (!apiIsPresentationContainer(embeddable)) throw new IncompatibleActionError();
 
       openLazyFlyout({
         core: coreServices,
         parentApi: embeddable,
+        returnFocus,
         loadContent: async ({ closeFlyout, ariaLabelledBy }) => {
           const { ConfigEditor } = await import('../components/config_editor');
           return (

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/mount.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/mount.tsx
@@ -22,7 +22,7 @@ export const mountInlinePanel = async ({
   core,
   api,
   loadContent,
-  options: { dataTestSubj, uuid, container } = {},
+  options: { dataTestSubj, uuid, container, returnFocus } = {},
 }: {
   core: CoreStart;
   api?: unknown;
@@ -36,6 +36,7 @@ export const mountInlinePanel = async ({
     dataTestSubj?: string;
     uuid?: string;
     container?: HTMLElement | null;
+    returnFocus?: () => void;
   };
 }) => {
   if (container) {
@@ -48,6 +49,7 @@ export const mountInlinePanel = async ({
   openLazyFlyout({
     core,
     parentApi: api,
+    returnFocus,
     loadContent,
     flyoutProps: {
       ...lensFlyoutProps,
@@ -74,7 +76,7 @@ const inlineFlyoutStyles = ({ euiTheme }: UseEuiTheme) => `
   }
 `;
 
-export const lensFlyoutProps: OverlayFlyoutOpenOptions & { triggerId?: string } = {
+export const lensFlyoutProps: OverlayFlyoutOpenOptions = {
   css: inlineFlyoutStyles,
   'data-test-subj': 'customizeLens',
   isResizable: true,

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/add_esql_panel_action.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/add_esql_panel_action.tsx
@@ -49,7 +49,7 @@ export class AddESQLPanelAction implements Action<EmbeddableApiContext> {
     return apiIsPresentationContainer(embeddable) && this.core.uiSettings.get(ENABLE_ESQL);
   }
 
-  public async execute({ embeddable: api }: EmbeddableApiContext) {
+  public async execute({ embeddable: api, returnFocus }: EmbeddableApiContext) {
     if (!apiIsPresentationContainer(api)) throw new IncompatibleActionError();
     if (!api || !apiHasAppContext(api)) {
       return;
@@ -76,7 +76,7 @@ export class AddESQLPanelAction implements Action<EmbeddableApiContext> {
           closeFlyout,
         });
       },
-      options: { uuid },
+      options: { uuid, returnFocus },
     });
   }
 }

--- a/x-pack/platform/plugins/shared/ml/public/ui_actions/create_anomaly_chart.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/ui_actions/create_anomaly_chart.tsx
@@ -68,6 +68,7 @@ export function createAddAnomalyChartsPanelAction(
       openLazyFlyout({
         core: coreStart,
         parentApi: context.embeddable,
+        returnFocus: context.returnFocus,
         flyoutProps: {
           'data-test-subj': 'mlAnomalyChartsEmbeddableInitializer',
           focusedPanelId: context.embeddable.uuid,

--- a/x-pack/platform/plugins/shared/ml/public/ui_actions/create_single_metric_viewer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/ui_actions/create_single_metric_viewer.tsx
@@ -74,6 +74,7 @@ export function createAddSingleMetricViewerPanelAction(
       openLazyFlyout({
         core: coreStart,
         parentApi: context.embeddable,
+        returnFocus: context.returnFocus,
         flyoutProps: {
           focusedPanelId: context.embeddable.uuid,
         },

--- a/x-pack/platform/plugins/shared/ml/public/ui_actions/create_swim_lane.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/ui_actions/create_swim_lane.tsx
@@ -69,6 +69,7 @@ export function createAddSwimlanePanelAction(
       openLazyFlyout({
         core: coreStart,
         parentApi: context.embeddable,
+        returnFocus: context.returnFocus,
         flyoutProps: {
           focusedPanelId: context.embeddable.uuid,
         },

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/create_add_service_map_panel_action.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/create_add_service_map_panel_action.test.ts
@@ -82,15 +82,17 @@ describe('createAddServiceMapPanelAction', () => {
 
   it('opens configuration flyout when executed', async () => {
     const embeddable = { addNewPanel: jest.fn() };
+    const returnFocus = jest.fn();
     mockApiIsPresentationContainer.mockReturnValue(true);
     const action = createAddServiceMapPanelAction(mockDeps);
 
-    await action.execute({ embeddable } as never);
+    await action.execute({ embeddable, returnFocus } as never);
 
     expect(mockOpenLazyFlyout).toHaveBeenCalledWith(
       expect.objectContaining({
         core: mockCoreStart,
         parentApi: embeddable,
+        returnFocus,
         loadContent: expect.any(Function),
       })
     );

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/create_add_service_map_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/create_add_service_map_panel_action.tsx
@@ -32,7 +32,7 @@ export function createAddServiceMapPanelAction(
     isCompatible: async ({ embeddable }) => {
       return deps.config.serviceMapEnabled && apiIsPresentationContainer(embeddable);
     },
-    execute: async ({ embeddable }) => {
+    execute: async ({ embeddable, returnFocus }) => {
       if (!deps.config.serviceMapEnabled || !apiIsPresentationContainer(embeddable)) {
         throw new IncompatibleActionError();
       }
@@ -44,6 +44,7 @@ export function createAddServiceMapPanelAction(
       openLazyFlyout({
         core: deps.coreStart,
         parentApi: embeddable,
+        returnFocus,
         flyoutProps: {
           size: 'm',
         },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Dashboard][a11y] Restore focus across panel workflows (#278559)](https://github.com/elastic/kibana/pull/278559)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marta Bondyra","email":"4283304+mbondyra@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-22T14:48:54Z","message":"[Dashboard][a11y] Restore focus across panel workflows (#278559)\n\n## Summary\n- use `returnFocus` from `AppMenuRunActionParams` (see #262131) so\nDashboard App Menu actions restore focus through the chrome-owned\nhandler instead of hardcoding trigger element IDs\n- return keyboard focus to the Dashboard **Add** button after add-panel\neditors close, including Lens/ES|QL, Image, Links, Controls, Alerts\ntable, and the add-panel flyout itself\n- skip restoring focus to **Add** when the user continues into a nested\neditor from the Add flyout, so the next flyout opens without an\nintermediate focus flash\n- preserve existing focus behavior when editing an existing panel\n\nbefore - focus gets lost when canceling/adding a panel\n\n\nhttps://github.com/user-attachments/assets/4f736b42-e638-426c-9369-b279df8d85cc\n\n\nafter - focus goes back to add\n\n\nhttps://github.com/user-attachments/assets/767b7e57-1988-4cbc-93ce-b37ed4d13ac4\n\n\n\n## Why return to Add\nReturning to the newly created panel required every panel type to expose\na stable, consistently mounted focus target and made the behavior depend\non each editor's lifecycle. Returning to **Add** gives every add\nworkflow one predictable destination with much less integration code.\n\nThis also follows the accessibility requirement that focus must not be\nleft on an element removed with a dialog or flyout. **Add** remains\nvisible, identifies the workflow the user just completed, and lets\nkeyboard and assistive-technology users continue from a known control.\nExisting-panel editing keeps its current source/panel return behavior.\n\nAddresses #278558\n\n### Manual workflows\nRun each workflow with keyboard navigation and verify focus is visibly\non **Add** after closing or completing the add editor:\n\n- [ ] **Add → close/cancel the Add panel flyout**\n- [ ] **Add → Image → Cancel** (also test X and Escape)\n- [ ] **Add → Links → Cancel**\n- [ ] **Add → Visualization → Cancel**\n- [ ] **Add → Visualization (query / ES|QL) → Cancel** (also test X and\nEscape)\n- [ ] **Add → Controls → create a data control → Cancel**\n- [ ] **Add → Alerts table → Cancel** (when available)\n- [ ] Complete representative Image, Lens, and ES|QL add workflows and\nverify focus returns to **Add**\n- [ ] Open one of the same editors from an existing panel and close it;\nverify focus returns to the existing panel/source rather than **Add**\n- [ ] Select a panel type from the Add flyout and verify its editor\nopens directly, without an intermediate focus animation or delay\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Nick Peihl <nick.peihl@elastic.co>","sha":"563d75b4858f46d99d5d6ec6778ee9986c7f6995","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","release_note:skip","backport:version","Team:obs-presentation","v9.5.0","v9.6.0","v9.4.5"],"title":"[Dashboard][a11y] Restore focus across panel workflows","number":278559,"url":"https://github.com/elastic/kibana/pull/278559","mergeCommit":{"message":"[Dashboard][a11y] Restore focus across panel workflows (#278559)\n\n## Summary\n- use `returnFocus` from `AppMenuRunActionParams` (see #262131) so\nDashboard App Menu actions restore focus through the chrome-owned\nhandler instead of hardcoding trigger element IDs\n- return keyboard focus to the Dashboard **Add** button after add-panel\neditors close, including Lens/ES|QL, Image, Links, Controls, Alerts\ntable, and the add-panel flyout itself\n- skip restoring focus to **Add** when the user continues into a nested\neditor from the Add flyout, so the next flyout opens without an\nintermediate focus flash\n- preserve existing focus behavior when editing an existing panel\n\nbefore - focus gets lost when canceling/adding a panel\n\n\nhttps://github.com/user-attachments/assets/4f736b42-e638-426c-9369-b279df8d85cc\n\n\nafter - focus goes back to add\n\n\nhttps://github.com/user-attachments/assets/767b7e57-1988-4cbc-93ce-b37ed4d13ac4\n\n\n\n## Why return to Add\nReturning to the newly created panel required every panel type to expose\na stable, consistently mounted focus target and made the behavior depend\non each editor's lifecycle. Returning to **Add** gives every add\nworkflow one predictable destination with much less integration code.\n\nThis also follows the accessibility requirement that focus must not be\nleft on an element removed with a dialog or flyout. **Add** remains\nvisible, identifies the workflow the user just completed, and lets\nkeyboard and assistive-technology users continue from a known control.\nExisting-panel editing keeps its current source/panel return behavior.\n\nAddresses #278558\n\n### Manual workflows\nRun each workflow with keyboard navigation and verify focus is visibly\non **Add** after closing or completing the add editor:\n\n- [ ] **Add → close/cancel the Add panel flyout**\n- [ ] **Add → Image → Cancel** (also test X and Escape)\n- [ ] **Add → Links → Cancel**\n- [ ] **Add → Visualization → Cancel**\n- [ ] **Add → Visualization (query / ES|QL) → Cancel** (also test X and\nEscape)\n- [ ] **Add → Controls → create a data control → Cancel**\n- [ ] **Add → Alerts table → Cancel** (when available)\n- [ ] Complete representative Image, Lens, and ES|QL add workflows and\nverify focus returns to **Add**\n- [ ] Open one of the same editors from an existing panel and close it;\nverify focus returns to the existing panel/source rather than **Add**\n- [ ] Select a panel type from the Add flyout and verify its editor\nopens directly, without an intermediate focus animation or delay\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Nick Peihl <nick.peihl@elastic.co>","sha":"563d75b4858f46d99d5d6ec6778ee9986c7f6995"}},"sourceBranch":"main","suggestedTargetBranches":["9.5","9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278559","number":278559,"mergeCommit":{"message":"[Dashboard][a11y] Restore focus across panel workflows (#278559)\n\n## Summary\n- use `returnFocus` from `AppMenuRunActionParams` (see #262131) so\nDashboard App Menu actions restore focus through the chrome-owned\nhandler instead of hardcoding trigger element IDs\n- return keyboard focus to the Dashboard **Add** button after add-panel\neditors close, including Lens/ES|QL, Image, Links, Controls, Alerts\ntable, and the add-panel flyout itself\n- skip restoring focus to **Add** when the user continues into a nested\neditor from the Add flyout, so the next flyout opens without an\nintermediate focus flash\n- preserve existing focus behavior when editing an existing panel\n\nbefore - focus gets lost when canceling/adding a panel\n\n\nhttps://github.com/user-attachments/assets/4f736b42-e638-426c-9369-b279df8d85cc\n\n\nafter - focus goes back to add\n\n\nhttps://github.com/user-attachments/assets/767b7e57-1988-4cbc-93ce-b37ed4d13ac4\n\n\n\n## Why return to Add\nReturning to the newly created panel required every panel type to expose\na stable, consistently mounted focus target and made the behavior depend\non each editor's lifecycle. Returning to **Add** gives every add\nworkflow one predictable destination with much less integration code.\n\nThis also follows the accessibility requirement that focus must not be\nleft on an element removed with a dialog or flyout. **Add** remains\nvisible, identifies the workflow the user just completed, and lets\nkeyboard and assistive-technology users continue from a known control.\nExisting-panel editing keeps its current source/panel return behavior.\n\nAddresses #278558\n\n### Manual workflows\nRun each workflow with keyboard navigation and verify focus is visibly\non **Add** after closing or completing the add editor:\n\n- [ ] **Add → close/cancel the Add panel flyout**\n- [ ] **Add → Image → Cancel** (also test X and Escape)\n- [ ] **Add → Links → Cancel**\n- [ ] **Add → Visualization → Cancel**\n- [ ] **Add → Visualization (query / ES|QL) → Cancel** (also test X and\nEscape)\n- [ ] **Add → Controls → create a data control → Cancel**\n- [ ] **Add → Alerts table → Cancel** (when available)\n- [ ] Complete representative Image, Lens, and ES|QL add workflows and\nverify focus returns to **Add**\n- [ ] Open one of the same editors from an existing panel and close it;\nverify focus returns to the existing panel/source rather than **Add**\n- [ ] Select a panel type from the Add flyout and verify its editor\nopens directly, without an intermediate focus animation or delay\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Nick Peihl <nick.peihl@elastic.co>","sha":"563d75b4858f46d99d5d6ec6778ee9986c7f6995"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->