### PR TITLE
Fix run_check Jest test: mock readdirSync

### DIFF
--- a/src/dev/run_check.test.ts
+++ b/src/dev/run_check.test.ts
@@ -67,6 +67,7 @@ jest.mock('@kbn/test', () => ({
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
   existsSync: jest.fn(),
+  readdirSync: jest.fn(),
 }));
 
 const mockExecaFn = jest.fn();


### PR DESCRIPTION
## Summary
- Fixes failing Jest test `run_check skips fast path for Scout test files` by mocking `fs.readdirSync` in `src/dev/run_check.test.ts`.
- Closes #280495

## Test plan
- [ ] `node scripts/jest src/dev/run_check.test.ts`


Made with [Cursor](https://cursor.com)