### PR TITLE
[VectorDB] Update getting started pill interactive states

### DIFF
--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/api_step.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/api_step.tsx
@@ -106,7 +106,7 @@ export const ApiStep = ({ tabs, consoleComment, docsPanel, pills, step, path }: 
       <EuiPanel paddingSize="s" hasBorder={false} hasShadow={false} color="subdued">
         {pills.length > 0 && (
           <>
-            <EuiPanel paddingSize="s" hasBorder={false} hasShadow={false} color="subdued">
+            <EuiPanel paddingSize="s" color="transparent">
               <OnboardingPills pills={pills} telemetryPrefix={telemetryPrefix} />
             </EuiPanel>
             <EuiSpacer size="s" />
@@ -211,7 +211,7 @@ export const ApiStep = ({ tabs, consoleComment, docsPanel, pills, step, path }: 
           </EuiCodeBlock>
         </EuiPanel>
         <EuiSpacer size="s" />
-        <EuiPanel paddingSize="xs" hasBorder={false} hasShadow={false} color="transparent">
+        <EuiPanel paddingSize="s" hasBorder={false} hasShadow={false} color="transparent">
           <EuiFlexGroup gutterSize="s" direction="row" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiIcon color="subdued" size="m" type="bulb" aria-hidden={true} />

--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/onboarding_pills.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/onboarding_pills.tsx
@@ -33,8 +33,9 @@ export const OnboardingPills = ({ pills, telemetryPrefix }: OnboardingPillsProps
           <EuiPopover
             button={
               <EuiBadge
-                iconType="plus"
+                iconType={openPillId === pill.id ? 'cross' : 'plus'}
                 iconSide="left"
+                fill={openPillId === pill.id ? (true as boolean) : (false as boolean)}
                 onClick={() => setOpenPillId((current) => (current === pill.id ? null : pill.id))}
                 onClickAriaLabel={i18n.translate(
                   'vectordbOnboarding.wizard.pills.toggleAriaLabel',

--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/onboarding_pills.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/onboarding_pills.tsx
@@ -35,7 +35,7 @@ export const OnboardingPills = ({ pills, telemetryPrefix }: OnboardingPillsProps
               <EuiBadge
                 iconType={openPillId === pill.id ? 'cross' : 'plus'}
                 iconSide="left"
-                fill={openPillId === pill.id ? (true as boolean) : (false as boolean)}
+                fill={openPillId === pill.id ? true : false}
                 onClick={() => setOpenPillId((current) => (current === pill.id ? null : pill.id))}
                 onClickAriaLabel={i18n.translate(
                   'vectordbOnboarding.wizard.pills.toggleAriaLabel',


### PR DESCRIPTION
## Summary

When selecting a pill, updates the active state that switches the fill and iconType.


https://github.com/user-attachments/assets/57140965-1e8b-4133-a5e7-68e9c6b07f65



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks.



