### PR TITLE
[Context Engine] AI index registration: index config + DLS (SML self-scoping)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_sml/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_sml/server/plugin.ts
@@ -91,6 +91,39 @@ export class AgentBuilderSmlPlugin
       getSmlService,
     });
 
+    // Runtime fields that reconcile the raw values stored on SML docs with the format
+    // Kibana grants use, so a DLS template can filter without any change to ingestion:
+    //  - space_resources: raw space id `marketing` -> `space:marketing` (global `*` passed through)
+    //  - space_perms:     (space x required-privilege) -> `space:marketing|saved_object:dashboard/get`
+    const spaceResourcesScript =
+      "for (def s : doc['spaces']) { emit(s == '*' ? '*' : 'space:' + s); }";
+    const spacePermsScript =
+      "for (def s : doc['spaces']) { for (def p : doc['permissions.kibana.privileges.name']) { " +
+      "emit((s == '*' ? '*' : 'space:' + s) + '|' + p); } }";
+
+    // Composite DLS: a KI is visible if the user holds its required privilege in one of the
+    // KI's spaces (space_perms), OR it is public (no required privilege) and lives in a space
+    // the user can access (space_resources). `_user.application_privileges` /
+    // `_user.application_resources` come from the Elasticsearch DLS-template extension.
+    const dlsSource = JSON.stringify({
+      bool: {
+        minimum_should_match: 1,
+        should: [
+          { terms: { space_perms: '__APP_PRIVS__' } },
+          {
+            bool: {
+              must: [
+                { terms: { space_resources: '__APP_RES__' } },
+                { bool: { must_not: { exists: { field: 'permissions.kibana.privileges.name' } } } },
+              ],
+            },
+          },
+        ],
+      },
+    })
+      .replace('"__APP_PRIVS__"', '{{#toJson}}_user.application_privileges{{/toJson}}')
+      .replace('"__APP_RES__"', '{{#toJson}}_user.application_resources{{/toJson}}');
+
     setupDeps.contextEngine?.registerAiIndex('elastic', {
       name: 'Elastic',
       description:
@@ -100,6 +133,18 @@ export class AgentBuilderSmlPlugin
       dest: { type: 'index', value: 'ai-index-idx-sml-data' },
       automations: [],
       sources: [],
+      index_config: {
+        mappings: {
+          runtime: {
+            space_resources: { type: 'keyword', script: { source: spaceResourcesScript } },
+            space_perms: { type: 'keyword', script: { source: spacePermsScript } },
+          },
+        },
+      },
+      dls: {
+        role: 'ai-index-elastic-reader',
+        query: JSON.stringify({ template: { source: dlsSource } }),
+      },
     });
 
     return {

--- a/x-pack/platform/plugins/shared/context_engine/common/http_api/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/http_api/ai_indices.ts
@@ -30,12 +30,42 @@ export interface AiIndexAutomation {
   value: string;
 }
 
+/**
+ * Index configuration a consumer may provide when registering an AI index. It is
+ * deep-merged into the AI index base template and applied to the dest index as a
+ * composable index template, so a consumer can add settings and mappings — including
+ * runtime fields — on top of the framework defaults without owning the whole template.
+ */
+export interface AiIndexIndexConfig {
+  settings?: Record<string, unknown>;
+  mappings?: {
+    dynamic?: boolean | 'strict' | 'runtime';
+    properties?: Record<string, unknown>;
+    runtime?: Record<string, unknown>;
+  };
+}
+
+/**
+ * Document-level security for an AI index. When provided at registration, an
+ * Elasticsearch role carrying this DLS query on the dest index is created/updated, so
+ * that consumers reading the ai-index as themselves only see permitted documents. The
+ * query may be a mustache template (e.g. referencing `_user.application_privileges`).
+ */
+export interface AiIndexDls {
+  role: string;
+  query: string;
+}
+
 export interface AiIndexProperties {
   name: string;
   description?: string;
   dest: AiIndexDest;
   automations: AiIndexAutomation[];
   sources: AiIndexSource[];
+  /** Optional index config merged into the base template and applied to the dest. */
+  index_config?: AiIndexIndexConfig;
+  /** Optional DLS applied as an Elasticsearch role scoping reads of the dest. */
+  dls?: AiIndexDls;
 }
 
 export interface AiIndexHttpItem extends AiIndexProperties {

--- a/x-pack/platform/plugins/shared/context_engine/moon.yml
+++ b/x-pack/platform/plugins/shared/context_engine/moon.yml
@@ -33,6 +33,7 @@ dependsOn:
   - '@kbn/shared-ux-page-kibana-template'
   - '@kbn/i18n-react'
   - '@kbn/kibana-react-plugin'
+  - '@kbn/core-elasticsearch-server-mocks'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/context_engine/server/ai_indices/index_config.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ai_indices/index_config.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type {
+  AiIndexDest,
+  AiIndexDls,
+  AiIndexIndexConfig,
+} from '../../common/http_api/ai_indices';
+
+/**
+ * The base template every AI index inherits. Consumer `index_config` is deep-merged
+ * on top of this. Intentionally minimal for now — this is the seam where the shared
+ * KI index template (search-team #15351) plugs in once it lands.
+ */
+export const AI_INDEX_BASE_TEMPLATE: AiIndexIndexConfig = {
+  mappings: {
+    dynamic: 'strict',
+  },
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Deep-merges `override` into `base`, recursing into plain objects and letting the
+ * override win on scalar/array conflicts. This is how consumer index config is
+ * composed with the base template.
+ */
+export const deepMerge = (
+  base: Record<string, unknown>,
+  override: Record<string, unknown>
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, overrideValue] of Object.entries(override)) {
+    const baseValue = result[key];
+    result[key] =
+      isPlainObject(baseValue) && isPlainObject(overrideValue)
+        ? deepMerge(baseValue, overrideValue)
+        : overrideValue;
+  }
+  return result;
+};
+
+export const mergeWithBaseTemplate = (config?: AiIndexIndexConfig): AiIndexIndexConfig =>
+  config
+    ? (deepMerge(
+        AI_INDEX_BASE_TEMPLATE as Record<string, unknown>,
+        config as Record<string, unknown>
+      ) as AiIndexIndexConfig)
+    : AI_INDEX_BASE_TEMPLATE;
+
+/**
+ * Applies a consumer's index config by creating/updating a composable index template
+ * (base template merged with the config) for the dest pattern, so the dest index
+ * inherits settings/mappings — including runtime fields — whenever it is (re)created.
+ * If the dest already exists, the mappings are also pushed so they take effect now.
+ * Idempotent; safe to call on every startup.
+ */
+export const applyIndexConfig = async ({
+  esClient,
+  id,
+  dest,
+  indexConfig,
+  logger,
+}: {
+  esClient: ElasticsearchClient;
+  id: string;
+  dest: AiIndexDest;
+  indexConfig: AiIndexIndexConfig | undefined;
+  logger: Logger;
+}): Promise<void> => {
+  const merged = mergeWithBaseTemplate(indexConfig);
+  try {
+    await esClient.indices.putIndexTemplate({
+      name: `ai-index-${id}`,
+      index_patterns: [dest.value],
+      // Above the default template priority so this ai-index's config wins for its dest.
+      priority: 500,
+      template: {
+        settings: merged.settings as estypes.IndicesIndexSettings | undefined,
+        mappings: merged.mappings as estypes.MappingTypeMapping | undefined,
+      },
+    });
+
+    const exists = await esClient.indices.exists({ index: dest.value });
+    if (exists && merged.mappings) {
+      await esClient.indices.putMapping({
+        index: dest.value,
+        ...(merged.mappings as estypes.MappingTypeMapping),
+      });
+    }
+    logger.debug(`Applied index config for AI index '${id}' (dest '${dest.value}')`);
+  } catch (err) {
+    logger.warn(
+      `Failed to apply index config for AI index '${id}': ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+};
+
+/**
+ * Creates/updates the Elasticsearch role that carries the DLS query on the dest index,
+ * so consumers reading the ai-index as themselves are scoped by the query. Idempotent.
+ */
+export const applyDls = async ({
+  esClient,
+  id,
+  dest,
+  dls,
+  logger,
+}: {
+  esClient: ElasticsearchClient;
+  id: string;
+  dest: AiIndexDest;
+  dls: AiIndexDls;
+  logger: Logger;
+}): Promise<void> => {
+  try {
+    await esClient.security.putRole({
+      name: dls.role,
+      indices: [
+        {
+          names: [dest.value],
+          privileges: ['read'],
+          query: dls.query,
+        },
+      ],
+    });
+    logger.debug(`Applied DLS role '${dls.role}' for AI index '${id}'`);
+  } catch (err) {
+    logger.warn(
+      `Failed to apply DLS role '${dls.role}' for AI index '${id}': ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/context_engine/server/ai_indices/index_config.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ai_indices/index_config.ts
@@ -8,11 +8,7 @@
 import type { estypes } from '@elastic/elasticsearch';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
-import type {
-  AiIndexDest,
-  AiIndexDls,
-  AiIndexIndexConfig,
-} from '../../common/http_api/ai_indices';
+import type { AiIndexDest, AiIndexDls, AiIndexIndexConfig } from '../../common/http_api/ai_indices';
 
 /**
  * The base template every AI index inherits. Consumer `index_config` is deep-merged

--- a/x-pack/platform/plugins/shared/context_engine/server/ai_indices/registry.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ai_indices/registry.test.ts
@@ -50,14 +50,24 @@ describe('AiIndexRegistry', () => {
       });
 
       registry.register('test', makeProperties());
-      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger });
+      await registry.startupRegister({
+        aiIndexService: service,
+        esClient,
+        isEnabled: true,
+        logger,
+      });
 
       expect(service.putManaged).toHaveBeenCalledWith('test', makeProperties());
     });
 
     it('throws if called after startupRegister has run', async () => {
       const service = makeServiceMock();
-      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: false, logger });
+      await registry.startupRegister({
+        aiIndexService: service,
+        esClient,
+        isEnabled: false,
+        logger,
+      });
 
       expect(() => registry.register('test', makeProperties())).toThrow(
         'registerAiIndex called after plugin start'
@@ -77,7 +87,12 @@ describe('AiIndexRegistry', () => {
       const service = makeServiceMock();
       registry.register('test', makeProperties());
 
-      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: false, logger });
+      await registry.startupRegister({
+        aiIndexService: service,
+        esClient,
+        isEnabled: false,
+        logger,
+      });
 
       expect(service.get).not.toHaveBeenCalled();
       expect(service.putManaged).not.toHaveBeenCalled();
@@ -95,7 +110,12 @@ describe('AiIndexRegistry', () => {
       });
       registry.register('test', makeProperties());
 
-      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger });
+      await registry.startupRegister({
+        aiIndexService: service,
+        esClient,
+        isEnabled: true,
+        logger,
+      });
 
       expect(service.putManaged).not.toHaveBeenCalled();
     });
@@ -107,7 +127,12 @@ describe('AiIndexRegistry', () => {
       });
       registry.register('test', makeProperties());
 
-      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger });
+      await registry.startupRegister({
+        aiIndexService: service,
+        esClient,
+        isEnabled: true,
+        logger,
+      });
 
       expect(service.putManaged).toHaveBeenCalledWith('test', makeProperties());
     });
@@ -148,7 +173,12 @@ describe('AiIndexRegistry', () => {
       registry.register('a', makeProperties({ name: 'A' }));
       registry.register('b', makeProperties({ name: 'B' }));
 
-      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger });
+      await registry.startupRegister({
+        aiIndexService: service,
+        esClient,
+        isEnabled: true,
+        logger,
+      });
 
       expect(service.putManaged).toHaveBeenCalledTimes(2);
       expect(service.putManaged).toHaveBeenCalledWith('a', makeProperties({ name: 'A' }));

--- a/x-pack/platform/plugins/shared/context_engine/server/ai_indices/registry.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ai_indices/registry.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { AiIndexRegistry } from './registry';
 import { AiIndexNotFoundError, InvalidAiIndexDestError } from './errors';
 import type { AiIndexService } from './service';
@@ -33,10 +34,12 @@ const makeServiceMock = (overrides: Partial<AiIndexService> = {}): jest.Mocked<A
 describe('AiIndexRegistry', () => {
   let registry: AiIndexRegistry;
   let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
 
   beforeEach(() => {
     registry = new AiIndexRegistry();
     logger = loggingSystemMock.createLogger();
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
   });
 
   describe('register()', () => {
@@ -47,14 +50,14 @@ describe('AiIndexRegistry', () => {
       });
 
       registry.register('test', makeProperties());
-      await registry.startupRegister({ aiIndexService: service, isEnabled: true, logger });
+      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger });
 
       expect(service.putManaged).toHaveBeenCalledWith('test', makeProperties());
     });
 
     it('throws if called after startupRegister has run', async () => {
       const service = makeServiceMock();
-      await registry.startupRegister({ aiIndexService: service, isEnabled: false, logger });
+      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: false, logger });
 
       expect(() => registry.register('test', makeProperties())).toThrow(
         'registerAiIndex called after plugin start'
@@ -74,7 +77,7 @@ describe('AiIndexRegistry', () => {
       const service = makeServiceMock();
       registry.register('test', makeProperties());
 
-      await registry.startupRegister({ aiIndexService: service, isEnabled: false, logger });
+      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: false, logger });
 
       expect(service.get).not.toHaveBeenCalled();
       expect(service.putManaged).not.toHaveBeenCalled();
@@ -92,7 +95,7 @@ describe('AiIndexRegistry', () => {
       });
       registry.register('test', makeProperties());
 
-      await registry.startupRegister({ aiIndexService: service, isEnabled: true, logger });
+      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger });
 
       expect(service.putManaged).not.toHaveBeenCalled();
     });
@@ -104,7 +107,7 @@ describe('AiIndexRegistry', () => {
       });
       registry.register('test', makeProperties());
 
-      await registry.startupRegister({ aiIndexService: service, isEnabled: true, logger });
+      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger });
 
       expect(service.putManaged).toHaveBeenCalledWith('test', makeProperties());
     });
@@ -117,7 +120,7 @@ describe('AiIndexRegistry', () => {
       registry.register('test', makeProperties());
 
       await expect(
-        registry.startupRegister({ aiIndexService: service, isEnabled: true, logger })
+        registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger })
       ).resolves.not.toThrow();
 
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('dest not ready'));
@@ -131,7 +134,7 @@ describe('AiIndexRegistry', () => {
       registry.register('test', makeProperties());
 
       await expect(
-        registry.startupRegister({ aiIndexService: service, isEnabled: true, logger })
+        registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger })
       ).resolves.not.toThrow();
 
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('ES cluster unavailable'));
@@ -145,7 +148,7 @@ describe('AiIndexRegistry', () => {
       registry.register('a', makeProperties({ name: 'A' }));
       registry.register('b', makeProperties({ name: 'B' }));
 
-      await registry.startupRegister({ aiIndexService: service, isEnabled: true, logger });
+      await registry.startupRegister({ aiIndexService: service, esClient, isEnabled: true, logger });
 
       expect(service.putManaged).toHaveBeenCalledTimes(2);
       expect(service.putManaged).toHaveBeenCalledWith('a', makeProperties({ name: 'A' }));

--- a/x-pack/platform/plugins/shared/context_engine/server/ai_indices/registry.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ai_indices/registry.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
+import type { ElasticsearchClient } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 import type { AiIndexProperties } from '../../common/http_api/ai_indices';
 import type { AiIndexService } from './service';
 import { AiIndexNotFoundError, InvalidAiIndexDestError } from './errors';
+import { applyDls, applyIndexConfig } from './index_config';
 
 export class AiIndexRegistry {
   private readonly entries = new Map<string, AiIndexProperties>();
@@ -26,10 +28,12 @@ export class AiIndexRegistry {
 
   async startupRegister({
     aiIndexService,
+    esClient,
     isEnabled,
     logger,
   }: {
     aiIndexService: AiIndexService;
+    esClient: ElasticsearchClient;
     isEnabled: boolean;
     logger: Logger;
   }): Promise<void> {
@@ -41,7 +45,7 @@ export class AiIndexRegistry {
     }
 
     for (const [id, properties] of this.entries) {
-      await this.registerOne({ id, properties, aiIndexService, logger });
+      await this.registerOne({ id, properties, aiIndexService, esClient, logger });
     }
   }
 
@@ -49,16 +53,28 @@ export class AiIndexRegistry {
     id,
     properties,
     aiIndexService,
+    esClient,
     logger,
   }: {
     id: string;
     properties: AiIndexProperties;
     aiIndexService: AiIndexService;
+    esClient: ElasticsearchClient;
     logger: Logger;
   }): Promise<void> {
+    // index_config and dls are applied to the dest, not stored on the ai-index doc.
+    const { index_config: indexConfig, dls, ...storedProperties } = properties;
+
+    // Apply the index template/mappings and DLS role on every startup — both are
+    // idempotent upserts, so they stay current even when the ai-index doc already exists.
+    await applyIndexConfig({ esClient, id, dest: properties.dest, indexConfig, logger });
+    if (dls) {
+      await applyDls({ esClient, id, dest: properties.dest, dls, logger });
+    }
+
     try {
       await aiIndexService.get(id);
-      logger.debug(`AI index '${id}' already registered — skipping`);
+      logger.debug(`AI index '${id}' already registered — skipping doc write`);
       return;
     } catch (err) {
       if (!(err instanceof AiIndexNotFoundError)) {
@@ -72,7 +88,7 @@ export class AiIndexRegistry {
     }
 
     try {
-      await aiIndexService.putManaged(id, properties);
+      await aiIndexService.putManaged(id, storedProperties);
       logger.info(`AI index '${id}' registered successfully`);
     } catch (err) {
       if (err instanceof InvalidAiIndexDestError) {

--- a/x-pack/platform/plugins/shared/context_engine/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/plugin.ts
@@ -61,8 +61,10 @@ export class ContextEnginePlugin
   start(coreStart: CoreStart): ContextEnginePluginStart {
     const aiIndexLogger = this.logger.get('ai_indices');
 
+    const esClient = coreStart.elasticsearch.client.asInternalUser;
+
     this.aiIndexService = new AiIndexService({
-      esClient: coreStart.elasticsearch.client.asInternalUser,
+      esClient,
       logger: aiIndexLogger,
     });
 
@@ -77,6 +79,7 @@ export class ContextEnginePlugin
       .then((isEnabled) =>
         registry.startupRegister({
           aiIndexService,
+          esClient,
           isEnabled: isEnabled ?? false,
           logger: aiIndexLogger,
         })

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -27,6 +27,7 @@
     "@kbn/shared-ux-router",
     "@kbn/shared-ux-page-kibana-template",
     "@kbn/i18n-react",
-    "@kbn/kibana-react-plugin"
+    "@kbn/kibana-react-plugin",
+    "@kbn/core-elasticsearch-server-mocks"
   ]
 }


### PR DESCRIPTION
> **Draft.** Depends on the Elasticsearch DLS-template extension
> [elastic/elasticsearch#154785](https://github.com/elastic/elasticsearch/pull/154785)
> and stacks on #279569 (auto-register SML AI index) — base branch is
> `seanstory/15289-auto-register-sml-ai-index`, not `main`.

## What

Two things:

1. **`registerAiIndex` gains index configuration + DLS.** A consumer can now pass:
   - `index_config` — settings + mappings (**including runtime fields**), deep-merged
     into the AI-index base template and applied to the dest as a **composable index
     template** (so the dest inherits it whenever it is created; if it already exists,
     the mappings are pushed immediately). The base template is the seam where the
     shared KI index template (search-team #15351) plugs in later.
   - `dls` — a query + role name; a matching Elasticsearch role carrying that DLS query
     on the dest is created/updated. Both are applied idempotently on every startup.

2. **`agent_builder_sml` uses it** to make the "elastic" ai-index self-scoping, with
   **no change to ingestion / crawlers**:
   - runtime fields `space_resources` (`marketing` → `space:marketing`) and `space_perms`
     (the `spaces` × required-privilege cross-product → `space:marketing|saved_object:dashboard/get`);
   - a composite DLS role: a KI is visible if the user holds its required privilege in one
     of the KI's spaces, or it is public (no required privilege) and lives in a space the
     user can access — using the ES `_user.application_resources` /
     `_user.application_privileges` DLS-template fields.

## Why

So an Agent Builder agent can query the "elastic" ai-index **as the user via ES|QL** and
have Elasticsearch enforce Kibana space + privilege scoping through DLS — removing the
need for the bespoke, internal-user SML retrieval authz. Full design + validation in
`plans/gmaster/kibana_dls_ai_index_plan.md`; the space+privilege DLS was validated
end-to-end against a patched ES node (including the per-space over-grant case).

## Validated / checked

- `context_engine` and `agent_builder_sml` type-check clean; eslint clean; registry
  unit tests pass (9/9).
- The composite DLS behavior (runtime fields + `_user.application_privileges`) was
  proven on a running patched ES node.

## Not in this PR (follow-up)

- **Removing the custom SML retrieval path** (`sml_search` tool + the internal-user
  `_terms_enum`/`checkPrivileges` authz in `sml_service.ts`) and repointing the agent to
  the generic `execute_esql` tool. That's the larger deletion; this PR lays the
  substrate (self-scoping ai-index) it depends on.
- **DLS-role delivery to Agent Builder users** + the sole-grant (DLS union) guarantee.
- **Base template content** — comes from #15351.
- **Global-KI (`spaces:["*"]`) policy** in the DLS query.

## Open questions for review

- Should `index_config`/`dls` live on `registerAiIndex` (as here) or on a separate
  registration surface? They are applied, not stored on the ai-index doc.
- Composable-index-template + priority 500 vs. owning the index directly.
- DLS-role naming/ownership and how it reaches users.
