### PR TITLE
[Agent Builder] Tool steps: replace inline expand with flyout

### DIFF
--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -10912,8 +10912,6 @@
     "xpack.agentBuilder.conversation.staleAttachments.dismissButton": "Verwerfen",
     "xpack.agentBuilder.conversation.staleAttachments.stageButton": "Aktualisierte Versionen verwenden",
     "xpack.agentBuilder.conversation.staleAttachments.title": "Einige Anhänge sind veraltet",
-    "xpack.agentBuilder.conversation.toolResponseFlyout.text": "Überprüfen Sie in diesem Schritt die Reaktion auf den Tool-Aufruf",
-    "xpack.agentBuilder.conversation.toolResponseFlyout.title": "Tool-Reaktion überprüfen",
     "xpack.agentBuilder.conversationActions.actions": "Mehr",
     "xpack.agentBuilder.conversationActions.actionsAriaLabel": "Mehr",
     "xpack.agentBuilder.conversationActions.agentDetails": "Agentendetails",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -10896,8 +10896,6 @@
     "xpack.agentBuilder.conversation.staleAttachments.dismissButton": "Rejeter",
     "xpack.agentBuilder.conversation.staleAttachments.stageButton": "Utiliser les versions mises à jour",
     "xpack.agentBuilder.conversation.staleAttachments.title": "Certaines pièces jointes sont obsolètes",
-    "xpack.agentBuilder.conversation.toolResponseFlyout.text": "Examinez la réponse à l'appel d'outil dans cette étape",
-    "xpack.agentBuilder.conversation.toolResponseFlyout.title": "Examiner la réponse de l'outil",
     "xpack.agentBuilder.conversationActions.actions": "Plus",
     "xpack.agentBuilder.conversationActions.actionsAriaLabel": "Plus",
     "xpack.agentBuilder.conversationActions.agentDetails": "Détails de l'agent",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -10941,8 +10941,6 @@
     "xpack.agentBuilder.conversation.staleAttachments.dismissButton": "閉じる",
     "xpack.agentBuilder.conversation.staleAttachments.stageButton": "更新されたバージョンを使用",
     "xpack.agentBuilder.conversation.staleAttachments.title": "添付ファイルの一部が古くなっています",
-    "xpack.agentBuilder.conversation.toolResponseFlyout.text": "このステップでツール呼び出しへの応答を検査します",
-    "xpack.agentBuilder.conversation.toolResponseFlyout.title": "ツールの応答を検査",
     "xpack.agentBuilder.conversationActions.actions": "詳細",
     "xpack.agentBuilder.conversationActions.actionsAriaLabel": "詳細",
     "xpack.agentBuilder.conversationActions.agentDetails": "エージェントの詳細",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -10939,8 +10939,6 @@
     "xpack.agentBuilder.conversation.staleAttachments.dismissButton": "关闭",
     "xpack.agentBuilder.conversation.staleAttachments.stageButton": "使用更新版本",
     "xpack.agentBuilder.conversation.staleAttachments.title": "部分附件可能已过时",
