### PR TITLE
Skip flaky Endpoint integrations FTR suite

### DIFF
--- a/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/index.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/index.ts
@@ -12,7 +12,8 @@ import type { FtrProviderContext } from '../../configs/ftr_provider_context';
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService, getPageObjects } = providerContext;
 
-  describe('integrations', function () {
+  // Skipped due to https://github.com/elastic/kibana/issues/252009
+  describe.skip('integrations', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');


### PR DESCRIPTION
## Summary

Skips the Endpoint integrations FTR suite because its shared setup hook is repeatedly failing while installing the Endpoint Fleet package.

Addresses #252009

## Verification

- node scripts/eslint x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/index.ts