### PR TITLE
[ES|QL] Improves the performance of the sources retrieval

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.test.ts
@@ -130,6 +130,34 @@ describe('useEsqlCallbacks', () => {
       expect(params.dataSourcesCache.has(DATA_SOURCES_CACHE_KEY)).toBe(true);
       expect(params.dataSourcesCache.get(DATA_SOURCES_CACHE_KEY)).toBe(cacheEntry);
     });
+
+    it('aborts the in-flight sources request when the editor unmounts', async () => {
+      const params = createDefaultParams();
+
+      let capturedSignal: AbortSignal | undefined;
+      (params.memoizedSources as unknown as jest.Mock).mockImplementation(
+        (
+          _core: unknown,
+          _getLicense: unknown,
+          _enrichSources: unknown,
+          signal?: AbortSignal
+        ) => {
+          capturedSignal = signal;
+          return { timestamp: Date.now(), result: new Promise(() => {}) };
+        }
+      );
+
+      const { result, unmount } = renderHook(() => useEsqlCallbacks(params));
+
+      void result.current.getSources!();
+
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal!.aborted).toBe(false);
+
+      unmount();
+
+      expect(capturedSignal!.aborted).toBe(true);
+    });
   });
 
   describe('getColumnsFor', () => {

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.test.ts
@@ -136,12 +136,7 @@ describe('useEsqlCallbacks', () => {
 
       let capturedSignal: AbortSignal | undefined;
       (params.memoizedSources as unknown as jest.Mock).mockImplementation(
-        (
-          _core: unknown,
-          _getLicense: unknown,
-          _enrichSources: unknown,
-          signal?: AbortSignal
-        ) => {
+        (_core: unknown, _getLicense: unknown, _enrichSources: unknown, signal?: AbortSignal) => {
           capturedSignal = signal;
           return { timestamp: Date.now(), result: new Promise(() => {}) };
         }

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.ts
@@ -58,7 +58,8 @@ type MemoizedSources = MemoizedFn<
   [
     CoreStart,
     (() => Promise<ILicense | undefined>) | undefined,
-    ((sources: ESQLSourceResult[]) => Promise<ESQLSourceResult[]>) | undefined
+    ((sources: ESQLSourceResult[]) => Promise<ESQLSourceResult[]>) | undefined,
+    AbortSignal | undefined
   ],
   ReturnType<typeof getESQLSources>
 >;
@@ -109,12 +110,18 @@ export const useEsqlCallbacks = ({
 }: UseEsqlCallbacksParams): ESQLCallbacks => {
   const columnsAbortControllerRef = useRef<AbortController | undefined>(undefined);
   const previousColumnsQueryRef = useRef<string | undefined>(undefined);
+  const sourcesAbortControllerRef = useRef(new AbortController());
 
   const getSources = useCallback(async () => {
     clearCacheWhenOld(dataSourcesCache, DATA_SOURCES_CACHE_KEY);
     const getLicense = esqlService?.getLicense;
     const enrichSources = esqlService?.enrichSources;
-    const sources = await memoizedSources(core, getLicense, enrichSources).result;
+    const sources = await memoizedSources(
+      core,
+      getLicense,
+      enrichSources,
+      sourcesAbortControllerRef.current.signal
+    ).result;
     return sources;
   }, [dataSourcesCache, memoizedSources, core, esqlService]);
 
@@ -184,11 +191,13 @@ export const useEsqlCallbacks = ({
   // Abort any in-flight getColumnsFor request when the editor unmounts. Without this, navigating away
   // from a long-running query leaves it polling in the browser and running on ES.
   useEffect(() => {
+    const sourcesController = sourcesAbortControllerRef.current;
     return () => {
       columnsAbortControllerRef.current?.abort();
       if (previousColumnsQueryRef.current) {
         esqlFieldsCache.delete(previousColumnsQueryRef.current);
       }
+      sourcesController.abort();
     };
   }, [esqlFieldsCache]);
 

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_memoized_caches.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_memoized_caches.ts
@@ -74,11 +74,12 @@ export const useMemoizedCaches = ({
         ...args: [
           CoreStart,
           (() => Promise<ILicense | undefined>) | undefined,
-          ((sources: ESQLSourceResult[]) => Promise<ESQLSourceResult[]>) | undefined
+          ((sources: ESQLSourceResult[]) => Promise<ESQLSourceResult[]>) | undefined,
+          AbortSignal | undefined
         ]
       ) => ({
         timestamp: Date.now(),
-        result: getESQLSources(...args, undefined, effectiveProjectRouting),
+        result: getESQLSources(...args, effectiveProjectRouting),
       }),
       () => DATA_SOURCES_CACHE_KEY
     );

--- a/src/platform/packages/shared/kbn-esql-server-utils/esql_service.test.ts
+++ b/src/platform/packages/shared/kbn-esql-server-utils/esql_service.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { SOURCES_TYPES } from '@kbn/esql-types';
+import { EsqlService } from './esql_service';
+
+const makeClient = (resolveIndexMock: jest.Mock) =>
+  ({ indices: { resolveIndex: resolveIndexMock } } as unknown as ElasticsearchClient);
+
+const emptyResponse = { indices: [], aliases: [], data_streams: [] };
+
+describe('EsqlService.getAllIndices', () => {
+  it('passes filter_path to limit response payload on both resolveIndex calls', async () => {
+    const resolveIndex = jest.fn().mockResolvedValue(emptyResponse);
+    const service = new EsqlService({ client: makeClient(resolveIndex) });
+
+    await service.getAllIndices('local');
+
+    expect(resolveIndex).toHaveBeenCalledTimes(2);
+    expect(resolveIndex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expand_wildcards: 'all',
+        filter_path: ['indices.name', 'indices.mode'],
+      })
+    );
+    expect(resolveIndex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expand_wildcards: 'open',
+        filter_path: [
+          'indices.name',
+          'indices.mode',
+          'aliases.name',
+          'data_streams.name',
+          'data_streams.backing_indices',
+        ],
+      })
+    );
+  });
+
+  it('correctly identifies time_series data streams via the hidden backing index mode map', async () => {
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [
+          { name: '.ds-metrics-001', mode: 'time_series' },
+          { name: 'logs-000001', mode: undefined },
+        ],
+        aliases: [],
+        data_streams: [],
+      })
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: [
+          { name: 'metrics', backing_indices: ['.ds-metrics-001'] },
+          { name: 'logs', backing_indices: ['logs-000001'] },
+        ],
+      });
+
+    const service = new EsqlService({ client: makeClient(resolveIndex) });
+    const result = await service.getAllIndices('local');
+
+    expect(result.find((r) => r.name === 'metrics')?.type).toBe(SOURCES_TYPES.TIMESERIES);
+    expect(result.find((r) => r.name === 'logs')?.type).toBe(SOURCES_TYPES.DATA_STREAM);
+  });
+
+  it('forwards projectRouting to both resolveIndex calls when provided', async () => {
+    const resolveIndex = jest.fn().mockResolvedValue(emptyResponse);
+    const service = new EsqlService({ client: makeClient(resolveIndex) });
+
+    await service.getAllIndices('local', 'my-project');
+
+    expect(resolveIndex).toHaveBeenCalledTimes(2);
+    expect(resolveIndex).toHaveBeenCalledWith(
+      expect.objectContaining({ project_routing: 'my-project' })
+    );
+    expect(resolveIndex).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ project_routing: 'my-project' })
+    );
+  });
+
+  it('queries remote clusters when scope is all', async () => {
+    const resolveIndex = jest.fn().mockResolvedValue(emptyResponse);
+    const service = new EsqlService({ client: makeClient(resolveIndex) });
+
+    await service.getAllIndices('all');
+
+    expect(resolveIndex).toHaveBeenCalledWith(expect.objectContaining({ name: ['*', '*:*'] }));
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-server-utils/esql_service.ts
+++ b/src/platform/packages/shared/kbn-esql-server-utils/esql_service.ts
@@ -117,11 +117,19 @@ export class EsqlService {
       client.indices.resolveIndex({
         name: namesToQuery,
         expand_wildcards: 'all', // this returns hidden indices too
+        filter_path: ['indices.name', 'indices.mode'], // only needed to build the mode map
         ...cpsParams,
       } as Parameters<typeof client.indices.resolveIndex>[0]),
       client.indices.resolveIndex({
         name: namesToQuery,
         expand_wildcards: 'open',
+        filter_path: [
+          'indices.name',
+          'indices.mode',
+          'aliases.name',
+          'data_streams.name',
+          'data_streams.backing_indices',
+        ],
         ...cpsParams,
       } as Parameters<typeof client.indices.resolveIndex>[0]),
     ])) as [ResolveIndexResponse, ResolveIndexResponse];


### PR DESCRIPTION
## Summary

This PR does 2 things:

- tries to improve the performance to retrieve the sources from ES by asking only for the fields we want
- aborts this request when the editor unmounts

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->