### PR TITLE
Make Canvas reactive to theme changes

### DIFF
--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable.scss
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable.scss
@@ -15,7 +15,6 @@
   }
 
   .embPanel--dragHandle:hover {
-    background-color: transparentize($euiColorWarning, lightOrDarkTheme(.9, .7));
     cursor: move;
   }
 

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
@@ -8,8 +8,10 @@
 import type { CoreStart } from '@kbn/core/public';
 import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 import React, { useEffect, useMemo, useRef } from 'react';
+import { css } from '@emotion/react';
+import { transparentize, useEuiTheme } from '@elastic/eui';
 import ReactDOM from 'react-dom';
 import { omit } from 'lodash';
 import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
@@ -27,6 +29,31 @@ import { embeddableInputToExpression } from './embeddable_input_to_expression';
 const { embeddable: strings } = RendererStrings;
 
 const children: Record<string, { setFilters: (filters: Filter[] | undefined) => void }> = {};
+
+const CanvasEmbeddableContainer: FC<{ children: ReactNode }> = ({ children: childNodes }) => {
+  const { euiTheme, colorMode } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      & .embPanel--dragHandle:hover {
+        background-color: ${transparentize(
+          euiTheme.colors.warning,
+          colorMode === 'DARK' ? 0.3 : 0.1
+        )};
+      }
+    `,
+    [colorMode, euiTheme]
+  );
+
+  return (
+    <div
+      className={CANVAS_EMBEDDABLE_CLASSNAME}
+      css={styles}
+      style={{ width: '100%', height: '100%', cursor: 'auto' }}
+    >
+      {childNodes}
+    </div>
+  );
+};
 
 const renderReactEmbeddable = ({
   type,
@@ -108,12 +135,9 @@ const renderReactEmbeddable = ({
 
   return (
     <KibanaRenderContextProvider {...core}>
-      <div
-        className={CANVAS_EMBEDDABLE_CLASSNAME}
-        style={{ width: '100%', height: '100%', cursor: 'auto' }}
-      >
+      <CanvasEmbeddableContainer>
         <RendererWrapper />
-      </div>
+      </CanvasEmbeddableContainer>
     </KibanaRenderContextProvider>
   );
 };

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/advanced_filter/component/advanced_filter.scss
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/advanced_filter/component/advanced_filter.scss
@@ -3,10 +3,8 @@
   font-size: inherit;
 
   .canvasAdvancedFilter__input {
-    background-color: $euiColorEmptyShade;
     width: 100%;
     padding: $euiSizeXS $euiSize;
-    border: $euiBorderThin;
     border-radius: $euiBorderRadius;
     font-size: inherit;
     line-height: 19px;
@@ -20,13 +18,7 @@
   .canvasAdvancedFilter__button {
     width: 100%;
     padding: $euiSizeXS $euiSizeS;
-    border: $euiBorderThin;
     border-radius: $euiBorderRadius;
-    background-color: $euiColorEmptyShade;
     font-size: inherit;
-
-    &:hover {
-      background-color: $euiColorLightestShade;
-    }
   }
 }

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/advanced_filter/component/advanced_filter.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/advanced_filter/component/advanced_filter.tsx
@@ -6,8 +6,9 @@
  */
 
 import type { FunctionComponent } from 'react';
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 const strings = {
@@ -31,29 +32,52 @@ export interface Props {
   commit: (value: string) => void;
 }
 
-export const AdvancedFilter: FunctionComponent<Props> = ({ value = '', onChange, commit }) => (
-  <form
-    onSubmit={(e) => {
-      e.preventDefault();
-      commit(value);
-    }}
-    className="canvasAdvancedFilter"
-  >
-    <EuiFlexGroup gutterSize="xs">
-      <EuiFlexItem>
-        <input
-          type="text"
-          className="canvasAdvancedFilter__input"
-          placeholder={strings.getInputPlaceholder()}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <button className="canvasAdvancedFilter__button" type="submit">
-          {strings.getApplyButtonLabel()}
-        </button>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </form>
-);
+export const AdvancedFilter: FunctionComponent<Props> = ({ value = '', onChange, commit }) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      & .canvasAdvancedFilter__input {
+        background-color: ${euiTheme.colors.emptyShade};
+        border: ${euiTheme.border.thin};
+      }
+
+      & .canvasAdvancedFilter__button {
+        border: ${euiTheme.border.thin};
+        background-color: ${euiTheme.colors.emptyShade};
+
+        &:hover {
+          background-color: ${euiTheme.colors.lightestShade};
+        }
+      }
+    `,
+    [euiTheme]
+  );
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        commit(value);
+      }}
+      className="canvasAdvancedFilter"
+      css={styles}
+    >
+      <EuiFlexGroup gutterSize="xs">
+        <EuiFlexItem>
+          <input
+            type="text"
+            className="canvasAdvancedFilter__input"
+            placeholder={strings.getInputPlaceholder()}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <button className="canvasAdvancedFilter__button" type="submit">
+            {strings.getApplyButtonLabel()}
+          </button>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </form>
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/textarea.js
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/textarea.js
@@ -10,11 +10,13 @@ import PropTypes from 'prop-types';
 import { EuiFormRow, EuiTextArea, EuiSpacer, EuiButton } from '@elastic/eui';
 import { templateFromReactComponent } from '../../../public/lib/template_from_react_component';
 import { withDebounceArg } from '../../../public/components/with_debounce_arg';
