### PR TITLE
[Agent Builder] Tool steps flyout: sub-execution drill-down

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/flyout_labels.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/flyout_labels.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const parametersLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.parametersLabel',
+  { defaultMessage: 'Parameters' }
+);
+
+export const executionLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.executionLabel',
+  { defaultMessage: 'Execution' }
+);
+
+export const resultLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.resultLabel',
+  { defaultMessage: 'Result' }
+);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/flyout_stack_context.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/flyout_stack_context.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createContext, useContext } from 'react';
+import type { ToolCallStep } from '@kbn/agent-builder-common/chat/conversation';
+
+interface FlyoutStackContextValue {
+  openToolStep: (step: ToolCallStep) => void;
+}
+
+export const FlyoutStackContext = createContext<FlyoutStackContextValue | null>(null);
+
+export const useFlyoutStack = () => useContext(FlyoutStackContext);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createToolCallStep } from '@kbn/agent-builder-common/chat/conversation';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { SubAgentExecutionFlyout } from './sub_agent_execution_flyout';
+
+jest.mock('../../../../../hooks/use_follow_execution', () => ({
+  useFollowExecution: jest.fn().mockReturnValue({
+    steps: [],
+    response: null,
+    streamingMessage: null,
+    error: null,
+  }),
+}));
+
+const { useFollowExecution } = jest.requireMock('../../../../../hooks/use_follow_execution');
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+const makeToolCallStep = () =>
+  createToolCallStep({
+    tool_call_id: 'c1',
+    tool_id: 'inner_tool',
+    params: {},
+    results: [{ tool_result_id: 'r1', type: ToolResultType.other, data: {} }],
+  });
+
+describe('SubAgentExecutionFlyout', () => {
+  beforeEach(() => {
+    useFollowExecution.mockReturnValue({
+      steps: [],
+      response: null,
+      streamingMessage: null,
+      error: null,
+    });
+  });
+
+  it('calls onBack when Back is clicked, not onClose', async () => {
+    const user = userEvent.setup();
+    const onBack = jest.fn();
+    const onClose = jest.fn();
+    renderWithProviders(
+      <SubAgentExecutionFlyout executionId="exec-1" onBack={onBack} onClose={onClose} />
+    );
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onBack).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('provides context: clicking a ToolCallStep inside opens a nested flyout', async () => {
+    const user = userEvent.setup();
+    useFollowExecution.mockReturnValue({
+      steps: [makeToolCallStep()],
+      response: null,
+      streamingMessage: null,
+      error: null,
+    });
+    renderWithProviders(
+      <SubAgentExecutionFlyout executionId="exec-1" onBack={jest.fn()} onClose={jest.fn()} />
+    );
+    expect(screen.getAllByRole('dialog')).toHaveLength(1);
+    await user.click(within(screen.getByTestId('agentBuilderToolCallStep')).getByRole('button'));
+    expect(screen.getAllByRole('dialog')).toHaveLength(2);
+  });
+
+  describe('nested ToolResponseFlyout', () => {
+    const renderWithNestedFlyoutOpen = async (
+      onBack: jest.Mock,
+      onClose: jest.Mock,
+      user: ReturnType<typeof userEvent.setup>
+    ) => {
+      useFollowExecution.mockReturnValue({
+        steps: [makeToolCallStep()],
+        response: null,
+        streamingMessage: null,
+        error: null,
+      });
+      renderWithProviders(
+        <SubAgentExecutionFlyout executionId="exec-1" onBack={onBack} onClose={onClose} />
+      );
+      await user.click(within(screen.getByTestId('agentBuilderToolCallStep')).getByRole('button'));
+    };
+
+    it('Back button on nested flyout closes L3 without calling root onClose', async () => {
+      const user = userEvent.setup();
+      const onClose = jest.fn();
+      await renderWithNestedFlyoutOpen(jest.fn(), onClose, user);
+      const nestedDialog = screen.getAllByRole('dialog').at(-1)!;
+      await user.click(within(nestedDialog).getByRole('button', { name: 'Back' }));
+      expect(screen.getAllByRole('dialog')).toHaveLength(1);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('close button on nested flyout calls root onClose', async () => {
+      const user = userEvent.setup();
+      const onClose = jest.fn();
+      await renderWithNestedFlyoutOpen(jest.fn(), onClose, user);
+      const nestedDialog = screen.getAllByRole('dialog').at(-1)!;
+      await user.click(within(nestedDialog).getByTestId('euiFlyoutCloseButton'));
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -19,7 +19,6 @@ import {
   EuiTitle,
   useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { ToolCallStep } from '@kbn/agent-builder-common/chat/conversation';
@@ -29,6 +28,7 @@ import { JsonCodeBlock } from '../json_code_block';
 import { FlyoutStackContext } from './flyout_stack_context';
 import { ToolResponseFlyout } from './tool_response_flyout';
 import { parametersLabel, executionLabel, resultLabel } from './flyout_labels';
+import { useSteppedFlyoutStyles } from './use_stepped_flyout_styles';
 
 const backLabel = i18n.translate('xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.back', {
   defaultMessage: 'Back',
@@ -67,6 +67,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
     error,
   } = useFollowExecution(executionId);
   const { euiTheme } = useEuiTheme();
+  const { backHeaderCss, stepsCss } = useSteppedFlyoutStyles();
   const displayMessage = response?.message ?? streamingMessage;
   const isRunning = !response && !error;
   const hasError = Boolean(error);
@@ -77,12 +78,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
           {
             title: parametersLabel,
             status: 'complete' as const,
-            children: (
-              <>
-                <EuiSpacer size="s" />
-                <JsonCodeBlock data={params} />
-              </>
-            ),
+            children: <JsonCodeBlock data={params} />,
           },
         ]
       : []),
@@ -92,12 +88,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
         | 'danger'
         | 'loading'
         | 'complete',
-      children: (
-        <>
-          <EuiSpacer size="s" />
-          <RoundEvents steps={executionSteps} />
-        </>
-      ),
+      children: <RoundEvents steps={executionSteps} />,
     },
     ...(!isRunning || displayMessage
       ? [
@@ -109,7 +100,6 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
               | 'complete',
             children: (
               <>
-                <EuiSpacer size="s" />
                 {hasError ? (
                   <EuiCallOut
                     announceOnMount
@@ -146,15 +136,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
         outsideClickCloses={onBack ? true : undefined}
       >
         {onBack && (
-          <EuiFlyoutHeader
-            hasBorder
-            css={css`
-              && {
-                padding-block: ${euiTheme.size.xs};
-                padding-left: ${euiTheme.size.s};
-              }
-            `}
-          >
+          <EuiFlyoutHeader hasBorder css={backHeaderCss}>
             <EuiButtonEmpty iconType="undo" onClick={onBack} flush="left" size="s" color="text">
               <EuiText size="xs" component="span">
                 {backLabel}
@@ -174,7 +156,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
           </EuiText>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
-          <EuiSteps headingElement="h3" titleSize="xxs" steps={euiSteps} />
+          <EuiSteps headingElement="h3" titleSize="xxs" steps={euiSteps} css={stepsCss} />
         </EuiFlyoutBody>
       </EuiFlyout>
       {nestedStep && (

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -61,7 +61,7 @@ const resultLabel = i18n.translate(
 interface SubAgentExecutionFlyoutProps {
   executionId: string;
   params?: Record<string, unknown>;
-  onBack: () => void;
+  onBack?: () => void;
   onClose: () => void;
 }
 
@@ -154,22 +154,24 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
         onClose={onClose}
         aria-labelledby="subAgentExecutionFlyoutTitle"
         size="m"
-        ownFocus={false}
-        outsideClickCloses
+        ownFocus={!onBack}
+        outsideClickCloses={onBack ? true : undefined}
       >
-        <EuiFlyoutHeader
-          hasBorder
-          css={css`
-            && {
-              padding-block: 4px;
-              padding-left: 8px;
-            }
-          `}
-        >
-          <EuiButtonEmpty iconType="undo" onClick={onBack} flush="left" size="s" color="text">
-            <EuiText size="xs">{backLabel}</EuiText>
-          </EuiButtonEmpty>
-        </EuiFlyoutHeader>
+        {onBack && (
+          <EuiFlyoutHeader
+            hasBorder
+            css={css`
+              && {
+                padding-block: 4px;
+                padding-left: 8px;
+              }
+            `}
+          >
+            <EuiButtonEmpty iconType="undo" onClick={onBack} flush="left" size="s" color="text">
+              <EuiText size="xs">{backLabel}</EuiText>
+            </EuiButtonEmpty>
+          </EuiFlyoutHeader>
+        )}
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="l">
             <h2 id="subAgentExecutionFlyoutTitle">{subAgentExecutionTitle}</h2>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -69,8 +69,6 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
   const { euiTheme } = useEuiTheme();
   const displayMessage = response?.message ?? streamingMessage;
   const isRunning = !response && !error;
-  const isStreaming =
-    !isCompleted && isRunning && (executionSteps.length > 0 || !!streamingMessage);
   const hasError = Boolean(error);
 
   const euiSteps = [
@@ -90,7 +88,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
       : []),
     {
       title: executionLabel,
-      status: (hasError ? 'danger' : isStreaming ? 'loading' : 'complete') as
+      status: (hasError ? 'danger' : isRunning && !isCompleted ? 'loading' : 'complete') as
         | 'danger'
         | 'loading'
         | 'complete',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -61,6 +61,7 @@ const resultLabel = i18n.translate(
 interface SubAgentExecutionFlyoutProps {
   executionId: string;
   params?: Record<string, unknown>;
+  isCompleted?: boolean;
   onBack?: () => void;
   onClose: () => void;
 }
@@ -68,6 +69,7 @@ interface SubAgentExecutionFlyoutProps {
 export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = ({
   executionId,
   params,
+  isCompleted = false,
   onBack,
   onClose,
 }) => {
@@ -81,6 +83,8 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
   const { euiTheme } = useEuiTheme();
   const displayMessage = response?.message ?? streamingMessage;
   const isRunning = !response && !error;
+  const isStreaming =
+    !isCompleted && isRunning && (executionSteps.length > 0 || !!streamingMessage);
   const hasError = Boolean(error);
 
   const euiSteps = [
@@ -100,7 +104,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
       : []),
     {
       title: executionLabel,
-      status: (hasError ? 'danger' : isRunning ? 'loading' : 'complete') as
+      status: (hasError ? 'danger' : isStreaming ? 'loading' : 'complete') as
         | 'danger'
         | 'loading'
         | 'complete',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -28,6 +28,7 @@ import { RoundEvents } from '../round_events';
 import { JsonCodeBlock } from '../json_code_block';
 import { FlyoutStackContext } from './flyout_stack_context';
 import { ToolResponseFlyout } from './tool_response_flyout';
+import { parametersLabel, executionLabel, resultLabel } from './flyout_labels';
 
 const backLabel = i18n.translate('xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.back', {
   defaultMessage: 'Back',
@@ -41,21 +42,6 @@ const subAgentExecutionTitle = i18n.translate(
 const executionIdLabel = i18n.translate(
   'xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.executionIdLabel',
   { defaultMessage: 'Execution ID' }
-);
-
-const parametersLabel = i18n.translate(
-  'xpack.agentBuilder.conversation.toolResponseFlyout.parametersLabel',
-  { defaultMessage: 'Parameters' }
-);
-
-const executionLabel = i18n.translate(
-  'xpack.agentBuilder.conversation.toolResponseFlyout.executionLabel',
-  { defaultMessage: 'Execution' }
-);
-
-const resultLabel = i18n.translate(
-  'xpack.agentBuilder.conversation.toolResponseFlyout.resultLabel',
-  { defaultMessage: 'Result' }
 );
 
 interface SubAgentExecutionFlyoutProps {
@@ -166,13 +152,15 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
             hasBorder
             css={css`
               && {
-                padding-block: 4px;
-                padding-left: 8px;
+                padding-block: ${euiTheme.size.xs};
+                padding-left: ${euiTheme.size.s};
               }
             `}
           >
             <EuiButtonEmpty iconType="undo" onClick={onBack} flush="left" size="s" color="text">
-              <EuiText size="xs">{backLabel}</EuiText>
+              <EuiText size="xs" component="span">
+                {backLabel}
+              </EuiText>
             </EuiButtonEmpty>
           </EuiFlyoutHeader>
         )}
@@ -181,7 +169,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
             <h2 id="subAgentExecutionFlyoutTitle">{subAgentExecutionTitle}</h2>
           </EuiTitle>
           <EuiSpacer size="xs" />
-          <EuiText size="s" color={`${euiTheme.colors.textSubdued}`}>
+          <EuiText size="s" color={euiTheme.colors.textSubdued}>
             <p>
               {executionIdLabel} {executionId}
             </p>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -22,7 +22,7 @@ import {
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
+import type { ToolCallStep } from '@kbn/agent-builder-common/chat/conversation';
 import { useFollowExecution } from '../../../../../hooks/use_follow_execution';
 import { RoundEvents } from '../round_events';
 import { JsonCodeBlock } from '../json_code_block';
@@ -71,7 +71,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
   onBack,
   onClose,
 }) => {
-  const [nestedStep, setNestedStep] = useState<ToolCallStepData | null>(null);
+  const [nestedStep, setNestedStep] = useState<ToolCallStep | null>(null);
   const {
     steps: executionSteps,
     response,
@@ -111,11 +111,14 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
         </>
       ),
     },
-    ...(!isRunning
+    ...(!isRunning || displayMessage
       ? [
           {
             title: resultLabel,
-            status: (hasError ? 'danger' : 'complete') as 'danger' | 'complete',
+            status: (hasError ? 'danger' : isRunning ? 'loading' : 'complete') as
+              | 'danger'
+              | 'loading'
+              | 'complete',
             children: (
               <>
                 <EuiSpacer size="s" />

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -7,22 +7,53 @@
 
 import React from 'react';
 import {
+  EuiButtonEmpty,
   EuiCallOut,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiMarkdownFormat,
-  EuiPanel,
   EuiSpacer,
+  EuiSteps,
   EuiText,
   EuiTitle,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { euiThemeVars } from '@kbn/ui-theme';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useFollowExecution } from '../../../../../hooks/use_follow_execution';
 import { RoundEvents } from '../round_events';
 import { JsonCodeBlock } from '../json_code_block';
+
+const backLabel = i18n.translate('xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.back', {
+  defaultMessage: 'Back',
+});
+
+const subAgentExecutionTitle = i18n.translate(
+  'xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.title',
+  { defaultMessage: 'Sub-agent execution' }
+);
+
+const executionIdLabel = i18n.translate(
+  'xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.executionIdLabel',
+  { defaultMessage: 'Execution ID' }
+);
+
+const parametersLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.parametersLabel',
+  { defaultMessage: 'Parameters' }
+);
+
+const executionLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.executionLabel',
+  { defaultMessage: 'Execution' }
+);
+
+const resultLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.resultLabel',
+  { defaultMessage: 'Result' }
+);
 
 interface SubAgentExecutionFlyoutProps {
   executionId: string;
@@ -30,18 +61,83 @@ interface SubAgentExecutionFlyoutProps {
   onClose: () => void;
 }
 
-/**
- * Flyout showing a sub-agent's full execution — params, error (if any), the
- * sub-agent's own steps (rendered recursively via `RoundEvents`), and the
- * final response message.
- */
 export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = ({
   executionId,
   params,
   onClose,
 }) => {
-  const { steps, response, streamingMessage, error } = useFollowExecution(executionId);
+  const {
+    steps: executionSteps,
+    response,
+    streamingMessage,
+    error,
+  } = useFollowExecution(executionId);
+  const { euiTheme } = useEuiTheme();
   const displayMessage = response?.message ?? streamingMessage;
+  const isRunning = !response && !error;
+  const hasError = Boolean(error);
+
+  const euiSteps = [
+    ...(params
+      ? [
+          {
+            title: parametersLabel,
+            status: 'complete' as const,
+            children: (
+              <>
+                <EuiSpacer size="s" />
+                <JsonCodeBlock data={params} />
+              </>
+            ),
+          },
+        ]
+      : []),
+    {
+      title: executionLabel,
+      status: (hasError ? 'danger' : isRunning ? 'loading' : 'complete') as
+        | 'danger'
+        | 'loading'
+        | 'complete',
+      children: (
+        <>
+          <EuiSpacer size="s" />
+          <RoundEvents steps={executionSteps} />
+        </>
+      ),
+    },
+    ...(!isRunning
+      ? [
+          {
+            title: resultLabel,
+            status: (hasError ? 'danger' : 'complete') as 'danger' | 'complete',
+            children: (
+              <>
+                <EuiSpacer size="s" />
+                {hasError ? (
+                  <EuiCallOut
+                    announceOnMount
+                    title={
+                      <FormattedMessage
+                        id="xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.errorTitle"
+                        defaultMessage="Execution error"
+                      />
+                    }
+                    color="danger"
+                    iconType="error"
+                  >
+                    <p>{error}</p>
+                  </EuiCallOut>
+                ) : displayMessage ? (
+                  <EuiText size="m">
+                    <EuiMarkdownFormat textSize="m">{displayMessage}</EuiMarkdownFormat>
+                  </EuiText>
+                ) : null}
+              </>
+            ),
+          },
+        ]
+      : []),
+  ];
 
   return (
     <EuiFlyout
@@ -49,82 +145,33 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
       aria-labelledby="subAgentExecutionFlyoutTitle"
       size="m"
       ownFocus={false}
-      css={css`
-        z-index: ${euiThemeVars.euiZFlyout + 4};
-      `}
     >
+      <EuiFlyoutHeader
+        hasBorder
+        css={css`
+          && {
+            padding-block: 4px;
+            padding-left: 8px;
+          }
+        `}
+      >
+        <EuiButtonEmpty iconType="undo" onClick={onClose} flush="left" size="s" color="text">
+          <EuiText size="xs">{backLabel}</EuiText>
+        </EuiButtonEmpty>
+      </EuiFlyoutHeader>
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m">
-          <h2 id="subAgentExecutionFlyoutTitle">
-            <FormattedMessage
-              id="xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.title"
-              defaultMessage="Sub-agent execution"
-            />
-          </h2>
+        <EuiTitle size="l">
+          <h2 id="subAgentExecutionFlyoutTitle">{subAgentExecutionTitle}</h2>
         </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiText color="subdued" size="s">
+        <EuiSpacer size="xs" />
+        <EuiText size="s" color={`${euiTheme.colors.textSubdued}`}>
           <p>
-            <FormattedMessage
-              id="xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.executionId"
-              defaultMessage="Execution ID: {executionId}"
-              values={{ executionId }}
-            />
+            {executionIdLabel} {executionId}
           </p>
         </EuiText>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        {params && (
-          <>
-            <JsonCodeBlock data={params} />
-            <EuiSpacer size="m" />
-          </>
-        )}
-        {error && (
-          <>
-            <EuiCallOut
-              announceOnMount
-              title={
-                <FormattedMessage
-                  id="xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.errorTitle"
-                  defaultMessage="Execution error"
-                />
-              }
-              color="danger"
-              iconType="error"
-            >
-              <p>{error}</p>
-            </EuiCallOut>
-            <EuiSpacer size="m" />
-          </>
-        )}
-        <RoundEvents steps={steps} />
-        {displayMessage && (
-          <>
-            <EuiSpacer size="m" />
-            <EuiPanel hasBorder paddingSize="m">
-              <EuiTitle size="xs">
-                <h3>
-                  {response ? (
-                    <FormattedMessage
-                      id="xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.finalResponse"
-                      defaultMessage="Final response"
-                    />
-                  ) : (
-                    <FormattedMessage
-                      id="xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.responding"
-                      defaultMessage="Responding..."
-                    />
-                  )}
-                </h3>
-              </EuiTitle>
-              <EuiSpacer size="s" />
-              <EuiText size="m">
-                <EuiMarkdownFormat textSize="m">{displayMessage}</EuiMarkdownFormat>
-              </EuiText>
-            </EuiPanel>
-          </>
-        )}
+        <EuiSteps headingElement="h3" titleSize="xxs" steps={euiSteps} />
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -18,6 +18,7 @@ import {
   EuiText,
   EuiTitle,
   useEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -68,6 +69,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
   } = useFollowExecution(executionId);
   const { euiTheme } = useEuiTheme();
   const { backHeaderCss, stepsCss } = useSteppedFlyoutStyles();
+  const titleId = useGeneratedHtmlId({ prefix: 'subAgentExecutionFlyout' });
   const displayMessage = response?.message ?? streamingMessage;
   const isRunning = !response && !error;
   const hasError = Boolean(error);
@@ -130,7 +132,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
     <FlyoutStackContext.Provider value={{ openToolStep: setNestedStep }}>
       <EuiFlyout
         onClose={onClose}
-        aria-labelledby="subAgentExecutionFlyoutTitle"
+        aria-labelledby={titleId}
         size="m"
         ownFocus={!onBack}
         outsideClickCloses={onBack ? true : undefined}
@@ -146,7 +148,7 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
         )}
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="l">
-            <h2 id="subAgentExecutionFlyoutTitle">{subAgentExecutionTitle}</h2>
+            <h2 id={titleId}>{subAgentExecutionTitle}</h2>
           </EuiTitle>
           <EuiSpacer size="xs" />
           <EuiText size="s" color={euiTheme.colors.textSubdued}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/sub_agent_execution_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiButtonEmpty,
   EuiCallOut,
@@ -22,9 +22,12 @@ import {
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
 import { useFollowExecution } from '../../../../../hooks/use_follow_execution';
 import { RoundEvents } from '../round_events';
 import { JsonCodeBlock } from '../json_code_block';
+import { FlyoutStackContext } from './flyout_stack_context';
+import { ToolResponseFlyout } from './tool_response_flyout';
 
 const backLabel = i18n.translate('xpack.agentBuilder.roundEvents.subAgentExecutionFlyout.back', {
   defaultMessage: 'Back',
@@ -58,14 +61,17 @@ const resultLabel = i18n.translate(
 interface SubAgentExecutionFlyoutProps {
   executionId: string;
   params?: Record<string, unknown>;
+  onBack: () => void;
   onClose: () => void;
 }
 
 export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = ({
   executionId,
   params,
+  onBack,
   onClose,
 }) => {
+  const [nestedStep, setNestedStep] = useState<ToolCallStepData | null>(null);
   const {
     steps: executionSteps,
     response,
@@ -140,39 +146,49 @@ export const SubAgentExecutionFlyout: React.FC<SubAgentExecutionFlyoutProps> = (
   ];
 
   return (
-    <EuiFlyout
-      onClose={onClose}
-      aria-labelledby="subAgentExecutionFlyoutTitle"
-      size="m"
-      ownFocus={false}
-    >
-      <EuiFlyoutHeader
-        hasBorder
-        css={css`
-          && {
-            padding-block: 4px;
-            padding-left: 8px;
-          }
-        `}
+    <FlyoutStackContext.Provider value={{ openToolStep: setNestedStep }}>
+      <EuiFlyout
+        onClose={onClose}
+        aria-labelledby="subAgentExecutionFlyoutTitle"
+        size="m"
+        ownFocus={false}
+        outsideClickCloses
       >
-        <EuiButtonEmpty iconType="undo" onClick={onClose} flush="left" size="s" color="text">
-          <EuiText size="xs">{backLabel}</EuiText>
-        </EuiButtonEmpty>
-      </EuiFlyoutHeader>
-      <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="l">
-          <h2 id="subAgentExecutionFlyoutTitle">{subAgentExecutionTitle}</h2>
-        </EuiTitle>
-        <EuiSpacer size="xs" />
-        <EuiText size="s" color={`${euiTheme.colors.textSubdued}`}>
-          <p>
-            {executionIdLabel} {executionId}
-          </p>
-        </EuiText>
-      </EuiFlyoutHeader>
-      <EuiFlyoutBody>
-        <EuiSteps headingElement="h3" titleSize="xxs" steps={euiSteps} />
-      </EuiFlyoutBody>
-    </EuiFlyout>
+        <EuiFlyoutHeader
+          hasBorder
+          css={css`
+            && {
+              padding-block: 4px;
+              padding-left: 8px;
+            }
+          `}
+        >
+          <EuiButtonEmpty iconType="undo" onClick={onBack} flush="left" size="s" color="text">
+            <EuiText size="xs">{backLabel}</EuiText>
+          </EuiButtonEmpty>
+        </EuiFlyoutHeader>
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="l">
+            <h2 id="subAgentExecutionFlyoutTitle">{subAgentExecutionTitle}</h2>
+          </EuiTitle>
+          <EuiSpacer size="xs" />
+          <EuiText size="s" color={`${euiTheme.colors.textSubdued}`}>
+            <p>
+              {executionIdLabel} {executionId}
+            </p>
+          </EuiText>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiSteps headingElement="h3" titleSize="xxs" steps={euiSteps} />
+        </EuiFlyoutBody>
+      </EuiFlyout>
+      {nestedStep && (
+        <ToolResponseFlyout
+          step={nestedStep}
+          onClose={onClose}
+          onBack={() => setNestedStep(null)}
+        />
+      )}
+    </FlyoutStackContext.Provider>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createToolCallStep } from '@kbn/agent-builder-common/chat/conversation';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { ToolResponseFlyout } from './tool_response_flyout';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+const makeStep = () =>
+  createToolCallStep({
+    tool_call_id: 'c1',
+    tool_id: 'my_tool',
+    params: {},
+    results: [{ tool_result_id: 'r1', type: ToolResultType.other, data: {} }],
+  });
+
+describe('ToolResponseFlyout', () => {
+  it('renders without a Back button when onBack is not provided', () => {
+    renderWithProviders(<ToolResponseFlyout step={makeStep()} onClose={jest.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+  });
+
+  it('renders a Back button when onBack is provided', () => {
+    renderWithProviders(
+      <ToolResponseFlyout step={makeStep()} onClose={jest.fn()} onBack={jest.fn()} />
+    );
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+  });
+
+  it('calls onBack when Back is clicked, not onClose', async () => {
+    const user = userEvent.setup();
+    const onBack = jest.fn();
+    const onClose = jest.fn();
+    renderWithProviders(
+      <ToolResponseFlyout step={makeStep()} onClose={onClose} onBack={onBack} />
+    );
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onBack).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when the flyout close button is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    renderWithProviders(<ToolResponseFlyout step={makeStep()} onClose={onClose} />);
+    await user.click(screen.getByTestId('euiFlyoutCloseButton'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.test.tsx
@@ -46,9 +46,7 @@ describe('ToolResponseFlyout', () => {
     const user = userEvent.setup();
     const onBack = jest.fn();
     const onClose = jest.fn();
-    renderWithProviders(
-      <ToolResponseFlyout step={makeStep()} onClose={onClose} onBack={onBack} />
-    );
+    renderWithProviders(<ToolResponseFlyout step={makeStep()} onClose={onClose} onBack={onBack} />);
     await user.click(screen.getByRole('button', { name: 'Back' }));
     expect(onBack).toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -16,6 +16,7 @@ import {
   EuiSteps,
   EuiLoadingSpinner,
   useEuiTheme,
+  useGeneratedHtmlId,
   EuiText,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -56,6 +57,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
 }) => {
   const { euiTheme } = useEuiTheme();
   const { backHeaderCss, stepsCss } = useSteppedFlyoutStyles();
+  const titleId = useGeneratedHtmlId({ prefix: 'toolResponseFlyout' });
   const [isSubFlyoutOpen, { on: openSubFlyout, off: closeSubFlyout }] = useBoolean();
 
   const isSubAgentCall = step.tool_id === internalTools.runSubagent;
@@ -126,7 +128,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
   return (
     <EuiFlyout
       onClose={onClose}
-      aria-labelledby="toolResponseFlyoutTitle"
+      aria-labelledby={titleId}
       size="m"
       ownFocus={!onBack}
       outsideClickCloses={onBack ? true : undefined}
@@ -142,7 +144,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
       )}
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
-          <h2 id="toolResponseFlyoutTitle">
+          <h2 id={titleId}>
             {toolLabel}: {step.tool_id}
           </h2>
         </EuiTitle>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -153,7 +153,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
       aria-labelledby="toolResponseFlyoutTitle"
       size="m"
       ownFocus={!onBack}
-      outsideClickCloses={!!onBack}
+      outsideClickCloses={onBack ? true : undefined}
     >
       {onBack && (
         <EuiFlyoutHeader

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -188,6 +188,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
         <SubAgentExecutionFlyout
           executionId={subAgentExecutionId}
           params={step.params}
+          isCompleted={!isSubAgentRunning}
           onBack={closeSubFlyout}
           onClose={onClose}
         />

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -52,6 +52,10 @@ const subAgentExecutionLabel = i18n.translate(
   { defaultMessage: 'Sub-agent execution' }
 );
 
+const toolLabel = i18n.translate('xpack.agentBuilder.conversation.toolResponseFlyout.toolLabel', {
+  defaultMessage: 'tool',
+});
+
 interface ToolResponseFlyoutProps {
   step: ToolCallStepData;
   onClose: () => void;
@@ -172,7 +176,9 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
       )}
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
-          <h2 id="toolResponseFlyoutTitle">tool: {step.tool_id}</h2>
+          <h2 id="toolResponseFlyoutTitle">
+            {toolLabel}: {step.tool_id}
+          </h2>
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -28,6 +28,10 @@ import { JsonCodeBlock } from '../json_code_block';
 import { ToolResult } from '../results/tool_result';
 import { SubAgentExecutionFlyout } from './sub_agent_execution_flyout';
 
+const backLabel = i18n.translate('xpack.agentBuilder.conversation.toolResponseFlyout.back', {
+  defaultMessage: 'Back',
+});
+
 const parametersLabel = i18n.translate(
   'xpack.agentBuilder.conversation.toolResponseFlyout.parametersLabel',
   { defaultMessage: 'Parameters' }
@@ -51,9 +55,10 @@ const subAgentExecutionLabel = i18n.translate(
 interface ToolResponseFlyoutProps {
   step: ToolCallStepData;
   onClose: () => void;
+  onBack?: () => void;
 }
 
-export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, onClose }) => {
+export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, onClose, onBack }) => {
   const { euiTheme } = useEuiTheme();
   const [isSubFlyoutOpen, { on: openSubFlyout, off: closeSubFlyout }] = useBoolean();
 
@@ -139,7 +144,22 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
   ];
 
   return (
-    <EuiFlyout onClose={onClose} aria-labelledby="toolResponseFlyoutTitle" size="m">
+    <EuiFlyout onClose={onClose} aria-labelledby="toolResponseFlyoutTitle" size="m" ownFocus={!onBack} outsideClickCloses={!!onBack}>
+      {onBack && (
+        <EuiFlyoutHeader
+          hasBorder
+          css={css`
+            && {
+              padding-block: 4px;
+              padding-left: 8px;
+            }
+          `}
+        >
+          <EuiButtonEmpty iconType="undo" onClick={onBack} flush="left" size="s" color="text">
+            <EuiText size="xs">{backLabel}</EuiText>
+          </EuiButtonEmpty>
+        </EuiFlyoutHeader>
+      )}
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
           <h2 id="toolResponseFlyoutTitle">tool: {step.tool_id}</h2>
@@ -152,7 +172,8 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
         <SubAgentExecutionFlyout
           executionId={subAgentExecutionId}
           params={step.params}
-          onClose={closeSubFlyout}
+          onBack={closeSubFlyout}
+          onClose={onClose}
         />
       )}
     </EuiFlyout>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -7,20 +7,26 @@
 
 import React, { Fragment } from 'react';
 import {
+  EuiButtonEmpty,
   EuiFlyout,
   EuiFlyoutHeader,
   EuiFlyoutBody,
   EuiTitle,
   EuiSpacer,
   EuiSteps,
+  EuiLoadingSpinner,
+  useEuiTheme,
   EuiText,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import { useBoolean } from '@kbn/react-hooks';
 import { internalTools } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
 import { isErrorResult } from '@kbn/agent-builder-common/tools/tool_result';
 import { JsonCodeBlock } from '../json_code_block';
 import { ToolResult } from '../results/tool_result';
+import { SubAgentExecutionFlyout } from './sub_agent_execution_flyout';
 
 const parametersLabel = i18n.translate(
   'xpack.agentBuilder.conversation.toolResponseFlyout.parametersLabel',
@@ -37,15 +43,24 @@ const resultLabel = i18n.translate(
   { defaultMessage: 'Result' }
 );
 
+const subAgentExecutionLabel = i18n.translate(
+  'xpack.agentBuilder.conversation.toolResponseFlyout.subAgentExecutionLabel',
+  { defaultMessage: 'Sub-agent execution' }
+);
+
 interface ToolResponseFlyoutProps {
   step: ToolCallStepData;
   onClose: () => void;
 }
 
 export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, onClose }) => {
+  const { euiTheme } = useEuiTheme();
+  const [isSubFlyoutOpen, { on: openSubFlyout, off: closeSubFlyout }] = useBoolean();
+
   const isSubAgentCall = step.tool_id === internalTools.runSubagent;
   const subAgentExecutionId = isSubAgentCall ? getSubAgentExecutionId(step) : undefined;
-  const showExecutionSection = Boolean(subAgentExecutionId);
+  const showExecutionSection = isSubAgentCall;
+  const isSubAgentRunning = isSubAgentCall && step.results.length === 0;
   const showResultSection = step.results.length > 0;
   const hasErrorResult = step.results.some(isErrorResult);
 
@@ -64,15 +79,39 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
       ? [
           {
             title: executionLabel,
-            status: 'complete' as const,
-            children: (
+            status: (isSubAgentRunning ? 'loading' : 'complete') as 'loading' | 'complete',
+            children: !subAgentExecutionId ? (
               <>
                 <EuiSpacer size="s" />
-                {/* TODO: replace with sub-agent execution drill-down — elastic/search-team#15172 */}
-                {/* <EuiText size="s" color="subdued"><EuiCode>{subAgentExecutionId}</EuiCode></EuiText> */}
-                <EuiText size="s" color="subdued">
-                  TODO
-                </EuiText>
+                <EuiLoadingSpinner size="s" />
+              </>
+            ) : (
+              <>
+                <EuiSpacer size="s" />
+                <ul
+                  css={css`
+                    list-style-type: disc;
+                    padding-inline-start: ${euiTheme.size.l};
+                    margin: 0;
+                  `}
+                >
+                  <li>
+                    <EuiButtonEmpty
+                      iconType="sortRight"
+                      iconSide="right"
+                      flush="left"
+                      size="s"
+                      css={css`
+                        color: ${euiTheme.colors.textDisabled};
+                      `}
+                      onClick={openSubFlyout}
+                    >
+                      <EuiText size="m" color={`${euiTheme.colors.textDisabled}`}>
+                        {subAgentExecutionLabel} {subAgentExecutionId}
+                      </EuiText>
+                    </EuiButtonEmpty>
+                  </li>
+                </ul>
               </>
             ),
           },
@@ -109,6 +148,13 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
       <EuiFlyoutBody>
         <EuiSteps headingElement="h3" titleSize="xxs" steps={steps} />
       </EuiFlyoutBody>
+      {isSubFlyoutOpen && subAgentExecutionId && (
+        <SubAgentExecutionFlyout
+          executionId={subAgentExecutionId}
+          params={step.params}
+          onClose={closeSubFlyout}
+        />
+      )}
     </EuiFlyout>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -28,6 +28,7 @@ import { JsonCodeBlock } from '../json_code_block';
 import { ToolResult } from '../results/tool_result';
 import { SubAgentExecutionFlyout } from './sub_agent_execution_flyout';
 import { parametersLabel, executionLabel, resultLabel } from './flyout_labels';
+import { useSteppedFlyoutStyles } from './use_stepped_flyout_styles';
 
 const backLabel = i18n.translate('xpack.agentBuilder.conversation.toolResponseFlyout.back', {
   defaultMessage: 'Back',
@@ -54,6 +55,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
   onBack,
 }) => {
   const { euiTheme } = useEuiTheme();
+  const { backHeaderCss, stepsCss } = useSteppedFlyoutStyles();
   const [isSubFlyoutOpen, { on: openSubFlyout, off: closeSubFlyout }] = useBoolean();
 
   const isSubAgentCall = step.tool_id === internalTools.runSubagent;
@@ -67,12 +69,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
     {
       title: parametersLabel,
       status: 'complete' as const,
-      children: (
-        <>
-          <EuiSpacer size="s" />
-          <JsonCodeBlock data={step.params} />
-        </>
-      ),
+      children: <JsonCodeBlock data={step.params} />,
     },
     ...(showExecutionSection
       ? [
@@ -80,38 +77,32 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
             title: executionLabel,
             status: (isSubAgentRunning ? 'loading' : 'complete') as 'loading' | 'complete',
             children: !subAgentExecutionId ? (
-              <>
-                <EuiSpacer size="s" />
-                <EuiLoadingSpinner size="s" />
-              </>
+              <EuiLoadingSpinner size="s" />
             ) : (
-              <>
-                <EuiSpacer size="s" />
-                <ul
-                  css={css`
-                    list-style-type: disc;
-                    padding-inline-start: ${euiTheme.size.l};
-                    margin: 0;
-                  `}
-                >
-                  <li>
-                    <EuiButtonEmpty
-                      iconType="sortRight"
-                      iconSide="right"
-                      flush="left"
-                      size="s"
-                      css={css`
-                        color: ${euiTheme.colors.textDisabled};
-                      `}
-                      onClick={openSubFlyout}
-                    >
-                      <EuiText size="m" color={`${euiTheme.colors.textDisabled}`}>
-                        {subAgentExecutionLabel} {subAgentExecutionId}
-                      </EuiText>
-                    </EuiButtonEmpty>
-                  </li>
-                </ul>
-              </>
+              <ul
+                css={css`
+                  list-style-type: disc;
+                  padding-inline-start: ${euiTheme.size.l};
+                  margin: 0;
+                `}
+              >
+                <li>
+                  <EuiButtonEmpty
+                    iconType="sortRight"
+                    iconSide="right"
+                    flush="left"
+                    size="s"
+                    css={css`
+                      color: ${euiTheme.colors.textDisabled};
+                    `}
+                    onClick={openSubFlyout}
+                  >
+                    <EuiText size="m" color={`${euiTheme.colors.textDisabled}`}>
+                      {subAgentExecutionLabel} {subAgentExecutionId}
+                    </EuiText>
+                  </EuiButtonEmpty>
+                </li>
+              </ul>
             ),
           },
         ]
@@ -121,17 +112,12 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
           {
             title: resultLabel,
             status: (hasErrorResult ? 'danger' : 'complete') as 'danger' | 'complete',
-            children: (
-              <>
-                <EuiSpacer size="s" />
-                {step.results.map((result, idx) => (
-                  <Fragment key={`flyout-result-${idx}`}>
-                    <ToolResult result={result} />
-                    {idx < step.results.length - 1 && <EuiSpacer size="s" />}
-                  </Fragment>
-                ))}
-              </>
-            ),
+            children: step.results.map((result, idx) => (
+              <Fragment key={`flyout-result-${idx}`}>
+                <ToolResult result={result} />
+                {idx < step.results.length - 1 && <EuiSpacer size="s" />}
+              </Fragment>
+            )),
           },
         ]
       : []),
@@ -146,15 +132,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
       outsideClickCloses={onBack ? true : undefined}
     >
       {onBack && (
-        <EuiFlyoutHeader
-          hasBorder
-          css={css`
-            && {
-              padding-block: 4px;
-              padding-left: 8px;
-            }
-          `}
-        >
+        <EuiFlyoutHeader hasBorder css={backHeaderCss}>
           <EuiButtonEmpty iconType="undo" onClick={onBack} flush="left" size="s" color="text">
             <EuiText size="xs" component="span">
               {backLabel}
@@ -170,7 +148,7 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <EuiSteps headingElement="h3" titleSize="xxs" steps={steps} />
+        <EuiSteps headingElement="h3" titleSize="xxs" steps={steps} css={stepsCss} />
       </EuiFlyoutBody>
       {isSubFlyoutOpen && subAgentExecutionId && (
         <SubAgentExecutionFlyout

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -58,7 +58,11 @@ interface ToolResponseFlyoutProps {
   onBack?: () => void;
 }
 
-export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, onClose, onBack }) => {
+export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
+  step,
+  onClose,
+  onBack,
+}) => {
   const { euiTheme } = useEuiTheme();
   const [isSubFlyoutOpen, { on: openSubFlyout, off: closeSubFlyout }] = useBoolean();
 
@@ -144,7 +148,13 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({ step, on
   ];
 
   return (
-    <EuiFlyout onClose={onClose} aria-labelledby="toolResponseFlyoutTitle" size="m" ownFocus={!onBack} outsideClickCloses={!!onBack}>
+    <EuiFlyout
+      onClose={onClose}
+      aria-labelledby="toolResponseFlyoutTitle"
+      size="m"
+      ownFocus={!onBack}
+      outsideClickCloses={!!onBack}
+    >
       {onBack && (
         <EuiFlyoutHeader
           hasBorder

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/tool_response_flyout.tsx
@@ -27,25 +27,11 @@ import { isErrorResult } from '@kbn/agent-builder-common/tools/tool_result';
 import { JsonCodeBlock } from '../json_code_block';
 import { ToolResult } from '../results/tool_result';
 import { SubAgentExecutionFlyout } from './sub_agent_execution_flyout';
+import { parametersLabel, executionLabel, resultLabel } from './flyout_labels';
 
 const backLabel = i18n.translate('xpack.agentBuilder.conversation.toolResponseFlyout.back', {
   defaultMessage: 'Back',
 });
-
-const parametersLabel = i18n.translate(
-  'xpack.agentBuilder.conversation.toolResponseFlyout.parametersLabel',
-  { defaultMessage: 'Parameters' }
-);
-
-const executionLabel = i18n.translate(
-  'xpack.agentBuilder.conversation.toolResponseFlyout.executionLabel',
-  { defaultMessage: 'Execution' }
-);
-
-const resultLabel = i18n.translate(
-  'xpack.agentBuilder.conversation.toolResponseFlyout.resultLabel',
-  { defaultMessage: 'Result' }
-);
 
 const subAgentExecutionLabel = i18n.translate(
   'xpack.agentBuilder.conversation.toolResponseFlyout.subAgentExecutionLabel',
@@ -170,7 +156,9 @@ export const ToolResponseFlyout: React.FC<ToolResponseFlyoutProps> = ({
           `}
         >
           <EuiButtonEmpty iconType="undo" onClick={onBack} flush="left" size="s" color="text">
-            <EuiText size="xs">{backLabel}</EuiText>
+            <EuiText size="xs" component="span">
+              {backLabel}
+            </EuiText>
           </EuiButtonEmpty>
         </EuiFlyoutHeader>
       )}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/use_stepped_flyout_styles.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/use_stepped_flyout_styles.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export const useSteppedFlyoutStyles = () => {
+  const { euiTheme } = useEuiTheme();
+
+  const backHeaderCss = css`
+    && {
+      padding-block: ${euiTheme.size.xs};
+      padding-left: ${euiTheme.size.s};
+    }
+  `;
+
+  const stepsCss = css`
+    .euiStep__content {
+      padding-block-start: ${euiTheme.size.s};
+      padding-block-end: ${euiTheme.size.base};
+    }
+  `;
+
+  return { backHeaderCss, stepsCss };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.test.tsx
@@ -15,6 +15,7 @@ import { createToolCallStep } from '@kbn/agent-builder-common/chat/conversation'
 import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { ToolCallStep } from './tool_call_step';
+import { FlyoutStackContext } from '../flyouts/flyout_stack_context';
 
 const renderWithProviders = (ui: React.ReactElement) =>
   render(
@@ -79,6 +80,22 @@ describe('ToolCallStep', () => {
     const badge = screen.getByRole('status').querySelector('.euiBadge');
     expect(badge).toHaveTextContent('tool: search');
     expect(badge?.className).toContain('danger');
+  });
+
+  describe('with FlyoutStackContext', () => {
+    it('delegates click to context and renders no flyout', async () => {
+      const user = userEvent.setup();
+      const openToolStep = jest.fn();
+      const step = makeStep([otherResult('r1')]);
+      renderWithProviders(
+        <FlyoutStackContext.Provider value={{ openToolStep }}>
+          <ToolCallStep step={step} />
+        </FlyoutStackContext.Provider>
+      );
+      await user.click(screen.getByRole('button'));
+      expect(openToolStep).toHaveBeenCalledWith(step);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('is always clickable for a running sub-agent call', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
@@ -11,6 +11,7 @@ import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
 import { StepLayout } from '../step_layout';
 import { ToolResponseFlyout } from '../flyouts/tool_response_flyout';
+import { useFlyoutStack } from '../flyouts/flyout_stack_context';
 import { ToolCallStepHeadline } from './tool_call_step_headline';
 
 interface ToolCallStepProps {
@@ -18,19 +19,21 @@ interface ToolCallStepProps {
 }
 
 export const ToolCallStep: React.FC<ToolCallStepProps> = ({ step }) => {
+  const flyoutStack = useFlyoutStack();
   const [isFlyoutOpen, { on: openFlyout, off: closeFlyout }] = useBoolean();
 
   const hasResults = step.results.length > 0;
+  const handleClick = flyoutStack ? () => flyoutStack.openToolStep(step) : openFlyout;
 
   return (
     <div data-test-subj="agentBuilderToolCallStep">
       <StepLayout
         label={<ToolCallStepHeadline step={step} hasResults={hasResults} />}
         isExpandable={false}
-        onClick={openFlyout}
+        onClick={handleClick}
         ebtAction={AGENT_BUILDER_UI_EBT.action.conversation.VIEW_TOOL_RESPONSE}
       />
-      {isFlyoutOpen && <ToolResponseFlyout step={step} onClose={closeFlyout} />}
+      {!flyoutStack && isFlyoutOpen && <ToolResponseFlyout step={step} onClose={closeFlyout} />}
     </div>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
@@ -33,7 +33,7 @@ export const ToolCallStep: React.FC<ToolCallStepProps> = ({ step }) => {
         onClick={handleClick}
         ebtAction={AGENT_BUILDER_UI_EBT.action.conversation.VIEW_TOOL_RESPONSE}
       />
-      {!flyoutStack && isFlyoutOpen && <ToolResponseFlyout step={step} onClose={closeFlyout} />}
+      {isFlyoutOpen && <ToolResponseFlyout step={step} onClose={closeFlyout} />}
     </div>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step_headline.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step_headline.tsx
@@ -86,19 +86,21 @@ export const ToolCallStepHeadline: React.FC<ToolCallStepHeadlineProps> = ({ step
           </span>
         </EuiFlexItem>
       </EuiFlexGroup>
-      {step.progression?.map((p, idx) => (
-        <EuiText key={`progression-${idx}`} size="s">
-          <p>
-            <span
-              css={css`
-                color: ${euiTheme.colors.textDisabled};
-              `}
-            >
-              {p.message}
-            </span>
-          </p>
-        </EuiText>
-      ))}
+      {step.progression
+        ?.filter((p) => !p.metadata?.agent_execution_id)
+        .map((p, idx) => (
+          <EuiText key={`progression-${idx}`} size="s">
+            <p>
+              <span
+                css={css`
+                  color: ${euiTheme.colors.textDisabled};
+                `}
+              >
+                {p.message}
+              </span>
+            </p>
+          </EuiText>
+        ))}
     </>
   );
 };


### PR DESCRIPTION
## Summary

- Opening a sub-agent from the conversation opens a flyout that contains the Execution step
- The Execution step is clickable and drills down to another flyout with the execution details
- The execution details can contain again some clickable tool step. Clicking on it drills recursively down to another flyout

This PR is the last on for the entire feature. The work is being merged into the integration branch.
1. https://github.com/elastic/search-team/issues/15170
2. https://github.com/elastic/search-team/issues/15171
3. This one

https://github.com/user-attachments/assets/d7fc1031-f7d8-47bd-8b14-22ef00029878


## Changed components

<img width="1146" height="682" alt="image" src="https://github.com/user-attachments/assets/2cdab450-38e1-492e-85d0-a24d3fb72654" />

<img width="1151" height="693" alt="image" src="https://github.com/user-attachments/assets/6384d8f5-3aec-4648-aa9b-335223162563" />

<img width="1155" height="690" alt="image" src="https://github.com/user-attachments/assets/416d1d64-929d-4527-ac29-2e3e0410f3f6" />

## Differencies agains the design
- The spacing in the flyout is defined by the EuiFlyout component. I kept defaults instead of creating custom spacing to reflect the design 100%
- Not implemented "Found 100 results"

<img width="834" height="711" alt="image" src="https://github.com/user-attachments/assets/4ee131a9-6abd-4d32-8355-51ccb08be360" />


## How the drilling works

1. The conversation timeline contains ToolCallStep components. Each shows a tool name and status like "ran".
4. Clicking a step opens ToolResponseFlyout (flyout 1). No context is involved yet — ToolCallStep sees no context above it and falls back to its own state.
5. If flyout 1 contains a sub-execution link and I click it, SubAgentExecutionFlyout opens (flyout 2). It always has a Back button.
6. Flyout 2 can contain a tool step — the same ToolCallStep component as in the conversation timeline.
7. Flyout 2 wraps its content in a FlyoutStackContext.Provider. That provider is rendered inside SubAgentExecutionFlyout.
8. When the tool step inside flyout 2 is clicked, ToolCallStep reads the context, sees it's nested, and its handleClick calls the function from the context instead of its own openFlyout.
9. That function is setNestedStep from flyout 2's internal state. Calling it sets the step inside flyout 2.
10. Flyout 2 re-renders, sees nestedStep is set, and renders ToolResponseFlyout (flyout 3) — passing onBack to it.
11. Flyout 3 receives onBack, so it shows a Back button. Clicking it calls setNestedStep(null) inside flyout 2, which removes flyout 3.
12. Flyout 3 can only contain a sub-execution link (no tool steps). Clicking it would open another SubAgentExecutionFlyout, which again provides a new FlyoutStackContext.Provider — making the whole pattern recursive.


## Test plan

- [x] Open a conversation where a `run_subagent` tool was called
- [x] Click the tool step → flyout opens with Parameters / Execution / Result steps
- [x] Execution step shows "Sub-agent execution [id] →" link in muted color with bullet and arrow icon
- [x] Clicking the link opens the 2nd-level flyout stacked on top
- [x] 2nd-level flyout shows Parameters, Execution (with sub-agent's own steps), Result
- [x] Back button closes the 2nd flyout, returns to the 1st
- [x] While sub-agent is still running: Execution step shows spinner instead of link
- [x] "Sub-agent execution [uuid] started" text no longer appears in conversation timeline

Closes elastic/search-team#15172
