### PR TITLE
[SigEvents] Rename editable agents off protected platform.* IDs

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/investigation/investigation_workflow.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/investigation/investigation_workflow.yaml
@@ -60,7 +60,7 @@ steps:
 
   - name: investigate
     type: ai.agent
-    agent-id: platform.sig_events.investigation
+    agent-id: significant_events.investigation
     # Keep connector-id-by-feature/plugin-id/aggregate-by in sync with @kbn/significant-events-schema
     # inference_feature_ids.ts (SIGNIFICANT_EVENTS_INVESTIGATION_INFERENCE_FEATURE_ID /
     # SIGNIFICANT_EVENTS_INFERENCE_PARENT_FEATURE_ID).

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/discovery.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/discovery.yaml
@@ -99,7 +99,7 @@ steps:
   # -----------------------------------------------------------------------
   - name: run_discovery_agent
     type: ai.agent
-    agent-id: "platform.streams.sig-events.discovery"
+    agent-id: "significant_events.discovery"
     # Keep connector-id-by-feature/plugin-id/aggregate-by in sync with @kbn/significant-events-schema
     # inference_feature_ids.ts (SIGNIFICANT_EVENTS_DISCOVERY_INFERENCE_FEATURE_ID /
     # SIGNIFICANT_EVENTS_INFERENCE_PARENT_FEATURE_ID).

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
@@ -107,7 +107,7 @@ steps:
   # -----------------------------------------------------------------------
   - name: run_judge_agent
     type: ai.agent
-    agent-id: "platform.streams.sig-events.discovery-judge"
+    agent-id: "significant_events.discovery-judge"
     # Keep connector-id-by-feature/plugin-id/aggregate-by in sync with @kbn/significant-events-schema
     # inference_feature_ids.ts (SIGNIFICANT_EVENTS_TRIAGE_INFERENCE_FEATURE_ID /
     # SIGNIFICANT_EVENTS_INFERENCE_PARENT_FEATURE_ID). Own feature — judge is a lighter,

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
@@ -306,7 +306,7 @@ export const runAgentStepCommonDefinition: CommonStepDefinition<
 \`\`\`yaml
 - name: investigate
   type: ${RunAgentStepTypeId}
-  agent-id: "platform.sig_events.investigation"
+  agent-id: "significant_events.investigation"
   connector-id-by-feature: "significant_events_investigation"
   with:
     message: "Investigate the significant events in this stream."

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/discovery.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/discovery.ts
@@ -11,7 +11,7 @@ import { platformSignificantEventsTools, platformCoreTools } from '@kbn/agent-bu
 import { SIGNIFICANT_EVENTS_KI_GROUNDING_SKILL_ID } from '../../skills/significant_events_ki_grounding';
 import instructions from './instructions/discovery.md.text';
 
-export const SIGNIFICANT_EVENTS_DISCOVERY_AGENT_ID = 'platform.streams.sig-events.discovery';
+export const SIGNIFICANT_EVENTS_DISCOVERY_AGENT_ID = 'significant_events.discovery';
 export const SIGNIFICANT_EVENTS_DISCOVERY_AGENT_TYPE_ID = 'platform.sig_events.discovery-type';
 
 export const discoveryAgentType = {

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/judge.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/judge.ts
@@ -11,7 +11,7 @@ import { platformSignificantEventsTools, platformCoreTools } from '@kbn/agent-bu
 import instructions from './instructions/judge.md.text';
 import { SIGNIFICANT_EVENTS_KI_GROUNDING_SKILL_ID } from '../../skills/significant_events_ki_grounding';
 
-export const SIGNIFICANT_EVENTS_JUDGE_AGENT_ID = 'platform.streams.sig-events.discovery-judge';
+export const SIGNIFICANT_EVENTS_JUDGE_AGENT_ID = 'significant_events.discovery-judge';
 export const SIGNIFICANT_EVENTS_JUDGE_AGENT_TYPE_ID = 'platform.sig_events.discovery-judge-type';
 
 export const judgeAgentType = {

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/index.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/index.ts
@@ -20,7 +20,7 @@ import {
   OBSERVABILITY_GET_TRACES_TOOL_ID,
 } from '../../../agent_builder/agents/discovery/constants';
 
-export const SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_ID = 'platform.sig_events.investigation';
+export const SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_ID = 'significant_events.investigation';
 export const SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_TYPE_ID =
   'platform.sig_events.investigation-type';
 


### PR DESCRIPTION
## Summary
- Rename user-editable Significant Events agent IDs off protected `platform.*` namespaces so the Agent Builder edit form accepts them
- `platform.streams.sig-events.discovery` → `significant_events.discovery`
- `platform.streams.sig-events.discovery-judge` → `significant_events.discovery-judge`
- `platform.sig_events.investigation` → `significant_events.investigation`
- Update managed workflow YAML references and the run-agent step example
- Agent **type** IDs stay under `platform.sig_events.*-type` (managed types, not form-validated as agent IDs)

No migration/backward compatibility for existing installed agent profiles.

## Test plan
- [ ] Enable Significant Events locally and confirm discovery, judge, and investigation agents install with the new IDs
- [ ] Open each agent in the Agent Builder edit form and confirm the ID validates / save succeeds (e.g. change a connector)
- [ ] Confirm managed discovery / triage / investigation workflows still resolve their `agent-id` steps


Made with [Cursor](https://cursor.com)