### PR TITLE
[CSP] Add Advanced Settings toggle for graph showUnknownTarget

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
@@ -47,6 +47,9 @@ export const SECURITY_ALERTS_PARTIAL_IDENTIFIER = '.alerts-security.alerts-';
 export const GRAPH_RUNTIME_EVALUATIONS_ENABLED_SETTING =
   'cloudSecurityPosture:graphRuntimeEvaluationsEnabled';
 
+export const GRAPH_SHOW_UNKNOWN_TARGET_ENABLED_SETTING =
+  'cloudSecurityPosture:graphShowUnknownTargetEnabled';
+
 export const CSP_BENCHMARK_RULES_BULK_ACTION_ROUTE_PATH =
   '/internal/cloud_security_posture/rules/_bulk_action';
 export const CSP_BENCHMARK_RULES_BULK_ACTION_API_CURRENT_VERSION = '1';

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/route.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/route.ts
@@ -14,6 +14,7 @@ import type { GraphRequest } from '@kbn/cloud-security-posture-common/types/grap
 import {
   GRAPH_ROUTE_PATH,
   GRAPH_RUNTIME_EVALUATIONS_ENABLED_SETTING,
+  GRAPH_SHOW_UNKNOWN_TARGET_ENABLED_SETTING,
 } from '../../../common/constants';
 import type { CspRequestHandlerContext, CspRouter } from '../../types';
 import { getGraph as getGraphV1 } from './v1';
@@ -47,7 +48,6 @@ export const defineGraphRoute = (router: CspRouter) =>
       },
       async (context: CspRequestHandlerContext, request, response) => {
         const cspContext = await context.csp;
-        const { nodesLimit, showUnknownTarget = true } = request.body;
         const {
           originEventIds,
           start,
@@ -71,6 +71,10 @@ export const defineGraphRoute = (router: CspRouter) =>
         const integrationRuntimeEvalsEnabled = await coreContext.uiSettings.client.get<boolean>(
           GRAPH_RUNTIME_EVALUATIONS_ENABLED_SETTING
         );
+        const showUnknownTargetDefault = await coreContext.uiSettings.client.get<boolean>(
+          GRAPH_SHOW_UNKNOWN_TARGET_ENABLED_SETTING
+        );
+        const { nodesLimit, showUnknownTarget = showUnknownTargetDefault } = request.body;
 
         try {
           const resp = await getGraphV1({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/ui_settings.ts
@@ -8,7 +8,10 @@
 import { i18n } from '@kbn/i18n';
 import { schema } from '@kbn/config-schema';
 import type { UiSettingsParams } from '@kbn/core/server';
-import { GRAPH_RUNTIME_EVALUATIONS_ENABLED_SETTING } from '../common/constants';
+import {
+  GRAPH_RUNTIME_EVALUATIONS_ENABLED_SETTING,
+  GRAPH_SHOW_UNKNOWN_TARGET_ENABLED_SETTING,
+} from '../common/constants';
 
 export const cspUiSettings: Record<string, UiSettingsParams> = {
   [GRAPH_RUNTIME_EVALUATIONS_ENABLED_SETTING]: {
@@ -19,6 +22,21 @@ export const cspUiSettings: Record<string, UiSettingsParams> = {
     description: i18n.translate('xpack.csp.uiSettings.graphRuntimeEvaluationsEnabledDescription', {
       defaultMessage:
         'When enabled, the Security graph enriches event nodes with integration-specific entity classification (actor sub-type, target identity, display names). Disable this setting if the graph returns errors after adding new integrations.',
+    }),
+    type: 'boolean',
+    category: ['securitySolution'],
+    requiresPageReload: false,
+    schema: schema.boolean(),
+    solutionViews: ['classic', 'security'],
+  },
+  [GRAPH_SHOW_UNKNOWN_TARGET_ENABLED_SETTING]: {
+    name: i18n.translate('xpack.csp.uiSettings.graphShowUnknownTargetEnabledName', {
+      defaultMessage: 'Cloud Security graph show unknown targets',
+    }),
+    value: true,
+    description: i18n.translate('xpack.csp.uiSettings.graphShowUnknownTargetEnabledDescription', {
+      defaultMessage:
+        'When enabled, the Security graph displays nodes whose target entity is unknown or unresolved. Disable this setting to hide unknown targets and reduce graph noise.',
     }),
     type: 'boolean',
     category: ['securitySolution'],


### PR DESCRIPTION
## Summary

- Adds a new Advanced Settings toggle `cloudSecurityPosture:graphShowUnknownTargetEnabled` (defaults to `true`) to control whether the Security graph displays nodes with unknown/unresolved targets
- Registers the setting in `ui_settings.ts` and wires it into the plugin `setup()` lifecycle, following the same pattern as the existing graph integration enrichment setting
- In the graph route, the setting value is used as the default for `showUnknownTarget`; callers who pass the field explicitly in the request body still take precedence

## Test plan

- [ ] Navigate to **Stack Management → Advanced Settings** and confirm the new "Cloud Security graph show unknown targets" toggle appears under the Security Solution category
- [ ] Toggle the setting off and confirm the graph hides unknown target nodes
- [ ] Toggle the setting on and confirm unknown target nodes reappear
- [ ] Pass `showUnknownTarget: false` explicitly in a graph API request with the setting enabled — confirm the explicit value wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)