### PR TITLE
[One Workflow] Preserve provided values during input validation

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/lib/field_conversion.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/field_conversion.test.ts
@@ -404,6 +404,34 @@ describe('applyInputDefaults', () => {
     });
   });
 
+  it('should identify default and provided values when rendering', () => {
+    const inputsSchema = normalizeFieldsToJsonSchema({
+      properties: {
+        greeting: { type: 'string', default: '{{ default_greeting }}' },
+        name: { type: 'string' },
+        settings: {
+          type: 'object',
+          properties: {
+            theme: { type: 'string', default: '{{ default_theme }}' },
+            locale: { type: 'string' },
+          },
+        },
+      },
+    });
+
+    const renderer = jest.fn((value: unknown) => value);
+    applyInputDefaults(
+      { name: '{{ user }}', settings: { locale: '{{ locale }}' } },
+      inputsSchema,
+      renderer
+    );
+
+    expect(renderer).toHaveBeenCalledWith('{{ default_greeting }}', 'default');
+    expect(renderer).toHaveBeenCalledWith('{{ user }}', 'provided');
+    expect(renderer).toHaveBeenCalledWith('{{ default_theme }}', 'default');
+    expect(renderer).toHaveBeenCalledWith('{{ locale }}', 'provided');
+  });
+
   it('should apply defaults for nested objects', () => {
     const inputsSchema = normalizeFieldsToJsonSchema({
       properties: {

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/field_conversion.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/field_conversion.ts
@@ -27,10 +27,19 @@ export type NormalizableFieldSchema =
   | JsonModelSchemaType
   | Array<LegacyWorkflowInput | WorkflowOutput>;
 
-export type RenderInputValue = (value: unknown) => unknown;
+/**
+ * Indicates whether an input value comes from the workflow schema or the caller.
+ */
+export type RenderInputValueSource = 'default' | 'provided';
 
-function renderValue(value: unknown, renderInputValue?: RenderInputValue): unknown {
-  return renderInputValue ? renderInputValue(value) : value;
+export type RenderInputValue = (value: unknown, source: RenderInputValueSource) => unknown;
+
+function renderValue(
+  value: unknown,
+  renderInputValue: RenderInputValue | undefined,
+  source: RenderInputValueSource
+): unknown {
+  return renderInputValue ? renderInputValue(value, source) : value;
 }
 
 /**
@@ -224,7 +233,7 @@ function applyDefaultToObjectProperty(
 ): unknown {
   if (currentValue === undefined) {
     if (prop.default !== undefined) {
-      return renderValue(prop.default, renderInputValue);
+      return renderValue(prop.default, renderInputValue, 'default');
     }
     if (prop.type === 'object' && prop.properties) {
       return applyDefaultFromSchema(prop, undefined, inputsSchema, renderInputValue);
@@ -241,7 +250,7 @@ function applyDefaultToObjectProperty(
     return applyDefaultFromSchema(prop, currentValue, inputsSchema, renderInputValue);
   }
 
-  return renderValue(currentValue, renderInputValue);
+  return renderValue(currentValue, renderInputValue, 'provided');
 }
 
 /**
@@ -414,12 +423,12 @@ function applyDefaultFromSchema(
         renderInputValue
       );
     }
-    return renderValue(value, renderInputValue);
+    return renderValue(value, renderInputValue, 'provided');
   }
 
   // If value is not provided, use default if available
   if (schema.default !== undefined) {
-    return renderValue(schema.default, renderInputValue);
+    return renderValue(schema.default, renderInputValue, 'default');
   }
 
   // For objects, create object with defaults for required properties or properties with defaults

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts
@@ -329,13 +329,15 @@ describe('validateWorkflowInputs', () => {
     setInputsSchema({
       properties: {
         field_syntax_markdown: { type: 'string' },
+        parser_error_syntax: { type: 'string' },
         valid_liquid_syntax: { type: 'string' },
       },
-      required: ['field_syntax_markdown', 'valid_liquid_syntax'],
+      required: ['field_syntax_markdown', 'parser_error_syntax', 'valid_liquid_syntax'],
     });
 
     const inputs = {
       field_syntax_markdown: 'Malware on {{ host.name SRVWIN07 }}',
+      parser_error_syntax: 'Malware on {{ host.name: web-01 }}',
       valid_liquid_syntax: '{{ some.thing }}',
     };
     const workflowExecution = createWorkflowExecution({ inputs });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts
@@ -295,7 +295,7 @@ describe('validateWorkflowInputs', () => {
     });
   });
 
-  it('should render provided input values before validation', async () => {
+  it('should render explicit expressions in provided input values before validation', async () => {
     setInputsSchema({
       properties: {
         severity: { type: 'string', enum: ['low', 'medium', 'high'] },
@@ -304,7 +304,7 @@ describe('validateWorkflowInputs', () => {
     });
 
     const workflowExecution = createWorkflowExecution(
-      { inputs: { severity: '{{ consts.default_severity }}' } },
+      { inputs: { severity: '${{ consts.default_severity }}' } },
       {
         workflowDefinition: {
           ...stubWorkflowExecution.workflowDefinition,
@@ -322,6 +322,73 @@ describe('validateWorkflowInputs', () => {
     expect(mockRepository.updateWorkflowExecution).toHaveBeenCalledWith({
       id: executionId,
       context: { inputs: { severity: 'high' } },
+    });
+  });
+
+  it('should preserve provided values that resemble Liquid templates', async () => {
+    setInputsSchema({
+      properties: {
+        field_syntax_markdown: { type: 'string' },
+        valid_liquid_syntax: { type: 'string' },
+      },
+      required: ['field_syntax_markdown', 'valid_liquid_syntax'],
+    });
+
+    const inputs = {
+      field_syntax_markdown: 'Malware on {{ host.name SRVWIN07 }}',
+      valid_liquid_syntax: '{{ some.thing }}',
+    };
+    const workflowExecution = createWorkflowExecution({ inputs });
+
+    const result = await callValidate(workflowExecution);
+
+    expect(result).toBe(true);
+    expect(workflowExecution.context.inputs).toEqual(inputs);
+    expect(mockRepository.updateWorkflowExecution).not.toHaveBeenCalled();
+  });
+
+  it('should preserve nested provided data while rendering explicit expressions', async () => {
+    setInputsSchema({
+      properties: {
+        attack_discoveries: {
+          type: 'array',
+          items: { type: 'object', additionalProperties: true },
+        },
+      },
+      required: ['attack_discoveries'],
+    });
+
+    const workflowExecution = createWorkflowExecution(
+      {
+        inputs: {
+          attack_discoveries: [
+            {
+              details_markdown: '{{ process.name mimikatz.exe }} on {{ host.name SRVWIN07 }}',
+              severity: '${{ consts.default_severity }}',
+            },
+          ],
+        },
+      },
+      {
+        workflowDefinition: {
+          ...stubWorkflowExecution.workflowDefinition,
+          consts: {
+            default_severity: 'high',
+          },
+        },
+      }
+    );
+
+    const result = await callValidate(workflowExecution);
+
+    expect(result).toBe(true);
+    expect(workflowExecution.context.inputs).toEqual({
+      attack_discoveries: [
+        {
+          details_markdown: '{{ process.name mimikatz.exe }} on {{ host.name SRVWIN07 }}',
+          severity: 'high',
+        },
+      ],
     });
   });
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
@@ -53,10 +53,38 @@ export const validateWorkflowInputs = async (
   const templateEngine = new WorkflowTemplatingEngine({
     liquidSettings: workflowExecution.workflowDefinition.settings?.liquid,
   });
+
+  // Caller-provided values are data. Evaluate only the explicit whole-expression
+  // form and preserve ordinary strings that happen to resemble Liquid templates.
+  const renderProvidedValue = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+      return value.startsWith('${{') && value.endsWith('}}')
+        ? templateEngine.render(value, renderContext)
+        : value;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(renderProvidedValue);
+    }
+
+    if (value !== null && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, nestedValue]) => [key, renderProvidedValue(nestedValue)])
+      );
+    }
+
+    return value;
+  };
+
   let inputsWithDefaults: Record<string, unknown> | undefined;
   try {
-    inputsWithDefaults = applyInputDefaults(renderContext.inputs, normalizedSchema, (value) =>
-      templateEngine.render(value, renderContext)
+    inputsWithDefaults = applyInputDefaults(
+      renderContext.inputs,
+      normalizedSchema,
+      (value, source) =>
+        source === 'default'
+          ? templateEngine.render(value, renderContext)
+          : renderProvidedValue(value)
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -50,6 +50,7 @@ import {
   hasWorkflowInputFields,
   isRacAlertsApiForbiddenError,
   isWorkflowTriggerTabDisabled,
+  omitUnchangedWorkflowInputDefaults,
   resolveInitialSelectedTrigger,
   type WorkflowTriggerTabAvailability,
 } from './workflow_execute_modal_helpers';
@@ -223,7 +224,11 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
         return;
       }
       setExecutionInputErrors(null);
-      onSubmit(parsed, selectedTrigger);
+      const submittedInput =
+        selectedTrigger === 'manual'
+          ? omitUnchangedWorkflowInputDefaults(parsed, normalizedInputs)
+          : parsed;
+      onSubmit(submittedInput, selectedTrigger);
       onClose();
     }, [
       canExecuteWorkflow,
@@ -232,6 +237,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
       onClose,
       executionInput,
       eventTriggerTableSelectionCount,
+      normalizedInputs,
     ]);
 
     const handleChangeTrigger = useCallback(

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
@@ -19,6 +19,7 @@ import {
   getWorkflowCustomTriggerTypeIds,
   hasCustomEventTrigger,
   isDefaultTriggerEventSearchScope,
+  omitUnchangedWorkflowInputDefaults,
   resolveInitialSelectedTrigger,
 } from './workflow_execute_modal_helpers';
 
@@ -42,6 +43,62 @@ function workflowWithExtensionTriggers(
     triggers: triggers as WorkflowYaml['triggers'],
   };
 }
+
+describe('omitUnchangedWorkflowInputDefaults', () => {
+  const inputsSchema = normalizeFieldsToJsonSchema({
+    properties: {
+      dynamicDefault: { type: 'string', default: '{{ consts.expected }}' },
+      staticDefault: { type: 'string', default: 'blue' },
+      tags: { type: 'array', items: { type: 'string' }, default: ['one', 'two'] },
+      settings: {
+        type: 'object',
+        properties: {
+          theme: { type: 'string', default: '{{ consts.theme }}' },
+          locale: { type: 'string', default: 'en' },
+        },
+      },
+      provided: { type: 'string' },
+    },
+  });
+
+  it('omits unchanged defaults while retaining caller-provided values', () => {
+    expect(
+      omitUnchangedWorkflowInputDefaults(
+        {
+          dynamicDefault: '{{ consts.expected }}',
+          staticDefault: 'blue',
+          tags: ['one', 'two'],
+          settings: {
+            theme: '{{ consts.theme }}',
+            locale: 'fr',
+          },
+          provided: '{{ literal.data }}',
+        },
+        inputsSchema
+      )
+    ).toEqual({
+      settings: { locale: 'fr' },
+      provided: '{{ literal.data }}',
+    });
+  });
+
+  it('retains defaults that the caller changed', () => {
+    expect(
+      omitUnchangedWorkflowInputDefaults(
+        {
+          dynamicDefault: 'literal override',
+          staticDefault: 'red',
+          tags: ['three'],
+        },
+        inputsSchema
+      )
+    ).toEqual({
+      dynamicDefault: 'literal override',
+      staticDefault: 'red',
+      tags: ['three'],
+    });
+  });
+});
 
 describe('hasCustomEventTrigger', () => {
   it('returns false when definition is null', () => {

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
@@ -10,7 +10,10 @@
 import type { Query } from '@kbn/es-query';
 import type { WorkflowYaml } from '@kbn/workflows';
 import { isTriggerType } from '@kbn/workflows';
-import { getInputsFromDefinition } from '@kbn/workflows/spec/lib/field_conversion';
+import {
+  applyInputDefaults,
+  getInputsFromDefinition,
+} from '@kbn/workflows/spec/lib/field_conversion';
 import type { JsonModelSchemaType } from '@kbn/workflows/spec/schema/common/json_model_schema';
 import { ENABLED_TRIGGER_TABS } from './constants';
 import type { WorkflowTriggerTab } from './types';
@@ -21,6 +24,68 @@ export type NormalizedWorkflowInputs = JsonModelSchemaType | undefined;
 export function hasWorkflowInputFields(normalized?: NormalizedWorkflowInputs): boolean {
   const props = normalized?.properties;
   return Boolean(props && Object.keys(props).length > 0);
+}
+
+const OMITTED_DEFAULT = Symbol('omittedDefault');
+
+const omitUnchangedDefault = (
+  value: unknown,
+  defaultValue: unknown
+): unknown | typeof OMITTED_DEFAULT => {
+  if (Object.is(value, defaultValue)) {
+    return OMITTED_DEFAULT;
+  }
+
+  if (Array.isArray(value) && Array.isArray(defaultValue)) {
+    const isUnchanged =
+      value.length === defaultValue.length &&
+      value.every(
+        (nestedValue, index) =>
+          omitUnchangedDefault(nestedValue, defaultValue[index]) === OMITTED_DEFAULT
+      );
+    return isUnchanged ? OMITTED_DEFAULT : value;
+  }
+
+  if (
+    value === null ||
+    defaultValue === null ||
+    typeof value !== 'object' ||
+    typeof defaultValue !== 'object' ||
+    Array.isArray(value) ||
+    Array.isArray(defaultValue)
+  ) {
+    return value;
+  }
+
+  const defaultRecord = defaultValue as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (Object.hasOwn(defaultRecord, key)) {
+      const nestedResult = omitUnchangedDefault(nestedValue, defaultRecord[key]);
+      if (nestedResult !== OMITTED_DEFAULT) {
+        result[key] = nestedResult;
+      }
+    } else {
+      result[key] = nestedValue;
+    }
+  }
+
+  return Object.keys(result).length === 0 ? OMITTED_DEFAULT : result;
+};
+
+/**
+ * Removes values copied unchanged from schema defaults by the manual-run form.
+ * The execution engine can then apply and render those values as defaults while
+ * retaining user-edited values as caller-provided runtime data.
+ */
+export function omitUnchangedWorkflowInputDefaults(
+  inputs: Record<string, unknown>,
+  inputsSchema: NormalizedWorkflowInputs
+): Record<string, unknown> {
+  const defaults = applyInputDefaults(undefined, inputsSchema) ?? {};
+  const result = omitUnchangedDefault(inputs, defaults);
+  return result === OMITTED_DEFAULT ? {} : (result as Record<string, unknown>);
 }
 
 /** True when the RAC alerts index API failed due to missing `rac` / auth. */


### PR DESCRIPTION
## Summary

- Treat caller-provided workflow inputs as runtime data instead of implicitly rendering Liquid-like strings.
- Continue rendering workflow-authored schema defaults, and retain explicit `${{ ... }}` evaluation for dynamic provided values.
- Omit unchanged defaults prefilled by the manual-run form so the engine still recognizes and renders them as defaults; user edits remain provided data.
- Cover invalid Liquid-like data, valid Liquid syntax that previously disappeared silently, nested values, default/provided source tracking, and manual-run default preservation.

## Behavior change

Provided input values that intentionally relied on implicit `{{ ... }}` rendering must use the explicit `${{ ... }}` whole-expression form. Schema defaults are unaffected and continue to support implicit Liquid rendering, including when launched from the manual-run modal.

## Test plan

- `node scripts/check.js --scope=local`
- `node scripts/jest src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.test.tsx`
- Scoped type checks for `kbn-workflows`, `workflows_execution_engine`, and `workflows_management`
- Manual verification of literal Liquid-like data, explicit expressions, implicit provided values, and prefilled dynamic defaults

## References

Closes elastic/security-team#18402

Supersedes #277921

Related to #272494 and elastic/docs-content#7358.

## Release note

Fixed workflow input validation failing or corrupting caller-provided values containing Liquid-like text. Provided values now remain literal unless they use the explicit `${{ ... }}` whole-expression form; schema defaults continue to support Liquid templates.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->