-    "xpack.agentBuilder.conversation.toolResponseFlyout.text": "检查此步骤中工具调用的响应",
-    "xpack.agentBuilder.conversation.toolResponseFlyout.title": "检查工具响应",
     "xpack.agentBuilder.conversationActions.actions": "更多",
     "xpack.agentBuilder.conversationActions.actionsAriaLabel": "更多",
     "xpack.agentBuilder.conversationActions.agentDetails": "代理详情",

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -17,9 +17,7 @@ import {
   EuiIcon,
   EuiSpacer,
   EuiText,
-  useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { internalTools } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
@@ -70,23 +68,13 @@ interface ToolResponseFlyoutProps {
 }
 
 export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, onClose }) => {
-  const { euiTheme } = useEuiTheme();
-
   const isSubAgentCall = step.tool_id === internalTools.runSubagent;
   const subAgentExecutionId = isSubAgentCall ? getSubAgentExecutionId(step) : undefined;
   const showExecutionSection = Boolean(subAgentExecutionId);
   const showResultSection = step.results.length > 0;
 
   return (
-    <EuiFlyout
-      onClose={onClose}
-      aria-labelledby="toolResponseFlyoutTitle"
-      size="m"
-      maskProps={{ style: 'background: transparent' }}
-      css={css`
-        z-index: ${Number(euiTheme.levels.flyout) + 4};
-      `}
-    >
+    <EuiFlyout onClose={onClose} aria-labelledby="toolResponseFlyoutTitle" size="m">
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
           <h2 id="toolResponseFlyoutTitle">tool: {step.tool_id}</h2>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -14,10 +14,7 @@ import {
   EuiSpacer,
   EuiSteps,
   EuiText,
-  useEuiFontSize,
-  useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { internalTools } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
@@ -46,8 +43,6 @@ interface ToolResponseFlyoutProps {
 }
 
 export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, onClose }) => {
-  const stepTitleSize = useEuiFontSize('s');
-  const { euiTheme } = useEuiTheme();
   const isSubAgentCall = step.tool_id === internalTools.runSubagent;
   const subAgentExecutionId = isSubAgentCall ? getSubAgentExecutionId(step) : undefined;
   const showExecutionSection = Boolean(subAgentExecutionId);
@@ -112,20 +107,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <div
-          css={css`
-            .euiStep__title {
-              ${stepTitleSize}
-            }
-            .euiStep__content {
-              margin-block-start: 0;
-              padding-block-start: 0;
-              padding-block-end: ${euiTheme.size.base};
-            }
-          `}
-        >
-          <EuiSteps headingElement="h3" titleSize="xxs" steps={steps} />
-        </div>
+        <EuiSteps headingElement="h3" titleSize="xxs" steps={steps} />
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -7,7 +7,6 @@
 
 import React, { Fragment } from 'react';
 import {
-  EuiCode,
   EuiFlyout,
   EuiFlyoutHeader,
   EuiFlyoutBody,
@@ -76,7 +75,9 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
                 <EuiSpacer size="s" />
                 {/* TODO: replace with sub-agent execution drill-down — elastic/search-team#15172 */}
                 {/* <EuiText size="s" color="subdued"><EuiCode>{subAgentExecutionId}</EuiCode></EuiText> */}
-                <EuiText size="s" color="subdued">TODO</EuiText>
+                <EuiText size="s" color="subdued">
+                  TODO
+                </EuiText>
               </>
             ),
           },

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -5,66 +5,133 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
+  EuiCode,
   EuiFlyout,
   EuiFlyoutHeader,
-  EuiTitle,
   EuiFlyoutBody,
-  EuiText,
+  EuiTitle,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
   EuiSpacer,
+  EuiText,
+  useEuiTheme,
 } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import { internalTools } from '@kbn/agent-builder-common';
+import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
+import { JsonCodeBlock } from '../json_code_block';
+import { ToolResult } from '../results/tool_result';
 
-const toolResponseFlyoutTitle = i18n.translate(
-  'xpack.agentBuilder.conversation.toolResponseFlyout.title',
-  {
-    defaultMessage: 'Inspect tool response',
-  }
+const parametersLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.parametersLabel',
+  { defaultMessage: 'Parameters' }
 );
 
-const toolResponseFlyoutText = i18n.translate(
-  'xpack.agentBuilder.conversation.toolResponseFlyout.text',
-  {
-    defaultMessage: 'Inspect the response to the tool call in this step',
-  }
+const executionLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.executionLabel',
+  { defaultMessage: 'Execution' }
+);
+
+const resultLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.resultLabel',
+  { defaultMessage: 'Result' }
+);
+
+interface SectionHeaderProps {
+  title: string;
+}
+
+const SectionHeader: React.FC<SectionHeaderProps> = ({ title }) => (
+  <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+    <EuiFlexItem grow={false}>
+      <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiText size="s">
+        <strong>{title}</strong>
+      </EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
 );
 
 interface ToolResponseFlyoutProps {
-  isOpen: boolean;
+  step: ToolCallStepData;
   onClose: () => void;
-  children: React.ReactNode;
 }
 
