### PR TITLE
[UIAM OAuth] Support expired application connection status

### DIFF
--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -47,6 +47,8 @@ export interface UiamOAuthConnectionResponse {
   revoked?: boolean;
   revocation?: string;
   revocation_reason?: string;
+  expired?: boolean;
+  expiration?: string;
   scopes?: string[];
   user_id?: string;
 }

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -17,6 +17,7 @@ export interface UiamOAuthClientLogo {
 export interface UiamOAuthConnectionsSummary {
   active?: string[];
   revoked?: string[];
+  expired?: string[];
 }
 
 export type UiamOAuthClientType = 'public' | 'confidential';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/oauth_clients/types/oauth_clients.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/oauth_clients/types/oauth_clients.ts
@@ -18,6 +18,7 @@ export interface OAuthClientLogo {
 export interface OAuthClientConnectionsSummary {
   active?: string[];
   revoked?: string[];
+  expired?: string[];
 }
 
 export interface OAuthClient {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_not_connected_banner.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_not_connected_banner.tsx
@@ -37,38 +37,41 @@ export const McpClientsNotConnectedBanner = ({ clients }: McpClientsNotConnected
     []
   );
 
-  const disconnectedClients = useMemo(
+  const neverConnectedClients = useMemo(
     () =>
       clients.filter(
         (client) =>
-          !client.revoked && (!client.connections?.active || client.connections.active.length === 0)
+          !client.revoked &&
+          (client.connections?.active?.length ?? 0) === 0 &&
+          (client.connections?.expired?.length ?? 0) === 0 &&
+          (client.connections?.revoked?.length ?? 0) === 0
       ),
     [clients]
   );
 
-  const hasUnseenDisconnectedClient = useMemo(() => {
+  const hasUnseenNeverConnectedClient = useMemo(() => {
     const dismissedSet = new Set(dismissedClientIds);
-    return disconnectedClients.some((client) => !dismissedSet.has(client.id));
-  }, [disconnectedClients, dismissedClientIds]);
+    return neverConnectedClients.some((client) => !dismissedSet.has(client.id));
+  }, [neverConnectedClients, dismissedClientIds]);
 
   const handleDismiss = useCallback(() => {
-    setDismissedClientIds(disconnectedClients.map((client) => client.id));
-  }, [setDismissedClientIds, disconnectedClients]);
+    setDismissedClientIds(neverConnectedClients.map((client) => client.id));
+  }, [setDismissedClientIds, neverConnectedClients]);
 
   const displayNames = useMemo(
     () =>
-      disconnectedClients
+      neverConnectedClients
         .filter((client) => client.client_name)
         .slice(0, MAX_DISPLAY_NAMES)
         .map((client) => client.client_name),
-    [disconnectedClients]
+    [neverConnectedClients]
   );
 
-  if (disconnectedClients.length === 0 || !hasUnseenDisconnectedClient) {
+  if (neverConnectedClients.length === 0 || !hasUnseenNeverConnectedClient) {
     return null;
   }
 
-  const remainingCount = disconnectedClients.length - MAX_DISPLAY_NAMES;
+  const remainingCount = neverConnectedClients.length - MAX_DISPLAY_NAMES;
 
   return (
     <EuiCallOut
@@ -82,7 +85,7 @@ export const McpClientsNotConnectedBanner = ({ clients }: McpClientsNotConnected
         id="xpack.agentBuilder.mcpClients.notConnectedBanner.message"
         defaultMessage="{count, plural, one {The MCP client {names} is} other {The MCP clients {names}{remaining} are}} not yet connected."
         values={{
-          count: disconnectedClients.length,
+          count: neverConnectedClients.length,
           names: (
             <>
               {displayNames.map((name, index) => (

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_not_connected_banner.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_not_connected_banner.tsx
@@ -31,47 +31,43 @@ export interface McpClientsNotConnectedBannerProps {
   clients: OAuthClient[];
 }
 
+const isUnusedClient = ({ revoked, connections }: OAuthClient) =>
+  !revoked &&
+  !connections?.active?.length &&
+  !connections?.expired?.length &&
+  !connections?.revoked?.length;
+
 export const McpClientsNotConnectedBanner = ({ clients }: McpClientsNotConnectedBannerProps) => {
   const [dismissedClientIds = [], setDismissedClientIds] = useLocalStorage<string[]>(
     storageKeys.mcpClientBannerDismissedIds,
     []
   );
 
-  const neverConnectedClients = useMemo(
-    () =>
-      clients.filter(
-        (client) =>
-          !client.revoked &&
-          (client.connections?.active?.length ?? 0) === 0 &&
-          (client.connections?.expired?.length ?? 0) === 0 &&
-          (client.connections?.revoked?.length ?? 0) === 0
-      ),
-    [clients]
-  );
+  const unusedClients = useMemo(() => clients.filter(isUnusedClient), [clients]);
 
-  const hasUnseenNeverConnectedClient = useMemo(() => {
+  const hasUnseenUnusedClient = useMemo(() => {
     const dismissedSet = new Set(dismissedClientIds);
-    return neverConnectedClients.some((client) => !dismissedSet.has(client.id));
-  }, [neverConnectedClients, dismissedClientIds]);
+    return unusedClients.some((client) => !dismissedSet.has(client.id));
+  }, [unusedClients, dismissedClientIds]);
 
   const handleDismiss = useCallback(() => {
-    setDismissedClientIds(neverConnectedClients.map((client) => client.id));
-  }, [setDismissedClientIds, neverConnectedClients]);
+    setDismissedClientIds(unusedClients.map((client) => client.id));
+  }, [setDismissedClientIds, unusedClients]);
 
   const displayNames = useMemo(
     () =>
-      neverConnectedClients
+      unusedClients
         .filter((client) => client.client_name)
         .slice(0, MAX_DISPLAY_NAMES)
         .map((client) => client.client_name),
-    [neverConnectedClients]
+    [unusedClients]
   );
 
-  if (neverConnectedClients.length === 0 || !hasUnseenNeverConnectedClient) {
+  if (unusedClients.length === 0 || !hasUnseenUnusedClient) {
     return null;
   }
 
-  const remainingCount = neverConnectedClients.length - MAX_DISPLAY_NAMES;
+  const remainingCount = unusedClients.length - MAX_DISPLAY_NAMES;
 
   return (
     <EuiCallOut
@@ -85,7 +81,7 @@ export const McpClientsNotConnectedBanner = ({ clients }: McpClientsNotConnected
         id="xpack.agentBuilder.mcpClients.notConnectedBanner.message"
         defaultMessage="{count, plural, one {The MCP client {names} is} other {The MCP clients {names}{remaining} are}} not yet connected."
         values={{
-          count: neverConnectedClients.length,
+          count: unusedClients.length,
           names: (
             <>
               {displayNames.map((name, index) => (

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table_columns.tsx
@@ -94,7 +94,7 @@ export const useMcpClientsTableColumns = (): Array<EuiBasicTableColumn<OAuthClie
         <McpClientActionsMenu
           clientId={id}
           clientName={client_name ?? id}
-          connectionCount={connections?.active?.length ?? 0}
+          connectionCount={(connections?.active?.length ?? 0) + (connections?.expired?.length ?? 0)}
           revoked={revoked ?? false}
         />
       ),

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -344,6 +344,121 @@ describe('ApplicationConnections', () => {
     expect(queryByText('Laptop session')).not.toBeInTheDocument();
   }, 15_000);
 
+  it('renders an "Expired" status for a connection that is expired but not revoked, and keeps it selectable', async () => {
+    setupHttpResponses(coreStart, {
+      clients: {
+        clients: [{ id: 'client-a', client_name: 'My MCP app', resource: 'cluster:elastic' }],
+      },
+      connections: {
+        connections: [
+          {
+            id: 'conn-expired',
+            client_id: 'client-a',
+            name: 'Stale session',
+            resource: 'cluster:elastic',
+            expired: true,
+          },
+        ],
+      },
+    });
+
+    const { findByText, findByTestId, getByTestId, queryByTestId } = renderPage(coreStart);
+
+    await findByText('My MCP app');
+    fireEvent.click(getByTestId('applicationConnectionsViewModeList'));
+
+    const listView = await findByTestId('applicationConnectionsListView');
+    await within(listView).findByText('Stale session');
+    expect(within(listView).getByText('Expired')).toBeInTheDocument();
+
+    expect(queryByTestId('applicationConnectionsBulkRevokeButton')).not.toBeInTheDocument();
+    const rowCheckbox = within(listView).getByLabelText(/Select connection 'Stale session'/);
+    fireEvent.click(rowCheckbox);
+    expect(await findByTestId('applicationConnectionsBulkRevokeButton')).toHaveTextContent(
+      'Revoke 1 connection'
+    );
+
+    expect(within(listView).getByTestId('revokeConnection-conn-expired')).toBeInTheDocument();
+  });
+
+  it('renders "Revoked" (not "Expired") when a connection is both expired and revoked', async () => {
+    setupHttpResponses(coreStart, {
+      clients: {
+        clients: [{ id: 'client-a', client_name: 'My MCP app', resource: 'cluster:elastic' }],
+      },
+      connections: {
+        connections: [
+          {
+            id: 'conn-both',
+            client_id: 'client-a',
+            name: 'Old session',
+            resource: 'cluster:elastic',
+            expired: true,
+            revoked: true,
+          },
+        ],
+      },
+    });
+
+    const { findByText, findByTestId, getByTestId } = renderPage(coreStart);
+
+    await findByText('My MCP app');
+    fireEvent.click(getByTestId('applicationConnectionsViewModeList'));
+
+    const listView = await findByTestId('applicationConnectionsListView');
+    await within(listView).findByText('Old session');
+    expect(within(listView).getAllByText('Revoked').length).toBeGreaterThan(0);
+    expect(within(listView).queryByText('Expired')).not.toBeInTheDocument();
+  });
+
+  it('filters by "Expired" inside a mixed-status grouped row', async () => {
+    setupHttpResponses(coreStart, {
+      clients: {
+        clients: [{ id: 'client-a', client_name: 'Mixed app', resource: 'cluster:elastic' }],
+      },
+      connections: {
+        connections: [
+          {
+            id: 'conn-active',
+            client_id: 'client-a',
+            name: 'Laptop session',
+            resource: 'cluster:elastic',
+          },
+          {
+            id: 'conn-expired',
+            client_id: 'client-a',
+            name: 'Stale session',
+            resource: 'cluster:elastic',
+            expired: true,
+          },
+          {
+            id: 'conn-revoked',
+            client_id: 'client-a',
+            name: 'Desktop session',
+            resource: 'cluster:elastic',
+            revoked: true,
+          },
+        ],
+      },
+    });
+
+    const { findByRole, findByTestId, findByText, getByRole, getByTestId, queryByText } =
+      renderPage(coreStart);
+
+    expect(await findByTestId('applicationConnectionsCount-client-a')).toHaveTextContent('3');
+
+    fireEvent.click(getByRole('button', { name: /Status Selection/ }));
+    fireEvent.click(await findByRole('option', { name: /Expired/ }));
+
+    await waitFor(() => {
+      expect(getByTestId('applicationConnectionsCount-client-a')).toHaveTextContent('1');
+    });
+    fireEvent.click(getByTestId('expandRow-client-a'));
+    expect(await findByText('Stale session')).toBeInTheDocument();
+    expect(queryByText('Laptop session')).not.toBeInTheDocument();
+    expect(queryByText('Desktop session')).not.toBeInTheDocument();
+  }, 15_000);
+
   it('renders the expanded connection table with the Figma-aligned columns (no Scopes, no Select-all)', async () => {
     setupHttpResponses(coreStart, {
       clients: {

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_filters.test.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_filters.test.ts
@@ -207,14 +207,23 @@ describe('#applicationConnectionMatchesStatus', () => {
     client: createClient({ revoked: false }),
     connection: createConnection({ revoked: true }),
   });
+  const expired = createApplicationConnection({
+    client: createClient({ revoked: false }),
+    connection: createConnection({ revoked: false, expired: true }),
+  });
+  const expiredAndRevoked = createApplicationConnection({
+    client: createClient({ revoked: false }),
+    connection: createConnection({ revoked: true, expired: true }),
+  });
 
   it('returns true for any row when the filter list is empty', () => {
     expect(applicationConnectionMatchesStatus(active, [])).toBe(true);
     expect(applicationConnectionMatchesStatus(clientRevoked, [])).toBe(true);
+    expect(applicationConnectionMatchesStatus(expired, [])).toBe(true);
   });
 
   describe('with status: ["connected"]', () => {
-    it('matches rows where neither client nor connection is revoked', () => {
+    it('matches rows where neither client nor connection is revoked and not expired', () => {
       expect(applicationConnectionMatchesStatus(active, ['connected'])).toBe(true);
     });
 
@@ -224,6 +233,24 @@ describe('#applicationConnectionMatchesStatus', () => {
 
     it('does not match when the connection is revoked', () => {
       expect(applicationConnectionMatchesStatus(connectionRevoked, ['connected'])).toBe(false);
+    });
+
+    it('does not match when the connection is expired', () => {
+      expect(applicationConnectionMatchesStatus(expired, ['connected'])).toBe(false);
+    });
+  });
+
+  describe('with status: ["expired"]', () => {
+    it('matches an expired connection', () => {
+      expect(applicationConnectionMatchesStatus(expired, ['expired'])).toBe(true);
+    });
+
+    it('does not match an active row', () => {
+      expect(applicationConnectionMatchesStatus(active, ['expired'])).toBe(false);
+    });
+
+    it('does not match a revoked row that is also expired (revoked takes precedence)', () => {
+      expect(applicationConnectionMatchesStatus(expiredAndRevoked, ['expired'])).toBe(false);
     });
   });
 
@@ -236,20 +263,26 @@ describe('#applicationConnectionMatchesStatus', () => {
       expect(applicationConnectionMatchesStatus(connectionRevoked, ['revoked'])).toBe(true);
     });
 
+    it('matches an expired-and-revoked row (revoked takes precedence)', () => {
+      expect(applicationConnectionMatchesStatus(expiredAndRevoked, ['revoked'])).toBe(true);
+    });
+
     it('does not match an active row', () => {
       expect(applicationConnectionMatchesStatus(active, ['revoked'])).toBe(false);
     });
+
+    it('does not match an expired row', () => {
+      expect(applicationConnectionMatchesStatus(expired, ['revoked'])).toBe(false);
+    });
   });
 
-  describe('with status: ["connected", "revoked"]', () => {
+  describe('with status: ["connected", "expired", "revoked"]', () => {
     it('matches every row (OR semantics)', () => {
-      expect(applicationConnectionMatchesStatus(active, ['connected', 'revoked'])).toBe(true);
-      expect(applicationConnectionMatchesStatus(clientRevoked, ['connected', 'revoked'])).toBe(
-        true
-      );
-      expect(applicationConnectionMatchesStatus(connectionRevoked, ['connected', 'revoked'])).toBe(
-        true
-      );
+      const statuses = ['connected', 'expired', 'revoked'] as const;
+      expect(applicationConnectionMatchesStatus(active, [...statuses])).toBe(true);
+      expect(applicationConnectionMatchesStatus(clientRevoked, [...statuses])).toBe(true);
+      expect(applicationConnectionMatchesStatus(connectionRevoked, [...statuses])).toBe(true);
+      expect(applicationConnectionMatchesStatus(expired, [...statuses])).toBe(true);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_filters.test.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_filters.test.ts
@@ -9,6 +9,8 @@ import {
   applicationConnectionMatchesFreeText,
   applicationConnectionMatchesStatus,
   applicationConnectionsMatchesFreeText,
+  getConnectionStatus,
+  isRevocable,
   toApplicationConnectionList,
 } from './application_connections_filters';
 import type { ApplicationConnection, ApplicationConnections } from '../constants/types';
@@ -284,5 +286,124 @@ describe('#applicationConnectionMatchesStatus', () => {
       expect(applicationConnectionMatchesStatus(connectionRevoked, [...statuses])).toBe(true);
       expect(applicationConnectionMatchesStatus(expired, [...statuses])).toBe(true);
     });
+  });
+});
+
+describe('#getConnectionStatus', () => {
+  it('returns "connected" when neither client nor connection is revoked or expired', () => {
+    expect(
+      getConnectionStatus(
+        createApplicationConnection({
+          client: createClient({ revoked: false }),
+          connection: createConnection({ revoked: false, expired: false }),
+        })
+      )
+    ).toBe('connected');
+  });
+
+  it('returns "expired" when the connection is expired but not revoked', () => {
+    expect(
+      getConnectionStatus(
+        createApplicationConnection({
+          connection: createConnection({ revoked: false, expired: true }),
+        })
+      )
+    ).toBe('expired');
+  });
+
+  it('returns "revoked" when the connection is revoked', () => {
+    expect(
+      getConnectionStatus(
+        createApplicationConnection({
+          connection: createConnection({ revoked: true }),
+        })
+      )
+    ).toBe('revoked');
+  });
+
+  it('returns "revoked" when the client is revoked', () => {
+    expect(
+      getConnectionStatus(
+        createApplicationConnection({
+          client: createClient({ revoked: true }),
+          connection: createConnection({ revoked: false }),
+        })
+      )
+    ).toBe('revoked');
+  });
+
+  it('prefers "revoked" over "expired" when the connection is both revoked and expired', () => {
+    expect(
+      getConnectionStatus(
+        createApplicationConnection({
+          connection: createConnection({ revoked: true, expired: true }),
+        })
+      )
+    ).toBe('revoked');
+  });
+
+  it('prefers "revoked" over "expired" when the client is revoked and the connection is expired', () => {
+    expect(
+      getConnectionStatus(
+        createApplicationConnection({
+          client: createClient({ revoked: true }),
+          connection: createConnection({ revoked: false, expired: true }),
+        })
+      )
+    ).toBe('revoked');
+  });
+});
+
+describe('#isRevocable', () => {
+  it('is revocable when neither client nor connection is revoked', () => {
+    expect(
+      isRevocable(
+        createApplicationConnection({
+          client: createClient({ revoked: false }),
+          connection: createConnection({ revoked: false }),
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('stays revocable when the connection is expired but not revoked', () => {
+    expect(
+      isRevocable(
+        createApplicationConnection({
+          connection: createConnection({ revoked: false, expired: true }),
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('is not revocable when the connection is revoked', () => {
+    expect(
+      isRevocable(
+        createApplicationConnection({
+          connection: createConnection({ revoked: true }),
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('is not revocable when the client is revoked', () => {
+    expect(
+      isRevocable(
+        createApplicationConnection({
+          client: createClient({ revoked: true }),
+          connection: createConnection({ revoked: false }),
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('is not revocable when the connection is both expired and revoked', () => {
+    expect(
+      isRevocable(
+        createApplicationConnection({
+          connection: createConnection({ revoked: true, expired: true }),
+        })
+      )
+    ).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_filters.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_filters.ts
@@ -13,6 +13,15 @@ import type {
   ApplicationConnectionStatusFilter,
 } from '../constants/types';
 
+export const getConnectionStatus = ({
+  client,
+  connection,
+}: ApplicationConnection): ApplicationConnectionStatusFilter => {
+  if (client.revoked || connection.revoked) return 'revoked';
+  if (connection.expired) return 'expired';
+  return 'connected';
+};
+
 export const toApplicationConnectionList = (
   connections: ApplicationConnections[]
 ): ApplicationConnection[] =>
@@ -63,9 +72,5 @@ export const applicationConnectionMatchesStatus = (
   statuses: ApplicationConnectionStatusFilter[]
 ): boolean => {
   if (statuses.length === 0) return true;
-  const isActive =
-    !applicationConnection.client.revoked && !applicationConnection.connection.revoked;
-  return (
-    (statuses.includes('connected') && isActive) || (statuses.includes('revoked') && !isActive)
-  );
+  return statuses.includes(getConnectionStatus(applicationConnection));
 };

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_filters.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_filters.ts
@@ -22,6 +22,9 @@ export const getConnectionStatus = ({
   return 'connected';
 };
 
+export const isRevocable = (applicationConnection: ApplicationConnection): boolean =>
+  getConnectionStatus(applicationConnection) !== 'revoked';
+
 export const toApplicationConnectionList = (
   connections: ApplicationConnections[]
 ): ApplicationConnection[] =>

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_table_search.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_table_search.tsx
@@ -13,6 +13,7 @@ import {
   applicationConnectionMatchesFreeText,
   applicationConnectionMatchesStatus,
   applicationConnectionsMatchesFreeText,
+  getConnectionStatus,
   toApplicationConnectionList,
 } from './application_connections_filters';
 import { ViewModeToggle } from './application_connections_view_mode_toggle';
@@ -28,8 +29,12 @@ import { useApplicationConnections } from '../hooks/use_application_connections'
 
 const STATUS_LABELS: Record<ApplicationConnectionStatusFilter, string> = {
   connected: labels.filters.statusConnected,
+  expired: labels.filters.statusExpired,
   revoked: labels.filters.statusRevoked,
 };
+
+const isStatusFilterValue = (value: unknown): value is ApplicationConnectionStatusFilter =>
+  value === 'connected' || value === 'expired' || value === 'revoked';
 
 export interface UseApplicationConnectionsTableSearchOptions {
   toolsLeft?: EuiSearchBarProps['toolsLeft'];
@@ -71,13 +76,12 @@ export const useApplicationConnectionsTableSearch = ({
     if (orClause) {
       const raw = Array.isArray(orClause.value) ? orClause.value : [orClause.value];
       for (const value of raw) {
-        if (value === 'connected' || value === 'revoked') statusValues.add(value);
+        if (isStatusFilterValue(value)) statusValues.add(value);
       }
     }
     const simpleClause = args.query.getSimpleFieldClause('status');
-    if (simpleClause) {
-      const value = simpleClause.value;
-      if (value === 'connected' || value === 'revoked') statusValues.add(value);
+    if (simpleClause && isStatusFilterValue(simpleClause.value)) {
+      statusValues.add(simpleClause.value);
     }
     setStatusFilter(Array.from(statusValues));
 
@@ -89,8 +93,8 @@ export const useApplicationConnectionsTableSearch = ({
 
   const matchesByStatus = useMemo(
     () =>
-      countBy(toApplicationConnectionList(applicationConnections), ({ client, connection }) =>
-        !client.revoked && !connection.revoked ? 'connected' : 'revoked'
+      countBy(toApplicationConnectionList(applicationConnections), (applicationConnection) =>
+        getConnectionStatus(applicationConnection)
       ),
     [applicationConnections]
   );

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_rows_table.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_rows_table.tsx
@@ -11,7 +11,8 @@ import { css } from '@emotion/react';
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useMemo } from 'react';
 
-import { isConnectionActive, useConnectionTableColumns } from './connection_table_columns';
+import { isRevocable } from './application_connections_filters';
+import { useConnectionTableColumns } from './connection_table_columns';
 import { labels } from '../constants/i18n';
 import type { ApplicationConnection } from '../constants/types';
 import type { OAuthClient, OAuthConnection } from '../service/application_connections_api_client';
@@ -68,7 +69,7 @@ export const ConnectionRowsTable: FunctionComponent<ConnectionRowsTableProps> = 
   const selectionConfig: EuiTableSelectionType<ApplicationConnection> = {
     selected: selectedItems,
     onSelectionChange: handleSelectionChange,
-    selectable: isConnectionActive,
+    selectable: isRevocable,
     selectableMessage: (selectable, { connection }) =>
       selectable
         ? labels.connectionColumns.selectRowLabel(connection.name ?? connection.id)

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_table_columns.tsx
@@ -13,7 +13,7 @@ import type {
 import { EuiHealth, EuiLink, EuiText, EuiTextColor, EuiToolTip, formatDate } from '@elastic/eui';
 import React, { useMemo } from 'react';
 
-import { getConnectionStatus } from './application_connections_filters';
+import { getConnectionStatus, isRevocable } from './application_connections_filters';
 import { ConnectedBy, getConnectedByDisplayName } from './connected_by';
 import { InlineEditConnectionName } from './inline_edit_connection_name';
 import { labels } from '../constants/i18n';
@@ -21,9 +21,6 @@ import type { ApplicationConnection, ApplicationConnectionStatusFilter } from '.
 import { useApplicationConnectionsActions } from '../context/application_connections_provider';
 
 const AUTHORIZATION_DATE_FORMAT = 'll';
-
-export const isConnectionActive = ({ client, connection }: ApplicationConnection): boolean =>
-  !client.revoked && !connection.revoked;
 
 const STATUS_SORT_ORDER: Record<ApplicationConnectionStatusFilter, number> = {
   connected: 0,
@@ -49,7 +46,7 @@ export const useConnectionTableColumns = ({
       render: (_, applicationConnection: ApplicationConnection) => {
         const { client, connection } = applicationConnection;
         const displayName = connection.name ?? connection.id;
-        if (!isConnectionActive(applicationConnection)) {
+        if (!isRevocable(applicationConnection)) {
           return (
             <EuiText size="s" data-test-subj={`applicationConnectionRow-${connection.id}`}>
               <EuiTextColor color="subdued">{displayName}</EuiTextColor>
@@ -140,7 +137,7 @@ export const useConnectionTableColumns = ({
       name: labels.connectionColumns.actions,
       render: (applicationConnection) => {
         const { client, connection } = applicationConnection;
-        if (!isConnectionActive(applicationConnection)) {
+        if (!isRevocable(applicationConnection)) {
           return (
             <EuiText size="s" color="subdued">
               {labels.connectionColumns.revokedLabel}

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_table_columns.tsx
@@ -13,16 +13,23 @@ import type {
 import { EuiHealth, EuiLink, EuiText, EuiTextColor, EuiToolTip, formatDate } from '@elastic/eui';
 import React, { useMemo } from 'react';
 
+import { getConnectionStatus } from './application_connections_filters';
 import { ConnectedBy, getConnectedByDisplayName } from './connected_by';
 import { InlineEditConnectionName } from './inline_edit_connection_name';
 import { labels } from '../constants/i18n';
-import type { ApplicationConnection } from '../constants/types';
+import type { ApplicationConnection, ApplicationConnectionStatusFilter } from '../constants/types';
 import { useApplicationConnectionsActions } from '../context/application_connections_provider';
 
 const AUTHORIZATION_DATE_FORMAT = 'll';
 
 export const isConnectionActive = ({ client, connection }: ApplicationConnection): boolean =>
   !client.revoked && !connection.revoked;
+
+const STATUS_SORT_ORDER: Record<ApplicationConnectionStatusFilter, number> = {
+  connected: 0,
+  expired: 1,
+  revoked: 2,
+};
 
 export interface ConnectionTableColumnsOptions {
   withClientNameColumn?: boolean;
@@ -109,15 +116,22 @@ export const useConnectionTableColumns = ({
     const statusColumn: EuiTableComputedColumnType<ApplicationConnection> = {
       name: labels.connectionColumns.status,
       width: '120px',
-      sortable: (applicationConnection) => (isConnectionActive(applicationConnection) ? 0 : 1),
-      render: (applicationConnection) =>
-        isConnectionActive(applicationConnection) ? (
+      sortable: (applicationConnection) =>
+        STATUS_SORT_ORDER[getConnectionStatus(applicationConnection)],
+      render: (applicationConnection) => {
+        const status = getConnectionStatus(applicationConnection);
+        if (status === 'expired') {
+          return <EuiHealth color="warning">{labels.status.expired}</EuiHealth>;
+        }
+        if (status === 'revoked') {
+          return <EuiHealth color="danger">{labels.status.revoked}</EuiHealth>;
+        }
+        return (
           <EuiToolTip content={labels.status.connectedTooltip} position="top" display="flex">
             <EuiHealth color="success">{labels.status.connected}</EuiHealth>
           </EuiToolTip>
-        ) : (
-          <EuiHealth color="danger">{labels.status.revoked}</EuiHealth>
-        ),
+        );
+      },
     };
 
     const actionsColumn: EuiTableComputedColumnType<ApplicationConnection> = {

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connections_list_table.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connections_list_table.tsx
@@ -10,9 +10,10 @@ import { EuiFlexGroup, EuiInMemoryTable, EuiText } from '@elastic/eui';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { ApplicationConnectionsEmptyPrompt } from './application_connections_empty_prompt';
+import { isRevocable } from './application_connections_filters';
 import { ApplicationConnectionsTableHeader } from './application_connections_table_header';
 import { flatTableStyles } from './application_connections_table_styles';
-import { isConnectionActive, useConnectionTableColumns } from './connection_table_columns';
+import { useConnectionTableColumns } from './connection_table_columns';
 import { labels } from '../constants/i18n';
 import type { ApplicationConnection } from '../constants/types';
 import { useNavigation } from '../hooks/use_navigation';
@@ -48,7 +49,7 @@ export const ConnectionsListTable = ({
   const selectionConfig: EuiTableSelectionType<ApplicationConnection> = {
     selected: selectedItems,
     onSelectionChange: (next) => onSelectionChange(next.map((row) => row.connection)),
-    selectable: isConnectionActive,
+    selectable: isRevocable,
     selectableMessage: (selectable, { connection }) =>
       selectable
         ? labels.connectionColumns.selectRowLabel(connection.name ?? connection.id)

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/i18n.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/i18n.ts
@@ -39,6 +39,10 @@ export const labels = {
       'xpack.security.management.applicationConnections.filters.statusConnected',
       { defaultMessage: 'Connected' }
     ),
+    statusExpired: i18n.translate(
+      'xpack.security.management.applicationConnections.filters.statusExpired',
+      { defaultMessage: 'Expired' }
+    ),
     statusRevoked: i18n.translate(
       'xpack.security.management.applicationConnections.filters.statusRevoked',
       { defaultMessage: 'Revoked' }
@@ -69,6 +73,9 @@ export const labels = {
           'This connection is authorized. Sessions expire after 30 days of inactivity.',
       }
     ),
+    expired: i18n.translate('xpack.security.management.applicationConnections.status.expired', {
+      defaultMessage: 'Expired',
+    }),
     revoked: i18n.translate('xpack.security.management.applicationConnections.status.revoked', {
       defaultMessage: 'Revoked',
     }),

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/types.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/types.ts
@@ -21,7 +21,7 @@ export interface ApplicationConnection {
   connection: OAuthConnection;
 }
 
-export type ApplicationConnectionStatusFilter = 'connected' | 'revoked';
+export type ApplicationConnectionStatusFilter = 'connected' | 'expired' | 'revoked';
 
 export type ApplicationConnectionsViewMode = 'grouped' | 'list';
 

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/service/application_connections_api_client.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/service/application_connections_api_client.ts
@@ -30,6 +30,8 @@ export interface OAuthConnection {
   revoked?: boolean;
   revocation?: string;
   revocation_reason?: string;
+  expired?: boolean;
+  expiration?: string;
   scopes?: string[];
   user_id?: string;
   user?: OAuthConnectionUser;

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -91,6 +91,30 @@ describe('List OAuth Connections route', () => {
     expect(response.payload).toEqual(mockResponse);
   });
 
+  it('passes through the expired flag and expiration timestamp from the connection response', async () => {
+    const mockResponse = {
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          expired: true,
+          expiration: '2026-07-12T18:18:32Z',
+        },
+      ],
+    };
+    oauthMock.listConnections.mockResolvedValue(mockResponse);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(mockResponse);
+  });
+
   it('adds user information to connections when available', async () => {
     oauthMock.listConnections.mockResolvedValue({
       connections: [

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/ui/tests/application_connections.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/ui/tests/application_connections.spec.ts
@@ -25,6 +25,7 @@ test.describe(
     let authHeaders: Record<string, string>;
     let clientId: string;
     const connectionIds: string[] = [];
+    let expiredConnectionId: string;
 
     test.beforeAll(async ({ apiClient, samlAuth, config: { organizationId } }) => {
       authHeaders = await createUiamAuthHeaders(samlAuth);
@@ -60,6 +61,23 @@ test.describe(
         }
         connectionIds.push(connectionId);
       }
+
+      // Seed a separate expired (but not revoked) connection to verify the
+      // "Expired" status is surfaced and the connection remains revocable.
+      expiredConnectionId = `scout-conn-expired-${Date.now()}`;
+      const expiredResult = await seedTestOAuthConnection({
+        connectionId: expiredConnectionId,
+        clientId,
+        organizationId: organizationId!,
+        userId,
+        resource: MCP_RESOURCE,
+        name: 'scout expired connection',
+        scopes: ['all'],
+        expired: true,
+      });
+      if (!expiredResult.success) {
+        throw new Error(`Failed to seed expired OAuth connection: ${expiredResult.message}`);
+      }
     });
 
     test.beforeEach(async ({ browserAuth }) => {
@@ -68,7 +86,9 @@ test.describe(
 
     test.afterAll(async ({ apiClient }) => {
       await Promise.all(
-        connectionIds.map((connectionId) => deleteTestOAuthConnection({ connectionId, clientId }))
+        [...connectionIds, expiredConnectionId]
+          .filter(Boolean)
+          .map((connectionId) => deleteTestOAuthConnection({ connectionId, clientId }))
       );
       if (clientId) {
         await revokeOAuthClient(apiClient, authHeaders, clientId);
@@ -121,6 +141,30 @@ test.describe(
       await expect(async () => {
         const rowText = await pageObjects.applicationConnections.getListConnectionRowText(
           connectionId
+        );
+        expect(rowText).toContain('Revoked');
+      }).toPass();
+    });
+
+    test('surfaces an "Expired" status for an expired connection that stays revocable', async ({
+      pageObjects,
+    }) => {
+      await pageObjects.applicationConnections.navigate();
+      await pageObjects.applicationConnections.switchToListView();
+      await pageObjects.applicationConnections.waitForListConnectionRow(expiredConnectionId);
+
+      await expect(async () => {
+        const rowText = await pageObjects.applicationConnections.getListConnectionRowText(
+          expiredConnectionId
+        );
+        expect(rowText).toContain('Expired');
+      }).toPass();
+
+      await pageObjects.applicationConnections.revokeConnection(expiredConnectionId);
+
+      await expect(async () => {
+        const rowText = await pageObjects.applicationConnections.getListConnectionRowText(
+          expiredConnectionId
         );
         expect(rowText).toContain('Revoked');
       }).toPass();


### PR DESCRIPTION
## Summary

Resolves #278286.

Adds an "Expired" connection status to the application connections management views, so admins can distinguish sessions that lapsed on their own from ones that were explicitly revoked. Also handles the `expired` bucket newly returned by the OAuth connections summary (`GET /uiam/api/v1/oauth/clients`) and updates the banner to only appear for connections that have yet to be connected (i.e. 0 active, expired, and revoked connections).

<img width="1677" height="1173" alt="image" src="https://github.com/user-attachments/assets/140a54ba-3790-43f9-ac27-f95d0afd7d3d" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
