### PR TITLE
[Security Solution] refresh AT results on scan completion

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_ab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_ab.test.tsx
@@ -1,0 +1,316 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { WorkflowInsightsAB } from './workflow_insights_ab';
+import { useFetchInsightsAB } from '../../../hooks/insights/use_fetch_insights_ab';
+import { useFetchPendingScans } from '../../../hooks/insights/use_fetch_pending_scans';
+import { useTriggerScanAB } from '../../../hooks/insights/use_trigger_scan_ab';
+
+jest.mock('../../../hooks/insights/use_fetch_insights_ab');
+jest.mock('../../../hooks/insights/use_fetch_pending_scans');
+jest.mock('../../../hooks/insights/use_trigger_scan_ab');
+
+const mockAddDanger = jest.fn();
+jest.mock('../../../../../../../common/lib/kibana', () => ({
+  useToasts: () => ({ addDanger: mockAddDanger }),
+}));
+
+jest.mock('./workflow_insights_scan_ab', () => ({
+  WorkflowInsightsScanSectionAB: ({
+    onScanButtonClick,
+  }: {
+    onScanButtonClick: (connectorId: string) => void;
+  }) => (
+    <button type="button" onClick={() => onScanButtonClick('connector-1')}>
+      {'scan'}
+    </button>
+  ),
+}));
+
+jest.mock('./components/stale_endpoint_package_banner', () => ({
+  StaleEndpointPackageBanner: () => <div />,
+}));
+
+jest.mock('./workflow_insights_results', () => ({
+  WorkflowInsightsResults: ({
+    scanCompleted,
+    results,
+  }: {
+    scanCompleted: boolean;
+    results?: Array<unknown>;
+  }) =>
+    scanCompleted && (results ?? []).length === 0 ? (
+      <div data-test-subj="workflowInsightsEmptyResultsCallout" />
+    ) : null,
+}));
+
+const useFetchInsightsABMock = useFetchInsightsAB as jest.Mock;
+const useFetchPendingScansMock = useFetchPendingScans as jest.Mock;
+const useTriggerScanABMock = useTriggerScanAB as jest.Mock;
+
+type TriggerScanConfig = Parameters<typeof useTriggerScanAB>[0];
+
+const EMPTY_RESULTS_CALLOUT = '[data-test-subj="workflowInsightsEmptyResultsCallout"]';
+
+const latestPendingConfig = () => {
+  const { calls } = useFetchPendingScansMock.mock;
+  return calls[calls.length - 1][0];
+};
+
+describe('WorkflowInsightsAB completion-time refresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useFetchPendingScansMock.mockReturnValue({ data: { pending: [] } });
+    useTriggerScanABMock.mockImplementation(({ onSuccess }: TriggerScanConfig) => ({
+      mutate: () =>
+        onSuccess({
+          executions: [{ executionId: 'e1', insightType: 'incompatible_antivirus' }],
+          failures: [],
+        }),
+      isLoading: false,
+    }));
+  });
+
+  it('does not refetch on mount poll success but refetches after a user-triggered scan succeeds', async () => {
+    const refetch = jest.fn().mockResolvedValue({ data: [] });
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+
+    render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      await latestPendingConfig().onSuccess();
+    });
+    expect(refetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('scan'));
+    });
+
+    await act(async () => {
+      await latestPendingConfig().onSuccess();
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches insights on user terminal failure and still surfaces a toast', async () => {
+    const refetch = jest.fn().mockResolvedValue({ data: [] });
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+
+    render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('scan'));
+    });
+
+    await act(async () => {
+      await latestPendingConfig().onFailure(['boom']);
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(mockAddDanger).toHaveBeenCalled();
+  });
+
+  it('does not finalize the empty-results state until the completion refetch resolves', async () => {
+    let resolveRefetch: (() => void) | undefined;
+    const refetch = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveRefetch = () => resolve({ data: [] });
+        })
+    );
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+
+    const { container } = render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('scan'));
+    });
+
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = latestPendingConfig().onSuccess();
+    });
+
+    expect(container.querySelector(EMPTY_RESULTS_CALLOUT)).toBeNull();
+
+    await act(async () => {
+      resolveRefetch?.();
+      await pending;
+    });
+    expect(container.querySelector(EMPTY_RESULTS_CALLOUT)).not.toBeNull();
+  });
+
+  it('stops pending polling before the completion refetch resolves so it cannot re-enter and duplicate the refetch', async () => {
+    let resolveRefetch: (() => void) | undefined;
+    const refetch = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveRefetch = () => resolve({ data: [] });
+        })
+    );
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+
+    render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('scan'));
+    });
+    expect(latestPendingConfig().isPolling).toBe(true);
+
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = latestPendingConfig().onSuccess();
+    });
+
+    expect(latestPendingConfig().isPolling).toBe(false);
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRefetch?.();
+      await pending;
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops pending polling before the failure refetch resolves and fires exactly one toast', async () => {
+    let resolveRefetch: (() => void) | undefined;
+    const refetch = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveRefetch = () => resolve({ data: [] });
+        })
+    );
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+
+    render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('scan'));
+    });
+
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = latestPendingConfig().onFailure(['boom']);
+    });
+
+    expect(latestPendingConfig().isPolling).toBe(false);
+    expect(mockAddDanger).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveRefetch?.();
+      await pending;
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(mockAddDanger).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WorkflowInsightsAB observer latch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useFetchPendingScansMock.mockReturnValue({ data: { pending: [] } });
+    useTriggerScanABMock.mockImplementation(({ onSuccess }: TriggerScanConfig) => ({
+      mutate: () =>
+        onSuccess({
+          executions: [{ executionId: 'e1', insightType: 'incompatible_antivirus' }],
+          failures: [],
+        }),
+      isLoading: false,
+    }));
+  });
+
+  it('observer-latched on running scan: terminal success refetches and shows empty results callout', async () => {
+    const refetch = jest.fn().mockResolvedValue({ data: [] });
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+    useFetchPendingScansMock.mockReturnValue({ data: { pending: [{ status: 'running' }] } });
+
+    const { container } = render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      await latestPendingConfig().onSuccess();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(EMPTY_RESULTS_CALLOUT)).not.toBeNull();
+    expect(mockAddDanger).not.toHaveBeenCalled();
+  });
+
+  it('observer-latched on running scan: terminal success with results refetches without empty callout', async () => {
+    const refetch = jest.fn().mockResolvedValue({});
+    useFetchInsightsABMock.mockReturnValue({
+      data: [
+        {
+          type: 'incompatible_antivirus',
+          action: { type: 'refreshed' },
+          '@timestamp': '2024-01-01T00:00:00Z',
+        },
+      ],
+      refetch,
+    });
+    useFetchPendingScansMock.mockReturnValue({ data: { pending: [{ status: 'running' }] } });
+
+    const { container } = render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      await latestPendingConfig().onSuccess();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(EMPTY_RESULTS_CALLOUT)).toBeNull();
+  });
+
+  it('observer-latched on running scan: terminal failure refetches and shows danger toast', async () => {
+    const refetch = jest.fn().mockResolvedValue({ data: [] });
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+    useFetchPendingScansMock.mockReturnValue({ data: { pending: [{ status: 'running' }] } });
+
+    render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      await latestPendingConfig().onFailure(['boom']);
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(mockAddDanger).toHaveBeenCalledTimes(1);
+  });
+
+  it('stale terminal failure on mount without prior running scan stays silent', async () => {
+    const refetch = jest.fn().mockResolvedValue({ data: [] });
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+    useFetchPendingScansMock.mockReturnValue({ data: { pending: [{ status: 'failed' }] } });
+
+    render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    await act(async () => {
+      await latestPendingConfig().onFailure(['boom']);
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+    expect(mockAddDanger).not.toHaveBeenCalled();
+  });
+
+  it('endpoint change resets observer latch so subsequent idle poll does not trigger feedback', async () => {
+    const refetch = jest.fn().mockResolvedValue({ data: [] });
+    useFetchInsightsABMock.mockReturnValue({ data: [], refetch });
+    useFetchPendingScansMock.mockReturnValue({ data: { pending: [{ status: 'running' }] } });
+
+    const { rerender } = render(<WorkflowInsightsAB endpointId="ep-1" />);
+
+    useFetchPendingScansMock.mockReturnValue({ data: { pending: [] } });
+    await act(async () => {
+      rerender(<WorkflowInsightsAB endpointId="ep-2" />);
+    });
+
+    await act(async () => {
+      await latestPendingConfig().onSuccess();
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_ab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_ab.tsx
@@ -51,6 +51,12 @@ export const WorkflowInsightsAB = ({ endpointId }: WorkflowInsightsABProps) => {
     setIsUserScanLoading(false);
   }, [endpointId]);
 
+  const { data: insights, refetch: refetchInsights } = useFetchInsightsAB({
+    endpointId,
+    scanTimestamp,
+    insightTypes: AB_INSIGHT_TYPES,
+  });
+
   // Mount poll success: no scan running, go idle. Insights are fetched independently.
   const onMountPollSuccess = useCallback(() => {
     setIsScanRunning(false);
@@ -62,17 +68,19 @@ export const WorkflowInsightsAB = ({ endpointId }: WorkflowInsightsABProps) => {
     setIsScanRunning(false);
   }, []);
 
-  // User-triggered scan: pending returned empty — scan complete
-  const onScanPollSuccess = useCallback(() => {
+  // User-triggered scan: pending returned empty — scan complete.
+  const onScanPollSuccess = useCallback(async () => {
     setIsScanRunning(false);
+    await refetchInsights();
     setIsUserScanLoading(false);
     setScanCompleted(true);
-  }, []);
+  }, [refetchInsights]);
 
-  // User-triggered scan: only terminal executions remain — scan failed
+  // User-triggered scan: only terminal executions remain — scan failed.
   const onScanPollFailure = useCallback(
-    (failureReasons: string[]) => {
+    async (failureReasons: string[]) => {
       setIsScanRunning(false);
+      await refetchInsights();
       setIsUserScanLoading(false);
       setScanCompleted(true);
       setScanFailed(true);
@@ -81,7 +89,7 @@ export const WorkflowInsightsAB = ({ endpointId }: WorkflowInsightsABProps) => {
         text: failureReasons.length > 0 ? failureReasons.join('; ') : undefined,
       });
     },
-    [toasts]
+    [refetchInsights, toasts]
   );
 
   const { data: pendingData } = useFetchPendingScans({
@@ -102,13 +110,11 @@ export const WorkflowInsightsAB = ({ endpointId }: WorkflowInsightsABProps) => {
   );
   const showScanLoading = isUserScanLoading || (isScanRunning && !!hasPendingActive);
 
-  // Always fetch insights on mount to display previous scan results.
-  // Also refetches when scanTimestamp changes (after a new scan completes).
-  const { data: insights } = useFetchInsightsAB({
-    endpointId,
-    scanTimestamp,
-    insightTypes: AB_INSIGHT_TYPES,
-  });
+  useEffect(() => {
+    if (hasPendingActive && !userTriggeredScan) {
+      setUserTriggeredScan(true);
+    }
+  }, [hasPendingActive, userTriggeredScan]);
 
   const { mutate: triggerScan, isLoading: isTriggerLoading } = useTriggerScanAB({
     onSuccess: ({ executions, failures }) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/get_pending.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/get_pending.test.ts
@@ -101,9 +101,9 @@ describe('Get Pending Insights Route Handler', () => {
     });
   });
 
-  describe('status filter', () => {
-    it('filters for running, scheduled, failed, and aborted statuses', async () => {
-      await callRoute();
+  describe('status filter (exact combo — both arrays supplied)', () => {
+    it('filters for running, scheduled, failed, aborted, and completed statuses', async () => {
+      await callRoute({ insightTypes: ['incompatible_antivirus'], endpointIds: ['endpoint-1'] });
 
       expect(mockAgentBuilder.execution.findExecutions).toHaveBeenCalledWith(
         expect.anything(),
@@ -114,10 +114,245 @@ describe('Get Pending Insights Route Handler', () => {
               ExecutionStatus.scheduled,
               ExecutionStatus.failed,
               ExecutionStatus.aborted,
+              ExecutionStatus.completed,
             ],
           }),
         })
       );
+    });
+  });
+
+  describe('query size and sort (exact combo — both arrays supplied)', () => {
+    it('requests size 1 and an explicit `@timestamp desc` sort for a single-combo query', async () => {
+      await callRoute({ insightTypes: ['incompatible_antivirus'], endpointIds: ['endpoint-1'] });
+
+      expect(mockAgentBuilder.execution.findExecutions).toHaveBeenCalledTimes(1);
+      expect(mockAgentBuilder.execution.findExecutions).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          size: 1,
+          sort: { field: '@timestamp', order: 'desc' },
+        })
+      );
+    });
+
+    it('requests size 1 and explicit `@timestamp desc` sort for every query in a multi-combo fan-out', async () => {
+      await callRoute({
+        insightTypes: ['incompatible_antivirus', 'policy_response_failure'],
+        endpointIds: ['endpoint-1'],
+      });
+
+      expect(mockAgentBuilder.execution.findExecutions).toHaveBeenCalledTimes(2);
+      for (const call of mockAgentBuilder.execution.findExecutions.mock.calls) {
+        expect(call[1]).toEqual(
+          expect.objectContaining({
+            size: 1,
+            sort: { field: '@timestamp', order: 'desc' },
+          })
+        );
+      }
+    });
+  });
+
+  describe('latest-per-combo semantics', () => {
+    const makeExecution = (overrides: Record<string, unknown>) => ({
+      executionId: 'exec',
+      status: ExecutionStatus.running,
+      metadata: {
+        insightType: 'incompatible_antivirus',
+        source: AUTOMATIC_TROUBLESHOOTING_TAG,
+        endpointId: 'endpoint-1',
+      },
+      '@timestamp': '2024-01-01T00:00:00Z',
+      agentId: 'agent-1',
+      executionMode: AgentExecutionMode.conversation,
+      spaceId: 'default',
+      agentParams: { conversationId: 'conv-1' },
+      eventCount: 0,
+      events: [],
+      ...overrides,
+    });
+
+    it('omits a latest completed execution from the response', async () => {
+      mockAgentBuilder.execution.findExecutions.mockResolvedValue([
+        makeExecution({ executionId: 'exec-completed', status: ExecutionStatus.completed }),
+      ]);
+
+      await callRoute({ insightTypes: ['incompatible_antivirus'], endpointIds: ['endpoint-1'] });
+
+      expect(mockResponse.ok).toHaveBeenCalledWith({ body: { pending: [] } });
+    });
+
+    it('returns a latest failed execution with its failureReason', async () => {
+      mockAgentBuilder.execution.findExecutions.mockResolvedValue([
+        makeExecution({
+          executionId: 'exec-failed',
+          status: ExecutionStatus.failed,
+          error: { message: 'connector timed out' },
+        }),
+      ]);
+
+      await callRoute({ insightTypes: ['incompatible_antivirus'], endpointIds: ['endpoint-1'] });
+
+      const callBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+      expect(callBody.pending).toHaveLength(1);
+      expect(callBody.pending[0].status).toBe(ExecutionStatus.failed);
+      expect(callBody.pending[0].failureReason).toBe('connector timed out');
+    });
+
+    it('returns a latest aborted execution', async () => {
+      mockAgentBuilder.execution.findExecutions.mockResolvedValue([
+        makeExecution({ executionId: 'exec-aborted', status: ExecutionStatus.aborted }),
+      ]);
+
+      await callRoute({ insightTypes: ['incompatible_antivirus'], endpointIds: ['endpoint-1'] });
+
+      const callBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+      expect(callBody.pending).toHaveLength(1);
+      expect(callBody.pending[0].status).toBe(ExecutionStatus.aborted);
+    });
+
+    it('returns a latest active (running) execution', async () => {
+      mockAgentBuilder.execution.findExecutions.mockResolvedValue([
+        makeExecution({ executionId: 'exec-running', status: ExecutionStatus.running }),
+      ]);
+
+      await callRoute({ insightTypes: ['incompatible_antivirus'], endpointIds: ['endpoint-1'] });
+
+      const callBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+      expect(callBody.pending).toHaveLength(1);
+      expect(callBody.pending[0].status).toBe(ExecutionStatus.running);
+    });
+
+    it('returns only the actionable combo when one latest is completed and the other failed', async () => {
+      mockAgentBuilder.execution.findExecutions
+        .mockResolvedValueOnce([
+          makeExecution({
+            executionId: 'exec-completed',
+            status: ExecutionStatus.completed,
+            metadata: {
+              insightType: 'incompatible_antivirus',
+              source: AUTOMATIC_TROUBLESHOOTING_TAG,
+              endpointId: 'endpoint-1',
+            },
+          }),
+        ])
+        .mockResolvedValueOnce([
+          makeExecution({
+            executionId: 'exec-failed',
+            status: ExecutionStatus.failed,
+            error: { message: 'boom' },
+            metadata: {
+              insightType: 'policy_response_failure',
+              source: AUTOMATIC_TROUBLESHOOTING_TAG,
+              endpointId: 'endpoint-1',
+            },
+          }),
+        ]);
+
+      await callRoute({
+        insightTypes: ['incompatible_antivirus', 'policy_response_failure'],
+        endpointIds: ['endpoint-1'],
+      });
+
+      const callBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+      expect(callBody.pending).toHaveLength(1);
+      expect(callBody.pending[0].executionId).toBe('exec-failed');
+      expect(callBody.pending[0].insightType).toBe('policy_response_failure');
+    });
+
+    it('returns empty when a historical failure has been superseded by a latest completed run', async () => {
+      mockAgentBuilder.execution.findExecutions.mockResolvedValue([
+        makeExecution({ executionId: 'exec-latest-completed', status: ExecutionStatus.completed }),
+      ]);
+
+      await callRoute({ insightTypes: ['incompatible_antivirus'], endpointIds: ['endpoint-1'] });
+
+      expect(mockResponse.ok).toHaveBeenCalledWith({ body: { pending: [] } });
+    });
+  });
+
+  describe('broad queries (partial or no filters) preserve size:100 and exclude completed', () => {
+    const broadShapes: Array<[string, Record<string, unknown>]> = [
+      ['only insightTypes', { insightTypes: ['incompatible_antivirus'] }],
+      ['only endpointIds', { endpointIds: ['endpoint-1'] }],
+      ['neither filter', {}],
+    ];
+
+    it.each(broadShapes)(
+      'requests size 100 without an explicit sort for %s',
+      async (_label, query) => {
+        await callRoute(query);
+
+        for (const call of mockAgentBuilder.execution.findExecutions.mock.calls) {
+          expect(call[1]).toEqual(expect.objectContaining({ size: 100 }));
+          expect(call[1]).not.toHaveProperty('sort');
+        }
+      }
+    );
+
+    it.each(broadShapes)(
+      'excludes completed from the status filter for %s',
+      async (_label, query) => {
+        await callRoute(query);
+
+        for (const call of mockAgentBuilder.execution.findExecutions.mock.calls) {
+          expect(call[1].filter.status).toEqual([
+            ExecutionStatus.running,
+            ExecutionStatus.scheduled,
+            ExecutionStatus.failed,
+            ExecutionStatus.aborted,
+          ]);
+          expect(call[1].filter.status).not.toContain(ExecutionStatus.completed);
+        }
+      }
+    );
+
+    it('returns multiple actionable executions for a broad query (no size:1 truncation)', async () => {
+      mockAgentBuilder.execution.findExecutions.mockResolvedValue([
+        {
+          executionId: 'exec-running',
+          status: ExecutionStatus.running,
+          metadata: {
+            insightType: 'incompatible_antivirus',
+            source: AUTOMATIC_TROUBLESHOOTING_TAG,
+            endpointId: 'endpoint-1',
+          },
+          '@timestamp': '2024-01-01T00:00:00Z',
+          agentId: 'agent-1',
+          executionMode: AgentExecutionMode.conversation,
+          spaceId: 'default',
+          agentParams: { conversationId: 'conv-1' },
+          eventCount: 0,
+          events: [],
+        },
+        {
+          executionId: 'exec-failed',
+          status: ExecutionStatus.failed,
+          metadata: {
+            insightType: 'incompatible_antivirus',
+            source: AUTOMATIC_TROUBLESHOOTING_TAG,
+            endpointId: 'endpoint-2',
+          },
+          '@timestamp': '2024-01-01T00:00:01Z',
+          agentId: 'agent-2',
+          executionMode: AgentExecutionMode.conversation,
+          spaceId: 'default',
+          agentParams: {},
+          eventCount: 0,
+          events: [],
+          error: { message: 'boom' },
+        },
+      ]);
+
+      await callRoute({ insightTypes: ['incompatible_antivirus'] });
+
+      const callBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+      expect(callBody.pending).toHaveLength(2);
+      expect(callBody.pending.map((p: { executionId: string }) => p.executionId)).toEqual([
+        'exec-running',
+        'exec-failed',
+      ]);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/get_pending.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/get_pending.ts
@@ -93,14 +93,24 @@ const getPendingRouteHandler = (
 
       const agentBuilder = endpointContext.service.getAgentBuilder();
 
+      const isExactCombo = Boolean(
+        insightTypes && insightTypes.length > 0 && endpointIds && endpointIds.length > 0
+      );
+
       // Terminal states (failed/aborted) are included so the FE can distinguish failure from
       // completion: empty response = scan complete; only failed/aborted = show error toast.
-      const statusFilter = [
+      const actionableStatuses = [
         ExecutionStatus.running,
         ExecutionStatus.scheduled,
         ExecutionStatus.failed,
         ExecutionStatus.aborted,
       ];
+
+      const statusFilter = isExactCombo
+        ? [...actionableStatuses, ExecutionStatus.completed]
+        : actionableStatuses;
+
+      const querySize = isExactCombo ? 1 : 100;
 
       // Known limitation: FindExecutionsFilter.metadata uses exact-match term queries
       // (Record<string, string>), so each findExecutions call can only filter by a single
@@ -147,25 +157,25 @@ const getPendingRouteHandler = (
 
       let allResults: Awaited<ReturnType<typeof agentBuilder.execution.findExecutions>>;
 
+      const buildFindOptions = (metadataFilter: Record<string, string>) => ({
+        filter: {
+          metadata: metadataFilter,
+          status: statusFilter,
+        },
+        size: querySize,
+        ...(isExactCombo ? { sort: { field: '@timestamp' as const, order: 'desc' as const } } : {}),
+      });
+
       if (metadataFilters.length === 1) {
-        allResults = await agentBuilder.execution.findExecutions(request, {
-          filter: {
-            metadata: metadataFilters[0],
-            status: statusFilter,
-          },
-          size: 100,
-        });
+        allResults = await agentBuilder.execution.findExecutions(
+          request,
+          buildFindOptions(metadataFilters[0])
+        );
       } else {
         const perComboResults = await pMap(
           metadataFilters,
           (metadataFilter) =>
-            agentBuilder.execution.findExecutions(request, {
-              filter: {
-                metadata: metadataFilter,
-                status: statusFilter,
-              },
-              size: 100,
-            }),
+            agentBuilder.execution.findExecutions(request, buildFindOptions(metadataFilter)),
           { concurrency: 5 }
         );
 
@@ -178,7 +188,11 @@ const getPendingRouteHandler = (
         });
       }
 
-      const pending = allResults.map((execution) => ({
+      const actionableResults = isExactCombo
+        ? allResults.filter((execution) => execution.status !== ExecutionStatus.completed)
+        : allResults;
+
+      const pending = actionableResults.map((execution) => ({
         executionId: execution.executionId,
         status: execution.status,
         conversationId:


### PR DESCRIPTION
## Summary

Refetch insights when a user-triggered scan reaches a terminal state so completed results replace prior-scan state instead of leaving the panel stale, and latch the observer on an already-running pending scan.

Purposely using tightly scoped minimal changes for legacy (elastic assistant backend) behavior parity since this UI will be sunset in the near future.

* FE: await refetchInsights() on scan poll success/failure before finalizing the completed/empty state.
* Server: exact-combo pending queries include the latest completed execution (size 1, `@timestamp` desc) so the FE can observe completion; broad queries keep size 100 and exclude completed.

https://github.com/user-attachments/assets/cd3512d2-ff18-4c32-9b7f-2f43e5b35675

Related: #279723 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->