-export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
-  isOpen,
-  onClose,
-  children,
-}) => {
-  if (!isOpen) return null;
+export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, onClose }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const isSubAgentCall = step.tool_id === internalTools.runSubagent;
+  const subAgentExecutionId = isSubAgentCall ? getSubAgentExecutionId(step) : undefined;
+  const showExecutionSection = Boolean(subAgentExecutionId);
+  const showResultSection = step.results.length > 0;
 
   return (
     <EuiFlyout
       onClose={onClose}
       aria-labelledby="toolResponseFlyoutTitle"
       size="m"
-      ownFocus={false}
+      maskProps={{ style: 'background: transparent' }}
       css={css`
-        z-index: ${euiThemeVars.euiZFlyout + 4};
+        z-index: ${Number(euiTheme.levels.flyout) + 4};
       `}
     >
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
-          <h2 id="toolResponseFlyoutTitle">{toolResponseFlyoutTitle}</h2>
+          <h2 id="toolResponseFlyoutTitle">tool: {step.tool_id}</h2>
         </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiText color="subdued">
-          <p>{toolResponseFlyoutText}</p>
-        </EuiText>
       </EuiFlyoutHeader>
-      <EuiFlyoutBody>{children}</EuiFlyoutBody>
+      <EuiFlyoutBody>
+        <SectionHeader title={parametersLabel} />
+        <EuiSpacer size="s" />
+        <JsonCodeBlock data={step.params} />
+
+        {showExecutionSection && (
+          <>
+            <EuiSpacer size="m" />
+            <SectionHeader title={executionLabel} />
+            <EuiSpacer size="s" />
+            {/* TODO: drilling into sub-agent execution — see elastic/search-team#15172 */}
+            <EuiText size="s" color="subdued">
+              <EuiCode>{subAgentExecutionId}</EuiCode>
+            </EuiText>
+          </>
+        )}
+
+        {showResultSection && (
+          <>
+            <EuiSpacer size="m" />
+            <SectionHeader title={resultLabel} />
+            <EuiSpacer size="s" />
+            {step.results.map((result, idx) => (
+              <Fragment key={`flyout-result-${idx}`}>
+                <ToolResult result={result} />
+                {idx < step.results.length - 1 && <EuiSpacer size="s" />}
+              </Fragment>
+            ))}
+          </>
+        )}
+      </EuiFlyoutBody>
     </EuiFlyout>
   );
