### PR TITLE
[9.4] [Entity Store] Fix too_long_http_line_exception in resolve closed indices (#279529)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
@@ -161,7 +161,7 @@ describe('resolveClosedIndexAdjustments', () => {
     expect(resolveIndex).toHaveBeenCalledTimes(1);
   });
 
-  it('second resolveIndex call uses the concrete backing index names', async () => {
+  it('batches backing index names into a single resolveIndex call when small enough to fit', async () => {
     const resolveIndex = jest
       .fn()
       .mockResolvedValueOnce({
@@ -185,6 +185,113 @@ describe('resolveClosedIndexAdjustments', () => {
         name: ['.ds-logs-foo-000001', '.ds-logs-foo-000002'],
       })
     );
+  });
+
+  it('splits backing index names across multiple batches when URL length would be exceeded', async () => {
+    // 300 names × ~21 bytes each exceeds 3500 bytes per batch, guaranteeing multiple batches
+    const allBackingIndices = Array.from(
+      { length: 300 },
+      (_, i) => `.ds-logs-batch-${String(i).padStart(6, '0')}`
+    );
+
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: [
+          {
+            name: 'logs-batch',
+            backing_indices: allBackingIndices,
+            timestamp_field: '@timestamp',
+          },
+        ],
+      })
+      .mockResolvedValue(emptyResolve);
+
+    await resolveClosedIndexAdjustments(makeEsClient(resolveIndex), ['logs-batch'], logger);
+
+    // More than 2 calls means batching occurred (call 1 = pattern resolve, calls 2+ = batches)
+    expect(resolveIndex.mock.calls.length).toBeGreaterThan(2);
+
+    // Every backing index name must appear in exactly one batch call
+    const batchCalls = resolveIndex.mock.calls.slice(1);
+    const allNamesFromBatches = batchCalls.flatMap((args) => (args[0] as { name: string[] }).name);
+    expect(allNamesFromBatches).toEqual(allBackingIndices);
+  });
+
+  it('merges closed backing index results across all batches', async () => {
+    const allBackingIndices = Array.from(
+      { length: 300 },
+      (_, i) => `.ds-logs-merge-${String(i).padStart(6, '0')}`
+    );
+    // Mark the first and last index as closed so they are guaranteed to be in different batches
+    const closedSet = new Set([
+      allBackingIndices[0],
+      allBackingIndices[allBackingIndices.length - 1],
+    ]);
+
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: [
+          {
+            name: 'logs-merge',
+            backing_indices: allBackingIndices,
+            timestamp_field: '@timestamp',
+          },
+        ],
+      })
+      .mockImplementation(({ name }: { name: string[] }) =>
+        Promise.resolve({
+          indices: name.map((n) => ({
+            name: n,
+            attributes: [closedSet.has(n) ? 'closed' : 'open'],
+          })),
+          aliases: [],
+          data_streams: [],
+        })
+      );
+
+    const result = await resolveClosedIndexAdjustments(
+      makeEsClient(resolveIndex),
+      ['logs-merge'],
+      logger
+    );
+
+    expect(result.negations).toContain('-logs-merge');
+    expect(result.openBackingIndices).toHaveLength(allBackingIndices.length - closedSet.size);
+    for (const closed of closedSet) {
+      expect(result.openBackingIndices).not.toContain(closed);
+    }
+  });
+
+  it('returns empty result and logs a warning if a batch resolveIndex call fails', async () => {
+    const backingIndices = ['.ds-logs-foo-000001', '.ds-logs-foo-000002'];
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: [
+          { name: 'logs-foo', backing_indices: backingIndices, timestamp_field: '@timestamp' },
+        ],
+      })
+      .mockRejectedValue(new Error('batch resolve failed'));
+
+    const result = await resolveClosedIndexAdjustments(
+      makeEsClient(resolveIndex),
+      ['logs-foo'],
+      logger
+    );
+
+    expect(result).toEqual({ openBackingIndices: [], negations: [] });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to resolve closed indices')
+    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('batch resolve failed'));
   });
 
   it('calls resolveIndex with correct expand_wildcards and ignore options', async () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
@@ -39,6 +39,32 @@ export interface ClosedIndexAdjustments {
 
 const toArray = (v: string | string[]): string[] => ([] as string[]).concat(v);
 
+// The ES client joins name arrays with commas then calls encodeURIComponent, so each comma
+// becomes %2C (3 bytes). Elasticsearch's Netty HTTP server rejects request lines > 4096 bytes,
+// so we cap each batch well below that limit.
+const MAX_URL_NAMES_BYTES = 3_500;
+
+const chunkByUrlLength = (names: string[]): string[][] => {
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentBytes = 0;
+
+  for (const name of names) {
+    const cost = name.length + (current.length > 0 ? 3 : 0); // 3 bytes for %2C separator
+    if (current.length > 0 && currentBytes + cost > MAX_URL_NAMES_BYTES) {
+      chunks.push(current);
+      current = [name];
+      currentBytes = name.length;
+    } else {
+      current.push(name);
+      currentBytes += cost;
+    }
+  }
+
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+};
+
 const resolveArgs = (name: string[]) => ({
   name,
   expand_wildcards: ['open', 'closed', 'hidden'] as Array<'open' | 'closed' | 'hidden'>,
@@ -69,12 +95,21 @@ export const resolveClosedIndexAdjustments = async (
 
     const backingIndexNames = resolved.data_streams.flatMap((ds) => toArray(ds.backing_indices));
     if (backingIndexNames.length > 0) {
-      // Second call with concrete backing index names — the first call returns them as plain
-      // strings with no open/closed attributes; we need this call to learn their status.
-      const backingResolved = await esClient.indices.resolveIndex(resolveArgs(backingIndexNames));
+      // The first resolveIndex call returns backing index names without open/closed attributes,
+      // so a second round is needed to learn their status. Batching avoids a
+      // too_long_http_line_exception when many backing indices would push the URL past the
+      // Elasticsearch Netty limit of 4096 bytes.
+      const batchResults = await Promise.all(
+        chunkByUrlLength(backingIndexNames).map((chunk) =>
+          esClient.indices.resolveIndex(resolveArgs(chunk))
+        )
+      );
 
       const closedBackingNames = new Set(
-        backingResolved.indices.filter((i) => i.attributes?.includes('closed')).map((i) => i.name)
+        batchResults
+          .flatMap((r) => r.indices)
+          .filter((i) => i.attributes?.includes('closed'))
+          .map((i) => i.name)
       );
 
       for (const ds of resolved.data_streams) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Store] Fix too_long_http_line_exception in resolve closed indices (#279529)](https://github.com/elastic/kibana/pull/279529)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Chen Ashuri","email":"chen.ashuri@elastic.co"},"sourceCommit":{"committedDate":"2026-07-21T09:11:07Z","message":"[Entity Store] Fix too_long_http_line_exception in resolve closed indices (#279529)\n\n## Summary\n\nCloses elastic/security-team#18279\n\nIn environments with many data streams and a large number of rollover\ngenerations, the closed-index pre-flight check throws a\n`too_long_http_line_exception`. The root cause is that the second\n`resolveIndex` call — needed to learn the open/closed status of each\nbacking index — passes all concrete backing index names as a\ncomma-joined URL path segment. Elasticsearch's Netty HTTP server rejects\nrequest lines larger than 4096 bytes, and a high backing-index count\neasily exceeds that limit.\n\nThe fix batches the backing index names into URL-safe chunks (capped at\n3 500 bytes of name content to stay well below the Netty limit), runs\nall batch requests concurrently via `Promise.all`, and merges the\nresults before determining which data streams contain closed indices.\nEnvironments with few rollovers are unaffected — their names fit in a\nsingle batch and the behaviour is identical to before.\n\n## Test plan\n- [ ] Unit tests updated and passing (`resolve_closed_indices.test.ts`)\n- [ ] Reproduce locally: create a data stream under `logs-*`, force\n~120+ rollovers, confirm the error no longer occurs when the entity\nstore runs its closed-index resolution\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1cda1f671fb240f8b855f678ef37c690a59a763a","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.4.4","v9.6.0"],"title":"[Entity Store] Fix too_long_http_line_exception in resolve closed indices","number":279529,"url":"https://github.com/elastic/kibana/pull/279529","mergeCommit":{"message":"[Entity Store] Fix too_long_http_line_exception in resolve closed indices (#279529)\n\n## Summary\n\nCloses elastic/security-team#18279\n\nIn environments with many data streams and a large number of rollover\ngenerations, the closed-index pre-flight check throws a\n`too_long_http_line_exception`. The root cause is that the second\n`resolveIndex` call — needed to learn the open/closed status of each\nbacking index — passes all concrete backing index names as a\ncomma-joined URL path segment. Elasticsearch's Netty HTTP server rejects\nrequest lines larger than 4096 bytes, and a high backing-index count\neasily exceeds that limit.\n\nThe fix batches the backing index names into URL-safe chunks (capped at\n3 500 bytes of name content to stay well below the Netty limit), runs\nall batch requests concurrently via `Promise.all`, and merges the\nresults before determining which data streams contain closed indices.\nEnvironments with few rollovers are unaffected — their names fit in a\nsingle batch and the behaviour is identical to before.\n\n## Test plan\n- [ ] Unit tests updated and passing (`resolve_closed_indices.test.ts`)\n- [ ] Reproduce locally: create a data stream under `logs-*`, force\n~120+ rollovers, confirm the error no longer occurs when the entity\nstore runs its closed-index resolution\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1cda1f671fb240f8b855f678ef37c690a59a763a"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279731","number":279731,"state":"MERGED","mergeCommit":{"sha":"63006e6e3546dfd6a6fccd377f28e8c705aea149","message":"[9.5] [Entity Store] Fix too_long_http_line_exception in resolve closed indices (#279529) (#279731)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Entity Store] Fix too_long_http_line_exception in resolve closed\nindices (#279529)](https://github.com/elastic/kibana/pull/279529)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Chen Ashuri <chen.ashuri@elastic.co>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279529","number":279529,"mergeCommit":{"message":"[Entity Store] Fix too_long_http_line_exception in resolve closed indices (#279529)\n\n## Summary\n\nCloses elastic/security-team#18279\n\nIn environments with many data streams and a large number of rollover\ngenerations, the closed-index pre-flight check throws a\n`too_long_http_line_exception`. The root cause is that the second\n`resolveIndex` call — needed to learn the open/closed status of each\nbacking index — passes all concrete backing index names as a\ncomma-joined URL path segment. Elasticsearch's Netty HTTP server rejects\nrequest lines larger than 4096 bytes, and a high backing-index count\neasily exceeds that limit.\n\nThe fix batches the backing index names into URL-safe chunks (capped at\n3 500 bytes of name content to stay well below the Netty limit), runs\nall batch requests concurrently via `Promise.all`, and merges the\nresults before determining which data streams contain closed indices.\nEnvironments with few rollovers are unaffected — their names fit in a\nsingle batch and the behaviour is identical to before.\n\n## Test plan\n- [ ] Unit tests updated and passing (`resolve_closed_indices.test.ts`)\n- [ ] Reproduce locally: create a data stream under `logs-*`, force\n~120+ rollovers, confirm the error no longer occurs when the entity\nstore runs its closed-index resolution\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1cda1f671fb240f8b855f678ef37c690a59a763a"}}]}] BACKPORT-->