### PR TITLE
Fix Rules breadcrumbs in Stack Management

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.test.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getAlertingSectionBreadcrumb } from './breadcrumb';
+import { getAlertingSectionBreadcrumb, getRulesBreadcrumbWithHref } from './breadcrumb';
 import { i18n } from '@kbn/i18n';
 import { routeToConnectors, routeToRules, routeToHome } from '../constants';
 
@@ -46,6 +46,17 @@ describe('getAlertingSectionBreadcrumb', () => {
       text: i18n.translate('xpack.triggersActionsUI.home.breadcrumbTitle', {
         defaultMessage: 'Rules',
       }),
+    });
+  });
+});
+
+describe('getRulesBreadcrumbWithHref', () => {
+  test('returns the rules route relative to the management app', () => {
+    expect(getRulesBreadcrumbWithHref()).toEqual({
+      text: i18n.translate('xpack.triggersActionsUI.rules.breadcrumbTitle', {
+        defaultMessage: 'Rules',
+      }),
+      href: routeToHome,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.ts
@@ -90,14 +90,8 @@ export const getAlertingSectionBreadcrumb = (
   }
 };
 
-export const getRulesBreadcrumbWithHref = (
-  getUrlForApp: (appId: string, options?: { path?: string }) => string
-) => {
-  const rulesBreadcrumb = getAlertingSectionBreadcrumb('rules', true);
-  const breadcrumbHref = getUrlForApp('rules', { path: '/' });
-
-  return {
-    ...rulesBreadcrumb,
-    href: breadcrumbHref,
-  };
-};
+export const getRulesBreadcrumbWithHref = () => ({
+  ...getAlertingSectionBreadcrumb('rules'),
+  // Management scopes breadcrumb hrefs to the mounted app.
+  href: routeToHome,
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
@@ -16,7 +16,6 @@ import {
   EuiPageSection,
   EuiCallOut,
   EuiSpacer,
-  EuiButton,
   EuiLink,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -141,7 +140,7 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
 
   // Set breadcrumb and page title
   useEffect(() => {
-    const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref(getUrlForApp);
+    const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref();
     setBreadcrumbs([rulesBreadcrumbWithAppPath, { text: rule.name }]);
     chrome.docTitle.change(getCurrentDocTitle('rules'));
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -203,34 +202,33 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
             }
           ),
           text: toMountPoint(
-            <>
-              <p>
-                <FormattedMessage
-                  id="xpack.triggersActionsUI.sections.ruleDetails.scheduleIntervalToastMessage"
-                  defaultMessage="This rule has an interval set below the minimum configured interval. This may impact performance."
-                />
-              </p>
-              {hasEditButton && (
-                <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-                  <EuiFlexItem grow={false}>
-                    <EuiButton
-                      data-test-subj="ruleIntervalToastEditButton"
-                      onClick={() => {
-                        toasts.remove(configurationToast);
-                        onEditRuleClick();
-                      }}
-                    >
-                      <FormattedMessage
-                        id="xpack.triggersActionsUI.sections.ruleDetails.scheduleIntervalToastMessageButton"
-                        defaultMessage="Edit rule"
-                      />
-                    </EuiButton>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              )}
-            </>,
+            <p>
+              <FormattedMessage
+                id="xpack.triggersActionsUI.sections.ruleDetails.scheduleIntervalToastMessage"
+                defaultMessage="This rule has an interval set below the minimum configured interval. This may impact performance."
+              />
+            </p>,
             { i18n: i18nStart, theme, userProfile }
           ),
+          ...(hasEditButton
+            ? {
+                actionProps: {
+                  primary: {
+                    'data-test-subj': 'ruleIntervalToastEditButton',
+                    onClick: () => {
+                      toasts.remove(configurationToast);
+                      onEditRuleClick();
+                    },
+                    children: i18n.translate(
+                      'xpack.triggersActionsUI.sections.ruleDetails.scheduleIntervalToastMessageButton',
+                      {
+                        defaultMessage: 'Edit rule',
+                      }
+                    ),
+                  },
+                },
+              }
+            : {}),
         });
       }
     }
@@ -319,7 +317,12 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
     }
   };
 
-  const backTarget = getRulesBreadcrumbWithHref(getUrlForApp);
+  const backTarget = {
+    ...getRulesBreadcrumbWithHref(),
+    href: getUrlForApp('management', {
+      path: 'insightsAndAlerting/triggersActions/',
+    }),
+  };
 
   const statusColor = getHealthColor(rule.executionStatus.status);
 

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details_route.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details_route.tsx
@@ -42,7 +42,6 @@ export const RuleDetailsRoute: React.FunctionComponent<RuleDetailsRouteProps> = 
     cps,
     notifications: { toasts },
     spaces: spacesApi,
-    application: { getUrlForApp },
     setBreadcrumbs,
   } = useKibana().services;
 
@@ -50,8 +49,8 @@ export const RuleDetailsRoute: React.FunctionComponent<RuleDetailsRouteProps> = 
 
   // sets a baseline breadcrumb regardless of the outcome of loading the rule
   useEffect(() => {
-    setBreadcrumbs([getRulesBreadcrumbWithHref(getUrlForApp)]);
-  }, [getUrlForApp, setBreadcrumbs]);
+    setBreadcrumbs([getRulesBreadcrumbWithHref()]);
+  }, [setBreadcrumbs]);
 
   const [rule, setRule] = useState<ResolvedRule | null>(null);
   const [ruleType, setRuleType] = useState<RuleType | null>(null);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_form/rule_form_route.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_form/rule_form_route.tsx
