### PR TITLE
[8.19] [CI] Update local checks (#271651)

### DIFF
--- a/packages/kbn-lint-ts-projects-cli/run_lint_ts_projects_cli.ts
+++ b/packages/kbn-lint-ts-projects-cli/run_lint_ts_projects_cli.ts
@@ -22,19 +22,34 @@ import { runLintRules, TsProjectLintTarget } from '@kbn/repo-linter';
 
 import { RULES } from './rules';
 
-function getFilter(input: string) {
+// Resolve a single user input (package id/name, or a path to a package or directory)
+// to every ts project it refers to. A directory input matches that project and all
+// projects nested under it, so passing a parent path lints everything beneath it.
+function resolveTargets(input: string, allTargets: TsProjectLintTarget[]) {
   const abs = Path.resolve(input);
 
-  return ({ tsProject }: TsProjectLintTarget) =>
-    tsProject.name === input ||
-    tsProject.repoRel === input ||
-    tsProject.repoRelDir === input ||
-    tsProject.path === abs ||
-    tsProject.directory === abs ||
-    abs.startsWith(tsProject.directory + '/') ||
-    tsProject.pkg?.normalizedRepoRelativeDir === input ||
-    tsProject.pkg?.directory === abs ||
-    (tsProject.pkg && abs.startsWith(tsProject.pkg.directory + '/'));
+  const matches = allTargets.filter(
+    ({ tsProject }) =>
+      tsProject.name === input ||
+      tsProject.repoRel === input ||
+      tsProject.repoRelDir === input ||
+      tsProject.path === abs ||
+      tsProject.directory === abs ||
+      tsProject.directory.startsWith(abs + '/') ||
+      tsProject.pkg?.normalizedRepoRelativeDir === input ||
+      tsProject.pkg?.directory === abs
+  );
+  if (matches.length) {
+    return matches;
+  }
+
+  // Fallback: input points inside a project (e.g. a file path) but isn't itself a
+  // project root — lint the closest enclosing project.
+  const enclosing = allTargets
+    .filter(({ tsProject }) => abs.startsWith(tsProject.directory + '/'))
+    .sort((a, b) => b.tsProject.directory.length - a.tsProject.directory.length);
+
+  return enclosing.length ? [enclosing[0]] : [];
 }
 
 function validateProjectOwnership(
@@ -112,24 +127,22 @@ run(
   async ({ log, flagsReader }) => {
     const filter = flagsReader.getPositionals();
     const packages = getPackages(REPO_ROOT);
-    const allTargets = Array.from(TS_PROJECTS, (p) => new TsProjectLintTarget(p)).sort(
-      (a, b) => b.repoRel.length - a.repoRel.length
-    );
+    const allTargets = Array.from(TS_PROJECTS, (p) => new TsProjectLintTarget(p));
 
     const toLint = Array.from(
       new Set(
         !filter.length
           ? allTargets
-          : filter.map((input) => {
-              const pkg = allTargets.find(getFilter(input));
+          : filter.flatMap((input) => {
+              const targets = resolveTargets(input, allTargets);
 
-              if (!pkg) {
+              if (!targets.length) {
                 throw createFailError(
                   `unable to find a package matching [${input}]. Supply either a package id/name or path to a package`
                 );
               }
 
-              return pkg;
+              return targets;
             })
       )
     ).sort((a, b) => a.repoRel.localeCompare(b.repoRel));

--- a/packages/kbn-moon/moon.yml
+++ b/packages/kbn-moon/moon.yml
@@ -19,6 +19,7 @@ project:
 dependsOn:
   - '@kbn/repo-info'
   - '@kbn/dev-utils'
+  - '@kbn/dev-cli-errors'
   - '@kbn/dev-cli-runner'
   - '@kbn/repo-packages'
   - '@kbn/tooling-log'

--- a/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
+++ b/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
@@ -20,6 +20,8 @@ import type { PackageManifestBaseFields } from '@kbn/repo-packages/modern/types'
 import { getPackages } from '@kbn/repo-packages';
 import type { ToolingLog } from '@kbn/tooling-log';
 
+import { createFailError } from '@kbn/dev-cli-errors';
+
 import { KIBANA_JSONC_FILENAME, MOON_CONFIG_KEY_ORDER, MOON_CONST } from '../const';
 import type { MoonProjectConfig } from './moon_project_type';
 import {
@@ -30,6 +32,7 @@ import {
   resolveFirstExisting,
   sortObjectByKeyPriority,
   writeYaml,
+  yamlMatchesFile,
 } from '../util';
 
 const scriptName = path.relative(REPO_ROOT, process.argv[1]);
@@ -40,7 +43,7 @@ const cliOptions = {
       `,
   flags: {
     string: ['filter'],
-    boolean: ['update', 'dependencies', 'dry-run', 'clear'],
+    boolean: ['update', 'dependencies', 'dry-run', 'clear', 'check'],
     default: {
       dependencies: true,
     },
@@ -50,6 +53,7 @@ const cliOptions = {
           --update                    Update existing project configuration(s)
           --no-dependencies           Do not include dependsOn section in the project configuration
           --dry-run                   Do not write to disk
+          --check                     Fail (exit 1) if any project configuration is out of date; never writes
           --clear                     Clear the project configuration
         `,
   },
@@ -62,8 +66,9 @@ export function regenerateMoonProjects() {
     logger = log;
 
     const filter = flagsReader.arrayOfStrings('filter');
-    const update = flags.update as boolean | undefined;
-    const dryRun = flags['dry-run'] as boolean | undefined;
+    const check = flags.check as boolean | undefined;
+    const update = (flags.update as boolean | undefined) || check;
+    const dryRun = (flags['dry-run'] as boolean | undefined) || check;
     const clear = flags.clear as boolean | undefined;
     const includeDependencies = !!flags.dependencies;
 
@@ -126,6 +131,17 @@ export function regenerateMoonProjects() {
         ` ${projectResults.skip.length} exists (use --update to update)`,
       ].join('\n')
     );
+
+    if (check) {
+      const outOfDate = [...projectResults.create, ...projectResults.update];
+      if (outOfDate.length > 0) {
+        throw createFailError(
+          `${outOfDate.length} Moon project configuration(s) out of date: ${outOfDate.join(
+            ', '
+          )}\nRun 'node ${scriptName} --update' to regenerate.`
+        );
+      }
+    }
   }, cliOptions);
 }
 
@@ -300,17 +316,17 @@ function writeProjectConfigFile(
   sortObjectByKeyPriority(projectConfig, MOON_CONFIG_KEY_ORDER);
 
   const name = projectConfig.id;
+  const preamble = getGeneratedPreambleForProject(projectConfig.id);
   const projectExists = fs.existsSync(targetPath);
   if (projectExists) {
     if (update) {
       if (dryRun) {
+        if (yamlMatchesFile(targetPath, projectConfig, preamble)) {
+          return 'intact';
+        }
         logger.info(`Would update ${name} project configuration.`);
       } else {
-        const didUpdate = writeYaml(
-          targetPath,
-          projectConfig,
-          getGeneratedPreambleForProject(projectConfig.id)
-        );
+        const didUpdate = writeYaml(targetPath, projectConfig, preamble);
         logger.info(`Updated ${name} project configuration.`);
         if (!didUpdate) {
           return 'intact';
@@ -336,7 +352,7 @@ function writeProjectConfigFile(
       logger.info(`Would create ${name} project configuration.`);
     } else {
       logger.info(`Creating ${name} project configuration @ ${targetPath}`);
-      writeYaml(targetPath, projectConfig, getGeneratedPreambleForProject(projectConfig.id));
+      writeYaml(targetPath, projectConfig, preamble);
     }
     return 'create';
   }

--- a/packages/kbn-moon/src/util.ts
+++ b/packages/kbn-moon/src/util.ts
@@ -64,7 +64,7 @@ export function filterPackages(allPackages: Package[], filter: string[]): Packag
   });
 }
 
-export function writeYaml(filePath: string, obj: any, preamble: string | null = null) {
+export function renderYaml(obj: any, preamble: string | null = null) {
   const doc = new Document(obj, { aliasDuplicateObjects: false });
 
   // Quote string values that start with YAML indicator characters, matching the
@@ -81,14 +81,21 @@ export function writeYaml(filePath: string, obj: any, preamble: string | null = 
     },
   });
 
-  let fileContent = doc.toString({
+  const fileContent = doc.toString({
     lineWidth: 300,
     singleQuote: true,
   });
 
-  if (preamble) {
-    fileContent = preamble + '\n\n' + fileContent;
-  }
+  return preamble ? preamble + '\n\n' + fileContent : fileContent;
+}
+
+/** True when `filePath` already holds exactly the rendered YAML (no write needed). */
+export function yamlMatchesFile(filePath: string, obj: any, preamble: string | null = null) {
+  return existsSync(filePath) && readFile(filePath) === renderYaml(obj, preamble);
+}
+
+export function writeYaml(filePath: string, obj: any, preamble: string | null = null) {
+  const fileContent = renderYaml(obj, preamble);
 
   if (existsSync(filePath) && readFile(filePath) === fileContent) {
     return false;

--- a/packages/kbn-moon/tsconfig.json
+++ b/packages/kbn-moon/tsconfig.json
@@ -18,6 +18,7 @@
   "kbn_references": [
     "@kbn/repo-info",
     "@kbn/dev-utils",
+    "@kbn/dev-cli-errors",
     "@kbn/dev-cli-runner",
     "@kbn/repo-packages",
     "@kbn/tooling-log"

--- a/src/dev/eslint/run_eslint_contract.ts
+++ b/src/dev/eslint/run_eslint_contract.ts
@@ -27,7 +27,8 @@ import type { ToolingLog } from '@kbn/tooling-log';
 
 import { File } from '../file';
 import { LINT_LABEL } from './constants';
-import { lintFiles, pickFilesToLint } from '.';
+import { lintFiles } from './lint_files';
+import { pickFilesToLint } from './pick_files_to_lint';
 
 export interface ExecuteEslintValidationOptions {
   baseContext: ValidationBaseContext;

--- a/src/dev/run_check.test.ts
+++ b/src/dev/run_check.test.ts
@@ -18,6 +18,7 @@ jest.mock('@kbn/dev-cli-errors', () => ({
 jest.mock('@kbn/dev-validation-runner', () => ({
   readValidationRunFlags: jest.fn(),
   resolveValidationBaseContext: jest.fn(),
+  resolveValidationAffectedProjects: jest.fn(),
   VALIDATION_RUN_HELP: [],
   VALIDATION_RUN_STRING_FLAGS: [],
 }));
@@ -76,11 +77,14 @@ const mockReadValidationRunFlags = jest.requireMock('@kbn/dev-validation-runner'
   .readValidationRunFlags as jest.Mock;
 const mockResolveValidationBaseContext = jest.requireMock('@kbn/dev-validation-runner')
   .resolveValidationBaseContext as jest.Mock;
+const mockResolveValidationAffectedProjects = jest.requireMock('@kbn/dev-validation-runner')
+  .resolveValidationAffectedProjects as jest.Mock;
 const mockExecuteTypeCheckValidation = jest.requireMock('./type_check_validation_loader')
   .executeTypeCheckValidation as jest.Mock;
 const mockExecuteEslintValidation = jest.requireMock('./eslint/run_eslint_contract')
   .executeEslintValidation as jest.Mock;
 const mockExistsSync = jest.requireMock('fs').existsSync as jest.Mock;
+const mockReaddirSync = jest.requireMock('fs').readdirSync as jest.Mock;
 const mockExeca = mockExecaFn;
 
 let handler: (args: {
@@ -155,6 +159,17 @@ describe('run_check', () => {
       warningCount: 0,
     });
     mockExecuteTypeCheckValidation.mockResolvedValue({ projectCount: 2 });
+    mockExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    // Default: tsproj resolves to no scoped projects (keeps existing assertions stable).
+    mockResolveValidationAffectedProjects.mockResolvedValue({
+      isRootProjectAffected: false,
+      affectedSourceRoots: [],
+    });
 
     // Default: successful Moon jest run
     mockRunJestViaMoon.mockResolvedValue({
@@ -274,7 +289,11 @@ describe('run_check', () => {
 
     await handler(createArgs());
 
-    expect(mockExeca).not.toHaveBeenCalled();
+    expect(mockExeca).not.toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(['scripts/jest']),
+      expect.anything()
+    );
     expect(mockRunJestViaMoon).toHaveBeenCalled();
   });
 
@@ -289,15 +308,48 @@ describe('run_check', () => {
       },
     });
 
-    mockExistsSync.mockImplementation(
-      (p: string) =>
-        p ===
-        '/repo/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/api/playwright.config.ts'
+    mockExistsSync.mockReturnValue(false);
+    mockReaddirSync.mockImplementation((dir: string) =>
+      dir === '/repo/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/api'
+        ? ['playwright.config.ts']
+        : []
     );
 
     await handler(createArgs());
 
-    expect(mockExeca).not.toHaveBeenCalled();
+    expect(mockExeca).not.toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(['scripts/jest']),
+      expect.anything()
+    );
+    expect(mockRunJestViaMoon).toHaveBeenCalled();
+  });
+
+  it('skips fast path for Scout test files with parallel playwright config', async () => {
+    mockResolveValidationBaseContext.mockResolvedValue({
+      ...baseContext,
+      runContext: {
+        ...baseContext.runContext,
+        changedFiles: [
+          'src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/fullscreen.spec.ts',
+        ],
+      },
+    });
+
+    mockExistsSync.mockReturnValue(false);
+    mockReaddirSync.mockImplementation((dir: string) =>
+      dir === '/repo/src/platform/plugins/shared/discover/test/scout/ui'
+        ? ['parallel.playwright.config.ts']
+        : []
+    );
+
+    await handler(createArgs());
+
+    expect(mockExeca).not.toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(['scripts/jest']),
+      expect.anything()
+    );
     expect(mockRunJestViaMoon).toHaveBeenCalled();
   });
 
@@ -495,5 +547,120 @@ describe('run_check', () => {
     expect(output).toContain('src/dev/run_check.ts:852:13: error TS1234: broken');
     expect(output).toContain('node scripts/type_check --project tsconfig.json');
     expect(output).not.toContain('node scripts/type_check --profile quick');
+  });
+
+  const execaCallFor = (script: string) =>
+    mockExeca.mock.calls.find(([, args]: [string, string[]]) => args?.includes(script));
+
+  describe('tsproj step', () => {
+    it('prints "no scoped projects" when only root-level inputs are affected', async () => {
+      mockResolveValidationAffectedProjects.mockResolvedValue({
+        isRootProjectAffected: true,
+        affectedSourceRoots: ['packages/foo'],
+      });
+
+      await handler(createArgs());
+
+      const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
+      expect(output).toContain('tsproj— no scoped projects');
+      expect(execaCallFor('scripts/lint_ts_projects')).toBeUndefined();
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('runs lint_ts_projects on affected roots and reports success', async () => {
+      mockResolveValidationAffectedProjects.mockResolvedValue({
+        isRootProjectAffected: false,
+        affectedSourceRoots: ['packages/foo', 'packages/bar'],
+      });
+
+      await handler(createArgs());
+
+      expect(mockExeca).toHaveBeenCalledWith(
+        process.execPath,
+        ['scripts/lint_ts_projects', '--fix', 'packages/foo', 'packages/bar'],
+        expect.objectContaining({ reject: false })
+      );
+      const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
+      expect(output).toContain('tsproj✓ 2 projects');
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('omits --fix when run with --no-fix', async () => {
+      mockResolveValidationAffectedProjects.mockResolvedValue({
+        isRootProjectAffected: false,
+        affectedSourceRoots: ['packages/foo'],
+      });
+
+      await handler(createArgs({ fix: false }));
+
+      const call = execaCallFor('scripts/lint_ts_projects');
+      expect(call?.[1]).toEqual(['scripts/lint_ts_projects', 'packages/foo']);
+    });
+
+    it('reports a failure and rerun command when lint_ts_projects fails', async () => {
+      mockResolveValidationAffectedProjects.mockResolvedValue({
+        isRootProjectAffected: false,
+        affectedSourceRoots: ['packages/foo'],
+      });
+      mockExeca.mockImplementation(async (_bin: string, args: string[]) =>
+        args.includes('scripts/lint_ts_projects')
+          ? { exitCode: 1, stdout: 'tsconfig drift detected', stderr: '' }
+          : { exitCode: 0, stdout: '', stderr: '' }
+      );
+
+      await handler(createArgs());
+
+      expect(process.exitCode).toBe(1);
+      const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
+      expect(output).toContain('tsproj✗ failed');
+      expect(output).toContain('tsconfig drift detected');
+      expect(output).toContain('node scripts/lint_ts_projects --fix packages/foo');
+    });
+  });
+
+  describe('moon step', () => {
+    it('runs regenerate with --update when fixing', async () => {
+      await handler(createArgs({ fix: true }));
+
+      expect(mockExeca).toHaveBeenCalledWith(
+        process.execPath,
+        ['scripts/regenerate_moon_projects.js', '--update'],
+        expect.objectContaining({ reject: false })
+      );
+      const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
+      expect(output).toContain('moon  ✓ projects regenerated');
+    });
+
+    it('runs regenerate with --check (no write) when --no-fix', async () => {
+      await handler(createArgs({ fix: false }));
+
+      expect(mockExeca).toHaveBeenCalledWith(
+        process.execPath,
+        ['scripts/regenerate_moon_projects.js', '--check'],
+        expect.objectContaining({ reject: false })
+      );
+      expect(mockExeca).not.toHaveBeenCalledWith(
+        process.execPath,
+        ['scripts/regenerate_moon_projects.js', '--update'],
+        expect.anything()
+      );
+      const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
+      expect(output).toContain('moon  ✓ up to date');
+    });
+
+    it('fails when regenerate reports drift under --no-fix', async () => {
+      mockExeca.mockImplementation(async (_bin: string, args: string[]) =>
+        args.includes('scripts/regenerate_moon_projects.js')
+          ? { exitCode: 1, stdout: '', stderr: '1 Moon project configuration(s) out of date' }
+          : { exitCode: 0, stdout: '', stderr: '' }
+      );
+
+      await handler(createArgs({ fix: false }));
+
+      expect(process.exitCode).toBe(1);
+      const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
+      expect(output).toContain('moon  ✗ failed');
+      expect(output).toContain('node scripts/regenerate_moon_projects.js --update');
+    });
   });
 });

--- a/src/dev/run_check.ts
+++ b/src/dev/run_check.ts
@@ -14,6 +14,7 @@ import { run } from '@kbn/dev-cli-runner';
 import { ProcRunner } from '@kbn/dev-proc-runner';
 import {
   readValidationRunFlags,
+  resolveValidationAffectedProjects,
   resolveValidationBaseContext,
   type ValidationBaseContext,
   VALIDATION_RUN_HELP,
@@ -161,6 +162,41 @@ const findJestUnitConfig = (filePath: string): string | undefined => {
 
 const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
 
+const runLintTsProjects = async (
+  affectedSourceRoots: string[],
+  fix: boolean
+): Promise<{ passed: boolean; output: string }> => {
+  const execa = (await import('execa')).default;
+  const args = ['scripts/lint_ts_projects'];
+  if (fix) args.push('--fix');
+  args.push(...affectedSourceRoots);
+
+  const result = await execa(process.execPath, args, {
+    cwd: REPO_ROOT,
+    reject: false,
+  });
+
+  return {
+    passed: result.exitCode === 0,
+    output: [result.stdout, result.stderr].filter(Boolean).join('\n'),
+  };
+};
+
+const runMoonRegeneration = async (fix: boolean): Promise<{ passed: boolean; output: string }> => {
+  const execa = (await import('execa')).default;
+  // --update writes regenerated configs; --check fails on drift without writing.
+  const result = await execa(
+    process.execPath,
+    ['scripts/regenerate_moon_projects.js', fix ? '--update' : '--check'],
+    { cwd: REPO_ROOT, reject: false }
+  );
+
+  return {
+    passed: result.exitCode === 0,
+    output: [result.stdout, result.stderr].filter(Boolean).join('\n'),
+  };
+};
+
 const runJestTestsDirectly = async (
   testFiles: string[]
 ): Promise<{ testCount: number; passed: boolean; output: string }> => {
@@ -233,6 +269,98 @@ run(
       (baseContext.runContext.kind === 'skip' ||
         baseContext.runContext.kind === 'full' ||
         baseContext.contract.testMode === 'all');
+
+    // Steps run in a fixed order: tsproj → moon → lint → jest → tsc.
+    // @kbn/ts-projects is cached for the process; tsproj autofixes tsconfigs in a
+    // subprocess, so lint/tsc must not load TS_PROJECTS until those fixes are on disk.
+    // Do not reorder or add top-level imports that pull in @kbn/ts-projects earlier.
+
+    // ── ts projects ────────────────────────────────────────────────────
+
+    {
+      const tsProjectsProgress = startProgress('tsproj');
+
+      if (isSkipOrFull) {
+        tsProjectsProgress.writeResult(
+          line('tsproj', '—', 'skipped', tsProjectsProgress.elapsed())
+        );
+      } else if (changedFiles.length === 0) {
+        tsProjectsProgress.writeResult(
+          line('tsproj', '—', 'no changed files', tsProjectsProgress.elapsed())
+        );
+      } else {
+        try {
+          const affected = await resolveValidationAffectedProjects({
+            changedFilesJson: JSON.stringify({ files: changedFiles }),
+            downstream: baseContext.mode === 'contract' ? baseContext.contract.downstream : 'none',
+          });
+
+          if (affected.isRootProjectAffected || affected.affectedSourceRoots.length === 0) {
+            // Root-level inputs touched (or nothing to scope to) — skip the scoped run; the
+            // repo-wide lint_ts_projects check still runs in its own dedicated CI step.
+            tsProjectsProgress.writeResult(
+              line('tsproj', '—', 'no scoped projects', tsProjectsProgress.elapsed())
+            );
+          } else {
+            const result = await runLintTsProjects(affected.affectedSourceRoots, fix);
+            if (result.passed) {
+              tsProjectsProgress.writeResult(
+                line(
+                  'tsproj',
+                  '✓',
+                  pluralize(affected.affectedSourceRoots.length, 'project'),
+                  tsProjectsProgress.elapsed()
+                )
+              );
+            } else {
+              tsProjectsProgress.writeResult(
+                line('tsproj', '✗', 'failed', tsProjectsProgress.elapsed())
+              );
+              writeln('');
+              const excerpt = result.output.split('\n').slice(-20);
+              for (const l of excerpt) writeln(`    ${l}`);
+              writeln(
+                `    $ node scripts/lint_ts_projects${
+                  fix ? ' --fix' : ''
+                } ${affected.affectedSourceRoots.join(' ')}`
+              );
+              writeln('');
+              errors.push(new Error('lint_ts_projects failed'));
+            }
+          }
+        } catch (error) {
+          tsProjectsProgress.writeResult(
+            line('tsproj', '✗', 'failed', tsProjectsProgress.elapsed())
+          );
+          errors.push(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
+    }
+
+    // ── moon ───────────────────────────────────────────────────────────
+
+    {
+      const moonProgress = startProgress('moon');
+      try {
+        const result = await runMoonRegeneration(fix);
+        if (result.passed) {
+          moonProgress.writeResult(
+            line('moon', '✓', fix ? 'projects regenerated' : 'up to date', moonProgress.elapsed())
+          );
+        } else {
+          moonProgress.writeResult(line('moon', '✗', 'failed', moonProgress.elapsed()));
+          writeln('');
+          const excerpt = result.output.split('\n').slice(-15);
+          for (const l of excerpt) writeln(`    ${l}`);
+          writeln('    $ node scripts/regenerate_moon_projects.js --update');
+          writeln('');
+          errors.push(new Error('regenerate_moon_projects failed'));
+        }
+      } catch (error) {
+        moonProgress.writeResult(line('moon', '✗', 'failed', moonProgress.elapsed()));
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
 
     // ── lint ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Update local checks (#271651)](https://github.com/elastic/kibana/pull/271651)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-06-30T11:37:33Z","message":"[CI] Update local checks (#271651)\n\n## Summary\nUpdate local checks to include tsproj (linting `tsconfig.json` files as\nseen in quick-checks) and moon project regeneration.\n- `tsproj` takes ~20s worst case, but 5-6s when ran selectively for a\nsmall subset\n- `moon` regen takes ~3s worst case\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ed5c2961f65716480895e4a6861cd25b70e3bed4","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport missing","backport:all-open","v9.5.0"],"title":"[CI] Update local checks","number":271651,"url":"https://github.com/elastic/kibana/pull/271651","mergeCommit":{"message":"[CI] Update local checks (#271651)\n\n## Summary\nUpdate local checks to include tsproj (linting `tsconfig.json` files as\nseen in quick-checks) and moon project regeneration.\n- `tsproj` takes ~20s worst case, but 5-6s when ran selectively for a\nsmall subset\n- `moon` regen takes ~3s worst case\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ed5c2961f65716480895e4a6861cd25b70e3bed4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271651","number":271651,"mergeCommit":{"message":"[CI] Update local checks (#271651)\n\n## Summary\nUpdate local checks to include tsproj (linting `tsconfig.json` files as\nseen in quick-checks) and moon project regeneration.\n- `tsproj` takes ~20s worst case, but 5-6s when ran selectively for a\nsmall subset\n- `moon` regen takes ~3s worst case\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ed5c2961f65716480895e4a6861cd25b70e3bed4"}}]}] BACKPORT-->