### PR TITLE
[9.5] [scout][saved_objects_tagging] improve tests cleanup and expose page objects via fixture (#279459)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
@@ -27,6 +27,7 @@ import { ListingTable } from './listing_table';
 import { LoginPage } from './login_page';
 import { HomePage } from './home_page';
 import { OverlaysPage } from './overlays';
+import { SavedObjectSaveModal } from './saved_object_save_modal';
 import { VisualizeApp } from './visualize_app';
 import { UnifiedFieldList } from './unified_field_list';
 import { UnifiedTabs } from './unified_tabs';
@@ -74,6 +75,7 @@ export interface PageObjects {
   overlays: OverlaysPage;
   visualize: VisualizeApp;
   unifiedFieldList: UnifiedFieldList;
+  saveModal: SavedObjectSaveModal;
   unifiedTabs: UnifiedTabs;
 }
 
@@ -103,6 +105,7 @@ export function createCorePageObjects(fixtures: PageObjectsFixtures): PageObject
     overlays: createLazyPageObject(OverlaysPage, fixtures.page),
     visualize: createLazyPageObject(VisualizeApp, fixtures.page),
     unifiedFieldList: createLazyPageObject(UnifiedFieldList, fixtures.page),
+    saveModal: createLazyPageObject(SavedObjectSaveModal, fixtures.page),
     unifiedTabs: createLazyPageObject(UnifiedTabs, fixtures.page),
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/maps_page.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/maps_page.ts
@@ -9,6 +9,7 @@
 
 import type { ScoutPage } from '..';
 import { EuiComboBoxWrapper } from '..';
+import { SavedObjectSaveModal } from './saved_object_save_modal';
 
 // Increased timeout because new map container is not always loaded within default one
 const DEFAULT_MAP_LOADING_TIMEOUT = 20_000;
@@ -21,10 +22,10 @@ export class MapsPage {
   public readonly addLayerButton;
   public readonly layerAddForm;
   public readonly importFileButton;
-  public readonly savedObjectTitleInput;
   public readonly returnToOriginSwitch;
-  public readonly confirmSaveButton;
   public readonly documentsItem;
+  /** Save modal locators/actions, shared with other apps (e.g. Visualize) via `SavedObjectSaveModal`. */
+  public readonly saveModal: SavedObjectSaveModal;
 
   constructor(private readonly page: ScoutPage) {
     this.mapContainer = this.page.locator('#maps-plugin');
@@ -36,10 +37,9 @@ export class MapsPage {
     this.addLayerButton = this.page.testSubj.locator('addLayerButton');
     this.layerAddForm = this.page.testSubj.locator('layerAddForm');
     this.importFileButton = this.page.testSubj.locator('importFileButton');
-    this.savedObjectTitleInput = this.page.testSubj.locator('savedObjectTitle');
     this.returnToOriginSwitch = this.page.testSubj.locator('returnToOriginModeSwitch');
-    this.confirmSaveButton = this.page.testSubj.locator('confirmSaveSavedObjectButton');
     this.documentsItem = this.page.testSubj.locator('documents');
+    this.saveModal = new SavedObjectSaveModal(this.page);
   }
 
   async gotoNewMap() {
@@ -68,15 +68,14 @@ export class MapsPage {
   }
 
   async saveFromModal(title: string, { redirectToOrigin = true }: { redirectToOrigin?: boolean }) {
-    await this.savedObjectTitleInput.fill(title);
+    await this.saveModal.fillTitle(title);
     if (await this.returnToOriginSwitch.isVisible()) {
       const isChecked = (await this.returnToOriginSwitch.getAttribute('aria-checked')) === 'true';
       if (isChecked !== redirectToOrigin) {
         await this.returnToOriginSwitch.click();
       }
     }
-    await this.confirmSaveButton.click();
-    await this.confirmSaveButton.waitFor({ state: 'hidden' });
+    await this.saveModal.confirm();
   }
 
   getLayerToggleButton(displayName: string) {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/saved_object_save_modal.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/saved_object_save_modal.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutPage } from '..';
+import { expect } from '..';
+
+/**
+ * Page object for the shared `SavedObjectSaveModal` (and its `SaveModalDashboardSelector`
+ * add-to-dashboard controls), used when saving visualizations, maps, and other saved objects.
+ * Assumes the modal is already open; each app opens it differently (e.g. Visualize's
+ * `visualizeSaveButton`, Maps' `saveButton`).
+ */
+export class SavedObjectSaveModal {
+  /** The modal container itself, exposed so callers can wait for it to open (e.g. after clicking an app-specific save button). */
+  readonly modal;
+  private readonly titleInput;
+  private readonly confirmSaveButton;
+  private readonly dashboardPicker;
+
+  constructor(private readonly page: ScoutPage) {
+    this.modal = this.page.testSubj.locator('savedObjectSaveModal');
+    this.titleInput = this.page.testSubj.locator('savedObjectTitle');
+    this.confirmSaveButton = this.page.testSubj.locator('confirmSaveSavedObjectButton');
+    this.dashboardPicker = this.page.testSubj.locator('open-dashboard-picker');
+  }
+
+  async fillTitle(name: string) {
+    await this.titleInput.fill(name);
+  }
+
+  async selectExistingDashboard(dashboardTitle: string) {
+    await this.page.locator('label[for="existing-dashboard-option"]').click();
+    await this.dashboardPicker.click();
+    await this.page.testSubj
+      .locator(`dashboard-picker-option-${dashboardTitle.split(' ').join('-')}`)
+      .click();
+  }
+
+  async selectNewDashboard() {
+    await this.page.locator('label[for="new-dashboard-option"]').click();
+  }
+
+  async selectNoDashboard() {
+    await this.page.locator('label[for="add-to-library-option"]').click();
+  }
+
+  async confirm() {
+    await this.confirmSaveButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  async saveToExistingDashboard(name: string, dashboardTitle: string) {
+    await this.fillTitle(name);
+    await this.selectExistingDashboard(dashboardTitle);
+    await this.confirm();
+  }
+
+  async saveToNewDashboard(name: string) {
+    await this.fillTitle(name);
+    await this.selectNewDashboard();
+    await this.confirm();
+  }
+
+  async saveToLibrary(name: string) {
+    await this.fillTitle(name);
+    await this.selectNoDashboard();
+    const addToLibraryCheckbox = this.page.locator('input#add-to-library-checkbox');
+    await expect(addToLibraryCheckbox).toBeChecked();
+    await expect(addToLibraryCheckbox).toBeDisabled();
+    await this.confirm();
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/visualize_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/visualize_app.ts
@@ -9,6 +9,7 @@
 
 import type { ScoutPage } from '..';
 import { expect } from '..';
+import { SavedObjectSaveModal } from './saved_object_save_modal';
 
 type VisType = 'lens' | 'vega' | 'metrics' | 'aggbased' | 'maps';
 
@@ -19,11 +20,11 @@ export class VisualizeApp {
   private readonly visNewDialogTypes;
   private readonly legacyTab;
   private readonly visualizeSaveButton;
-  private readonly saveModal;
-  private readonly savedObjectTitleInput;
-  private readonly confirmSaveButton;
   private readonly visualizationLoader;
   private readonly dashboardPicker;
+  private readonly editInLensButton;
+  /** Save modal locators/actions, shared with other apps (e.g. Maps) via `SavedObjectSaveModal`. */
+  readonly saveModal: SavedObjectSaveModal;
 
   constructor(private readonly page: ScoutPage) {
     this.landingPage = this.page.testSubj.locator('visualizationLandingPage');
@@ -32,11 +33,10 @@ export class VisualizeApp {
     this.visNewDialogTypes = this.page.testSubj.locator('visNewDialogTypes');
     this.legacyTab = this.page.testSubj.locator('groupModalLegacyTab');
     this.visualizeSaveButton = this.page.testSubj.locator('visualizeSaveButton');
-    this.saveModal = this.page.testSubj.locator('savedObjectSaveModal');
-    this.savedObjectTitleInput = this.page.testSubj.locator('savedObjectTitle');
-    this.confirmSaveButton = this.page.testSubj.locator('confirmSaveSavedObjectButton');
     this.visualizationLoader = this.page.testSubj.locator('visualizationLoader');
     this.dashboardPicker = this.page.testSubj.locator('open-dashboard-picker');
+    this.editInLensButton = this.page.testSubj.locator('visualizeEditInLensButton');
+    this.saveModal = new SavedObjectSaveModal(this.page);
   }
 
   async goto() {
@@ -81,55 +81,21 @@ export class VisualizeApp {
 
   async openSaveModal() {
     await this.visualizeSaveButton.click();
-    await expect(this.saveModal).toBeVisible();
-  }
-
-  async fillVisTitle(name: string) {
-    await this.savedObjectTitleInput.fill(name);
-  }
-
-  async selectExistingDashboard(dashboardTitle: string) {
-    await this.page.locator('label[for="existing-dashboard-option"]').click();
-    await this.dashboardPicker.click();
-    await this.page.testSubj
-      .locator(`dashboard-picker-option-${dashboardTitle.split(' ').join('-')}`)
-      .click();
-  }
-
-  async selectNewDashboard() {
-    await this.page.locator('label[for="new-dashboard-option"]').click();
-  }
-
-  async confirmSave() {
-    await this.confirmSaveButton.click();
-    await expect(this.saveModal).toBeHidden();
+    await expect(this.saveModal.modal).toBeVisible();
   }
 
   async saveToExistingDashboard(visName: string, dashboardTitle: string) {
     await this.openSaveModal();
-    await this.fillVisTitle(visName);
-    await this.selectExistingDashboard(dashboardTitle);
-    await this.confirmSave();
+    await this.saveModal.saveToExistingDashboard(visName, dashboardTitle);
   }
 
   async saveToNewDashboard(visName: string) {
     await this.openSaveModal();
-    await this.fillVisTitle(visName);
-    await this.selectNewDashboard();
-    await this.confirmSave();
-  }
-
-  async selectNoDashboard() {
-    await this.page.locator('label[for="add-to-library-option"]').click();
+    await this.saveModal.saveToNewDashboard(visName);
   }
 
   async saveToLibrary(visName: string) {
-    await this.fillVisTitle(visName);
-    await this.selectNoDashboard();
-    const addToLibraryCheckbox = this.page.locator('input#add-to-library-checkbox');
-    await expect(addToLibraryCheckbox).toBeChecked();
-    await expect(addToLibraryCheckbox).toBeDisabled();
-    await this.confirmSave();
+    await this.saveModal.saveToLibrary(visName);
   }
 
   async createAggBasedVisualization(subType: string, dataSource: string) {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/visualize_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/visualize_app.ts
@@ -21,8 +21,6 @@ export class VisualizeApp {
   private readonly legacyTab;
   private readonly visualizeSaveButton;
   private readonly visualizationLoader;
-  private readonly dashboardPicker;
-  private readonly editInLensButton;
   /** Save modal locators/actions, shared with other apps (e.g. Maps) via `SavedObjectSaveModal`. */
   readonly saveModal: SavedObjectSaveModal;
 
@@ -34,8 +32,6 @@ export class VisualizeApp {
     this.legacyTab = this.page.testSubj.locator('groupModalLegacyTab');
     this.visualizeSaveButton = this.page.testSubj.locator('visualizeSaveButton');
     this.visualizationLoader = this.page.testSubj.locator('visualizationLoader');
-    this.dashboardPicker = this.page.testSubj.locator('open-dashboard-picker');
-    this.editInLensButton = this.page.testSubj.locator('visualizeEditInLensButton');
     this.saveModal = new SavedObjectSaveModal(this.page);
   }
 

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/index.ts
@@ -9,14 +9,20 @@ import type { PageObjects, ScoutPage } from '@kbn/scout';
 import { createLazyPageObject } from '@kbn/scout';
 
 import { TagManagementPage } from './tag_management_page';
+import { SavedObjectsListingPage } from './saved_objects_listing_page';
+import { SavedObjectsManagementPage } from './saved_objects_management_page';
 
 export interface TaggingPageObjects extends PageObjects {
   tagManagement: TagManagementPage;
+  savedObjectsListing: SavedObjectsListingPage;
+  savedObjectsManagement: SavedObjectsManagementPage;
 }
 
 export function extendPageObjects(pageObjects: PageObjects, page: ScoutPage): TaggingPageObjects {
   return {
     ...pageObjects,
     tagManagement: createLazyPageObject(TagManagementPage, page),
+    savedObjectsListing: createLazyPageObject(SavedObjectsListingPage, page),
+    savedObjectsManagement: createLazyPageObject(SavedObjectsManagementPage, page),
   };
 }

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/saved_objects_management_page.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/saved_objects_management_page.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+
+/**
+ * Minimal Saved Objects Management listing page object — enough to drive
+ * the tag-filtering flows exercised by the tagging plugin. The full SOM page
+ * object lives in the `saved_objects_management` plugin and is not importable
+ * cross-plugin.
+ */
+export class SavedObjectsManagementPage {
+  readonly rows: Locator;
+  readonly searchInput: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.rows = this.page.testSubj.locator('~savedObjectsTableRow');
+    this.searchInput = this.page.locator(
+      '[data-test-subj="savedObjectSearchBar"] input, input[data-test-subj="savedObjectSearchBar"]'
+    );
+  }
+
+  async goto() {
+    await this.page.gotoApp('management/kibana/objects');
+    await this.waitForLoaded();
+  }
+
+  async waitForLoaded() {
+    await this.page.testSubj.waitForSelector('savedObjectSearchBar');
+    await this.searchInput.waitFor({ state: 'visible' });
+    await this.page.testSubj.waitForSelector('savedObjectsTableRowTitle');
+  }
+
+  getTitleLink(title: string): Locator {
+    return this.page.testSubj
+      .locator('savedObjectsTableRowTitle')
+      .getByRole('link', { name: title, exact: true });
+  }
+
+  async search(query: string) {
+    await this.searchInput.fill(query);
+    await this.searchInput.press('Enter');
+  }
+
+  async selectFilterTags(...tagNames: string[]) {
+    // EUI renders this filter button with aria-label "Tags Selection" (no dedicated test-subj).
+    // Regex matches the visible "Tags" text regardless of the i18n hint appended to aria-label.
+    await this.page.getByRole('button', { name: /Tags/i }).click();
+    for (const tagName of tagNames) {
+      await this.page.testSubj.click(`tag-searchbar-option-${tagName.replace(' ', '_')}`);
+    }
+    await this.page.testSubj.click('savedObjectSearchBar');
+  }
+
+  getTagBadges(title: string): Locator {
+    const row = this.rows.filter({
+      has: this.page.testSubj.locator('savedObjectsTableRowTitle').getByText(title),
+    });
+    return row.locator('[data-test-subj="listingTableRowTags"] [data-test-subj^="tag-badge-"]');
+  }
+}

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/tag_management_page.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/tag_management_page.ts
@@ -31,6 +31,11 @@ export class TagManagementPage {
     this.assignFlyout = new TagAssignFlyout(page);
   }
 
+  async goto() {
+    await this.page.gotoApp('management/kibana/tags');
+    await this.tagsTable.waitForLoaded();
+  }
+
   async editTag(tagName: string) {
     const row = this.tagsTable.rowByName(tagName);
     await row.locator('[data-test-subj="tagsTableAction-edit"]').click();

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_a11y.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_a11y.spec.ts
@@ -18,13 +18,12 @@ test.describe('Tags management — accessibility', { tag: tags.stateful.classic 
     await kbnClient.savedObjects.cleanStandardList();
   });
 
-  test('tags management page a11y', async ({ page, browserAuth, pageObjects, kbnUrl }) => {
+  test('tags management page a11y', async ({ page, browserAuth, pageObjects }) => {
     const { tagManagement } = pageObjects;
     const { tagModal, assignFlyout, tagsTable } = tagManagement;
 
     await browserAuth.loginAsPrivilegedUser();
-    await page.goto(kbnUrl.app('management/kibana/tags'));
-    await tagsTable.waitForLoaded();
+    await tagManagement.goto();
 
     await test.step('main page', async () => {
       const { violations } = await page.checkA11y({ include: A11Y_SELECTORS });

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_bulk_actions.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_bulk_actions.spec.ts
@@ -11,13 +11,18 @@ import { expect } from '@kbn/scout/ui';
 import { KBN_ARCHIVES, test } from '../fixtures';
 
 test.describe('Tags management bulk actions', { tag: tags.stateful.classic }, () => {
-  test.beforeEach(async ({ kbnClient, browserAuth, page, kbnUrl, pageObjects }) => {
+  test.beforeAll(async ({ kbnClient }) => {
     await kbnClient.savedObjects.cleanStandardList();
-    await kbnClient.importExport.load(KBN_ARCHIVES.FUNCTIONAL_BASE);
+  });
 
+  test.beforeEach(async ({ browserAuth, pageObjects, kbnClient }) => {
+    await kbnClient.importExport.load(KBN_ARCHIVES.FUNCTIONAL_BASE);
     await browserAuth.loginAsPrivilegedUser();
-    await page.goto(kbnUrl.app('management/kibana/tags'));
-    await pageObjects.tagManagement.tagsTable.waitForLoaded();
+    await pageObjects.tagManagement.goto();
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    await kbnClient.savedObjects.cleanStandardList();
   });
 
   test('deletes multiple tags', async ({ page, pageObjects }) => {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_bulk_assign.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_bulk_assign.spec.ts
@@ -11,13 +11,16 @@ import { expect } from '@kbn/scout/ui';
 import { KBN_ARCHIVES, test } from '../fixtures';
 
 test.describe('Tags management bulk assign', { tag: tags.stateful.classic }, () => {
-  test.beforeEach(async ({ kbnClient, browserAuth, page, kbnUrl, pageObjects }) => {
+  test.beforeEach(async ({ kbnClient, browserAuth, pageObjects }) => {
     await kbnClient.savedObjects.cleanStandardList();
     await kbnClient.importExport.load(KBN_ARCHIVES.BULK_ASSIGN);
 
     await browserAuth.loginAsPrivilegedUser();
-    await page.goto(kbnUrl.app('management/kibana/tags'));
-    await pageObjects.tagManagement.tagsTable.waitForLoaded();
+    await pageObjects.tagManagement.goto();
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    await kbnClient.savedObjects.cleanStandardList();
   });
 
   test('bulk assigns tags to objects', async ({ pageObjects }) => {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_create.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_create.spec.ts
@@ -11,17 +11,18 @@ import { expect } from '@kbn/scout/ui';
 import { KBN_ARCHIVES, test } from '../fixtures';
 
 test.describe('Tags management create', { tag: tags.stateful.classic }, () => {
-  test.beforeEach(async ({ kbnClient, browserAuth, page, kbnUrl, pageObjects }) => {
+  test.beforeAll(async ({ kbnClient }) => {
     await kbnClient.savedObjects.cleanStandardList();
-    await kbnClient.importExport.load(KBN_ARCHIVES.FUNCTIONAL_BASE);
-
-    await browserAuth.loginAsPrivilegedUser();
-    await page.goto(kbnUrl.app('management/kibana/tags'));
-    await pageObjects.tagManagement.tagsTable.waitForLoaded();
   });
 
-  test.afterEach(async ({ pageObjects }) => {
-    await pageObjects.tagManagement.tagModal.closeIfOpen();
+  test.beforeEach(async ({ browserAuth, pageObjects, kbnClient }) => {
+    await kbnClient.importExport.load(KBN_ARCHIVES.FUNCTIONAL_BASE);
+    await browserAuth.loginAsPrivilegedUser();
+    await pageObjects.tagManagement.goto();
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    await kbnClient.savedObjects.cleanStandardList();
   });
 
   test('creates a valid tag', async ({ pageObjects }) => {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_dashboard_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_dashboard_integration.spec.ts
@@ -9,28 +9,25 @@ import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
 import { ES_ARCHIVES, KBN_ARCHIVES, test } from '../fixtures';
-import { SavedObjectsListingPage } from '../fixtures/page_objects/saved_objects_listing_page';
 
 test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
   test.beforeAll(async ({ esArchiver }) => {
     await esArchiver.loadIfNeeded(ES_ARCHIVES.LOGSTASH_FUNCTIONAL);
   });
 
-  test.beforeEach(async ({ kbnClient, browserAuth, page, pageObjects }) => {
-    await kbnClient.savedObjects.cleanStandardList();
+  test.beforeEach(async ({ browserAuth, pageObjects, kbnClient }) => {
     await kbnClient.importExport.load(KBN_ARCHIVES.DASHBOARD);
-
     await browserAuth.loginAsPrivilegedUser();
     await pageObjects.dashboard.goto();
-    await new SavedObjectsListingPage(page).waitForLoaded();
+    await pageObjects.savedObjectsListing.waitForLoaded();
   });
 
   test.afterAll(async ({ kbnClient }) => {
     await kbnClient.savedObjects.cleanStandardList();
   });
 
-  test('allows to manually type tag filter query', async ({ page }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to manually type tag filter query', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await listingPage.searchForItemWithName('tag:(tag-1)', { escape: false });
 
     await expect(listingPage.getItemLinks('dashboard')).toHaveCount(2);
@@ -43,8 +40,8 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
     }
   });
 
-  test('allows to filter by selecting a tag in the filter menu', async ({ page }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to filter by selecting a tag in the filter menu', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await listingPage.selectFilterTags('tag-3');
 
     await expect(listingPage.getItemLinks('dashboard')).toHaveCount(2);
@@ -54,8 +51,8 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
     }
   });
 
-  test('allows to filter by multiple tags', async ({ page }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to filter by multiple tags', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await listingPage.selectFilterTags('tag-2', 'tag-3');
 
     await expect(listingPage.getItemLinks('dashboard')).toHaveCount(3);
@@ -70,7 +67,7 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
   });
 
   test('allows to select tags for a new dashboard', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+    const listingPage = pageObjects.savedObjectsListing;
     await pageObjects.dashboard.openNewDashboard();
 
     await page.testSubj.click('dashboardInteractiveSaveMenuItem');
@@ -87,7 +84,7 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
   });
 
   test('allows to create a tag from the tag selector', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+    const listingPage = pageObjects.savedObjectsListing;
     await pageObjects.dashboard.openNewDashboard();
 
     await page.testSubj.click('dashboardInteractiveSaveMenuItem');
@@ -112,8 +109,8 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
     expect(itemNames).toContain('dashboard-with-new-tag');
   });
 
-  test('allows to select tags for an existing dashboard', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to select tags for an existing dashboard', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await listingPage.clickItemLink('dashboard', 'dashboard 4 with real data (tag-1)');
 
     await pageObjects.dashboard.switchToEditMode();
@@ -129,8 +126,8 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
     expect(itemNames).toContain('dashboard 4 with real data (tag-1)');
   });
 
-  test('retains dashboard saved object tags after quicksave', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('retains dashboard saved object tags after quicksave', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await listingPage.clickItemLink('dashboard', 'dashboard 4 with real data (tag-1)');
 
     await pageObjects.dashboard.switchToEditMode();

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_discover_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_discover_integration.spec.ts
@@ -51,7 +51,6 @@ test.describe('Tags - discover integration', { tag: tags.stateful.classic }, () 
   });
 
   test.afterAll(async ({ kbnClient }) => {
-    await kbnClient.importExport.unload(KBN_ARCHIVES.DISCOVER);
     await kbnClient.savedObjects.cleanStandardList();
   });
 

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_edit.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_edit.spec.ts
@@ -11,17 +11,18 @@ import { expect } from '@kbn/scout/ui';
 import { KBN_ARCHIVES, test } from '../fixtures';
 
 test.describe('Tags management edit', { tag: tags.stateful.classic }, () => {
-  test.beforeEach(async ({ kbnClient, browserAuth, page, kbnUrl, pageObjects }) => {
+  test.beforeAll(async ({ kbnClient }) => {
     await kbnClient.savedObjects.cleanStandardList();
-    await kbnClient.importExport.load(KBN_ARCHIVES.FUNCTIONAL_BASE);
-
-    await browserAuth.loginAsPrivilegedUser();
-    await page.goto(kbnUrl.app('management/kibana/tags'));
-    await pageObjects.tagManagement.tagsTable.waitForLoaded();
   });
 
-  test.afterEach(async ({ pageObjects }) => {
-    await pageObjects.tagManagement.tagModal.closeIfOpen();
+  test.beforeEach(async ({ browserAuth, pageObjects, kbnClient }) => {
+    await kbnClient.importExport.load(KBN_ARCHIVES.FUNCTIONAL_BASE);
+    await browserAuth.loginAsPrivilegedUser();
+    await pageObjects.tagManagement.goto();
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    await kbnClient.savedObjects.cleanStandardList();
   });
 
   test('displays tag attributes in the edit form', async ({ pageObjects }) => {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_feature_control.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_feature_control.spec.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import type { KibanaRole, ScoutPage } from '@kbn/scout';
+import type { KibanaRole } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
 import { KBN_ARCHIVES, test } from '../fixtures';
+import type { TaggingPageObjects } from '../fixtures/page_objects';
 import type { TagsTable } from '../fixtures/page_objects/tags_table';
 import {
   getDefaultSpaceWriteRole,
@@ -126,19 +127,14 @@ const selectSomeTagsIfPossible = async (tagsTable: TagsTable) => {
 const loginAndOpenTagsPage = async ({
   role,
   browserAuth,
-  page,
-  kbnUrl,
-  tagsTable,
+  pageObjects,
 }: {
   role: KibanaRole;
   browserAuth: { loginWithCustomRole: (role: KibanaRole) => Promise<void> };
-  page: ScoutPage;
-  kbnUrl: { app: (path: string) => string };
-  tagsTable: TagsTable;
+  pageObjects: TaggingPageObjects;
 }) => {
   await browserAuth.loginWithCustomRole(role);
-  await page.goto(kbnUrl.app('management/kibana/tags'));
-  await tagsTable.waitForLoaded();
+  await pageObjects.tagManagement.goto();
 };
 
 // custom-role login is not supported in ECH yet, so this suite runs on local
@@ -164,27 +160,15 @@ test.describe('Tags management feature controls', { tag: '@local-stateful-classi
   });
 
   for (const suite of FEATURE_CONTROL_ROLE_SUITES) {
-    test(suite.titles.view, async ({ browserAuth, page, kbnUrl, pageObjects }) => {
-      await loginAndOpenTagsPage({
-        role: suite.role,
-        browserAuth,
-        page,
-        kbnUrl,
-        tagsTable: pageObjects.tagManagement.tagsTable,
-      });
+    test(suite.titles.view, async ({ browserAuth, pageObjects }) => {
+      await loginAndOpenTagsPage({ role: suite.role, browserAuth, pageObjects });
 
       const tagNames = await pageObjects.tagManagement.tagsTable.getDisplayedTagNames();
       expect(tagNames).toHaveLength(suite.privileges.view ? 5 : 0);
     });
 
-    test(suite.titles.delete, async ({ browserAuth, page, kbnUrl, pageObjects }) => {
-      await loginAndOpenTagsPage({
-        role: suite.role,
-        browserAuth,
-        page,
-        kbnUrl,
-        tagsTable: pageObjects.tagManagement.tagsTable,
-      });
+    test(suite.titles.delete, async ({ browserAuth, pageObjects }) => {
+      await loginAndOpenTagsPage({ role: suite.role, browserAuth, pageObjects });
 
       const canDelete = await pageObjects.tagManagement.tagsTable.isRowActionAvailable(
         'delete',
@@ -193,14 +177,8 @@ test.describe('Tags management feature controls', { tag: '@local-stateful-classi
       expect(canDelete).toBe(suite.privileges.delete);
     });
 
-    test(suite.titles.bulkDelete, async ({ browserAuth, page, kbnUrl, pageObjects }) => {
-      await loginAndOpenTagsPage({
-        role: suite.role,
-        browserAuth,
-        page,
-        kbnUrl,
-        tagsTable: pageObjects.tagManagement.tagsTable,
-      });
+    test(suite.titles.bulkDelete, async ({ browserAuth, pageObjects }) => {
+      await loginAndOpenTagsPage({ role: suite.role, browserAuth, pageObjects });
 
       const { tagsTable } = pageObjects.tagManagement;
       await selectSomeTagsIfPossible(tagsTable);
@@ -209,28 +187,16 @@ test.describe('Tags management feature controls', { tag: '@local-stateful-classi
       expect(canBulkDelete).toBe(suite.privileges.delete);
     });
 
-    test(suite.titles.create, async ({ browserAuth, page, kbnUrl, pageObjects }) => {
-      await loginAndOpenTagsPage({
-        role: suite.role,
-        browserAuth,
-        page,
-        kbnUrl,
-        tagsTable: pageObjects.tagManagement.tagsTable,
-      });
+    test(suite.titles.create, async ({ browserAuth, page, pageObjects }) => {
+      await loginAndOpenTagsPage({ role: suite.role, browserAuth, pageObjects });
 
       await expect(page.testSubj.locator('createTagButton')).toHaveCount(
         suite.privileges.create ? 1 : 0
       );
     });
 
-    test(suite.titles.edit, async ({ browserAuth, page, kbnUrl, pageObjects }) => {
-      await loginAndOpenTagsPage({
-        role: suite.role,
-        browserAuth,
-        page,
-        kbnUrl,
-        tagsTable: pageObjects.tagManagement.tagsTable,
-      });
+    test(suite.titles.edit, async ({ browserAuth, pageObjects }) => {
+      await loginAndOpenTagsPage({ role: suite.role, browserAuth, pageObjects });
 
       const canEdit = await pageObjects.tagManagement.tagsTable.isRowActionAvailable(
         'edit',
@@ -239,14 +205,8 @@ test.describe('Tags management feature controls', { tag: '@local-stateful-classi
       expect(canEdit).toBe(suite.privileges.edit);
     });
 
-    test(suite.titles.viewRelations, async ({ browserAuth, page, kbnUrl, pageObjects }) => {
-      await loginAndOpenTagsPage({
-        role: suite.role,
-        browserAuth,
-        page,
-        kbnUrl,
-        tagsTable: pageObjects.tagManagement.tagsTable,
-      });
+    test(suite.titles.viewRelations, async ({ browserAuth, pageObjects }) => {
+      await loginAndOpenTagsPage({ role: suite.role, browserAuth, pageObjects });
 
       const tagInfo = await pageObjects.tagManagement.tagsTable.getDisplayedTagInfo('tag-1');
       const hasRelationsLink = tagInfo?.connectionCount !== undefined;

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_listing.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_listing.spec.ts
@@ -11,17 +11,18 @@ import { expect } from '@kbn/scout/ui';
 import { KBN_ARCHIVES, test } from '../fixtures';
 
 test.describe('Tags management listing', { tag: tags.stateful.classic }, () => {
-  test.beforeEach(async ({ kbnClient, browserAuth, page, kbnUrl, pageObjects }) => {
+  test.beforeAll(async ({ kbnClient }) => {
     await kbnClient.savedObjects.cleanStandardList();
     await kbnClient.importExport.load(KBN_ARCHIVES.FUNCTIONAL_BASE);
-
-    await browserAuth.loginAsViewer();
-    await page.goto(kbnUrl.app('management/kibana/tags'));
-    await pageObjects.tagManagement.tagsTable.waitForLoaded();
   });
 
-  test.afterEach(async ({ pageObjects }) => {
-    await pageObjects.tagManagement.tagsTable.searchForTerm('');
+  test.beforeEach(async ({ browserAuth, pageObjects }) => {
+    await browserAuth.loginAsViewer();
+    await pageObjects.tagManagement.goto();
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    await kbnClient.savedObjects.cleanStandardList();
   });
 
   test('searches by term', async ({ pageObjects }) => {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_maps_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_maps_integration.spec.ts
@@ -9,80 +9,75 @@ import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
 import { KBN_ARCHIVES, test } from '../fixtures';
-import { SavedObjectsListingPage } from '../fixtures/page_objects/saved_objects_listing_page';
 
 test.describe('Maps integration', { tag: tags.stateful.classic }, () => {
-  test.beforeEach(async ({ kbnClient, browserAuth, kbnUrl, page }) => {
+  test.beforeAll(async ({ kbnClient }) => {
     await kbnClient.savedObjects.cleanStandardList();
     await kbnClient.importExport.load(KBN_ARCHIVES.MAPS);
+  });
 
+  test.beforeEach(async ({ browserAuth, kbnUrl, page, pageObjects }) => {
     await browserAuth.loginAsPrivilegedUser();
     await page.goto(kbnUrl.app('maps'));
-    await new SavedObjectsListingPage(page).waitForLoaded();
+    await pageObjects.savedObjectsListing.waitForLoaded();
   });
 
   test.afterAll(async ({ kbnClient }) => {
     await kbnClient.savedObjects.cleanStandardList();
   });
 
-  test('allows to manually type tag filter query', async ({ page }) => {
-    const listingPage = new SavedObjectsListingPage(page);
-    await listingPage.searchForItemWithName('tag:(tag-1)', { escape: false });
+  test('allows to manually type tag filter query', async ({ pageObjects }) => {
+    await pageObjects.savedObjectsListing.searchForItemWithName('tag:(tag-1)', { escape: false });
 
-    await expect(listingPage.getItemLinks('map')).toHaveCount(2);
-    const itemNames = await listingPage.getAllItemNames('map');
+    await expect(pageObjects.savedObjectsListing.getItemLinks('map')).toHaveCount(2);
+    const itemNames = await pageObjects.savedObjectsListing.getAllItemNames('map');
     for (const expectedName of ['map 3 (tag-1 and tag-3)', 'map 4 (tag-1)']) {
       expect(itemNames).toContain(expectedName);
     }
   });
 
-  test('allows to filter by selecting a tag in the filter menu', async ({ page }) => {
-    const listingPage = new SavedObjectsListingPage(page);
-    await listingPage.selectFilterTags('tag-3');
+  test('allows to filter by selecting a tag in the filter menu', async ({ pageObjects }) => {
+    await pageObjects.savedObjectsListing.selectFilterTags('tag-3');
 
-    await expect(listingPage.getItemLinks('map')).toHaveCount(2);
-    const itemNames = await listingPage.getAllItemNames('map');
+    await expect(pageObjects.savedObjectsListing.getItemLinks('map')).toHaveCount(2);
+    const itemNames = await pageObjects.savedObjectsListing.getAllItemNames('map');
     for (const expectedName of ['map 2 (tag-3)', 'map 3 (tag-1 and tag-3)']) {
       expect(itemNames).toContain(expectedName);
     }
   });
 
-  test('allows to filter by multiple tags', async ({ page }) => {
-    const listingPage = new SavedObjectsListingPage(page);
-    await listingPage.selectFilterTags('tag-2', 'tag-3');
+  test('allows to filter by multiple tags', async ({ pageObjects }) => {
+    await pageObjects.savedObjectsListing.selectFilterTags('tag-2', 'tag-3');
 
-    await expect(listingPage.getItemLinks('map')).toHaveCount(3);
-    const itemNames = await listingPage.getAllItemNames('map');
+    await expect(pageObjects.savedObjectsListing.getItemLinks('map')).toHaveCount(3);
+    const itemNames = await pageObjects.savedObjectsListing.getAllItemNames('map');
     for (const expectedName of ['map 1 (tag-2)', 'map 2 (tag-3)', 'map 3 (tag-1 and tag-3)']) {
       expect(itemNames).toContain(expectedName);
     }
   });
 
   test('allows to select tags for a new map', async ({ page, pageObjects, kbnUrl }) => {
-    const listingPage = new SavedObjectsListingPage(page);
     await pageObjects.maps.gotoNewMap();
 
     await pageObjects.maps.saveButton.click();
-    await pageObjects.maps.savedObjectTitleInput.fill('my-new-map');
-    await pageObjects.visualize.selectNoDashboard();
+    await pageObjects.saveModal.fillTitle('my-new-map');
+    await pageObjects.saveModal.selectNoDashboard();
     await pageObjects.tagManagement.selectSavedObjectTags('tag-1', 'tag-3');
-    await pageObjects.maps.confirmSaveButton.click();
-    await pageObjects.maps.confirmSaveButton.waitFor({ state: 'hidden' });
+    await pageObjects.saveModal.confirm();
 
     await page.goto(kbnUrl.app('maps'));
-    await listingPage.waitForLoaded();
-    await listingPage.selectFilterTags('tag-1');
-    const itemNames = await listingPage.getAllItemNames('map');
+    await pageObjects.savedObjectsListing.waitForLoaded();
+    await pageObjects.savedObjectsListing.selectFilterTags('tag-1');
+    const itemNames = await pageObjects.savedObjectsListing.getAllItemNames('map');
     expect(itemNames).toContain('my-new-map');
   });
 
   test('allows to create a tag from the tag selector', async ({ page, pageObjects, kbnUrl }) => {
-    const listingPage = new SavedObjectsListingPage(page);
     await pageObjects.maps.gotoNewMap();
 
     await pageObjects.maps.saveButton.click();
-    await pageObjects.maps.savedObjectTitleInput.fill('map-with-new-tag');
-    await pageObjects.visualize.selectNoDashboard();
+    await pageObjects.saveModal.fillTitle('map-with-new-tag');
+    await pageObjects.saveModal.selectNoDashboard();
     await pageObjects.tagManagement.openCreateTagFromSelector();
     await expect(pageObjects.tagManagement.tagModal.form).toBeVisible();
     await pageObjects.tagManagement.tagModal.fillForm({
@@ -92,36 +87,33 @@ test.describe('Maps integration', { tag: tags.stateful.classic }, () => {
     });
     await page.testSubj.click('createModalConfirmButton');
     await pageObjects.tagManagement.tagModal.form.waitFor({ state: 'hidden' });
-    await pageObjects.maps.confirmSaveButton.click();
-    await pageObjects.maps.confirmSaveButton.waitFor({ state: 'hidden' });
+    await pageObjects.saveModal.confirm();
 
     await page.goto(kbnUrl.app('maps'));
-    await listingPage.waitForLoaded();
-    await listingPage.selectFilterTags('my-new-tag');
-    const itemNames = await listingPage.getAllItemNames('map');
+    await pageObjects.savedObjectsListing.waitForLoaded();
+    await pageObjects.savedObjectsListing.selectFilterTags('my-new-tag');
+    const itemNames = await pageObjects.savedObjectsListing.getAllItemNames('map');
     expect(itemNames).toContain('map-with-new-tag');
   });
 
   test('allows to select tags for an existing map', async ({ page, pageObjects, kbnUrl }) => {
-    const listingPage = new SavedObjectsListingPage(page);
-    await listingPage.clickItemLink('map', 'map 4 (tag-1)');
+    await pageObjects.savedObjectsListing.clickItemLink('map', 'map 4 (tag-1)');
     await pageObjects.maps.waitForRenderComplete();
 
     await pageObjects.maps.saveButton.click();
     await pageObjects.tagManagement.selectSavedObjectTags('tag-3');
-    await pageObjects.maps.confirmSaveButton.click();
-    await pageObjects.maps.confirmSaveButton.waitFor({ state: 'hidden' });
+    await pageObjects.saveModal.confirm();
 
     await page.goto(kbnUrl.app('maps'));
-    await listingPage.waitForLoaded();
-    await listingPage.selectFilterTags('tag-3');
-    const itemNames = await listingPage.getAllItemNames('map');
+    await pageObjects.savedObjectsListing.waitForLoaded();
+    await pageObjects.savedObjectsListing.selectFilterTags('tag-3');
+    const itemNames = await pageObjects.savedObjectsListing.getAllItemNames('map');
     expect(itemNames).toContain('map 4 (tag-1)');
 
     await page.goto(kbnUrl.app('maps'));
-    await listingPage.waitForLoaded();
-    await listingPage.selectFilterTags('tag-1');
-    const itemNamesByOriginalTag = await listingPage.getAllItemNames('map');
+    await pageObjects.savedObjectsListing.waitForLoaded();
+    await pageObjects.savedObjectsListing.selectFilterTags('tag-1');
+    const itemNamesByOriginalTag = await pageObjects.savedObjectsListing.getAllItemNames('map');
     expect(itemNamesByOriginalTag).toContain('map 4 (tag-1)');
   });
 });

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_som_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_som_integration.spec.ts
@@ -5,40 +5,10 @@
  * 2.0.
  */
 
-import type { ScoutPage } from '@kbn/scout';
 import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
 import { KBN_ARCHIVES, test } from '../fixtures';
-
-const getSavedObjectsTableRows = (page: ScoutPage) =>
-  page.testSubj.locator('~savedObjectsTableRow');
-
-const getSavedObjectTitleLink = (page: ScoutPage, title: string) =>
-  page.testSubj
-    .locator('savedObjectsTableRowTitle')
-    .getByRole('link', { name: title, exact: true });
-
-const getSavedObjectSearchInput = (page: ScoutPage) =>
-  page.locator(
-    '[data-test-subj="savedObjectSearchBar"] input, input[data-test-subj="savedObjectSearchBar"]'
-  );
-
-const waitForSavedObjectsTable = async (page: ScoutPage) => {
-  await page.testSubj.waitForSelector('savedObjectSearchBar');
-  await getSavedObjectSearchInput(page).waitFor({ state: 'visible' });
-  await page.testSubj.waitForSelector('savedObjectsTableRowTitle');
-};
-
-const selectTagsInFilter = async (page: ScoutPage, ...tagNames: string[]) => {
-  // EUI renders this filter button with aria-label "Tags Selection" (no dedicated test-subj).
-  // Regex matches the visible "Tags" text regardless of the i18n hint appended to aria-label.
-  await page.getByRole('button', { name: /Tags/i }).click();
-  for (const tagName of tagNames) {
-    await page.testSubj.click(`tag-searchbar-option-${tagName.replace(' ', '_')}`);
-  }
-  await page.testSubj.click('savedObjectSearchBar');
-};
 
 test.describe('Tags - saved objects management integration', { tag: tags.stateful.classic }, () => {
   test.beforeAll(async ({ kbnClient }) => {
@@ -46,10 +16,9 @@ test.describe('Tags - saved objects management integration', { tag: tags.statefu
     await kbnClient.importExport.load(KBN_ARCHIVES.SO_MANAGEMENT);
   });
 
-  test.beforeEach(async ({ browserAuth, page, kbnUrl }) => {
+  test.beforeEach(async ({ browserAuth, pageObjects }) => {
     await browserAuth.loginAsViewer();
-    await page.goto(kbnUrl.app('management/kibana/objects'));
-    await waitForSavedObjectsTable(page);
+    await pageObjects.savedObjectsManagement.goto();
   });
 
   test.afterAll(async ({ kbnClient }) => {
@@ -70,48 +39,62 @@ test.describe('Tags - saved objects management integration', { tag: tags.statefu
     await tagRow.locator('[data-test-subj="tagsTableRowConnectionsLink"]').click();
 
     await expect(page).toHaveURL(/\/app\/management\/kibana\/objects/);
-    await waitForSavedObjectsTable(page);
-    await expect(getSavedObjectSearchInput(page)).toHaveValue('tag:("tag-1")');
-    await expect(getSavedObjectsTableRows(page)).toHaveCount(2);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 1 (tag-1)')).toHaveCount(1);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 3 (tag-1 + tag-3)')).toHaveCount(1);
-  });
-
-  test('allows manually typing tag filter query', async ({ page }) => {
-    const searchInput = getSavedObjectSearchInput(page);
-    await searchInput.fill('tag:(tag-2)');
-    await searchInput.press('Enter');
-
-    await expect(getSavedObjectsTableRows(page)).toHaveCount(2);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 2 (tag-2)')).toHaveCount(1);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 4 (tag-2)')).toHaveCount(1);
-  });
-
-  test('allows filtering by selecting a single tag in the filter menu', async ({ page }) => {
-    await selectTagsInFilter(page, 'tag-1');
-
-    await expect(getSavedObjectsTableRows(page)).toHaveCount(2);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 1 (tag-1)')).toHaveCount(1);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 3 (tag-1 + tag-3)')).toHaveCount(1);
-  });
-
-  test('allows filtering by selecting multiple tags in the filter menu', async ({ page }) => {
-    await selectTagsInFilter(page, 'tag-2', 'tag-3');
-
-    await expect(getSavedObjectsTableRows(page)).toHaveCount(3);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 2 (tag-2)')).toHaveCount(1);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 3 (tag-1 + tag-3)')).toHaveCount(1);
-    await expect(getSavedObjectTitleLink(page, 'Visualization 4 (tag-2)')).toHaveCount(1);
-  });
-
-  test('displays all tags for an object row', async ({ page }) => {
-    const row = page.testSubj.locator('~savedObjectsTableRow').filter({
-      has: page.testSubj
-        .locator('savedObjectsTableRowTitle')
-        .getByText('Visualization 3 (tag-1 + tag-3)'),
-    });
+    await pageObjects.savedObjectsManagement.waitForLoaded();
+    await expect(pageObjects.savedObjectsManagement.searchInput).toHaveValue('tag:("tag-1")');
+    await expect(pageObjects.savedObjectsManagement.rows).toHaveCount(2);
     await expect(
-      row.locator('[data-test-subj="listingTableRowTags"] [data-test-subj^="tag-badge-"]')
-    ).toHaveText(['tag-1', 'tag-3']);
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 1 (tag-1)')
+    ).toHaveCount(1);
+    await expect(
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 3 (tag-1 + tag-3)')
+    ).toHaveCount(1);
+  });
+
+  test('allows manually typing tag filter query', async ({ pageObjects }) => {
+    await pageObjects.savedObjectsManagement.search('tag:(tag-2)');
+
+    await expect(pageObjects.savedObjectsManagement.rows).toHaveCount(2);
+    await expect(
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 2 (tag-2)')
+    ).toHaveCount(1);
+    await expect(
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 4 (tag-2)')
+    ).toHaveCount(1);
+  });
+
+  test('allows filtering by selecting a single tag in the filter menu', async ({ pageObjects }) => {
+    await pageObjects.savedObjectsManagement.selectFilterTags('tag-1');
+
+    await expect(pageObjects.savedObjectsManagement.rows).toHaveCount(2);
+    await expect(
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 1 (tag-1)')
+    ).toHaveCount(1);
+    await expect(
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 3 (tag-1 + tag-3)')
+    ).toHaveCount(1);
+  });
+
+  test('allows filtering by selecting multiple tags in the filter menu', async ({
+    pageObjects,
+  }) => {
+    await pageObjects.savedObjectsManagement.selectFilterTags('tag-2', 'tag-3');
+
+    await expect(pageObjects.savedObjectsManagement.rows).toHaveCount(3);
+    await expect(
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 2 (tag-2)')
+    ).toHaveCount(1);
+    await expect(
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 3 (tag-1 + tag-3)')
+    ).toHaveCount(1);
+    await expect(
+      pageObjects.savedObjectsManagement.getTitleLink('Visualization 4 (tag-2)')
+    ).toHaveCount(1);
+  });
+
+  test('displays all tags for an object row', async ({ pageObjects }) => {
+    const tagBadges = pageObjects.savedObjectsManagement.getTagBadges(
+      'Visualization 3 (tag-1 + tag-3)'
+    );
+    await expect(tagBadges).toHaveText(['tag-1', 'tag-3']);
   });
 });

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_visualize_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_visualize_integration.spec.ts
@@ -9,16 +9,15 @@ import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
 import { ES_ARCHIVES, KBN_ARCHIVES, test } from '../fixtures';
-import { SavedObjectsListingPage } from '../fixtures/page_objects/saved_objects_listing_page';
 
 test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
-  test.beforeAll(async ({ esArchiver }) => {
+  test.beforeAll(async ({ esArchiver, kbnClient }) => {
     await esArchiver.loadIfNeeded(ES_ARCHIVES.LOGSTASH_FUNCTIONAL);
-  });
-
-  test.beforeEach(async ({ kbnClient, browserAuth }) => {
     await kbnClient.savedObjects.cleanStandardList();
     await kbnClient.importExport.load(KBN_ARCHIVES.VISUALIZE);
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
     await browserAuth.loginAsPrivilegedUser();
   });
 
@@ -26,8 +25,8 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
     await kbnClient.savedObjects.cleanStandardList();
   });
 
-  test('allows to manually type tag filter query', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to manually type tag filter query', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await pageObjects.visualize.goto();
 
     await listingPage.waitForLoaded();
@@ -40,8 +39,8 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
     }
   });
 
-  test('allows to filter by selecting a tag in the filter menu', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to filter by selecting a tag in the filter menu', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await pageObjects.visualize.goto();
 
     await listingPage.waitForLoaded();
@@ -54,8 +53,8 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
     }
   });
 
-  test('allows to filter by multiple tags', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to filter by multiple tags', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await pageObjects.visualize.goto();
 
     await listingPage.waitForLoaded();
@@ -68,14 +67,14 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
     }
   });
 
-  test('allows to select tags for a new visualization', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to select tags for a new visualization', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
     await pageObjects.visualize.createTSVBVisualization();
     await pageObjects.visualize.openSaveModal();
-    await pageObjects.visualize.fillVisTitle('my-new-visualization');
-    await pageObjects.visualize.selectNoDashboard();
+    await pageObjects.saveModal.fillTitle('my-new-visualization');
+    await pageObjects.saveModal.selectNoDashboard();
     await pageObjects.tagManagement.selectSavedObjectTags('myextratag');
-    await pageObjects.visualize.confirmSave();
+    await pageObjects.saveModal.confirm();
 
     await pageObjects.visualize.goto();
     await listingPage.waitForLoaded();
@@ -85,11 +84,11 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
   });
 
   test('allows to create a tag from the tag selector', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+    const listingPage = pageObjects.savedObjectsListing;
     await pageObjects.visualize.createTSVBVisualization();
     await pageObjects.visualize.openSaveModal();
-    await pageObjects.visualize.fillVisTitle('visualization-with-new-tag');
-    await pageObjects.visualize.selectNoDashboard();
+    await pageObjects.saveModal.fillTitle('visualization-with-new-tag');
+    await pageObjects.saveModal.selectNoDashboard();
 
     await pageObjects.tagManagement.openCreateTagFromSelector();
     await pageObjects.tagManagement.tagModal.fillForm({
@@ -99,7 +98,7 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
     });
     await page.testSubj.click('createModalConfirmButton');
     await pageObjects.tagManagement.tagModal.form.waitFor({ state: 'hidden' });
-    await pageObjects.visualize.confirmSave();
+    await pageObjects.saveModal.confirm();
 
     await pageObjects.visualize.goto();
     await listingPage.waitForLoaded();
@@ -108,21 +107,21 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
     expect(itemNames).toContain('visualization-with-new-tag');
   });
 
-  test('allows to select tags for an existing visualization', async ({ page, pageObjects }) => {
-    const listingPage = new SavedObjectsListingPage(page);
+  test('allows to select tags for an existing visualization', async ({ pageObjects }) => {
+    const listingPage = pageObjects.savedObjectsListing;
 
     await pageObjects.visualize.createTSVBVisualization();
     await pageObjects.visualize.openSaveModal();
-    await pageObjects.visualize.fillVisTitle('MarkdownViz');
-    await pageObjects.visualize.selectNoDashboard();
-    await pageObjects.visualize.confirmSave();
+    await pageObjects.saveModal.fillTitle('MarkdownViz');
+    await pageObjects.saveModal.selectNoDashboard();
+    await pageObjects.saveModal.confirm();
 
     await pageObjects.visualize.goto();
     await listingPage.waitForLoaded();
     await listingPage.clickItemLink('visualize', 'MarkdownViz');
     await pageObjects.visualize.openSaveModal();
     await pageObjects.tagManagement.selectSavedObjectTags('myextratag');
-    await pageObjects.visualize.confirmSave();
+    await pageObjects.saveModal.confirm();
 
     await pageObjects.visualize.goto();
     await listingPage.waitForLoaded();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[scout][saved_objects_tagging] improve tests cleanup and expose page objects via fixture (#279459)](https://github.com/elastic/kibana/pull/279459)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-07-23T11:49:32Z","message":"[scout][saved_objects_tagging] improve tests cleanup and expose page objects via fixture (#279459)\n\n## Summary\n\nUpdating scout tests for `saved_objects_tagging` plugin to use call page\nobject methods via Playwright fixture, not class instance.\n\nPR adjusts tests hooks to avoid repeatable actions and clean env after\nsuite is over.","sha":"5da951d5192f231afb1cdbcb88adfc7fe2ef4728","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","reviewer:scout","v9.6.0"],"title":"[scout][saved_objects_tagging] improve tests cleanup and expose page objects via fixture","number":279459,"url":"https://github.com/elastic/kibana/pull/279459","mergeCommit":{"message":"[scout][saved_objects_tagging] improve tests cleanup and expose page objects via fixture (#279459)\n\n## Summary\n\nUpdating scout tests for `saved_objects_tagging` plugin to use call page\nobject methods via Playwright fixture, not class instance.\n\nPR adjusts tests hooks to avoid repeatable actions and clean env after\nsuite is over.","sha":"5da951d5192f231afb1cdbcb88adfc7fe2ef4728"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279459","number":279459,"mergeCommit":{"message":"[scout][saved_objects_tagging] improve tests cleanup and expose page objects via fixture (#279459)\n\n## Summary\n\nUpdating scout tests for `saved_objects_tagging` plugin to use call page\nobject methods via Playwright fixture, not class instance.\n\nPR adjusts tests hooks to avoid repeatable actions and clean env after\nsuite is over.","sha":"5da951d5192f231afb1cdbcb88adfc7fe2ef4728"}}]}] BACKPORT-->