### PR TITLE
Add per-user isolation to pooled connector clients

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -50,4 +50,8 @@ export type {
   ClientRegistry,
   ClientTypeId,
   ClientTypeSpecs,
+  FetchLike,
+  ConfiguredFetchResource,
+  ConfiguredFetchOptions,
+  ConfiguredFetchFactory,
 } from './src/lib/clients';

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/configured_fetch_types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/configured_fetch_types.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Generic "configured fetch" primitive shared by HTTP-based client types.
+ *
+ * A `ConfiguredFetchFactory` produces a `fetch` that already applies the Actions outbound-HTTP
+ * policy (SSL/TLS, proxy, User-Agent, timeout, body-size limits). It is the `fetch` sibling of
+ * the axios instance vended by `get_axios_instance`. Client types compose it; the generic
+ * `BuildContext` intentionally does not carry it, so non-HTTP clients stay unaffected.
+ */
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface ConfiguredFetchResource {
+  readonly fetch: FetchLike;
+  close(): Promise<void>;
+}
+
+export interface ConfiguredFetchOptions {
+  readonly targetUrl: string;
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
+export type ConfiguredFetchFactory = (options: ConfiguredFetchOptions) => ConfiguredFetchResource;

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/index.ts
@@ -16,6 +16,13 @@ export type {
   CredentialAccessor,
 } from './client_type_spec';
 
+export type {
+  FetchLike,
+  ConfiguredFetchResource,
+  ConfiguredFetchOptions,
+  ConfiguredFetchFactory,
+} from './configured_fetch_types';
+
 // No client types are registered yet. `ClientTypeId` resolves to `never`
 // until a client type is added to `ClientRegistry`.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.mock.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.mock.ts
@@ -32,6 +32,7 @@ const createActionsClientMock = () => {
     getGlobalExecutionKpiWithAuth: jest.fn(),
     getGlobalExecutionLogWithAuth: jest.fn(),
     getAxiosInstance: jest.fn(),
+    evictClientPool: jest.fn(),
   };
   return mocked;
 };

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.test.ts
@@ -1978,8 +1978,16 @@ describe('delete()', () => {
       );
     });
 
-    test('calls evictClientPool with the connector id when provided', async () => {
-      const evictClientPool = jest.fn();
+    test('evicts clients before deleting connector tokens', async () => {
+      const callOrder: string[] = [];
+      const evictClientPool = jest.fn().mockImplementation(async () => {
+        callOrder.push('evictClientPoolStarted');
+        await Promise.resolve();
+        callOrder.push('evictClientPoolFinished');
+      });
+      connectorTokenClient.deleteConnectorTokens.mockImplementationOnce(async () => {
+        callOrder.push('deleteConnectorTokens');
+      });
       const client = new ActionsClient({
         logger,
         actionTypeRegistry,
@@ -2005,6 +2013,11 @@ describe('delete()', () => {
       await client.delete({ id: '1' });
 
       expect(evictClientPool).toHaveBeenCalledWith('1');
+      expect(callOrder).toEqual([
+        'evictClientPoolStarted',
+        'evictClientPoolFinished',
+        'deleteConnectorTokens',
+      ]);
     });
   });
 

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.ts
@@ -125,7 +125,7 @@ export interface ConstructorOptions {
   isESOCanEncrypt: boolean;
   connectorLifecycleListeners?: ConnectorLifecycleListener[];
   getCurrentUserProfileId?: (request: KibanaRequest) => Promise<string | undefined>;
-  evictClientPool?: (connectorId: string) => void;
+  evictClientPool?: (connectorId: string) => Promise<void>;
 }
 
 export interface ActionsClientContext {
@@ -153,7 +153,7 @@ export interface ActionsClientContext {
   isESOCanEncrypt: boolean;
   connectorLifecycleListeners?: ConnectorLifecycleListener[];
   getCurrentUserProfileId?: (request: KibanaRequest) => Promise<string | undefined>;
-  evictClientPool?: (connectorId: string) => void;
+  evictClientPool?: (connectorId: string) => Promise<void>;
 }
 
 const noop = async (_request: KibanaRequest): Promise<string | undefined> => undefined;
@@ -588,7 +588,12 @@ export class ActionsClient {
       );
     }
 
-    // Must run before the delete below — needs the connector's secrets to revoke its OAuth grant.
+    // Must run before deleting credentials or the saved object because client termination may
+    // need the connector's current credentials.
+    await this.context.evictClientPool?.(id);
+
+    // Must run before the saved-object delete below — needs the connector's secrets to revoke its
+    // OAuth grant.
     await this.deleteConnectorAuthTokens(id, authMode);
 
     const result = await this.context.unsecuredSavedObjectsClient.delete('action', id);
@@ -628,8 +633,6 @@ export class ActionsClient {
       },
       this.context.logger
     );
-
-    this.context.evictClientPool?.(id);
 
     return result;
   }
@@ -812,5 +815,9 @@ export class ActionsClient {
       );
       throw err;
     }
+  }
+
+  public async evictClientPool(connectorId: string): Promise<void> {
+    await this.context.evictClientPool?.(connectorId);
   }
 }

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.ts
@@ -209,7 +209,7 @@ export async function update({ context, id, action }: ConnectorUpdateParams): Pr
     throw result;
   }
 
