### PR TITLE
[Cases] Guard field definition rename against active template references

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.test.ts
@@ -203,6 +203,112 @@ describe('createFieldDefinitionsSubClient', () => {
         'A field definition with name "Other_Field" already exists for this owner.'
       );
     });
+
+    it('throws 409 when renaming a field that a single active template references', async () => {
+      const so = makeFieldDefinitionSO({ id: 'fd-1', name: 'my_field' });
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [so.attributes],
+        total: 1,
+      });
+      clientArgs.services.templatesService.getActiveTemplatesReferencingField.mockResolvedValue([
+        { name: 'Incident Template' },
+      ]);
+
+      await expect(
+        client.updateFieldDefinition('fd-1', { ...input, name: 'renamed_field' })
+      ).rejects.toThrow(
+        'Cannot rename field definition "my_field": it is referenced by 1 active template(s): "Incident Template"'
+      );
+      expect(
+        clientArgs.services.fieldDefinitionsService.updateFieldDefinition
+      ).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 listing all referencing templates when renaming a field referenced by multiple templates', async () => {
+      const so = makeFieldDefinitionSO({ id: 'fd-1', name: 'my_field' });
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [so.attributes],
+        total: 1,
+      });
+      clientArgs.services.templatesService.getActiveTemplatesReferencingField.mockResolvedValue([
+        { name: 'Template A' },
+        { name: 'Template B' },
+      ]);
+
+      await expect(
+        client.updateFieldDefinition('fd-1', { ...input, name: 'renamed_field' })
+      ).rejects.toThrow(
+        'Cannot rename field definition "my_field": it is referenced by 2 active template(s): "Template A", "Template B"'
+      );
+      expect(
+        clientArgs.services.fieldDefinitionsService.updateFieldDefinition
+      ).not.toHaveBeenCalled();
+    });
+
+    it('allows renaming a field when no active templates reference the old name', async () => {
+      const so = makeFieldDefinitionSO({ id: 'fd-1', name: 'my_field' });
+      const renamed = makeFieldDefinitionSO({ id: 'fd-1', name: 'renamed_field' });
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [so.attributes],
+        total: 1,
+      });
+      clientArgs.services.templatesService.getActiveTemplatesReferencingField.mockResolvedValue([]);
+      clientArgs.services.fieldDefinitionsService.updateFieldDefinition.mockResolvedValue(renamed);
+
+      const result = await client.updateFieldDefinition('fd-1', {
+        ...input,
+        name: 'renamed_field',
+      });
+
+      expect(result).toBe(renamed);
+      expect(
+        clientArgs.services.fieldDefinitionsService.updateFieldDefinition
+      ).toHaveBeenCalledWith('fd-1', { ...input, name: 'renamed_field' });
+    });
+
+    it('does not check template references when the name is unchanged', async () => {
+      const so = makeFieldDefinitionSO({ id: 'fd-1', name: 'my_field' });
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [so.attributes],
+        total: 1,
+      });
+      clientArgs.services.fieldDefinitionsService.updateFieldDefinition.mockResolvedValue(so);
+
+      // Update only the definition, keep the name the same
+      await client.updateFieldDefinition('fd-1', {
+        ...input,
+        definition: 'name: my_field\ncontrol: INPUT_TEXT\ntype: text\n',
+      });
+
+      expect(
+        clientArgs.services.templatesService.getActiveTemplatesReferencingField
+      ).not.toHaveBeenCalled();
+    });
+
+    it('passes the old name and owner to the template reference check when renaming', async () => {
+      const so = makeFieldDefinitionSO({ id: 'fd-1', name: 'priority', owner: 'securitySolution' });
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [so.attributes],
+        total: 1,
+      });
+      clientArgs.services.templatesService.getActiveTemplatesReferencingField.mockResolvedValue([]);
+      clientArgs.services.fieldDefinitionsService.updateFieldDefinition.mockResolvedValue(so);
+
+      await client.updateFieldDefinition('fd-1', {
+        ...input,
+        name: 'renamed',
+        owner: 'securitySolution',
+      });
+
+      expect(
+        clientArgs.services.templatesService.getActiveTemplatesReferencingField
+      ).toHaveBeenCalledWith('securitySolution', 'priority');
+    });
   });
 
   describe('deleteFieldDefinition', () => {

--- a/x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.test.ts
@@ -204,4 +204,63 @@ describe('createFieldDefinitionsSubClient', () => {
       );
     });
   });
