### PR TITLE
[9.5] [Alerting V2] Bugfix - Update notification policy widget counts on rule details (#278303)

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/linked_action_policies_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/linked_action_policies_step.test.tsx
@@ -39,7 +39,12 @@ const renderComponent = (
 
 describe('LinkedActionPoliciesStep', () => {
   it('always renders the title and subtext', () => {
-    mockUseMatchedActionPolicies.mockReturnValue({ isLoading: false, error: null, items: [] });
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: false,
+      error: null,
+      items: [],
+      total: 0,
+    });
 
     renderComponent();
 
@@ -48,7 +53,12 @@ describe('LinkedActionPoliciesStep', () => {
   });
 
   it('shows a loading spinner while fetching', () => {
-    mockUseMatchedActionPolicies.mockReturnValue({ isLoading: true, error: null, items: [] });
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: true,
+      error: null,
+      items: [],
+      total: 0,
+    });
 
     renderComponent();
 
@@ -56,7 +66,12 @@ describe('LinkedActionPoliciesStep', () => {
   });
 
   it('shows an empty state when no policies match', () => {
-    mockUseMatchedActionPolicies.mockReturnValue({ isLoading: false, error: null, items: [] });
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: false,
+      error: null,
+      items: [],
+      total: 0,
+    });
 
     renderComponent();
 
@@ -78,6 +93,7 @@ describe('LinkedActionPoliciesStep', () => {
           category: 'global-filtered',
         },
       ],
+      total: 2,
     });
 
     renderComponent();
@@ -93,6 +109,7 @@ describe('LinkedActionPoliciesStep', () => {
       isLoading: false,
       error: new Error('Network error'),
       items: [],
+      total: 0,
     });
 
     renderComponent();
@@ -102,7 +119,12 @@ describe('LinkedActionPoliciesStep', () => {
 
   it('passes name and tags from form values when ruleId is not provided', () => {
     mockUseWatch.mockReturnValue({ name: 'My Rule', tags: ['env:prod'] });
-    mockUseMatchedActionPolicies.mockReturnValue({ isLoading: false, error: null, items: [] });
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: false,
+      error: null,
+      items: [],
+      total: 0,
+    });
 
     renderComponent({ ruleId: undefined });
 
@@ -113,7 +135,12 @@ describe('LinkedActionPoliciesStep', () => {
 
   it('passes current form name and tags alongside ruleId so unsaved changes are reflected', () => {
     mockUseWatch.mockReturnValue({ name: 'My Rule', tags: ['env:prod'] });
-    mockUseMatchedActionPolicies.mockReturnValue({ isLoading: false, error: null, items: [] });
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: false,
+      error: null,
+      items: [],
+      total: 0,
+    });
 
     renderComponent({ ruleId: 'rule-abc' });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/use_matched_action_policies.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/use_matched_action_policies.test.tsx
@@ -26,6 +26,7 @@ describe('useMatchedActionPolicies', () => {
     const http = httpServiceMock.createStartContract();
     const fakeResponse = {
       items: [{ actionPolicy: { id: 'ap-1', name: 'Policy 1' }, category: 'global' }],
+      total: 42,
     };
     http.fetch.mockResolvedValueOnce(fakeResponse as any);
 
@@ -39,6 +40,7 @@ describe('useMatchedActionPolicies', () => {
 
     expect(result.current.error).toBeNull();
     expect(result.current.items).toEqual(fakeResponse.items);
+    expect(result.current.total).toBe(42);
     expect(http.fetch).toHaveBeenCalledWith(
       '/api/alerting/v2/action_policies/_match_for_rule',
       expect.objectContaining({
@@ -61,6 +63,7 @@ describe('useMatchedActionPolicies', () => {
     expect(result.current.error).toBeInstanceOf(Error);
     expect(result.current.error?.message).toBe('Network error');
     expect(result.current.items).toEqual([]);
+    expect(result.current.total).toBe(0);
   });
 
   it('re-fetches when ruleId changes', async () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/use_matched_action_policies.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/use_matched_action_policies.ts
@@ -23,6 +23,7 @@ export interface UseMatchedActionPoliciesResult {
   isLoading: boolean;
   error: Error | null;
   items: MatchedActionPolicy[];
+  total: number;
 }
 
 export const useMatchedActionPolicies = ({
@@ -57,5 +58,6 @@ export const useMatchedActionPolicies = ({
     isLoading: enabled && isLoading,
     error: error instanceof Error ? error : error != null ? new Error(String(error)) : null,
     items: data?.items ?? [],
+    total: data?.total ?? 0,
   };
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/matched_action_policies_response_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/matched_action_policies_response_schema.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { matchActionPoliciesForRuleResponseSchema } from './matched_action_policies_response_schema';
+
+describe('matchActionPoliciesForRuleResponseSchema', () => {
+  it('accepts a response with an empty item list and a total', () => {
+    const result = matchActionPoliciesForRuleResponseSchema.parse({ items: [], total: 0 });
+
+    expect(result).toEqual({ items: [], total: 0 });
+  });
+
+  it('rejects a response missing total', () => {
+    expect(() => matchActionPoliciesForRuleResponseSchema.parse({ items: [] })).toThrow();
+  });
+
+  it('rejects a negative total', () => {
+    expect(() =>
+      matchActionPoliciesForRuleResponseSchema.parse({ items: [], total: -1 })
+    ).toThrow();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/matched_action_policies_response_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/matched_action_policies_response_schema.ts
@@ -51,6 +51,13 @@ export type MatchedActionPolicy = z.infer<typeof matchedActionPolicySchema>;
 export const matchActionPoliciesForRuleResponseSchema = z
   .object({
     items: z.array(matchedActionPolicySchema).describe('The list of matched action policies.'),
+    total: z
+      .number()
+      .int()
+      .min(0)
+      .describe(
+        'Total number of action policies in the space. If greater than the number evaluated, the match results may be incomplete.'
+      ),
   })
   .describe('Action policies that match a given rule, grouped by match category.');
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
@@ -5,43 +5,38 @@
  * 2.0.
  */
 
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@kbn/react-query';
-import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
-import { buildRuleScopedMatcher } from '@kbn/alerting-v2-rule-form';
+import { renderHook } from '@testing-library/react';
+import type { MatchedActionPolicy } from '@kbn/alerting-v2-schemas';
 import {
   useLinkedActionPolicies,
   LINKED_ACTION_POLICIES_FETCH_LIMIT,
 } from './use_linked_action_policies';
-import { actionPolicyKeys } from '../../../../hooks/query_key_factory';
 
-const mockListActionPolicies = jest.fn();
+const mockUseMatchedActionPolicies = jest.fn();
+const mockHttp = { fake: 'http-start-contract' };
 
-jest.mock('../../../../services/action_policies_api', () => ({
-  ActionPoliciesApi: 'ActionPoliciesApi',
+jest.mock('@kbn/alerting-v2-rule-form', () => ({
+  useMatchedActionPolicies: (params: unknown) => mockUseMatchedActionPolicies(params),
 }));
 
 jest.mock('@kbn/core-di-browser', () => ({
-  useService: (token: unknown) => {
-    if (token === 'ActionPoliciesApi') {
-      return { listActionPolicies: mockListActionPolicies };
-    }
-    return {};
-  },
-  CoreStart: (key: string) => key,
+  useService: (token: unknown) => (token === 'CoreStart(http)' ? mockHttp : {}),
+  CoreStart: (key: string) => `CoreStart(${key})`,
 }));
 
 const RULE_ID = 'rule-1';
 
-const buildPolicy = (overrides: Partial<ActionPolicyResponse> = {}): ActionPolicyResponse =>
-  ({
+const buildItem = (
+  category: MatchedActionPolicy['category'],
+  overrides: Partial<MatchedActionPolicy['actionPolicy']> = {}
+): MatchedActionPolicy => ({
+  actionPolicy: {
     id: 'policy-1',
-    name: 'Alpha Policy',
+    name: 'Policy',
     description: '',
     enabled: true,
     destinations: [{ type: 'workflow', id: 'workflow-1' }],
-    matcher: buildRuleScopedMatcher(RULE_ID),
+    matcher: null,
     groupBy: null,
     tags: null,
     groupingMode: 'per_episode',
@@ -53,137 +48,87 @@ const buildPolicy = (overrides: Partial<ActionPolicyResponse> = {}): ActionPolic
     updatedBy: 'user',
     updatedAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
-  } as ActionPolicyResponse);
-
-const createWrapper =
-  (queryClient: QueryClient) =>
-  ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  } as MatchedActionPolicy['actionPolicy'],
+  category,
+});
 
 describe('useLinkedActionPolicies', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockListActionPolicies.mockResolvedValue({
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: false,
+      error: null,
       items: [],
       total: 0,
-      page: 1,
-      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
     });
   });
 
-  it('does not fetch when ruleId is empty', () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const Wrapper = createWrapper(queryClient);
-    renderHook(() => useLinkedActionPolicies(''), { wrapper: Wrapper });
+  it('delegates to useMatchedActionPolicies with the injected http contract and ruleId', () => {
+    renderHook(() => useLinkedActionPolicies(RULE_ID));
 
-    expect(mockListActionPolicies).not.toHaveBeenCalled();
+    expect(mockUseMatchedActionPolicies).toHaveBeenCalledWith({ http: mockHttp, ruleId: RULE_ID });
   });
 
-  it('uses a query key nested under action policy list keys', async () => {
-    mockListActionPolicies.mockResolvedValue({
-      items: [buildPolicy()],
-      total: 1,
-      page: 1,
-      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
-    });
-
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const Wrapper = createWrapper(queryClient);
-    renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
-
-    await waitFor(() => {
-      expect(queryClient.getQueryCache().getAll()).toHaveLength(1);
-    });
-
-    expect(queryClient.getQueryCache().getAll()[0]?.queryKey).toEqual(
-      actionPolicyKeys.linkedForRule(RULE_ID)
-    );
-    expect(actionPolicyKeys.linkedForRule(RULE_ID)).toEqual([
-      'actionPolicy',
-      'list',
-      'linkedForRule',
-      RULE_ID,
-    ]);
-  });
-
-  it('fetches policies and returns explicitly linked matches with counts', async () => {
-    mockListActionPolicies.mockResolvedValue({
+  it('counts items with category "global" as catch-all and "global-filtered" as matching criteria', () => {
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: false,
+      error: null,
       items: [
-        buildPolicy({ id: 'linked-catch-all', name: 'Catch all' }),
-        buildPolicy({
-          id: 'linked-filtered',
-          name: 'Filtered',
-          matcher: `rule.id: "${RULE_ID}" and severity: "high"`,
-        }),
-        buildPolicy({
-          id: 'global',
-          name: 'Global',
-          matcher: null,
-        }),
+        buildItem('global', { id: 'catch-all-1' }),
+        buildItem('global-filtered', { id: 'filtered-1' }),
+        buildItem('global-filtered', { id: 'filtered-2' }),
       ],
       total: 3,
-      page: 1,
-      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
     });
 
-    const Wrapper = createWrapper(
-      new QueryClient({
-        defaultOptions: { queries: { retry: false } },
-      })
-    );
-    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
+    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID));
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    expect(mockListActionPolicies).toHaveBeenCalledWith({
-      page: 1,
-      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
-    });
-    expect(result.current.totalCount).toBe(2);
+    expect(result.current.totalCount).toBe(3);
     expect(result.current.catchAllCount).toBe(1);
-    expect(result.current.matchingCriteriaCount).toBe(1);
+    expect(result.current.matchingCriteriaCount).toBe(2);
     expect(result.current.isCountTruncated).toBe(false);
     expect(result.current.isError).toBe(false);
     expect(result.current.error).toBeNull();
   });
 
-  it('flags truncated counts when the space has more policies than the fetch limit', async () => {
-    mockListActionPolicies.mockResolvedValue({
-      items: [buildPolicy({ id: 'linked-1' })],
+  it('flags truncated counts when the space has more policies than the evaluation limit', () => {
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: false,
+      error: null,
+      items: [buildItem('global-filtered')],
       total: LINKED_ACTION_POLICIES_FETCH_LIMIT + 1,
-      page: 1,
-      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
     });
 
-    const Wrapper = createWrapper(
-      new QueryClient({
-        defaultOptions: { queries: { retry: false } },
-      })
-    );
-    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID));
 
     expect(result.current.totalCount).toBe(1);
     expect(result.current.isCountTruncated).toBe(true);
   });
 
-  it('surfaces API errors', async () => {
-    mockListActionPolicies.mockRejectedValue(new Error('network error'));
+  it('passes through the loading state', () => {
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: true,
+      error: null,
+      items: [],
+      total: 0,
+    });
 
-    const Wrapper = createWrapper(
-      new QueryClient({
-        defaultOptions: { queries: { retry: false } },
-      })
-    );
-    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
+    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID));
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isLoading).toBe(true);
+  });
 
+  it('surfaces API errors', () => {
+    mockUseMatchedActionPolicies.mockReturnValue({
+      isLoading: false,
+      error: new Error('network error'),
+      items: [],
+      total: 0,
+    });
+
+    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID));
+
+    expect(result.current.isError).toBe(true);
     expect(result.current.error?.message).toBe('network error');
     expect(result.current.totalCount).toBe(0);
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.ts
@@ -5,20 +5,17 @@
  * 2.0.
  */
 
-import { useQuery } from '@kbn/react-query';
-import { useService } from '@kbn/core-di-browser';
-import { summarizeExplicitlyLinkedActionPolicies } from '@kbn/alerting-v2-rule-form';
-import { ActionPoliciesApi } from '../../../../services/action_policies_api';
-import { actionPolicyKeys } from '../../../../hooks/query_key_factory';
+import { useService, CoreStart } from '@kbn/core-di-browser';
+import { useMatchedActionPolicies } from '@kbn/alerting-v2-rule-form';
 
-/** Max policies fetched from the list API; linked counts may undercount when the space has more. */
+/** Max policies evaluated by _match_for_rule; counts may undercount when the space has more. */
 export const LINKED_ACTION_POLICIES_FETCH_LIMIT = 100;
 
 export interface UseLinkedActionPoliciesResult {
   totalCount: number;
   catchAllCount: number;
   matchingCriteriaCount: number;
-  /** True when the space has more policies than {@link LINKED_ACTION_POLICIES_FETCH_LIMIT} and the list response was truncated. */
+  /** True when the space has more policies than {@link LINKED_ACTION_POLICIES_FETCH_LIMIT} and some may not have been evaluated. */
   isCountTruncated: boolean;
   isLoading: boolean;
   isError: boolean;
@@ -26,40 +23,16 @@ export interface UseLinkedActionPoliciesResult {
 }
 
 export const useLinkedActionPolicies = (ruleId: string): UseLinkedActionPoliciesResult => {
-  const actionPoliciesApi = useService(ActionPoliciesApi);
-  const enabled = Boolean(ruleId);
-
-  const { isLoading, error, data } = useQuery({
-    queryKey: actionPolicyKeys.linkedForRule(ruleId),
-    queryFn: () =>
-      actionPoliciesApi.listActionPolicies({
-        page: 1,
-        perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
-      }),
-    enabled,
-    refetchOnWindowFocus: false,
-    /*
-     * Client-side filter for policies whose matcher explicitly includes rule.id.
-     * We do not use _match_for_rule here — that endpoint returns broader matches
-     * (global and global-filtered policies), not only explicit rule.id linkage.
-     */
-    select: (response) => {
-      const summary = summarizeExplicitlyLinkedActionPolicies(response.items, ruleId);
-
-      return {
-        ...summary,
-        isCountTruncated: response.total > LINKED_ACTION_POLICIES_FETCH_LIMIT,
-      };
-    },
-  });
+  const http = useService(CoreStart('http'));
+  const { isLoading, error, items, total } = useMatchedActionPolicies({ http, ruleId });
 
   return {
-    totalCount: data?.totalCount ?? 0,
-    catchAllCount: data?.catchAllCount ?? 0,
-    matchingCriteriaCount: data?.matchingCriteriaCount ?? 0,
-    isCountTruncated: data?.isCountTruncated ?? false,
-    isLoading: enabled && isLoading,
+    totalCount: items.length,
+    catchAllCount: items.filter((item) => item.category === 'global').length,
+    matchingCriteriaCount: items.filter((item) => item.category === 'global-filtered').length,
+    isCountTruncated: total > LINKED_ACTION_POLICIES_FETCH_LIMIT,
+    isLoading,
     isError: error != null,
-    error: error instanceof Error ? error : error != null ? new Error(String(error)) : null,
+    error,
   };
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_client/action_policy_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_client/action_policy_client.test.ts
@@ -2777,9 +2777,10 @@ describe('ActionPolicyClient', () => {
       const result = await client.matchActionPoliciesForRule({ ruleId: 'missing-rule' });
 
       expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
     });
 
-    it('returns global APs for policies with no matcher', async () => {
+    it('returns global APs for policies with no matcher, along with the space-wide total', async () => {
       jest.spyOn(rulesSavedObjectService, 'get').mockResolvedValueOnce({
         id: 'rule-1',
         attributes: ruleAttributes as never,
@@ -2787,7 +2788,10 @@ describe('ActionPolicyClient', () => {
       });
 
       mockSavedObjectsClient.find.mockResolvedValueOnce(
-        makeFindResponse([{ id: 'ap-catchall', attributes: { ...baseAttributes, matcher: null } }])
+        makeFindResponse(
+          [{ id: 'ap-catchall', attributes: { ...baseAttributes, matcher: null } }],
+          150
+        )
       );
 
       const result = await client.matchActionPoliciesForRule({ ruleId: 'rule-1' });
@@ -2795,6 +2799,7 @@ describe('ActionPolicyClient', () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0].category).toBe('global');
       expect(result.items[0].actionPolicy.id).toBe('ap-catchall');
+      expect(result.total).toBe(150);
     });
 
     it('returns global-filtered APs for policies where evaluateKql returns true', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_client/action_policy_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_client/action_policy_client.ts
@@ -353,7 +353,7 @@ export class ActionPolicyClient {
         resolvedTags = ruleTags ?? rule.attributes.metadata.tags ?? [];
       } catch (e) {
         if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
-          return { items: [] };
+          return { items: [], total: 0 };
         }
         throw e;
       }
@@ -400,7 +400,7 @@ export class ActionPolicyClient {
       }
     }
 
-    return { items };
+    return { items, total: allPolicies.total };
   }
 
   public async enableActionPolicy({ id }: { id: string }): Promise<ActionPolicyResponse> {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_client/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_client/types.ts
@@ -68,4 +68,5 @@ export interface MatchActionPoliciesForRuleParams {
 
 export interface MatchActionPoliciesForRuleResponse {
   items: MatchedActionPolicy[];
+  total: number;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Alerting V2] [9.5] Bugfix - Update notification policy widget counts on rule details (#278303)](https://github.com/elastic/kibana/pull/278303)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2026-07-16T16:21:31Z","message":"[Alerting V2] [9.5] Bugfix - Update notification policy widget counts on rule details (#278303)\n\n## Summary\n\nFixes the \"Notification policies\" widget on the V2 rule details Overview\ntab, which was showing the wrong counts. Follow-up to #276775. Related:\nelastic/kibana#263625.\n\n**The bug:** the widget only counted policies whose matcher named this\nrule's `rule.id`, and it labeled those as \"catch-all\". A real catch-all\npolicy (no matcher — dispatches for every rule) was never counted at\nall. On a rule with 1 catch-all policy + 2 rule-scoped policies, the\nwidget showed **2** (\"0 matching criteria and 2 catch-all\") when **3**\npolicies actually dispatch for that rule.\n\n**The fix:** the widget now reuses the same `_match_for_rule` endpoint\nthe rule form's Actions step already uses, so both surfaces agree on\nwhat applies to a rule. Same example now shows **3** (\"2 are matching\ncriteria and 1 is catch-all\").\n\nAn enabled, non-snoozed policy with no matcher matches every episode of\nevery rule in its space, unconditionally. That's what confirmed the\nwidget's undercount was real — before this fix, that policy dispatches\nfor the rule but the widget didn't count it.\n\n\n## Scope for this fix (9.5)\n\nThis is a counts-only bugfix. No wording, layout, or list-view changes:\n- Same component (`action_policies_artifacts_subsection.tsx`) —\nuntouched.\n- Same summary text — untouched.\n- No linked-policy list (name/destination/status) — that's separate\nscope tracked in elastic/rna-program#263625 / elastic/kibana#271324,\ndeferred to M3.\n\n## What changed\n\n- `use_linked_action_policies.ts` (the widget's data hook) now calls the\nshared `useMatchedActionPolicies` hook instead of its own\n`listActionPolicies` fetch + client-side matcher parsing.\n- Counts are derived from the same `category` field (`global` /\n`global-filtered`) the rule form already uses to group policies — see\n\"global vs global-filtered\" below.\n- `_match_for_rule` (client hook, plugin service, and server client) now\nalso returns `total`, used for the truncation indicator.\n\n### Dispatcher code reference\n\nWhy we're confident a no-matcher policy is a real catch-all\nThe dispatcher — the code that actually decides which policies fire — is\nthe source of truth here, not the UI. In evaluate_matchers_step.ts, a\npolicy with no matcher is pushed as matched with no KQL evaluation at\nall:\n\n```\nfor (const policy of spacePolicies) {\n  if (!policy.enabled) continue;\n  if (policy.snoozedUntil && new Date(policy.snoozedUntil) > new Date()) continue;\n\n  if (!policy.matcher) {\n    matched.push({ episode, policy });\n    continue;\n  }\n\n  context ??= createMatcherContext(episode, rule);\n  let isMatch = false;\n  try {\n    isMatch = evaluateKql(policy.matcher, context);\n  } catch (err) {\n    // ...treat as no-match, log a warning...\n    continue;\n  }\n\n  if (isMatch) {\n    matched.push({ episode, policy });\n  }\n}\n```\n\nhttps://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.ts\n\n## Why `total` is included\n\n`_match_for_rule` only evaluates the first 100 action policies in a\nspace. If a space has more than that, some policies aren't checked, so\nthe count can be a floor, not an exact number.\n\n`total` (the actual number of policies in the space) was already being\ncomputed internally by `matchActionPoliciesForRule` — it just wasn't\nreturned. We now surface it so the widget can show \"N+\" exactly like it\ndid before (when `total > 100`), instead of silently claiming a complete\ncount it can't guarantee.\n\n## Navigating \"global\" vs \"global-filtered\"\n\n`_match_for_rule` classifies every matched policy into one of two\nbuckets:\n- `global` — no matcher at all, applies to every rule unconditionally.\n- `global-filtered` — has a matcher, and it evaluated true for this\nrule.\n\nNeither name tells you *why* a `global-filtered` policy matched — it\ncould be `rule.id`, `rule.tags`, `rule.name`, or a combination. There's\nno separate \"this policy specifically names this rule\" category in this\nendpoint today (the route's own doc comment references a `direct`\ncategory that was apparently planned but never implemented).\n\nThis is exactly why the original widget (#276775) avoided this endpoint\nand built its own `rule.id`-parsing logic instead — it needed a\ndistinction this endpoint doesn't provide.\n\nFor this fix we made a deliberate choice to match the endpoint's model\nas-is: `global` → catch-all, `global-filtered` → matching criteria. This\nmeans a policy that matches via `rule.tags` (not `rule.id`) now counts\nas \"matching criteria,\" same as a `rule.id` match. We think this is the\nright trade-off for consistency (see below), but it's worth reviewers\nknowing this is a real semantic choice, not an oversight. If we want to\nsplit `rule.id` matches out from other filtered matches, that requires\neither an endpoint change or bringing back the client-side matcher\nparsing we removed here.\n\n## Goal: match what the rule form shows\n\nBefore this change, the rule details widget and the rule form's Actions\nstep could disagree about what applies to the same rule, because they\nused two different queries with two different definitions of \"matches.\"\nReusing `_match_for_rule` for both means the widget's count and the\nform's list are always describing the same set of policies.\n\n## Dead code we're knowingly leaving behind\n\nSwitching the widget away from client-side matcher parsing leaves these\nhelpers with no production callers (still covered by their own unit\ntests, so nothing is broken):\n\n- `isExplicitlyLinkedToRule`\n- `isRuleScopedCatchAllMatcher`\n- `summarizeExplicitlyLinkedActionPolicies` (+ its\n`LinkedActionPolicySummary` type)\n\nAll in `actions_form/helpers/explicitly_linked_action_policies.ts`,\nstill exported from the package.\n\nAlso now unused: the `actionPolicyKeys.linkedForRule` query key in the\nplugin's `query_key_factory.ts`.\n\nWe left these in place rather than deleting them in this PR, to keep the\ndiff focused on the count fix. **Flagging for reviewers:** do we want to\nremove these now, or track as a separate cleanup follow-up?\n\n## Test plan\n\n- Unit tests updated for the new data flow (widget hook, shared hook,\nschema, server client) — all passing.\n- Manually verified against a local rule with 1 catch-all + 2\nrule-scoped policies: widget count changed from **2** (\"0 matching\ncriteria and 2 catch-all\") to the correct **3** (\"2 are matching\ncriteria and 1 is catch-all\"), matching what the rule form's Actions\nstep already showed for the same rule.\n- `node scripts/type_check` clean on the alerting_v2 plugin,\nalerting-v2-rule-form package, and alerting-v2-schemas package.","sha":"833dd27842a57523ca01c831d0e1db110040b31e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","author:actionable-obs","v9.5.0","Team:rna-project","v9.6.0"],"title":"[Alerting V2] [9.5] Bugfix - Update notification policy widget counts on rule details","number":278303,"url":"https://github.com/elastic/kibana/pull/278303","mergeCommit":{"message":"[Alerting V2] [9.5] Bugfix - Update notification policy widget counts on rule details (#278303)\n\n## Summary\n\nFixes the \"Notification policies\" widget on the V2 rule details Overview\ntab, which was showing the wrong counts. Follow-up to #276775. Related:\nelastic/kibana#263625.\n\n**The bug:** the widget only counted policies whose matcher named this\nrule's `rule.id`, and it labeled those as \"catch-all\". A real catch-all\npolicy (no matcher — dispatches for every rule) was never counted at\nall. On a rule with 1 catch-all policy + 2 rule-scoped policies, the\nwidget showed **2** (\"0 matching criteria and 2 catch-all\") when **3**\npolicies actually dispatch for that rule.\n\n**The fix:** the widget now reuses the same `_match_for_rule` endpoint\nthe rule form's Actions step already uses, so both surfaces agree on\nwhat applies to a rule. Same example now shows **3** (\"2 are matching\ncriteria and 1 is catch-all\").\n\nAn enabled, non-snoozed policy with no matcher matches every episode of\nevery rule in its space, unconditionally. That's what confirmed the\nwidget's undercount was real — before this fix, that policy dispatches\nfor the rule but the widget didn't count it.\n\n\n## Scope for this fix (9.5)\n\nThis is a counts-only bugfix. No wording, layout, or list-view changes:\n- Same component (`action_policies_artifacts_subsection.tsx`) —\nuntouched.\n- Same summary text — untouched.\n- No linked-policy list (name/destination/status) — that's separate\nscope tracked in elastic/rna-program#263625 / elastic/kibana#271324,\ndeferred to M3.\n\n## What changed\n\n- `use_linked_action_policies.ts` (the widget's data hook) now calls the\nshared `useMatchedActionPolicies` hook instead of its own\n`listActionPolicies` fetch + client-side matcher parsing.\n- Counts are derived from the same `category` field (`global` /\n`global-filtered`) the rule form already uses to group policies — see\n\"global vs global-filtered\" below.\n- `_match_for_rule` (client hook, plugin service, and server client) now\nalso returns `total`, used for the truncation indicator.\n\n### Dispatcher code reference\n\nWhy we're confident a no-matcher policy is a real catch-all\nThe dispatcher — the code that actually decides which policies fire — is\nthe source of truth here, not the UI. In evaluate_matchers_step.ts, a\npolicy with no matcher is pushed as matched with no KQL evaluation at\nall:\n\n```\nfor (const policy of spacePolicies) {\n  if (!policy.enabled) continue;\n  if (policy.snoozedUntil && new Date(policy.snoozedUntil) > new Date()) continue;\n\n  if (!policy.matcher) {\n    matched.push({ episode, policy });\n    continue;\n  }\n\n  context ??= createMatcherContext(episode, rule);\n  let isMatch = false;\n  try {\n    isMatch = evaluateKql(policy.matcher, context);\n  } catch (err) {\n    // ...treat as no-match, log a warning...\n    continue;\n  }\n\n  if (isMatch) {\n    matched.push({ episode, policy });\n  }\n}\n```\n\nhttps://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.ts\n\n## Why `total` is included\n\n`_match_for_rule` only evaluates the first 100 action policies in a\nspace. If a space has more than that, some policies aren't checked, so\nthe count can be a floor, not an exact number.\n\n`total` (the actual number of policies in the space) was already being\ncomputed internally by `matchActionPoliciesForRule` — it just wasn't\nreturned. We now surface it so the widget can show \"N+\" exactly like it\ndid before (when `total > 100`), instead of silently claiming a complete\ncount it can't guarantee.\n\n## Navigating \"global\" vs \"global-filtered\"\n\n`_match_for_rule` classifies every matched policy into one of two\nbuckets:\n- `global` — no matcher at all, applies to every rule unconditionally.\n- `global-filtered` — has a matcher, and it evaluated true for this\nrule.\n\nNeither name tells you *why* a `global-filtered` policy matched — it\ncould be `rule.id`, `rule.tags`, `rule.name`, or a combination. There's\nno separate \"this policy specifically names this rule\" category in this\nendpoint today (the route's own doc comment references a `direct`\ncategory that was apparently planned but never implemented).\n\nThis is exactly why the original widget (#276775) avoided this endpoint\nand built its own `rule.id`-parsing logic instead — it needed a\ndistinction this endpoint doesn't provide.\n\nFor this fix we made a deliberate choice to match the endpoint's model\nas-is: `global` → catch-all, `global-filtered` → matching criteria. This\nmeans a policy that matches via `rule.tags` (not `rule.id`) now counts\nas \"matching criteria,\" same as a `rule.id` match. We think this is the\nright trade-off for consistency (see below), but it's worth reviewers\nknowing this is a real semantic choice, not an oversight. If we want to\nsplit `rule.id` matches out from other filtered matches, that requires\neither an endpoint change or bringing back the client-side matcher\nparsing we removed here.\n\n## Goal: match what the rule form shows\n\nBefore this change, the rule details widget and the rule form's Actions\nstep could disagree about what applies to the same rule, because they\nused two different queries with two different definitions of \"matches.\"\nReusing `_match_for_rule` for both means the widget's count and the\nform's list are always describing the same set of policies.\n\n## Dead code we're knowingly leaving behind\n\nSwitching the widget away from client-side matcher parsing leaves these\nhelpers with no production callers (still covered by their own unit\ntests, so nothing is broken):\n\n- `isExplicitlyLinkedToRule`\n- `isRuleScopedCatchAllMatcher`\n- `summarizeExplicitlyLinkedActionPolicies` (+ its\n`LinkedActionPolicySummary` type)\n\nAll in `actions_form/helpers/explicitly_linked_action_policies.ts`,\nstill exported from the package.\n\nAlso now unused: the `actionPolicyKeys.linkedForRule` query key in the\nplugin's `query_key_factory.ts`.\n\nWe left these in place rather than deleting them in this PR, to keep the\ndiff focused on the count fix. **Flagging for reviewers:** do we want to\nremove these now, or track as a separate cleanup follow-up?\n\n## Test plan\n\n- Unit tests updated for the new data flow (widget hook, shared hook,\nschema, server client) — all passing.\n- Manually verified against a local rule with 1 catch-all + 2\nrule-scoped policies: widget count changed from **2** (\"0 matching\ncriteria and 2 catch-all\") to the correct **3** (\"2 are matching\ncriteria and 1 is catch-all\"), matching what the rule form's Actions\nstep already showed for the same rule.\n- `node scripts/type_check` clean on the alerting_v2 plugin,\nalerting-v2-rule-form package, and alerting-v2-schemas package.","sha":"833dd27842a57523ca01c831d0e1db110040b31e"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278303","number":278303,"mergeCommit":{"message":"[Alerting V2] [9.5] Bugfix - Update notification policy widget counts on rule details (#278303)\n\n## Summary\n\nFixes the \"Notification policies\" widget on the V2 rule details Overview\ntab, which was showing the wrong counts. Follow-up to #276775. Related:\nelastic/kibana#263625.\n\n**The bug:** the widget only counted policies whose matcher named this\nrule's `rule.id`, and it labeled those as \"catch-all\". A real catch-all\npolicy (no matcher — dispatches for every rule) was never counted at\nall. On a rule with 1 catch-all policy + 2 rule-scoped policies, the\nwidget showed **2** (\"0 matching criteria and 2 catch-all\") when **3**\npolicies actually dispatch for that rule.\n\n**The fix:** the widget now reuses the same `_match_for_rule` endpoint\nthe rule form's Actions step already uses, so both surfaces agree on\nwhat applies to a rule. Same example now shows **3** (\"2 are matching\ncriteria and 1 is catch-all\").\n\nAn enabled, non-snoozed policy with no matcher matches every episode of\nevery rule in its space, unconditionally. That's what confirmed the\nwidget's undercount was real — before this fix, that policy dispatches\nfor the rule but the widget didn't count it.\n\n\n## Scope for this fix (9.5)\n\nThis is a counts-only bugfix. No wording, layout, or list-view changes:\n- Same component (`action_policies_artifacts_subsection.tsx`) —\nuntouched.\n- Same summary text — untouched.\n- No linked-policy list (name/destination/status) — that's separate\nscope tracked in elastic/rna-program#263625 / elastic/kibana#271324,\ndeferred to M3.\n\n## What changed\n\n- `use_linked_action_policies.ts` (the widget's data hook) now calls the\nshared `useMatchedActionPolicies` hook instead of its own\n`listActionPolicies` fetch + client-side matcher parsing.\n- Counts are derived from the same `category` field (`global` /\n`global-filtered`) the rule form already uses to group policies — see\n\"global vs global-filtered\" below.\n- `_match_for_rule` (client hook, plugin service, and server client) now\nalso returns `total`, used for the truncation indicator.\n\n### Dispatcher code reference\n\nWhy we're confident a no-matcher policy is a real catch-all\nThe dispatcher — the code that actually decides which policies fire — is\nthe source of truth here, not the UI. In evaluate_matchers_step.ts, a\npolicy with no matcher is pushed as matched with no KQL evaluation at\nall:\n\n```\nfor (const policy of spacePolicies) {\n  if (!policy.enabled) continue;\n  if (policy.snoozedUntil && new Date(policy.snoozedUntil) > new Date()) continue;\n\n  if (!policy.matcher) {\n    matched.push({ episode, policy });\n    continue;\n  }\n\n  context ??= createMatcherContext(episode, rule);\n  let isMatch = false;\n  try {\n    isMatch = evaluateKql(policy.matcher, context);\n  } catch (err) {\n    // ...treat as no-match, log a warning...\n    continue;\n  }\n\n  if (isMatch) {\n    matched.push({ episode, policy });\n  }\n}\n```\n\nhttps://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.ts\n\n## Why `total` is included\n\n`_match_for_rule` only evaluates the first 100 action policies in a\nspace. If a space has more than that, some policies aren't checked, so\nthe count can be a floor, not an exact number.\n\n`total` (the actual number of policies in the space) was already being\ncomputed internally by `matchActionPoliciesForRule` — it just wasn't\nreturned. We now surface it so the widget can show \"N+\" exactly like it\ndid before (when `total > 100`), instead of silently claiming a complete\ncount it can't guarantee.\n\n## Navigating \"global\" vs \"global-filtered\"\n\n`_match_for_rule` classifies every matched policy into one of two\nbuckets:\n- `global` — no matcher at all, applies to every rule unconditionally.\n- `global-filtered` — has a matcher, and it evaluated true for this\nrule.\n\nNeither name tells you *why* a `global-filtered` policy matched — it\ncould be `rule.id`, `rule.tags`, `rule.name`, or a combination. There's\nno separate \"this policy specifically names this rule\" category in this\nendpoint today (the route's own doc comment references a `direct`\ncategory that was apparently planned but never implemented).\n\nThis is exactly why the original widget (#276775) avoided this endpoint\nand built its own `rule.id`-parsing logic instead — it needed a\ndistinction this endpoint doesn't provide.\n\nFor this fix we made a deliberate choice to match the endpoint's model\nas-is: `global` → catch-all, `global-filtered` → matching criteria. This\nmeans a policy that matches via `rule.tags` (not `rule.id`) now counts\nas \"matching criteria,\" same as a `rule.id` match. We think this is the\nright trade-off for consistency (see below), but it's worth reviewers\nknowing this is a real semantic choice, not an oversight. If we want to\nsplit `rule.id` matches out from other filtered matches, that requires\neither an endpoint change or bringing back the client-side matcher\nparsing we removed here.\n\n## Goal: match what the rule form shows\n\nBefore this change, the rule details widget and the rule form's Actions\nstep could disagree about what applies to the same rule, because they\nused two different queries with two different definitions of \"matches.\"\nReusing `_match_for_rule` for both means the widget's count and the\nform's list are always describing the same set of policies.\n\n## Dead code we're knowingly leaving behind\n\nSwitching the widget away from client-side matcher parsing leaves these\nhelpers with no production callers (still covered by their own unit\ntests, so nothing is broken):\n\n- `isExplicitlyLinkedToRule`\n- `isRuleScopedCatchAllMatcher`\n- `summarizeExplicitlyLinkedActionPolicies` (+ its\n`LinkedActionPolicySummary` type)\n\nAll in `actions_form/helpers/explicitly_linked_action_policies.ts`,\nstill exported from the package.\n\nAlso now unused: the `actionPolicyKeys.linkedForRule` query key in the\nplugin's `query_key_factory.ts`.\n\nWe left these in place rather than deleting them in this PR, to keep the\ndiff focused on the count fix. **Flagging for reviewers:** do we want to\nremove these now, or track as a separate cleanup follow-up?\n\n## Test plan\n\n- Unit tests updated for the new data flow (widget hook, shared hook,\nschema, server client) — all passing.\n- Manually verified against a local rule with 1 catch-all + 2\nrule-scoped policies: widget count changed from **2** (\"0 matching\ncriteria and 2 catch-all\") to the correct **3** (\"2 are matching\ncriteria and 1 is catch-all\"), matching what the rule form's Actions\nstep already showed for the same rule.\n- `node scripts/type_check` clean on the alerting_v2 plugin,\nalerting-v2-rule-form package, and alerting-v2-schemas package.","sha":"833dd27842a57523ca01c831d0e1db110040b31e"}}]}] BACKPORT-->