### PR TITLE
[Security Solution] Defer explore data view initialisation and error reporting to explore pages

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
@@ -27,6 +27,7 @@ import { TopValuesPopover } from '../components/top_values_popover/top_values_po
 import { useInitDataViewManager } from '../../data_view_manager/hooks/use_init_data_view_manager';
 import { useRestoreDataViewManagerStateFromURL } from '../../data_view_manager/hooks/use_sync_url_state';
 import { useBrowserFields } from '../../data_view_manager/hooks/use_browser_fields';
+import { useInitExploreDataView } from '../../data_view_manager/hooks/use_init_explore_data_view';
 import { useFlyoutV2RestoreFromUrl } from '../../flyout_v2/shared/url_state/use_flyout_v2_restore';
 import {
   FLYOUT_V2_URL_PARAM,
@@ -41,9 +42,11 @@ interface HomePageProps {
 
 const HomePageComponent: React.FC<HomePageProps> = ({ children }) => {
   const { pathname } = useLocation();
-  const browserFields = useBrowserFields(getScopeFromPath(pathname));
+  const pageScope = getScopeFromPath(pathname);
+  const browserFields = useBrowserFields(pageScope);
 
-  useRestoreDataViewManagerStateFromURL(useInitDataViewManager(), getScopeFromPath(pathname));
+  useRestoreDataViewManagerStateFromURL(useInitDataViewManager(), pageScope);
+  useInitExploreDataView();
 
   useUrlState();
   // Interop must run before the restore hook so the legacy param is consumed first.

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSelector, useDispatch } from 'react-redux-v7';
+import { useLocation } from 'react-router-dom';
+import { useInitExploreDataView } from './use_init_explore_data_view';
+import { createExploreDataView } from '../utils/create_explore_data_view';
+import { getScopeFromPath } from '../../sourcerer/containers/sourcerer_paths';
+import { sharedStateSelector } from '../redux/selectors';
+import { sharedDataViewManagerSlice } from '../redux/slices';
+import { selectDataViewAsync } from '../redux/actions';
+import { PageScope } from '../constants';
+
+jest.mock('react-redux-v7', () => ({
+  ...jest.requireActual('react-redux-v7'),
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+}));
+
+jest.mock('../../sourcerer/containers/sourcerer_paths', () => ({
+  getScopeFromPath: jest.fn(),
+}));
+
+jest.mock('../utils/create_explore_data_view', () => ({
+  createExploreDataView: jest.fn(),
+}));
+
+const mockAddDanger = jest.fn();
+
+jest.mock('../../common/lib/kibana', () => ({
+  useKibana: () => ({
+    services: {
+      dataViews: { create: jest.fn() },
+      spaces: { getActiveSpace: async () => ({ id: 'default' }) },
+      notifications: { toasts: { addDanger: mockAddDanger } },
+    },
+  }),
+}));
+
+const mockDispatch = jest.fn();
+const mockExploreDataView = {
+  id: 'explore-data-view-default',
+  isPersisted: () => false,
+  toSpec: () => ({ id: 'explore-data-view-default', title: 'logs-*' }),
+};
+
+// The default security data view title always includes the alerts (signal) index as its last
+// pattern (appended server-side in `initialize_security_data_views`), and the alert data view's
+// title is exactly that same signal index. This mirrors production so the alerts-exclusion filter
+// in `createExploreDataView` is actually exercised.
+const ALERTS_INDEX_PATTERN = '.alerts-security.alerts-default';
+const readySharedState = {
+  status: 'ready' as const,
+  defaultDataViewId: 'default-dv-id',
+  alertDataViewId: 'alert-dv-id',
+  dataViews: [
+    { id: 'default-dv-id', title: `apm-*,auditbeat-*,logs-*,${ALERTS_INDEX_PATTERN}` },
+    { id: 'alert-dv-id', title: ALERTS_INDEX_PATTERN },
+  ],
+  adhocDataViews: [],
+  signalIndex: null,
+};
+
+/**
+ * Order-independent selector mock. The hook reads the explore scope via
+ * `sourcererAdapterSelector(PageScope.explore)` (a freshly created selector on every render)
+ * and the shared state via the stable `sharedStateSelector` reference, so we key off the
+ * latter rather than relying on call order.
+ */
+const mockSelectors = ({
+  exploreScope,
+  shared,
+}: {
+  exploreScope: { dataViewId: string | null };
+  shared: typeof readySharedState;
+}) => {
+  jest.mocked(useSelector).mockImplementation((selector: unknown) => {
+    if (selector === sharedStateSelector) {
+      return shared;
+    }
+    return exploreScope;
+  });
+};
+
+describe('useInitExploreDataView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useDispatch).mockReturnValue(mockDispatch);
+    jest.mocked(createExploreDataView).mockResolvedValue(mockExploreDataView as any);
+    // Default to being on an explore page; individual tests override as needed.
+    jest.mocked(useLocation).mockReturnValue({ pathname: '/hosts' } as ReturnType<
+      typeof useLocation
+    >);
+    jest.mocked(getScopeFromPath).mockReturnValue(PageScope.explore);
+  });
+
+  it('does nothing when not on an explore path, even if explore scope is uninitialized', () => {
+    jest.mocked(getScopeFromPath).mockReturnValue(PageScope.alerts);
+    mockSelectors({ exploreScope: { dataViewId: null }, shared: readySharedState });
+
+    renderHook(() => useInitExploreDataView());
+
+    expect(createExploreDataView).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('creates and dispatches the explore data view when on an explore path and not yet initialized', async () => {
+    mockSelectors({ exploreScope: { dataViewId: null }, shared: readySharedState });
+
+    renderHook(() => useInitExploreDataView());
+
+    // The hook forwards the full default patterns (including the alerts index) plus the alert
+    // pattern; `createExploreDataView` is responsible for filtering the alerts index out.
+    await waitFor(() =>
+      expect(createExploreDataView).toHaveBeenCalledWith(
+        expect.objectContaining({ dataViews: expect.anything(), spaces: expect.anything() }),
+        ['apm-*', 'auditbeat-*', 'logs-*', ALERTS_INDEX_PATTERN],
+        ALERTS_INDEX_PATTERN
+      )
+    );
+
+    await waitFor(() =>
+      expect(mockDispatch).toHaveBeenCalledWith(
+        sharedDataViewManagerSlice.actions.addDataView(mockExploreDataView as any)
+      )
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      selectDataViewAsync({ id: 'explore-data-view-default', scope: PageScope.explore })
+    );
+  });
+
+  it('does nothing when explore scope is already initialized', () => {
+    mockSelectors({
+      exploreScope: { dataViewId: 'explore-data-view-default' },
+      shared: readySharedState,
+    });
+
+    renderHook(() => useInitExploreDataView());
+
+    expect(createExploreDataView).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when shared state is not yet ready', () => {
+    mockSelectors({
+      exploreScope: { dataViewId: null },
+      shared: { ...readySharedState, status: 'pristine' as any },
+    });
+
+    renderHook(() => useInitExploreDataView());
+
+    expect(createExploreDataView).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when default data view id is not available yet', () => {
+    mockSelectors({
+      exploreScope: { dataViewId: null },
+      shared: { ...readySharedState, defaultDataViewId: null as any },
+    });
+
+    renderHook(() => useInitExploreDataView());
+
+    expect(createExploreDataView).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the resolved data view titles are missing from the specs', () => {
+    mockSelectors({
+      exploreScope: { dataViewId: null },
+      // ids are set on the shared state but there is no matching spec with a title
+      shared: { ...readySharedState, dataViews: [] },
+    });
+
+    renderHook(() => useInitExploreDataView());
+
+    expect(createExploreDataView).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a danger toast and does not dispatch when creation fails', async () => {
+    jest.mocked(createExploreDataView).mockRejectedValue(new Error('boom'));
+    mockSelectors({ exploreScope: { dataViewId: null }, shared: readySharedState });
+
+    renderHook(() => useInitExploreDataView());
+
+    await waitFor(() =>
+      expect(mockAddDanger).toHaveBeenCalledWith({
+        title: 'Error initializing the explore data view',
+        text: 'Error: boom',
+      })
+    );
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      sharedDataViewManagerSlice.actions.addDataView(mockExploreDataView as any)
+    );
+  });
+
+  it('does not create a second explore data view when re-rendered before the scope selection resolves', async () => {
+    mockSelectors({ exploreScope: { dataViewId: null }, shared: readySharedState });
+
+    const { rerender } = renderHook(() => useInitExploreDataView());
+
+    // The explore scope selection is applied asynchronously, so `exploreDataViewId` is still
+    // null on re-renders triggered while creation is in flight / just resolved. The init guard
+    // must prevent a duplicate creation.
+    rerender();
+    rerender();
+
+    await waitFor(() => expect(createExploreDataView).toHaveBeenCalled());
+
+    expect(createExploreDataView).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.test.ts
@@ -97,9 +97,9 @@ describe('useInitExploreDataView', () => {
     jest.mocked(useDispatch).mockReturnValue(mockDispatch);
     jest.mocked(createExploreDataView).mockResolvedValue(mockExploreDataView as any);
     // Default to being on an explore page; individual tests override as needed.
-    jest.mocked(useLocation).mockReturnValue({ pathname: '/hosts' } as ReturnType<
-      typeof useLocation
-    >);
+    jest
+      .mocked(useLocation)
+      .mockReturnValue({ pathname: '/hosts' } as ReturnType<typeof useLocation>);
     jest.mocked(getScopeFromPath).mockReturnValue(PageScope.explore);
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.test.ts
@@ -8,6 +8,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useSelector, useDispatch } from 'react-redux-v7';
 import { useLocation } from 'react-router-dom';
+import type { DataView } from '@kbn/data-views-plugin/public';
 import { useInitExploreDataView } from './use_init_explore_data_view';
 import { createExploreDataView } from '../utils/create_explore_data_view';
 import { getScopeFromPath } from '../../sourcerer/containers/sourcerer_paths';
@@ -34,7 +35,6 @@ jest.mock('../utils/create_explore_data_view', () => ({
   createExploreDataView: jest.fn(),
 }));
 
-const mockAddDanger = jest.fn();
 const mockDataViewsGet = jest.fn();
 const mockRefreshFields = jest.fn();
 
@@ -43,7 +43,6 @@ jest.mock('../../common/lib/kibana', () => ({
     services: {
       dataViews: { create: jest.fn(), get: mockDataViewsGet, refreshFields: mockRefreshFields },
       spaces: { getActiveSpace: async () => ({ id: 'default' }) },
-      notifications: { toasts: { addDanger: mockAddDanger } },
     },
   }),
 }));
@@ -60,8 +59,18 @@ const mockExploreDataView = {
 // title is exactly that same signal index. This mirrors production so the alerts-exclusion filter
 // in `createExploreDataView` is actually exercised.
 const ALERTS_INDEX_PATTERN = '.alerts-security.alerts-default';
-const readySharedState = {
-  status: 'ready' as const,
+
+// Explicitly typed so overrides (e.g. status: 'pristine', defaultDataViewId: null) don't require
+// `as any` casts at each call site.
+const readySharedState: {
+  status: 'pristine' | 'loading' | 'error' | 'ready';
+  defaultDataViewId: string | null;
+  alertDataViewId: string | null;
+  dataViews: Array<{ id: string; title: string }>;
+  adhocDataViews: unknown[];
+  signalIndex: null;
+} = {
+  status: 'ready',
   defaultDataViewId: 'default-dv-id',
   alertDataViewId: 'alert-dv-id',
   dataViews: [
@@ -97,7 +106,9 @@ describe('useInitExploreDataView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.mocked(useDispatch).mockReturnValue(mockDispatch);
-    jest.mocked(createExploreDataView).mockResolvedValue(mockExploreDataView as any);
+    jest
+      .mocked(createExploreDataView)
+      .mockResolvedValue(mockExploreDataView as unknown as DataView);
     // Default to being on an explore page; individual tests override as needed.
     jest
       .mocked(useLocation)
@@ -138,7 +149,7 @@ describe('useInitExploreDataView', () => {
 
     await waitFor(() =>
       expect(mockDispatch).toHaveBeenCalledWith(
-        sharedDataViewManagerSlice.actions.addDataView(mockExploreDataView as any)
+        sharedDataViewManagerSlice.actions.addDataView(mockExploreDataView as unknown as DataView)
       )
     );
     expect(mockDispatch).toHaveBeenCalledWith(
@@ -159,9 +170,11 @@ describe('useInitExploreDataView', () => {
     await waitFor(() =>
       expect(mockDataViewsGet).toHaveBeenCalledWith('explore-data-view-default', false)
     );
-    expect(mockRefreshFields).toHaveBeenCalledWith(existingDataView, false);
+    // refreshFields is called without a displayErrors arg so it defaults to true,
+    // enabling the platform's own "Error fetching fields" toast on failure.
+    expect(mockRefreshFields).toHaveBeenCalledWith(existingDataView);
     expect(mockDispatch).toHaveBeenCalledWith(
-      sharedDataViewManagerSlice.actions.addDataView(existingDataView as any)
+      sharedDataViewManagerSlice.actions.addDataView(existingDataView as unknown as DataView)
     );
     expect(mockDispatch).toHaveBeenCalledWith(
       selectDataViewAsync({ id: 'explore-data-view-default', scope: PageScope.explore })
@@ -204,7 +217,7 @@ describe('useInitExploreDataView', () => {
   it('does nothing when shared state is not yet ready', () => {
     mockSelectors({
       exploreScope: { dataViewId: null },
-      shared: { ...readySharedState, status: 'pristine' as any },
+      shared: { ...readySharedState, status: 'pristine' },
     });
 
     renderHook(() => useInitExploreDataView());
@@ -215,7 +228,7 @@ describe('useInitExploreDataView', () => {
   it('does nothing when default data view id is not available yet', () => {
     mockSelectors({
       exploreScope: { dataViewId: null },
-      shared: { ...readySharedState, defaultDataViewId: null as any },
+      shared: { ...readySharedState, defaultDataViewId: null },
     });
 
     renderHook(() => useInitExploreDataView());
@@ -235,21 +248,18 @@ describe('useInitExploreDataView', () => {
     expect(createExploreDataView).not.toHaveBeenCalled();
   });
 
-  it('surfaces a danger toast and does not dispatch when creation fails', async () => {
+  it('does not dispatch when creation fails, allowing a retry on the next dependency change', async () => {
+    // The platform's own toast (shown via refreshFields with displayErrors=true) is the
+    // user-facing feedback on failure — the hook's catch block no longer adds its own toast.
     jest.mocked(createExploreDataView).mockRejectedValue(new Error('boom'));
     mockSelectors({ exploreScope: { dataViewId: null }, shared: readySharedState });
 
     renderHook(() => useInitExploreDataView());
 
-    await waitFor(() =>
-      expect(mockAddDanger).toHaveBeenCalledWith({
-        title: 'Error initializing the explore data view',
-        text: 'Error: boom',
-      })
-    );
+    await waitFor(() => expect(createExploreDataView).toHaveBeenCalled());
 
     expect(mockDispatch).not.toHaveBeenCalledWith(
-      sharedDataViewManagerSlice.actions.addDataView(mockExploreDataView as any)
+      sharedDataViewManagerSlice.actions.addDataView(expect.anything())
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.test.ts
@@ -35,11 +35,13 @@ jest.mock('../utils/create_explore_data_view', () => ({
 }));
 
 const mockAddDanger = jest.fn();
+const mockDataViewsGet = jest.fn();
+const mockRefreshFields = jest.fn();
 
 jest.mock('../../common/lib/kibana', () => ({
   useKibana: () => ({
     services: {
-      dataViews: { create: jest.fn() },
+      dataViews: { create: jest.fn(), get: mockDataViewsGet, refreshFields: mockRefreshFields },
       spaces: { getActiveSpace: async () => ({ id: 'default' }) },
       notifications: { toasts: { addDanger: mockAddDanger } },
     },
@@ -101,6 +103,12 @@ describe('useInitExploreDataView', () => {
       .mocked(useLocation)
       .mockReturnValue({ pathname: '/hosts' } as ReturnType<typeof useLocation>);
     jest.mocked(getScopeFromPath).mockReturnValue(PageScope.explore);
+    // By default the already-registered explore DV has fields, so the refresh path is a no-op.
+    mockDataViewsGet.mockResolvedValue({
+      id: 'explore-data-view-default',
+      fields: [{ name: '@timestamp' }],
+    });
+    mockRefreshFields.mockResolvedValue(undefined);
   });
 
   it('does nothing when not on an explore path, even if explore scope is uninitialized', () => {
@@ -136,6 +144,50 @@ describe('useInitExploreDataView', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       selectDataViewAsync({ id: 'explore-data-view-default', scope: PageScope.explore })
     );
+  });
+
+  it('refreshes fields on the existing explore data view when it has none', async () => {
+    const existingDataView = { id: 'explore-data-view-default', fields: [] as unknown[] };
+    mockDataViewsGet.mockResolvedValue(existingDataView);
+    mockSelectors({
+      exploreScope: { dataViewId: 'explore-data-view-default' },
+      shared: readySharedState,
+    });
+
+    renderHook(() => useInitExploreDataView());
+
+    await waitFor(() =>
+      expect(mockDataViewsGet).toHaveBeenCalledWith('explore-data-view-default', false)
+    );
+    expect(mockRefreshFields).toHaveBeenCalledWith(existingDataView, false);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      sharedDataViewManagerSlice.actions.addDataView(existingDataView as any)
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      selectDataViewAsync({ id: 'explore-data-view-default', scope: PageScope.explore })
+    );
+    // The DV already exists — it must not be created from scratch.
+    expect(createExploreDataView).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the existing explore data view already has fields', async () => {
+    mockDataViewsGet.mockResolvedValue({
+      id: 'explore-data-view-default',
+      fields: [{ name: '@timestamp' }],
+    });
+    mockSelectors({
+      exploreScope: { dataViewId: 'explore-data-view-default' },
+      shared: readySharedState,
+    });
+
+    renderHook(() => useInitExploreDataView());
+
+    await waitFor(() =>
+      expect(mockDataViewsGet).toHaveBeenCalledWith('explore-data-view-default', false)
+    );
+    expect(mockRefreshFields).not.toHaveBeenCalled();
+    expect(createExploreDataView).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('does nothing when explore scope is already initialized', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.ts
@@ -8,23 +8,29 @@
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux-v7';
 import { useLocation } from 'react-router-dom';
+import { i18n } from '@kbn/i18n';
 import { PageScope } from '../constants';
 import { sourcererAdapterSelector, sharedStateSelector } from '../redux/selectors';
 import { sharedDataViewManagerSlice } from '../redux/slices';
 import { selectDataViewAsync } from '../redux/actions';
 import { createExploreDataView } from '../utils/create_explore_data_view';
+import { loadDataViewFields } from '../utils/load_data_view_fields';
 import { useKibana } from '../../common/lib/kibana';
 import { getScopeFromPath } from '../../sourcerer/containers/sourcerer_paths';
 
 /**
- * Lazily initializes the explore data view scope.
+ * Lazily loads the explore data view fields when the user lands on an explore page.
  *
- * This hook is a no-op when the user is not on an explore page (Hosts, Users, Network). When the
- * user is on an explore page and the explore scope has not yet been initialized, it creates the
- * explore data view from the default data view patterns and dispatches the scope selection.
+ * This hook is a no-op unless the user is on an explore page (Hosts, Users, Network). The explore
+ * data view is normally created ahead of time by the init listener with `skipFetchFields:true`, so
+ * that broad index patterns don't trigger expensive `_field_caps` requests on unrelated pages such
+ * as Alerts or Dashboards. When the user actually navigates to an explore page, this hook:
+ * - refreshes the fields on the already-registered explore data view (the common path), or
+ * - creates the explore data view from scratch as a fallback, if the init listener's eager
+ *   creation failed.
  *
- * This avoids fetching large _field_caps responses for broad index patterns on unrelated
- * pages such as Alerts or Dashboards.
+ * On success the refreshed/created data view is dispatched to the store and selected for the
+ * explore scope. On failure a danger toast is surfaced, since the user is on a page that needs it.
  */
 export const useInitExploreDataView = (): void => {
   const {
@@ -52,11 +58,6 @@ export const useInitExploreDataView = (): void => {
       return;
     }
 
-    // Already initialized
-    if (exploreDataViewId) {
-      return;
-    }
-
     // Shared state not ready yet — default/alert DV IDs not available
     if (status !== 'ready' || !defaultDataViewId || !alertDataViewId) {
       return;
@@ -78,14 +79,26 @@ export const useInitExploreDataView = (): void => {
 
     (async () => {
       try {
-        const exploreDataView = await createExploreDataView(
-          { dataViews, spaces },
-          defaultDataViewTitle.split(','),
-          alertDataViewTitle
-        );
+        if (exploreDataViewId) {
+          // The init listener created the DV with skipFetchFields:true — refresh fields now
+          // that we know the user is on an explore page and actually needs them. Returns null
+          // (a no-op) if the fields are already populated, e.g. the user revisited the page.
+          const refreshedDV = await loadDataViewFields(dataViews, exploreDataViewId);
+          if (refreshedDV) {
+            dispatch(sharedDataViewManagerSlice.actions.addDataView(refreshedDV));
+            dispatch(selectDataViewAsync({ id: refreshedDV.id, scope: PageScope.explore }));
+          }
+        } else {
+          // Init listener failed to register the explore DV — create from scratch.
+          const exploreDataView = await createExploreDataView(
+            { dataViews, spaces },
+            defaultDataViewTitle.split(','),
+            alertDataViewTitle
+          );
 
-        dispatch(sharedDataViewManagerSlice.actions.addDataView(exploreDataView));
-        dispatch(selectDataViewAsync({ id: exploreDataView.id, scope: PageScope.explore }));
+          dispatch(sharedDataViewManagerSlice.actions.addDataView(exploreDataView));
+          dispatch(selectDataViewAsync({ id: exploreDataView.id, scope: PageScope.explore }));
+        }
 
         // NOTE: intentionally leave `isInitializingRef` set on success. The explore scope
         // selection is applied asynchronously (via the `selectDataViewAsync` listener), so
@@ -96,8 +109,17 @@ export const useInitExploreDataView = (): void => {
         // Allow a retry on the next dependency change if creation failed.
         isInitializingRef.current = false;
         notifications.toasts.addDanger({
-          title: 'Error initializing the explore data view',
-          text: `Error: ${error instanceof Error ? error.message : 'unknown'}`,
+          title: i18n.translate(
+            'xpack.securitySolution.dataViewManager.exploreDataView.initErrorTitle',
+            { defaultMessage: 'Error initializing the explore data view' }
+          ),
+          text: i18n.translate(
+            'xpack.securitySolution.dataViewManager.exploreDataView.initErrorText',
+            {
+              defaultMessage: 'Error: {errorMessage}',
+              values: { errorMessage: error instanceof Error ? error.message : 'unknown' },
+            }
+          ),
         });
       }
     })();

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux-v7';
+import { useLocation } from 'react-router-dom';
+import { PageScope } from '../constants';
+import { sourcererAdapterSelector, sharedStateSelector } from '../redux/selectors';
+import { sharedDataViewManagerSlice } from '../redux/slices';
+import { selectDataViewAsync } from '../redux/actions';
+import { createExploreDataView } from '../utils/create_explore_data_view';
+import { useKibana } from '../../common/lib/kibana';
+import { getScopeFromPath } from '../../sourcerer/containers/sourcerer_paths';
+
+/**
+ * Lazily initializes the explore data view scope.
+ *
+ * This hook is a no-op when the user is not on an explore page (Hosts, Users, Network). When the
+ * user is on an explore page and the explore scope has not yet been initialized, it creates the
+ * explore data view from the default data view patterns and dispatches the scope selection.
+ *
+ * This avoids fetching large _field_caps responses for broad index patterns on unrelated
+ * pages such as Alerts or Dashboards.
+ */
+export const useInitExploreDataView = (): void => {
+  const {
+    services: { dataViews, spaces, notifications },
+  } = useKibana();
+
+  const { pathname } = useLocation();
+  const isExplorePath = getScopeFromPath(pathname) === PageScope.explore;
+
+  const dispatch = useDispatch();
+  const { dataViewId: exploreDataViewId } = useSelector(
+    sourcererAdapterSelector(PageScope.explore)
+  );
+  const {
+    defaultDataViewId,
+    alertDataViewId,
+    dataViews: dataViewSpecs,
+    status,
+  } = useSelector(sharedStateSelector);
+
+  const isInitializingRef = useRef(false);
+
+  useEffect(() => {
+    if (!isExplorePath) {
+      return;
+    }
+
+    // Already initialized
+    if (exploreDataViewId) {
+      return;
+    }
+
+    // Shared state not ready yet — default/alert DV IDs not available
+    if (status !== 'ready' || !defaultDataViewId || !alertDataViewId) {
+      return;
+    }
+
+    // Prevent concurrent init attempts
+    if (isInitializingRef.current) {
+      return;
+    }
+
+    const defaultDataViewTitle = dataViewSpecs.find((dv) => dv.id === defaultDataViewId)?.title;
+    const alertDataViewTitle = dataViewSpecs.find((dv) => dv.id === alertDataViewId)?.title;
+
+    if (!defaultDataViewTitle || !alertDataViewTitle) {
+      return;
+    }
+
+    isInitializingRef.current = true;
+
+    (async () => {
+      try {
+        const exploreDataView = await createExploreDataView(
+          { dataViews, spaces },
+          defaultDataViewTitle.split(','),
+          alertDataViewTitle
+        );
+
+        dispatch(sharedDataViewManagerSlice.actions.addDataView(exploreDataView));
+        dispatch(selectDataViewAsync({ id: exploreDataView.id, scope: PageScope.explore }));
+
+        // NOTE: intentionally leave `isInitializingRef` set on success. The explore scope
+        // selection is applied asynchronously (via the `selectDataViewAsync` listener), so
+        // `exploreDataViewId` is not yet populated at this point. Keeping the guard set
+        // prevents a re-render (e.g. triggered by `addDataView` updating the shared state)
+        // from creating and dispatching a duplicate explore data view.
+      } catch (error: unknown) {
+        // Allow a retry on the next dependency change if creation failed.
+        isInitializingRef.current = false;
+        notifications.toasts.addDanger({
+          title: 'Error initializing the explore data view',
+          text: `Error: ${error instanceof Error ? error.message : 'unknown'}`,
+        });
+      }
+    })();
+  }, [
+    isExplorePath,
+    exploreDataViewId,
+    status,
+    defaultDataViewId,
+    alertDataViewId,
+    dataViewSpecs,
+    dataViews,
+    spaces,
+    notifications,
+    dispatch,
+  ]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_explore_data_view.ts
@@ -8,7 +8,6 @@
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux-v7';
 import { useLocation } from 'react-router-dom';
-import { i18n } from '@kbn/i18n';
 import { PageScope } from '../constants';
 import { sourcererAdapterSelector, sharedStateSelector } from '../redux/selectors';
 import { sharedDataViewManagerSlice } from '../redux/slices';
@@ -30,11 +29,12 @@ import { getScopeFromPath } from '../../sourcerer/containers/sourcerer_paths';
  *   creation failed.
  *
  * On success the refreshed/created data view is dispatched to the store and selected for the
- * explore scope. On failure a danger toast is surfaced, since the user is on a page that needs it.
+ * explore scope. On failure the platform's own "Error fetching fields" toast is shown (via
+ * `refreshFields` with `displayErrors` defaulting to `true`) — no additional handling is needed.
  */
 export const useInitExploreDataView = (): void => {
   const {
-    services: { dataViews, spaces, notifications },
+    services: { dataViews, spaces },
   } = useKibana();
 
   const { pathname } = useLocation();
@@ -105,22 +105,10 @@ export const useInitExploreDataView = (): void => {
         // `exploreDataViewId` is not yet populated at this point. Keeping the guard set
         // prevents a re-render (e.g. triggered by `addDataView` updating the shared state)
         // from creating and dispatching a duplicate explore data view.
-      } catch (error: unknown) {
-        // Allow a retry on the next dependency change if creation failed.
+      } catch {
+        // Allow a retry on the next dependency change if field loading failed.
+        // The platform's own toast (shown by refreshFields) is the user-facing feedback.
         isInitializingRef.current = false;
-        notifications.toasts.addDanger({
-          title: i18n.translate(
-            'xpack.securitySolution.dataViewManager.exploreDataView.initErrorTitle',
-            { defaultMessage: 'Error initializing the explore data view' }
-          ),
-          text: i18n.translate(
-            'xpack.securitySolution.dataViewManager.exploreDataView.initErrorText',
-            {
-              defaultMessage: 'Error: {errorMessage}',
-              values: { errorMessage: error instanceof Error ? error.message : 'unknown' },
-            }
-          ),
-        });
       }
     })();
   }, [
@@ -132,7 +120,6 @@ export const useInitExploreDataView = (): void => {
     dataViewSpecs,
     dataViews,
     spaces,
-    notifications,
     dispatch,
   ]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -7,6 +7,7 @@
 
 import { createDataViewSelectedListener } from './data_view_selected';
 import { selectDataViewAsync } from '../actions';
+import { sharedDataViewManagerSlice } from '../slices';
 import type { DataViewsServicePublic, FieldSpec } from '@kbn/data-views-plugin/public';
 import type { AnyAction, Dispatch, ListenerEffectAPI } from 'redux-toolkit-v1';
 import type { RootState } from '../reducer';
@@ -23,6 +24,8 @@ const mockDataViewsService = {
     isPersisted: () => false,
     toSpec: () => ({ id: 'adhoc_test-*', title: 'test-*' }),
   }),
+  get: jest.fn(),
+  refreshFields: jest.fn(),
 } as unknown as DataViewsServicePublic;
 
 const mockedState: RootState = {
@@ -62,6 +65,14 @@ const mockedState: RootState = {
               type: 'date',
             } as unknown as FieldSpec,
           },
+        },
+        {
+          // Ad-hoc data view registered without fields (e.g. the explore DV created with
+          // skipFetchFields:true at init). Used to exercise the lazy field-loading branch.
+          id: 'adhoc_no-fields-*',
+          title: 'no-fields-*',
+          name: 'Friendly view name',
+          fields: {},
         },
       ],
       dataViews: [
@@ -292,5 +303,59 @@ describe('createDataViewSelectedListener', () => {
     expect(mockStorage.remove).toHaveBeenCalledWith(
       'securitySolution.dataViewManager.selectedDataView.default.analyzer'
     );
+  });
+
+  describe('lazy field loading for ad-hoc data views without fields', () => {
+    it('loads fields and dispatches the refreshed data view when the selected ad-hoc DV has none', async () => {
+      const refreshedDataView = { id: 'adhoc_no-fields-*', fields: [] as unknown[] };
+      jest.mocked(mockDataViewsService.get).mockResolvedValue(refreshedDataView as never);
+
+      await listener.effect(
+        selectDataViewAsync({ id: 'adhoc_no-fields-*', scope: PageScope.default }),
+        mockListenerApi
+      );
+
+      expect(mockDataViewsService.get).toHaveBeenCalledWith('adhoc_no-fields-*', false);
+      expect(mockDataViewsService.refreshFields).toHaveBeenCalledWith(refreshedDataView, false);
+      expect(mockDispatch).toHaveBeenCalledWith(
+        sharedDataViewManagerSlice.actions.addDataView(refreshedDataView as never)
+      );
+      expect(mockToastsDanger).not.toHaveBeenCalled();
+    });
+
+    it('does not load fields for the explore scope (useInitExploreDataView owns that)', async () => {
+      const exploreListener = createDataViewSelectedListener({
+        dataViews: mockDataViewsService,
+        notifications: {
+          toasts: { addDanger: mockToastsDanger },
+        } as unknown as CoreStart['notifications'],
+        scope: PageScope.explore,
+        spaces: mockSpaces,
+        storage: mockStorage,
+      });
+
+      await exploreListener.effect(
+        selectDataViewAsync({ id: 'adhoc_no-fields-*', scope: PageScope.explore }),
+        mockListenerApi
+      );
+
+      expect(mockDataViewsService.get).not.toHaveBeenCalled();
+      expect(mockDataViewsService.refreshFields).not.toHaveBeenCalled();
+      expect(mockToastsDanger).not.toHaveBeenCalled();
+    });
+
+    it('shows a toast using the friendly name when field loading fails', async () => {
+      jest.mocked(mockDataViewsService.get).mockRejectedValue(new Error('field caps too large'));
+
+      await listener.effect(
+        selectDataViewAsync({ id: 'adhoc_no-fields-*', scope: PageScope.default }),
+        mockListenerApi
+      );
+
+      expect(mockToastsDanger).toHaveBeenCalledWith({
+        title: 'Error loading data view fields',
+        text: 'Unable to load fields for "Friendly view name". field caps too large',
+      });
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -316,7 +316,9 @@ describe('createDataViewSelectedListener', () => {
       );
 
       expect(mockDataViewsService.get).toHaveBeenCalledWith('adhoc_no-fields-*', false);
-      expect(mockDataViewsService.refreshFields).toHaveBeenCalledWith(refreshedDataView, false);
+      // Called without a displayErrors arg (defaults to true) so the platform shows its own
+      // "Error fetching fields" toast on failure rather than re-throwing.
+      expect(mockDataViewsService.refreshFields).toHaveBeenCalledWith(refreshedDataView);
       expect(mockDispatch).toHaveBeenCalledWith(
         sharedDataViewManagerSlice.actions.addDataView(refreshedDataView as never)
       );
@@ -344,7 +346,9 @@ describe('createDataViewSelectedListener', () => {
       expect(mockToastsDanger).not.toHaveBeenCalled();
     });
 
-    it('shows a toast using the friendly name when field loading fails', async () => {
+    it('does not dispatch and does not show a custom toast when field loading fails', async () => {
+      // refreshFields uses displayErrors=true (the default) so the platform's own
+      // "Error fetching fields" toast is shown — no additional toast from this listener.
       jest.mocked(mockDataViewsService.get).mockRejectedValue(new Error('field caps too large'));
 
       await listener.effect(
@@ -352,10 +356,10 @@ describe('createDataViewSelectedListener', () => {
         mockListenerApi
       );
 
-      expect(mockToastsDanger).toHaveBeenCalledWith({
-        title: 'Error loading data view fields',
-        text: 'Unable to load fields for "Friendly view name". field caps too large',
-      });
+      expect(mockToastsDanger).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        sharedDataViewManagerSlice.actions.addDataView(expect.anything())
+      );
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -10,7 +10,6 @@ import type { AnyAction, Dispatch, ListenerEffectAPI } from 'redux-toolkit-v1';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { isEmpty } from 'lodash';
-import { i18n } from '@kbn/i18n';
 import type { CoreStart } from '@kbn/core/public';
 import type { RootState } from '../reducer';
 import { scopes } from '../reducer';
@@ -167,11 +166,11 @@ export const createDataViewSelectedListener = (dependencies: {
         // data view, which is registered at init with skipFetchFields:true to avoid expensive
         // _field_caps requests on pages like Alerts), load the fields now that the user has
         // actively selected it. On success, Redux is updated so the UI re-renders with fields.
-        // On failure, a toast is shown so the user knows why the data view appears empty.
+        // On failure, the platform's "Error fetching fields" toast (with "See the full error")
+        // is shown automatically via refreshFields — no additional handling needed here.
         //
         // NOTE: skip this for PageScope.explore — useInitExploreDataView owns field loading
-        // for that scope and will surface an appropriate toast when the user navigates to an
-        // explore page. Doing it here would fire a toast from background init, not user action.
+        // for that scope. Doing it here would fire a toast from background init, not user action.
         const resolvedAdHocSpec = state.dataViewManager.shared.adhocDataViews.find(
           (dv) => dv.id === resolvedIdToUse
         );
@@ -194,23 +193,9 @@ export const createDataViewSelectedListener = (dependencies: {
                 sharedDataViewManagerSlice.actions.addDataView(refreshedDataView)
               );
             }
-          } catch (error: unknown) {
-            // Prefer the human-friendly `name` (e.g. "Security solution explore") over `title`,
-            // which is the raw comma-joined index pattern.
-            const dataViewLabel =
-              resolvedAdHocSpec.name ?? resolvedAdHocSpec.title ?? resolvedIdToUse;
-            dependencies.notifications.toasts.addDanger({
-              title: i18n.translate('xpack.securitySolution.dataViewManager.loadFieldsErrorTitle', {
-                defaultMessage: 'Error loading data view fields',
-              }),
-              text: i18n.translate('xpack.securitySolution.dataViewManager.loadFieldsErrorText', {
-                defaultMessage: 'Unable to load fields for "{dataViewLabel}". {errorMessage}',
-                values: {
-                  dataViewLabel,
-                  errorMessage: error instanceof Error ? error.message : '',
-                },
-              }),
-            });
+          } catch {
+            // The platform surfaces its own "Error fetching fields" toast (with a "See the full
+            // error" button) via refreshFields — no additional toast needed here.
           }
         }
       } else if (dataViewByIdError || adhocDataViewCreationError) {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -10,6 +10,7 @@ import type { AnyAction, Dispatch, ListenerEffectAPI } from 'redux-toolkit-v1';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { isEmpty } from 'lodash';
+import { i18n } from '@kbn/i18n';
 import type { CoreStart } from '@kbn/core/public';
 import type { RootState } from '../reducer';
 import { scopes } from '../reducer';
@@ -17,6 +18,7 @@ import { selectDataViewAsync } from '../actions';
 import { sharedDataViewManagerSlice } from '../slices';
 import { PageScope } from '../../constants';
 import { getSelectedDataViewStorageKey } from './storage_keys';
+import { loadDataViewFields } from '../../utils/load_data_view_fields';
 
 /**
  * Creates a Redux listener for handling data view selection logic in the data view manager.
@@ -159,6 +161,57 @@ export const createDataViewSelectedListener = (dependencies: {
             getSelectedDataViewStorageKey(spaceId, action.payload.scope),
             resolvedIdToUse
           );
+        }
+
+        // If the resolved data view is an ad-hoc DV with no fields loaded (e.g. the explore
+        // data view, which is registered at init with skipFetchFields:true to avoid expensive
+        // _field_caps requests on pages like Alerts), load the fields now that the user has
+        // actively selected it. On success, Redux is updated so the UI re-renders with fields.
+        // On failure, a toast is shown so the user knows why the data view appears empty.
+        //
+        // NOTE: skip this for PageScope.explore — useInitExploreDataView owns field loading
+        // for that scope and will surface an appropriate toast when the user navigates to an
+        // explore page. Doing it here would fire a toast from background init, not user action.
+        const resolvedAdHocSpec = state.dataViewManager.shared.adhocDataViews.find(
+          (dv) => dv.id === resolvedIdToUse
+        );
+
+        if (
+          action.payload.scope !== PageScope.explore &&
+          resolvedAdHocSpec &&
+          isEmpty(resolvedAdHocSpec.fields)
+        ) {
+          try {
+            if (listenerApi.signal.aborted) {
+              return;
+            }
+            const refreshedDataView = await loadDataViewFields(
+              dependencies.dataViews,
+              resolvedIdToUse
+            );
+            if (refreshedDataView) {
+              listenerApi.dispatch(
+                sharedDataViewManagerSlice.actions.addDataView(refreshedDataView)
+              );
+            }
+          } catch (error: unknown) {
+            // Prefer the human-friendly `name` (e.g. "Security solution explore") over `title`,
+            // which is the raw comma-joined index pattern.
+            const dataViewLabel =
+              resolvedAdHocSpec.name ?? resolvedAdHocSpec.title ?? resolvedIdToUse;
+            dependencies.notifications.toasts.addDanger({
+              title: i18n.translate('xpack.securitySolution.dataViewManager.loadFieldsErrorTitle', {
+                defaultMessage: 'Error loading data view fields',
+              }),
+              text: i18n.translate('xpack.securitySolution.dataViewManager.loadFieldsErrorText', {
+                defaultMessage: 'Unable to load fields for "{dataViewLabel}". {errorMessage}',
+                values: {
+                  dataViewLabel,
+                  errorMessage: error instanceof Error ? error.message : '',
+                },
+              }),
+            });
+          }
         }
       } else if (dataViewByIdError || adhocDataViewCreationError) {
         const err = dataViewByIdError || adhocDataViewCreationError;

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -179,6 +179,14 @@ describe('createInitListener', () => {
       selectDataViewAsync(expect.objectContaining({ scope: PageScope.explore }))
     );
 
+    // explore DV is created with skipFetchFields:true to avoid expensive _field_caps on non-explore pages
+    expect(jest.mocked(createExploreDataView)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      { skipFetchFields: true }
+    );
+
     expect(mockToastsDanger).not.toHaveBeenCalled();
   });
 
@@ -196,6 +204,24 @@ describe('createInitListener', () => {
     expect(jest.mocked(mockListenerApi.dispatch)).not.toBeCalledWith(
       selectDataViewAsync(expect.objectContaining({ scope: PageScope.explore }))
     );
+    expect(mockToastsDanger).not.toHaveBeenCalled();
+  });
+
+  it('should swallow explore data view creation errors without dispatching error action', async () => {
+    jest.mocked(createExploreDataView).mockRejectedValue(new Error('field caps too large'));
+    jest.mocked(mockDataViewsService.getIdsWithTitle).mockResolvedValue([]);
+
+    await listener.effect(sharedDataViewManagerSlice.actions.init([]), mockListenerApi);
+
+    // Main init should still succeed
+    expect(jest.mocked(createDefaultDataView)).toHaveBeenCalled();
+
+    // Error action should NOT be dispatched
+    expect(jest.mocked(mockListenerApi.dispatch)).not.toBeCalledWith(
+      sharedDataViewManagerSlice.actions.error()
+    );
+
+    // Toast should NOT be shown
     expect(mockToastsDanger).not.toHaveBeenCalled();
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -20,10 +20,21 @@ import { selectDataViewAsync } from '../actions';
 import type { CoreStart } from '@kbn/core/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { createDefaultDataView } from '../../utils/create_default_data_view';
+import { createExploreDataView } from '../../utils/create_explore_data_view';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 
 jest.mock('../../utils/create_default_data_view', () => ({
   createDefaultDataView: jest.fn(),
+}));
+
+const mockExploreDataView = {
+  id: 'explore-dv-id',
+  isPersisted: () => false,
+  toSpec: () => ({ id: 'explore-dv-id', title: 'apm-*,auditbeat-*', managed: true }),
+};
+
+jest.mock('../../utils/create_explore_data_view', () => ({
+  createExploreDataView: jest.fn(),
 }));
 
 const mockDataViewsService = {
@@ -66,6 +77,8 @@ describe('createInitListener', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    jest.mocked(createExploreDataView).mockResolvedValue(mockExploreDataView as any);
 
     jest.mocked(createDefaultDataView).mockResolvedValue({
       defaultDataView: { id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, title: '' },
@@ -161,11 +174,28 @@ describe('createInitListener', () => {
       })
     );
 
-    // explore scope is intentionally deferred — useInitExploreDataView handles it lazily
-    expect(jest.mocked(mockListenerApi.dispatch)).not.toBeCalledWith(
+    // explore scope is created eagerly so it appears in data view pickers across the app
+    expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       selectDataViewAsync(expect.objectContaining({ scope: PageScope.explore }))
     );
 
+    expect(mockToastsDanger).not.toHaveBeenCalled();
+  });
+
+  it('silently swallows explore data view creation failure without showing an error modal', async () => {
+    jest.mocked(createExploreDataView).mockRejectedValue(new Error('_field_caps response too large'));
+
+    await listener.effect(sharedDataViewManagerSlice.actions.init([]), mockListenerApi);
+
+    // Other scopes must still be initialized correctly
+    expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
+      selectDataViewAsync({ id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, scope: PageScope.default })
+    );
+
+    // Explore scope failure must not surface a modal — useInitExploreDataView retries on explore pages
+    expect(jest.mocked(mockListenerApi.dispatch)).not.toBeCalledWith(
+      selectDataViewAsync(expect.objectContaining({ scope: PageScope.explore }))
+    );
     expect(mockToastsDanger).not.toHaveBeenCalled();
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -160,6 +160,12 @@ describe('createInitListener', () => {
         scope: PageScope.analyzer,
       })
     );
+
+    // explore scope is intentionally deferred — useInitExploreDataView handles it lazily
+    expect(jest.mocked(mockListenerApi.dispatch)).not.toBeCalledWith(
+      selectDataViewAsync(expect.objectContaining({ scope: PageScope.explore }))
+    );
+
     expect(mockToastsDanger).not.toHaveBeenCalled();
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -191,7 +191,9 @@ describe('createInitListener', () => {
   });
 
   it('silently swallows explore data view creation failure without showing an error modal', async () => {
-    jest.mocked(createExploreDataView).mockRejectedValue(new Error('_field_caps response too large'));
+    jest
+      .mocked(createExploreDataView)
+      .mockRejectedValue(new Error('_field_caps response too large'));
 
     await listener.effect(sharedDataViewManagerSlice.actions.init([]), mockListenerApi);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -8,7 +8,7 @@
 import type { AnyAction, Dispatch, ListenerEffectAPI } from 'redux-toolkit-v1';
 import { mockDataViewManagerState } from '../mock';
 import { createInitListener } from './init_listener';
-import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
+import type { DataView, DataViewsServicePublic } from '@kbn/data-views-plugin/public';
 import type { RootState } from '../reducer';
 import { sharedDataViewManagerSlice } from '../slices';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../../constants';
@@ -78,7 +78,9 @@ describe('createInitListener', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    jest.mocked(createExploreDataView).mockResolvedValue(mockExploreDataView as any);
+    jest
+      .mocked(createExploreDataView)
+      .mockResolvedValue(mockExploreDataView as unknown as DataView);
 
     jest.mocked(createDefaultDataView).mockResolvedValue({
       defaultDataView: { id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, title: '' },

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -15,7 +15,6 @@ import { sharedDataViewManagerSlice } from '../slices';
 import { PageScope } from '../../constants';
 import { selectDataViewAsync } from '../actions';
 import { createDefaultDataView } from '../../utils/create_default_data_view';
-import { createExploreDataView } from '../../utils/create_explore_data_view';
 import { getSelectedDataViewStorageKey } from './storage_keys';
 import type { DataViewSpec } from '../types';
 
@@ -23,12 +22,20 @@ import type { DataViewSpec } from '../types';
  * Creates a Redux listener for initializing the Data View Manager state.
  *
  * This listener is responsible for:
- * - Creating and preloading the default security data view using the provided dependencies.
+ * - Creating and preloading the default, alert, and attack security data views using the provided dependencies.
  * - Fetching all available data views and dispatching them to the store for use in selectors.
- * - Preloading the default data view for all defined scopes (detections, analyzer, timeline, default),
- *   but only for those scopes that have not already been initialized.
+ * - Preloading a data view for the `alerts`, `attacks`, `analyzer`, `timeline`, and `default` scopes,
+ *   but only for those scopes that have not already been initialized. For each of these scopes the
+ *   selection is resolved as follows:
+ *   - `attacks` is always preloaded with the dedicated attack data view.
+ *   - other scopes use the data view id previously persisted in storage for the active space, if present,
+ *     otherwise they fall back to the default data view.
  * - Handling any additional data view selections provided in the action payload (e.g., from URL storage).
- * - Dispatching an error action if initialization fails.
+ * - Dispatching an error action (and showing a danger toast) if initialization fails.
+ *
+ * The `explore` scope is intentionally NOT preloaded here — its data view is created lazily by
+ * `useInitExploreDataView` when the user navigates to an explore page (Hosts, Users, Network), to avoid
+ * fetching large `_field_caps` responses for broad index patterns on unrelated pages (e.g. Alerts).
  *
  * The listener ensures that race conditions are avoided by only initializing scopes that are not already set,
  * and that state is not reset for slices that already have selections.
@@ -59,18 +66,6 @@ export const createInitListener = (dependencies: {
           application: dependencies.application,
           http: dependencies.http,
         });
-
-        const exploreDataView = await createExploreDataView(
-          {
-            dataViews: dependencies.dataViews,
-            spaces: dependencies.spaces,
-          },
-          defaultDataView.title.split(','),
-          alertDataView.title
-        );
-
-        // Store the created data views in the Redux state
-        listenerApi.dispatch(sharedDataViewManagerSlice.actions.addDataView(exploreDataView));
 
         // NOTE: This is later used in the data view manager drop-down selector
         // We're using getIdsWithTitle instead of getAllDataViewLazy because to avoid a bug that happens in the savedObject api where id conflicts can happen between documents
@@ -107,20 +102,13 @@ export const createInitListener = (dependencies: {
           PageScope.analyzer,
           PageScope.timeline,
           PageScope.default,
-          PageScope.explore,
+          // NOTE: explore scope is intentionally omitted here — the explore data view
+          // is created lazily when the user navigates to an explore page (Hosts, Users, Network)
+          // to avoid fetching large _field_caps responses on unrelated pages (e.g. Alerts).
         ]
           // NOTE: only init default data view for slices that are not initialized yet
           .filter((scope) => !listenerApi.getState().dataViewManager[scope].dataViewId)
           .forEach((scope) => {
-            if (scope === PageScope.explore) {
-              return listenerApi.dispatch(
-                selectDataViewAsync({
-                  id: exploreDataView.id,
-                  scope,
-                })
-              );
-            }
-
             if (scope === PageScope.attacks) {
               return listenerApi.dispatch(
                 selectDataViewAsync({

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -15,6 +15,7 @@ import { sharedDataViewManagerSlice } from '../slices';
 import { PageScope } from '../../constants';
 import { selectDataViewAsync } from '../actions';
 import { createDefaultDataView } from '../../utils/create_default_data_view';
+import { createExploreDataView } from '../../utils/create_explore_data_view';
 import { getSelectedDataViewStorageKey } from './storage_keys';
 import type { DataViewSpec } from '../types';
 
@@ -33,9 +34,12 @@ import type { DataViewSpec } from '../types';
  * - Handling any additional data view selections provided in the action payload (e.g., from URL storage).
  * - Dispatching an error action (and showing a danger toast) if initialization fails.
  *
- * The `explore` scope is intentionally NOT preloaded here — its data view is created lazily by
- * `useInitExploreDataView` when the user navigates to an explore page (Hosts, Users, Network), to avoid
- * fetching large `_field_caps` responses for broad index patterns on unrelated pages (e.g. Alerts).
+ * The `explore` scope is handled separately from the main scopes loop. The explore data view is
+ * created eagerly so that it appears in data view pickers across the app (e.g. in Timeline), but
+ * its creation is wrapped in its own try/catch so that a failure (e.g. `_field_caps` response too
+ * large to parse on clusters with many indices) does not surface a modal on unrelated pages such as
+ * Alerts. If eager creation fails, `useInitExploreDataView` retries lazily the first time the user
+ * navigates to an explore page (Hosts, Users, Network).
  *
  * The listener ensures that race conditions are avoided by only initializing scopes that are not already set,
  * and that state is not reset for slices that already have selections.
@@ -102,9 +106,7 @@ export const createInitListener = (dependencies: {
           PageScope.analyzer,
           PageScope.timeline,
           PageScope.default,
-          // NOTE: explore scope is intentionally omitted here — the explore data view
-          // is created lazily when the user navigates to an explore page (Hosts, Users, Network)
-          // to avoid fetching large _field_caps responses on unrelated pages (e.g. Alerts).
+          // NOTE: explore scope is omitted from this loop — it is handled separately below.
         ]
           // NOTE: only init default data view for slices that are not initialized yet
           .filter((scope) => !listenerApi.getState().dataViewManager[scope].dataViewId)
@@ -146,6 +148,30 @@ export const createInitListener = (dependencies: {
         action.payload.forEach((defaultSelection) => {
           listenerApi.dispatch(selectDataViewAsync(defaultSelection));
         });
+
+        // Eagerly create the explore data view so it appears in data view pickers across the app
+        // (e.g. Timeline's picker). This is intentionally wrapped in its own try/catch so that a
+        // failure here — e.g. the _field_caps response is too large to parse on clusters with many
+        // indices matching the configured patterns — does not surface an error modal on pages that
+        // have no dependency on the explore data view (Alerts, Dashboard, Rules, Cases).
+        // If creation fails here, useInitExploreDataView retries lazily the first time the user
+        // navigates to an explore page (Hosts, Users, Network), where a failure IS surfaced via
+        // a danger toast because the user actually needs the explore data view there.
+        if (!listenerApi.getState().dataViewManager.explore.dataViewId) {
+          try {
+            const exploreDataView = await createExploreDataView(
+              { dataViews: dependencies.dataViews, spaces: dependencies.spaces },
+              defaultDataView.title.split(','),
+              alertDataView.title
+            );
+            listenerApi.dispatch(sharedDataViewManagerSlice.actions.addDataView(exploreDataView));
+            listenerApi.dispatch(
+              selectDataViewAsync({ id: exploreDataView.id, scope: PageScope.explore })
+            );
+          } catch {
+            // Intentionally swallowed — see comment above.
+          }
+        }
       } catch (error: unknown) {
         dependencies.notifications.toasts.addDanger({
           title: 'Error initializing data views',

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -162,7 +162,8 @@ export const createInitListener = (dependencies: {
             const exploreDataView = await createExploreDataView(
               { dataViews: dependencies.dataViews, spaces: dependencies.spaces },
               defaultDataView.title.split(','),
-              alertDataView.title
+              alertDataView.title,
+              { skipFetchFields: true }
             );
             listenerApi.dispatch(sharedDataViewManagerSlice.actions.addDataView(exploreDataView));
             listenerApi.dispatch(

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.test.ts
@@ -42,13 +42,35 @@ describe('createExploreDataView', () => {
     expect(result).toBe(mockCreatedDataView);
     expect(mockSpaces.getActiveSpace).toHaveBeenCalled();
     expect(mockDataViews.create).toHaveBeenCalledTimes(1);
-    expect(mockDataViews.create).toHaveBeenCalledWith({
-      id: `${EXPLORE_DATA_VIEW_PREFIX}-space1`,
-      name: SECURITY_SOLUTION_EXPLORE_DATA_VIEW,
-      timeFieldName: DEFAULT_TIME_FIELD,
-      title: ['pattern-1', 'pattern-2'].join(),
-      managed: true,
-    });
+    expect(mockDataViews.create).toHaveBeenCalledWith(
+      {
+        id: `${EXPLORE_DATA_VIEW_PREFIX}-space1`,
+        name: SECURITY_SOLUTION_EXPLORE_DATA_VIEW,
+        timeFieldName: DEFAULT_TIME_FIELD,
+        title: ['pattern-1', 'pattern-2'].join(),
+        managed: true,
+      },
+      false, // skipFetchFields — defaults to fetching fields
+      false // displayErrors — suppressed; callers handle error feedback
+    );
+  });
+
+  it('forwards skipFetchFields when requested', async () => {
+    await createExploreDataView(
+      {
+        dataViews: mockDataViews as DataViewsServicePublic,
+        spaces: mockSpaces as SpacesPluginStart,
+      },
+      ['pattern-1'],
+      'alerts-pattern',
+      { skipFetchFields: true }
+    );
+
+    expect(mockDataViews.create).toHaveBeenCalledWith(
+      expect.objectContaining({ id: `${EXPLORE_DATA_VIEW_PREFIX}-space1` }),
+      true,
+      false
+    );
   });
 
   it('filters out the alerts pattern and handles when there are no remaining patterns (title becomes empty string)', async () => {
@@ -65,13 +87,17 @@ describe('createExploreDataView', () => {
     );
 
     expect(result).toBe(mockCreatedDataView);
-    expect(mockDataViews.create).toHaveBeenCalledWith({
-      id: `${EXPLORE_DATA_VIEW_PREFIX}-space1`,
-      name: SECURITY_SOLUTION_EXPLORE_DATA_VIEW,
-      timeFieldName: DEFAULT_TIME_FIELD,
-      title: '',
-      managed: true,
-    });
+    expect(mockDataViews.create).toHaveBeenCalledWith(
+      {
+        id: `${EXPLORE_DATA_VIEW_PREFIX}-space1`,
+        name: SECURITY_SOLUTION_EXPLORE_DATA_VIEW,
+        timeFieldName: DEFAULT_TIME_FIELD,
+        title: '',
+        managed: true,
+      },
+      false,
+      false
+    );
   });
 
   it('propagates errors from dataViews.create', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.test.ts
@@ -5,12 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0.
- */
-
 import type { DataViewsServicePublic, DataView } from '@kbn/data-views-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { createExploreDataView } from './create_explore_data_view';

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
@@ -16,7 +16,8 @@ export const createExploreDataView = async (
     spaces: SpacesPluginStart;
   },
   defaultDataViewPatterns: string[],
-  alertsDataViewPattern: string
+  alertsDataViewPattern: string,
+  { skipFetchFields = false }: { skipFetchFields?: boolean } = {}
 ): Promise<DataView> => {
   const exploreDataViewPattern = defaultDataViewPatterns
     .filter((pattern) => pattern !== alertsDataViewPattern)
@@ -30,9 +31,7 @@ export const createExploreDataView = async (
       title: exploreDataViewPattern,
       managed: true,
     },
-    false, // skipFetchFields — always fetch fields so the data view is ready to use
-    false  // displayErrors — suppress the platform's built-in toast; callers handle errors
-    // appropriately: init_listener swallows silently (explore is not needed on Alerts/Dashboard),
-    // while useInitExploreDataView surfaces a danger toast (the user IS on an explore page).
+    skipFetchFields,
+    false // displayErrors — suppress platform toast; callers handle error feedback
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
@@ -22,11 +22,17 @@ export const createExploreDataView = async (
     .filter((pattern) => pattern !== alertsDataViewPattern)
     .join();
 
-  return dependencies.dataViews.create({
-    id: `${EXPLORE_DATA_VIEW_PREFIX}-${(await dependencies.spaces.getActiveSpace()).id}`,
-    name: SECURITY_SOLUTION_EXPLORE_DATA_VIEW,
-    timeFieldName: DEFAULT_TIME_FIELD,
-    title: exploreDataViewPattern,
-    managed: true,
-  });
+  return dependencies.dataViews.create(
+    {
+      id: `${EXPLORE_DATA_VIEW_PREFIX}-${(await dependencies.spaces.getActiveSpace()).id}`,
+      name: SECURITY_SOLUTION_EXPLORE_DATA_VIEW,
+      timeFieldName: DEFAULT_TIME_FIELD,
+      title: exploreDataViewPattern,
+      managed: true,
+    },
+    false, // skipFetchFields — always fetch fields so the data view is ready to use
+    false  // displayErrors — suppress the platform's built-in toast; callers handle errors
+    // appropriately: init_listener swallows silently (explore is not needed on Alerts/Dashboard),
+    // while useInitExploreDataView surfaces a danger toast (the user IS on an explore page).
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
@@ -31,7 +31,6 @@ export const createExploreDataView = async (
       title: exploreDataViewPattern,
       managed: true,
     },
-    skipFetchFields,
-    false // displayErrors — suppress platform toast; callers handle error feedback
+    skipFetchFields
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/load_data_view_fields.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/load_data_view_fields.test.ts
@@ -26,7 +26,9 @@ describe('loadDataViewFields', () => {
     const result = await loadDataViewFields(mockDataViews as DataViewsServicePublic, 'explore-dv');
 
     expect(mockDataViews.get).toHaveBeenCalledWith('explore-dv', false);
-    expect(mockDataViews.refreshFields).toHaveBeenCalledWith(dataView, false);
+    // Called without a displayErrors arg so it defaults to true — the platform shows its own
+    // "Error fetching fields" toast on failure rather than re-throwing.
+    expect(mockDataViews.refreshFields).toHaveBeenCalledWith(dataView);
     expect(result).toBe(dataView);
   });
 
@@ -41,11 +43,14 @@ describe('loadDataViewFields', () => {
     expect(result).toBeNull();
   });
 
-  it('propagates errors from the underlying data views service', async () => {
-    jest.mocked(mockDataViews.get!).mockRejectedValue(new Error('field caps too large'));
+  it('propagates errors thrown by the get call', async () => {
+    // Errors from dataViews.get (e.g. saved-object not found) propagate to the caller.
+    // Note: refreshFields errors are handled by the platform internally (displayErrors=true)
+    // and are not re-thrown — the platform shows its own "Error fetching fields" toast.
+    jest.mocked(mockDataViews.get!).mockRejectedValue(new Error('saved object not found'));
 
     await expect(
       loadDataViewFields(mockDataViews as DataViewsServicePublic, 'explore-dv')
-    ).rejects.toThrow('field caps too large');
+    ).rejects.toThrow('saved object not found');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/load_data_view_fields.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/load_data_view_fields.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
+import { loadDataViewFields } from './load_data_view_fields';
+
+describe('loadDataViewFields', () => {
+  let mockDataViews: Partial<DataViewsServicePublic>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDataViews = {
+      get: jest.fn(),
+      refreshFields: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it('refreshes and returns the data view when it has no fields', async () => {
+    const dataView = { id: 'explore-dv', fields: [] as unknown[] };
+    jest.mocked(mockDataViews.get!).mockResolvedValue(dataView as never);
+
+    const result = await loadDataViewFields(mockDataViews as DataViewsServicePublic, 'explore-dv');
+
+    expect(mockDataViews.get).toHaveBeenCalledWith('explore-dv', false);
+    expect(mockDataViews.refreshFields).toHaveBeenCalledWith(dataView, false);
+    expect(result).toBe(dataView);
+  });
+
+  it('returns null without refreshing when the data view already has fields', async () => {
+    const dataView = { id: 'explore-dv', fields: [{ name: '@timestamp' }] };
+    jest.mocked(mockDataViews.get!).mockResolvedValue(dataView as never);
+
+    const result = await loadDataViewFields(mockDataViews as DataViewsServicePublic, 'explore-dv');
+
+    expect(mockDataViews.get).toHaveBeenCalledWith('explore-dv', false);
+    expect(mockDataViews.refreshFields).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('propagates errors from the underlying data views service', async () => {
+    jest.mocked(mockDataViews.get!).mockRejectedValue(new Error('field caps too large'));
+
+    await expect(
+      loadDataViewFields(mockDataViews as DataViewsServicePublic, 'explore-dv')
+    ).rejects.toThrow('field caps too large');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/load_data_view_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/load_data_view_fields.ts
@@ -12,8 +12,9 @@ import type { DataView, DataViewsServicePublic } from '@kbn/data-views-plugin/pu
  * `skipFetchFields: true`, such as the explore data view). This is deferred until the fields are
  * actually needed to avoid expensive `_field_caps` requests on pages that don't use the data view.
  *
- * The lookup and refresh both pass `displayErrors: false`, so the platform's own error toast is
- * suppressed — callers are responsible for surfacing user-facing feedback on failure.
+ * `refreshFields` is called with `displayErrors` defaulting to `true`, so the platform surfaces its
+ * own "Error fetching fields" toast (which includes a "See the full error" button) on failure.
+ * The platform catches the error internally and does not re-throw, so no additional catch is needed.
  *
  * @returns the data view with its fields loaded, or `null` if it already had fields (no work done).
  */
@@ -27,7 +28,9 @@ export const loadDataViewFields = async (
     return null;
   }
 
-  await dataViews.refreshFields(dataView, false);
+  // Omitting the second arg lets displayErrors default to true: the platform shows its own
+  // "Error fetching fields" toast (with "See the full error") and catches the error internally.
+  await dataViews.refreshFields(dataView);
 
   return dataView;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/load_data_view_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/load_data_view_fields.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataView, DataViewsServicePublic } from '@kbn/data-views-plugin/public';
+
+/**
+ * Loads the fields for a data view that was registered without them (i.e. created with
+ * `skipFetchFields: true`, such as the explore data view). This is deferred until the fields are
+ * actually needed to avoid expensive `_field_caps` requests on pages that don't use the data view.
+ *
+ * The lookup and refresh both pass `displayErrors: false`, so the platform's own error toast is
+ * suppressed — callers are responsible for surfacing user-facing feedback on failure.
+ *
+ * @returns the data view with its fields loaded, or `null` if it already had fields (no work done).
+ */
+export const loadDataViewFields = async (
+  dataViews: DataViewsServicePublic,
+  id: string
+): Promise<DataView | null> => {
+  const dataView = await dataViews.get(id, false);
+
+  if (dataView.fields.length) {
+    return null;
+  }
+
+  await dataViews.refreshFields(dataView, false);
+
+  return dataView;
+};


### PR DESCRIPTION
### Summary

- This PR fixes error toasts appearing on the Alerts page (and other non-explore pages) when explore data view initialisation fails.
- Alerts doesn't use the explore data view, but because it was created inside the main init_listener try/catch, failures surfaced everywhere.
- This can be pretty confusing as a user.

**Solution:** 
- Wrap the explore data view creation in its own inner try/catch so failures don't bubble up to all security solution pages.
- Lazily load fields when the user navigates to explore pages — useInitExploreDataView.
**Timeline Updates:**
- Create the explore data view at init with `skipFetchFields: true` so that `_field_caps` does not fire on non-explore pages, but the data view is still registered in Redux and appears as an option in the timeline picker.
- When a user selects the explore data view in Timeline and field loading fails, the platform's native `"Error fetching fields"` toast is shown (via `refreshFields` with `displayErrors: true`).

**Note:** Timeline currently has only a `"no results found"` state for both empty results and error states, which could be a good follow-up.

**Previous Error page**

<img width="1999" height="1259" alt="image" src="https://github.com/user-attachments/assets/04267d5b-01c1-4a67-b4c5-e0d289233b8a" />

**Demo with updates**


https://github.com/user-attachments/assets/a0be773c-5917-4aa3-9c0c-7396d0475b86




<details>
<summary><b>How to reproduce (local)</b></summary>

1. Start Kibana locally
2. Open DevTools → Network tab → filter by `data_views/fields`
3. Navigate to the Security Solution **Alerts page**
4. Find the `fields?pattern=apm-*-transaction*,auditbeat-*,...` request (the multi-pattern one - this is the explore DV fetch). Note:URL will vary by your index pattern config.
5. Right-click it → **Override content** → replace the response body with `{"broken` → Save
6. Reload the Alerts page
7. The "Error fetching fields for data view ... (ID: explore-data-view-default)" modal appears — on a page that has no dependency on the explore data view

</details>
 
 
### Testing steps

1. Apply the DevTools override: on the Alerts page, find the `fields?pattern=apm-*-transaction*,auditbeat-*,...` request → Override content → replace with `{"broken"}`→ Save
2. Reload the Alerts page — confirm no error modal and no toast appears
3. Navigate to Hosts — confirm a danger toast ("Error initialising the explore data view") appears, since the explore data view is actually needed there
4. Remove the override and reload - confirm the Hosts page loads correctly with data
5. Open Timeline on any page - confirm `"Security solution explore"` appears in the data view picker along with error toast.
6. Navigate to Users and Network - both should load correctly

