### PR TITLE
[Entity Analytics] Polish threat hunting leads card and flyout UX

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
@@ -374,7 +374,7 @@ export const TopThreatHuntingLeads: React.FC<TopThreatHuntingLeadsProps> = ({
                     <EuiPanel paddingSize="m" hasBorder={false} hasShadow={false}>
                       <EuiSkeletonTitle size="xs" />
                       <EuiSpacer size="s" />
-                      <EuiSkeletonText lines={3} size="s" />
+                      <EuiSkeletonText lines={4} size="s" />
                     </EuiPanel>
                   </EuiFlexItem>
                 ))}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/lead_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/lead_card.tsx
@@ -50,7 +50,7 @@ export const LeadCard: React.FC<LeadCardProps> = ({ lead, onClick }) => {
             css={{
               overflowWrap: 'anywhere',
               display: '-webkit-box',
-              WebkitLineClamp: 3,
+              WebkitLineClamp: 4,
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
             }}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/threat_hunting_leads_flyout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/threat_hunting_leads_flyout.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 
 import { ThreatHuntingLeadsFlyout } from './threat_hunting_leads_flyout';
@@ -29,26 +29,12 @@ jest.mock('@kbn/expandable-flyout', () => ({
   }),
 }));
 
-const mockGetRedirectUrl = jest.fn().mockResolvedValue('https://kibana.test/app/discover#/');
-const mockLocatorsGet = jest.fn().mockReturnValue({ getRedirectUrl: mockGetRedirectUrl });
 jest.mock('../../../../common/lib/kibana', () => ({
   useKibana: () => ({
-    services: {
-      share: {
-        url: {
-          locators: {
-            get: mockLocatorsGet,
-          },
-        },
-      },
-    },
+    services: {},
   }),
   useDateFormat: jest.fn(() => 'MMM D, YYYY @ HH:mm:ss.SSS'),
   useTimeZone: jest.fn(() => 'UTC'),
-}));
-
-jest.mock('../../../../common/hooks/use_space_id', () => ({
-  useSpaceId: jest.fn(() => 'default'),
 }));
 
 const mockUseQuery = jest.requireMock('@kbn/react-query').useQuery as jest.Mock;
