### PR TITLE
[Entity Analytics] Rename risk score history chart series label to 'Max risk score'

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_timeline/risk_score_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_timeline/risk_score_timeline.tsx
@@ -368,7 +368,7 @@ const TimelineChart: React.FC<TimelineChartProps> = ({
         name={i18n.translate(
           'xpack.securitySolution.entityAnalytics.riskScoreTimeline.seriesName',
           {
-            defaultMessage: 'Risk score',
+            defaultMessage: 'Max risk score',
           }
         )}
         xScaleType={ScaleType.Time}


### PR DESCRIPTION
## Summary

Renames the `LineSeries` `name` in the risk score history timeline chart from `'Risk score'` to `'Max risk score'`. This is the label shown in the hover tooltip — each data point represents the maximum calculated risk score within the aggregation bucket for that time period, so the label should reflect that.

## How to test

1. Open a host/user/service entity flyout that has risk score history data.
2. Navigate to the **Risk inputs** tab → **Risk score history** chart.
3. Hover over any data point — the tooltip label should read **Max risk score** instead of **Risk score**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->