### PR TITLE
[Discover] [ES|QL] Fix cascade drilldown for TS queries by converting to FROM

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers/index.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers/index.test.ts
@@ -224,6 +224,16 @@ describe('cascaded documents helpers utils', () => {
         { aggregation: 'MEDIAN', identifier: 'median' },
       ]);
     });
+
+    it('should return an empty array of group by fields and applied functions if the query contains the TS_INFO command', () => {
+      const queryString = `
+        TS kibana_sample_data_logstsdb | TS_INFO | STATS count = COUNT() BY metric_name
+      `;
+
+      const result = getESQLStatsQueryMeta(queryString);
+      expect(result.groupByFields).toEqual([]);
+      expect(result.appliedFunctions).toEqual([]);
+    });
   });
 
   describe('constructCascadeQuery', () => {
@@ -418,6 +428,37 @@ describe('cascaded documents helpers utils', () => {
           expect(cascadeQuery).toBeDefined();
           expect(cascadeQuery!.esql).toBe(
             'FROM kibana_sample_data_logs | WHERE MATCH_PHRASE(tags, "some random pattern")'
+          );
+        });
+
+        it('constructs a FROM-based cascade query when the editor query uses a TS command', () => {
+          const editorQuery: AggregateQuery = {
+            esql: `
+              TS kibana_sample_data_logstsdb
+              | STATS count = COUNT(AVG_OVER_TIME(bytes_gauge)) BY agent.keyword
+            `,
+          };
+
+          const nodePath = ['agent.keyword'];
+          const nodePathMap = { 'agent.keyword': 'Mozilla/5.0' };
+
+          jest.spyOn(dataViewMock.fields, 'getByName').mockReturnValueOnce({
+            esTypes: ['text', 'keyword'],
+            aggregatable: false,
+          } as unknown as DataViewField);
+
+          const cascadeQuery = constructCascadeQuery({
+            query: editorQuery,
+            dataView: dataViewMock,
+            esqlVariables: [],
+            nodeType,
+            nodePath,
+            nodePathMap,
+          });
+
+          expect(cascadeQuery).toBeDefined();
+          expect(cascadeQuery!.esql).toBe(
+            'FROM kibana_sample_data_logstsdb | WHERE MATCH_PHRASE(`agent.keyword`, "Mozilla/5.0")'
           );
         });
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers/index.ts
@@ -39,6 +39,10 @@ import { getUsedFields, getFieldTerminals, getFieldDefinitionFromArg } from '../
 import { extractCategorizeTokens } from '../extract_categorize_tokens';
 import { getOperator } from '../append_to_query/utils';
 import {
+  convertTimeseriesCommandNodeToFrom,
+  hasTimeseriesInfoCommand,
+} from '../query_parsing_helpers';
+import {
   isSupportedStatsFunction,
   type SupportedFieldTypes,
   type FieldValue,
@@ -92,6 +96,12 @@ export interface ESQLStatsQueryMeta {
 export const getESQLStatsQueryMeta = (queryString: string): ESQLStatsQueryMeta => {
   const groupByFields: ESQLStatsQueryMeta['groupByFields'] = [];
   const appliedFunctions: ESQLStatsQueryMeta['appliedFunctions'] = [];
+
+  if (hasTimeseriesInfoCommand(queryString)) {
+    // TS_INFO/METRICS_INFO rows are synthetic metric metadata rather than documents,
+    // so there's no underlying document to drive a cascade experience from
+    return { groupByFields, appliedFunctions };
+  }
 
   const esqlQuery = EsqlQuery.fromSrc(queryString);
 
@@ -463,7 +473,11 @@ function handleStatsByColumnLeafOperation(
         continue;
       }
     } else {
-      mutate.generic.commands.insert(cascadeOperationQuery.ast, cmd, 0);
+      mutate.generic.commands.insert(
+        cascadeOperationQuery.ast,
+        convertTimeseriesCommandNodeToFrom(cmd),
+        0
+      );
     }
   }
 
@@ -523,7 +537,10 @@ function handleStatsByCategorizeLeafOperation(
       return;
     }
 
-    mutate.generic.commands.append(cascadeOperationQuery.ast, cmd);
+    mutate.generic.commands.append(
+      cascadeOperationQuery.ast,
+      convertTimeseriesCommandNodeToFrom(cmd)
+    );
   });
 
   // we select the first argument because that's the field being categorized

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -28,6 +28,7 @@ import type {
   ESQLSource,
   ESQLFunction,
   ESQLColumn,
+  ESQLCommand,
   ESQLSingleAstItem,
   ESQLInlineCast,
   ESQLCommandOption,
@@ -177,6 +178,14 @@ export function removeDropCommandsFromESQLQuery(esql?: string): string {
 }
 
 /**
+ * Converts a single TS command node to an equivalent FROM command node, preserving its
+ * source arguments. Returns the command unchanged if it isn't a TS command.
+ */
+export function convertTimeseriesCommandNodeToFrom<T extends ESQLCommand>(cmd: T): T {
+  return cmd.name === 'ts' ? { ...cmd, name: 'from' } : cmd;
+}
+
+/**
  * Converts timeseries (TS) commands to FROM commands in an ES|QL query
  * @param esql - The ES|QL query string
  * @returns The modified query with TS commands converted to FROM commands
@@ -186,10 +195,7 @@ export function convertTimeseriesCommandToFrom(esql?: string): string {
   const timeseriesCommand = Walker.commands(root).find(({ name }) => name === 'ts');
   if (!timeseriesCommand) return esql || '';
 
-  const fromCommand = {
-    ...timeseriesCommand,
-    name: 'from',
-  };
+  const fromCommand = convertTimeseriesCommandNodeToFrom(timeseriesCommand);
 
   // Replace the ts command with the from command in the commands array
   const newCommands = root.commands.map((command) =>


### PR DESCRIPTION
## Summary

This PR fixes cascade drilldown for ES|QL `TS` (timeseries) queries in Discover. The drilldown builds a subquery reusing the original data source command, but `TS` queries don't support functions like `MATCH_PHRASE` outside `STATS`, so opening a group failed. `TS` commands in the generated subquery are now converted to `FROM`, and queries containing `TS_INFO`/`METRICS_INFO` (synthetic metric rows with no real documents to cascade into) now return no cascade metadata instead of failing.

Fixes #280402.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->