### PR TITLE
[Inference UI] Prevent region preferences modal from resizing on callout dismiss

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
@@ -35,7 +35,7 @@ interface ManageRegionsModalProps {
 }
 
 const modalStyles = ({ euiTheme }: UseEuiTheme) => css`
-  min-width: ${euiTheme.base * 35}px;
+  width: ${euiTheme.base * 45}px;
 `;
 
 export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose }) => {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
@@ -34,8 +34,8 @@ interface ManageRegionsModalProps {
   onClose: () => void;
 }
 
-const modalStyles = ({ euiTheme }: UseEuiTheme) => css`
-  width: ${euiTheme.base * 45}px;
+const bodyContentStyles = ({ euiTheme }: UseEuiTheme) => css`
+  min-width: ${euiTheme.base * 45}px;
 `;
 
 export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose }) => {
@@ -96,7 +96,6 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
   return (
     <>
       <EuiModal
-        css={modalStyles}
         onClose={showConfirmation ? handleCancelConfirmation : onClose}
         aria-labelledby={modalTitleId}
         data-test-subj="manageRegionsModal"
@@ -109,7 +108,7 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
-        <EuiModalBody>
+        <EuiModalBody css={bodyContentStyles}>
           {isError && (
             <EuiCallOut
               announceOnMount={false}

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
@@ -34,7 +34,7 @@ interface ManageRegionsModalProps {
   onClose: () => void;
 }
 
-const bodyContentStyles = ({ euiTheme }: UseEuiTheme) => css`
+const modalStyles = ({ euiTheme }: UseEuiTheme) => css`
   min-width: ${euiTheme.base * 45}px;
 `;
 
@@ -96,6 +96,7 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
   return (
     <>
       <EuiModal
+        css={modalStyles}
         onClose={showConfirmation ? handleCancelConfirmation : onClose}
         aria-labelledby={modalTitleId}
         data-test-subj="manageRegionsModal"
@@ -108,7 +109,7 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
-        <EuiModalBody css={bodyContentStyles}>
+        <EuiModalBody>
           {isError && (
             <EuiCallOut
               announceOnMount={false}


### PR DESCRIPTION
## Summary

The region preferences modal would suddenly shrink when you dismissed the model availability notice, so it now stays a steady size.


### Screen Recording

https://github.com/user-attachments/assets/f642214a-3962-4481-9f0c-70744f179c47



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



## Release note

Fixes the region preferences modal shrinking unexpectedly when the model availability notice is dismissed.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->