### PR TITLE
[Security Solution] Fix typo in deprecated rules callout title

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_deprecation/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_deprecation/translations.ts
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 export const DEPRECATION_CALLOUT_TITLE = (count: number) =>
   i18n.translate('xpack.securitySolution.detectionEngine.deprecation.calloutTitle', {
     defaultMessage:
-      '{count} of your installed Elastic {count, plural, one {rule has} other {rules have}} been deprecated and {count, plural, one {is} other {are}} no longer being maintained',
+      '{count} of your installed Elastic rules {count, plural, one {has} other {have}} been deprecated and {count, plural, one {is} other {are}} no longer being maintained',
     values: { count },
   });
 


### PR DESCRIPTION
## Summary

The deprecated rules callout on the Detection Rules page shows "1 of your installed Elastic rule has been deprecated..." when exactly one rule is deprecated. The word "rule" should be "rules" here regardless of count, since the phrase refers to the category.

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->