### PR TITLE
fix(entityStore): cap closed-index warn logs to avoid huge messages

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
@@ -7,7 +7,11 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { loggerMock } from '@kbn/logging-mocks';
-import { resolveClosedIndexAdjustments } from './resolve_closed_indices';
+import {
+  formatErrorForLog,
+  formatNameListForLog,
+  resolveClosedIndexAdjustments,
+} from './resolve_closed_indices';
 
 const makeEsClient = (resolveIndexImpl: jest.Mock) =>
   ({
@@ -346,5 +350,61 @@ describe('resolveClosedIndexAdjustments', () => {
     await resolveClosedIndexAdjustments(makeEsClient(resolveIndex), ['logs-*'], logger);
 
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('-logs-closed-ds'));
+  });
+
+  it('summarizes long closed-index lists in the warning instead of joining all names', async () => {
+    const closedNames = Array.from({ length: 12 }, (_, i) => `.ds-logs-closed-${i}-000001`);
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: closedNames.map((name, i) => ({
+          name: `logs-closed-${i}`,
+          backing_indices: [name],
+          timestamp_field: '@timestamp',
+        })),
+      })
+      .mockResolvedValueOnce({
+        indices: closedNames.map((name) => ({ name, attributes: ['closed'] })),
+        aliases: [],
+        data_streams: [],
+      });
+
+    await resolveClosedIndexAdjustments(makeEsClient(resolveIndex), ['logs-*'], logger);
+
+    const warnMessage = (logger.warn as jest.Mock).mock.calls
+      .map((call) => String(call[0]))
+      .find((msg) => msg.includes('Detected closed backing indices'));
+
+    expect(warnMessage).toBeDefined();
+    expect(warnMessage).toContain('… and 7 more (total 12)');
+    // Must not dump every negation into the log line.
+    expect(warnMessage).not.toContain('-logs-closed-11');
+  });
+});
+
+describe('formatNameListForLog', () => {
+  it('joins short lists in full', () => {
+    expect(formatNameListForLog(['a', 'b'])).toBe('a, b');
+  });
+
+  it('truncates long lists with a total count', () => {
+    expect(formatNameListForLog(['a', 'b', 'c', 'd', 'e', 'f', 'g'])).toBe(
+      'a, b, c, d, e … and 2 more (total 7)'
+    );
+  });
+});
+
+describe('formatErrorForLog', () => {
+  it('returns short messages unchanged', () => {
+    expect(formatErrorForLog(new Error('boom'))).toBe('boom');
+  });
+
+  it('truncates very long error messages', () => {
+    const long = 'x'.repeat(600);
+    const formatted = formatErrorForLog(new Error(long));
+    expect(formatted.length).toBeLessThan(long.length);
+    expect(formatted).toContain('truncated, original length 600');
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
@@ -72,6 +72,36 @@ const resolveArgs = (name: string[]) => ({
   allow_no_indices: true,
 });
 
+/** Max names included verbatim in a warn log; remainder summarized by count. */
+const MAX_LOGGED_NAMES = 5;
+/** Cap error.message size in logs (414 HTML bodies are small; keep a hard ceiling anyway). */
+const MAX_LOGGED_ERROR_CHARS = 500;
+
+export const formatNameListForLog = (
+  names: string[],
+  maxNames: number = MAX_LOGGED_NAMES
+): string => {
+  if (names.length === 0) {
+    return '(none)';
+  }
+  if (names.length <= maxNames) {
+    return names.join(', ');
+  }
+  const shown = names.slice(0, maxNames).join(', ');
+  return `${shown} … and ${names.length - maxNames} more (total ${names.length})`;
+};
+
+export const formatErrorForLog = (
+  error: unknown,
+  maxChars: number = MAX_LOGGED_ERROR_CHARS
+): string => {
+  const raw = error instanceof Error ? error.message : String(error);
+  if (raw.length <= maxChars) {
+    return raw;
+  }
+  return `${raw.slice(0, maxChars)}… (truncated, original length ${raw.length})`;
+};
+
 export const resolveClosedIndexAdjustments = async (
   esClient: ElasticsearchClient,
   includePatterns: string[],
@@ -128,10 +158,15 @@ export const resolveClosedIndexAdjustments = async (
     const negations = [...closedStandaloneNegations, ...dataStreamNegations];
 
     if (negations.length > 0 || openBackingIndices.length > 0) {
+      // Never join unbounded index lists into a single log line — on large clusters
+      // that can produce multi-MB messages and contribute to write EPIPE crashes when
+      // the logging pipeline cannot absorb them.
       logger.warn(
-        `Detected closed backing indices. Excluding data streams/indices: ${negations.join(', ')}` +
+        `Detected closed backing indices. Excluding data streams/indices: ${formatNameListForLog(
+          negations
+        )}` +
           (openBackingIndices.length > 0
-            ? `; adding open backing indices back: ${openBackingIndices.join(', ')}`
+            ? `; adding open backing indices back: ${formatNameListForLog(openBackingIndices)}`
             : '')
       );
     }
@@ -139,9 +174,9 @@ export const resolveClosedIndexAdjustments = async (
     return { openBackingIndices, negations };
   } catch (error) {
     logger.warn(
-      `Failed to resolve closed indices (falling back to unfiltered patterns): ${
-        error instanceof Error ? error.message : String(error)
-      }`
+      `Failed to resolve closed indices (falling back to unfiltered patterns): ${formatErrorForLog(
+        error
+      )}`
     );
     return { openBackingIndices: [], negations: [] };
   }


### PR DESCRIPTION
## Summary
- Caps `logger.warn` output in `resolveClosedIndexAdjustments` so closed-index negations / open backing indices are summarized (sample + total count) instead of `join(',')` of unbounded lists.
- Also truncates very long `error.message` values in the failure-path warn.
- Large joined log lines on big clusters can stress the logging pipeline and have been implicated alongside `write EPIPE` process crashes.

## Test plan
- [ ] Unit tests in `resolve_closed_indices.test.ts` (summary for long lists; helper coverage)
- [ ] Confirm warn logs for a small closed-index set still include concrete names


Made with [Cursor](https://cursor.com)