### PR TITLE
[Search Inference Endpoints] Make region count text clickable in manage regions modal

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.test.tsx
@@ -330,6 +330,34 @@ describe('ManageRegionsModal', () => {
       });
     });
 
+    it('expands a zone when the region count text/icon is clicked', async () => {
+      mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
+        typeof useRegionPolicy
+      >);
+      mockUseEisModels.mockReturnValue({
+        data: [endpointWithRegions],
+        isLoading: false,
+      } as unknown as ReturnType<typeof useEisModels>);
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      fireEvent.click(screen.getByTestId('manageRegionsRegionsTab'));
+      await waitFor(() => {
+        expect(screen.getByTestId('manageRegionsZoneCountToggle-us')).toBeInTheDocument();
+      });
+
+      // Clicking the count/icon button (not the zone title) should expand the zone.
+      fireEvent.click(screen.getByTestId('manageRegionsZoneCountToggle-us'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('manageRegionsCheckbox-aws::us-east-1')).toBeInTheDocument();
+      });
+    });
+
     it('shows "N of N selected" when there is no existing policy', async () => {
       mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
         typeof useRegionPolicy

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/region_zone_item.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/region_zone_item.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiAccordion, EuiCheckbox, EuiPanel, EuiText } from '@elastic/eui';
+import { EuiAccordion, EuiButtonEmpty, EuiCheckbox, EuiPanel } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { getRegionDisplayName, regionKey } from '../../utils/eis_utils';
 import type { ZoneGroup } from '../../utils/eis_utils';
@@ -28,14 +28,25 @@ export const RegionZoneItem: React.FC<RegionZoneItemProps> = ({
 }) => {
   const zoneKeys = zone.regions.map(regionKey);
   const checkedCount = zoneKeys.filter((k) => checkedKeys.has(k)).length;
+  const accordionId = `zone-accordion-${zone.geo}`;
+  const isOpen = expandedZones.has(zone.geo);
 
   const extraAction = (
-    <EuiText size="s" color="subdued">
+    <EuiButtonEmpty
+      size="s"
+      color="text"
+      iconType={isOpen ? 'arrowUp' : 'arrowDown'}
+      iconSide="right"
+      onClick={() => onToggleExpand(zone.geo, !isOpen)}
+      aria-expanded={isOpen}
+      aria-controls={accordionId}
+      data-test-subj={`manageRegionsZoneCountToggle-${zone.geo}`}
+    >
       {i18n.translate('xpack.searchInferenceEndpoints.manageRegions.zoneCount', {
         defaultMessage: '{checked} of {total, plural, one {# region} other {# regions}}',
         values: { checked: checkedCount, total: zone.regions.length },
       })}
-    </EuiText>
+    </EuiButtonEmpty>
   );
 
   return (
@@ -46,13 +57,13 @@ export const RegionZoneItem: React.FC<RegionZoneItemProps> = ({
       data-test-subj={`manageRegionsZone-${zone.geo}`}
     >
       <EuiAccordion
-        id={`zone-accordion-${zone.geo}`}
-        arrowDisplay="right"
+        id={accordionId}
+        arrowDisplay="none"
         buttonContent={<strong>{zone.displayName}</strong>}
         buttonProps={{ 'data-test-subj': `manageRegionsZoneToggle-${zone.geo}` }}
         extraAction={extraAction}
-        forceState={expandedZones.has(zone.geo) ? 'open' : 'closed'}
-        onToggle={(isOpen) => onToggleExpand(zone.geo, isOpen)}
+        forceState={isOpen ? 'open' : 'closed'}
+        onToggle={(nextIsOpen) => onToggleExpand(zone.geo, nextIsOpen)}
         paddingSize="s"
       >
         {zone.regions.map((r) => {


### PR DESCRIPTION
## Summary

Makes the region count text next to each zone clickable, not just the toggle icon, in the manage region preferences modal.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



## Release note

Fixes the region count text in the manage region preferences modal so clicking it, not just the icon next to it, expands or collapses the zone.



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->