### PR TITLE
[Failed Test Reporter] Polish auto-close comment on stale failed-test issues

### DIFF
--- a/.github/workflows/close-stale-failed-test-issues.yml
+++ b/.github/workflows/close-stale-failed-test-issues.yml
@@ -101,7 +101,7 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: item.number,
                 body: [
-                  `Closing as this test hasn't failed in ${DAYS_UNTIL_CLOSE} days. It'll reopen automatically on a new failure.`,
+                  `Closing as this test hasn't failed in 3 weeks, which likely means the flakiness has resolved itself. This issue will reopen automatically if the test fails again.`,
                   '',
                   '<!-- failed-test-stale-closed -->',
                 ].join('\n'),


### PR DESCRIPTION
Rewords the comment the `Close stale failed-test issues` workflow posts when it auto-closes a stale `failed-test` issue, so it reads in plain English and explains *why* it's being closed.