### PR TITLE
Drop custom AppHeader title size on execution history

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.test.tsx
@@ -6,10 +6,8 @@
  */
 
 import React from 'react';
-import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { euiFontSize, useEuiTheme } from '@elastic/eui';
-import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
 import { ListPageTestProviders } from '../../test_utils/test_providers';
 import type { PolicyExecutionHistoryItem } from '../../services/execution_history_api';
 import type { useFetchRuleExecutions } from '../../hooks/use_fetch_rule_executions';
@@ -213,19 +211,6 @@ describe('ExecutionHistoryPage', () => {
       screen.getByRole('heading', { level: 1, name: /execution history/i })
     ).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /rules/i })).toHaveAttribute('aria-selected', 'true');
-  });
-
-  it('renders the page title with xs size to match other management pages', () => {
-    mockFetchResult();
-    renderPage();
-
-    const { result } = renderHook(() => useEuiTheme());
-    const { fontSize, lineHeight } = euiFontSize(result.current, 'm');
-    const titleSelector = `[data-test-subj='${APP_HEADER_TEST_SUBJECTS.root}'] h1`;
-    const page = screen.getByTestId('executionHistoryPage');
-
-    expect(page).toHaveStyleRule('font-size', fontSize, { target: titleSelector });
-    expect(page).toHaveStyleRule('line-height', lineHeight, { target: titleSelector });
   });
 
   it('renders the experimental badge in the page header', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.tsx
@@ -6,10 +6,9 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { EuiSpacer, euiFontSize, useEuiTheme } from '@elastic/eui';
-import { AppHeader, APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
+import { EuiSpacer } from '@elastic/eui';
+import { AppHeader } from '@kbn/app-header';
 import type { AppHeaderTab } from '@kbn/app-header';
-import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { experimentalBadge } from '../../components/experimental_badge';
 import { ActionPolicyDetailsFlyoutContainer } from '../../components/action_policy/details_flyout/action_policy_details_flyout_container';
@@ -56,11 +55,6 @@ const getExecutionHistoryTabs = ({
 
 export const ExecutionHistoryPage = () => {
   useBreadcrumbs('execution_history_list');
-  const euiThemeContext = useEuiTheme();
-  const { fontSize: titleFontSize, lineHeight: titleLineHeight } = euiFontSize(
-    euiThemeContext,
-    'm'
-  );
 
   const [selectedTabId, setSelectedTabId] = useState<TabId>(RULES_TAB_ID);
   const [policyToViewId, setPolicyToViewId] = useState<string | null>(null);
@@ -82,18 +76,8 @@ export const ExecutionHistoryPage = () => {
     [selectedTabId]
   );
 
-  const pageStyles = useMemo(
-    () => css`
-      [data-test-subj='${APP_HEADER_TEST_SUBJECTS.root}'] h1 {
-        font-size: ${titleFontSize};
-        line-height: ${titleLineHeight};
-      }
-    `,
-    [titleFontSize, titleLineHeight]
-  );
-
   return (
-    <div css={pageStyles} data-test-subj="executionHistoryPage">
+    <div data-test-subj="executionHistoryPage">
       <AppHeader
         sticky={false}
         title={EXECUTION_HISTORY_PAGE_TITLE}


### PR DESCRIPTION
## Summary

Removes a local CSS override that forced the Execution History page title to EUI medium size. The page now uses AppHeader's default typography.

Discussed with @jcger , I believe this hack was needed before - https://github.com/elastic/kibana/pull/277500

<img width="2276" height="1315" alt="Screenshot 2026-07-23 at 12 26 18" src="https://github.com/user-attachments/assets/2a0134b6-ffa8-48be-8865-7f32f7c3cc96" />
<img width="2276" height="1315" alt="Screenshot 2026-07-23 at 12 26 34" src="https://github.com/user-attachments/assets/a60a6d67-b3f4-4fcb-9e74-1f99e18e039c" />
<img width="2276" height="1315" alt="Screenshot 2026-07-23 at 12 26 35" src="https://github.com/user-attachments/assets/a220ca10-bba6-4bfe-89f6-c92e4345a096" />
<img width="2276" height="1315" alt="Screenshot 2026-07-23 at 12 26 37" src="https://github.com/user-attachments/assets/29e6ca18-3347-459c-bf11-b5fd5bffc771" />
