### PR TITLE
[9.5] [Vega][ES|QL] Publish ES|QL data views for unified search (#277120)

### DIFF
--- a/src/platform/plugins/private/vis_types/vega/public/lib/extract_index_pattern.test.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/lib/extract_index_pattern.test.ts
@@ -8,10 +8,21 @@
  */
 
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
+import { httpServiceMock } from '@kbn/core/public/mocks';
+import { getESQLAdHocDataview, getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
 import { extractIndexPatternsFromSpec } from './extract_index_pattern';
-import { setDataViews } from '../services';
+import { setDataViews, setHttp } from '../services';
 
 import type { VegaSpec } from '../data_model/types';
+import { vegaVisType } from '../vega_type';
+
+jest.mock('@kbn/esql-utils', () => ({
+  getIndexPatternFromESQLQuery: jest.fn(),
+  getESQLAdHocDataview: jest.fn(),
+}));
+jest.mock('../default_spec', () => ({
+  getDefaultSpec: jest.fn(() => ''),
+}));
 
 const getMockedSpec = (mockedObj: any) => mockedObj as unknown as VegaSpec;
 
@@ -20,6 +31,21 @@ describe('extractIndexPatternsFromSpec', () => {
 
   beforeAll(() => {
     setDataViews(dataViewsStart);
+    setHttp(httpServiceMock.createStartContract());
+  });
+
+  beforeEach(() => {
+    (getIndexPatternFromESQLQuery as jest.Mock).mockImplementation((query: string) =>
+      query.replace(/^(?:FROM|TS)\s+([^\s|]+).*$/is, '$1')
+    );
+    (getESQLAdHocDataview as jest.Mock).mockImplementation(async ({ query }) => {
+      const indexPattern = (getIndexPatternFromESQLQuery as jest.Mock)(query);
+      return { id: `esql-${indexPattern}`, title: indexPattern };
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   test('should not throw errors if no index is specified', async () => {
@@ -111,5 +137,154 @@ describe('extractIndexPatternsFromSpec', () => {
         },
       ]
     `);
+  });
+
+  test('should resolve an ad-hoc data view from an ES|QL data url', async () => {
+    const spec = getMockedSpec({
+      data: {
+        url: {
+          '%type%': 'esql',
+          query: 'FROM metrics-hostmetricsreceiver.otel-default | LIMIT 10',
+        },
+      },
+    });
+
+    const indexes = await extractIndexPatternsFromSpec(spec);
+
+    expect(getESQLAdHocDataview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'FROM metrics-hostmetricsreceiver.otel-default | LIMIT 10',
+      })
+    );
+    expect(indexes).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": "esql-metrics-hostmetricsreceiver.otel-default",
+          "title": "metrics-hostmetricsreceiver.otel-default",
+        },
+      ]
+    `);
+  });
+
+  test('should combine classic index and ES|QL data views', async () => {
+    const spec = getMockedSpec({
+      data: [
+        {
+          url: {
+            index: 'test',
+          },
+        },
+        {
+          url: {
+            '%type%': 'esql',
+            query: 'FROM logs-* | LIMIT 10',
+          },
+        },
+      ],
+    });
+
+    const indexes = await extractIndexPatternsFromSpec(spec);
+
+    expect(indexes).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": "test",
+          "title": "test",
+        },
+        Object {
+          "id": "esql-logs-*",
+          "title": "logs-*",
+        },
+      ]
+    `);
+  });
+
+  test('should extract data views from nested specs (facet/layer/concat)', async () => {
+    const spec = getMockedSpec({
+      // top-level facet wraps an inner spec that holds the data
+      facet: { field: 'host_name', type: 'nominal' },
+      spec: {
+        layer: [
+          {
+            data: {
+              url: {
+                '%type%': 'esql',
+                query: 'TS metrics-* | LIMIT 10',
+              },
+            },
+          },
+          {
+            data: {
+              url: {
+                index: 'nested-classic',
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const indexes = await extractIndexPatternsFromSpec(spec);
+
+    expect(indexes).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": "nested-classic",
+          "title": "nested-classic",
+        },
+        Object {
+          "id": "esql-metrics-*",
+          "title": "metrics-*",
+        },
+      ]
+    `);
+  });
+
+  test('should de-duplicate ES|QL data views that resolve to the same index', async () => {
+    const spec = getMockedSpec({
+      data: [
+        {
+          url: {
+            '%type%': 'esql',
+            query: 'FROM logs-* | LIMIT 10',
+          },
+        },
+        {
+          url: {
+            '%type%': 'esql',
+            query: 'FROM logs-* | WHERE foo == "bar"',
+          },
+        },
+      ],
+    });
+
+    const indexes = await extractIndexPatternsFromSpec(spec);
+
+    expect(getESQLAdHocDataview).toHaveBeenCalledTimes(1);
+    expect(indexes).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": "esql-logs-*",
+          "title": "logs-*",
+        },
+      ]
+    `);
+  });
+
+  test('should return no data views when asynchronous data view resolution fails', async () => {
+    (getESQLAdHocDataview as jest.Mock).mockRejectedValueOnce(new Error('resolution failed'));
+
+    const getUsedIndexPattern = vegaVisType.getUsedIndexPattern;
+    if (!getUsedIndexPattern) {
+      throw new Error('Vega must define getUsedIndexPattern');
+    }
+
+    await expect(
+      getUsedIndexPattern({
+        spec: JSON.stringify({
+          data: { url: { '%type%': 'esql', query: 'FROM logs-*' } },
+        }),
+      })
+    ).resolves.toEqual([]);
   });
 });

--- a/src/platform/plugins/private/vis_types/vega/public/lib/extract_index_pattern.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/lib/extract_index_pattern.ts
@@ -7,31 +7,67 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { flatten } from 'lodash';
+import { flatten, isPlainObject, uniqBy } from 'lodash';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import { getDataViews } from '../services';
+import { getESQLAdHocDataview, getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
+import { getDataViews, getHttp } from '../services';
 
-import type { Data, VegaSpec } from '../data_model/types';
+import { CONSTANTS } from '../data_model/types';
+import type { UrlObject, VegaSpec } from '../data_model/types';
+
+const isEsqlDataUrl = (url: UrlObject): url is UrlObject & { query: string } =>
+  url[CONSTANTS.TYPE] === 'esql' && typeof url.query === 'string';
+
+/**
+ * Recursively collects the `url` objects of every data source in a Vega/Vega-Lite spec.
+ *
+ * `data` can be nested anywhere in the spec (e.g. inside `spec`, `layer`, `concat`,
+ * `hconcat`, `vconcat`, `facet`, ...), so this mirrors the traversal that the Vega parser
+ * itself performs in `_findObjectDataUrls`: any object located under a `data` key that has
+ * a plain-object `url` is treated as a data source.
+ */
+const collectDataUrls = (node: unknown, parentKey?: string, accumulator: UrlObject[] = []) => {
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectDataUrls(child, parentKey, accumulator));
+  } else if (isPlainObject(node)) {
+    const obj = node as Record<string, unknown>;
+    if (parentKey === 'data' && isPlainObject(obj.url)) {
+      accumulator.push(obj.url as UrlObject);
+    } else {
+      Object.keys(obj).forEach((key) => collectDataUrls(obj[key], key, accumulator));
+    }
+  }
+
+  return accumulator;
+};
 
 export const extractIndexPatternsFromSpec = async (spec: VegaSpec) => {
   const dataViews = getDataViews();
-  let data: Data[] = [];
+  const urls = collectDataUrls(spec);
 
-  if (Array.isArray(spec.data)) {
-    data = spec.data;
-  } else if (spec.data) {
-    data = [spec.data];
-  }
+  const indexPatternPromises = urls.reduce<Array<Promise<DataView[]>>>((accumulator, url) => {
+    if (url.index) {
+      accumulator.push(dataViews.find(url.index, 1));
+    }
 
-  return flatten<DataView>(
-    await Promise.all(
-      data.reduce<Array<Promise<DataView[]>>>((accumulator, currentValue) => {
-        if (currentValue.url?.index) {
-          accumulator.push(dataViews.find(currentValue.url.index, 1));
-        }
+    return accumulator;
+  }, []);
 
-        return accumulator;
-      }, [])
-    )
+  const esqlUrls = urls.filter(isEsqlDataUrl);
+  const esqlQueries = uniqBy(esqlUrls, (url) => getIndexPatternFromESQLQuery(url.query));
+
+  const esqlDataViewPromises = esqlQueries.map(async ({ query }) => {
+    const dataView = await getESQLAdHocDataview({
+      dataViewsService: dataViews,
+      query,
+      http: getHttp(),
+    });
+    return [dataView];
+  });
+
+  const resolved = flatten<DataView>(
+    await Promise.all([...indexPatternPromises, ...esqlDataViewPromises])
   );
+
+  return uniqBy(resolved, 'id');
 };

--- a/src/platform/plugins/private/vis_types/vega/public/plugin.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/plugin.ts
@@ -31,6 +31,7 @@ import {
   setDocLinks,
   setMapsEms,
   setUsageCollectionStart,
+  setHttp,
 } from './services';
 
 import type { IServiceSettings } from './vega_view/vega_map_view/service_settings/service_settings_types';
@@ -107,6 +108,7 @@ export class VegaPlugin implements Plugin<void, void> {
 
   public start(core: CoreStart, deps: VegaPluginStartDependencies) {
     setNotifications(core.notifications);
+    setHttp(core.http);
     setData(deps.data);
     setDataViews(deps.dataViews);
     setDocLinks(core.docLinks);

--- a/src/platform/plugins/private/vis_types/vega/public/services.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/services.ts
@@ -7,7 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { NotificationsStart, DocLinksStart, ThemeServiceStart } from '@kbn/core/public';
+import type {
+  NotificationsStart,
+  DocLinksStart,
+  ThemeServiceStart,
+  HttpStart,
+} from '@kbn/core/public';
 
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
@@ -22,6 +27,8 @@ export const [getDataViews, setDataViews] =
 
 export const [getNotifications, setNotifications] =
   createGetterSetter<NotificationsStart>('Notifications');
+
+export const [getHttp, setHttp] = createGetterSetter<HttpStart>('Http');
 
 export const [getMapsEms, setMapsEms] = createGetterSetter<MapsEmsPluginPublicStart>('mapsEms');
 

--- a/src/platform/plugins/private/vis_types/vega/public/vega_type.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_type.ts
@@ -58,7 +58,7 @@ export const vegaVisType: VisTypeDefinition<VisParams> = {
     try {
       const spec = parse(visParams.spec, { legacyRoot: false, keepWsc: true });
 
-      return extractIndexPatternsFromSpec(spec);
+      return await extractIndexPatternsFromSpec(spec);
     } catch (e) {
       // spec is invalid
     }

--- a/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -102,6 +102,16 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
       initialVisInstance.type.usesEsql?.(initialVisInstance.params) ?? false
     );
 
+    const getUsedDataViews = async (visInstance: Vis) => {
+      if (visInstance.type.getUsedIndexPattern) {
+        return visInstance.type.getUsedIndexPattern(visInstance.params);
+      }
+      return visInstance.data.indexPattern ? [visInstance.data.indexPattern] : [];
+    };
+    const dataViews$ = new BehaviorSubject<DataView[] | undefined>(
+      await getUsedDataViews(initialVisInstance)
+    );
+
     // Track UI state
     const onUiStateChange = () => serializedVis$.next(vis$.getValue().serialize());
 
@@ -126,6 +136,17 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
           const usesEsql = vis.type.usesEsql?.(vis.params) ?? false;
           if (usesEsql$.getValue() !== usesEsql) {
             usesEsql$.next(usesEsql);
+          }
+
+          try {
+            const nextDataViews = await getUsedDataViews(vis);
+            const currentDataViewIds = (dataViews$.getValue() ?? []).map(({ id }) => id);
+            const nextDataViewIds = nextDataViews.map(({ id }) => id);
+            if (!isEqual(currentDataViewIds, nextDataViewIds)) {
+              dataViews$.next(nextDataViews);
+            }
+          } catch {
+            // keep the previously resolved data views if resolution fails
           }
 
           const { params, abortController } = await getExpressionParams();
@@ -167,16 +188,6 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
       : undefined;
 
     const inspectorAdapters$ = new BehaviorSubject<Record<string, unknown>>({});
-
-    // Track data views
-    let initialDataViews: DataView[] | undefined = [];
-    if (initialVisInstance.data.indexPattern)
-      initialDataViews = [initialVisInstance.data.indexPattern];
-    if (initialVisInstance.type.getUsedIndexPattern) {
-      initialDataViews = await initialVisInstance.type.getUsedIndexPattern(
-        initialVisInstance.params
-      );
-    }
 
     const dataLoading$ = new BehaviorSubject<boolean | undefined>(true);
 
@@ -263,7 +274,7 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
       ...stateApi,
       defaultTitle$,
       dataLoading$,
-      dataViews$: new BehaviorSubject<DataView[] | undefined>(initialDataViews),
+      dataViews$,
       projectRoutingOverrides$,
       usesEsql$,
       rendered$: hasRendered$,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Vega][ES|QL] Publish ES|QL data views for unified search (#277120)](https://github.com/elastic/kibana/pull/277120)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marta Bondyra","email":"4283304+mbondyra@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-12T09:52:15Z","message":"[Vega][ES|QL] Publish ES|QL data views for unified search (#277120)\n\nVega charts that read from an ES|QL data source now resolve an ad-hoc\ndata view from the query (via getESQLAdHocDataview) so the dashboard's\nunified search (KQL query bar, filter pills, controls) recognizes the\nindex, matching ES|QL Lens panels and controls.\n\n- `extractIndexPatternsFromSpec` now recursively walks the spec\n(mirroring the Vega parser's _findObjectDataUrls) and resolves both\nclassic url.index sources and %type%: esql queries, so nested data\nsources in Vega-Lite compositions (facet/layer/concat) are covered.\n- The visualize embeddable republishes dataViews$ when the vis spec\nchanges, so suggestions stay in sync while editing.\n\nCloses #276957\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"02b1a2c92ae13f96504f7f2a62902772a76820aa","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","loe:small","Team:Visualizations","release_note:skip","backport:version","v9.5.0","v9.6.0"],"title":"[Vega][ES|QL] Publish ES|QL data views for unified search","number":277120,"url":"https://github.com/elastic/kibana/pull/277120","mergeCommit":{"message":"[Vega][ES|QL] Publish ES|QL data views for unified search (#277120)\n\nVega charts that read from an ES|QL data source now resolve an ad-hoc\ndata view from the query (via getESQLAdHocDataview) so the dashboard's\nunified search (KQL query bar, filter pills, controls) recognizes the\nindex, matching ES|QL Lens panels and controls.\n\n- `extractIndexPatternsFromSpec` now recursively walks the spec\n(mirroring the Vega parser's _findObjectDataUrls) and resolves both\nclassic url.index sources and %type%: esql queries, so nested data\nsources in Vega-Lite compositions (facet/layer/concat) are covered.\n- The visualize embeddable republishes dataViews$ when the vis spec\nchanges, so suggestions stay in sync while editing.\n\nCloses #276957\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"02b1a2c92ae13f96504f7f2a62902772a76820aa"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277120","number":277120,"mergeCommit":{"message":"[Vega][ES|QL] Publish ES|QL data views for unified search (#277120)\n\nVega charts that read from an ES|QL data source now resolve an ad-hoc\ndata view from the query (via getESQLAdHocDataview) so the dashboard's\nunified search (KQL query bar, filter pills, controls) recognizes the\nindex, matching ES|QL Lens panels and controls.\n\n- `extractIndexPatternsFromSpec` now recursively walks the spec\n(mirroring the Vega parser's _findObjectDataUrls) and resolves both\nclassic url.index sources and %type%: esql queries, so nested data\nsources in Vega-Lite compositions (facet/layer/concat) are covered.\n- The visualize embeddable republishes dataViews$ when the vis spec\nchanges, so suggestions stay in sync while editing.\n\nCloses #276957\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"02b1a2c92ae13f96504f7f2a62902772a76820aa"}}]}] BACKPORT-->