@@ -12,7 +12,7 @@ import { AlertConsumers, getRulesAppDetailsRoute } from '@kbn/rule-data-utils';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { ProjectRoutingAccess, useRouteBasedCpsPickerAccess } from '@kbn/cps-utils';
 import { useKibana } from '../../../common/lib/kibana';
-import { getAlertingSectionBreadcrumb } from '../../lib/breadcrumb';
+import { getAlertingSectionBreadcrumb, getRulesBreadcrumbWithHref } from '../../lib/breadcrumb';
 import { getCurrentDocTitle } from '../../lib/doc_title';
 import { RuleTemplateError } from './components/rule_template_error';
 import { CenterJustifiedSpinner } from '../../components/center_justified_spinner';
@@ -37,7 +37,6 @@ export const RuleFormRoute = () => {
     setBreadcrumbs,
     ...startServices
   } = useKibana().services;
-  const { getUrlForApp } = application;
 
   const location = useLocation<{ returnApp?: string; returnPath?: string }>();
   const history = useHistory();
@@ -70,13 +69,7 @@ export const RuleFormRoute = () => {
 
   // Set breadcrumb and page title
   useEffect(() => {
-    const rulesBreadcrumb = getAlertingSectionBreadcrumb('rules', true);
-    const breadcrumbHref = getUrlForApp('rules', { path: '/' });
-
-    const rulesBreadcrumbWithAppPath = {
-      ...rulesBreadcrumb,
-      href: breadcrumbHref,
-    };
+    const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref();
 
     if (id) {
       setBreadcrumbs([rulesBreadcrumbWithAppPath, getAlertingSectionBreadcrumb('editRule')]);
@@ -87,7 +80,7 @@ export const RuleFormRoute = () => {
       chrome.docTitle.change(getCurrentDocTitle('createRule'));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ruleTypeId, templateId, id, getUrlForApp]);
+  }, [ruleTypeId, templateId, id]);
 
   if (isLoadingRuleTemplate) {
     return <CenterJustifiedSpinner />;

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
@@ -191,7 +191,7 @@ const RulesPage = () => {
   useEffect(() => {
     if (setBreadcrumbs) {
       if (currentSection === 'logs') {
-        const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref(getUrlForApp);
+        const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref();
         setBreadcrumbs([rulesBreadcrumbWithAppPath, getAlertingSectionBreadcrumb('logs')]);
       } else {
         setBreadcrumbs([getAlertingSectionBreadcrumb('rules')]);


### PR DESCRIPTION
## Summary

Fixes Rules breadcrumbs after the page moved into Stack Management (https://github.com/elastic/kibana/pull/269568). 

Breadcrumb links now use the local Rules route so Stack Management can handle navigation correctly, avoiding duplicated URLs and ensuring the Rules list loads immediately when navigating back from rule details or forms.

Before:
https://github.com/user-attachments/assets/97e5b68b-827f-426d-bf25-e247ccd6377e

After:
https://github.com/user-attachments/assets/eedb741a-d339-4ea9-82d9-fa0d5b9ea8d1


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->