### PR TITLE
[Dashboard][PoC] Cancel embeddable requests on exit

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common-2/index.ts
+++ b/src/platform/packages/shared/kbn-lens-common-2/index.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  CanCancelRequests,
   HasEditCapabilities,
   HasLibraryTransforms,
   HasSupportedTriggers,
@@ -130,7 +131,8 @@ export type LensApi = Simplify<
     LensApiCallbacks &
     LensHasEditPanel &
     LegacyLensStateApi &
-    SupportsJsonExport
+    SupportsJsonExport &
+    CanCancelRequests
 >;
 
 /**

--- a/src/platform/packages/shared/presentation/presentation_publishing/index.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/index.ts
@@ -27,6 +27,10 @@ export {
   type CanAccessViewMode,
 } from './interfaces/can_access_view_mode';
 export {
+  apiCanCancelRequests,
+  type CanCancelRequests,
+} from './interfaces/can_cancel_requests';
+export {
   apiCanLockHoverActions,
   type CanLockHoverActions,
 } from './interfaces/can_lock_hover_actions';

--- a/src/platform/packages/shared/presentation/presentation_publishing/index.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/index.ts
@@ -26,10 +26,7 @@ export {
   getViewModeSubject,
   type CanAccessViewMode,
 } from './interfaces/can_access_view_mode';
-export {
-  apiCanCancelRequests,
-  type CanCancelRequests,
-} from './interfaces/can_cancel_requests';
+export { apiCanCancelRequests, type CanCancelRequests } from './interfaces/can_cancel_requests';
 export {
   apiCanLockHoverActions,
   type CanLockHoverActions,

--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/can_cancel_requests.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/can_cancel_requests.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * This API can cancel in-flight requests
+ */
+export interface CanCancelRequests {
+  cancelRequests: () => void;
+}
+
+export const apiCanCancelRequests = (api: unknown): api is CanCancelRequests => {
+  return Boolean(api && typeof (api as CanCancelRequests).cancelRequests === 'function');
+};

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
@@ -39,6 +39,7 @@ import { DEFAULT_PINNED_CONTROL_STATE } from '@kbn/controls-constants';
 import { i18n } from '@kbn/i18n';
 import type { SerializedTitles, PanelPackage } from '@kbn/presentation-publishing';
 import {
+  apiCanCancelRequests,
   childrenUnsavedChanges$,
   apiHasLibraryTransforms,
   apiHasSerializableState,
@@ -691,6 +692,11 @@ export function initializeLayoutManager(
       },
     },
     cleanup: () => {
+      Object.values(children$.value).forEach((childApi) => {
+        if (apiCanCancelRequests(childApi)) {
+          childApi.cancelRequests();
+        }
+      });
       childrenChangesSubscription.unsubscribe();
       gridLayoutSubscription.unsubscribe();
     },

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
@@ -200,6 +200,13 @@ export const createLensEmbeddableFactory = (
           ...stateConfig.api,
           ...dashboardConfig.api,
           supportsJsonExport: true,
+          cancelRequests: () => {
+            const abortController = internalApi.expressionAbortController$.getValue();
+            if (abortController) {
+              abortController.abort();
+              internalApi.updateAbortController(new AbortController());
+            }
+          },
         }
       );
 


### PR DESCRIPTION
## Summary

This is a PoC related to https://github.com/elastic/kibana/issues/230208 that implements an embeddable API for parents (e.g. dashboard app) to cancel in-flight requests created by embeddables.

It has been implemented for Lens only in this PoC.

Here you can see the cancelations of all Lens searches when navigating away from the sample logs dashboard mid-load:

<img width="945" height="778" alt="Screenshot 2026-07-22 at 12 54 27 PM" src="https://github.com/user-attachments/assets/a3b46d01-cf53-4bd2-9c8d-c216c722d7b7" />