-  context.evictClientPool?.(id);
+  await context.evictClientPool?.(id);
 
   try {
     await context.connectorTokenClient.deleteConnectorTokens({

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
@@ -33,6 +33,7 @@ import { PassThrough } from 'stream';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { createTaskRunError, getErrorSource } from '@kbn/task-manager-plugin/server/task_running';
 import { ConnectorAuthorizationError } from '@kbn/connector-specs';
+import { ACTION_TYPE_SOURCES } from '@kbn/actions-types';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import type { ConnectorRateLimiter } from './connector_rate_limiter';
 import { createMockInMemoryConnector } from '../application/connector/mocks';
@@ -309,6 +310,26 @@ beforeEach(() => {
 });
 
 describe('Action Executor', () => {
+  test('passes the space and saved-object version only to spec connector executors', async () => {
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValueOnce({
+      ...connectorSavedObject,
+      version: 'WzEsMV0=',
+    });
+    connectorTypeRegistry.get.mockReturnValueOnce({
+      ...connectorType,
+      source: ACTION_TYPE_SOURCES.spec,
+    });
+
+    await actionExecutor.execute(executeParams);
+
+    expect(connectorType.executor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectorVersion: 'WzEsMV0=',
+        spaceId: 'some-namespace',
+      })
+    );
+  });
+
   for (const executeUnsecure of [false, true]) {
     const label = executeUnsecure ? 'executes unsecured' : 'executes';
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
@@ -22,6 +22,8 @@ import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import { getErrorSource as getTaskManagerErrorSource } from '@kbn/task-manager-plugin/server/task_running';
 import { isConnectorAuthorizationError } from '@kbn/connector-specs';
+import { ACTION_TYPE_SOURCES } from '@kbn/actions-types';
+import { IN_MEMORY_CONNECTOR_REVISION } from './single_file_connectors/build_client_lease_key';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import { ConnectorUsageCollector } from '../usage/connector_usage_collector';
 import {
@@ -342,6 +344,7 @@ export class ActionExecutor {
         secrets: inMemoryAction.secrets,
         actionId,
         isInMemory: true,
+        connectorVersion: IN_MEMORY_CONNECTOR_REVISION,
         rawAction: { ...inMemoryAction, isMissingSecrets: false },
       };
     }
@@ -373,6 +376,7 @@ export class ActionExecutor {
         config,
         secrets,
         actionId,
+        connectorVersion: rawAction.version,
         rawAction: rawAction.attributes,
       };
     } catch (e) {
@@ -423,7 +427,8 @@ export class ActionExecutor {
 
         const actionInfo = await this.getActionInfoInternal(actionId, namespace.namespace);
 
-        const { actionTypeId, name, config, secrets, rawAction } = actionInfo;
+        const { actionTypeId, name, config, secrets, rawAction, connectorVersion, isInMemory } =
+          actionInfo;
         const authMode = rawAction.authMode;
         const profileUid = providedProfileUid || currentUser?.profile_uid;
         const loggerId = actionTypeId.startsWith('.') ? actionTypeId.substring(1) : actionTypeId;
@@ -582,6 +587,12 @@ export class ActionExecutor {
             signal,
             authMode,
             profileUid,
+            ...(actionType.source === ACTION_TYPE_SOURCES.spec
+              ? {
+                  connectorVersion: isInMemory ? IN_MEMORY_CONNECTOR_REVISION : connectorVersion,
+                  spaceId: spaceId ?? 'default',
+                }
+              : {}),
           });
 
           if (rawResult && rawResult.status === 'error') {
@@ -741,6 +752,7 @@ export interface ActionInfo {
   secrets: ActionTypeSecrets;
   actionId: string;
   isInMemory?: boolean;
+  connectorVersion?: string;
   rawAction: RawAction;
 }
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/configured_fetch.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/configured_fetch.test.ts
@@ -1,0 +1,582 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Agent, ProxyAgent } from 'undici';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { actionsConfigMock } from '../actions_config.mock';
+import { buildConfiguredFetch } from './configured_fetch';
+
+jest.mock('undici', () => {
+  const MockAgent = jest.fn().mockImplementation(() => ({
+    close: jest.fn().mockResolvedValue(undefined),
+  }));
+  const MockProxyAgent = jest.fn().mockImplementation(() => ({
+    close: jest.fn().mockResolvedValue(undefined),
+  }));
+  return {
+    Agent: MockAgent,
+    ProxyAgent: MockProxyAgent,
+  };
+});
+
+describe('buildConfiguredFetch', () => {
+  const logger = loggingSystemMock.createLogger();
+  const targetUrl = 'https://mcp-server.example.com/v1/mcp';
+  const allowedHosts = ['mcp-server.example.com', 'allowed.example.com'];
+
+  let configurationUtilities: ReturnType<typeof actionsConfigMock.create>;
+  let globalFetchSpy: jest.SpyInstance;
+
+  const mockRedirectResponse = (status: number, location: string | null): Response => {
+    const headers = new Headers();
+    if (location !== null) {
+      headers.set('location', location);
+    }
+    return new Response(null, { status, headers });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    configurationUtilities = actionsConfigMock.create();
+
+    configurationUtilities.getSSLSettings.mockReturnValue({});
+    configurationUtilities.getProxySettings.mockReturnValue(undefined);
+    configurationUtilities.getCustomHostSettings.mockReturnValue(undefined);
+    configurationUtilities.getResponseSettings.mockReturnValue({
+      maxContentLength: 1_000_000,
+      timeout: 60_000,
+    });
+
+    configurationUtilities.ensureUriAllowed.mockImplementation((uri: string) => {
+      const { hostname } = new URL(uri);
+      if (!allowedHosts.includes(hostname)) {
+        throw new Error(
+          `target url "${uri}" is not added to the Kibana config xpack.actions.allowedHosts`
+        );
+      }
+    });
+
+    globalFetchSpy = jest.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    globalFetchSpy.mockRestore();
+  });
+
+  describe('initial URL validation', () => {
+    it('throws immediately if the target URL is not allowed', () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      expect(() => factory({ targetUrl: 'https://evil.internal.example.com/steal' })).toThrow(
+        'target url "https://evil.internal.example.com/steal" is not added to the Kibana config xpack.actions.allowedHosts'
+      );
+      expect(globalFetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not throw for an allowed target URL', () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      expect(() => factory({ targetUrl })).not.toThrow();
+    });
+
+    it('validates every directly requested URL, not only the resource target', async () => {
+      const resource = buildConfiguredFetch(configurationUtilities, logger)({ targetUrl });
+
+      await expect(resource.fetch('https://evil.internal.example.com/steal')).rejects.toThrow(
+        'target url "https://evil.internal.example.com/steal" is not added to the Kibana config xpack.actions.allowedHosts'
+      );
+      expect(globalFetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('redirect URL validation', () => {
+    it('validates each redirect URL against the allowlist', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      const redirectUrl = 'https://allowed.example.com/v1/mcp';
+      const finalResponse = new Response('final', { status: 200 });
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, redirectUrl))
+        .mockResolvedValueOnce(finalResponse);
+
+      await resource.fetch(targetUrl, { method: 'POST' });
+
+      expect(configurationUtilities.ensureUriAllowed).toHaveBeenCalledWith(redirectUrl);
+    });
+
+    it('throws when a redirect URL is not on the allowlist', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy.mockResolvedValueOnce(
+        mockRedirectResponse(302, 'https://evil.internal.example.com/steal')
+      );
+
+      await expect(resource.fetch(targetUrl, { method: 'POST' })).rejects.toThrow(
+        'target url "https://evil.internal.example.com/steal" is not added to the Kibana config xpack.actions.allowedHosts'
+      );
+    });
+  });
+
+  describe('dispatcher caching', () => {
+    it('creates one dispatcher per resource and reuses it', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      const finalResponse = new Response('ok', { status: 200 });
+      globalFetchSpy.mockResolvedValue(finalResponse);
+
+      await resource.fetch(targetUrl);
+      await resource.fetch(targetUrl);
+
+      // Only one Agent should have been created (same policy key)
+      expect(Agent).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates separate dispatchers for different destination policies', async () => {
+      // Different proxy policies for different hosts
+      configurationUtilities.getProxySettings.mockReturnValue({
+        proxyUrl: 'https://proxy.example.com:8080',
+        proxyBypassHosts: new Set(['mcp-server.example.com']),
+        proxyOnlyHosts: undefined,
+        proxyHeaders: {},
+        proxySSLSettings: { verificationMode: 'full' as const },
+      });
+
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      const redirectUrl = 'https://allowed.example.com/v1';
+      const finalResponse = new Response('ok', { status: 200 });
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, redirectUrl))
+        .mockResolvedValueOnce(finalResponse);
+
+      await resource.fetch(targetUrl);
+
+      // The original host bypasses proxy (Agent); the redirect host uses ProxyAgent
+      expect(Agent).toHaveBeenCalledTimes(1);
+      expect(ProxyAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses a direct connection when the host is not in proxyOnlyHosts', async () => {
+      configurationUtilities.getProxySettings.mockReturnValue({
+        proxyUrl: 'https://proxy.example.com:8080',
+        proxyBypassHosts: undefined,
+        proxyOnlyHosts: new Set(['other.example.com']),
+        proxyHeaders: {},
+        proxySSLSettings: { verificationMode: 'full' },
+      });
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+      const resource = buildConfiguredFetch(configurationUtilities, logger)({ targetUrl });
+      await resource.fetch(targetUrl);
+
+      expect(Agent).toHaveBeenCalledTimes(1);
+      expect(ProxyAgent).not.toHaveBeenCalled();
+    });
+
+    it('applies global certificates and TLS settings to direct connections', async () => {
+      const sslSettings = {
+        verificationMode: 'certificate' as const,
+        cert: Buffer.from('client certificate'),
+        key: Buffer.from('client key'),
+        pfx: Buffer.from('client pfx'),
+        passphrase: 'secret',
+        ca: Buffer.from('certificate authority'),
+        allowPartialTrustChain: true,
+      };
+      configurationUtilities.getSSLSettings.mockReturnValue(sslSettings);
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+      const resource = buildConfiguredFetch(configurationUtilities, logger)({ targetUrl });
+      await resource.fetch(targetUrl);
+
+      expect(Agent).toHaveBeenCalledWith({
+        connect: expect.objectContaining({
+          cert: sslSettings.cert,
+          key: sslSettings.key,
+          pfx: sslSettings.pfx,
+          passphrase: sslSettings.passphrase,
+          ca: sslSettings.ca,
+          allowPartialTrustChain: sslSettings.allowPartialTrustChain,
+          rejectUnauthorized: true,
+          checkServerIdentity: expect.any(Function),
+        }),
+        headersTimeout: 60_000,
+        bodyTimeout: 60_000,
+      });
+    });
+
+    it('applies custom host CA data and verification mode overrides', async () => {
+      configurationUtilities.getSSLSettings.mockReturnValue({
+        verificationMode: 'certificate',
+      });
+      configurationUtilities.getCustomHostSettings.mockReturnValue({
+        url: 'https://mcp-server.example.com:443',
+        ssl: {
+          certificateAuthoritiesData: 'custom host ca',
+          verificationMode: 'full',
+        },
+      });
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+      const resource = buildConfiguredFetch(configurationUtilities, logger)({ targetUrl });
+      await resource.fetch(targetUrl);
+
+      const connectOptions = (Agent as unknown as jest.Mock).mock.calls[0][0].connect;
+      expect(connectOptions).toEqual(
+        expect.objectContaining({
+          ca: Buffer.from('custom host ca'),
+          rejectUnauthorized: true,
+        })
+      );
+      expect(connectOptions.checkServerIdentity).toBeUndefined();
+    });
+
+    it('applies target and proxy TLS settings independently', async () => {
+      const targetCa = Buffer.from('target ca');
+      const proxyCa = Buffer.from('proxy ca');
+      configurationUtilities.getSSLSettings.mockReturnValue({
+        verificationMode: 'full',
+        ca: targetCa,
+      });
+      configurationUtilities.getProxySettings.mockReturnValue({
+        proxyUrl: 'https://proxy.example.com:8080',
+        proxyBypassHosts: undefined,
+        proxyOnlyHosts: undefined,
+        proxyHeaders: { 'Proxy-Authorization': 'Basic token' },
+        proxySSLSettings: {
+          verificationMode: 'none',
+          ca: proxyCa,
+        },
+      });
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+      const resource = buildConfiguredFetch(configurationUtilities, logger)({ targetUrl });
+      await resource.fetch(targetUrl);
+
+      expect(ProxyAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestTls: expect.objectContaining({
+            ca: targetCa,
+            rejectUnauthorized: true,
+          }),
+          proxyTls: expect.objectContaining({
+            ca: proxyCa,
+            rejectUnauthorized: false,
+          }),
+          headers: { 'Proxy-Authorization': 'Basic token' },
+          headersTimeout: 60_000,
+          bodyTimeout: 60_000,
+        })
+      );
+    });
+  });
+
+  describe('redirect behaviour', () => {
+    it('changes method to GET and strips body for 301', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(301, 'https://allowed.example.com/v1'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await resource.fetch(targetUrl, { method: 'POST', body: '{"data":true}' });
+
+      const { method, body } = globalFetchSpy.mock.calls[1][1];
+      expect(method).toBe('GET');
+      expect(body).toBeUndefined();
+    });
+
+    it('changes method to GET and strips body for 302', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, 'https://allowed.example.com/v1'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await resource.fetch(targetUrl, { method: 'POST', body: '{"data":true}' });
+
+      const { method, body } = globalFetchSpy.mock.calls[1][1];
+      expect(method).toBe('GET');
+      expect(body).toBeUndefined();
+    });
+
+    it('changes method to GET and strips body for 303', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(303, 'https://allowed.example.com/v1'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await resource.fetch(targetUrl, { method: 'POST', body: '{"data":true}' });
+
+      const { method, body } = globalFetchSpy.mock.calls[1][1];
+      expect(method).toBe('GET');
+      expect(body).toBeUndefined();
+    });
+
+    it('preserves method and body for 307', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(307, 'https://allowed.example.com/v1'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await resource.fetch(targetUrl, { method: 'POST', body: '{"data":true}' });
+
+      const { method, body } = globalFetchSpy.mock.calls[1][1];
+      expect(method).toBe('POST');
+      expect(body).toBe('{"data":true}');
+    });
+
+    it('preserves method and body for 308', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(308, 'https://allowed.example.com/v1'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await resource.fetch(targetUrl, { method: 'POST', body: '{"data":true}' });
+
+      const { method, body } = globalFetchSpy.mock.calls[1][1];
+      expect(method).toBe('POST');
+      expect(body).toBe('{"data":true}');
+    });
+
+    it('strips authorization header on cross-origin redirect', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(307, 'https://allowed.example.com/v1'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await resource.fetch(targetUrl, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer secret', 'Content-Type': 'application/json' },
+      });
+
+      const redirectInit = globalFetchSpy.mock.calls[1][1];
+      const headers =
+        redirectInit.headers instanceof Headers
+          ? Object.fromEntries((redirectInit.headers as Headers).entries())
+          : redirectInit.headers;
+      expect(headers).not.toHaveProperty('authorization');
+      expect(headers).toHaveProperty('content-type', 'application/json');
+    });
+
+    it('does not restore default authorization on a cross-origin redirect', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({
+        targetUrl,
+        headers: { Authorization: 'Bearer secret' },
+      });
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(307, 'https://allowed.example.com/v1'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await resource.fetch(targetUrl);
+
+      const redirectHeaders = globalFetchSpy.mock.calls[1][1].headers as Headers;
+      expect(redirectHeaders.has('authorization')).toBe(false);
+    });
+
+    it('preserves authorization header on same-origin redirect', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(307, 'https://mcp-server.example.com/v2/mcp'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await resource.fetch(targetUrl, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer secret', 'Content-Type': 'application/json' },
+      });
+
+      const redirectInit = globalFetchSpy.mock.calls[1][1];
+      const headers =
+        redirectInit.headers instanceof Headers
+          ? Object.fromEntries((redirectInit.headers as Headers).entries())
+          : redirectInit.headers;
+      expect(headers).toHaveProperty('authorization', 'Bearer secret');
+    });
+
+    it('throws when max redirects are exceeded', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy.mockResolvedValue(
+        mockRedirectResponse(302, 'https://allowed.example.com/loop')
+      );
+
+      await expect(resource.fetch(targetUrl)).rejects.toThrow('Max redirects (20) exceeded');
+      expect(globalFetchSpy).toHaveBeenCalledTimes(21);
+    });
+
+    it('throws when a redirect is missing the Location header', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy.mockResolvedValueOnce(mockRedirectResponse(302, null));
+
+      await expect(resource.fetch(targetUrl)).rejects.toThrow(
+        'Redirect response 302 missing Location header'
+      );
+    });
+  });
+
+  describe('response settings', () => {
+    it('rejects a declared response larger than maxResponseContentLength', async () => {
+      configurationUtilities.getResponseSettings.mockReturnValue({
+        maxContentLength: 5,
+        timeout: 60_000,
+      });
+      globalFetchSpy.mockResolvedValueOnce(
+        new Response('too large', { headers: { 'content-length': '9' } })
+      );
+
+      const resource = buildConfiguredFetch(configurationUtilities, logger)({ targetUrl });
+
+      await expect(resource.fetch(targetUrl)).rejects.toThrow(
+        'Response content length 9 exceeds limit of 5'
+      );
+    });
+
+    it('applies responseTimeout to headers and body inactivity', async () => {
+      configurationUtilities.getResponseSettings.mockReturnValue({
+        maxContentLength: 1_000_000,
+        timeout: 12_345,
+      });
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok'));
+
+      const resource = buildConfiguredFetch(configurationUtilities, logger)({ targetUrl });
+      await resource.fetch(targetUrl);
+
+      expect(Agent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headersTimeout: 12_345,
+          bodyTimeout: 12_345,
+        })
+      );
+    });
+  });
+
+  describe('SSE passthrough', () => {
+    it('passes GET response body through as a stream', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      const sseResponse = new Response('data: hello\n\n', {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+      globalFetchSpy.mockResolvedValueOnce(sseResponse);
+
+      const result = await resource.fetch(targetUrl, { method: 'GET' });
+      expect(result).toBe(sseResponse);
+    });
+
+    it('passes POST response with text/event-stream content-type through as a stream', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      const sseResponse = new Response('data: hello\n\n', {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+      });
+      globalFetchSpy.mockResolvedValueOnce(sseResponse);
+
+      const result = await resource.fetch(targetUrl, { method: 'POST' });
+      expect(result).toBe(sseResponse);
+    });
+  });
+
+  describe('Cloud User-Agent', () => {
+    it('applies a User-Agent header derived from cloud info', async () => {
+      // Provide a minimal cloud mock. The actual CloudSetup type has many fields;
+      // buildUserAgent only needs serverless.projectId or deploymentId.
+      const mockCloud = { serverless: { projectId: 'proj-abc' } } as Parameters<
+        typeof buildConfiguredFetch
+      >[2];
+
+      const factory = buildConfiguredFetch(configurationUtilities, logger, mockCloud);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+      await resource.fetch(targetUrl);
+
+      const requestInit = globalFetchSpy.mock.calls[0][1];
+      const headers = requestInit.headers as Headers;
+      const ua = headers.get('user-agent');
+      expect(ua).toContain('elastic');
+      expect(ua).toContain('proj-abc');
+    });
+
+    it('applies a User-Agent header even without cloud info', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+      await resource.fetch(targetUrl);
+
+      const requestInit = globalFetchSpy.mock.calls[0][1];
+      const headers = requestInit.headers as Headers;
+      const ua = headers.get('user-agent');
+      expect(ua).toBeTruthy();
+    });
+  });
+
+  describe('close()', () => {
+    it('closes all cached dispatchers', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+      await resource.fetch(targetUrl);
+
+      await resource.close();
+
+      const agentInstance = (Agent as unknown as jest.Mock).mock.results[0].value;
+      expect(agentInstance.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('is idempotent: calling close() twice does not throw', async () => {
+      const factory = buildConfiguredFetch(configurationUtilities, logger);
+      const resource = factory({ targetUrl });
+
+      globalFetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+      await resource.fetch(targetUrl);
+
+      await expect(resource.close()).resolves.toBeUndefined();
+      await expect(resource.close()).resolves.toBeUndefined();
+
+      const agentInstance = (Agent as unknown as jest.Mock).mock.results[0].value;
+      // Second close should be a no-op
+      expect(agentInstance.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects requests after the resource is closed', async () => {
+      const resource = buildConfiguredFetch(configurationUtilities, logger)({ targetUrl });
+      await resource.close();
+
+      await expect(resource.fetch(targetUrl)).rejects.toThrow(
+        'Configured fetch resource is closed.'
+      );
+      expect(globalFetchSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/actions/server/lib/configured_fetch.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/configured_fetch.ts
@@ -1,0 +1,371 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Agent, ProxyAgent, type Dispatcher } from 'undici';
+import type { Logger } from '@kbn/core/server';
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import { getNodeSSLOptions, type CustomHostSettings, type SSLSettings } from '@kbn/actions-utils';
+import type {
+  ConfiguredFetchFactory,
+  ConfiguredFetchResource,
+  FetchLike,
+} from '@kbn/connector-specs';
+import type { ActionsConfigurationUtilities } from '../actions_config';
+import { buildUserAgent } from './get_axios_instance';
+
+function buildTlsConnectOptions(
+  logger: Logger,
+  sslSettings: SSLSettings,
+  customHostSettings?: CustomHostSettings
+): ReturnType<typeof getNodeSSLOptions> {
+  const options = getNodeSSLOptions(logger, sslSettings.verificationMode, sslSettings);
+
+  const hostSsl = customHostSettings?.ssl;
+  if (hostSsl) {
+    logger.debug(`Creating customized connection settings for: ${customHostSettings.url}`);
+    if (hostSsl.certificateAuthoritiesData) {
+      options.ca = Buffer.from(hostSsl.certificateAuthoritiesData);
+    }
+    if (hostSsl.verificationMode) {
+      delete options.checkServerIdentity;
+      Object.assign(options, getNodeSSLOptions(logger, hostSsl.verificationMode));
+    }
+  }
+
+  return options;
+}
+
+function shouldUseProxy(
+  logger: Logger,
+  proxySettings: { proxyBypassHosts?: Set<string>; proxyOnlyHosts?: Set<string>; proxyUrl: string },
+  targetUrl: string
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    logger.warn(
+      `error determining proxy state for invalid url "${targetUrl}", using direct connection`
+    );
+    return false;
+  }
+
+  const { hostname } = parsed;
+
+  if (proxySettings.proxyBypassHosts?.has(hostname)) {
+    return false;
+  }
+  if (proxySettings.proxyOnlyHosts && !proxySettings.proxyOnlyHosts.has(hostname)) {
+    return false;
+  }
+
+  return true;
+}
+
+function buildDispatcherForUrl(
+  configurationUtilities: ActionsConfigurationUtilities,
+  logger: Logger,
+  targetUrl: string
+): Dispatcher {
+  const sslSettings = configurationUtilities.getSSLSettings();
+  const proxySettings = configurationUtilities.getProxySettings();
+  const { timeout } = configurationUtilities.getResponseSettings();
+  const customHostSettings = configurationUtilities.getCustomHostSettings(targetUrl);
+  const tlsOptions = buildTlsConnectOptions(logger, sslSettings, customHostSettings);
+  const timeoutOptions = timeout > 0 ? { headersTimeout: timeout, bodyTimeout: timeout } : {};
+
+  if (proxySettings && shouldUseProxy(logger, proxySettings, targetUrl)) {
+    let proxyUrl: URL;
+    try {
+      proxyUrl = new URL(proxySettings.proxyUrl);
+    } catch {
+      logger.warn(`invalid proxy URL "${proxySettings.proxyUrl}" ignored, using direct connection`);
+      return new Agent({ connect: tlsOptions, ...timeoutOptions });
+    }
+
+    const proxyTls = getNodeSSLOptions(
+      logger,
+      proxySettings.proxySSLSettings.verificationMode,
+      proxySettings.proxySSLSettings
+    );
+
+    return new ProxyAgent({
+      uri: proxyUrl.toString(),
+      requestTls: tlsOptions,
+      proxyTls,
+      headers: proxySettings.proxyHeaders,
+      ...timeoutOptions,
+    });
+  }
+
+  return new Agent({ connect: tlsOptions, ...timeoutOptions });
+}
+
+/**
+ * Merges multiple AbortSignals into one that aborts when any of the sources abort.
+ */
+function mergeAbortSignals(signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      return controller.signal;
+    }
+    signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
+  }
+  return controller.signal;
+}
+
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 20;
+const BLOCKED_CROSS_ORIGIN_HEADERS = ['authorization'];
+const STRIPPED_METHOD_CHANGE_HEADERS = [
+  'content-encoding',
+  'content-language',
+  'content-location',
+  'content-type',
+];
+
+const SSE_CONTENT_TYPE = 'text/event-stream';
+
+const enforceResponseContentLength = (response: Response, maxContentLength: number): Response => {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (maxContentLength <= 0 || contentType.includes(SSE_CONTENT_TYPE)) {
+    return response;
+  }
+
+  const contentLengthHeader = response.headers.get('content-length');
+  if (contentLengthHeader !== null) {
+    const contentLength = Number.parseInt(contentLengthHeader, 10);
+    if (!Number.isNaN(contentLength) && contentLength > maxContentLength) {
+      void response.body?.cancel();
+      throw new Error(
+        `Response content length ${contentLength} exceeds limit of ${maxContentLength}`
+      );
+    }
+  }
+
+  if (!response.body) {
+    return response;
+  }
+
+  let receivedBytes = 0;
+  const limitedBody = response.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        receivedBytes += chunk.byteLength;
+        if (receivedBytes > maxContentLength) {
+          controller.error(
+            new Error(
+              `Response content length ${receivedBytes} exceeds limit of ${maxContentLength}`
+            )
+          );
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    })
+  );
+
+  const limitedResponse = new Response(limitedBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+  Object.defineProperties(limitedResponse, {
+    url: { value: response.url },
+    redirected: { value: response.redirected },
+    type: { value: response.type },
+  });
+  return limitedResponse;
+};
+
+/**
+ * Creates a `ConfiguredFetchResource` for a given target URL.
+ *
+ * The resource owns a cache of Undici dispatchers (keyed by destination origin).
+ * Dispatchers are built lazily on first request to a destination and reused within the same
+ * resource lifetime. Call `close()` when the resource is no longer needed so all open sockets
+ * are released.
+ */
+function createConfiguredFetchResource(
+  configurationUtilities: ActionsConfigurationUtilities,
+  logger: Logger,
+  cloud: CloudSetup | undefined,
+  targetUrl: string,
+  defaultHeaders?: Readonly<Record<string, string>>
+): ConfiguredFetchResource {
+  // Validate the initial target URL up front so callers get an immediate error
+  // rather than a deferred failure on the first network hop.
+  configurationUtilities.ensureUriAllowed(targetUrl);
+
+  const userAgent = buildUserAgent(cloud);
+  const { timeout, maxContentLength } = configurationUtilities.getResponseSettings();
+
+  const dispatchers = new Map<string, Dispatcher>();
+  let closed = false;
+
+  const getOrCreateDispatcher = (url: string): Dispatcher => {
+    const origin = new URL(url).origin;
+    let dispatcher = dispatchers.get(origin);
+    if (!dispatcher) {
+      dispatcher = buildDispatcherForUrl(configurationUtilities, logger, url);
+      dispatchers.set(origin, dispatcher);
+    }
+    return dispatcher;
+  };
+
+  const followRedirects = async (
+    url: string | URL,
+    init?: RequestInit,
+    redirectCount = 0
+  ): Promise<Response> => {
+    if (closed) {
+      throw new Error('Configured fetch resource is closed.');
+    }
+
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    const dispatcher = getOrCreateDispatcher(urlStr);
+
+    const requestHeaders = new Headers(init?.headers);
+    if (!requestHeaders.has('user-agent')) {
+      requestHeaders.set('user-agent', userAgent);
+    }
+
+    // Build abort signals: request signal + optional timeout
+    const signals: AbortSignal[] = [];
+    if (init?.signal) {
+      signals.push(init.signal as AbortSignal);
+    }
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    if (timeout > 0) {
+      const controller = new AbortController();
+      timeoutHandle = setTimeout(() => {
+        controller.abort(new Error(`Request timed out after ${timeout}ms`));
+      }, timeout);
+      signals.push(controller.signal);
+    }
+
+    const mergedSignal = signals.length > 0 ? mergeAbortSignals(signals) : undefined;
+
+    let response: Response;
+    try {
+      response = await fetch(urlStr, {
+        ...init,
+        headers: requestHeaders,
+        redirect: 'manual',
+        ...(mergedSignal ? { signal: mergedSignal } : {}),
+        dispatcher,
+      } as RequestInit);
+    } finally {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+
+    if (!REDIRECT_STATUS_CODES.has(response.status)) {
+      return enforceResponseContentLength(response, maxContentLength);
+    }
+
+    if (redirectCount >= MAX_REDIRECTS) {
+      try {
+        await response.body?.cancel();
+      } catch {
+        // ignore
+      }
+      throw new Error(`Max redirects (${MAX_REDIRECTS}) exceeded`);
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      try {
+        await response.body?.cancel();
+      } catch {
+        // ignore
+      }
+      throw new Error(`Redirect response ${response.status} missing Location header`);
+    }
+
+    const resolvedUrl = new URL(location, urlStr).toString();
+
+    // Validate each redirect destination against the allowlist.
+    configurationUtilities.ensureUriAllowed(resolvedUrl);
+    logger.debug(`configured-fetch: following redirect (${response.status}) to ${resolvedUrl}`);
+
+    try {
+      await response.body?.cancel();
+    } catch {
+      // ignore
+    }
+
+    const preserveMethod = response.status === 307 || response.status === 308;
+    const redirectInit: RequestInit = { ...init, headers: requestHeaders };
+
+    if (!preserveMethod) {
+      const sanitizedHeaders = new Headers(redirectInit.headers);
+      STRIPPED_METHOD_CHANGE_HEADERS.forEach((h) => sanitizedHeaders.delete(h));
+      redirectInit.headers = sanitizedHeaders;
+      redirectInit.method = 'GET';
+      delete redirectInit.body;
+    }
+
+    // Per WHATWG Fetch spec: strip authorization header on cross-origin redirects.
+    const requestOrigin = new URL(urlStr).origin;
+    const redirectOrigin = new URL(resolvedUrl).origin;
+    if (requestOrigin !== redirectOrigin) {
+      const sanitizedHeaders = new Headers(redirectInit.headers);
+      BLOCKED_CROSS_ORIGIN_HEADERS.forEach((h) => sanitizedHeaders.delete(h));
+      redirectInit.headers = sanitizedHeaders;
+    }
+
+    return followRedirects(resolvedUrl, redirectInit, redirectCount + 1);
+  };
+
+  const fetchFn: FetchLike = async (url, init) => {
+    const urlString = typeof url === 'string' ? url : url.toString();
+    configurationUtilities.ensureUriAllowed(urlString);
+    const headers = new Headers(defaultHeaders);
+    new Headers(init?.headers).forEach((value, key) => headers.set(key, value));
+    return followRedirects(urlString, { ...init, headers });
+  };
+
+  return {
+    fetch: fetchFn,
+    async close(): Promise<void> {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      for (const [, dispatcher] of dispatchers) {
+        try {
+          await dispatcher.close();
+        } catch {
+          // ignore errors on close
+        }
+      }
+      dispatchers.clear();
+    },
+  };
+}
+
+/**
+ * Returns a `ConfiguredFetchFactory` that applies Kibana's actions-plugin
+ * SSL/TLS, proxy, User-Agent, timeout, and body-size settings to every
+ * outbound fetch request.
+ *
+ * The factory validates the `targetUrl` on creation, caches Undici dispatchers
+ * per destination policy so that different redirect hops can use different
+ * transports, and returns a `close()` method that drains all open sockets.
+ */
+export function buildConfiguredFetch(
+  configurationUtilities: ActionsConfigurationUtilities,
+  logger: Logger,
+  cloud?: CloudSetup
+): ConfiguredFetchFactory {
+  return ({ targetUrl, headers }) =>
+    createConfiguredFetchResource(configurationUtilities, logger, cloud, targetUrl, headers);
+}

--- a/x-pack/platform/plugins/shared/actions/server/lib/lease_pool.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/lease_pool.test.ts
@@ -120,7 +120,7 @@ describe('LeasePool', () => {
       });
       const firstLease = pool.lease('conn:mcp:shared', async () => firstBuild, noopTerminate);
 
-      pool.evict('conn');
+      const evictionPromise = pool.evict('conn');
 
       const replacementTerminate = jest.fn().mockResolvedValue(undefined);
       const replacementBuild = jest.fn().mockResolvedValue('replacement-client');
@@ -130,7 +130,7 @@ describe('LeasePool', () => {
 
       rejectFirstBuild(new Error('stale build failed'));
       await expect(firstLease).rejects.toThrow('stale build failed');
-      await Promise.resolve();
+      await evictionPromise;
 
       const unexpectedBuild = jest.fn().mockResolvedValue('unexpected-client');
       await expect(pool.lease('conn:mcp:shared', unexpectedBuild, noopTerminate)).resolves.toBe(
@@ -207,9 +207,7 @@ describe('LeasePool', () => {
       await pool.lease('conn-a:mcp:shared', async () => 'client-a', terminateA);
       await pool.lease('conn-b:mcp:shared', async () => 'client-b', terminateB);
 
-      pool.evict('conn-a');
-
-      await Promise.resolve();
+      await pool.evict('conn-a');
 
       expect(terminateA).toHaveBeenCalledWith('client-a');
       expect(terminateB).not.toHaveBeenCalled();
@@ -221,8 +219,7 @@ describe('LeasePool', () => {
 
       await pool.lease('conn-x:mcp:shared', async () => 'client-x', terminateFailing);
 
-      pool.evict('conn-x');
-      await Promise.resolve();
+      await pool.evict('conn-x');
 
       let buildCount = 0;
       await pool.lease(
@@ -237,6 +234,33 @@ describe('LeasePool', () => {
       expect(buildCount).toBe(1);
     });
 
+    it('waits for termination to finish', async () => {
+      const pool = new LeasePool<string>();
+      let resolveTermination!: () => void;
+      const terminationPromise = new Promise<void>((resolve) => {
+        resolveTermination = resolve;
+      });
+
+      await pool.lease(
+        'conn-w:mcp:shared',
+        async () => 'client-w',
+        async () => terminationPromise
+      );
+
+      let evictionFinished = false;
+      const evictionPromise = pool.evict('conn-w').then(() => {
+        evictionFinished = true;
+      });
+      await Promise.resolve();
+
+      expect(evictionFinished).toBe(false);
+
+      resolveTermination();
+      await evictionPromise;
+
+      expect(evictionFinished).toBe(true);
+    });
+
     it('terminates after resolve when evicting an in-progress entry', async () => {
       const pool = new LeasePool<string>();
       let resolveClient!: (v: string) => void;
@@ -247,14 +271,14 @@ describe('LeasePool', () => {
 
       const leasePromise = pool.lease('conn-y:mcp:shared', async () => inFlight, terminateSpy);
 
-      pool.evict('conn-y');
+      const evictionPromise = pool.evict('conn-y');
       await Promise.resolve();
 
       expect(terminateSpy).not.toHaveBeenCalled();
 
       resolveClient('client-y');
       await leasePromise;
-      await Promise.resolve();
+      await evictionPromise;
 
       expect(terminateSpy).toHaveBeenCalledTimes(1);
       expect(terminateSpy).toHaveBeenCalledWith('client-y');
@@ -270,12 +294,12 @@ describe('LeasePool', () => {
 
       const leasePromise = pool.lease('conn-z:mcp:shared', async () => inFlight, terminateSpy);
 
-      pool.evict('conn-z');
+      const evictionPromise = pool.evict('conn-z');
       await Promise.resolve();
 
       rejectClient(new Error('build failed'));
       await expect(leasePromise).rejects.toThrow('build failed');
-      await Promise.resolve();
+      await evictionPromise;
 
       expect(terminateSpy).not.toHaveBeenCalled();
     });
@@ -286,8 +310,7 @@ describe('LeasePool', () => {
 
       await pool.lease('other-conn:mcp:shared', async () => 'other-client', terminateOther);
 
-      pool.evict('my-conn');
-      await Promise.resolve();
+      await pool.evict('my-conn');
 
       expect(terminateOther).not.toHaveBeenCalled();
     });

--- a/x-pack/platform/plugins/shared/actions/server/lib/lease_pool.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/lease_pool.ts
@@ -14,6 +14,7 @@ const MAX_ENTRIES = 1000;
 interface PoolEntry<TClient> {
   promise: Promise<TClient>;
   terminate: (client: TClient) => Promise<void>;
+  terminationPromise?: Promise<void>;
 }
 
 export class LeasePool<TClient> {
@@ -29,13 +30,7 @@ export class LeasePool<TClient> {
       updateAgeOnGet: true,
       max: MAX_ENTRIES,
       dispose: (value, key) => {
-        void value.promise.then(
-          (client) =>
-            value.terminate(client).catch((err) => {
-              this.logger?.warn(`Failed to terminate client for key "${key}": ${err.message}`);
-            }),
-          () => {}
-        );
+        void this.terminateEntry(value, key);
       },
     });
   }
@@ -62,15 +57,37 @@ export class LeasePool<TClient> {
     return promise;
   }
 
-  evict(connectorId: string): void {
-    const prefix = `${connectorId}:`;
+  async evict(connectorId: string): Promise<void> {
+    const prefix = `${encodeURIComponent(connectorId)}:`;
     const keysToEvict = [...this.cache.keys()].filter((key) => key.startsWith(prefix));
+    const entriesToTerminate = keysToEvict.flatMap((key) => {
+      const entry = this.cache.peek(key);
+      return entry === undefined ? [] : [{ entry, key }];
+    });
+
     for (const key of keysToEvict) {
       this.cache.delete(key);
     }
+
+    await Promise.all(entriesToTerminate.map(({ entry, key }) => this.terminateEntry(entry, key)));
   }
 
   stop(): void {
     this.cache.clear();
+  }
+
+  private terminateEntry(entry: PoolEntry<TClient>, key: string): Promise<void> {
+    entry.terminationPromise ??= entry.promise.then(
+      async (client) => {
+        try {
+          await entry.terminate(client);
+        } catch (err) {
+          this.logger?.warn(`Failed to terminate client for key "${key}": ${err.message}`);
+        }
+      },
+      () => {}
+    );
+
+    return entry.terminationPromise;
   }
 }

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/build_client_lease_key.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/build_client_lease_key.test.ts
@@ -8,11 +8,38 @@
 import { buildClientLeaseKey } from './build_client_lease_key';
 
 describe('buildClientLeaseKey', () => {
-  it('formats key as connectorId:clientTypeId:shared', () => {
-    expect(buildClientLeaseKey('connector-abc', 'mcp')).toBe('connector-abc:mcp:shared');
+  const identity = {
+    connectorId: 'connector-abc',
+    spaceId: 'default',
+    clientTypeId: 'mcp',
+    connectorVersion: 'WzEsMV0=',
+  };
+
+  it('shares a client across users when auth is shared', () => {
+    expect(buildClientLeaseKey({ ...identity, profileUid: 'user-a' })).toBe(
+      buildClientLeaseKey({ ...identity, profileUid: 'user-b' })
+    );
   });
 
-  it('preserves special characters in connectorId', () => {
-    expect(buildClientLeaseKey('.github', 'mcp')).toBe('.github:mcp:shared');
+  it('isolates per-user clients and encodes every identity component', () => {
+    const userA = buildClientLeaseKey({
+      ...identity,
+      authMode: 'per-user',
+      profileUid: 'user:a',
+    });
+    const userB = buildClientLeaseKey({
+      ...identity,
+      authMode: 'per-user',
+      profileUid: 'user:b',
+    });
+
+    expect(userA).not.toBe(userB);
+    expect(userA).toContain('user%3Aa');
+  });
+
+  it('requires a profile UID for per-user clients', () => {
+    expect(() => buildClientLeaseKey({ ...identity, authMode: 'per-user' })).toThrow(
+      'A profile UID is required'
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/build_client_lease_key.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/build_client_lease_key.ts
@@ -5,14 +5,38 @@
  * 2.0.
  */
 
-/**
- * Pool key = one shared client instance per (connector instance, client type).
- *
- * - connectorId: execOptions.actionId (two saved connectors must not share a session).
- * - clientTypeId: registry slot ('mcp').
- * - ':shared': one pool entry per connector+type (not per sub-action). Per-user OAuth pool
- *   key isolation via profileUid is the deferred next term.
- */
-export function buildClientLeaseKey(connectorId: string, clientTypeId: string): string {
-  return `${connectorId}:${clientTypeId}:shared`;
+export const IN_MEMORY_CONNECTOR_REVISION = 'in-memory';
+
+interface ClientLeaseIdentity {
+  connectorId: string;
+  spaceId: string;
+  clientTypeId: string;
+  authMode?: string;
+  profileUid?: string;
+  connectorVersion: string;
 }
+
+const encodeComponent = (component: string): string => encodeURIComponent(component);
+
+/**
+ * Pool key identity is connector, space, client type, authentication identity, and connector
+ * revision. The connector remains the first encoded component so LeasePool can evict every
+ * client for a connector efficiently.
+ */
+export const buildClientLeaseKey = ({
+  connectorId,
+  spaceId,
+  clientTypeId,
+  authMode,
+  profileUid,
+  connectorVersion,
+}: ClientLeaseIdentity): string => {
+  if (authMode === 'per-user' && !profileUid) {
+    throw new Error('A profile UID is required to lease a per-user connector client.');
+  }
+
+  const authIdentity = authMode === 'per-user' ? profileUid! : 'shared';
+  return [connectorId, spaceId, clientTypeId, authIdentity, connectorVersion]
+    .map(encodeComponent)
+    .join(':');
+};

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
@@ -46,6 +46,8 @@ describe('generateExecutorFunction', () => {
       signal: undefined,
       authMode: undefined,
       profileUid: undefined,
+      connectorVersion: 'WzEsMV0=',
+      spaceId: 'default',
       // satisfies the type but unused by the function under test
       services: {} as never,
       configurationUtilities: {} as never,
@@ -703,6 +705,75 @@ describe('generateExecutorFunction', () => {
 
       expect(buildCount).toBe(2);
       expect(c1).not.toBe(c2);
+    });
+
+    it.each([
+      ['spaces', { spaceId: 'space-a' }, { spaceId: 'space-b' }],
+      ['connector revisions', { connectorVersion: 'version-a' }, { connectorVersion: 'version-b' }],
+    ])('does not reuse clients across different %s', async (_identityPart, first, second) => {
+      const fakeClientType = {
+        id: 'fake',
+        build: jest.fn().mockResolvedValue({}),
+        terminate: jest.fn(),
+      };
+      const capturedGetClients: GetClient[] = [];
+      const pool = new LeasePool<unknown>();
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        capturedGetClients.push(ctx.getClient as unknown as GetClient);
+        return {};
+      });
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: { fake: fakeClientType },
+      });
+
+      await executor({
+        ...makeExecOptions({ subAction: 'testAction', subActionParams: {} }),
+        ...first,
+      });
+      await executor({
+        ...makeExecOptions({ subAction: 'testAction', subActionParams: {} }),
+        ...second,
+      });
+      await Promise.all(capturedGetClients.map((getClient) => getClient('fake')));
+
+      expect(fakeClientType.build).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not build a per-user client without a profile UID', async () => {
+      const fakeClientType = {
+        id: 'fake',
+        build: jest.fn().mockResolvedValue({}),
+        terminate: jest.fn(),
+      };
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        await (ctx.getClient as unknown as GetClient)('fake');
+        return {};
+      });
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => fakeLeasePool,
+        network: mockNetwork,
+        clientTypes: { fake: fakeClientType },
+      });
+
+      const result = await executor({
+        ...makeExecOptions({ subAction: 'testAction', subActionParams: {} }),
+        authMode: 'per-user',
+      });
+
+      expect(result).toMatchObject({
+        status: 'error',
+        retry: false,
+        errorSource: TaskErrorSource.USER,
+      });
+      expect(fakeClientType.build).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -122,6 +122,8 @@ export const generateExecutorFunction = ({
       signal,
       authMode,
       profileUid,
+      connectorVersion,
+      spaceId,
     } = execOptions;
     const { subAction, subActionParams, fetchOptions } = params as ExecutorParams & {
       fetchOptions?: FetchOptions;
@@ -160,9 +162,25 @@ export const generateExecutorFunction = ({
       if (!clientType) {
         throw new Error(`[Action][ExternalService] Unknown client type ${id}.`);
       }
+      if (authMode === 'per-user' && !profileUid) {
+        throw createTaskRunError(
+          new Error('A profile UID is required to lease a per-user connector client.'),
+          TaskErrorSource.USER
+        );
+      }
       try {
+        if (!connectorVersion) {
+          throw new Error(`Missing saved-object version for persisted connector "${connectorId}".`);
+        }
         return await pool.lease(
-          buildClientLeaseKey(connectorId, id),
+          buildClientLeaseKey({
+            connectorId,
+            spaceId: spaceId ?? 'default',
+            clientTypeId: id,
+            authMode,
+            profileUid,
+            connectorVersion,
+          }),
           () => clientType.build({ logger, axiosInstance, config, network, credential }),
           clientType.terminate
         );

--- a/x-pack/platform/plugins/shared/actions/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/actions/server/mocks.ts
@@ -35,6 +35,7 @@ const createSetupMock = () => {
     registerSubActionConnectorType: jest.fn(),
     getAxiosInstanceWithAuth: jest.fn(),
     getCredential: jest.fn(),
+    getConfiguredFetchFactory: jest.fn(),
     getClientLeasePool: jest.fn(),
     isPreconfiguredConnector: jest.fn(),
     getSubActionConnectorClass: jest.fn(),

--- a/x-pack/platform/plugins/shared/actions/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/plugin.test.ts
@@ -370,6 +370,14 @@ describe('Actions Plugin', () => {
       });
     });
 
+    describe('getConfiguredFetchFactory()', () => {
+      it('exposes an Actions-configured fetch factory', async () => {
+        const pluginSetup = await plugin.setup(coreSetup as any, pluginsSetup);
+
+        expect(pluginSetup.getConfiguredFetchFactory()).toEqual(expect.any(Function));
+      });
+    });
+
     describe('isPreconfiguredConnector', () => {
       function setup(config: ActionsConfig) {
         context = coreMock.createPluginInitializerContext<ActionsConfig>(config);

--- a/x-pack/platform/plugins/shared/actions/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/server/plugin.ts
@@ -631,7 +631,9 @@ export class ActionsPlugin
         encryptedSavedObjectsClient,
         connectorLifecycleListeners: this.connectorLifecycleListeners,
         getCurrentUserProfileId,
-        evictClientPool: (connectorId: string) => this.clientLeasePool?.evict(connectorId),
+        evictClientPool: async (connectorId: string) => {
+          await this.clientLeasePool?.evict(connectorId);
+        },
       });
     };
 
@@ -1013,7 +1015,9 @@ export class ActionsPlugin
       connectorLifecycleListeners,
     } = this;
     const getSkippedPreconfiguredIds = () => this.skippedPreconfiguredConnectorIds;
-    const evictClientPool = (connectorId: string) => this.clientLeasePool?.evict(connectorId);
+    const evictClientPool = async (connectorId: string): Promise<void> => {
+      await this.clientLeasePool?.evict(connectorId);
+    };
 
     return async function actionsRouteHandlerContext(context, request) {
       const [coreStart, pluginsStart] = await core.getStartServices();
@@ -1144,6 +1148,7 @@ export class ActionsPlugin
       return false;
     }
     this.inMemoryConnectors.splice(index, 1);
+    void this.clientLeasePool?.evict(connectorId);
     this.logger.info(`Unregistered dynamic connector with id ${connectorId}`);
     return true;
   };

--- a/x-pack/platform/plugins/shared/actions/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/server/plugin.ts
@@ -46,7 +46,7 @@ import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverle
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { AxiosInstance } from 'axios';
 import type { UsageApiSetup } from '@kbn/usage-api-plugin/server';
-import type { CredentialAccessor } from '@kbn/connector-specs';
+import type { ConfiguredFetchFactory, CredentialAccessor } from '@kbn/connector-specs';
 import { type ActionsConfig, type EnabledConnectorTypes } from './config';
 import { AllowedHosts, getValidatedConfig } from './config';
 import { resolveCustomHosts } from './lib/custom_host_settings';
@@ -128,6 +128,7 @@ import { OAuthRateLimiter } from './lib/oauth_rate_limiter';
 import type { GetAxiosInstanceWithAuthFnOpts, GetCredentialFnOpts } from './lib/get_axios_instance';
 import { getAxiosInstanceWithAuth, getCredentialWithAuth } from './lib/get_axios_instance';
 import { RelayClient, type RelayClientContract } from './lib/relay';
+import { buildConfiguredFetch } from './lib/configured_fetch';
 
 export interface PluginSetupContract {
   registerType<
@@ -149,6 +150,9 @@ export interface PluginSetupContract {
   getAxiosInstanceWithAuth(opts: GetAxiosInstanceWithAuthFnOpts): Promise<AxiosInstance>;
 
   getCredential(opts: GetCredentialFnOpts): CredentialAccessor;
+
+  /** Provides fetch resources configured with the Actions proxy, certificate, and TLS policy. */
+  getConfiguredFetchFactory(): ConfiguredFetchFactory;
 
   /** PoC: process-wide pool for reusable connector clients (MCP, future DB/gRPC). */
   getClientLeasePool(): LeasePool<unknown>;
@@ -509,6 +513,8 @@ export class ActionsPlugin
         plugins.cloud
       ),
       getCredential: this.getCredentialHelper(actionsConfigUtils),
+      getConfiguredFetchFactory: () =>
+        buildConfiguredFetch(actionsConfigUtils, this.logger, plugins.cloud),
       getClientLeasePool: () => this.clientLeasePool!,
       isPreconfiguredConnector: (connectorId: string): boolean => {
         return !!this.inMemoryConnectors.find(

--- a/x-pack/platform/plugins/shared/actions/server/routes/oauth_callback.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/oauth_callback.test.ts
@@ -50,6 +50,10 @@ const mockConnectorTokenClientInstance = {
   createWithRefreshToken: jest.fn(),
 };
 
+const mockActionsClient = {
+  evictClientPool: jest.fn(),
+};
+
 const mockEncryptedSavedObjectsClient = {
   getClient: jest.fn().mockReturnValue({
     getDecryptedAsInternalUser: jest.fn(),
@@ -100,7 +104,7 @@ const createMockContext = (
     },
   }),
   actions: Promise.resolve({
-    getActionsClient: jest.fn(),
+    getActionsClient: jest.fn().mockReturnValue(mockActionsClient),
   }),
 });
 
@@ -119,6 +123,7 @@ describe('oauthCallbackRoute', () => {
     mockEncryptedSavedObjectsClient.getClient.mockReturnValue({
       getDecryptedAsInternalUser: jest.fn(),
     });
+    mockActionsClient.evictClientPool.mockReset();
 
     MockOAuthStateClient.mockImplementation(() => mockOAuthStateClientInstance as never);
     MockUserConnectorTokenClient.mockImplementation(
@@ -293,6 +298,7 @@ describe('oauthCallbackRoute', () => {
   });
 
   it('exchanges code for tokens and redirects on success', async () => {
+    const credentialMutationOrder: string[] = [];
     const mockOAuthState = {
       id: 'state-id',
       state: 'valid-state',
@@ -327,8 +333,17 @@ describe('oauthCallbackRoute', () => {
       expiresIn: 3600,
     });
 
-    mockConnectorTokenClientInstance.deleteConnectorTokens.mockResolvedValue(undefined);
-    mockConnectorTokenClientInstance.createWithRefreshToken.mockResolvedValue(undefined);
+    mockActionsClient.evictClientPool.mockImplementation(async () => {
+      credentialMutationOrder.push('evictClientPoolStarted');
+      await Promise.resolve();
+      credentialMutationOrder.push('evictClientPoolFinished');
+    });
+    mockConnectorTokenClientInstance.deleteConnectorTokens.mockImplementation(async () => {
+      credentialMutationOrder.push('deleteConnectorTokens');
+    });
+    mockConnectorTokenClientInstance.createWithRefreshToken.mockImplementation(async () => {
+      credentialMutationOrder.push('createWithRefreshToken');
+    });
 
     const [, handler] = registerRoute();
     const context = createMockContext();
@@ -375,6 +390,13 @@ describe('oauthCallbackRoute', () => {
       tokenType: 'access_token',
       profileUid: 'test-profile-uid',
     });
+    expect(mockActionsClient.evictClientPool).toHaveBeenCalledWith('connector-1');
+    expect(credentialMutationOrder).toEqual([
+      'evictClientPoolStarted',
+      'evictClientPoolFinished',
+      'deleteConnectorTokens',
+      'createWithRefreshToken',
+    ]);
 
     // Verify state cleanup
     expect(mockOAuthStateClientInstance.delete).toHaveBeenCalledWith('state-id');

--- a/x-pack/platform/plugins/shared/actions/server/routes/oauth_callback.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/oauth_callback.ts
@@ -656,6 +656,8 @@ export const oauthCallbackRoute = (
           // skipRevocation: we just minted a fresh token above; the new token
           // shares the same provider grant, so revoking it here would
           // invalidate the token we are about to store.
+          await (await context.actions).getActionsClient().evictClientPool(stateConnectorId);
+
           await userConnectorTokenClient.deleteConnectorTokens({
             connectorId: stateConnectorId,
             tokenType: 'access_token',

--- a/x-pack/platform/plugins/shared/actions/server/routes/oauth_disconnect.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/oauth_disconnect.test.ts
@@ -34,6 +34,7 @@ const mockEncryptedSavedObjectsClient = {
 
 const mockActionsClient = {
   get: jest.fn(),
+  evictClientPool: jest.fn(),
 };
 
 const createMockCoreSetup = () => ({
@@ -134,8 +135,16 @@ describe('oauthDisconnectRoute', () => {
   });
 
   it('returns 204 on successful disconnect', async () => {
+    const callOrder: string[] = [];
     mockActionsClient.get.mockResolvedValue({ id: 'connector-1' });
-    mockConnectorTokenClientInstance.deleteConnectorTokens.mockResolvedValue(undefined);
+    mockActionsClient.evictClientPool.mockImplementation(async () => {
+      callOrder.push('evictClientPoolStarted');
+      await Promise.resolve();
+      callOrder.push('evictClientPoolFinished');
+    });
+    mockConnectorTokenClientInstance.deleteConnectorTokens.mockImplementation(async () => {
+      callOrder.push('deleteConnectorTokens');
+    });
 
     const [, handler] = registerRoute();
     const context = createMockContext();
@@ -147,6 +156,12 @@ describe('oauthDisconnectRoute', () => {
     await handler(context, req, res);
 
     expect(res.noContent).toHaveBeenCalled();
+    expect(mockActionsClient.evictClientPool).toHaveBeenCalledWith('connector-1');
+    expect(callOrder).toEqual([
+      'evictClientPoolStarted',
+      'evictClientPoolFinished',
+      'deleteConnectorTokens',
+    ]);
   });
 
   it('verifies the connector exists before deleting tokens', async () => {

--- a/x-pack/platform/plugins/shared/actions/server/routes/oauth_disconnect.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/oauth_disconnect.ts
@@ -122,6 +122,8 @@ export const oauthDisconnectRoute = (
           );
         }
 
+        await actionsClient.evictClientPool(connectorId);
+
         await connectorTokenClient.deleteConnectorTokens({
           connectorId,
           profileUid,

--- a/x-pack/platform/plugins/shared/actions/server/types.ts
+++ b/x-pack/platform/plugins/shared/actions/server/types.ts
@@ -100,6 +100,10 @@ export interface ActionTypeExecutorOptions<
   signal?: AbortSignal;
   authMode?: AuthMode;
   profileUid?: string;
+  /** Present only for spec connector executors, where it scopes pooled client leases. */
+  connectorVersion?: string;
+  /** Present only for spec connector executors, where it scopes pooled client leases. */
+  spaceId?: string;
 }
 
 export type ActionResult = Connector;


### PR DESCRIPTION
## Summary
- scope pooled spec connector clients by space, authentication identity, and connector saved-object version
- reject per-user leases without a profile UID and invalidate stale clients on connector or OAuth credential changes
- await client termination before credential mutation and cover isolation, invalidation, and ordering with regression tests

Depends on #280445.

Addresses #275613.

## Test plan
- [x] `node scripts/jest x-pack/platform/plugins/shared/actions/server/lib/lease_pool.test.ts x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.test.ts x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.test.ts x-pack/platform/plugins/shared/actions/server/routes/oauth_callback.test.ts x-pack/platform/plugins/shared/actions/server/routes/oauth_disconnect.test.ts`
- [x] `node scripts/type_check --project x-pack/platform/plugins/shared/actions/tsconfig.json`
- [x] ESLint on modified files