### PR TITLE
[Response Ops][Task Manager] Gate task polling on all plugins started (core.plugins.onStarted)

### DIFF
--- a/src/core/packages/lifecycle/server-mocks/src/core_setup.mock.ts
+++ b/src/core/packages/lifecycle/server-mocks/src/core_setup.mock.ts
@@ -89,6 +89,7 @@ export function createCoreSetupMock({
     plugins: lazyObject({
       onSetup: jest.fn(),
       onStart: jest.fn(),
+      onStarted: jest.fn().mockResolvedValue(undefined),
     }),
     pricing: pricingServiceMock.createSetupContract(),
     injection: injectionServiceMock.createSetupContract(),

--- a/src/core/packages/lifecycle/server-mocks/src/core_start.mock.ts
+++ b/src/core/packages/lifecycle/server-mocks/src/core_start.mock.ts
@@ -50,6 +50,7 @@ export function createCoreStartMock() {
     injection: injectionServiceMock.createStartContract(),
     plugins: lazyObject({
       onStart: jest.fn(),
+      onStarted: jest.fn().mockResolvedValue(undefined),
     }),
     pricing: pricingServiceMock.createStartContract(),
     dataStreams: dataStreamServiceMock.createStartContract(),

--- a/src/core/packages/plugins/contracts-server/index.ts
+++ b/src/core/packages/plugins/contracts-server/index.ts
@@ -12,6 +12,7 @@ export type {
   PluginsServiceStart,
   PluginContractMap,
   PluginContractResolver,
+  PluginStartedResolver,
   PluginContractResolverResponse,
   PluginContractResolverResponseItem,
   FoundPluginContractResolverResponseItem,

--- a/src/core/packages/plugins/contracts-server/src/contracts.ts
+++ b/src/core/packages/plugins/contracts-server/src/contracts.ts
@@ -81,6 +81,32 @@ export interface PluginsServiceSetup {
    * ```
    */
   onStart: PluginContractResolver;
+  /**
+   * Returns a promise that resolves once all plugins have completed their `start` lifecycle,
+   * and before Core's `start` lifecycle is resumed.
+   *
+   * If called when plugins are already started, the returned promise resolves instantly.
+   *
+   * Unlike {@link PluginsServiceSetup.onStart}, this does not resolve any plugin contract and
+   * does not require declaring a dependency — it is a plugin-agnostic signal for "all plugins
+   * have started". Use it when you need to defer work until the whole plugin `start` phase has
+   * completed (e.g. before running background work that may depend on any plugin being ready).
+   *
+   * This is a stable lifecycle signal (not a cyclic-dependency workaround): it resolves exactly
+   * once, right after every plugin's `start` lifecycle has completed. If the plugin `start` phase
+   * cannot complete, Core aborts server startup, so this promise never resolves for a running
+   * Kibana without all plugins having started.
+   *
+   * @example
+   * ```ts
+   * setup(core) {
+   *   core.plugins.onStarted().then(() => {
+   *     // safe to assume every plugin has finished its start lifecycle
+   *   });
+   * }
+   * ```
+   */
+  onStarted: PluginStartedResolver;
 }
 
 /**
@@ -122,7 +148,38 @@ export interface PluginsServiceStart {
    * @experimental
    */
   onStart: PluginContractResolver;
+  /**
+   * Returns a promise that resolves once all plugins have completed their `start` lifecycle,
+   * and before Core's `start` lifecycle is resumed.
+   *
+   * If called when plugins are already started, the returned promise resolves instantly.
+   *
+   * Unlike {@link PluginsServiceStart.onStart}, this does not resolve any plugin contract and
+   * does not require declaring a dependency — it is a plugin-agnostic signal for "all plugins
+   * have started".
+   *
+   * This is a stable lifecycle signal (not a cyclic-dependency workaround): it resolves exactly
+   * once, right after every plugin's `start` lifecycle has completed.
+   *
+   * @example
+   * ```ts
+   * start(core) {
+   *   core.plugins.onStarted().then(() => {
+   *     // safe to assume every plugin has finished its start lifecycle
+   *   });
+   * }
+   * ```
+   */
+  onStarted: PluginStartedResolver;
 }
+
+/**
+ * A resolver for the plugin-agnostic "all plugins started" signal.
+ *
+ * @see {@link PluginsServiceSetup} and {@link PluginsServiceStart}
+ * @public
+ */
+export type PluginStartedResolver = () => Promise<void>;
 
 /**
  * Contract resolver response for found plugins.

--- a/src/core/packages/plugins/server-internal/src/plugin_context.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin_context.ts
@@ -307,6 +307,7 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>({
     plugins: {
       onSetup: (...dependencyNames) => runtimeResolver.onSetup(plugin.name, dependencyNames),
       onStart: (...dependencyNames) => runtimeResolver.onStart(plugin.name, dependencyNames),
+      onStarted: () => runtimeResolver.onStarted(),
     },
     pricing: {
       isFeatureAvailable: deps.pricing.isFeatureAvailable,
@@ -420,6 +421,7 @@ export function createPluginStartContext<TPlugin, TPluginDependencies>({
     },
     plugins: {
       onStart: (...dependencyNames) => runtimeResolver.onStart(plugin.name, dependencyNames),
+      onStarted: () => runtimeResolver.onStarted(),
     },
     pricing: deps.pricing,
     security: {

--- a/src/core/packages/plugins/server-internal/src/plugin_contract_resolver.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin_contract_resolver.test.ts
@@ -340,4 +340,51 @@ describe('RuntimePluginContractResolver', () => {
       );
     });
   });
+
+  describe('onStarted', () => {
+    it('does not resolve until resolveStartRequests is called', async () => {
+      const handler = jest.fn();
+      resolver.onStarted().then(() => handler());
+
+      await fewTicks();
+      expect(handler).not.toHaveBeenCalled();
+
+      resolver.resolveStartRequests(toMap({ pluginA: pluginAContract }));
+
+      await fewTicks();
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves all pending onStarted requests once when started', async () => {
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+      resolver.onStarted().then(() => handler1());
+      resolver.onStarted().then(() => handler2());
+
+      await fewTicks();
+      expect(handler1).not.toHaveBeenCalled();
+      expect(handler2).not.toHaveBeenCalled();
+
+      resolver.resolveStartRequests(toMap({ pluginA: pluginAContract }));
+
+      await fewTicks();
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves instantly when called after resolveStartRequests', async () => {
+      resolver.resolveStartRequests(toMap({ pluginA: pluginAContract }));
+
+      const handler = jest.fn();
+      resolver.onStarted().then(() => handler());
+
+      await fewTicks();
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not require a declared dependency', async () => {
+      // onStarted is plugin-agnostic; unlike onStart it should never throw.
+      expect(() => resolver.onStarted()).not.toThrow();
+    });
+  });
 });

--- a/src/core/packages/plugins/server-internal/src/plugin_contract_resolver.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin_contract_resolver.ts
@@ -25,9 +25,25 @@ export class RuntimePluginContractResolver {
   private readonly setupRequestQueue: PluginContractRequest[] = [];
   private readonly startRequestQueue: PluginContractRequest[] = [];
 
+  private startedPromise?: Promise<void>;
+  private resolveStarted?: () => void;
+
   setDependencyMap(depMap: Map<PluginName, Set<PluginName>>) {
     this.dependencyMap = new Map(depMap.entries());
   }
+
+  onStarted = (): Promise<void> => {
+    // Already started: resolve immediately.
+    if (this.startContracts) {
+      return Promise.resolve();
+    }
+    if (!this.startedPromise) {
+      this.startedPromise = new Promise<void>((resolve) => {
+        this.resolveStarted = resolve;
+      });
+    }
+    return this.startedPromise;
+  };
 
   onSetup = <T extends PluginContractMap>(
     pluginName: PluginName,
@@ -114,6 +130,10 @@ export class RuntimePluginContractResolver {
       throw new Error('resolveStartRequests can only be called once');
     }
     this.startContracts = startContracts;
+
+    // Resolve the plugin-agnostic "all plugins started" signal first, so it can never be blocked
+    // by an unexpected failure while resolving individual contract requests below.
+    this.resolveStarted?.();
 
     for (const startRequest of this.startRequestQueue) {
       const response = createContractRequestResponse(startRequest.pluginNames, startContracts);

--- a/src/core/packages/plugins/server-internal/src/test_helpers/plugin_contract_resolver.mock.ts
+++ b/src/core/packages/plugins/server-internal/src/test_helpers/plugin_contract_resolver.mock.ts
@@ -15,6 +15,7 @@ export const createRuntimePluginContractResolverMock =
       setDependencyMap: jest.fn(),
       onSetup: jest.fn(),
       onStart: jest.fn(),
+      onStarted: jest.fn().mockResolvedValue(undefined),
       resolveSetupRequests: jest.fn(),
       resolveStartRequests: jest.fn(),
     };

--- a/src/core/packages/plugins/server-mocks/src/plugins_service.mock.ts
+++ b/src/core/packages/plugins/server-mocks/src/plugins_service.mock.ts
@@ -42,6 +42,7 @@ const createSetupContractMock = () => {
   const contract: jest.Mocked<PluginsServiceSetup> = lazyObject({
     onSetup: jest.fn(),
     onStart: jest.fn(),
+    onStarted: jest.fn().mockResolvedValue(undefined),
   });
 
   return contract;
@@ -50,6 +51,7 @@ const createSetupContractMock = () => {
 const createStartContractMock = () => {
   const contract: jest.Mocked<PluginsServiceStart> = lazyObject({
     onStart: jest.fn(),
+    onStarted: jest.fn().mockResolvedValue(undefined),
   });
   return contract;
 };

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_plugins_started.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_plugins_started.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { firstValueFrom, lastValueFrom, take, toArray } from 'rxjs';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { getPluginsStarted$, WAIT_FOR_ALL_PLUGINS_STARTED_TIMEOUT } from './get_plugins_started';
+
+describe('getPluginsStarted$', () => {
+  const logger = loggingSystemMock.create().get();
+
+  beforeEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('emits false initially', async () => {
+    const onStarted = () => new Promise<void>(() => {}); // never resolves
+    const first = await firstValueFrom(getPluginsStarted$({ onStarted, logger }));
+    expect(first).toBe(false);
+  });
+
+  it('emits false then true once all plugins have started', async () => {
+    const onStarted = () => Promise.resolve();
+    const values = await lastValueFrom(
+      getPluginsStarted$({ onStarted, logger }).pipe(take(2), toArray())
+    );
+    expect(values).toEqual([false, true]);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('fails open (emits true) and warns if the signal never arrives within the timeout', async () => {
+    jest.useFakeTimers();
+    const onStarted = () => new Promise<void>(() => {}); // never resolves
+
+    const emissions: boolean[] = [];
+    const sub = getPluginsStarted$({ onStarted, logger, timeoutMs: 1000 }).subscribe((v) =>
+      emissions.push(v)
+    );
+
+    // Before the timeout, only the initial `false` has been emitted.
+    await Promise.resolve();
+    expect(emissions).toEqual([false]);
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(emissions).toEqual([false, true]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('did not receive the "all plugins started" signal')
+    );
+    sub.unsubscribe();
+  });
+
+  it('fails open (emits true) and logs an error if the signal rejects', async () => {
+    const onStarted = () => Promise.reject(new Error('boom'));
+    const values = await lastValueFrom(
+      getPluginsStarted$({ onStarted, logger }).pipe(take(2), toArray())
+    );
+    expect(values).toEqual([false, true]);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('has a fail-safe timeout that is generously larger than Core plugin start timeouts', () => {
+    // Core caps each async plugin start at 10s; the fail-safe should be well above that.
+    expect(WAIT_FOR_ALL_PLUGINS_STARTED_TIMEOUT).toBeGreaterThanOrEqual(60 * 1000);
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_plugins_started.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_plugins_started.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
+import { catchError, map, startWith, timeout } from 'rxjs';
+import type { Logger } from '@kbn/core/server';
+
+export interface GetPluginsStartedOpts {
+  /**
+   * Core's plugin-agnostic "all plugins started" signal (`core.plugins.onStarted`). Resolves once
+   * every plugin has completed its `start` lifecycle.
+   */
+  onStarted: () => Promise<void>;
+  logger: Logger;
+  /** Fail-safe deadline after which the poller starts regardless. */
+  timeoutMs?: number;
+}
+
+/**
+ * Fail-safe deadline for the "all plugins started" signal.
+ *
+ * If Kibana finished starting, `onStarted` resolves in well under this window (Core caps each
+ * async plugin `start` at 10s and aborts the whole server start otherwise). This timeout only
+ * exists so that an unexpected failure to receive the signal can never permanently wedge the task
+ * poller — matching the existing fail-open behaviour of the Elasticsearch cluster-health gate.
+ */
+export const WAIT_FOR_ALL_PLUGINS_STARTED_TIMEOUT = 2 * 60 * 1000;
+
+/**
+ * Emits `false` immediately, then `true` once all plugins have completed their `start` lifecycle.
+ *
+ * This is used to gate the task poller so tasks aren't claimed/run before their owning plugins are
+ * ready. It fails open: if the signal doesn't arrive within {@link WAIT_FOR_ALL_PLUGINS_STARTED_TIMEOUT}
+ * (or rejects), it emits `true` and logs, so the poller is never permanently blocked.
+ */
+export function getPluginsStarted$({
+  onStarted,
+  logger,
+  timeoutMs = WAIT_FOR_ALL_PLUGINS_STARTED_TIMEOUT,
+}: GetPluginsStartedOpts): Observable<boolean> {
+  return from(onStarted()).pipe(
+    timeout({
+      first: timeoutMs,
+      with: () => {
+        logger.warn(
+          `Task Manager did not receive the "all plugins started" signal within ${timeoutMs}ms. Starting the task poller regardless.`
+        );
+        return of(undefined);
+      },
+    }),
+    map(() => true),
+    catchError((e) => {
+      // `onStarted` is not expected to reject, but never let a rejection permanently block polling.
+      logger.error(
+        `Error waiting for plugins to start. Starting the task poller regardless. Error: ${e.message}`
+      );
+      return of(true);
+    }),
+    startWith(false)
+  );
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -67,6 +67,7 @@ import {
   scheduleMarkRemovedTasksAsUnrecognizedDefinition,
 } from './removed_tasks/mark_removed_tasks_as_unrecognized';
 import { getElasticsearchAndSOAvailability } from './lib/get_es_and_so_availability';
+import { getPluginsStarted$ } from './lib/get_plugins_started';
 import { LicenseSubscriber } from './license_subscriber';
 import type {
   ApiKeyInvalidationFn,
@@ -147,6 +148,7 @@ export class TaskManagerPlugin
   private definitions: TaskTypeDictionary;
   private middleware: Middleware = createInitialMiddleware();
   private elasticsearchAndSOAvailability$?: Observable<boolean>;
+  private pluginsStarted$?: Observable<boolean>;
   private monitoringStats$ = new Subject<MonitoringStats>();
   private metrics$ = new Subject<Metrics>();
   private resetMetrics$ = new Subject<boolean>();
@@ -208,6 +210,15 @@ export class TaskManagerPlugin
       isServerless,
       logger: this.logger,
       getClusterClient: () => clusterClientPromise,
+    });
+
+    // Emits `true` once every plugin has completed its `start` lifecycle. Used to gate the task
+    // poller so we don't claim/run tasks before their owning plugins have finished starting
+    // (which otherwise causes startup-ordering failures, e.g. missing SO mappings or DI bindings).
+    // Fails open so the poller can never be permanently blocked (see getPluginsStarted$).
+    this.pluginsStarted$ = getPluginsStarted$({
+      onStarted: () => core.plugins.onStarted(),
+      logger: this.logger,
     });
 
     core.metrics
@@ -461,6 +472,7 @@ export class TaskManagerPlugin
         usageCounter: this.usageCounter,
         middleware: this.middleware,
         elasticsearchAndSOAvailability$: this.elasticsearchAndSOAvailability$!,
+        pluginsStarted$: this.pluginsStarted$!,
         taskPartitioner,
         startingCapacity,
         apiKeyStrategy,

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
@@ -6,7 +6,7 @@
  */
 
 import sinon from 'sinon';
-import { Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 import type { TaskLifecycleEvent } from './polling_lifecycle';
 import { TaskPollingLifecycle, claimAvailableTasks } from './polling_lifecycle';
@@ -140,6 +140,7 @@ describe('TaskPollingLifecycle', () => {
     middleware: createInitialMiddleware(),
     startingCapacity: 20,
     executionContext,
+    pluginsStarted$: of(true),
     taskPartitioner: new TaskPartitioner({
       logger: taskManagerLogger,
       podName: 'test',
@@ -184,6 +185,52 @@ describe('TaskPollingLifecycle', () => {
 
       elasticsearchAndSOAvailability$.next(true);
 
+      await retryUntil(
+        'polling started',
+        () => mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable.mock.calls.length > 0
+      );
+    });
+
+    test('does not begin polling until all plugins have started', async () => {
+      clock.restore();
+      const elasticsearchAndSOAvailability$ = new Subject<boolean>();
+      const pluginsStarted$ = new Subject<boolean>();
+      new TaskPollingLifecycle({
+        ...taskManagerOpts,
+        elasticsearchAndSOAvailability$,
+        pluginsStarted$,
+      });
+
+      // Infrastructure is available, but plugins haven't finished starting yet.
+      elasticsearchAndSOAvailability$.next(true);
+      pluginsStarted$.next(false);
+      await delay(100);
+      expect(mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable).not.toHaveBeenCalled();
+
+      // Once all plugins have started, polling begins.
+      pluginsStarted$.next(true);
+      await retryUntil(
+        'polling started',
+        () => mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable.mock.calls.length > 0
+      );
+    });
+
+    test('does not begin polling when plugins have started but ES/SO are unavailable', async () => {
+      clock.restore();
+      const elasticsearchAndSOAvailability$ = new Subject<boolean>();
+      const pluginsStarted$ = new Subject<boolean>();
+      new TaskPollingLifecycle({
+        ...taskManagerOpts,
+        elasticsearchAndSOAvailability$,
+        pluginsStarted$,
+      });
+
+      pluginsStarted$.next(true);
+      elasticsearchAndSOAvailability$.next(false);
+      await delay(100);
+      expect(mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable).not.toHaveBeenCalled();
+
+      elasticsearchAndSOAvailability$.next(true);
       await retryUntil(
         'polling started',
         () => mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable.mock.calls.length > 0

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Observable } from 'rxjs';
-import { Subject, withLatestFrom, BehaviorSubject } from 'rxjs';
+import { combineLatest, Subject, withLatestFrom, BehaviorSubject } from 'rxjs';
 import { distinctUntilChanged, startWith } from 'rxjs';
 import { pipe } from 'fp-ts/pipeable';
 import { map as mapOptional, none } from 'fp-ts/Option';
@@ -78,6 +78,8 @@ export interface TaskPollingLifecycleOpts {
   config: TaskManagerConfig;
   middleware: Middleware;
   elasticsearchAndSOAvailability$: Observable<boolean>;
+  // Emits `true` once all plugins have completed their `start` lifecycle.
+  pluginsStarted$: Observable<boolean>;
   executionContext: ExecutionContextStart;
   usageCounter?: UsageCounter;
   taskPartitioner: TaskPartitioner;
@@ -142,6 +144,8 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     config,
     // Elasticsearch and SavedObjects availability status
     elasticsearchAndSOAvailability$,
+    // Emits `true` once all plugins have finished starting
+    pluginsStarted$,
     taskStore,
     definitions,
     executionContext,
@@ -246,16 +250,22 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
 
     this.subscribeToPoller(this.poller.events$);
 
-    elasticsearchAndSOAvailability$.subscribe((areESAndSOAvailable) => {
-      if (areESAndSOAvailable && !this.started) {
-        // set synchronously so repeat availability emissions (e.g. ES
-        // reconnects) can never trigger a second reconciliation or poller start
-        this.started = true;
-        // fire-and-forget: reconcileAndStartPolling never rejects (it handles
-        // its own errors) and starts the poller when it settles
-        void this.reconcileAndStartPolling();
+    // Only start polling once infrastructure is available (ES + SavedObjects) AND every plugin
+    // has completed its `start` lifecycle. Gating on plugin startup prevents claiming/running
+    // tasks before their owning plugins are ready, which otherwise surfaces as startup-ordering
+    // failures (e.g. missing saved object mappings or unresolved DI bindings).
+    combineLatest([elasticsearchAndSOAvailability$, pluginsStarted$]).subscribe(
+      ([areESAndSOAvailable, pluginsStarted]) => {
+        if (areESAndSOAvailable && pluginsStarted && !this.started) {
+          // set synchronously so repeat availability emissions (e.g. ES
+          // reconnects) can never trigger a second reconciliation or poller start
+          this.started = true;
+          // fire-and-forget: reconcileAndStartPolling never rejects (it handles
+          // its own errors) and starts the poller when it settles
+          void this.reconcileAndStartPolling();
+        }
       }
-    });
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

> ⚠️ **Prototype for discussion** (draft). Opening this to align with the Core team on a first-class "all plugins started" lifecycle signal before polishing. Not intended to merge as-is.

### Problem

Task Manager begins claiming and running tasks as soon as **Elasticsearch and SavedObjects are available** — it does not wait for dependent plugins to finish their `start()` lifecycle. On startup (especially serverless), the ES cluster-health gate can resolve while later plugins in Core's start loop haven't run yet, so tasks execute against a half-initialized system. This surfaces as recurring production errors, e.g.:

- `Task alerting_telemetry "…" failed: Error: Missing mappings for saved objects types: 'maintenance-window'`
- `Task alerting_v2:dispatcher "…" failed: Error: No bindings found for service: "Symbol(core.start.injection)"`

Root cause: Core starts plugins sequentially in dependency order (`plugins_system.ts`), and `taskManager.start()` (a dependency of `alerting`, `alerting_v2`, `maintenance-windows`, …) runs *before* those consumer plugins. TM only subscribes to ES/SO availability, so the poller can start during an `await` gap in the start loop — before the owning plugins have registered their SO types / DI bindings.

### Change

1. **New Core signal `core.plugins.onStarted()`** — a first-class, plugin-agnostic `Promise<void>` that resolves once *every* plugin has completed its `start()` lifecycle (fired at the existing `resolveStartRequests` barrier). Unlike `onStart(...)`, it takes no plugin name and never throws. Wired through the runtime resolver into both setup and start plugin contexts; mocks updated.

2. **Task Manager gates the poller on it** — polling now starts only when **both** ES/SO are available **and** all plugins have started (`combineLatest`). A new `getPluginsStarted$` helper **fails open** (emits `true` + logs) after a generous timeout or on rejection, so the poller can never be permanently blocked — mirroring the existing ES cluster-health "start regardless" behaviour.

### Why it's safe (can it wedge TM?)

`resolveStartRequests` runs unconditionally after the start loop. The only ways it's skipped are when no plugins are set up / `plugins.initialize === false` — in which case **TM itself never starts** either. If a plugin's `start()` hangs or throws, Core aborts the whole server start (pre-existing). So there's no path where a running Kibana never resolves `onStarted()`. The fail-open timeout is a belt-and-suspenders safety net on top of that.

### Testing

- `getPluginsStarted$` unit tests (normal, timeout fail-open, reject fail-open).
- `RuntimePluginContractResolver.onStarted` unit tests.
- `TaskPollingLifecycle` tests: does not poll until plugins started; does not poll when plugins started but ES/SO unavailable.
- Type-check + ESLint clean on all touched packages.

### Open questions for Core

- Naming / placement (`core.plugins.onStarted`) and promise-vs-observable shape.
- Whether Core is comfortable with TM's fail-open timeout as a safety net vs. a hard dependency.
- Browser-side symmetry (`onStarted` on the browser contract) — omitted here since this is server-only.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- Task polling on each node is now delayed until that node's plugin `start` phase completes (bounded; Core caps async plugin start at 10s each). Fail-open timeout prevents permanent blockage.
