### PR TITLE
[Entity Store] Backport: batch concurrency limit and closed-index warning truncation (9.5)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
@@ -307,6 +307,68 @@ describe('resolveClosedIndexAdjustments', () => {
     });
   });
 
+  it('limits concurrent batch resolveIndex calls to 30 at a time', async () => {
+    // Long names (~183 chars) keep each URL chunk to ~18 indices.
+    // 800 names → ~45 chunks, well above the 30 concurrency cap.
+    const longPrefix = '.ds-logs-climit-' + 'a'.repeat(160);
+    const allBackingIndices = Array.from(
+      { length: 800 },
+      (_, i) => `${longPrefix}-${String(i).padStart(6, '0')}`
+    );
+
+    let activeCalls = 0;
+    let peakActiveCalls = 0;
+    const pendingResolvers: Array<() => void> = [];
+
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: [
+          {
+            name: 'logs-climit',
+            backing_indices: allBackingIndices,
+            timestamp_field: '@timestamp',
+          },
+        ],
+      })
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            activeCalls++;
+            peakActiveCalls = Math.max(peakActiveCalls, activeCalls);
+            pendingResolvers.push(() => {
+              activeCalls--;
+              resolve(emptyResolve);
+            });
+          })
+      );
+
+    const resultPromise = resolveClosedIndexAdjustments(
+      makeEsClient(resolveIndex),
+      ['logs-climit'],
+      logger
+    );
+
+    // Flush all microtasks so pLimit fills up to its concurrency cap before we inspect.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(peakActiveCalls).toBe(30);
+    expect(activeCalls).toBe(30);
+
+    // Drain in rounds: resolving a batch lets pLimit start the next queued chunks.
+    while (pendingResolvers.length > 0) {
+      pendingResolvers.splice(0).forEach((r) => r());
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    await resultPromise;
+
+    // Sanity check: there were more than 30 chunks, so the cap was actually exercised.
+    expect(resolveIndex.mock.calls.length - 1).toBeGreaterThan(30);
+  });
+
   it('returns empty result and logs a warning on resolveIndex failure', async () => {
     const resolveIndex = jest.fn().mockRejectedValue(new Error('connection refused'));
 

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
@@ -132,11 +132,10 @@ export const resolveClosedIndexAdjustments = async (
     const negations = [...closedStandaloneNegations, ...dataStreamNegations];
 
     if (negations.length > 0 || openBackingIndices.length > 0) {
+      const preview = negations.slice(0, 20).join(', ');
+      const overflow = negations.length > 20 ? ` … and ${negations.length - 20} more` : '';
       logger.warn(
-        `Detected closed backing indices. Excluding data streams/indices: ${negations.join(', ')}` +
-          (openBackingIndices.length > 0
-            ? `; adding open backing indices back: ${openBackingIndices.join(', ')}`
-            : '')
+        `Detected closed backing indices. Excluding data streams/indices: ${preview}${overflow}`
       );
     }
 

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import pLimit from 'p-limit';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 
@@ -43,6 +44,7 @@ const toArray = (v: string | string[]): string[] => ([] as string[]).concat(v);
 // becomes %2C (3 bytes). Elasticsearch's Netty HTTP server rejects request lines > 4096 bytes,
 // so we cap each batch well below that limit.
 const MAX_URL_NAMES_BYTES = 3_500;
+const BATCH_CONCURRENCY_LIMIT = 30;
 
 const chunkByUrlLength = (names: string[]): string[][] => {
   const chunks: string[][] = [];
@@ -98,10 +100,12 @@ export const resolveClosedIndexAdjustments = async (
       // The first resolveIndex call returns backing index names without open/closed attributes,
       // so a second round is needed to learn their status. Batching avoids a
       // too_long_http_line_exception when many backing indices would push the URL past the
-      // Elasticsearch Netty limit of 4096 bytes.
+      // Elasticsearch Netty limit of 4096 bytes. Concurrency is capped to avoid overwhelming
+      // the cluster when there are many chunks.
+      const limit = pLimit(BATCH_CONCURRENCY_LIMIT);
       const batchResults = await Promise.all(
         chunkByUrlLength(backingIndexNames).map((chunk) =>
-          esClient.indices.resolveIndex(resolveArgs(chunk))
+          limit(() => esClient.indices.resolveIndex(resolveArgs(chunk)))
         )
       );
 


### PR DESCRIPTION
## Summary

Manual backport of https://github.com/elastic/kibana/pull/280347 to 9.5.

- **Cap concurrent resolveIndex batch calls with pLimit** — limits concurrency to avoid overwhelming Elasticsearch with parallel index-resolution requests.
- **Truncate closed-index warning to first 20 negations** — prevents excessively long warning messages when many closed indices are detected.

## Commits cherry-picked

- `0bf75196eb13` [Entity Store] Cap concurrent resolveIndex batch calls with pLimit
- `59a8280dd74a` [Entity Store] Truncate closed-index warning to first 20 negations

