### PR TITLE
[Security Solution] Keep Attack Discovery pending during validation

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.test.tsx
@@ -42,6 +42,12 @@ describe('LoadingCallout', () => {
     approximateFutureTime: new Date(),
     localStorageAttackDiscoveryMaxAlerts: '50',
   };
+  const validationTracking = {
+    alertRetrieval: null,
+    gate: null,
+    generation: null,
+    validation: { workflowId: 'validation-workflow', workflowRunId: 'validation-run' },
+  };
 
   const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
 
@@ -117,6 +123,67 @@ describe('LoadingCallout', () => {
       .querySelector('[data-euiicon-type="logoElastic"]');
 
     expect(icon).not.toBeNull();
+  });
+
+  it('remains in progress when generation succeeded but validation results are pending', () => {
+    render(
+      <TestProviders>
+        <LoadingCallout
+          {...defaultProps}
+          discoveries={0}
+          executionUuid="uuid-123"
+          status="succeeded"
+          workflowExecutions={validationTracking}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('loadingElastic')).toBeInTheDocument();
+    expect(screen.queryByText(/Attack discovery ran successfully/)).not.toBeInTheDocument();
+  });
+
+  it('renders terminal success for a completed validation with zero persisted discoveries', () => {
+    render(
+      <TestProviders>
+        <LoadingCallout
+          {...defaultProps}
+          discoveries={0}
+          duplicatesDroppedCount={7}
+          executionUuid="uuid-123"
+          generatedCount={7}
+          persistedCount={0}
+          status="succeeded"
+          workflowExecutions={validationTracking}
+        />
+      </TestProviders>
+    );
+
+    const icon = screen
+      .getByTestId('loadingCallout')
+      .querySelector('[data-euiicon-type="logoElastic"]');
+
+    expect(icon).not.toBeNull();
+    expect(screen.getByText(/0 new attacks were discovered/)).toBeInTheDocument();
+  });
+
+  it('keeps terminal success behavior for generations without validation tracking', () => {
+    render(
+      <TestProviders>
+        <LoadingCallout
+          {...defaultProps}
+          discoveries={0}
+          executionUuid="uuid-123"
+          status="succeeded"
+        />
+      </TestProviders>
+    );
+
+    const icon = screen
+      .getByTestId('loadingCallout')
+      .querySelector('[data-euiicon-type="logoElastic"]');
+
+    expect(icon).not.toBeNull();
+    expect(screen.getByText(/0 new attacks were discovered/)).toBeInTheDocument();
   });
 
   it('renders terminal state icon for failed', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.tsx
@@ -133,7 +133,15 @@ const LoadingCalloutComponent: React.FC<Props> = ({
     loadFeatureFlag();
   }, [featureFlags, uiSettings]);
 
-  const isTerminalState = useMemo(() => getIsTerminalState(status), [status]);
+  // A generation-succeeded event is emitted before validation finishes. Keep the
+  // callout in progress until validation writes the persisted result. A persisted
+  // count of 0 is a valid final result and must remain a terminal success.
+  const displayStatus =
+    status === 'succeeded' && workflowExecutions?.validation != null && persistedCount == null
+      ? 'started'
+      : status;
+
+  const isTerminalState = useMemo(() => getIsTerminalState(displayStatus), [displayStatus]);
 
   const leftContent = useMemo(
     () => (
@@ -166,7 +174,7 @@ const LoadingCalloutComponent: React.FC<Props> = ({
             persistedCount={persistedCount}
             reason={reason}
             start={start}
-            status={status}
+            status={displayStatus}
           />
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -187,7 +195,7 @@ const LoadingCalloutComponent: React.FC<Props> = ({
       persistedCount,
       reason,
       start,
-      status,
+      displayStatus,
     ]
   );
 
@@ -196,11 +204,11 @@ const LoadingCalloutComponent: React.FC<Props> = ({
     const successBackgroundColor = euiTheme.colors.backgroundBaseSuccess;
     const failedBackgroundColor = euiTheme.colors.backgroundBaseDanger;
 
-    if (status === 'succeeded') {
+    if (displayStatus === 'succeeded') {
       return successBackgroundColor;
     }
 
-    if (status === 'failed') {
+    if (displayStatus === 'failed') {
       return failedBackgroundColor;
     }
 
@@ -208,8 +216,8 @@ const LoadingCalloutComponent: React.FC<Props> = ({
   }, [
     euiTheme.colors.backgroundBaseDanger,
     euiTheme.colors.backgroundBaseSuccess,
+    displayStatus,
     isDarkMode,
-    status,
   ]);
 
   const borderColor = useMemo(() => {
@@ -217,11 +225,11 @@ const LoadingCalloutComponent: React.FC<Props> = ({
     const successBorderColor = euiTheme.colors.borderBaseSuccess;
     const failedBorderColor = euiTheme.colors.borderBaseDanger;
 
-    if (status === 'succeeded') {
+    if (displayStatus === 'succeeded') {
       return successBorderColor;
     }
 
-    if (status === 'failed') {
+    if (displayStatus === 'failed') {
       return failedBorderColor;
     }
 
@@ -230,8 +238,8 @@ const LoadingCalloutComponent: React.FC<Props> = ({
     euiTheme.colors.borderBaseDanger,
     euiTheme.colors.borderBaseSuccess,
     euiTheme.colors.lightShade,
+    displayStatus,
     isDarkMode,
-    status,
   ]);
 
   const { mutateAsync: dismissAttackDiscoveryGeneration } = useDismissAttackDiscoveryGeneration();


### PR DESCRIPTION
## Summary

- keep the Attack Discovery callout visually in progress after generation succeeds while tracked validation has not published its persisted result
- use the presentation-only status consistently for the icon, message, colors, and countdown while retaining the raw generation status for workflow details
- preserve legitimate zero-result validation and legacy generations without validation tracking

## Root cause

The generation workflow emits `generation-succeeded` before validation completes. During that gap, the generations API reports a terminal generation status without `persisted_count`, so the shared callout rendered success and could claim an incorrect result before validation published the actual persisted count.

## Before/after evidence

- Before: the banner could report success and an incorrect count while the validation stage was still loading, as documented in #280257.
- After: live execution `5b75f2d0-523b-4403-9777-5e4184efd897` remained animated and in progress when `status=succeeded`, validation was tracked, and `persisted_count` was absent; it then rendered terminal success with the final persisted count of 5.

## Test plan

- [x] Targeted `LoadingCallout` Jest suite (38 tests)
- [x] Related callout, loading-message, and workflow-details Jest suites (120 tests)
- [x] ESLint on both changed files
- [x] Scoped Security Solution type-check
- [x] Live local Attack Discovery generation through validation and final persistence
- [x] Independent principal test review and request-scope critique

Closes #280257

Made with [Cursor](https://cursor.com)