+
+  describe('deleteFieldDefinition', () => {
+    it('deletes the field definition when no active templates reference it', async () => {
+      const so = makeFieldDefinitionSO();
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.templatesService.getActiveTemplatesReferencingField.mockResolvedValue([]);
+
+      await client.deleteFieldDefinition('fd-1');
+
+      expect(
+        clientArgs.services.fieldDefinitionsService.deleteFieldDefinition
+      ).toHaveBeenCalledWith('fd-1');
+    });
+
+    it('throws 409 when a single template references the field', async () => {
+      // FAILURE SCENARIO: user tries to delete "my_field" while "Incident Template" has $ref: my_field
+      const so = makeFieldDefinitionSO();
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.templatesService.getActiveTemplatesReferencingField.mockResolvedValue([
+        { name: 'Incident Template' },
+      ]);
+
+      await expect(client.deleteFieldDefinition('fd-1')).rejects.toThrow(
+        'Cannot delete field definition "my_field": it is referenced by 1 active template(s): "Incident Template"'
+      );
+      expect(
+        clientArgs.services.fieldDefinitionsService.deleteFieldDefinition
+      ).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 listing all referencing templates when multiple templates reference the field', async () => {
+      // FAILURE SCENARIO: two templates both reference the field — error message lists all names
+      const so = makeFieldDefinitionSO();
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.templatesService.getActiveTemplatesReferencingField.mockResolvedValue([
+        { name: 'Template A' },
+        { name: 'Template B' },
+      ]);
+
+      await expect(client.deleteFieldDefinition('fd-1')).rejects.toThrow(
+        'Cannot delete field definition "my_field": it is referenced by 2 active template(s): "Template A", "Template B"'
+      );
+      expect(
+        clientArgs.services.fieldDefinitionsService.deleteFieldDefinition
+      ).not.toHaveBeenCalled();
+    });
+
+    it('passes the field owner and name to the templates reference check', async () => {
+      const so = makeFieldDefinitionSO({ name: 'priority', owner: 'securitySolution' });
+      clientArgs.services.fieldDefinitionsService.getFieldDefinition.mockResolvedValue(so);
+      clientArgs.services.templatesService.getActiveTemplatesReferencingField.mockResolvedValue([]);
+
+      await client.deleteFieldDefinition('fd-1');
+
+      expect(
+        clientArgs.services.templatesService.getActiveTemplatesReferencingField
+      ).toHaveBeenCalledWith('securitySolution', 'priority');
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.ts
@@ -131,6 +131,20 @@ export const createFieldDefinitionsSubClient = (
         operation: Operations.manageTemplate,
         entities: [{ owner: fieldDef.attributes.owner, id: fieldDef.id }],
       });
+
+      const { templatesService } = services;
+      const referencingTemplates = await templatesService.getActiveTemplatesReferencingField(
+        fieldDef.attributes.owner,
+        fieldDef.attributes.name
+      );
+
+      if (referencingTemplates.length > 0) {
+        const names = referencingTemplates.map(({ name }) => `"${name}"`).join(', ');
+        throw Boom.conflict(
+          `Cannot delete field definition "${fieldDef.attributes.name}": it is referenced by ${referencingTemplates.length} active template(s): ${names}`
+        );
+      }
+
       return fieldDefinitionsService.deleteFieldDefinition(id);
     },
   };

--- a/x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.ts
@@ -122,6 +122,25 @@ export const createFieldDefinitionsSubClient = (
         );
       }
 
