### PR TITLE
[9.5] [Security Solution][Attacks] Truncate attack grouping summary to a single line (#279189)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -21,7 +21,11 @@ const contextId = 'FieldMarkdownRenderer';
 
 const inlineFieldWrapperCss = css`
   display: inline-block;
-  vertical-align: top;
+  vertical-align: middle;
+
+  .euiBadge {
+    vertical-align: middle;
+  }
 `;
 
 export const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
@@ -101,11 +105,13 @@ export const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
 
   if (disableActions) {
     return (
-      <EuiToolTip content={name} data-test-subj="fieldMarkdownRendererToolTip" position="top">
-        <EuiBadge color="hollow" data-test-subj="disabledActionsBadge" iconType={icon}>
-          {value}
-        </EuiBadge>
-      </EuiToolTip>
+      <span css={inlineFieldWrapperCss} data-test-subj="fieldMarkdownRendererInlineWrapper">
+        <EuiToolTip content={name} data-test-subj="fieldMarkdownRendererToolTip" position="top">
+          <EuiBadge color="hollow" data-test-subj="disabledActionsBadge" iconType={icon}>
+            {value}
+          </EuiBadge>
+        </EuiToolTip>
+      </span>
     );
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/index.tsx
@@ -117,7 +117,7 @@ export const AttackGroupContent = React.memo<AttackGroupContentProps>(
             />
           </EuiToolTip>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem css={{ minWidth: 0 }}>
           <EuiFlexGroup
             data-test-subj={`${dataTestSubj}${ATTACK_GROUP_TEST_ID_SUFFIX}`}
             direction="column"
@@ -157,6 +157,7 @@ export const AttackGroupContent = React.memo<AttackGroupContentProps>(
             </EuiFlexItem>
             <EuiFlexItem
               grow={false}
+              css={{ minWidth: 0 }}
               data-test-subj={`${dataTestSubj}${ATTACK_DESCRIPTION_TEST_ID_SUFFIX}`}
             >
               <Subtitle attack={attack} showAnonymized={showAnonymized} />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 import { useBulkGetUserProfiles } from '../../../../../common/components/user_profiles/use_bulk_get_user_profiles';
-import { Subtitle } from './subtitle';
+import { getSummaryPlainText, Subtitle } from './subtitle';
 import { getMockAttackDiscoveryAlerts } from '../../../../../attack_discovery/pages/mock/mock_attack_discovery_alerts';
 
 import { getFormattedDate } from '../../../../../attack_discovery/pages/loading_callout/loading_messages/get_formatted_time';
@@ -42,6 +43,22 @@ jest.mock('../../../../../common/components/user_profiles/use_bulk_get_user_prof
 
 const mockAttack = getMockAttackDiscoveryAlerts()[0];
 
+describe('getSummaryPlainText', () => {
+  it('should strip field markdown syntax and keep field values', () => {
+    expect(
+      getSummaryPlainText(
+        'Malware and credential theft detected on {{ host.name SRVMAC08 }} by {{ user.name james }}.'
+      )
+    ).toBe('Malware and credential theft detected on SRVMAC08 by james.');
+  });
+
+  it('should return the original string when there is no field markdown', () => {
+    expect(getSummaryPlainText('Plain summary without fields.')).toBe(
+      'Plain summary without fields.'
+    );
+  });
+});
+
 describe('Subtitle', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -61,6 +78,18 @@ describe('Subtitle', () => {
     );
   });
 
+  it('should show full plain-text summary in tooltip on hover', async () => {
+    const user = userEvent.setup();
+    const scheduledAttack = { ...mockAttack, alertRuleUuid: 'some_other_rule_id' };
+    render(<Subtitle attack={scheduledAttack} />);
+
+    await user.hover(screen.getByTestId('mock-markdown-formatter'));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Malware and credential theft detected on SRVMAC08 by james.'
+    );
+  });
+
   it('should render with formatted date only if summary is missing', () => {
     const attackWithoutSummary = {
       ...mockAttack,
@@ -71,6 +100,7 @@ describe('Subtitle', () => {
 
     expect(getByTestId('attack-subtitle')).toHaveTextContent('Detected on 2023-10-27 10:00:00');
     expect(queryByTestId('mock-markdown-formatter')).not.toBeInTheDocument();
+    expect(queryByTestId('attack-subtitle-summary')).not.toBeInTheDocument();
   });
 
   it('should render anonymized summary when showAnonymized is true', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiAvatar, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiAvatar, EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip } from '@elastic/eui';
+import { css } from '@emotion/react';
 import {
   replaceAnonymizedValuesWithOriginalValues,
   type AttackDiscoveryAlert,
@@ -42,6 +43,33 @@ export const UNKNOWN_USER_LABEL = i18n.translate(
   }
 );
 
+/**
+ * Converts attack discovery field markdown (`{{ field.value }}`) to plain text for tooltips.
+ */
+export const getSummaryPlainText = (markdown: string): string =>
+  markdown.replace(/\{\{\s*\S+\s+(.*?)\s*\}\}/g, '$1');
+
+const truncatedSummaryCss = css`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  .euiMarkdownFormat {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    > * {
+      display: inline;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+`;
+
 export interface SubtitleProps {
   /**
    * The attack discovery alert object containing details about the attack.
@@ -71,6 +99,11 @@ export const Subtitle = React.memo<SubtitleProps>(({ attack, showAnonymized = fa
       : null;
   }, [attack.entitySummaryMarkdown, attack.replacements, showAnonymized]);
 
+  const summaryPlainText = useMemo(
+    () => (summary != null ? getSummaryPlainText(summary) : null),
+    [summary]
+  );
+
   const formattedTimestamp = useMemo(() => {
     return getFormattedDate({
       date: attack.timestamp,
@@ -96,7 +129,7 @@ export const Subtitle = React.memo<SubtitleProps>(({ attack, showAnonymized = fa
       alignItems="center"
       gutterSize="s"
       responsive={false}
-      wrap={true}
+      wrap={false}
       data-test-subj="attack-subtitle"
     >
       {formattedTimestamp && (
@@ -140,7 +173,7 @@ export const Subtitle = React.memo<SubtitleProps>(({ attack, showAnonymized = fa
         </>
       )}
 
-      {summary && (
+      {summary && summaryPlainText && (
         <>
           {(formattedTimestamp || isManual) && (
             <EuiFlexItem grow={false}>
@@ -149,13 +182,23 @@ export const Subtitle = React.memo<SubtitleProps>(({ attack, showAnonymized = fa
               </EuiText>
             </EuiFlexItem>
           )}
-          <EuiFlexItem grow={false}>
-            <AttackDiscoveryMarkdownFormatter
-              scopeId={TableId.alertsOnAttacksPage}
-              disableActions={showAnonymized}
-              markdown={summary}
-              alertIds={originalAlertIds}
-            />
+          <EuiFlexItem
+            grow
+            css={css`
+              min-width: 0;
+            `}
+            data-test-subj="attack-subtitle-summary"
+          >
+            <EuiToolTip content={summaryPlainText} display="block" anchorClassName="eui-fullWidth">
+              <div css={truncatedSummaryCss}>
+                <AttackDiscoveryMarkdownFormatter
+                  scopeId={TableId.alertsOnAttacksPage}
+                  disableActions={showAnonymized}
+                  markdown={summary}
+                  alertIds={originalAlertIds}
+                />
+              </div>
+            </EuiToolTip>
           </EuiFlexItem>
         </>
       )}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Security Solution][Attacks] Truncate attack grouping summary to a single line (#279189)](https://github.com/elastic/kibana/pull/279189)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Agustina Nahir Ruidiaz","email":"61565784+agusruidiazgd@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-20T08:43:24Z","message":"[Security Solution][Attacks] Truncate attack grouping summary to a single line (#279189)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/278602\n\n- Keeps attack grouping summary text on a single line with ellipsis\ntruncation on resize\n- Shows the full plain-text summary in a tooltip on hover\n- Aligns entity badges with surrounding text in `FieldMarkdownRenderer`\n(Attacks table + flyout)\n\n\nhttps://github.com/user-attachments/assets/db815e6e-57b2-422f-807f-a3c7c8d06346\n\n\n## Test plan\n\n- [ ] Open **Attacks** page with attack grouping enabled\n- [ ] Confirm long summaries stay on one line and truncate with `…` when\nthe viewport/row is narrow\n- [ ] Hover truncated summary and confirm tooltip shows the full\nplain-text summary\n- [ ] Confirm row heights stay consistent across groups with short vs\nlong summaries\n- [ ] Confirm entity badges (host/user) are vertically aligned with\nsurrounding text in the grouping row and in the attack details flyout\n- [ ] Unit tests: `node scripts/jest\nx-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx`","sha":"78fdcaf48103df32a97ab31d8ea87afdd2e69af8","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Threat Hunting","Team: SecuritySolution","backport:version","v9.5.0","v9.6.0"],"title":"[Security Solution][Attacks] Truncate attack grouping summary to a single line","number":279189,"url":"https://github.com/elastic/kibana/pull/279189","mergeCommit":{"message":"[Security Solution][Attacks] Truncate attack grouping summary to a single line (#279189)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/278602\n\n- Keeps attack grouping summary text on a single line with ellipsis\ntruncation on resize\n- Shows the full plain-text summary in a tooltip on hover\n- Aligns entity badges with surrounding text in `FieldMarkdownRenderer`\n(Attacks table + flyout)\n\n\nhttps://github.com/user-attachments/assets/db815e6e-57b2-422f-807f-a3c7c8d06346\n\n\n## Test plan\n\n- [ ] Open **Attacks** page with attack grouping enabled\n- [ ] Confirm long summaries stay on one line and truncate with `…` when\nthe viewport/row is narrow\n- [ ] Hover truncated summary and confirm tooltip shows the full\nplain-text summary\n- [ ] Confirm row heights stay consistent across groups with short vs\nlong summaries\n- [ ] Confirm entity badges (host/user) are vertically aligned with\nsurrounding text in the grouping row and in the attack details flyout\n- [ ] Unit tests: `node scripts/jest\nx-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx`","sha":"78fdcaf48103df32a97ab31d8ea87afdd2e69af8"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279189","number":279189,"mergeCommit":{"message":"[Security Solution][Attacks] Truncate attack grouping summary to a single line (#279189)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/278602\n\n- Keeps attack grouping summary text on a single line with ellipsis\ntruncation on resize\n- Shows the full plain-text summary in a tooltip on hover\n- Aligns entity badges with surrounding text in `FieldMarkdownRenderer`\n(Attacks table + flyout)\n\n\nhttps://github.com/user-attachments/assets/db815e6e-57b2-422f-807f-a3c7c8d06346\n\n\n## Test plan\n\n- [ ] Open **Attacks** page with attack grouping enabled\n- [ ] Confirm long summaries stay on one line and truncate with `…` when\nthe viewport/row is narrow\n- [ ] Hover truncated summary and confirm tooltip shows the full\nplain-text summary\n- [ ] Confirm row heights stay consistent across groups with short vs\nlong summaries\n- [ ] Confirm entity badges (host/user) are vertically aligned with\nsurrounding text in the grouping row and in the attack details flyout\n- [ ] Unit tests: `node scripts/jest\nx-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx`","sha":"78fdcaf48103df32a97ab31d8ea87afdd2e69af8"}}]}] BACKPORT-->