### PR TITLE
[test] Add test_workflows_connector to validate per-connector CODEOWNERS check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2498,6 +2498,7 @@ src/platform/packages/shared/kbn-connector-specs/src/specs/sharepoint_server/** 
 
 # Connector Agent Skills
 src/platform/packages/shared/kbn-connector-specs/.claude/skills @elastic/workchat-eng
+src/platform/packages/shared/kbn-connector-specs/src/specs/test_workflows_connector/** @elastic/workflows-eng
 
 # Connector Workflow Tests
 src/platform/plugins/shared/workflows_management/test/connector_workflows @elastic/workchat-eng

--- a/docs/reference/connectors-kibana/_snippets/elastic-connectors-list.md
+++ b/docs/reference/connectors-kibana/_snippets/elastic-connectors-list.md
@@ -2,3 +2,4 @@
 * [Index](/reference/connectors-kibana/index-action-type.md): Index data into Elasticsearch.
 * [Observability AI Assistant](/reference/connectors-kibana/obs-ai-assistant-action-type.md): Send alerts to the AI Assistant.
 * [ServerLog](/reference/connectors-kibana/server-log-action-type.md): Add a message to a Kibana log.
+* [Test workflows connector](/reference/connectors-kibana/test-workflows-connector-action-type.md): TODO: Add brief description.

--- a/docs/reference/connectors-kibana/test-workflows-connector-action-type.md
+++ b/docs/reference/connectors-kibana/test-workflows-connector-action-type.md
@@ -1,0 +1,45 @@
+---
+navigation_title: "Test workflows connector"
+applies_to:
+  stack: preview
+  serverless: preview
+---
+
+# Test workflows connector connector [test-workflows-connector-action-type]
+
+The Test workflows connector connector communicates with the Test workflows connector API.
+
+## Create connectors in {{kib}} [define-test-workflows-connector-ui]
+
+You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**. For example:
+
+### Connector configuration [test-workflows-connector-connector-configuration]
+
+Test workflows connector connectors have the following configuration properties:
+
+<!-- TODO: Add action descriptions here -->
+<!-- Example:
+API Key
+:   The Test workflows connector API key for authentication.
+-->
+
+
+## Test connectors [test-workflows-connector-action-configuration]
+
+You can test connectors as you're creating or editing the connector in {{kib}}.
+
+The Test workflows connector connector has the following actions:
+
+<!-- TODO: Add action descriptions here -->
+<!-- Example:
+Action Name
+:   Description of what this action does.
+    - **Parameter Name** (required/optional): Parameter description.
+-->
+
+
+## Get API credentials [test-workflows-connector-api-credentials]
+
+To use the Test workflows connector connector, you need to:
+
+<!-- TODO: Add instructions here -->

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -46,6 +46,7 @@ toc:
           - file: connectors-kibana/index-action-type.md
           - file: connectors-kibana/obs-ai-assistant-action-type.md
           - file: connectors-kibana/server-log-action-type.md
+          - file: connectors-kibana/test-workflows-connector-action-type.md
       - file: connectors-kibana/alerting-cases-connectors.md
         children:
           - file: connectors-kibana/crowdstrike-action-type.md

--- a/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
@@ -41,3 +41,4 @@ export * from './specs/microsoft_teams/microsoft_teams';
 export * from './specs/tavily/tavily';
 export * from './specs/pagerduty/pagerduty';
 export * from './specs/snowflake/snowflake';
+export * from './specs/test_workflows_connector/test_workflows_connector';

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
@@ -197,4 +197,14 @@ export const ConnectorIconsMap: Map<
     '.snowflake',
     lazy(() => import(/* webpackChunkName: "connectorIconsnowflake" */ './specs/snowflake/icon')),
   ],
+
+  [
+    '.test-workflows-connector',
+    lazy(
+      () =>
+        import(
+          /* webpackChunkName: "connectorIcontestworkflowsconnector" */ './specs/test_workflows_connector/icon'
+        )
+    ),
+  ],
 ]);

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/test_workflows_connector/icon/index.tsx
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/test_workflows_connector/icon/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiIcon } from '@elastic/eui';
+import type { ConnectorIconProps } from '../../../types';
+
+export default (props: ConnectorIconProps) => {
+  // Placeholder icon: use built-in EUI icon until a custom one is added
+  return <EuiIcon type="globe" {...props} />;
+};

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/test_workflows_connector/test_workflows_connector.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/test_workflows_connector/test_workflows_connector.test.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { TestWorkflowsConnector } from './test_workflows_connector';
+
+describe('TestWorkflowsConnector', () => {
+  it('should be defined', () => {
+    expect(TestWorkflowsConnector).toBeDefined();
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/test_workflows_connector/test_workflows_connector.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/test_workflows_connector/test_workflows_connector.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { ConnectorSpec } from '../../connector_spec';
+
+export const TestWorkflowsConnector: ConnectorSpec = {
+  metadata: {
+    id: '.test-workflows-connector',
+    displayName: 'Test workflows connector',
+    description: '',
+    minimumLicense: 'basic',
+    supportedFeatureIds: ['workflows', 'agentBuilder'],
+  },
+  schema: z.object({}),
+  actions: {},
+  test: {
+    handler: async () => ({ ok: true }),
+  },
+};


### PR DESCRIPTION
## Summary

Test PR to validate PR #280401's per-connector CODEOWNERS ownership check.

- Adds a minimal `test_workflows_connector` scaffold via the generator
- CODEOWNERS entry assigns `@elastic/workflows-eng` (not `@elastic/response-ops`) for the connector directory
- Checking whether GitHub auto-requests `@elastic/response-ops` as reviewer due to their ownership of the broader `kbn-connector-specs` package

**This PR is for testing only and should not be merged.**