### PR TITLE
[ES|QL] Improves the performance of columns after

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/columns_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/columns_after.test.ts
@@ -40,21 +40,15 @@ describe('FROM columnsAfter', () => {
       { name: 'field3', type: 'text', userDefined: false },
     ];
 
+    const fieldsByIndex: Record<string, ESQLFieldWithMetadata[]> = {
+      index1: index1Fields,
+      index2: index2Fields,
+    };
+
     const result = await columnsAfter(command, [], '', {
       fromFrom: (cmd) => {
-        if (cmd.args.length === 1 && isSource(cmd.args[0])) {
-          const sourceName = cmd.args[0].name;
-
-          if (sourceName === 'index1') {
-            return Promise.resolve(index1Fields);
-          }
-
-          if (sourceName === 'index2') {
-            return Promise.resolve(index2Fields);
-          }
-        }
-
-        return Promise.resolve([]);
+        const sources = cmd.args.filter((arg) => !Array.isArray(arg) && isSource(arg));
+        return Promise.resolve(sources.flatMap((s) => fieldsByIndex[s.name] ?? []));
       },
       fromJoin: () => Promise.resolve([]),
       fromEnrich: () => Promise.resolve([]),
@@ -105,33 +99,18 @@ describe('FROM columnsAfter', () => {
       { name: 'other5', type: 'keyword', userDefined: false },
     ];
 
+    const fieldsByIndex: Record<string, ESQLFieldWithMetadata[]> = {
+      index1: index1Fields,
+      index2: index2Fields,
+      index3: index3Fields,
+      index4: index4Fields,
+      index5: index5Fields,
+    };
+
     const result = await columnsAfter(command, [], '', {
       fromFrom: (cmd) => {
-        if (cmd.args.length === 1 && isSource(cmd.args[0])) {
-          const sourceName = cmd.args[0].name;
-
-          if (sourceName === 'index1') {
-            return Promise.resolve(index1Fields);
-          }
-
-          if (sourceName === 'index2') {
-            return Promise.resolve(index2Fields);
-          }
-
-          if (sourceName === 'index3') {
-            return Promise.resolve(index3Fields);
-          }
-
-          if (sourceName === 'index4') {
-            return Promise.resolve(index4Fields);
-          }
-
-          if (sourceName === 'index5') {
-            return Promise.resolve(index5Fields);
-          }
-        }
-
-        return Promise.resolve([]);
+        const sources = cmd.args.filter((arg) => !Array.isArray(arg) && isSource(arg));
+        return Promise.resolve(sources.flatMap((s) => fieldsByIndex[s.name] ?? []));
       },
       fromJoin: () => Promise.resolve([]),
       fromEnrich: () => Promise.resolve([]),
@@ -188,5 +167,32 @@ describe('FROM columnsAfter', () => {
     expect(fieldNames).toContain('field1');
     expect(fieldNames).toContain('_id');
     expect(fieldNames).toContain('_index');
+  });
+
+  it('batches multiple plain sources into a single fromFrom call', async () => {
+    const command = synth.cmd`FROM index1, index2, index3`;
+
+    const fromFromMock = jest.fn().mockResolvedValue([
+      { name: 'field1', type: 'keyword', userDefined: false },
+      { name: 'field2', type: 'long', userDefined: false },
+    ]);
+
+    await columnsAfter(command, [], '', {
+      fromFrom: fromFromMock,
+      fromJoin: () => Promise.resolve([]),
+      fromEnrich: () => Promise.resolve([]),
+    });
+
+    expect(fromFromMock).toHaveBeenCalledTimes(1);
+
+    const calledSources = fromFromMock.mock.calls[0][0].args.filter(
+      (arg: unknown) => !Array.isArray(arg) && isSource(arg)
+    );
+    expect(calledSources).toHaveLength(3);
+    expect(calledSources.map((s: { name: string }) => s.name)).toEqual([
+      'index1',
+      'index2',
+      'index3',
+    ]);
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/columns_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/columns_after.test.ts
@@ -47,8 +47,13 @@ describe('FROM columnsAfter', () => {
 
     const result = await columnsAfter(command, [], '', {
       fromFrom: (cmd) => {
-        const sources = cmd.args.filter((arg) => !Array.isArray(arg) && isSource(arg));
-        return Promise.resolve(sources.flatMap((s) => fieldsByIndex[s.name] ?? []));
+        const fields: ESQLFieldWithMetadata[] = [];
+        for (const arg of cmd.args) {
+          if (!Array.isArray(arg) && isSource(arg)) {
+            fields.push(...(fieldsByIndex[arg.name] ?? []));
+          }
+        }
+        return Promise.resolve(fields);
       },
       fromJoin: () => Promise.resolve([]),
       fromEnrich: () => Promise.resolve([]),
@@ -109,8 +114,13 @@ describe('FROM columnsAfter', () => {
 
     const result = await columnsAfter(command, [], '', {
       fromFrom: (cmd) => {
-        const sources = cmd.args.filter((arg) => !Array.isArray(arg) && isSource(arg));
-        return Promise.resolve(sources.flatMap((s) => fieldsByIndex[s.name] ?? []));
+        const fields: ESQLFieldWithMetadata[] = [];
+        for (const arg of cmd.args) {
+          if (!Array.isArray(arg) && isSource(arg)) {
+            fields.push(...(fieldsByIndex[arg.name] ?? []));
+          }
+        }
+        return Promise.resolve(fields);
       },
       fromJoin: () => Promise.resolve([]),
       fromEnrich: () => Promise.resolve([]),
@@ -185,14 +195,12 @@ describe('FROM columnsAfter', () => {
 
     expect(fromFromMock).toHaveBeenCalledTimes(1);
 
-    const calledSources = fromFromMock.mock.calls[0][0].args.filter(
-      (arg: unknown) => !Array.isArray(arg) && isSource(arg)
-    );
-    expect(calledSources).toHaveLength(3);
-    expect(calledSources.map((s: { name: string }) => s.name)).toEqual([
-      'index1',
-      'index2',
-      'index3',
-    ]);
+    const sourceNames: string[] = [];
+    for (const arg of fromFromMock.mock.calls[0][0].args) {
+      if (!Array.isArray(arg) && isSource(arg)) {
+        sourceNames.push(arg.name);
+      }
+    }
+    expect(sourceNames).toEqual(['index1', 'index2', 'index3']);
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/columns_after.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/columns_after.ts
@@ -25,19 +25,20 @@ export const columnsAfter = async (
   const sources = command.args.filter((arg) => !Array.isArray(arg) && arg.type === 'source');
   const subqueries = command.args.filter(isSubQuery);
 
-  const promises = [
-    ...sources.map((source) =>
-      additionalFields.fromFrom({ ...command, args: [source, ...options] })
-    ),
-    ...subqueries.map((subquery) =>
-      processSubquery(subquery.child, query, additionalFields, unmappedFieldsStrategy)
-    ),
-  ];
+  const promises: Array<Promise<ESQLColumnData[]>> = [];
+
+  // Batch all plain sources into a single FROM s1, s2, ... request instead of N individual
+  // ones. ES returns the column-union in one round-trip, which is identical to merging N results.
+  if (sources.length > 0) {
+    promises.push(additionalFields.fromFrom({ ...command, args: [...sources, ...options] }));
+  }
+
+  for (const subquery of subqueries) {
+    promises.push(processSubquery(subquery.child, query, additionalFields, unmappedFieldsStrategy));
+  }
 
   const results = await Promise.all(promises);
-  const allColumns = results.flat();
-
-  return uniqBy(allColumns, 'name');
+  return uniqBy(results.flat(), 'name');
 };
 
 async function processSubquery(


### PR DESCRIPTION
## Summary

This is a change in the implementation when we added the subqueries. We are initializing different requests for each source in columns after. So if the query is:

```
FROM index1, index2, index3
```

It will run:

```
From index1 | limit 0
From index2 | limit 0
From index3 | limit 0

```

This is problematic for multiple comma separated sources. I am now sending only one request.
Subqueries are unchanged (still processed individually via processSubquery)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->