### PR TITLE
[dashboard] fix tslint error in main - july 22 2026

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/export_json_action.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/export_json_action.tsx
@@ -136,7 +136,6 @@ export class ExportJSONAction implements Action<EmbeddableApiContext> {
       flyoutProps: {
         'data-test-subj': 'export_json_flyout',
         focusedPanelId: embeddable.uuid,
-        triggerId: `presentationPanelContextMenu-${embeddable.uuid}`,
       },
     });
   }


### PR DESCRIPTION
Merge conflict between https://github.com/elastic/kibana/pull/273427 and https://github.com/elastic/kibana/pull/278559

 https://github.com/elastic/kibana/pull/273427 merged first. Added a new usage of `openLazyFlyout` with `triggerId`
https://github.com/elastic/kibana/pull/278559 merge later and removed `triggerId` prop from `openLazyFlyout`