+};
+
+interface SubAgentResultData {
+  agent_execution_id?: string;
+}
+
+const getSubAgentExecutionId = (step: ToolCallStepData): string | undefined => {
+  const fromResults = step.results.find(
+    (r) => (r.data as SubAgentResultData | undefined)?.agent_execution_id
+  );
+  if (fromResults) {
+    return (fromResults.data as SubAgentResultData).agent_execution_id;
+  }
+  return step.progression?.find((p) => p.metadata?.agent_execution_id)?.metadata
+    ?.agent_execution_id;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -12,12 +12,13 @@ import {
   EuiFlyoutHeader,
   EuiFlyoutBody,
   EuiTitle,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
   EuiSpacer,
+  EuiSteps,
   EuiText,
+  useEuiFontSize,
+  useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { internalTools } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
@@ -40,38 +41,67 @@ const resultLabel = i18n.translate(
   { defaultMessage: 'Result' }
 );
 
-interface SectionHeaderProps {
-  title: string;
-  isError?: boolean;
-}
-
-const SectionHeader: React.FC<SectionHeaderProps> = ({ title, isError = false }) => (
-  <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-    <EuiFlexItem grow={false}>
-      <EuiIcon
-        type={isError ? 'alert' : 'checkInCircleFilled'}
-        color={isError ? 'danger' : 'success'}
-        aria-hidden={true}
-      />
-    </EuiFlexItem>
-    <EuiFlexItem grow={false}>
-      <EuiText size="s">
-        <strong>{title}</strong>
-      </EuiText>
-    </EuiFlexItem>
-  </EuiFlexGroup>
-);
-
 interface ToolResponseFlyoutProps {
   step: ToolCallStepData;
   onClose: () => void;
 }
 
 export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, onClose }) => {
+  const stepTitleSize = useEuiFontSize('s');
+  const { euiTheme } = useEuiTheme();
   const isSubAgentCall = step.tool_id === internalTools.runSubagent;
   const subAgentExecutionId = isSubAgentCall ? getSubAgentExecutionId(step) : undefined;
   const showExecutionSection = Boolean(subAgentExecutionId);
   const showResultSection = step.results.length > 0;
+  const hasErrorResult = step.results.some(isErrorResult);
+
+  const steps = [
+    {
+      title: parametersLabel,
+      status: 'complete' as const,
+      children: (
+        <>
+          <EuiSpacer size="s" />
+          <JsonCodeBlock data={step.params} />
+        </>
+      ),
+    },
+    ...(showExecutionSection
+      ? [
+          {
+            title: executionLabel,
+            status: 'complete' as const,
+            children: (
+              <>
+                <EuiSpacer size="s" />
+                {/* TODO: replace with sub-agent execution drill-down — elastic/search-team#15172 */}
+                {/* <EuiText size="s" color="subdued"><EuiCode>{subAgentExecutionId}</EuiCode></EuiText> */}
+                <EuiText size="s" color="subdued">TODO</EuiText>
+              </>
+            ),
+          },
+        ]
+      : []),
+    ...(showResultSection
+      ? [
+          {
+            title: resultLabel,
+            status: (hasErrorResult ? 'danger' : 'complete') as 'danger' | 'complete',
+            children: (
+              <>
+                <EuiSpacer size="s" />
+                {step.results.map((result, idx) => (
+                  <Fragment key={`flyout-result-${idx}`}>
+                    <ToolResult result={result} />
+                    {idx < step.results.length - 1 && <EuiSpacer size="s" />}
+                  </Fragment>
+                ))}
+              </>
+            ),
+          },
+        ]
+      : []),
+  ];
 
   return (
     <EuiFlyout onClose={onClose} aria-labelledby="toolResponseFlyoutTitle" size="m">
@@ -81,35 +111,20 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <SectionHeader title={parametersLabel} />
-        <EuiSpacer size="s" />
-        <JsonCodeBlock data={step.params} />
-
-        {showExecutionSection && (
-          <>
-            <EuiSpacer size="m" />
-            <SectionHeader title={executionLabel} />
-            <EuiSpacer size="s" />
-            {/* TODO: drilling into sub-agent execution — see elastic/search-team#15172 */}
-            <EuiText size="s" color="subdued">
-              <EuiCode>{subAgentExecutionId}</EuiCode>
-            </EuiText>
-          </>
-        )}
-
-        {showResultSection && (
-          <>
-            <EuiSpacer size="m" />
-            <SectionHeader title={resultLabel} isError={step.results.some(isErrorResult)} />
-            <EuiSpacer size="s" />
-            {step.results.map((result, idx) => (
-              <Fragment key={`flyout-result-${idx}`}>
-                <ToolResult result={result} />
-                {idx < step.results.length - 1 && <EuiSpacer size="s" />}
-              </Fragment>
-            ))}
-          </>
-        )}
+        <div
+          css={css`
+            .euiStep__title {
+              ${stepTitleSize}
+            }
+            .euiStep__content {
+              margin-block-start: 0;
+              padding-block-start: 0;
+              padding-block-end: ${euiTheme.size.base};
+            }
+          `}
+        >
+          <EuiSteps headingElement="h3" titleSize="xxs" steps={steps} />
+        </div>
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -23,6 +23,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { internalTools } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
+import { isErrorResult } from '@kbn/agent-builder-common/tools/tool_result';
 import { JsonCodeBlock } from '../json_code_block';
 import { ToolResult } from '../results/tool_result';
 
@@ -43,12 +44,17 @@ const resultLabel = i18n.translate(
 
 interface SectionHeaderProps {
   title: string;
+  isError?: boolean;
 }
 
-const SectionHeader: React.FC<SectionHeaderProps> = ({ title }) => (
+const SectionHeader: React.FC<SectionHeaderProps> = ({ title, isError = false }) => (
   <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
     <EuiFlexItem grow={false}>
-      <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
+      <EuiIcon
+        type={isError ? 'alert' : 'checkInCircleFilled'}
+        color={isError ? 'danger' : 'success'}
+        aria-hidden={true}
+      />
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <EuiText size="s">
@@ -106,7 +112,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
         {showResultSection && (
           <>
             <EuiSpacer size="m" />
-            <SectionHeader title={resultLabel} />
+            <SectionHeader title={resultLabel} isError={step.results.some(isErrorResult)} />
             <EuiSpacer size="s" />
             {step.results.map((result, idx) => (
               <Fragment key={`flyout-result-${idx}`}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/background_agent_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/background_agent_step.tsx
@@ -17,9 +17,7 @@ import {
   EuiLink,
   EuiText,
   EuiTitle,
-  useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import type { BackgroundAgentCompleteStep as BackgroundAgentCompleteStepData } from '@kbn/agent-builder-common';
@@ -47,7 +45,6 @@ export const BackgroundAgentStep: React.FC<BackgroundAgentStepProps> = ({ step }
 };
 
 const BackgroundAgentHeadline: React.FC<{ step: BackgroundAgentCompleteStepData }> = ({ step }) => {
-  const { euiTheme } = useEuiTheme();
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   const openFlyout = useCallback(() => setIsFlyoutOpen(true), []);
   const closeFlyout = useCallback(() => setIsFlyoutOpen(false), []);
@@ -103,15 +100,7 @@ const BackgroundAgentHeadline: React.FC<{ step: BackgroundAgentCompleteStepData 
         </EuiLink>
       </EuiFlexItem>
       {isFlyoutOpen && (
-        <EuiFlyout
-          onClose={closeFlyout}
-          aria-labelledby="backgroundAgentFlyoutTitle"
-          size="m"
-          ownFocus={false}
-          css={css`
-            z-index: ${Number(euiTheme.levels.flyout) + 4};
-          `}
-        >
+        <EuiFlyout onClose={closeFlyout} aria-labelledby="backgroundAgentFlyoutTitle" size="m">
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
               <h2 id="backgroundAgentFlyoutTitle">{flyoutTitle}</h2>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/background_agent_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/background_agent_step.tsx
@@ -5,22 +5,37 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLink, EuiText } from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiIcon,
+  EuiLink,
+  EuiText,
+  EuiTitle,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import type { BackgroundAgentCompleteStep as BackgroundAgentCompleteStepData } from '@kbn/agent-builder-common';
 import { ExecutionStatus, AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
-import type { ToolResult as ToolResultData } from '@kbn/agent-builder-common/tools/tool_result';
-import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { getEbtProps } from '@kbn/ebt-click';
 import { StepLayout } from '../step_layout';
-import { ToolResult } from '../results/tool_result';
-import { ToolResponseFlyout } from '../flyouts/tool_response_flyout';
+import { JsonCodeBlock } from '../json_code_block';
 
 const viewJsonLabel = i18n.translate(
   'xpack.agentBuilder.roundEvents.steps.backgroundAgent.viewJson',
   { defaultMessage: 'View JSON' }
+);
+
+const flyoutTitle = i18n.translate(
+  'xpack.agentBuilder.roundEvents.steps.backgroundAgent.flyoutTitle',
+  { defaultMessage: 'Background agent result' }
 );
 
 interface BackgroundAgentStepProps {
@@ -32,6 +47,7 @@ export const BackgroundAgentStep: React.FC<BackgroundAgentStepProps> = ({ step }
 };
 
 const BackgroundAgentHeadline: React.FC<{ step: BackgroundAgentCompleteStepData }> = ({ step }) => {
+  const { euiTheme } = useEuiTheme();
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   const openFlyout = useCallback(() => setIsFlyoutOpen(true), []);
   const closeFlyout = useCallback(() => setIsFlyoutOpen(false), []);
@@ -39,22 +55,13 @@ const BackgroundAgentHeadline: React.FC<{ step: BackgroundAgentCompleteStepData 
   const isFailure =
     step.status === ExecutionStatus.failed || step.status === ExecutionStatus.aborted;
 
-  // Synthetic `ToolResult` of type `other` so `ToolResponseFlyout` can render
-  // the completion payload via its existing JSON-dump path.
-  const syntheticResult: ToolResultData = useMemo(
-    () => ({
-      type: ToolResultType.other,
-      tool_result_id: `bg-${step.execution_id}`,
-      data: {
-        execution_id: step.execution_id,
-        status: step.status,
-        response: step.response,
-        error: step.error,
-        completed_at: step.completed_at,
-      },
-    }),
-    [step]
-  );
+  const flyoutData = {
+    execution_id: step.execution_id,
+    status: step.status,
+    response: step.response,
+    error: step.error,
+    completed_at: step.completed_at,
+  };
 
   return (
     <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" responsive={false}>
@@ -95,9 +102,26 @@ const BackgroundAgentHeadline: React.FC<{ step: BackgroundAgentCompleteStepData 
           {viewJsonLabel}
         </EuiLink>
       </EuiFlexItem>
-      <ToolResponseFlyout isOpen={isFlyoutOpen} onClose={closeFlyout}>
-        <ToolResult result={syntheticResult} />
-      </ToolResponseFlyout>
+      {isFlyoutOpen && (
+        <EuiFlyout
+          onClose={closeFlyout}
+          aria-labelledby="backgroundAgentFlyoutTitle"
+          size="m"
+          ownFocus={false}
+          css={css`
+            z-index: ${Number(euiTheme.levels.flyout) + 4};
+          `}
+        >
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="m">
+              <h2 id="backgroundAgentFlyoutTitle">{flyoutTitle}</h2>
+            </EuiTitle>
+          </EuiFlyoutHeader>
+          <EuiFlyoutBody>
+            <JsonCodeBlock data={flyoutData} />
+          </EuiFlyoutBody>
+        </EuiFlyout>
+      )}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_group.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_group.test.tsx
@@ -75,6 +75,6 @@ describe('ToolCallGroup', () => {
     expect(childStatuses.every((el) => el.textContent?.includes('ran.'))).toBe(true);
 
     await user.click(screen.getAllByRole('button')[1]);
-    expect(screen.getByText('Inspect tool response')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.test.tsx
@@ -44,12 +44,14 @@ const makeStep = (results: ToolResult[]) =>
   });
 
 describe('ToolCallStep', () => {
-  it('shows "tool: search" and "running…" and is not clickable while no results have arrived', () => {
+  it('shows "tool: search" and "running…" and is clickable (opens parameters flyout)', async () => {
+    const user = userEvent.setup();
     renderWithProviders(<ToolCallStep step={makeStep([])} />);
     const status = screen.getByRole('status');
     expect(status.querySelector('.euiBadge')).toHaveTextContent('tool: search');
     expect(status).toHaveTextContent('running…');
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByText('tool: search')).toBeInTheDocument();
   });
 
   it('shows "tool: search" and "ran." and opens the response flyout directly on click', async () => {
@@ -58,18 +60,18 @@ describe('ToolCallStep', () => {
     const status = screen.getByRole('status');
     expect(status.querySelector('.euiBadge')).toHaveTextContent('tool: search');
     expect(status).toHaveTextContent('ran.');
-    expect(screen.queryByText('Inspect tool response')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button'));
-    expect(screen.getByText('Inspect tool response')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('closes the flyout when its close button is clicked', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ToolCallStep step={makeStep([otherResult('r1')])} />);
     await user.click(screen.getByRole('button'));
-    expect(screen.getByText('Inspect tool response')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
     await user.click(screen.getByTestId('euiFlyoutCloseButton'));
-    expect(screen.queryByText('Inspect tool response')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('still shows "ran." for an error result, with the danger badge color', () => {
@@ -79,7 +81,7 @@ describe('ToolCallStep', () => {
     expect(badge?.className).toContain('danger');
   });
 
-  it('is clickable for a running sub-agent call once its execution id is known', () => {
+  it('is always clickable for a running sub-agent call', () => {
     const step = createToolCallStep({
       tool_call_id: 'call-1',
       tool_id: internalTools.runSubagent,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
@@ -5,15 +5,12 @@
  * 2.0.
  */
 
-import React, { Fragment } from 'react';
-import { EuiSpacer } from '@elastic/eui';
+import React from 'react';
 import { useBoolean } from '@kbn/react-hooks';
-import { internalTools, AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
+import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
 import { StepLayout } from '../step_layout';
-import { ToolResult } from '../results/tool_result';
 import { ToolResponseFlyout } from '../flyouts/tool_response_flyout';
-import { SubAgentExecutionFlyout } from '../flyouts/sub_agent_execution_flyout';
 import { ToolCallStepHeadline } from './tool_call_step_headline';
 
 interface ToolCallStepProps {
@@ -25,55 +22,15 @@ export const ToolCallStep: React.FC<ToolCallStepProps> = ({ step }) => {
 
   const hasResults = step.results.length > 0;
 
-  const isSubAgentCall = step.tool_id === internalTools.runSubagent;
-  const subAgentExecutionId = isSubAgentCall ? getSubAgentExecutionId(step) : undefined;
-  const showSubAgentFlyout = isSubAgentCall && Boolean(subAgentExecutionId);
-  const canOpenFlyout = showSubAgentFlyout || hasResults;
-
   return (
     <div data-test-subj="agentBuilderToolCallStep">
       <StepLayout
         label={<ToolCallStepHeadline step={step} hasResults={hasResults} />}
         isExpandable={false}
-        onClick={canOpenFlyout ? openFlyout : undefined}
-        ebtAction={
-          showSubAgentFlyout
-            ? AGENT_BUILDER_UI_EBT.action.conversation.VIEW_SUB_AGENT_EXECUTION
-            : AGENT_BUILDER_UI_EBT.action.conversation.VIEW_TOOL_RESPONSE
-        }
+        onClick={openFlyout}
+        ebtAction={AGENT_BUILDER_UI_EBT.action.conversation.VIEW_TOOL_RESPONSE}
       />
-      {isFlyoutOpen && showSubAgentFlyout && (
-        <SubAgentExecutionFlyout
-          executionId={subAgentExecutionId!}
-          params={step.params}
-          onClose={closeFlyout}
-        />
-      )}
-      {isFlyoutOpen && !showSubAgentFlyout && (
-        <ToolResponseFlyout isOpen onClose={closeFlyout}>
-          {step.results.map((result, idx) => (
-            <Fragment key={`flyout-result-${idx}`}>
-              <ToolResult result={result} />
-              {idx < step.results.length - 1 && <EuiSpacer size="m" />}
-            </Fragment>
-          ))}
-        </ToolResponseFlyout>
-      )}
+      {isFlyoutOpen && <ToolResponseFlyout step={step} onClose={closeFlyout} />}
     </div>
   );
-};
-
-interface SubAgentResultData {
-  agent_execution_id?: string;
-}
-
-const getSubAgentExecutionId = (step: ToolCallStepData): string | undefined => {
-  const fromResults = step.results.find(
-    (r) => (r.data as SubAgentResultData | undefined)?.agent_execution_id
-  );
-  if (fromResults) {
-    return (fromResults.data as SubAgentResultData).agent_execution_id;
-  }
-  return step.progression?.find((p) => p.metadata?.agent_execution_id)?.metadata
-    ?.agent_execution_id;
 };


### PR DESCRIPTION
## Summary

- After clicking a tool step, the flyout now contains all the information (Parameters / Execution / Result)
- Flyout closes on click outside (without triggering the clicked element's action)
- Sub-execution drill-down is a placeholder pending elastic/search-team#15172

<img width="1402" height="832" alt="flyout" src="https://github.com/user-attachments/assets/d08afdae-7107-4ac2-8813-af5428a1fe29" />


### Screenshots

**orange = changed by this PR**

**`ToolCallStep`** — tool steps are now clickable rows that open the flyout:

![ToolCallStep changed](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260723/szmk65fq-pr-1-ToolCallStep.png)

**`ToolResponseFlyout`** — the flyout now holds Parameters / Execution / Result:

![ToolResponseFlyout changed](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260723/ttb99coo-pr-2-ToolResponseFlyout.png)

**`BackgroundAgentStep`** — "View JSON" opens an inline flyout:

![BackgroundAgentStep changed](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260723/or6l77tm-pr-3-BackgroundAgentStep.png)

## References

Closes https://github.com/elastic/search-team/issues/15171
