### PR TITLE
[8.19] Bound unbounded strings in content-management, home, feedback, and intercepts route schemas (#280138)

### DIFF
--- a/src/platform/packages/shared/content-management/content_insights/content_insights_server/src/register.ts
+++ b/src/platform/packages/shared/content-management/content_insights/content_insights_server/src/register.ts
@@ -81,7 +81,7 @@ export const registerContentInsights = (
   const router = http.createRouter();
   const validate = {
     params: schema.object({
-      id: schema.string(),
+      id: schema.string({ minLength: 1, maxLength: 256 }),
       eventType: schema.literal('viewed'),
     }),
   };

--- a/src/platform/packages/shared/content-management/favorites/favorites_server/src/favorites_routes.ts
+++ b/src/platform/packages/shared/content-management/favorites/favorites_server/src/favorites_routes.ts
@@ -45,6 +45,8 @@ export function registerFavoritesRoutes({
   favoritesRegistry: FavoritesRegistry;
 }) {
   const typeSchema = schema.string({
+    minLength: 1,
+    maxLength: 256,
     validate: (type) => {
       if (!favoritesRegistry.hasType(type)) {
         return `Unknown favorite type: ${type}`;
@@ -79,7 +81,7 @@ export function registerFavoritesRoutes({
       path: '/internal/content_management/favorites/{type}/{id}/favorite',
       validate: {
         params: schema.object({
-          id: schema.string(),
+          id: schema.string({ minLength: 1, maxLength: 256 }),
           type: typeSchema,
         }),
         body: schema.maybe(
@@ -149,7 +151,7 @@ export function registerFavoritesRoutes({
       path: '/internal/content_management/favorites/{type}/{id}/unfavorite',
       validate: {
         params: schema.object({
-          id: schema.string(),
+          id: schema.string({ minLength: 1, maxLength: 256 }),
           type: typeSchema,
         }),
       },

--- a/src/platform/plugins/shared/home/server/routes/fetch_es_hits_status.ts
+++ b/src/platform/plugins/shared/home/server/routes/fetch_es_hits_status.ts
@@ -22,8 +22,8 @@ export const registerHitsStatusRoute = (router: IRouter) => {
       },
       validate: {
         body: schema.object({
-          index: schema.string(),
-          query: schema.recordOf(schema.string(), schema.any()),
+          index: schema.string({ minLength: 1, maxLength: 1024 }),
+          query: schema.recordOf(schema.string({ maxLength: 1024 }), schema.any()),
         }),
       },
     },

--- a/src/platform/plugins/shared/home/server/services/sample_data/routes/install.ts
+++ b/src/platform/plugins/shared/home/server/services/sample_data/routes/install.ts
@@ -34,9 +34,9 @@ export function createInstallRoute(
         },
       },
       validate: {
-        params: schema.object({ id: schema.string() }),
+        params: schema.object({ id: schema.string({ minLength: 1, maxLength: 256 }) }),
         // TODO validate now as date
-        query: schema.object({ now: schema.maybe(schema.string()) }),
+        query: schema.object({ now: schema.maybe(schema.string({ maxLength: 64 })) }),
       },
     },
     async (context, req, res) => {

--- a/src/platform/plugins/shared/home/server/services/sample_data/routes/uninstall.ts
+++ b/src/platform/plugins/shared/home/server/services/sample_data/routes/uninstall.ts
@@ -34,7 +34,7 @@ export function createUninstallRoute(
         },
       },
       validate: {
-        params: schema.object({ id: schema.string() }),
+        params: schema.object({ id: schema.string({ minLength: 1, maxLength: 256 }) }),
       },
     },
     async (context, request, response) => {

--- a/x-pack/platform/plugins/private/intercepts/server/orchestrator.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/orchestrator.ts
@@ -110,7 +110,7 @@ export class InterceptsTriggerOrchestrator {
         path: TRIGGER_INFO_API_ROUTE,
         validate: {
           body: schema.object({
-            triggerId: schema.string(),
+            triggerId: schema.string({ minLength: 1, maxLength: 256 }),
           }),
         },
         security: {

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_user_interaction.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_user_interaction.ts
@@ -33,7 +33,7 @@ export class InterceptUserInteractionService {
         path: TRIGGER_USER_INTERACTION_METADATA_API_ROUTE,
         validate: {
           params: schema.object({
-            triggerId: schema.string(),
+            triggerId: schema.string({ minLength: 1, maxLength: 256 }),
           }),
         },
         security: {
@@ -65,7 +65,7 @@ export class InterceptUserInteractionService {
         path: TRIGGER_USER_INTERACTION_METADATA_API_ROUTE,
         validate: {
           params: schema.object({
-            triggerId: schema.string(),
+            triggerId: schema.string({ minLength: 1, maxLength: 256 }),
           }),
           body: schema.object({
             lastInteractedInterceptId: schema.number(),


### PR DESCRIPTION
Backports the following commits to 8.19:
- Bound unbounded strings in content-management, home, feedback, and intercepts route schemas (#280138)

Manual backport (the automated 8.19 backport failed due to merge conflicts). The `access_control` route and `feedback/send_feedback` route do not exist on 8.19, so their bounds are omitted; the remaining request-schema bounds (content_insights, favorites, home sample_data/hits_status, intercepts) apply cleanly.