@@ -325,45 +311,5 @@ describe('ThreatHuntingLeadsFlyout', () => {
     render(<ThreatHuntingLeadsFlyout {...defaultProps} />);
 
     expect(screen.queryByTestId('leadsFlyoutGeneratedTimestamp')).not.toBeInTheDocument();
-  });
-
-  it('opens the leads archive index in Discover when the link is clicked', async () => {
-    const openSpy = jest.spyOn(window, 'open').mockImplementation();
-
-    render(<ThreatHuntingLeadsFlyout {...defaultProps} />);
-
-    fireEvent.click(screen.getByTestId('viewLeadsArchiveIndexButton'));
-
-    expect(mockLocatorsGet).toHaveBeenCalledWith('DISCOVER_APP_LOCATOR');
-    await waitFor(() => expect(mockGetRedirectUrl).toHaveBeenCalled());
-    expect(mockGetRedirectUrl).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataViewSpec: expect.objectContaining({
-          id: 'entity-analytics-threat-hunting-leads-archive-default',
-          title:
-            '.entity_analytics.entity-leads-adhoc.entity-default,.entity_analytics.entity-leads-scheduled.entity-default',
-          allowHidden: true,
-        }),
-      })
-    );
-    await waitFor(() =>
-      expect(openSpy).toHaveBeenCalledWith(
-        'https://kibana.test/app/discover#/',
-        '_blank',
-        'noopener,noreferrer'
-      )
-    );
-
-    openSpy.mockRestore();
-  });
-
-  it('disables the leads archive index link while the space id has not resolved yet', () => {
-    const mockUseSpaceId = jest.requireMock('../../../../common/hooks/use_space_id')
-      .useSpaceId as jest.Mock;
-    mockUseSpaceId.mockReturnValueOnce(undefined);
-
-    render(<ThreatHuntingLeadsFlyout {...defaultProps} />);
-
-    expect(screen.getByTestId('viewLeadsArchiveIndexButton')).toBeDisabled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/threat_hunting_leads_flyout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/threat_hunting_leads_flyout.tsx
@@ -7,7 +7,6 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import {
-  EuiButtonEmpty,
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
@@ -27,9 +26,6 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useQuery } from '@kbn/react-query';
-import { getLeadsIndexName } from '../../../../../common/entity_analytics/lead_generation/constants';
-import { useKibana } from '../../../../common/lib/kibana';
-import { useSpaceId } from '../../../../common/hooks/use_space_id';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
 import type { HuntingLead } from './types';
 import { fromApiLead } from './types';
@@ -52,33 +48,6 @@ export const ThreatHuntingLeadsFlyout: React.FC<ThreatHuntingLeadsFlyoutProps> =
   const [searchQuery, setSearchQuery] = useState('');
 
   const { fetchLeads } = useEntityAnalyticsRoutes();
-  const { share } = useKibana().services;
-  const spaceId = useSpaceId();
-
-  const handleViewLeadsArchiveIndex = useCallback(async () => {
-    const discoverLocator = share?.url.locators.get('DISCOVER_APP_LOCATOR');
-    if (!discoverLocator || !spaceId) return;
-
-    // Scope the data view to this space's leads indices only. The underlying indices are
-    // per-space (see getLeadsIndexName), so a `-*` wildcard would span every space's leads
-    // and is only guarded by raw ES index privileges, not Kibana space isolation.
-    const spaceLeadsIndexPattern = [
-      getLeadsIndexName(spaceId, 'adhoc'),
-      getLeadsIndexName(spaceId, 'scheduled'),
-    ].join(',');
-
-    const url = await discoverLocator.getRedirectUrl({
-      dataViewSpec: {
-        id: `entity-analytics-threat-hunting-leads-archive-${spaceId}`,
-        title: spaceLeadsIndexPattern,
-        allowHidden: true,
-      },
-    });
-
-    if (url) {
-      window.open(url, '_blank', 'noopener,noreferrer');
-    }
-  }, [share, spaceId]);
 
   const { data, isLoading } = useQuery({
     queryKey: ['hunting-leads-flyout'],
@@ -134,29 +103,14 @@ export const ThreatHuntingLeadsFlyout: React.FC<ThreatHuntingLeadsFlyoutProps> =
         <EuiText size="s" color="subdued">
           {i18n.ALL_HUNTING_LEADS_DESCRIPTION}
         </EuiText>
-        <EuiSpacer size="s" />
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
-          {lastRunTimestamp && (
-            <EuiFlexItem grow={false}>
-              <EuiText size="xs" color="subdued" data-test-subj="leadsFlyoutGeneratedTimestamp">
-                <GeneratedOnLabel timestamp={lastRunTimestamp} />
-              </EuiText>
-            </EuiFlexItem>
-          )}
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              size="xs"
-              iconType="external"
-              flush="left"
-              iconSide="right"
-              onClick={handleViewLeadsArchiveIndex}
-              isDisabled={!spaceId}
-              data-test-subj="viewLeadsArchiveIndexButton"
-            >
-              {i18n.VIEW_LEADS_ARCHIVE_INDEX}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        {lastRunTimestamp && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiText size="xs" color="subdued" data-test-subj="leadsFlyoutGeneratedTimestamp">
+              <GeneratedOnLabel timestamp={lastRunTimestamp} />
+            </EuiText>
+          </>
+        )}
       </EuiFlyoutHeader>
 
       <EuiFlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
@@ -260,8 +260,3 @@ export const VIEW_ENTITY_DETAILS = i18n.translate(
   'xpack.securitySolution.entityAnalytics.threatHunting.leads.viewEntityDetails',
   { defaultMessage: 'View entity details' }
 );
-
-export const VIEW_LEADS_ARCHIVE_INDEX = i18n.translate(
-  'xpack.securitySolution.entityAnalytics.threatHunting.leads.viewLeadsArchiveIndex',
-  { defaultMessage: 'View leads archive index' }
-);


### PR DESCRIPTION
## Summary

Small UX polish for Threat Hunting leads on the Entity Analytics home page:

- Bump the lead card byline clamp from `3` → `4` lines so truncated text is more readable
- Remove the `View leads archive index` link from the Recent threat hunting leads flyout — the archive index only holds the same recent leads set, so sending users to Discover there was not useful

Also drops the unused i18n string and the flyout tests/mocks for that link.

> **Note:** I could not attach screenshots here — local Kibana had no generated leads in the space I checked, and the leads API was unavailable with the current config. Happy to add them once I have leads rendered.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Low risk UI-only change; no API / data path impact.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->