### PR TITLE
[9.5] [Lens as code] Preserve ad-hoc data view field settings and allow_hidden_indices through the config-builder round-trip (#280086)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -85109,6 +85109,10 @@ components:
     Kibana_HTTP_APIs_kbn-data-view-spec-schema:
       additionalProperties: false
       properties:
+        allow_hidden_indices:
+          description: When `true`, allows the data view to match hidden indices.
+          title: Allow hidden and system indices
+          type: boolean
         field_settings:
           additionalProperties:
             $ref: '#/components/schemas/Kibana_HTTP_APIs_kbn-field-settings-entry'

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -98183,6 +98183,10 @@ components:
     Kibana_HTTP_APIs_kbn-data-view-spec-schema:
       additionalProperties: false
       properties:
+        allow_hidden_indices:
+          description: When `true`, allows the data view to match hidden indices.
+          title: Allow hidden and system indices
+          type: boolean
         field_settings:
           additionalProperties:
             $ref: '#/components/schemas/Kibana_HTTP_APIs_kbn-field-settings-entry'

--- a/src/platform/packages/shared/as-code/data-views-schema/index.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/index.ts
@@ -12,6 +12,7 @@ export {
   AS_CODE_DATA_VIEW_SPEC_TYPE,
 } from './src/data_views/constants';
 export { AS_CODE_ESQL_DATA_SOURCE_TYPE } from './src/constants';
+export { RUNTIME_FIELD_COMPOSITE_TYPE } from './src/runtime_fields/common';
 export {
   dataViewReferenceSchema,
   dataViewSchema,

--- a/src/platform/packages/shared/as-code/data-views-schema/src/data_views/common.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/data_views/common.ts
@@ -39,3 +39,12 @@ export const fieldSettingsFieldNameSchema = schema.string({
       'Field name this entry applies to. Use a field from the backing indices for display overrides, or the runtime field name when the entry defines a runtime field. Example: "user.name".',
   },
 });
+
+export const allowHiddenIndicesSchema = schema.maybe(
+  schema.boolean({
+    meta: {
+      title: 'Allow hidden and system indices',
+      description: 'When `true`, allows the data view to match hidden indices.',
+    },
+  })
+);

--- a/src/platform/packages/shared/as-code/data-views-schema/src/data_views/schema_embedded_data_view.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/data_views/schema_embedded_data_view.ts
@@ -14,7 +14,12 @@ import {
 } from '../runtime_fields/schema_embedded_runtime_field';
 import { fieldSettingsBaseSchema } from '../schema_field_settings';
 import { AS_CODE_DATA_VIEW_REFERENCE_TYPE, AS_CODE_DATA_VIEW_SPEC_TYPE } from './constants';
-import { fieldSettingsFieldNameSchema, indexPatternSchema, timeFieldSchema } from './common';
+import {
+  allowHiddenIndicesSchema,
+  fieldSettingsFieldNameSchema,
+  indexPatternSchema,
+  timeFieldSchema,
+} from './common';
 
 export const fieldSettingsSchema = schema.oneOf(
   [compositeRuntimeFieldSchema, primitiveRuntimeFieldSchema, fieldSettingsBaseSchema],
@@ -46,6 +51,7 @@ export const dataViewSpecSchema = schema.object(
     type: schema.literal(AS_CODE_DATA_VIEW_SPEC_TYPE),
     index_pattern: indexPatternSchema,
     time_field: timeFieldSchema,
+    allow_hidden_indices: allowHiddenIndicesSchema,
     field_settings: schema.maybe(
       schema.recordOf(fieldSettingsFieldNameSchema, fieldSettingsSchema)
     ),

--- a/src/platform/packages/shared/as-code/data-views-schema/src/data_views/schema_saved_data_view.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/data_views/schema_saved_data_view.ts
@@ -8,7 +8,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { fieldSettingsFieldNameSchema, indexPatternSchema, timeFieldSchema } from './common';
+import {
+  allowHiddenIndicesSchema,
+  fieldSettingsFieldNameSchema,
+  indexPatternSchema,
+  timeFieldSchema,
+} from './common';
 import {
   savedCompositeRuntimeFieldSchema,
   savedPrimitiveRuntimeFieldSchema,
@@ -54,14 +59,7 @@ export const savedDataViewSpecSchema = schema.object(
         },
       })
     ),
-    allow_hidden_indices: schema.maybe(
-      schema.boolean({
-        meta: {
-          title: 'Allow hidden and system indices',
-          description: 'When `true`, allows the data view to match hidden indices.',
-        },
-      })
-    ),
+    allow_hidden_indices: allowHiddenIndicesSchema,
     field_filters: schema.maybe(
       schema.arrayOf(schema.string({ minLength: 1, maxLength: 1000 }), {
         maxSize: 10_000,

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_data_view.test.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_data_view.test.ts
@@ -22,6 +22,27 @@ describe('fromStoredDataView', () => {
     });
   });
 
+  it('maps inline allowHidden to allow_hidden_indices and round-trips', () => {
+    const stored = {
+      title: 'my-hidden-*',
+      timeFieldName: '@timestamp',
+      allowHidden: true,
+    };
+    const api = fromStoredDataView(stored);
+    expect(api).toEqual({
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'my-hidden-*',
+      time_field: '@timestamp',
+      allow_hidden_indices: true,
+    });
+    expect(toStoredDataView(api)).toEqual(stored);
+  });
+
+  it('omits allow_hidden_indices when allowHidden is undefined', () => {
+    const api = fromStoredDataView({ title: 'logs-*' });
+    expect(api).not.toHaveProperty('allow_hidden_indices');
+  });
+
   it('maps inline spec with indexed field formats and attrs to field_settings', () => {
     expect(
       fromStoredDataView({

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_data_view.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_data_view.ts
@@ -41,6 +41,7 @@ export function fromStoredDataView(
     type: AS_CODE_DATA_VIEW_SPEC_TYPE,
     index_pattern: index.title,
     time_field: index.timeFieldName,
+    ...(index.allowHidden !== undefined ? { allow_hidden_indices: index.allowHidden } : {}),
     ...(fieldSettings && { field_settings: fieldSettings }),
   };
 }

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_fields.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_fields.ts
@@ -18,13 +18,14 @@
  * Three DataViewSpec maps are combined into a single `field_settings` map keyed by field name.
  */
 
-import { RUNTIME_FIELD_COMPOSITE_TYPE, type DataViewSpec } from '@kbn/data-views-plugin/common';
-import type {
-  AsCodeRuntimeBaseField,
-  AsCodeFieldSettings,
-  AsCodeDataViewSpec,
-  AsCodeSavedDataView,
-  AsCodeSavedFieldSettings,
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
+import {
+  RUNTIME_FIELD_COMPOSITE_TYPE,
+  type AsCodeRuntimeBaseField,
+  type AsCodeFieldSettings,
+  type AsCodeDataViewSpec,
+  type AsCodeSavedDataView,
+  type AsCodeSavedFieldSettings,
 } from '@kbn/as-code-data-views-schema';
 
 /**

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_data_view.test.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_data_view.test.ts
@@ -47,15 +47,27 @@ describe('toStoredDataView', () => {
       fieldFormats: {
         rt: { id: 'string', params: undefined },
       },
-      fieldAttrs: {
-        rt: {},
-      },
       runtimeFieldMap: {
         rt: {
           type: 'keyword',
           script: { source: 'emit(doc["id"].value)' },
         },
       },
+    });
+  });
+
+  it('maps inline allow_hidden_indices to allowHidden', () => {
+    const dataView: AsCodeDataViewSpec = {
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'my-hidden-*',
+      time_field: '@timestamp',
+      allow_hidden_indices: true,
+    };
+    const result = toStoredDataView(dataView);
+    expect(result).toEqual({
+      title: 'my-hidden-*',
+      timeFieldName: '@timestamp',
+      allowHidden: true,
     });
   });
 
@@ -118,9 +130,6 @@ describe('toStoredDataView', () => {
       },
       fieldFormats: {
         rt: { id: 'string', params: undefined },
-      },
-      fieldAttrs: {
-        rt: {},
       },
     });
   });

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_data_view.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_data_view.ts
@@ -43,6 +43,9 @@ export function toStoredDataView(
   return {
     title: dataView.index_pattern,
     ...(dataView.time_field !== undefined && { timeFieldName: dataView.time_field }),
+    ...(dataView.allow_hidden_indices !== undefined && {
+      allowHidden: dataView.allow_hidden_indices,
+    }),
     ...(runtimeFieldMap && Object.keys(runtimeFieldMap).length > 0 && { runtimeFieldMap }),
     ...(fieldFormats && Object.keys(fieldFormats).length > 0 && { fieldFormats }),
     ...(fieldAttrs && Object.keys(fieldAttrs).length > 0 && { fieldAttrs }),
@@ -53,12 +56,7 @@ export function toStoredDataView(
 function isSavedDataView(
   dataView: AsCodeDataView | AsCodeSavedDataView
 ): dataView is AsCodeSavedDataView {
-  return (
-    'id' in dataView ||
-    'name' in dataView ||
-    'allow_hidden_indices' in dataView ||
-    'field_filters' in dataView
-  );
+  return 'id' in dataView || 'name' in dataView || 'field_filters' in dataView;
 }
 
 function getSavedDataViewFields(dataView: AsCodeSavedDataView): Partial<DataViewSpec> {
@@ -66,7 +64,6 @@ function getSavedDataViewFields(dataView: AsCodeSavedDataView): Partial<DataView
   return {
     id: dataView.id,
     name: dataView.name,
-    allowHidden: dataView.allow_hidden_indices,
     sourceFilters: dataView.field_filters?.map((filter) => ({ value: filter })),
   };
 }

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_fields.test.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_fields.test.ts
@@ -256,11 +256,11 @@ describe('toStoredFieldAttributes', () => {
   });
 
   describe('primitive fields', () => {
-    it('always writes the entry even when all optional attrs are absent', () => {
+    it('omits the entry when all optional attrs are absent', () => {
       const result = toStoredFieldAttributes({
         my_field: { type: 'keyword' },
       });
-      expect(result).toHaveProperty('my_field');
+      expect(result).toEqual({});
     });
 
     it('sets customLabel when custom_label is present', () => {
@@ -300,21 +300,21 @@ describe('toStoredFieldAttributes', () => {
 
     it('omits count when popularity is absent', () => {
       const result = toStoredFieldAttributes({
-        my_field: { type: 'keyword' },
+        my_field: { type: 'keyword', custom_label: 'My Label' },
       });
       expect(result!.my_field).not.toHaveProperty('count');
     });
   });
 
   describe('composite fields', () => {
-    it('always writes an entry for each subfield keyed as "parentName.subFieldName"', () => {
+    it('omits the entry for a subfield with no attrs', () => {
       const result = toStoredFieldAttributes({
         my_composite: {
           type: RUNTIME_FIELD_COMPOSITE_TYPE,
           fields: { sub: { type: 'keyword' } },
         },
       });
-      expect(result!['my_composite.sub']).toEqual({});
+      expect(result).toEqual({});
     });
 
     it('writes entry for subfields with at least one attr set, keyed as "parentName.subFieldName"', () => {

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_fields.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_fields.ts
@@ -19,17 +19,17 @@
  * Use the three exported helpers together to reconstruct DataViewSpec field state.
  */
 
-import type { RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
-import { type DataViewSpec, RUNTIME_FIELD_COMPOSITE_TYPE } from '@kbn/data-views-plugin/common';
-import type {
-  AsCodeCompositeRuntimeField,
-  AsCodeDataViewSpec,
-  AsCodeFieldSettings,
-  AsCodeRuntimeField,
-  AsCodeSavedCompositeRuntimeField,
-  AsCodeSavedDataView,
-  AsCodeSavedFieldSettings,
-  AsCodeSavedRuntimeField,
+import type { DataViewSpec, RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
+import {
+  RUNTIME_FIELD_COMPOSITE_TYPE,
+  type AsCodeCompositeRuntimeField,
+  type AsCodeDataViewSpec,
+  type AsCodeFieldSettings,
+  type AsCodeRuntimeField,
+  type AsCodeSavedCompositeRuntimeField,
+  type AsCodeSavedDataView,
+  type AsCodeSavedFieldSettings,
+  type AsCodeSavedRuntimeField,
 } from '@kbn/as-code-data-views-schema';
 
 export function isRuntimeField(
@@ -92,14 +92,17 @@ export function toStoredFieldFormats(
   const fieldFormats: DataViewSpec['fieldFormats'] = {};
   for (const [name, field] of Object.entries(fieldSettings)) {
     if ('format' in field && field.format) {
-      fieldFormats[name] = { id: field.format.type, params: field.format.params };
+      fieldFormats[name] = {
+        id: field.format.type,
+        ...(field.format.params ? { params: field.format.params } : {}),
+      };
     }
     if (!isCompositeRuntimeField(field)) continue;
     for (const [subName, subField] of Object.entries(field.fields)) {
       if ('format' in subField && subField.format) {
         fieldFormats[`${name}.${subName}`] = {
           id: subField.format.type,
-          params: subField.format.params,
+          ...(subField.format.params ? { params: subField.format.params } : {}),
         };
       }
     }
@@ -109,8 +112,8 @@ export function toStoredFieldFormats(
 
 /**
  * Convert as-code `field_settings` to the `fieldAttrs` entry of a DataViewSpec.
- * Indexed field settings without attrs are skipped. Runtime fields and composite runtime subfields
- * always produce an entry (possibly empty) to preserve current stored shape.
+ * Only fields with at least one attribute (`customLabel`, `customDescription`, or `count`) produce
+ * an entry.
  * Composite subfields are written under the fully-qualified `parent.child` key.
  *
  * @param fieldSettings Map of field name → indexed overrides or inline runtime definition
@@ -120,32 +123,34 @@ export function toStoredFieldAttributes(
   fieldSettings: AsCodeDataViewSpec['field_settings'] | AsCodeSavedDataView['field_settings'] = {}
 ): DataViewSpec['fieldAttrs'] {
   const fieldAttrs: DataViewSpec['fieldAttrs'] = {};
+
+  const assignAttrs = (key: string, field: AsCodeFieldSettings | AsCodeSavedFieldSettings) => {
+    const attrs = buildFieldAttrs(field);
+    if (Object.keys(attrs).length > 0) {
+      fieldAttrs[key] = attrs;
+    }
+  };
+
   for (const [name, field] of Object.entries(fieldSettings)) {
-    if (isRuntimeField(field)) {
-      if (!isCompositeRuntimeField(field)) {
-        fieldAttrs[name] = {
-          ...(field.custom_label && { customLabel: field.custom_label }),
-          ...(field.custom_description && { customDescription: field.custom_description }),
-          ...getPopularity(field),
-        };
-      } else {
-        for (const [subName, subField] of Object.entries(field.fields)) {
-          fieldAttrs[`${name}.${subName}`] = {
-            ...(subField.custom_label && { customLabel: subField.custom_label }),
-            ...(subField.custom_description && { customDescription: subField.custom_description }),
-            ...getPopularity(subField),
-          };
-        }
+    if (isCompositeRuntimeField(field)) {
+      for (const [subName, subField] of Object.entries(field.fields)) {
+        assignAttrs(`${name}.${subName}`, subField);
       }
-    } else if ('custom_label' in field || 'custom_description' in field || 'popularity' in field) {
-      fieldAttrs[name] = {
-        ...(field.custom_label && { customLabel: field.custom_label }),
-        ...(field.custom_description && { customDescription: field.custom_description }),
-        ...getPopularity(field),
-      };
+    } else {
+      assignAttrs(name, field);
     }
   }
+
   return fieldAttrs;
+}
+
+function buildFieldAttrs(field: AsCodeFieldSettings | AsCodeSavedFieldSettings) {
+  return {
+    ...('custom_label' in field && field.custom_label && { customLabel: field.custom_label }),
+    ...('custom_description' in field &&
+      field.custom_description && { customDescription: field.custom_description }),
+    ...getPopularity(field),
+  };
 }
 
 function getPopularity(field: AsCodeFieldSettings | AsCodeSavedFieldSettings) {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/common.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/common.ts
@@ -55,14 +55,6 @@ const COMMON_STATE_IGNORE_PATHS = [
   'state.datasourceStates.textBased.layers.*.columns.*.meta', // meta is inferred by the transform -> originals may have it, miss it, or have different values
   'state.datasourceStates.textBased.layers.*.allColumns', // runtime-only property, not persisted or produced by transform
   'state.datasourceStates.textBased.layers.*.timeField', // inferred at runtime from the data view -> original may have undefined while transform sets @timestamp from query.esql
-  // TODO: check missing/different properties on adHocDataViews
-  'state.adHocDataViews.*.timeFieldName', // not saved in API re-derived at runtime
-  'state.adHocDataViews.*.fieldAttrs',
-  'state.adHocDataViews.*.managed',
-  'state.adHocDataViews.*.allowNoIndex', // hardcoded to false by transform; if original was true, missing indices would error instead of returning empty
-  'state.adHocDataViews.*.allowHidden', // hardcoded to false by transform; if original was true, hidden indices would no longer be queried
-  'state.adHocDataViews.*.fieldFormats', // custom field formats (e.g. url formatters) will be lost
-  'state.adHocDataViews.*.runtimeFieldMap', // runtime field definitions will be lost
   // TODO: check missing/different properties on colorMapping
   'state.visualization.columns.*.colorMapping.assignments.*.touched', // dropped at state -> API and only applied from API -> State, hardcoded to false by transform
   'state.visualization.columns.*.colorMapping.specialAssignments.*.touched',
@@ -144,6 +136,10 @@ function normalizeESQLAdHocDataViews(
       adHocDataView.id = newId;
       adHocDataView.name = indexPattern;
       adHocDataView.title = indexPattern;
+      // The transform re-derives the time field from the ES|QL query rather than trusting the
+      // persisted value (getAdHocDataViewSpec <- getDataSourceIndex.esql), so align the stored
+      // timeFieldName here instead of skipping it entirely.
+      adHocDataView.timeFieldName = timeFieldName;
       // Transform always sets type: 'esql' on ESQL adHocDataViews (via getAdHocDataViewSpec)
       adHocDataView.type = 'esql';
       attributes.state.adHocDataViews[newId] = adHocDataView;
@@ -269,6 +265,39 @@ function pruneEmptyColumnTextBasedLayers(attributes: LensAttributes) {
   }
 }
 
+/**
+ * Normalize ad-hoc data view spec noise the SO -> API -> SO round-trip introduces.
+ *
+ * DROP verdicts — not carried by the embedded API, loss is accepted:
+ * - `managed`: leaked saved-object metadata, never authored on a Lens ad-hoc data view and stripped from
+ *   the public data-views API anyway.
+ * - `allowNoIndex`: a field-fetch option (ES|`allow_no_indices`), not something authored on an
+ *   ad-hoc data-view. The embedded API has no field for it and the transform always emits `false`, so a
+ *   stored `true` (e.g. Fleet dashboards shipped before their indices exist) can't survive the
+ *   round-trip. Coerce the original to `false` to match the transform.
+ * - `allowHidden` on ES|QL DataViews: an ES|QL ad-hoc DataView serializes as an `{ type: 'esql', query }`
+ *   datasource that carries no `allow_hidden_indices`, so the flag is dropped on that path. Strip
+ *   it here. Form-based DataViews round-trip `allowHidden` faithfully and are compared directly.
+ */
+function normalizeAdHocDataViewSpec(dv: DataViewSpec) {
+  delete dv.managed;
+  dv.allowNoIndex = false;
+
+  if (dv.type === 'esql' && dv.allowHidden === false) {
+    delete dv.allowHidden;
+  }
+
+  if (Object.keys(dv.fieldAttrs ?? {}).length === 0) {
+    delete dv.fieldAttrs;
+  }
+  if (Object.keys(dv.fieldFormats ?? {}).length === 0) {
+    delete dv.fieldFormats;
+  }
+  if (Object.keys(dv.runtimeFieldMap ?? {}).length === 0) {
+    delete dv.runtimeFieldMap;
+  }
+}
+
 function normalizeAdHocDataViews(attributes: LensAttributes) {
   // Clear empty typeMeta objects
   for (const dv of Object.values(attributes.state.adHocDataViews ?? {})) {
@@ -281,6 +310,12 @@ function normalizeAdHocDataViews(attributes: LensAttributes) {
   removeOrphanedAdHocDataViews(attributes, internalReferences);
   internalReferences = normalizeESQLAdHocDataViews(attributes, internalReferences);
   internalReferences = normalizeFormBasedAdHocDataViews(attributes, internalReferences);
+
+  // Normalize spec noise last so it covers every ad-hoc data view (both the ES|QL and form-based paths
+  // rebuild/remap specs above).
+  for (const dv of Object.values(attributes.state.adHocDataViews ?? {})) {
+    normalizeAdHocDataViewSpec(dv);
+  }
 
   if (Object.keys(attributes.state.adHocDataViews ?? {}).length === 0) {
     delete attributes.state.adHocDataViews;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/field_settings.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/field_settings.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
+import type { AsCodeDataViewSpec } from '@kbn/as-code-data-views-schema';
+import {
+  fromStoredFields,
+  toStoredFieldAttributes,
+  toStoredFieldFormats,
+  toStoredRuntimeFields,
+} from '@kbn/as-code-data-views-transforms';
+
+/**
+ * Build the embedded-API `field_settings` map from a form-based ad-hoc `DataViewSpec`.
+ *
+ * The three per-field DataViewSpec maps (`runtimeFieldMap`, `fieldFormats`,
+ * `fieldAttrs`) are merged into a single `field_settings` record keyed by field
+ * name.
+ */
+export function toApiFieldSettings(spec: DataViewSpec): AsCodeDataViewSpec['field_settings'] {
+  return fromStoredFields(spec.runtimeFieldMap, spec.fieldFormats, spec.fieldAttrs);
+}
+
+/**
+ * Rebuild the three per-field `DataViewSpec` maps from the embedded-API
+ * `field_settings` record.
+ */
+export function fromApiFieldSettings(
+  fieldSettings?: AsCodeDataViewSpec['field_settings']
+): Pick<DataViewSpec, 'runtimeFieldMap' | 'fieldFormats' | 'fieldAttrs'> {
+  const runtimeFieldMap = toStoredRuntimeFields(fieldSettings) ?? {};
+  const fieldFormats = toStoredFieldFormats(fieldSettings) ?? {};
+  const fieldAttrs = toStoredFieldAttributes(fieldSettings) ?? {};
+
+  return {
+    ...(Object.keys(runtimeFieldMap).length > 0 ? { runtimeFieldMap } : {}),
+    ...(Object.keys(fieldFormats).length > 0 ? { fieldFormats } : {}),
+    ...(Object.keys(fieldAttrs).length > 0 ? { fieldAttrs } : {}),
+  };
+}

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/types.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { AsCodeDataViewSpec } from '@kbn/as-code-data-views-schema';
 import type {
   CountIndexPatternColumn,
   CardinalityIndexPatternColumn,
@@ -86,4 +87,6 @@ export interface APIAdHocDataView {
   timeFieldName: string | undefined;
   dataSourceType?: string;
   esqlQuery?: string;
+  allowHidden?: boolean;
+  fieldSettings?: AsCodeDataViewSpec['field_settings'];
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -11,6 +11,7 @@ import {
   buildDatasourceStates,
   buildReferences,
   getDataSourceIndex,
+  getAdHocDataViewSpec,
   addLayerColumn,
   operationFromColumn,
   buildDataSourceState,
@@ -19,6 +20,7 @@ import {
   generateApiLayer,
   filtersAndQueryToLensState,
   filtersAndQueryToApiFormat,
+  buildDataSourceStateNoESQL,
 } from './utils';
 import type {
   GenericIndexPatternColumn,
@@ -106,6 +108,29 @@ describe('getDatasetIndex', () => {
         "timeFieldName": undefined,
       }
     `);
+  });
+
+  test('threads allow_hidden_indices into allowHidden when set', () => {
+    const result = getDataSourceIndex({
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'my-hidden-*',
+      time_field: '@timestamp',
+      allow_hidden_indices: true,
+    });
+    expect(result).toEqual({
+      index: 'my-hidden-*',
+      timeFieldName: '@timestamp',
+      allowHidden: true,
+    });
+  });
+
+  test('omits allowHidden when allow_hidden_indices is not set', () => {
+    const result = getDataSourceIndex({
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+      time_field: '@timestamp',
+    });
+    expect(result).not.toHaveProperty('allowHidden');
   });
 });
 
@@ -456,6 +481,93 @@ describe('buildDataSourceState', () => {
         "type": "data_view_spec",
       }
     `);
+  });
+});
+
+describe('buildDataSourceStateNoESQL', () => {
+  test('emits allow_hidden_indices for an adhoc dataview with allowHidden', () => {
+    const formBasedLayer = {
+      indexPatternId: 'my-adhoc-dataview-id',
+      columns: {},
+      columnOrder: [],
+    } as FormBasedLayer;
+
+    const result = buildDataSourceStateNoESQL(
+      formBasedLayer,
+      'layer_1',
+      {
+        'my-adhoc-dataview-id': {
+          index: 'test-id',
+          title: 'my-hidden-*',
+          timeFieldName: '@timestamp',
+          allowHidden: true,
+        },
+      },
+      [],
+      [
+        {
+          type: 'index-pattern',
+          id: 'my-adhoc-dataview-id',
+          name: 'indexpattern-datasource-layer-layer_1',
+        },
+      ]
+    );
+    expect(result).toEqual({
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'my-hidden-*',
+      time_field: '@timestamp',
+      allow_hidden_indices: true,
+    });
+  });
+
+  test('omits allow_hidden_indices for an adhoc dataview without allowHidden', () => {
+    const formBasedLayer = {
+      indexPatternId: 'my-adhoc-dataview-id',
+      columns: {},
+      columnOrder: [],
+    } as FormBasedLayer;
+
+    const result = buildDataSourceStateNoESQL(
+      formBasedLayer,
+      'layer_1',
+      {
+        'my-adhoc-dataview-id': {
+          index: 'test-id',
+          title: 'logs-*',
+          timeFieldName: '@timestamp',
+        },
+      },
+      [],
+      [
+        {
+          type: 'index-pattern',
+          id: 'my-adhoc-dataview-id',
+          name: 'indexpattern-datasource-layer-layer_1',
+        },
+      ]
+    );
+    expect(result).not.toHaveProperty('allow_hidden_indices');
+  });
+});
+
+describe('getAdHocDataViewSpec', () => {
+  test('preserves allowHidden when true', () => {
+    const spec = getAdHocDataViewSpec({
+      type: 'adHocDataView',
+      index: 'my-hidden-*',
+      timeFieldName: '@timestamp',
+      allowHidden: true,
+    });
+    expect(spec).toHaveProperty('allowHidden', true);
+  });
+
+  test('omits allowHidden when not provided', () => {
+    const spec = getAdHocDataViewSpec({
+      type: 'adHocDataView',
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+    });
+    expect(spec).not.toHaveProperty('allowHidden');
   });
 });
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -35,6 +35,7 @@ import type { AsCodeDataViewReference } from '@kbn/as-code-data-views-schema';
 import type { LensAttributes } from '../types';
 import type { LensApiAllOperations, LensApiConfig, NarrowByType } from '../schema';
 import { fromBucketLensStateToAPI } from './columns/buckets';
+import { toApiFieldSettings, fromApiFieldSettings } from './columns/field_settings';
 import { getMetricApiColumnFromLensState } from './columns/metric';
 import type { AnyLensStateColumn, APIAdHocDataView, APIDataView } from './columns/types';
 import { isLensStateBucketColumnType } from './columns/utils';
@@ -162,11 +163,9 @@ export function getAdHocDataViewSpec(dataView: APIAdHocDataView) {
     name: dataView.index,
     timeFieldName: dataView.timeFieldName,
     sourceFilters: [],
-    fieldFormats: {},
-    runtimeFieldMap: {},
-    fieldAttrs: {},
+    ...fromApiFieldSettings(dataView.fieldSettings),
     allowNoIndex: false,
-    allowHidden: false,
+    ...(dataView.allowHidden !== undefined ? { allowHidden: dataView.allowHidden } : {}),
     ...(dataView.dataSourceType ? { type: dataView.dataSourceType } : {}),
   };
 }
@@ -241,10 +240,15 @@ export function buildDataSourceStateNoESQL(
   if (adhocReference && adHocDataViews?.[adhocReference.id]) {
     const dataViewSpec = adHocDataViews[adhocReference.id];
     if (isDataViewSpec(dataViewSpec) && dataViewSpec.title) {
+      const fieldSettings = toApiFieldSettings(dataViewSpec);
       return {
         type: AS_CODE_DATA_VIEW_SPEC_TYPE,
         index_pattern: dataViewSpec.title,
         time_field: dataViewSpec.timeFieldName,
+        ...(dataViewSpec.allowHidden !== undefined
+          ? { allow_hidden_indices: dataViewSpec.allowHidden }
+          : {}),
+        ...(fieldSettings ? { field_settings: fieldSettings } : {}),
       };
     }
   }
@@ -325,6 +329,10 @@ export function getDataSourceIndex(dataSource: DataSourceType) {
       return {
         index: dataSource.index_pattern,
         timeFieldName: dataSource.time_field ?? timeFieldName,
+        ...(dataSource.allow_hidden_indices !== undefined
+          ? { allowHidden: dataSource.allow_hidden_indices }
+          : {}),
+        ...(dataSource.field_settings ? { fieldSettings: dataSource.field_settings } : {}),
       };
     case 'esql':
       return {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/moon.yml
@@ -20,6 +20,7 @@ dependsOn:
   - '@kbn/core'
   - '@kbn/as-code-filters-schema'
   - '@kbn/as-code-data-views-schema'
+  - '@kbn/as-code-data-views-transforms'
   - '@kbn/as-code-filters-transforms'
   - '@kbn/data-views-plugin'
   - '@kbn/event-annotation-common'

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/tsconfig.json
@@ -13,6 +13,7 @@
     "@kbn/core",
     "@kbn/as-code-filters-schema",
     "@kbn/as-code-data-views-schema",
+    "@kbn/as-code-data-views-transforms",
     "@kbn/as-code-filters-transforms",
     "@kbn/data-views-plugin",
     "@kbn/event-annotation-common",

--- a/src/platform/plugins/shared/discover/common/embeddable/transform_utils.test.ts
+++ b/src/platform/plugins/shared/discover/common/embeddable/transform_utils.test.ts
@@ -550,9 +550,6 @@ describe('search embeddable transform utils', () => {
         fieldFormats: {
           rt: { id: 'string' },
         },
-        fieldAttrs: {
-          rt: {},
-        },
         runtimeFieldMap: {
           rt: {
             type: 'keyword',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Lens as code] Preserve ad-hoc data view field settings and allow_hidden_indices through the config-builder round-trip (#280086)](https://github.com/elastic/kibana/pull/280086)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"andreana.malama@elastic.co"},"sourceCommit":{"committedDate":"2026-07-23T01:17:16Z","message":"[Lens as code] Preserve ad-hoc data view field settings and allow_hidden_indices through the config-builder round-trip (#280086)\n\n## Summary\n\nPart of #279517\n\nWhich is the skipped-property audit for the Lens config-builder `SO →\nAPI → SO` round-trip meta-issue. This PR closes out the `adHocDataViews`\nspec batch.\n\n\n### The bug\nFor an ad-hoc data view, the round-trip only carried `index_pattern` and\n`time_field`. Everything else was thrown away because\n`getAdHocDataViewSpec` hardcoded empty/default values:\n\n```ts\nfieldFormats: {},      // hardcoded empty\nruntimeFieldMap: {},   // hardcoded empty\nfieldAttrs: {},        // hardcoded empty\nallowNoIndex: false,   // hardcoded false\nallowHidden: false,    // hardcoded false\n```\n\nSo a form-based ad-hoc data view that carried user-authored runtime\nfields, field formatters, custom labels/descriptions, or that queried\nhidden indices silently lost that configuration on export/import through\nthe config-builder API, breaking or visually changing the panel.\n\n## What changed\n- Preserve field-level settings. Runtime fields, field formats, and\nfield attrs are now wired through the embedded data-view schema's\nexisting `field_settings` record, reusing\n`@kbn/as-code-data-views-transforms` (new `field_settings.ts` helpers\n`toApiFieldSettings` / `fromApiFieldSettings`). A field carrying both a\nruntime definition and a format/label is merged into a single\n`field_settings` entry.\n- Preserve `allow_hidden_indices`. Added `allow_hidden_indices` to the\nembedded data-view schema (hoisted the shared `allowHiddenIndicesSchema`\ninto `common.ts`) and round-tripped it for form-based ad-hoc data views\nvia `to_stored_data_view` / `from_stored_data_view` and\n`buildDataSourceStateNoESQL` / `getDataSourceIndex`.\n- Drop true no-op metadata. `managed` and `allowNoIndex` are not\nauthorable on a Lens ad-hoc data view and have no embedded-API home, so\nthey are normalized away rather than preserved.\n- Stopped emitting empty `fieldAttrs` entries for runtime fields /\ncomposite subfields when no attributes are present.\n- Normalizer cleanup. Removed the adhoc dataview hard ignore paths for\nthe ad-hoc spec and replaced them with a modeled\n`normalizeAdHocDataViewSpec` (drop `managed`, coerce `allowNoIndex`,\nstrip `allowHidden` only on the ES|QL path where the Dataview is\nregenerated from the query).\n- Discover session fixtures/tests updated to reflect that `allowHidden`\nnow round-trips.\n\n## Behavioral notes\n- ES|QL ad-hoc data views carry no field-level settings by design and\nare regenerated deterministically from the query, so `field_settings`,\n`allow_hidden_indices`, and `time_field` are intentionally not preserved\non that path.\n\n\n## Test\n\nIn order to test:\n- install the kibana_sample_data_logs\n- create a hidden index:\n```\n PUT my-hidden-idx\n{\n  \"settings\": { \"index.hidden\": true },\n  \"mappings\": {\n    \"properties\": {\n      \"@timestamp\": { \"type\": \"date\" },\n      \"bytes\": { \"type\": \"long\" },\n      \"host\": { \"type\": \"keyword\" }\n    }\n  }\n}\n\nPOST my-hidden-idx/_bulk?refresh=true\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T10:00:00Z\", \"bytes\": 42, \"host\": \"a\" }\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T11:00:00Z\", \"bytes\": 50, \"host\": \"a\" }\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T12:00:00Z\", \"bytes\": 60, \"host\": \"b\" }\n```\n\n- import the dashboard: \n\n[ad-hoc-dataview.ndjson.txt](https://github.com/user-attachments/files/30267263/ad-hoc-dataview.ndjson.txt)\n\n\n## Screeshots\n\n- Before (Left: API flag OFF, Right: API flag ON): \n- Lens panel with adhoc Dataview with runtime fields, format and custom\nlabel/description was failing\n  - Lens panel with adhoc Dataview from a hidden index was failing\n\n<img width=\"1497\" height=\"739\" alt=\"Screenshot 2026-07-22 at 2 57 48 PM\"\nsrc=\"https://github.com/user-attachments/assets/09fad056-4525-4146-a08c-9309abef6f38\"\n/>\n<img width=\"1499\" height=\"735\" alt=\"Screenshot 2026-07-22 at 2 58 43 PM\"\nsrc=\"https://github.com/user-attachments/assets/970f46b6-da57-40fc-a22f-f80b2482e58e\"\n/>\n\n- After (Left: API flag OFF, Right: API flag ON): \n- Lens panel with adhoc Dataview with runtime fields, format and custom\nlabel/description renders without issues\n- Lens panel with adhoc Dataview from a hidden index renders without\nissues\n  \n<img width=\"1496\" height=\"738\" alt=\"Screenshot 2026-07-22 at 2 51 32 PM\"\nsrc=\"https://github.com/user-attachments/assets/af2e1a5b-b86b-4794-a302-84f9d8b7ab57\"\n/>\n\n  \n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"913d2f6db22076d570953f0d7199b8de8869050e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:version","v9.5.0","v9.6.0","v9.4.5"],"title":"[Lens as code] Preserve ad-hoc data view field settings and allow_hidden_indices through the config-builder round-trip","number":280086,"url":"https://github.com/elastic/kibana/pull/280086","mergeCommit":{"message":"[Lens as code] Preserve ad-hoc data view field settings and allow_hidden_indices through the config-builder round-trip (#280086)\n\n## Summary\n\nPart of #279517\n\nWhich is the skipped-property audit for the Lens config-builder `SO →\nAPI → SO` round-trip meta-issue. This PR closes out the `adHocDataViews`\nspec batch.\n\n\n### The bug\nFor an ad-hoc data view, the round-trip only carried `index_pattern` and\n`time_field`. Everything else was thrown away because\n`getAdHocDataViewSpec` hardcoded empty/default values:\n\n```ts\nfieldFormats: {},      // hardcoded empty\nruntimeFieldMap: {},   // hardcoded empty\nfieldAttrs: {},        // hardcoded empty\nallowNoIndex: false,   // hardcoded false\nallowHidden: false,    // hardcoded false\n```\n\nSo a form-based ad-hoc data view that carried user-authored runtime\nfields, field formatters, custom labels/descriptions, or that queried\nhidden indices silently lost that configuration on export/import through\nthe config-builder API, breaking or visually changing the panel.\n\n## What changed\n- Preserve field-level settings. Runtime fields, field formats, and\nfield attrs are now wired through the embedded data-view schema's\nexisting `field_settings` record, reusing\n`@kbn/as-code-data-views-transforms` (new `field_settings.ts` helpers\n`toApiFieldSettings` / `fromApiFieldSettings`). A field carrying both a\nruntime definition and a format/label is merged into a single\n`field_settings` entry.\n- Preserve `allow_hidden_indices`. Added `allow_hidden_indices` to the\nembedded data-view schema (hoisted the shared `allowHiddenIndicesSchema`\ninto `common.ts`) and round-tripped it for form-based ad-hoc data views\nvia `to_stored_data_view` / `from_stored_data_view` and\n`buildDataSourceStateNoESQL` / `getDataSourceIndex`.\n- Drop true no-op metadata. `managed` and `allowNoIndex` are not\nauthorable on a Lens ad-hoc data view and have no embedded-API home, so\nthey are normalized away rather than preserved.\n- Stopped emitting empty `fieldAttrs` entries for runtime fields /\ncomposite subfields when no attributes are present.\n- Normalizer cleanup. Removed the adhoc dataview hard ignore paths for\nthe ad-hoc spec and replaced them with a modeled\n`normalizeAdHocDataViewSpec` (drop `managed`, coerce `allowNoIndex`,\nstrip `allowHidden` only on the ES|QL path where the Dataview is\nregenerated from the query).\n- Discover session fixtures/tests updated to reflect that `allowHidden`\nnow round-trips.\n\n## Behavioral notes\n- ES|QL ad-hoc data views carry no field-level settings by design and\nare regenerated deterministically from the query, so `field_settings`,\n`allow_hidden_indices`, and `time_field` are intentionally not preserved\non that path.\n\n\n## Test\n\nIn order to test:\n- install the kibana_sample_data_logs\n- create a hidden index:\n```\n PUT my-hidden-idx\n{\n  \"settings\": { \"index.hidden\": true },\n  \"mappings\": {\n    \"properties\": {\n      \"@timestamp\": { \"type\": \"date\" },\n      \"bytes\": { \"type\": \"long\" },\n      \"host\": { \"type\": \"keyword\" }\n    }\n  }\n}\n\nPOST my-hidden-idx/_bulk?refresh=true\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T10:00:00Z\", \"bytes\": 42, \"host\": \"a\" }\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T11:00:00Z\", \"bytes\": 50, \"host\": \"a\" }\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T12:00:00Z\", \"bytes\": 60, \"host\": \"b\" }\n```\n\n- import the dashboard: \n\n[ad-hoc-dataview.ndjson.txt](https://github.com/user-attachments/files/30267263/ad-hoc-dataview.ndjson.txt)\n\n\n## Screeshots\n\n- Before (Left: API flag OFF, Right: API flag ON): \n- Lens panel with adhoc Dataview with runtime fields, format and custom\nlabel/description was failing\n  - Lens panel with adhoc Dataview from a hidden index was failing\n\n<img width=\"1497\" height=\"739\" alt=\"Screenshot 2026-07-22 at 2 57 48 PM\"\nsrc=\"https://github.com/user-attachments/assets/09fad056-4525-4146-a08c-9309abef6f38\"\n/>\n<img width=\"1499\" height=\"735\" alt=\"Screenshot 2026-07-22 at 2 58 43 PM\"\nsrc=\"https://github.com/user-attachments/assets/970f46b6-da57-40fc-a22f-f80b2482e58e\"\n/>\n\n- After (Left: API flag OFF, Right: API flag ON): \n- Lens panel with adhoc Dataview with runtime fields, format and custom\nlabel/description renders without issues\n- Lens panel with adhoc Dataview from a hidden index renders without\nissues\n  \n<img width=\"1496\" height=\"738\" alt=\"Screenshot 2026-07-22 at 2 51 32 PM\"\nsrc=\"https://github.com/user-attachments/assets/af2e1a5b-b86b-4794-a302-84f9d8b7ab57\"\n/>\n\n  \n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"913d2f6db22076d570953f0d7199b8de8869050e"}},"sourceBranch":"main","suggestedTargetBranches":["9.5","9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280086","number":280086,"mergeCommit":{"message":"[Lens as code] Preserve ad-hoc data view field settings and allow_hidden_indices through the config-builder round-trip (#280086)\n\n## Summary\n\nPart of #279517\n\nWhich is the skipped-property audit for the Lens config-builder `SO →\nAPI → SO` round-trip meta-issue. This PR closes out the `adHocDataViews`\nspec batch.\n\n\n### The bug\nFor an ad-hoc data view, the round-trip only carried `index_pattern` and\n`time_field`. Everything else was thrown away because\n`getAdHocDataViewSpec` hardcoded empty/default values:\n\n```ts\nfieldFormats: {},      // hardcoded empty\nruntimeFieldMap: {},   // hardcoded empty\nfieldAttrs: {},        // hardcoded empty\nallowNoIndex: false,   // hardcoded false\nallowHidden: false,    // hardcoded false\n```\n\nSo a form-based ad-hoc data view that carried user-authored runtime\nfields, field formatters, custom labels/descriptions, or that queried\nhidden indices silently lost that configuration on export/import through\nthe config-builder API, breaking or visually changing the panel.\n\n## What changed\n- Preserve field-level settings. Runtime fields, field formats, and\nfield attrs are now wired through the embedded data-view schema's\nexisting `field_settings` record, reusing\n`@kbn/as-code-data-views-transforms` (new `field_settings.ts` helpers\n`toApiFieldSettings` / `fromApiFieldSettings`). A field carrying both a\nruntime definition and a format/label is merged into a single\n`field_settings` entry.\n- Preserve `allow_hidden_indices`. Added `allow_hidden_indices` to the\nembedded data-view schema (hoisted the shared `allowHiddenIndicesSchema`\ninto `common.ts`) and round-tripped it for form-based ad-hoc data views\nvia `to_stored_data_view` / `from_stored_data_view` and\n`buildDataSourceStateNoESQL` / `getDataSourceIndex`.\n- Drop true no-op metadata. `managed` and `allowNoIndex` are not\nauthorable on a Lens ad-hoc data view and have no embedded-API home, so\nthey are normalized away rather than preserved.\n- Stopped emitting empty `fieldAttrs` entries for runtime fields /\ncomposite subfields when no attributes are present.\n- Normalizer cleanup. Removed the adhoc dataview hard ignore paths for\nthe ad-hoc spec and replaced them with a modeled\n`normalizeAdHocDataViewSpec` (drop `managed`, coerce `allowNoIndex`,\nstrip `allowHidden` only on the ES|QL path where the Dataview is\nregenerated from the query).\n- Discover session fixtures/tests updated to reflect that `allowHidden`\nnow round-trips.\n\n## Behavioral notes\n- ES|QL ad-hoc data views carry no field-level settings by design and\nare regenerated deterministically from the query, so `field_settings`,\n`allow_hidden_indices`, and `time_field` are intentionally not preserved\non that path.\n\n\n## Test\n\nIn order to test:\n- install the kibana_sample_data_logs\n- create a hidden index:\n```\n PUT my-hidden-idx\n{\n  \"settings\": { \"index.hidden\": true },\n  \"mappings\": {\n    \"properties\": {\n      \"@timestamp\": { \"type\": \"date\" },\n      \"bytes\": { \"type\": \"long\" },\n      \"host\": { \"type\": \"keyword\" }\n    }\n  }\n}\n\nPOST my-hidden-idx/_bulk?refresh=true\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T10:00:00Z\", \"bytes\": 42, \"host\": \"a\" }\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T11:00:00Z\", \"bytes\": 50, \"host\": \"a\" }\n{ \"index\": {} }\n{ \"@timestamp\": \"2026-07-21T12:00:00Z\", \"bytes\": 60, \"host\": \"b\" }\n```\n\n- import the dashboard: \n\n[ad-hoc-dataview.ndjson.txt](https://github.com/user-attachments/files/30267263/ad-hoc-dataview.ndjson.txt)\n\n\n## Screeshots\n\n- Before (Left: API flag OFF, Right: API flag ON): \n- Lens panel with adhoc Dataview with runtime fields, format and custom\nlabel/description was failing\n  - Lens panel with adhoc Dataview from a hidden index was failing\n\n<img width=\"1497\" height=\"739\" alt=\"Screenshot 2026-07-22 at 2 57 48 PM\"\nsrc=\"https://github.com/user-attachments/assets/09fad056-4525-4146-a08c-9309abef6f38\"\n/>\n<img width=\"1499\" height=\"735\" alt=\"Screenshot 2026-07-22 at 2 58 43 PM\"\nsrc=\"https://github.com/user-attachments/assets/970f46b6-da57-40fc-a22f-f80b2482e58e\"\n/>\n\n- After (Left: API flag OFF, Right: API flag ON): \n- Lens panel with adhoc Dataview with runtime fields, format and custom\nlabel/description renders without issues\n- Lens panel with adhoc Dataview from a hidden index renders without\nissues\n  \n<img width=\"1496\" height=\"738\" alt=\"Screenshot 2026-07-22 at 2 51 32 PM\"\nsrc=\"https://github.com/user-attachments/assets/af2e1a5b-b86b-4794-a302-84f9d8b7ab57\"\n/>\n\n  \n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"913d2f6db22076d570953f0d7199b8de8869050e"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->