+      // Guard rename: if the name is changing, block it while any active template still
+      // references the old name via $ref.  Case-sensitive comparison is intentional —
+      // $ref matching is exact, so even a case-only change would orphan existing references.
+      const isRename = input.name !== fieldDef.attributes.name;
+      if (isRename) {
+        const { templatesService } = services;
+        const referencingTemplates = await templatesService.getActiveTemplatesReferencingField(
+          fieldDef.attributes.owner,
+          fieldDef.attributes.name
+        );
+
+        if (referencingTemplates.length > 0) {
+          const names = referencingTemplates.map(({ name }) => `"${name}"`).join(', ');
+          throw Boom.conflict(
+            `Cannot rename field definition "${fieldDef.attributes.name}": it is referenced by ${referencingTemplates.length} active template(s): ${names}`
+          );
+        }
+      }
+
       return fieldDefinitionsService.updateFieldDefinition(id, input);
     },
 

--- a/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
@@ -235,6 +235,7 @@ export const createTemplatesServiceMock = (): TemplatesServiceMock => {
     getTags: jest.fn(),
     getAuthors: jest.fn(),
     getTemplateVersionsForExtendedFieldSearch: jest.fn().mockResolvedValue([]),
+    getActiveTemplatesReferencingField: jest.fn().mockResolvedValue([]),
   });
 
   // the cast here is required because jest.Mocked tries to include private members and would throw an error

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
@@ -1712,7 +1712,7 @@ describe('TemplatesService', () => {
                   bool: expect.objectContaining({
                     should: expect.arrayContaining([
                       expect.objectContaining({
-                        match: expect.objectContaining({
+                        match_phrase: expect.objectContaining({
                           [`${SO}.owner`]: 'securitySolution',
                         }),
                       }),

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
@@ -1689,18 +1689,12 @@ describe('TemplatesService', () => {
 
     const makeHit = (id: string) => ({ _id: id, _index: '.kibana_cases' });
 
-    const makeSO = (
-      id: string,
-      definition: string,
-      name = 'Template'
-    ): SavedObject<Template> =>
+    const makeSO = (id: string, definition: string, name = 'Template'): SavedObject<Template> =>
       createTemplateSO(id, { templateId: id, name, definition });
 
     it('sends a search call with a match_phrase pre-filter on definition and the owner/isLatest/deletedAt filters', async () => {
       const service = createService();
-      unsecuredSavedObjectsClient.search.mockResolvedValue(
-        createMockSearchResponse([])
-      );
+      unsecuredSavedObjectsClient.search.mockResolvedValue(createMockSearchResponse([]));
 
       await service.getActiveTemplatesReferencingField('securitySolution', 'priority');
 
@@ -1847,9 +1841,7 @@ describe('TemplatesService', () => {
         },
       } as unknown as ReturnType<typeof createMockSearchResponse>);
 
-      savedObjectsSerializer.rawToSavedObject
-        .mockReturnValueOnce(soA)
-        .mockReturnValueOnce(soB);
+      savedObjectsSerializer.rawToSavedObject.mockReturnValueOnce(soA).mockReturnValueOnce(soB);
 
       const result = await service.getActiveTemplatesReferencingField(
         'securitySolution',

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
@@ -1684,6 +1684,182 @@ describe('TemplatesService', () => {
     });
   });
 
+  describe('getActiveTemplatesReferencingField', () => {
+    const SO = CASE_TEMPLATE_SAVED_OBJECT;
+
+    const makeHit = (id: string) => ({ _id: id, _index: '.kibana_cases' });
+
+    const makeSO = (
+      id: string,
+      definition: string,
+      name = 'Template'
+    ): SavedObject<Template> =>
+      createTemplateSO(id, { templateId: id, name, definition });
+
+    it('sends a search call with a match_phrase pre-filter on definition and the owner/isLatest/deletedAt filters', async () => {
+      const service = createService();
+      unsecuredSavedObjectsClient.search.mockResolvedValue(
+        createMockSearchResponse([])
+      );
+
+      await service.getActiveTemplatesReferencingField('securitySolution', 'priority');
+
+      expect(unsecuredSavedObjectsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: SO,
+          namespaces: ['default'],
+          from: 0,
+          size: 10000,
+          query: expect.objectContaining({
+            bool: expect.objectContaining({
+              filter: expect.arrayContaining([
+                // owner filter
+                expect.objectContaining({
+                  bool: expect.objectContaining({
+                    should: expect.arrayContaining([
+                      expect.objectContaining({
+                        match: expect.objectContaining({
+                          [`${SO}.owner`]: 'securitySolution',
+                        }),
+                      }),
+                    ]),
+                  }),
+                }),
+              ]),
+              must: [
+                {
+                  match_phrase: {
+                    [`${SO}.definition`]: '$ref: priority',
+                  },
+                },
+              ],
+            }),
+          }),
+        })
+      );
+
+      // Verify owner, isLatest, and NOT deletedAt are all in the filter
+      const searchCall = unsecuredSavedObjectsClient.search.mock.calls[0][0];
+      const filterStr = JSON.stringify(searchCall?.query?.bool?.filter);
+      expect(filterStr).toContain('securitySolution');
+      expect(filterStr).toContain('isLatest');
+      expect(filterStr).toContain('deletedAt');
+    });
+
+    it('returns templates where YAML parse confirms $ref === fieldName', async () => {
+      // FAILURE SCENARIO: two ES hits returned by match_phrase; one is a genuine
+      // $ref: priority, the other is a false-positive (text that happens to
+      // tokenize as ref+priority but has no actual $ref key). Only the real one
+      // should appear in the result.
+      const service = createService();
+
+      const realRefDefinition = yamlStringify({
+        name: 'Incident Template',
+        fields: [{ $ref: 'priority' }],
+      });
+      const falsePositiveDefinition =
+        // "ref priority" appears as description text — same tokens, no YAML $ref key
+        'name: Other Template\ndescription: "This is a ref priority note"\nfields: []\n';
+
+      const soReal = makeSO('so-real', realRefDefinition, 'Incident Template');
+      const soFalse = makeSO('so-false', falsePositiveDefinition, 'Other Template');
+
+      unsecuredSavedObjectsClient.search.mockResolvedValue({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: {
+          total: { value: 2, relation: 'eq' },
+          max_score: null,
+          hits: [makeHit('so-real'), makeHit('so-false')],
+        },
+      } as unknown as ReturnType<typeof createMockSearchResponse>);
+
+      savedObjectsSerializer.rawToSavedObject
+        .mockReturnValueOnce(soReal)
+        .mockReturnValueOnce(soFalse);
+
+      const result = await service.getActiveTemplatesReferencingField(
+        'securitySolution',
+        'priority'
+      );
+
+      expect(result).toEqual([{ name: 'Incident Template' }]);
+    });
+
+    it('returns an empty array when no hits are returned from ES', async () => {
+      const service = createService();
+      unsecuredSavedObjectsClient.search.mockResolvedValue(createMockSearchResponse([]));
+
+      const result = await service.getActiveTemplatesReferencingField(
+        'securitySolution',
+        'priority'
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('skips a template with unparseable YAML rather than blocking the delete', async () => {
+      // FAILURE SCENARIO: a corrupt definition is in ES — the guard must not
+      // throw; it should skip the corrupt template and return [] (unblocked).
+      const service = createService();
+
+      const soCorrupt = makeSO('so-corrupt', ': {not valid yaml', 'Corrupt Template');
+
+      unsecuredSavedObjectsClient.search.mockResolvedValue({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: {
+          total: { value: 1, relation: 'eq' },
+          max_score: null,
+          hits: [makeHit('so-corrupt')],
+        },
+      } as unknown as ReturnType<typeof createMockSearchResponse>);
+
+      savedObjectsSerializer.rawToSavedObject.mockReturnValueOnce(soCorrupt);
+
+      const result = await service.getActiveTemplatesReferencingField(
+        'securitySolution',
+        'priority'
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('collects all referencing templates when multiple real references exist', async () => {
+      const service = createService();
+
+      const makeRefDef = (refName: string, templateName: string) =>
+        yamlStringify({ name: templateName, fields: [{ $ref: refName }] });
+
+      const soA = makeSO('so-a', makeRefDef('priority', 'Template A'), 'Template A');
+      const soB = makeSO('so-b', makeRefDef('priority', 'Template B'), 'Template B');
+
+      unsecuredSavedObjectsClient.search.mockResolvedValue({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: {
+          total: { value: 2, relation: 'eq' },
+          max_score: null,
+          hits: [makeHit('so-a'), makeHit('so-b')],
+        },
+      } as unknown as ReturnType<typeof createMockSearchResponse>);
+
+      savedObjectsSerializer.rawToSavedObject
+        .mockReturnValueOnce(soA)
+        .mockReturnValueOnce(soB);
+
+      const result = await service.getActiveTemplatesReferencingField(
+        'securitySolution',
+        'priority'
+      );
+
+      expect(result).toEqual([{ name: 'Template A' }, { name: 'Template B' }]);
+    });
+  });
+
   describe('cases-analytics v2 data view refresh hook', () => {
     // The templates service can't observe template SOs directly — it owns
     // them. So when fields land or change, it has to tell the v2 subsystem

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
@@ -607,24 +607,52 @@ export class TemplatesService {
     owner: string,
     fieldName: string
   ): Promise<Array<{ name: string }>> {
-    const escapedOwner = escapeKuery(owner);
-    const soType = CASE_TEMPLATE_SAVED_OBJECT;
+    interface SearchResult {
+      hits: {
+        hits: SavedObjectsRawDoc[];
+        total: { value: number };
+      };
+    }
 
-    const result = await this.dependencies.unsecuredSavedObjectsClient.find<Template>({
-      type: soType,
+    const escapedOwner = escapeKuery(owner);
+    const SO = CASE_TEMPLATE_SAVED_OBJECT;
+
+    // Push the $ref lookup down to ES: only fetch candidate templates whose
+    // `definition` text contains the token sequence `ref <fieldName>` (the
+    // standard analyzer strips `$` and `:`, leaving adjacent tokens).
+    // match_phrase requires the tokens to be adjacent and in order, so this
+    // is a tight pre-filter that virtually eliminates false positives.
+    // The exact YAML parse below is the correctness gate — it handles any
+    // residual analyzer edge-cases and alias-overridden ref fields.
+    const filters = [
+      toElasticsearchQuery(fromKueryExpression(`${SO}.owner: "${escapedOwner}"`)),
+      toElasticsearchQuery(fromKueryExpression(`${SO}.isLatest: true`)),
+      toElasticsearchQuery(fromKueryExpression(`NOT ${SO}.deletedAt: *`)),
+    ];
+
+    const findResult = (await this.dependencies.unsecuredSavedObjectsClient.search({
+      type: SO,
       namespaces: [this.dependencies.namespace],
-      page: 1,
-      perPage: 10000,
-      fields: ['name', 'definition'],
-      filter: fromKueryExpression(
-        `${soType}.attributes.owner: "${escapedOwner}" AND ` +
-          `${soType}.attributes.isLatest: true AND NOT ${soType}.attributes.deletedAt: *`
-      ),
-    });
+      from: 0,
+      size: 10000,
+      query: {
+        bool: {
+          filter: filters,
+          must: [
+            {
+              match_phrase: {
+                [`${SO}.definition`]: `$ref: ${fieldName}`,
+              },
+            },
+          ],
+        },
+      },
+    })) as SearchResult;
 
     const referencing: Array<{ name: string }> = [];
 
-    for (const so of result.saved_objects) {
+    for (const hit of findResult.hits.hits) {
+      const so = this.dependencies.savedObjectsSerializer.rawToSavedObject<Template>(hit);
       try {
         const parsed = parseYaml(so.attributes.definition ?? '');
         const fields: unknown[] = Array.isArray(parsed?.fields) ? parsed.fields : [];

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
@@ -595,6 +595,57 @@ export class TemplatesService {
    * writes are used on create/update), so the practical collision window is small. Enforcing true
    * atomicity would require a dedicated uniqueness SO or an alias/lock, which is out of scope here.
    */
+
+  /**
+   * Returns the names of active (non-deleted, latest-version) templates for the given owner
+   * that contain a `$ref: <fieldName>` reference in their YAML definition.
+   *
+   * Used by the field-definitions client to block deleting a library field that is still
+   * referenced by at least one template.
+   */
+  async getActiveTemplatesReferencingField(
+    owner: string,
+    fieldName: string
+  ): Promise<Array<{ name: string }>> {
+    const escapedOwner = escapeKuery(owner);
+    const soType = CASE_TEMPLATE_SAVED_OBJECT;
+
+    const result = await this.dependencies.unsecuredSavedObjectsClient.find<Template>({
+      type: soType,
+      namespaces: [this.dependencies.namespace],
+      page: 1,
+      perPage: 10000,
+      fields: ['name', 'definition'],
+      filter: fromKueryExpression(
+        `${soType}.attributes.owner: "${escapedOwner}" AND ` +
+          `${soType}.attributes.isLatest: true AND NOT ${soType}.attributes.deletedAt: *`
+      ),
+    });
+
+    const referencing: Array<{ name: string }> = [];
+
+    for (const so of result.saved_objects) {
+      try {
+        const parsed = parseYaml(so.attributes.definition ?? '');
+        const fields: unknown[] = Array.isArray(parsed?.fields) ? parsed.fields : [];
+        const hasRef = fields.some(
+          (f) =>
+            typeof f === 'object' &&
+            f !== null &&
+            '$ref' in f &&
+            (f as Record<string, unknown>).$ref === fieldName
+        );
+        if (hasRef) {
+          referencing.push({ name: so.attributes.name });
+        }
+      } catch {
+        // Unparseable YAML — skip; do not block the delete for a corrupt template
+      }
+    }
+
+    return referencing;
+  }
+
   private async assertTemplateNameIsUnique({
     name,
     owner,

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
@@ -372,6 +372,34 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(body.message).to.contain('"Incident Template"');
       });
 
+      it('returns 409 when a template references the field via $ref with a local name alias', async () => {
+        // FAILURE SCENARIO: The template uses { $ref: 'priority', name: 'Custom Label' }.
+        // The `fieldDefinitions` keyword cache stores "Custom Label" as the resolved name.
+        // A query against the cache would miss this ref. The hybrid approach (match_phrase
+        // pre-filter + YAML parse) finds the $ref: priority value correctly regardless.
+        await supertest
+          .post(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            name: 'Aliased Ref Template',
+            owner: 'securitySolutionFixture',
+            definition: stringify({
+              name: 'Aliased Ref Template',
+              fields: [{ $ref: 'priority', name: 'Custom Priority Label' }],
+            }),
+            isEnabled: true,
+          })
+          .expect(200);
+
+        const { body } = await supertestWithoutAuth
+          .delete(`${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}/${fieldDefinitionId}`)
+          .auth(secOnlyManageTemplates.username, secOnlyManageTemplates.password)
+          .set('kbn-xsrf', 'true')
+          .expect(409);
+
+        expect(body.message).to.contain('"Aliased Ref Template"');
+      });
+
       it('succeeds when the only referencing template has been deleted', async () => {
         // Create a template that references the field, then soft-delete it
         const { body: templateBody } = await supertest

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
@@ -301,6 +301,91 @@ export default ({ getService }: FtrProviderContext): void => {
           .send(buildCreateBody())
           .expect(404);
       });
+
+      it('returns 409 when renaming a field that an active template references via $ref', async () => {
+        // FAILURE SCENARIO: renaming "priority" to "urgency" while "Incident Template" has $ref: priority
+        await supertest
+          .post(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            name: 'Incident Template',
+            owner: 'securitySolutionFixture',
+            definition: stringify({
+              name: 'Incident Template',
+              fields: [{ $ref: 'priority' }],
+            }),
+            isEnabled: true,
+          })
+          .expect(200);
+
+        const { body } = await supertestWithoutAuth
+          .put(`${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}/${fieldDefinitionId}`)
+          .auth(secOnlyManageTemplates.username, secOnlyManageTemplates.password)
+          .set('kbn-xsrf', 'true')
+          .send(buildCreateBody({ name: 'urgency' }))
+          .expect(409);
+
+        expect(body.message).to.contain('"Incident Template"');
+        expect(body.message).to.contain('priority');
+      });
+
+      it('allows updating a field definition without changing its name while a template references it', async () => {
+        // Non-rename updates (definition text, description, isGlobal) must not be blocked
+        await supertest
+          .post(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            name: 'Blocking Template',
+            owner: 'securitySolutionFixture',
+            definition: stringify({
+              name: 'Blocking Template',
+              fields: [{ $ref: 'priority' }],
+            }),
+            isEnabled: true,
+          })
+          .expect(200);
+
+        // Same name, different definition text → must succeed
+        await supertestWithoutAuth
+          .put(`${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}/${fieldDefinitionId}`)
+          .auth(secOnlyManageTemplates.username, secOnlyManageTemplates.password)
+          .set('kbn-xsrf', 'true')
+          .send(
+            buildCreateBody({
+              definition: 'name: priority\ncontrol: SELECT_BASIC\ntype: keyword\nlabel: Priority\n',
+            })
+          )
+          .expect(200);
+      });
+
+      it('allows renaming a field once the only referencing template has been deleted', async () => {
+        const { body: templateBody } = await supertest
+          .post(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            name: 'To Be Deleted',
+            owner: 'securitySolutionFixture',
+            definition: stringify({
+              name: 'To Be Deleted',
+              fields: [{ $ref: 'priority' }],
+            }),
+            isEnabled: true,
+          })
+          .expect(200);
+
+        await supertest
+          .delete(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}/${templateBody.templateId}`)
+          .set('kbn-xsrf', 'true')
+          .expect(204);
+
+        // Template is soft-deleted — rename is now unblocked
+        await supertestWithoutAuth
+          .put(`${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}/${fieldDefinitionId}`)
+          .auth(secOnlyManageTemplates.username, secOnlyManageTemplates.password)
+          .set('kbn-xsrf', 'true')
+          .send(buildCreateBody({ name: 'urgency' }))
+          .expect(200);
+      });
     });
 
     describe('DELETE /internal/cases/field_definitions/{field_definition_id}', () => {
@@ -417,9 +502,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .expect(200);
 
         await supertest
-          .delete(
-            `${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}/${templateBody.templateId}`
-          )
+          .delete(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}/${templateBody.templateId}`)
           .set('kbn-xsrf', 'true')
           .expect(204);
 

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from '@kbn/expect';
+import { stringify } from 'yaml';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { deleteAllCaseItems, getSpaceUrlPrefix } from '../../../../common/lib/api';
 import {
@@ -17,6 +18,7 @@ import {
 } from '../../../../common/lib/authentication/users';
 
 const FIELD_DEFINITIONS_URL = '/internal/cases/field_definitions';
+const TEMPLATES_URL = '/internal/cases/templates';
 
 const buildCreateBody = (overrides: Record<string, unknown> = {}) => ({
   name: 'priority',
@@ -343,6 +345,62 @@ export default ({ getService }: FtrProviderContext): void => {
           .auth(secOnlyManageTemplates.username, secOnlyManageTemplates.password)
           .set('kbn-xsrf', 'true')
           .expect(404);
+      });
+
+      it('returns 409 when an active template references the field via $ref', async () => {
+        // FAILURE SCENARIO: deleting "priority" while "Incident Template" has $ref: priority in its definition
+        await supertest
+          .post(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            name: 'Incident Template',
+            owner: 'securitySolutionFixture',
+            definition: stringify({
+              name: 'Incident Template',
+              fields: [{ $ref: 'priority' }],
+            }),
+            isEnabled: true,
+          })
+          .expect(200);
+
+        const { body } = await supertestWithoutAuth
+          .delete(`${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}/${fieldDefinitionId}`)
+          .auth(secOnlyManageTemplates.username, secOnlyManageTemplates.password)
+          .set('kbn-xsrf', 'true')
+          .expect(409);
+
+        expect(body.message).to.contain('"Incident Template"');
+      });
+
+      it('succeeds when the only referencing template has been deleted', async () => {
+        // Create a template that references the field, then soft-delete it
+        const { body: templateBody } = await supertest
+          .post(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            name: 'Deleted Template',
+            owner: 'securitySolutionFixture',
+            definition: stringify({
+              name: 'Deleted Template',
+              fields: [{ $ref: 'priority' }],
+            }),
+            isEnabled: true,
+          })
+          .expect(200);
+
+        await supertest
+          .delete(
+            `${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}/${templateBody.templateId}`
+          )
+          .set('kbn-xsrf', 'true')
+          .expect(204);
+
+        // Field definition can now be deleted because the only referencing template is gone
+        await supertestWithoutAuth
+          .delete(`${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}/${fieldDefinitionId}`)
+          .auth(secOnlyManageTemplates.username, secOnlyManageTemplates.password)
+          .set('kbn-xsrf', 'true')
+          .expect(204);
       });
     });
   });

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
@@ -359,6 +359,19 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('allows renaming a field once the only referencing template has been deleted', async () => {
+        // Use a field name distinct from 'priority' so that stale templates created by
+        // earlier tests in this describe block (which reference 'priority') cannot
+        // interfere with the getActiveTemplatesReferencingField search here.
+        const { body: tempField } = await supertest
+          .post(`${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            name: 'rename_after_delete_field',
+            owner: 'securitySolutionFixture',
+            definition: 'name: rename_after_delete_field\ncontrol: SELECT_BASIC\ntype: keyword\n',
+          })
+          .expect(200);
+
         const { body: templateBody } = await supertest
           .post(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}`)
           .set('kbn-xsrf', 'true')
@@ -367,7 +380,7 @@ export default ({ getService }: FtrProviderContext): void => {
             owner: 'securitySolutionFixture',
             definition: stringify({
               name: 'To Be Deleted',
-              fields: [{ $ref: 'priority' }],
+              fields: [{ $ref: 'rename_after_delete_field' }],
             }),
             isEnabled: true,
           })
@@ -380,10 +393,16 @@ export default ({ getService }: FtrProviderContext): void => {
 
         // Template is soft-deleted — rename is now unblocked
         await supertestWithoutAuth
-          .put(`${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}/${fieldDefinitionId}`)
+          .put(
+            `${getSpaceUrlPrefix('space1')}${FIELD_DEFINITIONS_URL}/${tempField.fieldDefinitionId}`
+          )
           .auth(secOnlyManageTemplates.username, secOnlyManageTemplates.password)
           .set('kbn-xsrf', 'true')
-          .send(buildCreateBody({ name: 'urgency' }))
+          .send({
+            name: 'rename_after_delete_renamed',
+            owner: 'securitySolutionFixture',
+            definition: 'name: rename_after_delete_renamed\ncontrol: SELECT_BASIC\ntype: keyword\n',
+          })
           .expect(200);
       });
     });


### PR DESCRIPTION
## Summary

Merge this first: https://github.com/elastic/kibana/pull/280493

- Extends the delete guard (already in this branch) to cover **renames**: `updateFieldDefinition` now rejects a `name` change with **HTTP 409 Conflict** when at least one active (latest-version, non-soft-deleted) template for the same owner references the old name via a `$ref` entry in its YAML definition.
- Updates that **do not change the name** (definition text, description, `isGlobal`) are unaffected and skip the extra ES round-trip entirely.
- The rename comparison is **case-sensitive** — `$ref` matching is exact, so a case-only rename would silently orphan template references.
- Reuses the existing `TemplatesService.getActiveTemplatesReferencingField` with no new service method.

## Changes

| File | What changed |
|---|---|
| `server/client/field_definitions/client.ts` | Rename guard in `updateFieldDefinition` — calls `getActiveTemplatesReferencingField` on the **old** name only when `input.name !== fieldDef.attributes.name` |
| `server/client/field_definitions/client.test.ts` | 5 new unit tests: blocked (1 template), blocked (N templates), allowed (no refs), no-rename skips check, correct args passed |
| `security_and_spaces/tests/trial/internal/field_definitions.ts` | 3 new integration tests: rename blocked, non-rename allowed while referenced, rename allowed after template soft-delete |

## Test plan

- [x] Unit tests: `node scripts/jest x-pack/platform/plugins/shared/cases/server/client/field_definitions/client.test.ts` — 20/20 pass
- [x] Type check: `node scripts/type_check --project x-pack/platform/plugins/shared/cases/tsconfig.json` — clean
- [x] Lint: `node scripts/eslint --fix <changed files>` — no errors
- [ ] Integration tests: trial `field_definitions` FTR suite (run via CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)