+import { useCanvasTextAreaCodeStyles } from '../../../public/lib/use_canvas_text_area_code_styles';
 import { ArgumentStrings } from '../../../i18n';
 
 const { Textarea: strings } = ArgumentStrings;
 
 const TextAreaArgInput = ({ argValue, typeInstance, onValueChange, renderError, argId }) => {
+  const textAreaCodeStyles = useCanvasTextAreaCodeStyles();
   const confirm = typeInstance?.options?.confirm;
   const [value, setValue] = useState(argValue);
 
@@ -43,6 +45,7 @@ const TextAreaArgInput = ({ argValue, typeInstance, onValueChange, renderError, 
       <EuiFormRow display="rowCompressed">
         <EuiTextArea
           className="canvasTextArea__code"
+          css={textAreaCodeStyles}
           id={argId}
           compressed
           rows={10}

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/datasources/essql.js
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/datasources/essql.js
@@ -12,9 +12,37 @@ import { EuiFormRow, EuiLink, EuiText } from '@elastic/eui';
 import { CodeEditorField } from '@kbn/code-editor';
 import { getSimpleArg, setSimpleArg } from '../../../public/lib/arg_helpers';
 import { templateFromReactComponent } from '../../../public/lib/template_from_react_component';
+import { useCanvasTextAreaCodeStyles } from '../../../public/lib/use_canvas_text_area_code_styles';
 import { DataSourceStrings, SQL_URL } from '../../../i18n';
 
 const { Essql: strings } = DataSourceStrings;
+
+const EssqlCodeEditor = ({ value, onChange, editorDidMount }) => {
+  const textAreaCodeStyles = useCanvasTextAreaCodeStyles();
+
+  return (
+    <CodeEditorField
+      languageId={SQLLang.ID}
+      value={value}
+      onChange={onChange}
+      className="canvasTextArea__code"
+      css={textAreaCodeStyles}
+      options={{
+        fontSize: 14,
+        scrollBeyondLastLine: false,
+        quickSuggestions: true,
+        minimap: { enabled: false },
+        wordWrap: 'on',
+        wrappingIndent: 'indent',
+        lineNumbers: 'off',
+        glyphMargin: false,
+        folding: false,
+      }}
+      height="350px"
+      editorDidMount={editorDidMount}
+    />
+  );
+};
 
 class EssqlDatasource extends PureComponent {
   componentDidMount() {
@@ -77,23 +105,9 @@ class EssqlDatasource extends PureComponent {
           </EuiText>
         }
       >
-        <CodeEditorField
-          languageId={SQLLang.ID}
+        <EssqlCodeEditor
           value={this.getQuery()}
           onChange={this.onChange}
-          className="canvasTextArea__code"
-          options={{
-            fontSize: 14,
-            scrollBeyondLastLine: false,
-            quickSuggestions: true,
-            minimap: { enabled: false },
-            wordWrap: 'on',
-            wrappingIndent: 'indent',
-            lineNumbers: 'off',
-            glyphMargin: false,
-            folding: false,
-          }}
-          height="350px"
           editorDidMount={this.editorDidMount}
         />
       </EuiFormRow>

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/datasources/timelion.js
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/datasources/timelion.js
@@ -20,11 +20,13 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { getSimpleArg, setSimpleArg } from '../../../public/lib/arg_helpers';
 import { templateFromReactComponent } from '../../../public/lib/template_from_react_component';
+import { useCanvasTextAreaCodeStyles } from '../../../public/lib/use_canvas_text_area_code_styles';
 import { DataSourceStrings, TIMELION_QUERY_URL, TIMELION, CANVAS } from '../../../i18n';
 
 const { Timelion: strings } = DataSourceStrings;
 
 const TimelionDatasource = ({ args, updateArgs, defaultIndex }) => {
+  const textAreaCodeStyles = useCanvasTextAreaCodeStyles();
   const DEFAULT_QUERY = `.es(index=${defaultIndex})`;
 
   const setArg = (name, value) => {
@@ -99,6 +101,7 @@ const TimelionDatasource = ({ args, updateArgs, defaultIndex }) => {
       >
         <EuiTextArea
           className="canvasTextArea__code"
+          css={textAreaCodeStyles}
           value={getQuery()}
           onChange={(e) => setArg(argName, e.target.value)}
           rows={15}

--- a/x-pack/platform/plugins/private/canvas/public/components/app/index.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/app/index.tsx
@@ -8,7 +8,9 @@
 import type { AppUpdater, ScopedHistory } from '@kbn/core/public';
 import PropTypes from 'prop-types';
 import type { FC } from 'react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
 import type { BehaviorSubject } from 'rxjs';
 // @ts-expect-error
 import { shortcutManager } from '../../lib/shortcut_manager';
@@ -36,6 +38,10 @@ export const App: FC<{ history: ScopedHistory; appUpdater: BehaviorSubject<AppUp
   history,
   appUpdater,
 }) => {
+  const { euiTheme } = useEuiTheme();
+  // Reacts to reload-less color-mode toggles (replaces `background-color` in main.scss).
+  const containerStyles = useMemo(() => css({ backgroundColor: euiTheme.colors.body }), [euiTheme]);
+
   useEffect(() => {
     return history.listen(({ pathname, search }) => {
       const path = pathname + search;
@@ -52,7 +58,7 @@ export const App: FC<{ history: ScopedHistory; appUpdater: BehaviorSubject<AppUp
 
   return (
     <ShortcutManagerContextWrapper>
-      <div className="canvas canvasContainer">
+      <div className="canvas canvasContainer" css={containerStyles}>
         <CanvasRouter history={history} />
         <Flyouts />
       </div>

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_add/arg_add.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_add/arg_add.scss
@@ -2,16 +2,4 @@
   padding: $euiSizeM;
   text-align: left;
   width: 100%;
-
-  &:not(:last-child) {
-    border-bottom: $euiBorderThin;
-  }
-
-  &:hover {
-    background-color: $euiColorLightestShade;
-
-    label {
-      color: $euiColorDarkestShade;
-    }
-  }
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_add/arg_add.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_add/arg_add.tsx
@@ -6,11 +6,13 @@
  */
 
 import type { FC, ReactEventHandler } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
 import {
   EuiDescriptionList,
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
+  useEuiTheme,
 } from '@elastic/eui';
 
 interface Props {
@@ -20,8 +22,26 @@ interface Props {
 }
 
 export const ArgAdd: FC<Props> = ({ onValueAdd = () => {}, displayName, help }) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      &:not(:last-child) {
+        border-bottom: ${euiTheme.border.thin};
+      }
+
+      &:hover {
+        background-color: ${euiTheme.colors.lightestShade};
+
+        label {
+          color: ${euiTheme.colors.darkestShade};
+        }
+      }
+    `,
+    [euiTheme]
+  );
+
   return (
-    <button className="canvasArg__add" onClick={onValueAdd}>
+    <button className="canvasArg__add" css={styles} onClick={onValueAdd}>
       <EuiDescriptionList compressed>
         <EuiDescriptionListTitle>{displayName}</EuiDescriptionListTitle>
         <EuiDescriptionListDescription>

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_add_popover/arg_add_popover.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_add_popover/arg_add_popover.scss
@@ -3,8 +3,6 @@
 }
 
 .canvasArg__addPopover {
-  @include euiScrollBar;
-
   width: 250px;
   max-height: 500px;
 

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_add_popover/arg_add_popover.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_add_popover/arg_add_popover.tsx
@@ -6,8 +6,9 @@
  */
 
 import type { MouseEventHandler, FC } from 'react';
-import React from 'react';
-import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { EuiButtonIcon, EuiToolTip, useEuiScrollBar } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Popover } from '../popover';
 import { ArgAdd } from '../arg_add';
@@ -31,6 +32,14 @@ interface Props {
 }
 
 export const ArgAddPopover: FC<Props> = ({ options }) => {
+  const scrollBarStyles = useEuiScrollBar();
+  const panelStyles = useMemo(
+    () => css`
+      ${scrollBarStyles}
+    `,
+    [scrollBarStyles]
+  );
+
   const button = (handleClick: MouseEventHandler<HTMLButtonElement>) => (
     <EuiToolTip content={strings.getAddAriaLabel()} disableScreenReaderOutput>
       <EuiButtonIcon
@@ -46,6 +55,7 @@ export const ArgAddPopover: FC<Props> = ({ options }) => {
     <Popover
       id="arg-add-popover"
       panelClassName="canvasArg__addPopover"
+      panelProps={{ css: panelStyles }}
       panelPaddingSize="none"
       button={button}
     >

--- a/x-pack/platform/plugins/private/canvas/public/components/asset_manager/asset.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/asset_manager/asset.component.tsx
@@ -20,6 +20,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
+import { useCanvasCheckeredStyles } from '../../lib/use_canvas_checkered_styles';
 import { useNotifyService } from '../../services';
 
 import { ConfirmModal } from '../confirm_modal';
@@ -73,6 +74,7 @@ export interface Props {
 
 export const Asset: FC<Props> = ({ asset, onCreate, onDelete }) => {
   const { success } = useNotifyService();
+  const checkeredStyles = useCanvasCheckeredStyles();
   const [isConfirmModalVisible, setIsConfirmModalVisible] = useState(false);
 
   const onCopy = (result: boolean) => result && success(`Copied '${asset.id}' to clipboard`);
@@ -137,7 +139,7 @@ export const Asset: FC<Props> = ({ asset, onCreate, onDelete }) => {
   );
 
   const thumbnail = (
-    <div className="canvasAsset__thumb canvasCheckered">
+    <div className="canvasAsset__thumb canvasCheckered" css={checkeredStyles}>
       <EuiImage
         className="canvasAsset__img"
         size="original"

--- a/x-pack/platform/plugins/private/canvas/public/components/asset_picker/asset_picker.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/asset_picker/asset_picker.scss
@@ -1,5 +1,4 @@
 .canvasAssetPicker {
-  @include euiScrollBar;
   max-height: $euiSizeXXL * 3;
   overflow-x: hidden;
   overflow-y: auto;
@@ -9,10 +8,6 @@
     width: 100%;
     height: 100%;
     text-align: center;
-
-    &:hover {
-      outline: solid $euiSizeXS transparentize($euiColorPrimary, .9);
-    }
   }
 
   .canvasAssetPicker__selected {

--- a/x-pack/platform/plugins/private/canvas/public/components/asset_picker/asset_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/asset_picker/asset_picker.tsx
@@ -5,17 +5,66 @@
  * 2.0.
  */
 
-import React, { PureComponent } from 'react';
-import { EuiFlexGrid, EuiFlexItem, EuiLink, EuiImage, EuiIcon } from '@elastic/eui';
+import React, { PureComponent, useMemo } from 'react';
+import type { FC, PropsWithChildren } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiLink,
+  EuiImage,
+  EuiIcon,
+  transparentize,
+  useEuiScrollBar,
+  useEuiTheme,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import type { CanvasAsset } from '../../../types';
+import { useCanvasCheckeredStyles } from '../../lib/use_canvas_checkered_styles';
 
 const strings = {
   getAssetAltText: () =>
     i18n.translate('xpack.canvas.assetpicker.assetAltText', {
       defaultMessage: 'Asset thumbnail',
     }),
+};
+
+const AssetPickerGrid: FC<PropsWithChildren<{}>> = ({ children }) => {
+  const { euiTheme } = useEuiTheme();
+  const scrollBar = useEuiScrollBar();
+  const styles = useMemo(
+    () => css`
+      ${scrollBar}
+
+      & .canvasAssetPicker__link:hover {
+        outline: solid ${euiTheme.size.xs} ${transparentize(euiTheme.colors.primary, 0.1)};
+      }
+    `,
+    [euiTheme, scrollBar]
+  );
+
+  return (
+    <EuiFlexGrid
+      id="canvasAssetPicker"
+      className="canvasAssetPicker"
+      css={styles}
+      gutterSize="s"
+      columns={4}
+    >
+      {children}
+    </EuiFlexGrid>
+  );
+};
+
+const CheckeredFlexItem: FC<PropsWithChildren<{ id?: string }>> = ({ children, id }) => {
+  const checkeredStyles = useCanvasCheckeredStyles();
+
+  return (
+    <EuiFlexItem id={id} className="canvasCheckered" css={checkeredStyles}>
+      {children}
+    </EuiFlexItem>
+  );
 };
 
 interface Props {
@@ -36,12 +85,11 @@ export class AssetPicker extends PureComponent<Props> {
     const { assets, selected, onChange } = this.props;
 
     return (
-      <EuiFlexGrid id="canvasAssetPicker" className="canvasAssetPicker" gutterSize="s" columns={4}>
+      <AssetPickerGrid>
         {assets.map((asset) => (
-          <EuiFlexItem
+          <CheckeredFlexItem
             key={asset.id}
             id={asset.id === selected ? 'canvasAssetPicker__selectedAsset' : ''}
-            className="canvasCheckered"
           >
             <EuiLink
               className={`canvasAssetPicker__link`}
@@ -59,9 +107,9 @@ export class AssetPicker extends PureComponent<Props> {
                 />
               )}
             </EuiLink>
-          </EuiFlexItem>
+          </CheckeredFlexItem>
         ))}
-      </EuiFlexGrid>
+      </AssetPickerGrid>
     );
   }
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/color_dot/color_dot.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_dot/color_dot.scss
@@ -15,7 +15,6 @@
 
   .canvasColorDot__foreground {
     position: absolute;
-    border: $euiBorderThin;
     height: $euiSizeXL;
     width: $euiSizeXL;
     border-radius: $euiBorderRadius;

--- a/x-pack/platform/plugins/private/canvas/public/components/color_dot/color_dot.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_dot/color_dot.tsx
@@ -6,8 +6,11 @@
  */
 
 import type { FC, ReactNode } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
 import chroma from 'chroma-js';
+import { useCanvasCheckeredStyles } from '../../lib/use_canvas_checkered_styles';
 
 interface Props {
   /** Nodes to display within the dot.  Should fit within the constraints. */
@@ -17,6 +20,17 @@ interface Props {
 }
 
 export const ColorDot: FC<Props> = ({ value, children }) => {
+  const { euiTheme } = useEuiTheme();
+  const checkeredStyles = useCanvasCheckeredStyles();
+  const styles = useMemo(
+    () => css`
+      & .canvasColorDot__foreground {
+        border: ${euiTheme.border.thin};
+      }
+    `,
+    [euiTheme]
+  );
+
   let style = {};
 
   if (chroma.valid(value)) {
@@ -24,8 +38,8 @@ export const ColorDot: FC<Props> = ({ value, children }) => {
   }
 
   return (
-    <div className="canvasColorDot">
-      <div className="canvasColorDot__background canvasCheckered" />
+    <div className="canvasColorDot" css={styles}>
+      <div className="canvasColorDot__background canvasCheckered" css={checkeredStyles} />
       <div className="canvasColorDot__foreground" style={style}>
         {children}
       </div>

--- a/x-pack/platform/plugins/private/canvas/public/components/custom_element_modal/custom_element_modal.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/custom_element_modal/custom_element_modal.scss
@@ -10,7 +10,3 @@
 .canvasCustomElementForm__thumbnail {
   padding-bottom: 0;
 }
-
-.canvasCustomElementForm__thumbnailHelp {
-  color: $euiColorDarkShade;
-}

--- a/x-pack/platform/plugins/private/canvas/public/components/custom_element_modal/custom_element_modal.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/custom_element_modal/custom_element_modal.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import React, { PureComponent } from 'react';
+import React, { PureComponent, useMemo } from 'react';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { css } from '@emotion/react';
 import { get } from 'lodash';
 import {
   EuiButton,
@@ -24,12 +26,13 @@ import {
   EuiText,
   EuiTextArea,
   EuiTitle,
+  useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { encode } from '../../lib';
 import { VALID_IMAGE_TYPES } from '../../../common/lib/constants';
-import { ElementCard } from '../element_card';
+import { ElementCard, ElementCardWrapper } from '../element_card';
 const MAX_NAME_LENGTH = 40;
 const MAX_DESCRIPTION_LENGTH = 100;
 
@@ -75,6 +78,27 @@ const strings = {
       defaultMessage: 'Save',
     }),
 };
+
+const CustomElementForm: FC<
+  PropsWithChildren<{ grow?: ComponentProps<typeof EuiFlexItem>['grow'] }>
+> = ({ children, grow }) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      & .canvasCustomElementForm__thumbnailHelp {
+        color: ${euiTheme.colors.darkShade};
+      }
+    `,
+    [euiTheme]
+  );
+
+  return (
+    <EuiFlexItem className="canvasCustomElementForm" css={styles} grow={grow}>
+      {children}
+    </EuiFlexItem>
+  );
+};
+
 interface Props {
   /**
    * initial value of the name of the custom element
@@ -154,7 +178,7 @@ export class CustomElementModal extends PureComponent<Props, State> {
         </EuiModalHeader>
         <EuiModalBody>
           <EuiFlexGroup justifyContent="spaceBetween" alignItems="flexStart">
-            <EuiFlexItem className="canvasCustomElementForm" grow={2}>
+            <CustomElementForm grow={2}>
               <EuiFormRow
                 label={strings.getNameInputLabel()}
                 helpText={strings.getCharactersRemainingDescription(MAX_NAME_LENGTH - name.length)}
@@ -202,17 +226,14 @@ export class CustomElementModal extends PureComponent<Props, State> {
               <EuiText className="canvasCustomElementForm__thumbnailHelp" size="xs">
                 <p>{strings.getImageInputDescription()}</p>
               </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem
-              className="canvasElementCard__wrapper canvasCustomElementForm__preview"
-              grow={1}
-            >
+            </CustomElementForm>
+            <ElementCardWrapper className="canvasCustomElementForm__preview" grow={1}>
               <EuiTitle size="xxxs">
                 <h4>{strings.getElementPreviewTitle()}</h4>
               </EuiTitle>
               <EuiSpacer size="s" />
               <ElementCard title={name} description={description} image={image} />
-            </EuiFlexItem>
+            </ElementCardWrapper>
           </EuiFlexGroup>
         </EuiModalBody>
         <EuiModalFooter>

--- a/x-pack/platform/plugins/private/canvas/public/components/datatable/datatable.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/datatable/datatable.scss
@@ -6,16 +6,9 @@
   justify-content: space-between;
 
   .canvasDataTable__tableWrapper {
-    @include euiScrollBar;
     width: 100%;
     height: 100%;
     overflow: auto;
-
-    // removes white square in the scrollbar corner
-    // sass-lint:disable no-vendor-prefixes
-    &::-webkit-scrollbar-corner {
-      background: transparent;
-    }
   }
 
   .canvasDataTable__footer {
@@ -23,7 +16,6 @@
     display: flex;
     justify-content: space-around;
     padding: $euiSizeS;
-    border-top: $euiBorderThin;
   }
 
   .canvasDataTable__table {
@@ -33,7 +25,6 @@
   .canvasDataTable__th,
   .canvasDataTable__td {
     padding: $euiSizeS $euiSizeXS;
-    border-bottom: $euiBorderThin;
   }
 
   .canvasDataTable__th {

--- a/x-pack/platform/plugins/private/canvas/public/components/datatable/datatable.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/datatable/datatable.tsx
@@ -6,9 +6,10 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { EuiIcon, EuiPagination, useEuiScrollBar, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { EuiIcon, EuiPagination } from '@elastic/eui';
 import moment from 'moment';
 import { Paginate } from '../paginate';
 import type {
@@ -68,51 +69,77 @@ export const Datatable: FC<Props> = ({
   paginate = false,
   perPage = 10,
   showHeader = false,
-}) => (
-  <Paginate rows={datatable.rows} perPage={perPage}>
-    {({ rows, setPage, pageNumber, totalPages }) => (
-      <div className="canvasDataTable">
-        <div className="canvasDataTable__tableWrapper">
-          <table className="canvasDataTable__table">
-            {!showHeader ? null : (
-              <thead className="canvasDataTable__thead">
-                <tr className="canvasDataTable__tr">
-                  {datatable.columns.map((col) => (
-                    <th key={`header-${getColumnName(col)}`} className="canvasDataTable__th">
-                      {getColumnName(col)}
-                      &nbsp;
-                      {getIcon(getColumnType(col))}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-            )}
-            <tbody className="canvasDataTable__tbody">
-              {rows.map((row, i) => (
-                <tr key={i} className="canvasDataTable__tr">
-                  {datatable.columns.map((col) => (
-                    <td key={`row-${i}-${getColumnName(col)}`} className="canvasDataTable__td">
-                      {getFormattedValue(row[getColumnId(col)], getColumnType(col))}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        {paginate && (
-          <div className="canvasDataTable__footer">
-            <EuiPagination
-              aria-label={i18n.translate('xpack.canvas.canvasDatatable.pagination.ariaLabel', {
-                defaultMessage: 'Data table pages',
-              })}
-              pageCount={totalPages}
-              activePage={pageNumber}
-              onPageClick={setPage}
-            />
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const scrollBar = useEuiScrollBar();
+  const styles = useMemo(
+    () => css`
+      & .canvasDataTable__tableWrapper {
+        ${scrollBar}
+
+        &::-webkit-scrollbar-corner {
+          background: transparent;
+        }
+      }
+
+      & .canvasDataTable__footer {
+        border-top: ${euiTheme.border.thin};
+      }
+
+      & .canvasDataTable__th,
+      & .canvasDataTable__td {
+        border-bottom: ${euiTheme.border.thin};
+      }
+    `,
+    [euiTheme, scrollBar]
+  );
+
+  return (
+    <Paginate rows={datatable.rows} perPage={perPage}>
+      {({ rows, setPage, pageNumber, totalPages }) => (
+        <div className="canvasDataTable" css={styles}>
+          <div className="canvasDataTable__tableWrapper">
+            <table className="canvasDataTable__table">
+              {!showHeader ? null : (
+                <thead className="canvasDataTable__thead">
+                  <tr className="canvasDataTable__tr">
+                    {datatable.columns.map((col) => (
+                      <th key={`header-${getColumnName(col)}`} className="canvasDataTable__th">
+                        {getColumnName(col)}
+                        &nbsp;
+                        {getIcon(getColumnType(col))}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+              )}
+              <tbody className="canvasDataTable__tbody">
+                {rows.map((row, i) => (
+                  <tr key={i} className="canvasDataTable__tr">
+                    {datatable.columns.map((col) => (
+                      <td key={`row-${i}-${getColumnName(col)}`} className="canvasDataTable__td">
+                        {getFormattedValue(row[getColumnId(col)], getColumnType(col))}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-        )}
-      </div>
-    )}
-  </Paginate>
-);
+          {paginate && (
+            <div className="canvasDataTable__footer">
+              <EuiPagination
+                aria-label={i18n.translate('xpack.canvas.canvasDatatable.pagination.ariaLabel', {
+                  defaultMessage: 'Data table pages',
+                })}
+                pageCount={totalPages}
+                activePage={pageNumber}
+                onPageClick={setPage}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </Paginate>
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/components/element_card/element_card.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/element_card/element_card.scss
@@ -17,7 +17,6 @@
     opacity: 0;
     transition: opacity $euiAnimSpeedFast $euiAnimSlightResistance;
     transition-delay: $euiAnimSpeedNormal;
-    background: transparentize($euiColorPlainLight, .5);
     border-radius: $euiBorderRadius;
   }
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/element_card/element_card.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/element_card/element_card.tsx
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
-import React from 'react';
-import { EuiCard, EuiIcon } from '@elastic/eui';
+import type { FC, PropsWithChildren } from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import type { EuiFlexItemProps } from '@elastic/eui';
+import { EuiCard, EuiFlexItem, EuiIcon, transparentize, useEuiTheme } from '@elastic/eui';
+import classNames from 'classnames';
 import { TagList } from '../tag_list';
 
 export interface Props {
@@ -33,6 +37,32 @@ export interface Props {
 }
 
 const tagType = 'badge';
+
+export const ElementCardWrapper: FC<PropsWithChildren<EuiFlexItemProps>> = ({
+  children,
+  className,
+  ...rest
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      & .canvasElementCard__controls {
+        background: ${transparentize(euiTheme.colors.plainLight, 0.5)};
+      }
+    `,
+    [euiTheme]
+  );
+
+  return (
+    <EuiFlexItem
+      className={classNames('canvasElementCard__wrapper', className)}
+      css={styles}
+      {...rest}
+    >
+      {children}
+    </EuiFlexItem>
+  );
+};
 
 export const ElementCard = ({ title, description, image, tags = [], onClick, ...rest }: Props) => (
   <EuiCard

--- a/x-pack/platform/plugins/private/canvas/public/components/element_card/index.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/element_card/index.tsx
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { ElementCard } from './element_card';
+export { ElementCard, ElementCardWrapper } from './element_card';

--- a/x-pack/platform/plugins/private/canvas/public/components/expression/expression.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/expression/expression.scss
@@ -53,6 +53,4 @@
 
 .canvasExpression__settings {
   padding: $euiSizeM $euiSize;
-  border-top: $euiBorderThin;
-  background-color: $euiColorEmptyShade;
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/expression/expression.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/expression/expression.tsx
@@ -6,7 +6,8 @@
  */
 
 import type { FC } from 'react';
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
+import { css } from '@emotion/react';
 import {
   EuiPanel,
   EuiButton,
@@ -16,6 +17,7 @@ import {
   EuiToolTip,
   EuiLink,
   EuiPortal,
+  useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { monaco } from '@kbn/monaco';
@@ -99,7 +101,17 @@ export const Expression: FC<Props> = ({
   isCompact,
   toggleCompactView,
 }) => {
+  const { euiTheme } = useEuiTheme();
   const refExpressionInput: ExpressionInputEditorRef = useRef(null);
+
+  const settingsStyles = useMemo(
+    () =>
+      css({
+        borderTop: euiTheme.border.thin,
+        backgroundColor: euiTheme.colors.emptyShade,
+      }),
+    [euiTheme]
+  );
 
   const handleRun = () => {
     setExpression(formState.expression);
@@ -150,7 +162,7 @@ export const Expression: FC<Props> = ({
         onEditorDidMount={onEditorDidMount}
         editorRef={refExpressionInput}
       />
-      <div className="canvasExpression__settings">
+      <div className="canvasExpression__settings" css={settingsStyles}>
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center">

--- a/x-pack/platform/plugins/private/canvas/public/components/fullscreen/fullscreen.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/fullscreen/fullscreen.scss
@@ -15,11 +15,6 @@ body.canvas-isFullscreen {
     display: none;
   }
 
-  // set the background color
-  .canvasLayout {
-    background: $euiColorPlainDark;
-  }
-
   // hide all the interface parts
   .canvasLayout__stageHeader,
   .canvasLayout__sidebar,

--- a/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/upload_dropzone.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/upload_dropzone.component.tsx
@@ -6,7 +6,9 @@
  */
 
 import type { FC, PropsWithChildren } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
 import Dropzone from 'react-dropzone';
 
 import './upload_dropzone.scss';
@@ -21,6 +23,17 @@ export const UploadDropzone: FC<PropsWithChildren<Props>> = ({
   disabled,
   children,
 }) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      &.canvasWorkpad__dropzone--active {
+        background-color: ${euiTheme.colors.lightestShade};
+        border-color: ${euiTheme.colors.lightShade};
+      }
+    `,
+    [euiTheme]
+  );
+
   const dropFn = (acceptedFiles: File[]) => {
     const fileList = acceptedFiles as unknown as FileList;
     onDrop(fileList);
@@ -34,6 +47,7 @@ export const UploadDropzone: FC<PropsWithChildren<Props>> = ({
               isDragActive ? ' canvasWorkpad__dropzone--active' : ''
             }`,
           })}
+          css={styles}
         >
           {children}
         </div>

--- a/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/upload_dropzone.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/upload_dropzone.scss
@@ -1,8 +1,3 @@
 .canvasWorkpad__dropzone {
   border: 2px dashed transparent;
 }
-
-.canvasWorkpad__dropzone--active {
-  background-color: $euiColorLightestShade;
-  border-color: $euiColorLightShade;
-}

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/border_connection.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/border_connection.tsx
@@ -6,7 +6,9 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -16,16 +18,28 @@ interface Props {
   width: number;
 }
 
-export const BorderConnection: FC<Props> = ({ transformMatrix, width, height }) => (
-  <div
-    className="canvasBorderConnection canvasLayoutAnnotation"
-    style={{
-      height,
-      marginLeft: -width / 2,
-      marginTop: -height / 2,
-      position: 'absolute',
-      transform: matrixToCSS(transformMatrix),
-      width,
-    }}
-  />
-);
+export const BorderConnection: FC<Props> = ({ transformMatrix, width, height }) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      border-top: 1px dashed ${euiTheme.colors.lightShade};
+      border-left: 1px dashed ${euiTheme.colors.lightShade};
+    `,
+    [euiTheme]
+  );
+
+  return (
+    <div
+      className="canvasBorderConnection canvasLayoutAnnotation"
+      css={styles}
+      style={{
+        height,
+        marginLeft: -width / 2,
+        marginTop: -height / 2,
+        position: 'absolute',
+        transform: matrixToCSS(transformMatrix),
+        width,
+      }}
+    />
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/border_resize_handle.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/border_resize_handle.tsx
@@ -6,7 +6,9 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiShadow, useEuiTheme } from '@elastic/eui';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -15,11 +17,25 @@ interface Props {
   zoomScale?: number;
 }
 
-export const BorderResizeHandle: FC<Props> = ({ transformMatrix, zoomScale = 1 }) => (
-  <div
-    className="canvasBorderResizeHandle canvasLayoutAnnotation"
-    style={{
-      transform: `${matrixToCSS(transformMatrix)} scale3d(${1 / zoomScale},${1 / zoomScale}, 1)`,
-    }}
-  />
-);
+export const BorderResizeHandle: FC<Props> = ({ transformMatrix, zoomScale = 1 }) => {
+  const { euiTheme } = useEuiTheme();
+  const slightShadow = useEuiShadow('xs');
+  const styles = useMemo(
+    () => css`
+      ${slightShadow}
+      background-color: ${euiTheme.colors.emptyShade};
+      border: 1px solid ${euiTheme.colors.darkShade};
+    `,
+    [euiTheme, slightShadow]
+  );
+
+  return (
+    <div
+      className="canvasBorderResizeHandle canvasLayoutAnnotation"
+      css={styles}
+      style={{
+        transform: `${matrixToCSS(transformMatrix)} scale3d(${1 / zoomScale},${1 / zoomScale}, 1)`,
+      }}
+    />
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/dragbox_annotation.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/dragbox_annotation.tsx
@@ -6,7 +6,9 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -16,15 +18,26 @@ interface Props {
   width: number;
 }
 
-export const DragBoxAnnotation: FC<Props> = ({ transformMatrix, width, height }) => (
-  <div
-    className="canvasDragBoxAnnotation canvasLayoutAnnotation"
-    style={{
-      height,
-      marginLeft: -width / 2,
-      marginTop: -height / 2,
-      transform: matrixToCSS(transformMatrix),
-      width,
-    }}
-  />
-);
+export const DragBoxAnnotation: FC<Props> = ({ transformMatrix, width, height }) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      outline: dashed 1px ${euiTheme.colors.darkShade};
+    `,
+    [euiTheme]
+  );
+
+  return (
+    <div
+      className="canvasDragBoxAnnotation canvasLayoutAnnotation"
+      css={styles}
+      style={{
+        height,
+        marginLeft: -width / 2,
+        marginTop: -height / 2,
+        transform: matrixToCSS(transformMatrix),
+        width,
+      }}
+    />
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/hover_annotation.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/hover_annotation.tsx
@@ -6,7 +6,9 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -16,15 +18,26 @@ interface Props {
   width: number;
 }
 
-export const HoverAnnotation: FC<Props> = ({ transformMatrix, width, height }) => (
-  <div
-    className="canvasHoverAnnotation canvasLayoutAnnotation"
-    style={{
-      width,
-      height,
-      marginLeft: -width / 2,
-      marginTop: -height / 2,
-      transform: matrixToCSS(transformMatrix),
-    }}
-  />
-);
+export const HoverAnnotation: FC<Props> = ({ transformMatrix, width, height }) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      outline: solid 1px ${euiTheme.colors.vis.euiColorVis0};
+    `,
+    [euiTheme]
+  );
+
+  return (
+    <div
+      className="canvasHoverAnnotation canvasLayoutAnnotation"
+      css={styles}
+      style={{
+        width,
+        height,
+        marginLeft: -width / 2,
+        marginTop: -height / 2,
+        transform: matrixToCSS(transformMatrix),
+      }}
+    />
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/layout_annotations.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/layout_annotations.scss
@@ -9,12 +9,9 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  border-top: 1px dashed $euiColorLightShade;
-  border-left: 1px dashed $euiColorLightShade;
 }
 
 .canvasBorderResizeHandle {
-  @include euiSlightShadow;
   transform-origin: center center; /* the default, only for clarity */
   transform-style: preserve-3d;
   display: block;
@@ -23,8 +20,6 @@
   width: $euiSizeS;
   margin-left: -4px;
   margin-top: -4px;
-  background-color: $euiColorEmptyShade;
-  border: 1px solid $euiColorDarkShade;
 }
 
 .canvasDragBoxAnnotation {
@@ -32,7 +27,6 @@
   background: none;
   transform-origin: center center; /* the default, only for clarity */
   transform-style: preserve-3d;
-  outline: dashed 1px $euiColorDarkShade;
   pointer-events: none;
 }
 
@@ -41,7 +35,6 @@
   background: none;
   transform-origin: center center; /* the default, only for clarity */
   transform-style: preserve-3d;
-  outline: solid 1px $euiColorVis0;
   pointer-events: none;
 }
 
@@ -54,8 +47,6 @@
   width: 0;
   margin-left: -1px;
   margin-top: -12px;
-  border-top: 1px dashed $euiColorLightShade;
-  border-left: 1px dashed $euiColorLightShade;
 }
 
 .canvasRotationHandle__handle {
@@ -68,11 +59,9 @@
   margin-left: -5px;
   margin-top: -6px;
   border-radius: 50%;
-  background-color: $euiColorMediumShade;
 }
 
 .tooltipAnnotation {
-  @include euiToolTipStyle($size: 's');
   position: absolute;
   transform-origin: center center; /* the default, only for clarity */
   transform-style: preserve-3d;

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/rotation_handle.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/rotation_handle.tsx
@@ -6,7 +6,9 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -15,16 +17,32 @@ interface Props {
   zoomScale?: number;
 }
 
-export const RotationHandle: FC<Props> = ({ transformMatrix, zoomScale = 1 }) => (
-  <div
-    className="canvasRotationHandle canvasLayoutAnnotation"
-    style={{
-      transform: matrixToCSS(transformMatrix),
-    }}
-  >
+export const RotationHandle: FC<Props> = ({ transformMatrix, zoomScale = 1 }) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemo(
+    () => css`
+      border-top: 1px dashed ${euiTheme.colors.lightShade};
+      border-left: 1px dashed ${euiTheme.colors.lightShade};
+
+      .canvasRotationHandle__handle {
+        background-color: ${euiTheme.colors.mediumShade};
+      }
+    `,
+    [euiTheme]
+  );
+
+  return (
     <div
-      className="canvasRotationHandle__handle"
-      style={{ transform: `scale3d(${1 / zoomScale},${1 / zoomScale},1)` }}
-    />
-  </div>
-);
+      className="canvasRotationHandle canvasLayoutAnnotation"
+      css={styles}
+      style={{
+        transform: matrixToCSS(transformMatrix),
+      }}
+    >
+      <div
+        className="canvasRotationHandle__handle"
+        style={{ transform: `scale3d(${1 / zoomScale},${1 / zoomScale},1)` }}
+      />
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/tooltip_annotation.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/tooltip_annotation.tsx
@@ -6,7 +6,11 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
+// @ts-expect-error style types not defined
+import { euiToolTipStyles } from '@elastic/eui/lib/components/tool_tip/tool_tip.styles';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -16,11 +20,20 @@ interface Props {
 }
 
 export const TooltipAnnotation: FC<Props> = ({ transformMatrix, text }) => {
+  const euiThemeContext = useEuiTheme();
+  const styles = useMemo(() => {
+    const euiStyles = euiToolTipStyles(euiThemeContext);
+
+    return css`
+      ${euiStyles.euiToolTip}
+    `;
+  }, [euiThemeContext]);
+
   const newStyle = {
     transform: `${matrixToCSS(transformMatrix)} translate(1em, -1em)`,
   };
   return (
-    <div className="tooltipAnnotation canvasLayoutAnnotation" style={newStyle}>
+    <div className="tooltipAnnotation canvasLayoutAnnotation" css={styles} style={newStyle}>
       <p>{text}°</p>
     </div>
   );

--- a/x-pack/platform/plugins/private/canvas/public/components/loading/loading.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/loading/loading.scss
@@ -1,5 +1,4 @@
 .canvasLoading {
   display: flex;
-  color: $euiColorLightShade;
   align-items: center;
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/loading/loading.test.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/loading/loading.test.tsx
@@ -14,7 +14,7 @@ describe('<Loading />', () => {
     const { container } = render(<Loading />);
     expect(container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="canvasLoading"
+        class="canvasLoading css-rut3xs-loadingStyles"
       >
         <span
           aria-hidden="true"
@@ -29,7 +29,7 @@ describe('<Loading />', () => {
     const { container } = render(<Loading animated />);
     expect(container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="canvasLoading"
+        class="canvasLoading css-rut3xs-loadingStyles"
       >
         <span
           aria-label="Loading"

--- a/x-pack/platform/plugins/private/canvas/public/components/loading/loading.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/loading/loading.tsx
@@ -6,8 +6,9 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
-import { EuiIcon, EuiLoadingSpinner, isColorDark } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { EuiIcon, EuiLoadingSpinner, isColorDark, useEuiTheme } from '@elastic/eui';
 import { hexToRgb } from '../../../common/lib/hex_to_rgb';
 
 interface Props {
@@ -21,9 +22,12 @@ export const Loading: FC<Props> = ({
   text = '',
   backgroundColor = '#000000',
 }) => {
+  const { euiTheme } = useEuiTheme();
+  const loadingStyles = useMemo(() => css({ color: euiTheme.colors.lightShade }), [euiTheme]);
+
   if (animated) {
     return (
-      <div className="canvasLoading">
+      <div className="canvasLoading" css={loadingStyles}>
         {text && (
           <span>
             {text}
@@ -43,7 +47,7 @@ export const Loading: FC<Props> = ({
   }
 
   return (
-    <div className="canvasLoading">
+    <div className="canvasLoading" css={loadingStyles}>
       {text && (
         <span>
           {text}

--- a/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.component.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Fragment, Component } from 'react';
+import React, { Fragment, Component, useMemo } from 'react';
 import type { DragDropContextProps } from '@elastic/eui';
 import {
   EuiIcon,
@@ -16,7 +16,13 @@ import {
   EuiDragDropContext,
   EuiDraggable,
   EuiDroppable,
+  shade,
+  transparentize,
+  useEuiScrollBar,
+  useEuiShadow,
+  useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 
 import { ConfirmModal } from '../confirm_modal';
@@ -60,6 +66,73 @@ interface State {
   showTrayPop: boolean;
   removeId: string | null;
 }
+
+const PageManagerRoot = ({ children }: { children: React.ReactNode }) => {
+  const { euiTheme } = useEuiTheme();
+  const scrollBar = useEuiScrollBar();
+  const shadowSmall = useEuiShadow('s');
+  const shadowMedium = useEuiShadow('m');
+  const styles = useMemo(
+    () => css`
+      & .canvasPageManager__pageList {
+        ${scrollBar}
+      }
+
+      & .canvasPageManager__addPage {
+        background: ${euiTheme.colors.primary};
+        color: ${euiTheme.colors.plainLight};
+      }
+
+      & .canvasPageManager__page {
+        &:focus,
+        &.canvasPageManager__page-isActive {
+          background-color: ${transparentize(shade(euiTheme.colors.lightestShade, 0.3), 0.5)};
+        }
+
+        &.canvasPageManager__page-isActive:focus {
+          .canvasPageManager__pagePreview {
+            outline-color: ${euiTheme.colors.vis.euiColorVis0};
+          }
+        }
+
+        &:hover,
+        &:focus {
+          .canvasPageManager__pagePreview {
+            ${shadowMedium}
+          }
+        }
+
+        &.canvasPageManager__page-isActive {
+          .canvasPageManager__pagePreview {
+            ${shadowMedium}
+            outline: ${euiTheme.border.thick};
+            outline-color: ${euiTheme.colors.darkShade};
+          }
+        }
+      }
+
+      & .canvasPageManager__pageNumber {
+        color: ${euiTheme.colors.darkShade};
+      }
+
+      & .canvasPageManager__pagePreview {
+        ${shadowSmall}
+        color: ${euiTheme.colors.text};
+      }
+
+      & .canvasPageManager__controls {
+        background: ${transparentize(euiTheme.colors.plainLight, 0.5)};
+      }
+    `,
+    [euiTheme, scrollBar, shadowSmall, shadowMedium]
+  );
+
+  return (
+    <EuiFlexGroup gutterSize="none" className="canvasPageManager" css={styles}>
+      {children}
+    </EuiFlexGroup>
+  );
+};
 
 export class PageManager extends Component<Props, State> {
   constructor(props: Props) {
@@ -204,7 +277,7 @@ export class PageManager extends Component<Props, State> {
 
     return (
       <Fragment>
-        <EuiFlexGroup gutterSize="none" className="canvasPageManager">
+        <PageManagerRoot>
           <EuiFlexItem className="canvasPageManager__pages">
             <EuiDragDropContext onDragEnd={this.onDragEnd}>
               <EuiDroppable droppableId="droppable-page-manager" grow={true} direction="horizontal">
@@ -236,7 +309,7 @@ export class PageManager extends Component<Props, State> {
               </EuiToolTip>
             </EuiFlexItem>
           )}
-        </EuiFlexGroup>
+        </PageManagerRoot>
         <ConfirmModal
           isOpen={removeId !== null}
           title={strings.getConfirmRemoveTitle()}

--- a/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.scss
@@ -20,7 +20,6 @@
   }
 
   .canvasPageManager__pageList {
-    @include euiScrollBar;
     display: flex;
     overflow-x: auto;
     overflow-y: hidden;
@@ -33,8 +32,6 @@
 
   .canvasPageManager__addPage {
     width: $euiSizeXXL + $euiSize;
-    background: $euiColorPrimary;
-    color: $euiColorPlainLight;
     opacity: 0;
     animation: buttonPop $euiAnimSpeedNormal $euiAnimSlightResistance;
     animation-fill-mode: forwards;
@@ -50,49 +47,24 @@
 
     &:focus,
     &-isActive {
-      background-color: transparentize(darken($euiColorLightestShade, 30%), .5);
       outline: none;
       text-decoration: none;
-    }
-
-    &-isActive:focus {
-      .canvasPageManager__pagePreview {
-        outline-color: $euiColorVis0;
-      }
     }
 
     &:hover,
     &:focus {
       text-decoration: none;
 
-      .canvasPageManager__pagePreview {
-        @include euiBottomShadowMedium;
-      }
-
       .canvasPageManager__controls {
         visibility: visible;
         opacity: 1;
       }
     }
-
-    &-isActive {
-      .canvasPageManager__pagePreview {
-        @include euiBottomShadowMedium;
-        outline: $euiBorderThick;
-        outline-color: $euiColorDarkShade;
-      }
-    }
-  }
-
-  .canvasPageManager__pageNumber {
-    color: $euiColorDarkShade;
   }
 
   .canvasPageManager__pagePreview {
-    @include euiBottomShadowSmall;
     position: relative;
     overflow: hidden;
-    color: $euiTextColor;
 
     .canvasPositionable {
       position: absolute;
@@ -107,7 +79,6 @@
     opacity: 0;
     transition: opacity $euiAnimSpeedFast $euiAnimSlightResistance;
     transition-delay: $euiAnimSpeedNormal;
-    background: transparentize($euiColorPlainLight, .5);
     border-radius: $euiBorderRadius;
   }
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/popover/popover.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/popover/popover.tsx
@@ -16,6 +16,7 @@ interface Props {
   ownFocus?: boolean;
   tooltip?: string;
   panelClassName?: string;
+  panelProps?: React.ComponentProps<typeof EuiPopover>['panelProps'];
   anchorPosition?: string;
   panelPaddingSize?: 'none' | 's' | 'm' | 'l';
   id?: string;

--- a/x-pack/platform/plugins/private/canvas/public/components/saved_elements_modal/element_grid.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/saved_elements_modal/element_grid.tsx
@@ -7,10 +7,10 @@
 
 import React from 'react';
 import { map } from 'lodash';
-import { EuiFlexItem, EuiFlexGrid } from '@elastic/eui';
+import { EuiFlexGrid } from '@elastic/eui';
 import { ElementControls } from './element_controls';
 import type { CustomElement } from '../../../types';
-import { ElementCard } from '../element_card';
+import { ElementCard, ElementCardWrapper } from '../element_card';
 
 export interface Props {
   /**
@@ -54,7 +54,7 @@ export const ElementGrid = ({ elements, filterText = '', onClick, onEdit, onDele
         }
 
         return (
-          <EuiFlexItem key={index} className="canvasElementCard__wrapper">
+          <ElementCardWrapper key={index}>
             <ElementCard
               title={displayName || name}
               description={help}
@@ -62,7 +62,7 @@ export const ElementGrid = ({ elements, filterText = '', onClick, onEdit, onDele
               onClick={whenClicked}
             />
             <ElementControls onEdit={() => onEdit(element)} onDelete={() => onDelete(element)} />
-          </EuiFlexItem>
+          </ElementCardWrapper>
         );
       })}
     </EuiFlexGrid>

--- a/x-pack/platform/plugins/private/canvas/public/components/sidebar/sidebar.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/sidebar/sidebar.scss
@@ -1,6 +1,4 @@
 .canvasSidebar {
-  @include euiScrollBar;
-
   width: 100%;
   max-height: 100vh;
   overflow-y: auto;
@@ -20,12 +18,10 @@
 }
 
 .canvasSidebar__elementButtons {
-  background: darken($euiColorLightestShade, 5%);
   margin-bottom: $euiSizeS;
 }
 
 .canvasSidebar__panel {
-  border-bottom: $euiBorderThin;
   padding: $euiSizeS $euiSizeM;
 
   &--isEmpty {
@@ -66,12 +62,7 @@
 .canvasSidebar__accordion {
   padding: $euiSizeM;
   margin: 0 (-$euiSizeM);
-  background: $euiColorLightestShade;
   position: relative;
-
-  &.euiAccordion-isOpen {
-    background: transparent;
-  }
 
   &:before,
   &:after {
@@ -80,7 +71,6 @@
     position: absolute;
     left: 0;
     width: 100%;
-    background: $euiColorLightShade;
   }
 
   &:before {

--- a/x-pack/platform/plugins/private/canvas/public/components/sidebar/sidebar.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/sidebar/sidebar.tsx
@@ -6,7 +6,9 @@
  */
 
 import type { FunctionComponent } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { shade, useEuiScrollBar, useEuiTheme } from '@elastic/eui';
 import { SidebarContent } from './sidebar_content';
 
 interface Props {
@@ -14,8 +16,38 @@ interface Props {
 }
 
 export const Sidebar: FunctionComponent<Props> = ({ commit }) => {
+  const { euiTheme } = useEuiTheme();
+  const scrollBar = useEuiScrollBar();
+  const styles = useMemo(
+    () => css`
+      ${scrollBar}
+
+      & .canvasSidebar__elementButtons {
+        background: ${shade(euiTheme.colors.lightestShade, 0.05)};
+      }
+
+      & .canvasSidebar__panel {
+        border-bottom: ${euiTheme.border.thin};
+      }
+
+      & .canvasSidebar__accordion {
+        background: ${euiTheme.colors.lightestShade};
+
+        &.euiAccordion-isOpen {
+          background: transparent;
+        }
+
+        &:before,
+        &:after {
+          background: ${euiTheme.colors.lightShade};
+        }
+      }
+    `,
+    [euiTheme, scrollBar]
+  );
+
   return (
-    <div className="canvasSidebar">
+    <div className="canvasSidebar" css={styles}>
       <SidebarContent commit={commit} />
     </div>
   );

--- a/x-pack/platform/plugins/private/canvas/public/components/toolbar/toolbar.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/toolbar/toolbar.component.tsx
@@ -6,8 +6,16 @@
  */
 
 import type { FC } from 'react';
-import React, { useState, useContext, useEffect } from 'react';
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React, { useState, useContext, useEffect, useMemo } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  shade,
+  transparentize,
+  useEuiTheme,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { PageManager } from '../page_manager';
@@ -59,8 +67,25 @@ export const Toolbar: FC<Props> = ({
   totalPages,
   workpadName,
 }) => {
+  const { euiTheme } = useEuiTheme();
   const [activeTray, setActiveTray] = useState<TrayType | null>(null);
   const { getUrl, previousPage } = useContext(WorkpadRoutingContext);
+  const styles = useMemo(
+    () => css`
+      & .canvasTray__toggle {
+        background-color: ${euiTheme.components.forms.background};
+
+        button {
+          box-shadow: 0 -2px 1px ${transparentize(euiTheme.colors.fullShade, 0.1)};
+        }
+      }
+
+      & .canvasToolbar__container {
+        background-color: ${shade(euiTheme.colors.lightestShade, 0.05)};
+      }
+    `,
+    [euiTheme]
+  );
 
   // While the tray doesn't get activated if the workpad isn't writeable,
   // this effect will ensure that if the tray is open and the workpad
@@ -90,7 +115,7 @@ export const Toolbar: FC<Props> = ({
   };
 
   return (
-    <div className="canvasToolbar hide-for-sharing">
+    <div className="canvasToolbar hide-for-sharing" css={styles}>
       {activeTray !== null && <Tray done={() => setActiveTray(null)}>{trays[activeTray]}</Tray>}
       <div className="canvasToolbar__container">
         <EuiFlexGroup gutterSize="none" alignItems="center">

--- a/x-pack/platform/plugins/private/canvas/public/components/toolbar/toolbar.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/toolbar/toolbar.scss
@@ -6,7 +6,6 @@
   position: absolute;
   top: $euiSize * -1.25;
   left: 50%;
-  background-color: $euiFormBackgroundColor;
   margin: 0;
   border-radius: $euiBorderRadius $euiBorderRadius 0 0;
 
@@ -16,7 +15,6 @@
 
   button {
     padding: $euiSizeXS $euiSizeM;
-    box-shadow: 0 -2px 1px transparentize($euiColorFullShade, .9);
   }
 }
 
@@ -33,7 +31,6 @@
 .canvasToolbar__container {
   width: 100%;
   height: $euiSizeXL * 2;
-  background-color: darken($euiColorLightestShade, 5%);
   position: relative;
   z-index: 200;
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/toolbar/tray/tray.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/toolbar/tray/tray.scss
@@ -1,9 +1,7 @@
 .canvasTray {
-  @include euiBottomShadowFlat;
   flex-direction: column;
 }
 
 .canvasTray__panel {
-  background-color: $euiFormBackgroundColor;
   border-radius: 0;
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/toolbar/tray/tray.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/toolbar/tray/tray.tsx
@@ -6,8 +6,16 @@
  */
 
 import type { ReactNode, MouseEventHandler } from 'react';
-import React from 'react';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiToolTip,
+  useEuiShadowFlat,
+  useEuiTheme,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 const strings = {
@@ -23,6 +31,19 @@ interface Props {
 }
 
 export const Tray = ({ children, done }: Props) => {
+  const { euiTheme } = useEuiTheme();
+  const shadowFlat = useEuiShadowFlat();
+  const styles = useMemo(
+    () => css`
+      ${shadowFlat}
+
+      & .canvasTray__panel {
+        background-color: ${euiTheme.components.forms.background};
+      }
+    `,
+    [euiTheme, shadowFlat]
+  );
+
   return (
     <>
       <EuiFlexGroup className="canvasTray__toggle" justifyContent="spaceAround">
@@ -37,7 +58,9 @@ export const Tray = ({ children, done }: Props) => {
           </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <div className="canvasTray">{children}</div>
+      <div className="canvasTray" css={styles}>
+        {children}
+      </div>
     </>
   );
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad/workpad.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad/workpad.component.tsx
@@ -8,10 +8,12 @@
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
 // @ts-expect-error
 import { WorkpadPage } from '../workpad_page';
 import { Fullscreen } from '../fullscreen';
 import { WORKPAD_CANVAS_BUFFER, DEFAULT_WORKPAD_CSS } from '../../../common/lib/constants';
+import { useCanvasCheckeredStyles } from '../../lib/use_canvas_checkered_styles';
 import type { CommitFn, CanvasPage } from '../../../types';
 import { WorkpadShortcuts } from './workpad_shortcuts.component';
 
@@ -68,6 +70,22 @@ export const Workpad: FC<Props> = ({
   zoomOut,
   zoomScale,
 }) => {
+  const { euiTheme } = useEuiTheme();
+  const checkeredStyles = useCanvasCheckeredStyles();
+  const workpadStyles = useMemo(
+    () => css`
+      .canvasGrid {
+        background-image: linear-gradient(
+            to right,
+            ${euiTheme.colors.mediumShade} 1px,
+            transparent 1px
+          ),
+          linear-gradient(to bottom, ${euiTheme.colors.mediumShade} 1px, transparent 1px);
+      }
+    `,
+    [euiTheme]
+  );
+
   const headerBannerOffset = useMemo(() => {
     if (!hasHeaderBanner) return 0;
     if (typeof document === 'undefined') return 0;
@@ -88,6 +106,7 @@ export const Workpad: FC<Props> = ({
     <div className="canvasWorkpad__buffer" style={bufferStyle}>
       <div
         className="canvasCheckered"
+        css={checkeredStyles}
         style={{
           height,
           width,
@@ -133,7 +152,7 @@ export const Workpad: FC<Props> = ({
             // NOTE: the data-shared-* attributes here are used for reporting
             return (
               <div
-                css={css(workpadCss || DEFAULT_WORKPAD_CSS)}
+                css={[css(workpadCss || DEFAULT_WORKPAD_CSS), workpadStyles]}
                 className={`canvasWorkpad ${isFullscreenProp ? 'fullscreen' : ''}`}
                 style={fsStyle}
                 data-shared-items-count={totalElementCount}

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad/workpad.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad/workpad.scss
@@ -11,8 +11,6 @@
   position: absolute;
   user-select: none;
   pointer-events: none;
-  background-image: linear-gradient(to right, $euiColorMediumShade 1px, transparent 1px),
-    linear-gradient(to bottom, $euiColorMediumShade 1px, transparent 1px);
   background-size: 50px 50px;
   top: 0;
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_app/workpad_app.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_app/workpad_app.component.tsx
@@ -6,7 +6,9 @@
  */
 
 import type { FC, MouseEventHandler } from 'react';
-import React, { useRef, useCallback, useEffect, useMemo } from 'react';
+import React, { useContext, useRef, useCallback, useEffect, useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiScrollBar, useEuiTheme } from '@elastic/eui';
 import { CANVAS } from '../../../i18n';
 import { Sidebar } from '../sidebar';
 import { Toolbar } from '../toolbar';
@@ -15,6 +17,7 @@ import { WorkpadHeader } from '../workpad_header';
 import { CANVAS_LAYOUT_STAGE_CONTENT_SELECTOR } from '../../../common/lib/constants';
 import type { CanvasWorkpad, CommitFn } from '../../../types';
 import { getUntitledWorkpadLabel } from '../../lib/doc_title';
+import { WorkpadRoutingContext } from '../../routes/workpad';
 
 export const WORKPAD_CONTAINER_ID = 'canvasWorkpadContainer';
 
@@ -25,6 +28,29 @@ export interface Props {
 }
 
 export const WorkpadApp: FC<Props> = ({ deselectElement, isWriteable, workpad }) => {
+  const { isFullscreen } = useContext(WorkpadRoutingContext);
+  const { euiTheme } = useEuiTheme();
+  const scrollBarStyles = useEuiScrollBar();
+  const styles = useMemo(
+    () => ({
+      // Theme-dependent chrome styling lives here (instead of workpad_app.scss)
+      // so Canvas reacts to reload-less light/dark color-mode toggles.
+      layout: css({
+        background: isFullscreen ? euiTheme.colors.plainDark : euiTheme.colors.body,
+      }),
+      stageHeader: css({
+        background: euiTheme.colors.lightestShade,
+        borderBottom: euiTheme.border.thin,
+      }),
+      sidebar: css({
+        background: euiTheme.colors.lightestShade,
+        borderLeft: euiTheme.border.thin,
+      }),
+      footer: css({ backgroundColor: euiTheme.colors.body }),
+    }),
+    [euiTheme, isFullscreen]
+  );
+
   const interactivePageLayout = useRef<CommitFn | null>(null); // future versions may enable editing on multiple pages => use array then
   const workpadTitle = useRef<HTMLHeadingElement>(null); // future versions may enable editing on multiple pages => use array then
 
@@ -50,11 +76,11 @@ export const WorkpadApp: FC<Props> = ({ deselectElement, isWriteable, workpad })
   const untitledWorkpadLabel = useMemo(() => getUntitledWorkpadLabel(), []);
 
   return (
-    <div className="canvasLayout">
+    <div className="canvasLayout" css={styles.layout}>
       <div className="canvasLayout__rows">
         <div className="canvasLayout__cols">
           <div className="canvasLayout__stage">
-            <div className="canvasLayout__stageHeader">
+            <div className="canvasLayout__stageHeader" css={styles.stageHeader}>
               <h1
                 id="canvasWorkpadTitle"
                 className="euiScreenReaderOnly"
@@ -72,6 +98,7 @@ export const WorkpadApp: FC<Props> = ({ deselectElement, isWriteable, workpad })
               <div
                 id={WORKPAD_CONTAINER_ID}
                 className="canvasWorkpadContainer canvasLayout__stageContentOverflow"
+                css={scrollBarStyles}
               >
                 <Workpad registerLayout={registerLayout} unregisterLayout={unregisterLayout} />
               </div>
@@ -79,13 +106,13 @@ export const WorkpadApp: FC<Props> = ({ deselectElement, isWriteable, workpad })
           </div>
 
           {isWriteable && (
-            <div className="canvasLayout__sidebar hide-for-sharing">
+            <div className="canvasLayout__sidebar hide-for-sharing" css={styles.sidebar}>
               <Sidebar commit={commit} />
             </div>
           )}
         </div>
 
-        <div className="canvasLayout__footer hide-for-sharing">
+        <div className="canvasLayout__footer hide-for-sharing" css={styles.footer}>
           <Toolbar />
         </div>
       </div>

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_app/workpad_app.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_app/workpad_app.scss
@@ -2,7 +2,6 @@ $canvasLayoutFontSize: $euiFontSizeS;
 
 .canvasLayout {
   display: flex;
-  background: $euiPageBackgroundColor;
   flex-grow: 1;
   overflow: hidden;
 }
@@ -33,8 +32,6 @@ $canvasLayoutFontSize: $euiFontSizeS;
   flex-basis: auto;
   padding: $euiSizeS $euiSize;
   font-size: $canvasLayoutFontSize;
-  border-bottom: $euiBorderThin;
-  background: $euiColorLightestShade;
   user-select: none;
 }
 
@@ -49,8 +46,6 @@ $canvasLayoutFontSize: $euiFontSizeS;
 }
 
 .canvasLayout__stageContentOverflow {
-  @include euiScrollBar;
-
   position: absolute;
   top: 0;
   left: 0;
@@ -65,10 +60,8 @@ $canvasLayoutFontSize: $euiFontSizeS;
   flex-grow: 0;
   flex-basis: auto;
   width: 350px;
-  background: $euiColorLightestShade;
   display: flex;
   position: relative;
-  border-left: $euiBorderThin;
 
   .euiPanel {
     margin-bottom: $euiSizeS;
@@ -82,7 +75,6 @@ $canvasLayoutFontSize: $euiFontSizeS;
   flex-grow: 0;
   flex-basis: auto;
   width: 100%;
-  background-color: $euiPageBackgroundColor;
   z-index: $euiZNavigation;
   font-size: $canvasLayoutFontSize;
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/edit_menu/edit_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/edit_menu/edit_menu.component.tsx
@@ -13,6 +13,7 @@ import type { ClosePopoverFn } from '../../popover';
 import { Popover } from '../../popover';
 import { ShortcutStrings } from '../../../../i18n/shortcuts';
 import { flattenPanelTree } from '../../../lib/flatten_panel_tree';
+import { useCanvasContextMenuTopBorderStyles } from '../../../lib/use_canvas_context_menu_top_border_styles';
 import { CustomElementModal } from '../../custom_element_modal';
 import { CONTEXT_MENU_TOP_BORDER_CLASSNAME } from '../../../../common/lib/constants';
 import type { PositionedElement } from '../../../../types';
@@ -237,6 +238,7 @@ export const EditMenu: FunctionComponent<Props> = ({
   redoHistory,
   hasPasteData,
 }) => {
+  const contextMenuTopBorderStyles = useCanvasContextMenuTopBorderStyles();
   const [isModalVisible, setModalVisible] = useState(false);
   const showModal = () => setModalVisible(true);
   const hideModal = () => setModalVisible(false);
@@ -497,6 +499,7 @@ export const EditMenu: FunctionComponent<Props> = ({
           <EuiContextMenu
             initialPanelId={0}
             panels={flattenPanelTree(getPanelTree(closePopover))}
+            css={contextMenuTopBorderStyles}
           />
         )}
       </Popover>

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
@@ -16,6 +16,7 @@ import { getId } from '../../../lib/get_id';
 import { CONTEXT_MENU_TOP_BORDER_CLASSNAME } from '../../../../common/lib';
 import type { ElementSpec } from '../../../../types';
 import { flattenPanelTree } from '../../../lib/flatten_panel_tree';
+import { useCanvasContextMenuTopBorderStyles } from '../../../lib/use_canvas_context_menu_top_border_styles';
 import { AssetManager } from '../../asset_manager';
 import type { ClosePopoverFn } from '../../popover';
 import { SavedElementsModal } from '../../saved_elements_modal';
@@ -121,6 +122,7 @@ export interface Props {
 }
 
 export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) => {
+  const contextMenuTopBorderStyles = useCanvasContextMenuTopBorderStyles();
   const [isAssetModalVisible, setAssetModalVisible] = useState(false);
   const [isSavedElementsModalVisible, setSavedElementsModalVisible] = useState(false);
 
@@ -215,6 +217,7 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
           <EuiContextMenu
             initialPanelId={0}
             panels={flattenPanelTree(getPanelTree(closePopover))}
+            css={contextMenuTopBorderStyles}
           />
         )}
       </ToolbarPopover>

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/view_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/view_menu.component.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../../common/lib/constants';
 
 import { flattenPanelTree } from '../../../lib/flatten_panel_tree';
+import { useCanvasContextMenuTopBorderStyles } from '../../../lib/use_canvas_context_menu_top_border_styles';
 import { AutoRefreshControls } from './auto_refresh_controls';
 import { KioskControls } from './kiosk_controls';
 
@@ -166,6 +167,7 @@ export const ViewMenu: FunctionComponent<Props> = ({
   autoplayInterval,
   setAutoplayInterval,
 }) => {
+  const contextMenuTopBorderStyles = useCanvasContextMenuTopBorderStyles();
   const setRefresh = (val: number) => setRefreshInterval(val);
 
   const disableInterval = () => {
@@ -291,6 +293,7 @@ export const ViewMenu: FunctionComponent<Props> = ({
           initialPanelId={0}
           panels={flattenPanelTree(getPanelTree(closePopover))}
           className="canvasViewMenu"
+          css={contextMenuTopBorderStyles}
         />
       )}
     </Popover>

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_page/use_workpad_page_styles.ts
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_page/use_workpad_page_styles.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiShadowFlat, useEuiTheme } from '@elastic/eui';
+
+export const useWorkpadPageStyles = () => {
+  const { euiTheme } = useEuiTheme();
+  const flatShadow = useEuiShadowFlat();
+
+  return useMemo(
+    () => css`
+      ${flatShadow}
+      background-color: ${euiTheme.colors.emptyShade};
+    `,
+    [euiTheme, flatShadow]
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_page/workpad_interactive_page/interactive_workpad_page.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_page/workpad_interactive_page/interactive_workpad_page.js
@@ -18,6 +18,7 @@ import {
 } from '../../layout_annotations';
 import { WorkpadShortcuts } from '../../workpad_shortcuts';
 import { interactiveWorkpadPagePropTypes } from '../prop_types';
+import { WorkpadPageRoot } from '../workpad_page_root';
 import { InteractionBoundary } from './interaction_boundary';
 
 export class InteractiveWorkpadPage extends PureComponent {
@@ -71,7 +72,7 @@ export class InteractiveWorkpadPage extends PureComponent {
     shortcuts = <WorkpadShortcuts {...shortcutProps} />;
 
     return (
-      <div
+      <WorkpadPageRoot
         key={pageId}
         id={pageId}
         ref={(node) => {
@@ -131,7 +132,7 @@ export class InteractiveWorkpadPage extends PureComponent {
             }
           })
           .filter((element) => !!element)}
-      </div>
+      </WorkpadPageRoot>
     );
   }
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_page/workpad_page.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_page/workpad_page.scss
@@ -1,8 +1,6 @@
 .canvasPage {
-  @include euiBottomShadowFlat;
   z-index: initial;
   position: absolute;
   top: 0;
   transform-style: preserve-3d !important; // sass-lint:disable-line no-important
-  background-color: $euiColorEmptyShade;
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_page/workpad_page_root.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_page/workpad_page_root.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComponentProps } from 'react';
+import React, { forwardRef } from 'react';
+import { useWorkpadPageStyles } from './use_workpad_page_styles';
+
+// Forwards the ref to the underlying page element: the interactive page relies on
+// it to capture the DOM node for `saveCanvasOrigin` (used by pointer math).
+export const WorkpadPageRoot = forwardRef<HTMLDivElement, ComponentProps<'div'>>(
+  ({ css: cssProp, ...props }, ref) => {
+    const pageStyles = useWorkpadPageStyles();
+
+    return <div ref={ref} css={[pageStyles, cssProp]} {...props} />;
+  }
+);
+
+WorkpadPageRoot.displayName = 'WorkpadPageRoot';

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_page/workpad_static_page/static_workpad_page.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_page/workpad_static_page/static_workpad_page.js
@@ -9,6 +9,7 @@ import React, { PureComponent } from 'react';
 import { ElementWrapper } from '../../element_wrapper';
 import { staticWorkpadPagePropTypes } from '../prop_types';
 import { isGroupId } from '../../../lib/workpad';
+import { WorkpadPageRoot } from '../workpad_page_root';
 
 export class StaticWorkpadPage extends PureComponent {
   static propTypes = staticWorkpadPagePropTypes;
@@ -17,7 +18,7 @@ export class StaticWorkpadPage extends PureComponent {
     const { pageId, pageStyle, className, animationStyle, elements, height, width } = this.props;
 
     return (
-      <div
+      <WorkpadPageRoot
         key={pageId}
         id={pageId}
         data-test-subj="canvasWorkpadPage"
@@ -30,7 +31,7 @@ export class StaticWorkpadPage extends PureComponent {
           .map((element) => (
             <ElementWrapper key={element.id} element={element} />
           ))}
-      </div>
+      </WorkpadPageRoot>
     );
   }
 }

--- a/x-pack/platform/plugins/private/canvas/public/lib/use_canvas_checkered_styles.ts
+++ b/x-pack/platform/plugins/private/canvas/public/lib/use_canvas_checkered_styles.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { css, type SerializedStyles } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
+
+export const useCanvasCheckeredStyles = (): SerializedStyles => {
+  const { euiTheme } = useEuiTheme();
+
+  return useMemo(
+    () => css`
+      background-color: ${euiTheme.colors.plainLight};
+      background-image: linear-gradient(45deg, ${euiTheme.colors.lightShade} 25%, transparent 25%),
+        linear-gradient(-45deg, ${euiTheme.colors.lightShade} 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, ${euiTheme.colors.lightShade} 75%),
+        linear-gradient(-45deg, transparent 75%, ${euiTheme.colors.lightShade} 75%);
+    `,
+    [euiTheme]
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/lib/use_canvas_context_menu_top_border_styles.ts
+++ b/x-pack/platform/plugins/private/canvas/public/lib/use_canvas_context_menu_top_border_styles.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { css, type SerializedStyles } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
+
+export const useCanvasContextMenuTopBorderStyles = (): SerializedStyles => {
+  const { euiTheme } = useEuiTheme();
+
+  return useMemo(
+    () => css`
+      & .canvasContextMenu--topBorder {
+        border-top: ${euiTheme.border.thin};
+      }
+    `,
+    [euiTheme]
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/lib/use_canvas_text_area_code_styles.ts
+++ b/x-pack/platform/plugins/private/canvas/public/lib/use_canvas_text_area_code_styles.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { css, type SerializedStyles } from '@emotion/react';
+import { useEuiScrollBar } from '@elastic/eui';
+
+export const useCanvasTextAreaCodeStyles = (): SerializedStyles => {
+  const scrollBar = useEuiScrollBar();
+
+  return useMemo(
+    () =>
+      css`
+        ${scrollBar}
+      `,
+    [scrollBar]
+  );
+};

--- a/x-pack/platform/plugins/private/canvas/public/routes/workpad/hooks/use_theme_refresh.test.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/routes/workpad/hooks/use_theme_refresh.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { BehaviorSubject } from 'rxjs';
+import type { CoreTheme } from '@kbn/core/public';
+import { coreServices } from '../../../services/kibana_services';
+import { useThemeRefresh } from './use_theme_refresh';
+
+const mockDispatch = jest.fn();
+const refreshAction = { type: 'fetchAllRenderables' };
+
+const lightTheme: CoreTheme = { darkMode: false, name: 'borealis' };
+const darkTheme: CoreTheme = { darkMode: true, name: 'borealis' };
+
+jest.mock('react-redux-v7', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../../state/actions/elements', () => ({
+  fetchAllRenderables: () => refreshAction,
+}));
+
+jest.mock('../../../services/kibana_services', () => {
+  const { BehaviorSubject: MockBehaviorSubject } = jest.requireActual('rxjs');
+  return {
+    coreServices: {
+      theme: {
+        theme$: new MockBehaviorSubject({ darkMode: false, name: 'borealis' }),
+      },
+    },
+  };
+});
+
+const theme$ = coreServices.theme.theme$ as BehaviorSubject<CoreTheme>;
+
+describe('useThemeRefresh', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    theme$.next(lightTheme);
+  });
+
+  test('does not refresh on the initial theme emission', () => {
+    renderHook(() => useThemeRefresh());
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('refreshes renderables when dark mode changes', () => {
+    renderHook(() => useThemeRefresh());
+
+    theme$.next(darkTheme);
+
+    expect(mockDispatch).toHaveBeenCalledWith(refreshAction);
+  });
+
+  test('does not refresh when irrelevant theme values change', () => {
+    renderHook(() => useThemeRefresh());
+
+    theme$.next({ ...lightTheme });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useThemeRefresh());
+
+    unmount();
+    theme$.next(darkTheme);
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/private/canvas/public/routes/workpad/hooks/use_theme_refresh.ts
+++ b/x-pack/platform/plugins/private/canvas/public/routes/workpad/hooks/use_theme_refresh.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux-v7';
+import { distinctUntilChanged, skip } from 'rxjs';
+// @ts-expect-error untyped local
+import { fetchAllRenderables } from '../../../state/actions/elements';
+import { coreServices } from '../../../services/kibana_services';
+
+/**
+ * Re-interprets workpad elements when the Kibana theme (dark mode / theme name)
+ * changes so Canvas pick up theme-aware palette colors without a reload.
+ */
+export const useThemeRefresh = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const subscription = coreServices.theme.theme$
+      .pipe(
+        distinctUntilChanged(
+          (previous, next) => previous.darkMode === next.darkMode && previous.name === next.name
+        ),
+        skip(1)
+      )
+      .subscribe(() => {
+        dispatch(fetchAllRenderables());
+      });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [dispatch]);
+};

--- a/x-pack/platform/plugins/private/canvas/public/routes/workpad/workpad_presentation_helper.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/routes/workpad/workpad_presentation_helper.tsx
@@ -15,6 +15,7 @@ import { getWorkpad } from '../../state/selectors/workpad';
 import { useFullscreenPresentationHelper } from './hooks/use_fullscreen_presentation_helper';
 import { useAutoplayHelper } from './hooks/use_autoplay_helper';
 import { useRefreshHelper } from './hooks/use_refresh_helper';
+import { useThemeRefresh } from './hooks/use_theme_refresh';
 import { coreServices, spacesService } from '../../services/kibana_services';
 
 const getWorkpadLabel = () =>
@@ -27,6 +28,7 @@ export const WorkpadPresentationHelper: FC<PropsWithChildren<unknown>> = ({ chil
   useFullscreenPresentationHelper();
   useAutoplayHelper();
   useRefreshHelper();
+  useThemeRefresh();
   const history = useHistory();
 
   useEffect(() => {

--- a/x-pack/platform/plugins/private/canvas/public/style/main.scss
+++ b/x-pack/platform/plugins/private/canvas/public/style/main.scss
@@ -12,7 +12,6 @@ $canvasElementCardWidth: 210px;
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  background-color: $euiPageBackgroundColor;
 }
 
 .canvasContainer--loading {
@@ -24,27 +23,15 @@ $canvasElementCardWidth: 210px;
 }
 
 .canvasCheckered {
-  background-color: $euiColorPlainLight;
-
-  // sass-lint:disable-block indentation
-  background-image: linear-gradient(45deg, $euiColorLightShade 25%, transparent 25%),
-    linear-gradient(-45deg, $euiColorLightShade 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, $euiColorLightShade 75%),
-    linear-gradient(-45deg, transparent 75%, $euiColorLightShade 75%);
   background-size: $euiSizeS $euiSizeS;
   position: relative;
 }
 
 .canvasTextArea__code {
-  @include euiScrollBar;
   font-size: $euiFontSizeS;
   font-family: $euiCodeFontFamily;
   width: 100%;
   max-width: 100%;
-}
-
-.canvasContextMenu--topBorder {
-  border-top: $euiBorderThin;
 }
 
 // sass-lint:disable-block no-ids


### PR DESCRIPTION
## Summary

This PR makes the Canvas plugin react to reload-less light/dark color-mode toggles.

- Re-interprets workpad elements when the Kibana theme changes: a new `useThemeRefresh` hook subscribes to `core.theme.theme$` (distinct on `darkMode`/`name`, skipping the initial emission) and dispatches `fetchAllRenderables`, so `plot`/`pie` charts re-resolve their palette colors and redraw without a page reload.
- Migrates theme-dependent Canvas chrome from static SCSS to Emotion via `useEuiTheme()` (plus `useEuiShadow`/`useEuiShadowFlat` and `useEuiScrollBar`), so backgrounds, borders, shadows, scrollbars, and text colors update live. This covers the app shell (layout, stage header, sidebar, footer, container), left chrome (sidebar, toolbar, tray, page manager), the workpad stage (workpad grid, pages, layout annotations, fullscreen, loading), side panels (datasource, expression, arg add/popover), modals and pickers (custom element modal, color dot, asset picker, upload dropzone, element card), and renderers/global styles (checkered background, context-menu border, embeddable drag handle, advanced filter, datatable).
- Keeps DOM structure and class names unchanged: theme-dependent declarations are moved into `css` blocks with nested selectors on existing elements, while purely structural rules stay in SCSS. SASS helpers are mapped to their EUI runtime equivalents (`transparentize`/`shade`/`tint`, shadow hooks, scrollbar hook).
- Fixes a drag/pointer regression from the workpad-page migration: `WorkpadPageRoot` now uses `forwardRef` so `InteractiveWorkpadPage` can still capture the page DOM node for `saveCanvasOrigin` (otherwise pointer math threw `canvasOrigin is not a function`).
- Adds `panelProps` to the custom `Popover` component's types so the arg-add popover can pass a reactive scrollbar `css` through to `EuiPopover`.

Not migrated (documented, out of scope): imperative plot legend labels (`plot.scss .legendLabel`, drawn by jQuery), and orphaned/dead SCSS rules with no live consumer (`#canvas-app .window-error`, `canvasArgImage--preview`, share-menu code-block scrollbar). 