### PR TITLE
[River] Add Elasticsearch and Kibana services

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -8,11 +8,7 @@ yarn = "1.22.21"
 description = "Install and link Kibana dependencies"
 run = "yarn kbn bootstrap"
 
-[tasks."river:warm"]
-description = "Warm Kibana and Elasticsearch caches for a River image"
+[tasks."river:prebuild"]
+description = "Prebuild River sandbox image"
 depends = ["bootstrap"]
 run = "bash .river/warm.sh"
-
-[tasks.river-prebuild]
-description = "Prepare Kibana for a River sandbox image"
-depends = ["river:warm"]

--- a/.river/config.yaml
+++ b/.river/config.yaml
@@ -1,0 +1,25 @@
+services:
+  elasticsearch:
+    # Services can't declare dependency ordering, so wait for bootstrap to link
+    # the @kbn/* workspaces before starting; otherwise `yarn es` fails with
+    # "Cannot find module '@kbn/setup-node-env'". Prepared images are already
+    # bootstrapped, so this guard passes immediately on a warm start.
+    start: |
+      until node -e "require.resolve('@kbn/setup-node-env')" 2>/dev/null; do
+        echo "Waiting for bootstrap to finish before starting Elasticsearch..."
+        sleep 5
+      done
+      yarn es snapshot
+    port: 9200
+    ready: curl -sf -u elastic:changeme http://localhost:9200/_cluster/health
+  kibana:
+    start: |
+      until node -e "require.resolve('@kbn/setup-node-env')" 2>/dev/null; do
+        echo "Waiting for bootstrap to finish before starting Kibana..."
+        sleep 5
+      done
+      yarn start --no-base-path --server.host=0.0.0.0
+    port: 5601
+    ready: |
+      until curl -sf -o /dev/null http://localhost:5601/api/status; do sleep 5; done
+      curl -sf -o /dev/null http://localhost:5601/login


### PR DESCRIPTION
Add .river/config.yaml declaring the Elasticsearch and Kibana runtime services River starts in a sandbox, mirroring the services block from .ona/automations.yaml.

Also collapse the Mise prebuild tasks into a single river:prebuild task matching River's renamed default setup task.
