### PR TITLE
[8.19] [Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll (#279828)

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts
@@ -7,16 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
-import { InternalCoreStart } from '@kbn/core-lifecycle-server-internal';
-import { Root } from '@kbn/core-root-server-internal';
+import type { estypes } from '@elastic/elasticsearch';
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import type { ElasticsearchClient } from '../../../../..';
-import {
-  createRootWithCorePlugins,
-  createTestServers,
-  type TestElasticsearchUtils,
-} from '@kbn/core-test-helpers-kbn-server';
+import { createTestServers, type TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
 import {
   isWriteBlockException,
   isClusterShardLimitExceeded,
@@ -29,23 +23,12 @@ const { startES } = createTestServers({
 });
 
 describe('Elasticsearch Errors', () => {
-  let root: Root;
-  let start: InternalCoreStart;
   let client: ElasticsearchClient;
   let esServer: TestElasticsearchUtils;
 
   beforeAll(async () => {
     esServer = await startES();
-    root = createRootWithCorePlugins({
-      server: {
-        basePath: '/foo',
-      },
-    });
-
-    await root.preboot();
-    await root.setup();
-    start = await root.start();
-    client = start.elasticsearch.client.asInternalUser;
+    client = esServer.es.getClient();
 
     await createIndex({
       client,
@@ -57,8 +40,7 @@ describe('Elasticsearch Errors', () => {
   });
 
   afterAll(async () => {
-    await esServer.stop();
-    await root.shutdown();
+    await esServer?.stop();
   });
 
   describe('isWriteBlockException', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll (#279828)](https://github.com/elastic/kibana/pull/279828)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kibana Machine","email":"42973632+kibanamachine@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-21T17:54:28Z","message":"[Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll (#279828)\n\nFixes #204302\n\n### Summary\n\n- The `beforeAll` hook in `es_errors.test.ts` timed out (`Exceeded\ntimeout of 280000 ms for a hook`), failing all `Elasticsearch Errors`\ncases.\n- It booted a full Kibana root (`createRootWithCorePlugins` → `preboot`\n→ `setup` → `start`) only to grab an ES client — doubling the heaviest\npart of setup.\n- This patch drops the root boot and takes the client straight from the\ntest ES server (`esServer.es.getClient()`), exactly as the sibling\n`actions.test.ts` already does.\n\n### Context\n\n- Follows the fix proposed by the [Failed Test\nInvestigator](https://github.com/elastic/kibana/issues/204302#issuecomment-5027155567)\n(2026-07-20); the analysis is current and matches the latest failure.\n- Failures recur as a `beforeAll` timeout, mostly on `kibana-fips`\nbetween April–June 2026; in [FIPS build\n1869](https://buildkite.com/elastic/kibana-fips/builds/1869#019ee483-5ad2-4637-a002-07dd50640c68)\nonly `es_errors.test.ts` failed while sibling `actions.test.ts` (which\nalso calls `startES()` but boots no root) passed — pointing at the extra\nroot boot inflating the hook past 280s on FIPS agents.\n- Nothing in the file uses `root`/`start` beyond `client`, so removing\nthem is safe. The July 17–20 snapshot-verify failures are a separate\nupstream ES-snapshot break and unrelated to this test.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n`✅ Passed: node scripts/eslint\nsrc/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts`\n`✅ Passed: node scripts/type_check --project src/core/tsconfig.json`\n\n#### Not verified locally\n\n- The Jest integration test itself needs a live Elasticsearch and cannot\nrun in this environment; it relies on CI.\n- The timeout only reproduces under FIPS-agent load, which can't be\nexercised here — the fix strictly reduces the hook's work regardless.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:all-open`. The failing test file exists with the\nidentical `beforeAll` root-boot anti-pattern on every open release\nbranch in `versions.json` (9.5, 9.4, 9.3, 8.19) and this patch applies\nthere unchanged, so the fix is safe to propagate to all of them.\n\n</details>\n\n> [!NOTE]\n> Requested by @rgodfrey-elastic. Share feedback in #kibana-qa. Mention\n`@copilot` to make quick changes.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/29832566128) for\n#204302 · 245.1 AIC · ⌖ 29 AIC · ⊞ 6.7K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>","sha":"4cdbed7421fe9bda713bf83e21137d8e038908c3","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0","flaky-test-fixer","v9.4.4","flaky-fix-check:skipped","v9.6.0","v9.3.8"],"title":"[Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll","number":279828,"url":"https://github.com/elastic/kibana/pull/279828","mergeCommit":{"message":"[Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll (#279828)\n\nFixes #204302\n\n### Summary\n\n- The `beforeAll` hook in `es_errors.test.ts` timed out (`Exceeded\ntimeout of 280000 ms for a hook`), failing all `Elasticsearch Errors`\ncases.\n- It booted a full Kibana root (`createRootWithCorePlugins` → `preboot`\n→ `setup` → `start`) only to grab an ES client — doubling the heaviest\npart of setup.\n- This patch drops the root boot and takes the client straight from the\ntest ES server (`esServer.es.getClient()`), exactly as the sibling\n`actions.test.ts` already does.\n\n### Context\n\n- Follows the fix proposed by the [Failed Test\nInvestigator](https://github.com/elastic/kibana/issues/204302#issuecomment-5027155567)\n(2026-07-20); the analysis is current and matches the latest failure.\n- Failures recur as a `beforeAll` timeout, mostly on `kibana-fips`\nbetween April–June 2026; in [FIPS build\n1869](https://buildkite.com/elastic/kibana-fips/builds/1869#019ee483-5ad2-4637-a002-07dd50640c68)\nonly `es_errors.test.ts` failed while sibling `actions.test.ts` (which\nalso calls `startES()` but boots no root) passed — pointing at the extra\nroot boot inflating the hook past 280s on FIPS agents.\n- Nothing in the file uses `root`/`start` beyond `client`, so removing\nthem is safe. The July 17–20 snapshot-verify failures are a separate\nupstream ES-snapshot break and unrelated to this test.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n`✅ Passed: node scripts/eslint\nsrc/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts`\n`✅ Passed: node scripts/type_check --project src/core/tsconfig.json`\n\n#### Not verified locally\n\n- The Jest integration test itself needs a live Elasticsearch and cannot\nrun in this environment; it relies on CI.\n- The timeout only reproduces under FIPS-agent load, which can't be\nexercised here — the fix strictly reduces the hook's work regardless.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:all-open`. The failing test file exists with the\nidentical `beforeAll` root-boot anti-pattern on every open release\nbranch in `versions.json` (9.5, 9.4, 9.3, 8.19) and this patch applies\nthere unchanged, so the fix is safe to propagate to all of them.\n\n</details>\n\n> [!NOTE]\n> Requested by @rgodfrey-elastic. Share feedback in #kibana-qa. Mention\n`@copilot` to make quick changes.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/29832566128) for\n#204302 · 245.1 AIC · ⌖ 29 AIC · ⊞ 6.7K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>","sha":"4cdbed7421fe9bda713bf83e21137d8e038908c3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279938","number":279938,"state":"MERGED","mergeCommit":{"sha":"036b4595c88cd3c3167d0fc0ad41c2074649fcbe","message":"[9.5] [Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll (#279828) (#279938)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Core] Drop unneeded Kibana root boot from es_errors integration test\nbeforeAll (#279828)](https://github.com/elastic/kibana/pull/279828)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279937","number":279937,"state":"MERGED","mergeCommit":{"sha":"71639124a2397d552c708b8f46fda5300a366bdd","message":"[9.4] [Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll (#279828) (#279937)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Core] Drop unneeded Kibana root boot from es_errors integration test\nbeforeAll (#279828)](https://github.com/elastic/kibana/pull/279828)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nCo-authored-by: Ryan <ryan.godfrey@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279828","number":279828,"mergeCommit":{"message":"[Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll (#279828)\n\nFixes #204302\n\n### Summary\n\n- The `beforeAll` hook in `es_errors.test.ts` timed out (`Exceeded\ntimeout of 280000 ms for a hook`), failing all `Elasticsearch Errors`\ncases.\n- It booted a full Kibana root (`createRootWithCorePlugins` → `preboot`\n→ `setup` → `start`) only to grab an ES client — doubling the heaviest\npart of setup.\n- This patch drops the root boot and takes the client straight from the\ntest ES server (`esServer.es.getClient()`), exactly as the sibling\n`actions.test.ts` already does.\n\n### Context\n\n- Follows the fix proposed by the [Failed Test\nInvestigator](https://github.com/elastic/kibana/issues/204302#issuecomment-5027155567)\n(2026-07-20); the analysis is current and matches the latest failure.\n- Failures recur as a `beforeAll` timeout, mostly on `kibana-fips`\nbetween April–June 2026; in [FIPS build\n1869](https://buildkite.com/elastic/kibana-fips/builds/1869#019ee483-5ad2-4637-a002-07dd50640c68)\nonly `es_errors.test.ts` failed while sibling `actions.test.ts` (which\nalso calls `startES()` but boots no root) passed — pointing at the extra\nroot boot inflating the hook past 280s on FIPS agents.\n- Nothing in the file uses `root`/`start` beyond `client`, so removing\nthem is safe. The July 17–20 snapshot-verify failures are a separate\nupstream ES-snapshot break and unrelated to this test.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n`✅ Passed: node scripts/eslint\nsrc/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts`\n`✅ Passed: node scripts/type_check --project src/core/tsconfig.json`\n\n#### Not verified locally\n\n- The Jest integration test itself needs a live Elasticsearch and cannot\nrun in this environment; it relies on CI.\n- The timeout only reproduces under FIPS-agent load, which can't be\nexercised here — the fix strictly reduces the hook's work regardless.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:all-open`. The failing test file exists with the\nidentical `beforeAll` root-boot anti-pattern on every open release\nbranch in `versions.json` (9.5, 9.4, 9.3, 8.19) and this patch applies\nthere unchanged, so the fix is safe to propagate to all of them.\n\n</details>\n\n> [!NOTE]\n> Requested by @rgodfrey-elastic. Share feedback in #kibana-qa. Mention\n`@copilot` to make quick changes.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/29832566128) for\n#204302 · 245.1 AIC · ⌖ 29 AIC · ⊞ 6.7K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>","sha":"4cdbed7421fe9bda713bf83e21137d8e038908c3"}},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279936","number":279936,"state":"MERGED","mergeCommit":{"sha":"0145bcfc3ca28189dced64b001e194063189eda6","message":"[9.3] [Core] Drop unneeded Kibana root boot from es_errors integration test beforeAll (#279828) (#279936)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Core] Drop unneeded Kibana root boot from es_errors integration test\nbeforeAll (#279828)](https://github.com/elastic/kibana/pull/279828)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nCo-authored-by: Ryan <ryan.godfrey@elastic.co>"}}]}] BACKPORT-->