### PR TITLE
[Fleet] Retry transient EPR errors in install-all-packages test

### DIFF
--- a/x-pack/platform/test/fleet_packages/tests/install_all.ts
+++ b/x-pack/platform/test/fleet_packages/tests/install_all.ts
@@ -12,6 +12,8 @@
  * 2.0.
  */
 
+import pRetry from 'p-retry';
+
 import type { FtrProviderContext } from '../../api_integration/ftr_provider_context';
 
 const DEPRECATED_PACKAGES = [
@@ -37,33 +39,38 @@ export default function (providerContext: FtrProviderContext) {
 
   async function installPackage(
     name: string,
-    version: string,
-    maxRetries = 3
+    version: string
   ): Promise<{ name: string; version: string; success: boolean; error?: any; took?: number }> {
     const start = Date.now();
-    let lastError: any;
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        await supertest
-          .post(`/api/fleet/epm/packages/${name}/${version}`)
-          .set('kbn-xsrf', 'xxx')
-          .set(API_VERSION_HEADER_NAME, API_VERSION)
-          .send({ force: true })
-          .expect(200);
-        return { name, version, success: true, took: (Date.now() - start) / 1000 };
-      } catch (error) {
-        lastError = error;
-        if (!isTransientError(error) || attempt === maxRetries) {
-          break;
+    try {
+      await pRetry(
+        () =>
+          supertest
+            .post(`/api/fleet/epm/packages/${name}/${version}`)
+            .set('kbn-xsrf', 'xxx')
+            .set(API_VERSION_HEADER_NAME, API_VERSION)
+            .send({ force: true })
+            .expect(200),
+        {
+          retries: 3,
+          factor: 2,
+          minTimeout: 2000,
+          onFailedAttempt: (error) => {
+            if (!isTransientError(error)) {
+              throw error;
+            }
+            logger.warning(
+              `Install ${name}@${version} failed with transient error (attempt ${
+                error.attemptNumber
+              }/${error.attemptNumber + error.retriesLeft}), retrying: ${error.message}`
+            );
+          },
         }
-        const delayMs = 2000 * attempt;
-        logger.warning(
-          `Install ${name}@${version} failed with transient error (attempt ${attempt}/${maxRetries}), retrying in ${delayMs}ms: ${error?.message}`
-        );
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-      }
+      );
+      return { name, version, success: true, took: (Date.now() - start) / 1000 };
+    } catch (error) {
+      return { name, version, success: false, error };
     }
-    return { name, version, success: false, error: lastError };
   }
 
   async function deletePackage(

--- a/x-pack/platform/test/fleet_packages/tests/install_all.ts
+++ b/x-pack/platform/test/fleet_packages/tests/install_all.ts
@@ -44,13 +44,18 @@ export default function (providerContext: FtrProviderContext) {
     const start = Date.now();
     try {
       await pRetry(
-        () =>
-          supertest
+        async () => {
+          const res = await supertest
             .post(`/api/fleet/epm/packages/${name}/${version}`)
             .set('kbn-xsrf', 'xxx')
             .set(API_VERSION_HEADER_NAME, API_VERSION)
-            .send({ force: true })
-            .expect(200),
+            .send({ force: true });
+          if (res.status !== 200) {
+            const err: any = new Error(`Install failed with status ${res.status}`);
+            err.status = res.status;
+            throw err;
+          }
+        },
         {
           retries: 3,
           factor: 2,

--- a/x-pack/platform/test/fleet_packages/tests/install_all.ts
+++ b/x-pack/platform/test/fleet_packages/tests/install_all.ts
@@ -26,24 +26,44 @@ export default function (providerContext: FtrProviderContext) {
   const API_VERSION = '2023-10-31';
   const API_VERSION_HEADER_NAME = 'elastic-api-version';
 
-  function installPackage(
+  function isTransientError(error: any): boolean {
+    const status = error?.response?.status ?? error?.status;
+    if (status != null) {
+      return status >= 500;
+    }
+    // Network-level errors (ECONNRESET, ETIMEDOUT, etc.)
+    return error?.code != null;
+  }
+
+  async function installPackage(
     name: string,
-    version: string
+    version: string,
+    maxRetries = 3
   ): Promise<{ name: string; version: string; success: boolean; error?: any; took?: number }> {
     const start = Date.now();
-    return supertest
-      .post(`/api/fleet/epm/packages/${name}/${version}`)
-      .set('kbn-xsrf', 'xxx')
-      .set(API_VERSION_HEADER_NAME, API_VERSION)
-      .send({ force: true })
-      .expect(200)
-      .then(() => {
-        const end = Date.now();
-        return { name, version, success: true, took: (end - start) / 1000 };
-      })
-      .catch((error) => {
-        return { name, version, success: false, error };
-      });
+    let lastError: any;
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        await supertest
+          .post(`/api/fleet/epm/packages/${name}/${version}`)
+          .set('kbn-xsrf', 'xxx')
+          .set(API_VERSION_HEADER_NAME, API_VERSION)
+          .send({ force: true })
+          .expect(200);
+        return { name, version, success: true, took: (Date.now() - start) / 1000 };
+      } catch (error) {
+        lastError = error;
+        if (!isTransientError(error) || attempt === maxRetries) {
+          break;
+        }
+        const delayMs = 2000 * attempt;
+        logger.warning(
+          `Install ${name}@${version} failed with transient error (attempt ${attempt}/${maxRetries}), retrying in ${delayMs}ms: ${error?.message}`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+    return { name, version, success: false, error: lastError };
   }
 
   async function deletePackage(


### PR DESCRIPTION
## Summary

The `install_all.ts` test installs every package from EPR in sequence. On a single transient network or server error (5xx, connection reset, timeout), the entire package was counted as failed and the test threw at the end.

This uses `p-retry` (already a project dependency) to retry on transient errors only — HTTP 5xx responses and network-level errors. 4xx errors (bad request, not found) are not retried since they indicate a real problem.

## Changes

- `installPackage` uses `pRetry` with `retries: 3`, exponential backoff (`factor: 2`, `minTimeout: 2s`)
- `isTransientError` distinguishes transient (5xx / network) from permanent (4xx) errors — non-transient errors abort immediately via `throw` in `onFailedAttempt`
- Logs a warning on each retried attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)