### PR TITLE
[UIAM OAuth] Handle expired bucket returned by OAuthConnectionsSummary

### DIFF
--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -17,6 +17,7 @@ export interface UiamOAuthClientLogo {
 export interface UiamOAuthConnectionsSummary {
   active?: string[];
   revoked?: string[];
+  expired?: string[];
 }
 
 export type UiamOAuthClientType = 'public' | 'confidential';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/oauth_clients/types/oauth_clients.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/oauth_clients/types/oauth_clients.ts
@@ -18,6 +18,7 @@ export interface OAuthClientLogo {
 export interface OAuthClientConnectionsSummary {
   active?: string[];
   revoked?: string[];
+  expired?: string[];
 }
 
 export interface OAuthClient {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_not_connected_banner.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_not_connected_banner.tsx
@@ -37,38 +37,41 @@ export const McpClientsNotConnectedBanner = ({ clients }: McpClientsNotConnected
     []
   );
 
-  const disconnectedClients = useMemo(
+  const neverConnectedClients = useMemo(
     () =>
       clients.filter(
         (client) =>
-          !client.revoked && (!client.connections?.active || client.connections.active.length === 0)
+          !client.revoked &&
+          (client.connections?.active?.length ?? 0) === 0 &&
+          (client.connections?.expired?.length ?? 0) === 0 &&
+          (client.connections?.revoked?.length ?? 0) === 0
       ),
     [clients]
   );
 
-  const hasUnseenDisconnectedClient = useMemo(() => {
+  const hasUnseenNeverConnectedClient = useMemo(() => {
     const dismissedSet = new Set(dismissedClientIds);
-    return disconnectedClients.some((client) => !dismissedSet.has(client.id));
-  }, [disconnectedClients, dismissedClientIds]);
+    return neverConnectedClients.some((client) => !dismissedSet.has(client.id));
+  }, [neverConnectedClients, dismissedClientIds]);
 
   const handleDismiss = useCallback(() => {
-    setDismissedClientIds(disconnectedClients.map((client) => client.id));
-  }, [setDismissedClientIds, disconnectedClients]);
+    setDismissedClientIds(neverConnectedClients.map((client) => client.id));
+  }, [setDismissedClientIds, neverConnectedClients]);
 
   const displayNames = useMemo(
     () =>
-      disconnectedClients
+      neverConnectedClients
         .filter((client) => client.client_name)
         .slice(0, MAX_DISPLAY_NAMES)
         .map((client) => client.client_name),
-    [disconnectedClients]
+    [neverConnectedClients]
   );
 
-  if (disconnectedClients.length === 0 || !hasUnseenDisconnectedClient) {
+  if (neverConnectedClients.length === 0 || !hasUnseenNeverConnectedClient) {
     return null;
   }
 
-  const remainingCount = disconnectedClients.length - MAX_DISPLAY_NAMES;
+  const remainingCount = neverConnectedClients.length - MAX_DISPLAY_NAMES;
 
   return (
     <EuiCallOut
@@ -82,7 +85,7 @@ export const McpClientsNotConnectedBanner = ({ clients }: McpClientsNotConnected
         id="xpack.agentBuilder.mcpClients.notConnectedBanner.message"
         defaultMessage="{count, plural, one {The MCP client {names} is} other {The MCP clients {names}{remaining} are}} not yet connected."
         values={{
-          count: disconnectedClients.length,
+          count: neverConnectedClients.length,
           names: (
             <>
               {displayNames.map((name, index) => (

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table_columns.tsx
@@ -94,7 +94,7 @@ export const useMcpClientsTableColumns = (): Array<EuiBasicTableColumn<OAuthClie
         <McpClientActionsMenu
           clientId={id}
           clientName={client_name ?? id}
-          connectionCount={connections?.active?.length ?? 0}
+          connectionCount={(connections?.active?.length ?? 0) + (connections?.expired?.length ?? 0)}
           revoked={revoked ?? false}
         />
       ),


### PR DESCRIPTION
## Summary

Handles the `expired` bucket newly returned by the OAuth connections summary (`GET /uiam/api/v1/oauth/clients`) and updates the banner to only appear for connections that have yet to be connected (i.e. 0 active, expired, and revoked connections).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
