### PR TITLE
[UIAM OAuth] Pass serverless project type to UIAM during client creation

### DIFF
--- a/src/core/packages/security/server/src/authentication/index.ts
+++ b/src/core/packages/security/server/src/authentication/index.ts
@@ -43,6 +43,7 @@ export type {
   UiamOAuthClientResponse,
   UiamOAuthClientLogo,
   UiamOAuthClientType,
+  UiamOAuthProjectType,
   UiamOAuthConnectionsSummary,
   UiamOAuthConnectionResponse,
   CreateUiamOAuthClientParams,

--- a/src/core/packages/security/server/src/authentication/oauth/index.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/index.ts
@@ -12,6 +12,7 @@ export type {
   UiamOAuthClientResponse,
   UiamOAuthClientLogo,
   UiamOAuthClientType,
+  UiamOAuthProjectType,
   UiamOAuthConnectionsSummary,
   UiamOAuthConnectionResponse,
   CreateUiamOAuthClientParams,

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -22,12 +22,7 @@ export interface UiamOAuthConnectionsSummary {
 
 export type UiamOAuthClientType = 'public' | 'confidential';
 
-export type UiamOAuthProjectType =
-  | 'elasticsearch'
-  | 'observability'
-  | 'security'
-  | 'workplaceai'
-  | 'vectordb';
+export type UiamOAuthProjectType = 'elasticsearch' | 'observability' | 'security' | 'vectordb';
 
 export interface UiamOAuthClientResponse {
   id: string;

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -22,6 +22,13 @@ export interface UiamOAuthConnectionsSummary {
 
 export type UiamOAuthClientType = 'public' | 'confidential';
 
+export type UiamOAuthProjectType =
+  | 'elasticsearch'
+  | 'observability'
+  | 'security'
+  | 'workplaceai'
+  | 'vectordb';
+
 export interface UiamOAuthClientResponse {
   id: string;
   client_name?: string;
@@ -57,6 +64,7 @@ export interface UiamOAuthConnectionResponse {
 export interface CreateUiamOAuthClientParams {
   resource: string;
   project_id: string;
+  project_type?: UiamOAuthProjectType;
   client_name?: string;
   client_type?: UiamOAuthClientType;
   client_metadata?: Record<string, string>;

--- a/x-pack/platform/plugins/shared/security/moon.yml
+++ b/x-pack/platform/plugins/shared/security/moon.yml
@@ -114,6 +114,7 @@ dependsOn:
   - '@kbn/core-user-profile-common'
   - '@kbn/core-chrome-browser-components'
   - '@kbn/core-logging-server'
+  - '@kbn/projects-solutions-groups'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/security/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/security/server/plugin.ts
@@ -364,6 +364,7 @@ export class SecurityPlugin
       getAnonymousAccessService: this.getAnonymousAccess,
       getUserProfileService: this.getUserProfileService,
       serverlessProjectId: cloud?.serverless?.projectId,
+      serverlessProjectType: cloud?.serverless?.projectType,
       analyticsService: this.analyticsService.setup({ analytics: core.analytics }),
       buildFlavor: this.initializerContext.env.packageInfo.buildFlavor,
       docLinks: core.docLinks,

--- a/x-pack/platform/plugins/shared/security/server/routes/index.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/index.mock.ts
@@ -55,6 +55,7 @@ export const routeDefinitionParamsMock = {
       getAnonymousAccessService: jest.fn(),
       getUserProfileService: jest.fn().mockReturnValue(userProfileServiceMock.createStart()),
       serverlessProjectId: 'mock-project-id',
+      serverlessProjectType: 'search',
       analyticsService: analyticsServiceMock.createSetup(),
       buildFlavor: 'traditional',
       docLinks: { links: getDocLinks({ kibanaBranch: 'main', buildFlavor: 'traditional' }) },

--- a/x-pack/platform/plugins/shared/security/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/index.ts
@@ -17,6 +17,7 @@ import type {
 } from '@kbn/core/server';
 import type { KibanaFeature } from '@kbn/features-plugin/server';
 import type { SubFeaturePrivilegeIterator } from '@kbn/features-plugin/server/feature_privilege_iterator';
+import type { KibanaSolution } from '@kbn/projects-solutions-groups';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 
 import { defineAnalyticsRoutes } from './analytics';
@@ -66,6 +67,7 @@ export interface RouteDefinitionParams {
   getUserProfileService: () => UserProfileServiceStartInternal;
   getAnonymousAccessService: () => AnonymousAccessServiceStart;
   serverlessProjectId: string | undefined;
+  serverlessProjectType: KibanaSolution | undefined;
   analyticsService: AnalyticsServiceSetup;
   buildFlavor: BuildFlavor;
   docLinks: DocLinksServiceSetup;

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
@@ -281,6 +281,21 @@ describe('Create OAuth Client route', () => {
     expect(oauthMock.createClient).not.toHaveBeenCalled();
   });
 
+  it('returns 404 when the serverless project type has no UIAM mapping', async () => {
+    ({ routeHandler, oauthMock } = setup(mcpConfig, { serverlessProjectType: 'workplaceai' }));
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        body: { client_name: 'Test' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.createClient).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when OAuth is not available', async () => {
     authc.oauth = null;
 

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
@@ -11,6 +11,7 @@ import type { RequestHandler } from '@kbn/core/server';
 import { kibanaResponseFactory } from '@kbn/core/server';
 import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
 import type { UiamOAuthType } from '@kbn/core-security-server';
+import type { KibanaSolution } from '@kbn/projects-solutions-groups';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 
 import { defineCreateOAuthClientRoute } from './create_client';
@@ -21,6 +22,7 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 const RESOURCE = 'https://test-project.kb.us-central1.gcp.elastic.cloud/api/agent_builder/mcp';
 const PROJECT_ID = 'mock-project-id';
+const UIAM_PROJECT_TYPE = 'elasticsearch';
 
 const mcpConfig = {
   mcp: {
@@ -48,13 +50,16 @@ describe('Create OAuth Client route', () => {
 
   function setup(
     rawConfig: Record<string, unknown> = mcpConfig,
-    options: { serverlessProjectId?: string } = {}
+    options: { serverlessProjectId?: string; serverlessProjectType?: KibanaSolution } = {}
   ) {
     const mockRouteDefinitionParams = routeDefinitionParamsMock.create(rawConfig, {
       serverless: true,
     });
     mockRouteDefinitionParams.serverlessProjectId =
       'serverlessProjectId' in options ? options.serverlessProjectId : PROJECT_ID;
+    if ('serverlessProjectType' in options) {
+      mockRouteDefinitionParams.serverlessProjectType = options.serverlessProjectType;
+    }
     const authcMock = authenticationServiceMock.createStart();
     mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authcMock);
 
@@ -91,7 +96,7 @@ describe('Create OAuth Client route', () => {
     expect(response.payload).toEqual({ message: 'test forbidden message' });
   });
 
-  it('injects the configured resource and serverless project id and returns the created client on success', async () => {
+  it('injects the configured resource, serverless project id and project type and returns the created client on success', async () => {
     const mockClient = {
       id: 'client-1',
       resource: RESOURCE,
@@ -111,9 +116,42 @@ describe('Create OAuth Client route', () => {
       client_name: 'Test',
       resource: RESOURCE,
       project_id: PROJECT_ID,
+      project_type: UIAM_PROJECT_TYPE,
     });
     expect(response.status).toBe(200);
     expect(response.payload).toEqual(mockClient);
+  });
+
+  it('maps the `search` solution to the `elasticsearch` UIAM project type', async () => {
+    ({ routeHandler, oauthMock } = setup(mcpConfig, { serverlessProjectType: 'search' }));
+    oauthMock.createClient.mockResolvedValue({ id: 'client-1', resource: RESOURCE });
+
+    await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ body: { client_name: 'Test' } }),
+      kibanaResponseFactory
+    );
+
+    expect(oauthMock.createClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ project_type: 'elasticsearch' })
+    );
+  });
+
+  it('passes through a directly-matching project type unchanged', async () => {
+    ({ routeHandler, oauthMock } = setup(mcpConfig, { serverlessProjectType: 'security' }));
+    oauthMock.createClient.mockResolvedValue({ id: 'client-1', resource: RESOURCE });
+
+    await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ body: { client_name: 'Test' } }),
+      kibanaResponseFactory
+    );
+
+    expect(oauthMock.createClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ project_type: 'security' })
+    );
   });
 
   it('rejects unknown body fields (including `resource`) at the schema layer', () => {
@@ -188,6 +226,7 @@ describe('Create OAuth Client route', () => {
       client_name: 'Test',
       resource: RESOURCE,
       project_id: PROJECT_ID,
+      project_type: UIAM_PROJECT_TYPE,
     });
   });
 
@@ -208,11 +247,27 @@ describe('Create OAuth Client route', () => {
       client_name: 'Test',
       resource: RESOURCE,
       project_id: PROJECT_ID,
+      project_type: UIAM_PROJECT_TYPE,
     });
   });
 
   it('returns 404 when the serverless project id is not configured', async () => {
     ({ routeHandler, oauthMock } = setup(mcpConfig, { serverlessProjectId: undefined }));
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        body: { client_name: 'Test' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.createClient).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the serverless project type is not configured', async () => {
+    ({ routeHandler, oauthMock } = setup(mcpConfig, { serverlessProjectType: undefined }));
 
     const response = await routeHandler(
       getMockContext(),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -11,7 +11,6 @@ import {
   KIBANA_SEARCH_SOLUTION,
   KIBANA_SECURITY_SOLUTION,
   KIBANA_VECTORDB_SOLUTION,
-  KIBANA_WORKPLACE_AI_SOLUTION,
   type KibanaSolution,
 } from '@kbn/projects-solutions-groups';
 
@@ -21,13 +20,13 @@ import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
 
-const KIBANA_SOLUTION_TO_UIAM_PROJECT_TYPE: Record<KibanaSolution, UiamOAuthProjectType> = {
-  [KIBANA_SEARCH_SOLUTION]: 'elasticsearch',
-  [KIBANA_OBSERVABILITY_SOLUTION]: 'observability',
-  [KIBANA_SECURITY_SOLUTION]: 'security',
-  [KIBANA_WORKPLACE_AI_SOLUTION]: 'workplaceai',
-  [KIBANA_VECTORDB_SOLUTION]: 'vectordb',
-};
+const KIBANA_SOLUTION_TO_UIAM_PROJECT_TYPE: Partial<Record<KibanaSolution, UiamOAuthProjectType>> =
+  {
+    [KIBANA_SEARCH_SOLUTION]: 'elasticsearch',
+    [KIBANA_OBSERVABILITY_SOLUTION]: 'observability',
+    [KIBANA_SECURITY_SOLUTION]: 'security',
+    [KIBANA_VECTORDB_SOLUTION]: 'vectordb',
+  };
 
 export function defineCreateOAuthClientRoute({
   router,

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -5,17 +5,36 @@
  * 2.0.
  */
 
+import type { UiamOAuthProjectType } from '@kbn/core-security-server';
+import {
+  KIBANA_OBSERVABILITY_SOLUTION,
+  KIBANA_SEARCH_SOLUTION,
+  KIBANA_SECURITY_SOLUTION,
+  KIBANA_VECTORDB_SOLUTION,
+  KIBANA_WORKPLACE_AI_SOLUTION,
+  type KibanaSolution,
+} from '@kbn/projects-solutions-groups';
+
 import { createClientBodySchema } from './schemas';
 import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
 
+const KIBANA_SOLUTION_TO_UIAM_PROJECT_TYPE: Record<KibanaSolution, UiamOAuthProjectType> = {
+  [KIBANA_SEARCH_SOLUTION]: 'elasticsearch',
+  [KIBANA_OBSERVABILITY_SOLUTION]: 'observability',
+  [KIBANA_SECURITY_SOLUTION]: 'security',
+  [KIBANA_WORKPLACE_AI_SOLUTION]: 'workplaceai',
+  [KIBANA_VECTORDB_SOLUTION]: 'vectordb',
+};
+
 export function defineCreateOAuthClientRoute({
   router,
   config,
   getAuthenticationService,
   serverlessProjectId,
+  serverlessProjectType,
 }: RouteDefinitionParams) {
   router.post(
     {
@@ -66,10 +85,20 @@ export function defineCreateOAuthClientRoute({
             });
           }
 
+          if (!serverlessProjectType) {
+            return response.notFound({
+              body: {
+                message:
+                  'OAuth management is not available: serverless project type is not configured',
+              },
+            });
+          }
+
           const result = await oauth.createClient(request, {
             ...request.body,
             resource,
             project_id: serverlessProjectId,
+            project_type: KIBANA_SOLUTION_TO_UIAM_PROJECT_TYPE[serverlessProjectType],
           });
           if (!result) {
             return response.notFound({

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -72,9 +72,6 @@ export function defineCreateOAuthClientRoute({
             });
           }
 
-          // UIAM requires the project the client belongs to. It is always available on serverless
-          // (where OAuth client management is offered), so a missing value indicates a
-          // deployment where this feature is not available.
           if (!serverlessProjectId) {
             return response.notFound({
               body: {
@@ -93,11 +90,21 @@ export function defineCreateOAuthClientRoute({
             });
           }
 
+          const projectType = KIBANA_SOLUTION_TO_UIAM_PROJECT_TYPE[serverlessProjectType];
+          if (!projectType) {
+            return response.notFound({
+              body: {
+                message:
+                  'OAuth management is not available: serverless project type is not supported',
+              },
+            });
+          }
+
           const result = await oauth.createClient(request, {
             ...request.body,
             resource,
             project_id: serverlessProjectId,
-            project_type: KIBANA_SOLUTION_TO_UIAM_PROJECT_TYPE[serverlessProjectType],
+            project_type: projectType,
           });
           if (!result) {
             return response.notFound({

--- a/x-pack/platform/plugins/shared/security/tsconfig.json
+++ b/x-pack/platform/plugins/shared/security/tsconfig.json
@@ -116,6 +116,7 @@
     "@kbn/core-user-profile-common",
     "@kbn/core-chrome-browser-components",
     "@kbn/core-logging-server",
+    "@kbn/projects-solutions-groups",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Passes the serverless project type through to UIAM when creating an OAuth client, so UIAM can associate the client with the correct project type in addition to the project id.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
