### PR TITLE
[Agent Builder] Remove any mention to traces events from docs and skill

### DIFF
--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/agent_builder_tracing/agent_builder_tracing_section.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/agent_builder_tracing/agent_builder_tracing_section.tsx
@@ -234,16 +234,11 @@ export const AgentBuilderTracingSection: React.FC = () => {
                       <br />
                       <FormattedMessage
                         id="xpack.genAiSettings.agentBuilderTracing.indices"
-                        defaultMessage="Traces are stored in {index1} and {index2}"
+                        defaultMessage="Traces are stored in {index1}"
                         values={{
                           index1: (
                             <code css={{ color: euiTheme.colors.subduedText }}>
                               traces-agent_builder.otel-*
-                            </code>
-                          ),
-                          index2: (
-                            <code css={{ color: euiTheme.colors.subduedText }}>
-                              logs-agent_builder.otel-*
                             </code>
                           ),
                         }}

--- a/x-pack/platform/plugins/shared/agent_builder/common/traces.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/traces.test.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import {
-  buildAgentBuilderTracesIndexPattern,
-  buildAgentBuilderTraceLogsIndexPattern,
-} from './traces';
+import { buildAgentBuilderTracesIndexPattern } from './traces';
 
 describe('buildAgentBuilderTracesIndexPattern', () => {
   it('returns the space-scoped index pattern for a given space', () => {
@@ -20,20 +17,6 @@ describe('buildAgentBuilderTracesIndexPattern', () => {
   it('returns the default space index pattern', () => {
     expect(buildAgentBuilderTracesIndexPattern('default')).toBe(
       'traces-agent_builder.otel-default'
-    );
-  });
-});
-
-describe('buildAgentBuilderTraceLogsIndexPattern', () => {
-  it('returns the space-scoped logs index pattern for span events', () => {
-    expect(buildAgentBuilderTraceLogsIndexPattern('marketing')).toBe(
-      'logs-agent_builder.otel-marketing'
-    );
-  });
-
-  it('returns the default space logs index pattern', () => {
-    expect(buildAgentBuilderTraceLogsIndexPattern('default')).toBe(
-      'logs-agent_builder.otel-default'
     );
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/common/traces.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/traces.ts
@@ -8,7 +8,3 @@
 export const buildAgentBuilderTracesIndexPattern = (spaceId: string) => {
   return `traces-agent_builder.otel-${spaceId}`;
 };
-
-export const buildAgentBuilderTraceLogsIndexPattern = (spaceId: string) => {
-  return `logs-agent_builder.otel-${spaceId}`;
-};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/agent_builder_traces_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/agent_builder_traces_skill.ts
@@ -32,7 +32,7 @@ messages** — for example:
 - Tool-call volume, the most-used tools, and tool error/success rates.
 - Trends of any of the above over time.
 - User prompts, LLM responses, system prompts, tool results, or other message content captured
-  in trace span events (when privacy settings allow).
+  as attributes on the chat spans (when privacy settings allow).
 - "What did users ask?" / "Show me recent prompts or conversations" about Agent Builder usage.
 
 ## Questions This Skill Can Answer
@@ -55,49 +55,36 @@ Do **not** use this skill when:
 
 ## Data Source
 
-Agent Builder ships OTel data to two per-space ES|QL sources. The inline tool selects the right
-one via \`dataSource\` — always pass it explicitly:
-
-| \`dataSource\` | Index pattern | Use for |
-|---|---|---|
-| \`"traces"\` | \`traces-agent_builder.otel-<space-id>\` | Spans: tokens, latency, tool calls, errors, model/provider breakdowns |
-| \`"logs"\` | \`logs-agent_builder.otel-<space-id>\` | Span events: user prompts, LLM responses, system prompts, tool results |
+Agent Builder ships all OTel data — span telemetry **and** captured message content — to a single
+per-space traces index: \`traces-agent_builder.otel-<space-id>\`.
 
 Always use \`${AGENT_BUILDER_TRACES_ESQL_INLINE_TOOL_ID}\` for trace questions. It resolves the
-current space's indices automatically. Do not use \`traces-agent_builder.otel-*\` or
-\`logs-agent_builder.otel-*\` wildcards, which would mix in other spaces' data.
+current space's index automatically. Do not use a \`traces-agent_builder.otel-*\` wildcard, which
+would mix in other spaces' data.
 
-**Choosing \`dataSource\`:** pick based on what the user is asking for, not the word "traces" in
-their question. Message-content questions still use \`dataSource: "logs"\` even when the user says
-"prompts in traces".
-
-| Question type | \`dataSource\` | Examples |
-|---|---|---|
-| Span telemetry | \`"traces"\` | token usage, latency, tool-call volume, error rates, model/provider stats |
-| Message content | \`"logs"\` | user prompts, LLM responses, system prompts, tool result text |
-
-If you need to run ES|QL manually, use the exact indices returned by the inline tool.
+If you need to run ES|QL manually, use the exact index returned by the inline tool.
 
 Always constrain the time range with \`@timestamp\` to the window the user asked about (default to
 the last 24 hours when they do not specify one).
 
-### Message content (span events in the logs index)
+### Message content (attributes on chat spans)
 
-User prompts, LLM responses, system prompts, and tool results are **not** stored as span attributes
-on the traces index. They are captured as OTel **span events** and routed by Elasticsearch to the
-logs index for the same space.
+User prompts, LLM responses, system prompts, and tool results follow the OTel GenAI v1.37.0
+convention: they are stored as **attributes on the \`chat\` spans** in the traces index (as JSON
+strings), not as separate span events or in a separate logs index.
 
-Each event is a log document linked to its parent span via \`trace_id\` and \`span_id\`.
-
-| Event name | Content | Privacy setting (Gen AI Settings) |
+| Attribute | Content | Privacy setting (Gen AI Settings) |
 |---|---|---|
-| \`gen_ai.user.message\` | User prompt text in \`attributes.content\` | \`agentBuilder:tracing:includeUserPrompts\` (off by default) |
-| \`gen_ai.assistant.message\` / \`gen_ai.choice\` | LLM response | \`agentBuilder:tracing:includeLlmResponses\` (off by default) |
-| \`gen_ai.system.message\` | System prompt | \`agentBuilder:tracing:includeSystemPrompt\` (off by default) |
-| \`gen_ai.tool.message\` | Tool result | \`agentBuilder:tracing:includeToolDetails\` (off by default) |
+| \`attributes.gen_ai.input.messages\` | Chat history sent to the model — user prompts plus prior assistant/tool turns | \`agentBuilder:tracing:includeUserPrompts\` / \`includeLlmResponses\` / \`includeToolDetails\` (roles filtered per setting; all off by default) |
+| \`attributes.gen_ai.output.messages\` | LLM response(s) | \`agentBuilder:tracing:includeLlmResponses\` (off by default) |
+| \`attributes.gen_ai.system_instructions\` | System prompt | \`agentBuilder:tracing:includeSystemPrompt\` (off by default) |
 
-If a message-content query returns no rows, explain that the relevant privacy setting may be disabled
-or the time window may be empty. Do not fabricate message text.
+Each attribute is a JSON string (an array of \`{ role, parts: [...] }\`, or \`{ type, content }\` for
+system instructions). Message text is not indexed as individual fields — \`KEEP\` the whole attribute
+and parse the JSON when you need the text.
+
+If a message-content query returns no rows or the attribute is empty, explain that the relevant
+privacy setting may be disabled or the time window may be empty. Do not fabricate message text.
 
 ### Span names (\`span.name\` field, traces index)
 
@@ -119,29 +106,23 @@ Span names follow the OTel \`{operation} {identifier}\` convention:
 - \`duration\` — span duration in **nanoseconds**; divide by \`1000000000.0\` for seconds.
 - \`status.code\` — equals \`"Error"\` for failed spans.
 
-### Useful fields (logs index — span events)
+### Message-content fields (chat spans)
 
-- \`event_name\` — event type (e.g. \`gen_ai.user.message\`).
-- \`attributes.content\` — message text for user, assistant, and system events.
-- \`trace_id\` / \`span_id\` — link back to the parent span in the traces index.
+- \`attributes.gen_ai.input.messages\` — JSON string of the chat history (user prompts and prior turns).
+- \`attributes.gen_ai.output.messages\` — JSON string of the model response(s).
+- \`attributes.gen_ai.system_instructions\` — JSON string of the system prompt.
 
 ## How to Answer
 
-1. Decide \`dataSource\` from the question (see table above).
-2. Call \`${AGENT_BUILDER_TRACES_ESQL_INLINE_TOOL_ID}\` with \`prompt\` and \`dataSource\`:
-   - \`dataSource: "traces"\` — tokens, latency, tool calls, errors, and other span telemetry.
-   - \`dataSource: "logs"\` — user prompts, LLM responses, system prompts, and tool message content.
-3. Use ${platformCoreTools.executeEsql} only when you already have a validated ES|QL query from the inline tool.
-4. Prefer compact \`STATS\` aggregations over returning raw spans, and report the numbers in plain language.
-
-If a question needs both telemetry and message text, make separate tool calls with the appropriate
-\`dataSource\` for each part rather than defaulting to \`"traces"\`.
+1. Call \`${AGENT_BUILDER_TRACES_ESQL_INLINE_TOOL_ID}\` with a \`prompt\` describing what the user wants
+   (span telemetry such as tokens/latency/tool calls/errors, or message content such as prompts and responses).
+2. Use ${platformCoreTools.executeEsql} only when you already have a validated ES|QL query from the inline tool.
+3. Prefer compact \`STATS\` aggregations over returning raw spans, and report the numbers in plain language.
 
 ### Example query patterns
 
-These patterns assume the current space indices. Replace \`<traces-index>\` and \`<logs-index>\`
-with the indices returned by the inline tool. Use \`dataSource: "traces"\` for the traces examples
-and \`dataSource: "logs"\` for the logs example.
+These patterns assume the current space index. Replace \`<traces-index>\` with the index returned by
+the inline tool.
 
 Total tokens by model (last 24h):
 
@@ -197,25 +178,25 @@ FROM <traces-index>
 | LIMIT 15
 \`\`\`
 
-Recent user prompts (logs index; requires \`agentBuilder:tracing:includeUserPrompts\`):
+Recent user prompts (requires \`agentBuilder:tracing:includeUserPrompts\`):
 
 \`\`\`esql
-FROM <logs-index>
+FROM <traces-index>
 | WHERE @timestamp >= NOW() - 24 hours
-| WHERE event_name == "gen_ai.user.message"
+| WHERE span.name LIKE "chat *" AND attributes.gen_ai.input.messages IS NOT NULL
 | SORT @timestamp DESC
 | LIMIT 20
-| KEEP @timestamp, attributes.content, trace_id, span_id
+| KEEP @timestamp, attributes.gen_ai.input.messages, trace_id, span_id
 \`\`\`
 
 ## Edge Cases
 
 - If a query returns no rows, explain that the time window may be empty or that
   the \`${AGENT_BUILDER_TRACING_ENABLED_SETTING_ID}\` UI setting is not enabled. Do not fabricate values.
-- Using the wrong \`dataSource\` (e.g. \`"traces"\` for a user-prompt question) will query the wrong
-  index and return no message fields — always use \`"logs"\` for message content.
-- Message-content queries against the logs index return no rows when the corresponding privacy
-  setting is disabled (user prompts, LLM responses, system prompt, and tool details are all off by default).
+- Message content lives on chat spans (\`span.name LIKE "chat *"\`) as the \`attributes.gen_ai.*.messages\`
+  / \`attributes.gen_ai.system_instructions\` JSON attributes — filter to chat spans for prompt/response text.
+- Those attributes are empty when the corresponding privacy setting is disabled (user prompts, LLM
+  responses, system prompt, and tool details are all off by default).
 - Token fields can be missing on non-LLM spans; always filter to \`span.name LIKE "chat *"\`
   before aggregating token usage.
 - \`duration\` is in nanoseconds — never report it raw; convert to seconds (or ms) for the user.

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/inline_tools/traces_esql.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/inline_tools/traces_esql.ts
@@ -15,10 +15,7 @@ import {
   type ToolHandlerResult,
 } from '@kbn/agent-builder-server';
 import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
-import {
-  buildAgentBuilderTracesIndexPattern,
-  buildAgentBuilderTraceLogsIndexPattern,
-} from '@kbn/agent-builder-plugin/common/traces';
+import { buildAgentBuilderTracesIndexPattern } from '@kbn/agent-builder-plugin/common/traces';
 
 export const AGENT_BUILDER_TRACES_ESQL_INLINE_TOOL_ID = 'agent-builder-traces.generate_esql';
 
@@ -27,12 +24,7 @@ const tracesEsqlSchema = z.object({
     .string()
     .max(1024)
     .describe(
-      'Natural language question about Agent Builder OTel traces (token usage, latency, tool calls, errors, etc.).'
-    ),
-  dataSource: z
-    .enum(['traces', 'logs'])
-    .describe(
-      'Which index to query: "traces" for spans (tokens, latency, tool calls, errors) or "logs" for span events (user prompts, LLM responses, system prompts, tool results).'
+      'Natural language question about Agent Builder OTel traces (token usage, latency, tool calls, errors, or captured message content).'
     ),
 });
 
@@ -53,42 +45,26 @@ This is a set of rules that you must follow strictly when generating ES|QL for A
 * duration is in nanoseconds — divide by 1000000000.0 for seconds
 * status.code == "Error" marks failed spans
 * For percentage calculations, multiply by 100.0 before dividing (e.g. ROUND((total - errors) * 100.0 / total, 2)) to avoid integer division
-* Prefer compact STATS aggregations over returning raw spans unless the user asked for individual span details
-`.trim();
-
-const buildLogsQueryRules = (traceLogsIndex: string) =>
-  `
-This is a set of rules that you must follow strictly when generating ES|QL for Agent Builder span-event logs:
-* Use ONLY this index: ${traceLogsIndex} — do not use a logs-agent_builder.otel-* wildcard or query any other index.
-* Always constrain the time range with @timestamp to the window the user asked about (default to the last 24 hours when they do not specify one).
-* Message content (user prompts, LLM responses, system prompts, tool results) is stored as OTel span events in this logs index.
-* User prompt events: event_name == "gen_ai.user.message" — prompt text is in attributes.content (requires agentBuilder:tracing:includeUserPrompts).
-* LLM response events: event_name IN ("gen_ai.assistant.message", "gen_ai.choice") — requires agentBuilder:tracing:includeLlmResponses.
-* System prompt events: event_name == "gen_ai.system.message" — requires agentBuilder:tracing:includeSystemPrompt.
-* Tool result events: event_name == "gen_ai.tool.message" — requires agentBuilder:tracing:includeToolDetails.
-* Span-event log documents link to parent spans via trace_id and span_id.
-* Prefer compact STATS aggregations over returning raw messages unless the user asked for message text
+* Message content (user prompts, LLM responses, system prompts, tool results) lives on chat spans (span.name LIKE "chat *") as JSON-string attributes, not on a separate logs index:
+  - attributes.gen_ai.input.messages — chat history sent to the model (user prompts and prior assistant/tool turns). Requires agentBuilder:tracing:includeUserPrompts / includeLlmResponses / includeToolDetails for the respective roles.
+  - attributes.gen_ai.output.messages — the model's response(s). Requires agentBuilder:tracing:includeLlmResponses.
+  - attributes.gen_ai.system_instructions — system prompt. Requires agentBuilder:tracing:includeSystemPrompt.
+* These attributes are JSON strings (arrays of { role, parts:[...] }); message text is not indexed as individual fields, so KEEP the whole attribute and let the caller parse it. Do not invent an attributes.content field.
+* Prefer compact STATS aggregations over returning raw spans unless the user asked for individual span details or message text
 `.trim();
 
 export const createTracesEsqlTool = (): BuiltinSkillBoundedTool<typeof tracesEsqlSchema> => ({
   id: AGENT_BUILDER_TRACES_ESQL_INLINE_TOOL_ID,
   type: ToolType.builtin,
   description:
-    'Generate and execute ES|QL against the current space Agent Builder OTel traces or logs index. ' +
-    'Pass dataSource "traces" for span telemetry or "logs" for message content. ' +
-    'Scopes queries to the active Kibana space automatically.',
+    'Generate and execute ES|QL against the current space Agent Builder OTel traces index ' +
+    '(span telemetry and captured message content). Scopes queries to the active Kibana space automatically.',
   schema: tracesEsqlSchema,
   confirmation: { askUser: 'never' },
-  handler: async ({ prompt, dataSource }, context) => {
+  handler: async ({ prompt }, context) => {
     const { esClient, events, modelProvider, logger, spaceId } = context;
     const tracesIndex = buildAgentBuilderTracesIndexPattern(spaceId);
-    const traceLogsIndex = buildAgentBuilderTraceLogsIndexPattern(spaceId);
-
-    const index = dataSource === 'logs' ? traceLogsIndex : tracesIndex;
-    const additionalContext =
-      dataSource === 'logs'
-        ? buildLogsQueryRules(traceLogsIndex)
-        : buildTracesQueryRules(tracesIndex);
+    const additionalContext = buildTracesQueryRules(tracesIndex);
 
     try {
       const model = await modelProvider.getDefaultModel();
@@ -98,7 +74,7 @@ export const createTracesEsqlTool = (): BuiltinSkillBoundedTool<typeof tracesEsq
         events,
         nlQuery: prompt,
         esClient: esClient.asCurrentUser,
-        index,
+        index: tracesIndex,
         additionalContext,
       });
 
@@ -117,10 +93,7 @@ export const createTracesEsqlTool = (): BuiltinSkillBoundedTool<typeof tracesEsq
           tool_result_id: getToolResultId(),
           type: ToolResultType.other,
           data: {
-            message:
-              dataSource === 'logs'
-                ? `Agent Builder span-event logs index for this space: ${traceLogsIndex}.`
-                : `Agent Builder traces index for this space: ${tracesIndex}.`,
+            message: `Agent Builder traces index for this space: ${tracesIndex}.`,
           },
         },
       ];


### PR DESCRIPTION
## Summary

Follow-up to #277640, which migrated Agent Builder tracing from per-message OTel events to structured span attributes. That change left `logs-agent_builder.otel-*` empty, but the UI, docs, and traces skill still described message content as living there as span events.

This PR updates them to reflect reality — message content (user prompts, LLM responses, system prompts, tool results) now lives on the `chat` spans in `traces-agent_builder.otel-*` as `gen_ai.input.messages` / `gen_ai.output.messages` / `gen_ai.system_instructions` attributes:

- **Gen AI Settings UI**: no longer lists the (empty) logs index.
- **Traces skill + inline ES|QL tool**: dropped the `logs` data source; message-content queries now target the span attributes.


Docs/skill-only change — no runtime tracing behavior changes.

### Release note

Fixed Agent Builder trace documentation and assistant guidance to reference span attributes instead of the removed trace events.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->