### PR TITLE
fix Failing test: Suggestions API - non time based - returns 404 if index is not found

### DIFF
--- a/src/platform/plugins/shared/kql/server/autocomplete/value_suggestions_route.ts
+++ b/src/platform/plugins/shared/kql/server/autocomplete/value_suggestions_route.ts
@@ -83,12 +83,12 @@ export function registerValueSuggestionsRoute(router: IRouter, config$: Observab
           // When an index is not found for _terms_enum request
           // * serverless: elasticsearch returns 200 and 'terms: []'
           // * cloud: elasticsearch returns 404
-          // 
+          //
           // To keep kibana route consistent between environments
           // route returns 200 with no suggstions when a 404 is encountered
           if (kbnErr.statusCode === 404) {
             return response.ok({ body: [] });
-          } 
+          }
 
           return reportServerError(response, kbnErr);
         }

--- a/src/platform/plugins/shared/kql/server/autocomplete/value_suggestions_route.ts
+++ b/src/platform/plugins/shared/kql/server/autocomplete/value_suggestions_route.ts
@@ -85,7 +85,7 @@ export function registerValueSuggestionsRoute(router: IRouter, config$: Observab
           // * cloud: elasticsearch returns 404
           //
           // To keep kibana route consistent between environments
-          // route returns 200 with no suggstions when a 404 is encountered
+          // route returns 200 with no suggestions when a 404 is encountered
           if (kbnErr.statusCode === 404) {
             return response.ok({ body: [] });
           }

--- a/src/platform/plugins/shared/kql/server/autocomplete/value_suggestions_route.ts
+++ b/src/platform/plugins/shared/kql/server/autocomplete/value_suggestions_route.ts
@@ -79,6 +79,17 @@ export function registerValueSuggestionsRoute(router: IRouter, config$: Observab
           return response.ok({ body });
         } catch (e) {
           const kbnErr = getKbnServerError(e);
+
+          // When an index is not found for _terms_enum request
+          // * serverless: elasticsearch returns 200 and 'terms: []'
+          // * cloud: elasticsearch returns 404
+          // 
+          // To keep kibana route consistent between environments
+          // route returns 200 with no suggstions when a 404 is encountered
+          if (kbnErr.statusCode === 404) {
+            return response.ok({ body: [] });
+          } 
+
           return reportServerError(response, kbnErr);
         }
       }

--- a/src/platform/plugins/shared/kql/test/scout/api/tests/value_suggestions.spec.ts
+++ b/src/platform/plugins/shared/kql/test/scout/api/tests/value_suggestions.spec.ts
@@ -92,14 +92,15 @@ apiTest.describe('Suggestions API - non time based', { tag: tags.deploymentAgnos
     expect(response.body).toStrictEqual(['nestedValue']);
   });
 
-  apiTest('returns 404 if index is not found', async ({ apiClient }) => {
+  apiTest('returns no suggestions if index is not found', async ({ apiClient }) => {
     const response = await apiClient.post(`${SUGGESTIONS_VALUES_PATH}/not_found`, {
       headers: { ...COMMON_HEADERS, ...cookieHeader },
       responseType: 'json',
       body: { field: 'baz.keyword', query: '1' },
     });
 
-    expect(response).toHaveStatusCode(404);
+    expect(response).toHaveStatusCode(200);
+    expect(response.body).toStrictEqual([]);
   });
 
   apiTest('returns 400 without a query', async ({ apiClient }) => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/277849

### Background
Running the request below returns different results on serverless and cloud.

```
POST /not_found/_terms_enum
{
    "field" : "machine.os.keyword"
}
```

Serverless returns 200 with the following body
```

  "_shards": {
    "total": 0,
    "successful": 0,
    "failed": 0
  },
  "terms": [],
  "complete": true
}
```

Cloud returns 404 with the following body
```
{
  "error": {
    "root_cause": [
      {
        "type": "index_not_found_exception",
        "reason": "no such index [not_found]",
        "resource.type": "index_or_alias",
        "resource.id": "not_found",
        "index_uuid": "_na_",
        "index": "not_found"
      }
    ],
    "type": "index_not_found_exception",
    "reason": "no such index [not_found]",
    "resource.type": "index_or_alias",
    "resource.id": "not_found",
    "index_uuid": "_na_",
    "index": "not_found"
  },
  "status": 404
}
```

### Solution
PR resolves issue by updating Kibana route to return 200 with [] when 404 is returned so the route is consistent in any environment.

This change will have no meaningful impact on users. With a 200 response, results are cached for 60 seconds. With an error response, results are removed from the cache and and empty suggestions are returned.


Code snippets from src/platform/plugins/shared/kql/public/autocomplete/providers/value_suggestion_provider.ts. 
```
// memoize resolver
function resolver(title: string, field: DataViewField, query: string, filters: any[]) {
    // Only cache results for a minute
    const ttl = Math.floor(Date.now() / 1000 / 60);
    return [ttl, query, title, field.name, JSON.stringify(filters)].join('|');
  }

// getSuggestions function
return async ({
    indexPattern,
    field,
    query,
    useTimeRange,
    boolFilter,
    signal,
    method,
    querySuggestionKey,
  }: ValueSuggestionsGetFnArgs): Promise<any[]> => {
    const shouldSuggestValues = core!.uiSettings.get<boolean>(
      UI_SETTINGS.FILTERS_EDITOR_SUGGEST_VALUES
    );
    useTimeRange =
      useTimeRange ?? core!.uiSettings.get<boolean>(UI_SETTINGS.AUTOCOMPLETE_USE_TIMERANGE);
    const { title } = indexPattern;

    const isVersionFieldType = field.type === 'string' && field.esTypes?.includes('version');

    if (field.type === 'boolean') {
      return [true, false];
    } else if (
      !shouldSuggestValues ||
      !field.aggregatable ||
      (field.type !== 'string' && field.type !== 'ip') ||
      isVersionFieldType // suggestions don't work for version fields
    ) {
      return [];
    }

    const timeFilter = useTimeRange
      ? getAutocompleteTimefilter(timefilter, indexPattern)
      : undefined;
    const filterQuery = timeFilter ? buildQueryFromFilters([timeFilter], indexPattern).filter : [];
    const filters = [...(boolFilter ? boolFilter : []), ...filterQuery];
    try {
      usageCollector?.trackCall();
      return await requestSuggestions(
        title,
        field,
        query,
        filters,
        signal,
        method,
        querySuggestionKey
      );
    } catch (e) {
      if (!signal?.aborted) {
        usageCollector?.trackError();
      }
      // Remove rejected results from memoize cache
      requestSuggestions.cache.delete(resolver(title, field, query, filters));
      return [];
    }
  };
```

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->