### PR TITLE
[Saved Objects] [Data Views] Surface relationships across spaces in data view and saved objects management

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -47,7 +47,7 @@ pageLoadAssetSize:
   dataUsage: 8743
   dataViewEditor: 7735
   dataViewFieldEditor: 26024
-  dataViewManagement: 6250
+  dataViewManagement: 6500
   dataViews: 66000
   dataVisualizer: 32727
   developerToolbar: 6043
@@ -156,7 +156,7 @@ pageLoadAssetSize:
   sampleDataIngest: 2640
   savedObjects: 11735
   savedObjectsFinder: 4319
-  savedObjectsManagement: 22361
+  savedObjectsManagement: 23000
   savedObjectsTagging: 23144
   savedObjectsTaggingOss: 2163
   savedSearch: 11000

--- a/src/core/packages/saved-objects/common/src/server_types.ts
+++ b/src/core/packages/saved-objects/common/src/server_types.ts
@@ -116,6 +116,11 @@ export interface SavedObject<T = unknown> {
    */
   namespaces?: string[];
   /**
+   * The single space that this saved object exists in, for saved object types registered with
+   * `namespaceType: 'single'`. Types that can exist in multiple spaces use `namespaces` instead.
+   */
+  namespace?: string;
+  /**
    * The ID of the saved object this originated from. This is set if this object's `id` was regenerated; that can happen during migration
    * from a legacy single-namespace type, or during import. It is only set during migration or create operations. This is used during import
    * to ensure that ID regeneration is deterministic, so saved objects will be overwritten if they are imported multiple times into a given

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout.test.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout.test.tsx
@@ -48,6 +48,7 @@ const defaultProps = {
   selectedRelationships: {
     '1': [],
   },
+  allowedTypes: [],
   hasSpaces: false,
   onDelete: jest.fn(),
   onClose: jest.fn(),

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout.tsx
@@ -21,7 +21,10 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
-import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/common';
+import type {
+  SavedObjectRelation,
+  SavedObjectManagementTypeInfo,
+} from '@kbn/saved-objects-management-plugin/common';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { asyncForEach } from '@kbn/std';
@@ -42,6 +45,7 @@ interface RemoveDataViewDeps {
   dataViewArray: RemoveDataViewProps[];
   selectedRelationships: Record<string, SavedObjectRelation[]>;
   hasSpaces: boolean;
+  allowedTypes: SavedObjectManagementTypeInfo[];
   onDelete: () => void;
   onClose: () => void;
 }
@@ -51,6 +55,7 @@ export const DeleteDataViewFlyout = ({
   dataViewArray,
   selectedRelationships,
   hasSpaces,
+  allowedTypes,
   onDelete,
   onClose,
 }: RemoveDataViewDeps) => {
@@ -117,6 +122,7 @@ export const DeleteDataViewFlyout = ({
           views={dataViewArray}
           hasSpaces={hasSpaces}
           relationships={selectedRelationships}
+          allowedTypes={allowedTypes}
         />
       </EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.test.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.test.tsx
@@ -13,6 +13,7 @@ import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/p
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
 import {
   DeleteModalContent,
   relationshipCalloutText,
@@ -70,6 +71,7 @@ describe('DeleteModalContent', () => {
             relationships={mockRelationships}
             reviewedItems={reviewedItems}
             setReviewedItems={setReviewedItems}
+            allowedTypes={[]}
             {...overrides}
           />
         </KibanaContextProvider>
@@ -79,7 +81,6 @@ describe('DeleteModalContent', () => {
   it('renders warning callout when no relationships', () => {
     renderContent({ relationships: { '1': [], '2': [] } });
     expect(screen.getByText(spacesWarningText)).toBeVisible();
-    expect(screen.getByText(/Successfully deleted 2 data views/i)).toBeVisible();
   });
 
   it('renders danger callout when relationships exist', () => {
@@ -107,6 +108,15 @@ describe('DeleteModalContent', () => {
     expect(setReviewedItems).toHaveBeenCalled();
   });
 
+  it('renders the relations table with a Type icon column before the Title column', async () => {
+    renderContent();
+    await userEvent.click(screen.getByRole('button', { name: /Expand/i }));
+
+    const headers = screen.getAllByRole('columnheader').map((header) => header.textContent);
+    expect(headers.indexOf('Type')).toBeLessThan(headers.indexOf('Title'));
+    expect(screen.getByTestId('relationshipsObjectType')).toBeVisible();
+  });
+
   it('renders related object links with the current space basePath', async () => {
     const context = mockManagementPlugin.createIndexPatternManagmentContext();
     context.http = httpServiceMock.createStartContract({ basePath: '/s/space-a' });
@@ -123,5 +133,57 @@ describe('DeleteModalContent', () => {
   it('renders without spaces column if hasSpaces is false', () => {
     renderContent({ hasSpaces: false });
     expect(screen.queryByText('Spaces')).not.toBeInTheDocument();
+  });
+
+  describe('with a relation in a different space', () => {
+    const renderWithCrossSpaceRelation = async () => {
+      const context = mockManagementPlugin.createIndexPatternManagmentContext();
+      context.http = httpServiceMock.createStartContract();
+      context.http.basePath = httpServiceMock.createBasePath({ serverBasePath: '' });
+      context.http.basePath.get.mockReturnValue('/s/space-a');
+      context.spaces = spacesPluginMock.createStartContract();
+      (context.spaces.ui.components.getSpacesContextProvider as jest.Mock).mockImplementation(
+        ({ children }: React.PropsWithChildren<{}>) => <>{children}</>
+      );
+      (context.spaces.ui.components.getSpaceList as jest.Mock).mockImplementation(
+        ({ namespaces }: { namespaces: string[] }) => (
+          <span data-test-subj="spaceList">{namespaces.join(',')}</span>
+        )
+      );
+
+      renderContent(
+        {
+          relationships: {
+            '1': [
+              {
+                id: 'rel-1',
+                type: 'dashboard',
+                namespaces: ['space-b'],
+                meta: {
+                  title: 'Dashboard 1',
+                  inAppUrl: { path: '/app/dashboards#/view/rel-1', uiCapabilitiesPath: '' },
+                },
+              } as SavedObjectRelation,
+            ],
+            '2': [],
+          },
+        },
+        context
+      );
+      await userEvent.click(screen.getByRole('button', { name: /Expand/i }));
+    };
+
+    it('renders a Spaces column showing the relation namespaces', async () => {
+      await renderWithCrossSpaceRelation();
+      expect(screen.getByTestId('spaceList')).toHaveTextContent('space-b');
+    });
+
+    it('links to the relation own space rather than the current space', async () => {
+      await renderWithCrossSpaceRelation();
+      expect(screen.getByText('Dashboard 1').closest('a')).toHaveAttribute(
+        'href',
+        '/s/space-b/app/dashboards#/view/rel-1'
+      );
+    });
   });
 });

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { EuiTableFieldDataColumnType } from '@elastic/eui';
+import type { EuiTableFieldDataColumnType, HorizontalAlignment } from '@elastic/eui';
 import {
   EuiCallOut,
   EuiBasicTable,
@@ -15,13 +15,23 @@ import {
   EuiScreenReaderOnly,
   EuiLink,
   EuiIcon,
+  EuiIconTip,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiText,
   useIsWithinBreakpoints,
 } from '@elastic/eui';
-import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/public';
-import { FormattedMessage } from '@kbn/i18n-react';
+import type {
+  SavedObjectRelation,
+  SavedObjectManagementTypeInfo,
+} from '@kbn/saved-objects-management-plugin/public';
+import {
+  RelationshipSpacesCell,
+  SpacesContextWrapper,
+  getRelationshipHref,
+  shouldShowSpacesColumn,
+} from '@kbn/saved-objects-management-plugin/public';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import React, { useState, type ReactNode } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -43,6 +53,13 @@ const dataViewColumnName = i18n.translate(
 const spacesColumnName = i18n.translate('indexPatternManagement.dataViewTable.spacesColumnName', {
   defaultMessage: 'Spaces',
 });
+
+const relationshipSpacesColumnName = i18n.translate(
+  'indexPatternManagement.dataViewTable.relationshipSpacesColumnName',
+  {
+    defaultMessage: 'Spaces',
+  }
+);
 
 const tableTitle = i18n.translate('indexPatternManagement.dataViewTable.tableTitle', {
   defaultMessage: 'Data views selected for deletion',
@@ -77,6 +94,7 @@ interface ModalProps {
   relationships: Record<string, SavedObjectRelation[]>;
   reviewedItems: Set<string>;
   setReviewedItems: React.Dispatch<React.SetStateAction<Set<string>>>;
+  allowedTypes: SavedObjectManagementTypeInfo[];
 }
 
 export const DeleteModalContent: React.FC<ModalProps> = ({
@@ -85,8 +103,10 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
   relationships,
   reviewedItems,
   setReviewedItems,
+  allowedTypes,
 }) => {
-  const { http } = useKibana<IndexPatternManagmentContext>().services;
+  const { http, spaces, savedObjectsManagement } =
+    useKibana<IndexPatternManagmentContext>().services;
 
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<Record<string, ReactNode>>(
     {}
@@ -99,28 +119,70 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
     if (itemIdToExpandedRowMapValues[id]) {
       delete itemIdToExpandedRowMapValues[id];
     } else {
+      const targetNamespaces = views.find((view) => view.id === id)?.namespaces;
       const relationsColumns: Array<EuiTableFieldDataColumnType<SavedObjectRelation>> = [
-        {
-          field: 'meta',
-          name: i18n.translate('indexPatternManagement.dataViewTable.relationshipMetaTitle', {
-            defaultMessage: 'Name',
-          }),
-          render: (meta: SavedObjectRelation['meta']) => {
-            return meta.inAppUrl ? (
-              <EuiLink target="_blank" href={http.basePath.prepend(meta.inAppUrl.path)}>
-                {meta.title}
-              </EuiLink>
-            ) : (
-              meta.title
-            );
-          },
-        },
         {
           field: 'type',
           name: i18n.translate('indexPatternManagement.dataViewTable.relationshipType', {
             defaultMessage: 'Type',
           }),
+          width: '50px',
+          align: 'center' as HorizontalAlignment,
+          sortable: false,
+          render: (type: string, relation: SavedObjectRelation) => {
+            const typeLabel = savedObjectsManagement.getSavedObjectLabel(type, allowedTypes);
+            return (
+              <EuiIconTip
+                content={typeLabel}
+                position="top"
+                aria-label={typeLabel}
+                type={relation.meta.icon || 'apps'}
+                size="s"
+                iconProps={{
+                  'data-test-subj': 'relationshipsObjectType',
+                }}
+              />
+            );
+          },
         },
+        {
+          field: 'meta.title',
+          name: i18n.translate('indexPatternManagement.dataViewTable.relationshipMetaTitle', {
+            defaultMessage: 'Title',
+          }),
+          sortable: false,
+          render: (title: string, relation: SavedObjectRelation) => {
+            return relation.meta.inAppUrl ? (
+              <EuiLink
+                target="_blank"
+                href={getRelationshipHref(
+                  http.basePath,
+                  relation.namespaces,
+                  relation.meta.inAppUrl.path
+                )}
+              >
+                {title}
+              </EuiLink>
+            ) : (
+              title
+            );
+          },
+        },
+        ...(shouldShowSpacesColumn(spaces, relationships[id], http.basePath)
+          ? [
+              {
+                field: 'namespaces',
+                name: relationshipSpacesColumnName,
+                render: (namespaces: string[] | undefined) => (
+                  <RelationshipSpacesCell
+                    spacesApi={spaces as SpacesPluginStart}
+                    namespaces={namespaces}
+                    targetNamespaces={targetNamespaces}
+                  />
+                ),
+              } as EuiTableFieldDataColumnType<SavedObjectRelation>,
+            ]
+          : []),
       ];
       const relationsTable = (
         <div>
@@ -233,43 +295,26 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
   );
 
   return (
-    <div>
-      {showRelationshipsCallout ? (
-        <>
-          <EuiCallOut
-            announceOnMount={false}
-            color="danger"
-            iconType="warning"
-            title={relationshipCalloutText}
-          />
-        </>
-      ) : (
-        <EuiCallOut
-          announceOnMount={false}
-          color="warning"
-          iconType="warning"
-          title={spacesWarningText}
-        />
-      )}
-      <EuiSpacer size="m" />
+    <SpacesContextWrapper spacesApi={spaces}>
       <div>
-        <FormattedMessage
-          id="indexPatternManagement.dataViewTable.deleteConfirmSummary"
-          defaultMessage="Successfully deleted {count, number} {count, plural,
-          one {data view}
-          other {data views}
-}."
-          values={{ count: views.length }}
+        {showRelationshipsCallout ? (
+          <EuiCallOut announceOnMount={false} color="danger" iconType="warning">
+            <p>{relationshipCalloutText}</p>
+          </EuiCallOut>
+        ) : (
+          <EuiCallOut announceOnMount={false} color="warning" iconType="warning">
+            <p>{spacesWarningText}</p>
+          </EuiCallOut>
+        )}
+        <EuiSpacer size="m" />
+        <EuiBasicTable
+          tableCaption={tableTitle}
+          items={views}
+          itemId="id"
+          itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+          columns={columns}
         />
       </div>
-      <EuiSpacer size="m" />
-      <EuiBasicTable
-        tableCaption={tableTitle}
-        items={views}
-        itemId="id"
-        itemIdToExpandedRowMap={itemIdToExpandedRowMap}
-        columns={columns}
-      />
-    </div>
+    </SpacesContextWrapper>
   );
 };

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -289,6 +289,7 @@ export const EditIndexPattern = withRouter(
               [dataView.id as RemoveDataViewProps['id']]: relationships,
             }}
             hasSpaces={Boolean(dataView.namespaces)}
+            allowedTypes={allowedTypes}
             onDelete={() => {
               history.push('');
             }}

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/i18n.ts
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/i18n.ts
@@ -38,6 +38,18 @@ export const filterTitle = i18n.translate(
   { defaultMessage: 'Type' }
 );
 
+export const spacesFieldName = i18n.translate(
+  'indexPatternManagement.objectsTable.relationships.columnSpacesName',
+  {
+    defaultMessage: 'Spaces',
+  }
+);
+
+export const spacesFieldDescription = i18n.translate(
+  'indexPatternManagement.objectsTable.relationships.columnSpacesDescription',
+  { defaultMessage: 'The spaces this saved object is shared into' }
+);
+
 export const managedBadge = i18n.translate(
   'indexPatternManagement.objectsTable.relationships.managedBadge',
   {

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/relationships_table.test.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/relationships_table.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
+import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/public';
+import { RelationshipsTable } from './relationships_table';
+
+const relationships: Array<SavedObjectRelation & { title: string }> = [
+  {
+    id: 'rel-1',
+    type: 'dashboard',
+    relationship: 'parent',
+    managed: false,
+    references: [],
+    title: 'Dashboard 1',
+    meta: {
+      title: 'Dashboard 1',
+      inAppUrl: { path: '/app/dashboards#/view/rel-1', uiCapabilitiesPath: '' },
+    },
+    namespaces: ['space-b'],
+  },
+];
+
+const renderTable = (overrides: Partial<React.ComponentProps<typeof RelationshipsTable>> = {}) => {
+  const basePath = httpServiceMock.createBasePath({ serverBasePath: '' });
+  basePath.get.mockReturnValue('/s/space-a');
+
+  return render(
+    <IntlProvider>
+      <RelationshipsTable
+        basePath={basePath}
+        capabilities={{} as any}
+        id="target-id"
+        navigateToUrl={jest.fn()}
+        getDefaultTitle={() => 'Untitled'}
+        getSavedObjectLabel={() => 'Dashboard'}
+        relationships={relationships}
+        allowedTypes={[]}
+        {...overrides}
+      />
+    </IntlProvider>
+  );
+};
+
+describe('RelationshipsTable', () => {
+  it('does not render a Spaces column when the spaces plugin is unavailable', () => {
+    renderTable();
+    expect(screen.queryByText('Spaces')).not.toBeInTheDocument();
+  });
+
+  it('renders a Spaces column and links to the correct space when a relation lives elsewhere', () => {
+    const spacesApi = spacesPluginMock.createStartContract();
+    (spacesApi.ui.components.getSpacesContextProvider as jest.Mock).mockImplementation(
+      ({ children }: React.PropsWithChildren<{}>) => <>{children}</>
+    );
+    (spacesApi.ui.components.getSpaceList as jest.Mock).mockImplementation(
+      ({ namespaces }: { namespaces: string[] }) => (
+        <span data-test-subj="spaceList">{namespaces.join(',')}</span>
+      )
+    );
+
+    renderTable({ spacesApi, targetNamespaces: ['space-a', 'space-b'] });
+
+    expect(screen.getByText('Spaces')).toBeVisible();
+    expect(screen.getByTestId('spaceList')).toHaveTextContent('space-b');
+    expect(screen.getByText('Dashboard 1').closest('a')).toHaveAttribute(
+      'href',
+      '/s/space-b/app/dashboards#/view/rel-1'
+    );
+  });
+});

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/relationships_table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/relationships_table.tsx
@@ -22,13 +22,18 @@ import { get } from 'lodash';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import { useEuiTablePersist } from '@kbn/shared-ux-table-persist';
 import type { SavedObjectsTaggingApi } from '@kbn/saved-objects-tagging-oss-plugin/public';
-
 import type {
   SavedObjectRelation,
   SavedObjectManagementTypeInfo,
   SavedObjectsManagementPluginStart,
 } from '@kbn/saved-objects-management-plugin/public';
-
+import {
+  RelationshipSpacesCell,
+  SpacesContextWrapper,
+  getRelationshipHref,
+  shouldShowSpacesColumn,
+} from '@kbn/saved-objects-management-plugin/public';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { SearchFilterConfig } from '@elastic/eui';
 import { EuiIconTip } from '@elastic/eui';
 import { IPM_APP_ID } from '../../../constants';
@@ -40,6 +45,8 @@ import {
   filterTitle,
   managedBadge,
   relationshipsTableCaption,
+  spacesFieldName,
+  spacesFieldDescription,
 } from './i18n';
 
 const canGoInApp = (
@@ -62,6 +69,8 @@ export const RelationshipsTable = ({
   relationships,
   allowedTypes,
   savedObjectsTagging,
+  spacesApi,
+  targetNamespaces,
 }: {
   basePath: CoreStart['http']['basePath'];
   capabilities: CoreStart['application']['capabilities'];
@@ -72,6 +81,8 @@ export const RelationshipsTable = ({
   relationships: SavedObjectRelation[];
   allowedTypes: SavedObjectManagementTypeInfo[];
   savedObjectsTagging?: SavedObjectsTaggingApi;
+  spacesApi?: SpacesPluginStart;
+  targetNamespaces?: string[];
 }) => {
   const columns = [
     {
@@ -119,7 +130,10 @@ export const RelationshipsTable = ({
         return (
           <EuiFlexGroup gutterSize="xs" alignItems="center">
             {showUrl ? (
-              <EuiLink href={basePath.prepend(path)} data-test-subj="relationshipsTitle">
+              <EuiLink
+                href={getRelationshipHref(basePath, object.namespaces, path)}
+                data-test-subj="relationshipsTitle"
+              >
                 {titleDisplayed}
               </EuiLink>
             ) : (
@@ -143,6 +157,23 @@ export const RelationshipsTable = ({
         );
       },
     },
+    ...(shouldShowSpacesColumn(spacesApi, relationships, basePath)
+      ? [
+          {
+            field: 'namespaces',
+            name: spacesFieldName,
+            description: spacesFieldDescription,
+            sortable: false,
+            render: (namespaces: string[] | undefined) => (
+              <RelationshipSpacesCell
+                spacesApi={spacesApi as SpacesPluginStart}
+                namespaces={namespaces}
+                targetNamespaces={targetNamespaces}
+              />
+            ),
+          },
+        ]
+      : []),
   ];
 
   const filterTypesMap = new Map(
@@ -180,20 +211,22 @@ export const RelationshipsTable = ({
   });
 
   return (
-    <RedirectAppLinks currentAppId={IPM_APP_ID} navigateToUrl={navigateToUrl}>
-      <EuiInMemoryTable<SavedObjectRelation>
-        items={relationships}
-        columns={columns}
-        tableCaption={relationshipsTableCaption}
-        pagination={{
-          pageSize,
-        }}
-        onTableChange={onTableChange}
-        search={search}
-        rowProps={() => ({
-          'data-test-subj': `relationshipsTableRow`,
-        })}
-      />
-    </RedirectAppLinks>
+    <SpacesContextWrapper spacesApi={spacesApi}>
+      <RedirectAppLinks currentAppId={IPM_APP_ID} navigateToUrl={navigateToUrl}>
+        <EuiInMemoryTable<SavedObjectRelation>
+          items={relationships}
+          columns={columns}
+          tableCaption={relationshipsTableCaption}
+          pagination={{
+            pageSize,
+          }}
+          onTableChange={onTableChange}
+          search={search}
+          rowProps={() => ({
+            'data-test-subj': `relationshipsTableRow`,
+          })}
+        />
+      </RedirectAppLinks>
+    </SpacesContextWrapper>
   );
 };

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/tabs/tabs.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/tabs/tabs.tsx
@@ -186,6 +186,7 @@ export const Tabs: React.FC<TabsProps> = ({
     savedObjectsManagement,
     savedObjectsTagging,
     dataViewMgmtService,
+    spaces,
     ...startServices
   } = useKibana<IndexPatternManagmentContext>().services;
   const [fieldFilter, setFieldFilter] = useState<string>('');
@@ -580,6 +581,8 @@ export const Tabs: React.FC<TabsProps> = ({
                 getDefaultTitle={savedObjectsManagement.getDefaultTitle}
                 getSavedObjectLabel={savedObjectsManagement.getSavedObjectLabel}
                 savedObjectsTagging={savedObjectsTagging}
+                spacesApi={spaces}
+                targetNamespaces={indexPattern.namespaces}
               />
             </Fragment>
           );
@@ -611,6 +614,7 @@ export const Tabs: React.FC<TabsProps> = ({
       allowedTypes,
       relationships,
       dataViewMgmtService,
+      spaces,
     ]
   );
 

--- a/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -26,7 +26,10 @@ import type { RouteComponentProps } from 'react-router-dom';
 import { withRouter } from 'react-router-dom';
 import useObservable from 'react-use/lib/useObservable';
 
-import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/common';
+import type {
+  SavedObjectRelation,
+  SavedObjectManagementTypeInfo,
+} from '@kbn/saved-objects-management-plugin/common';
 import { reactRouterNavigate, useKibana } from '@kbn/kibana-react-plugin/public';
 import { NoDataViewsPromptComponent, useOnTryESQL } from '@kbn/shared-ux-prompt-no-data-views';
 import type { SpacesContextProps } from '@kbn/spaces-plugin/public';
@@ -100,6 +103,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
   const [selectedRelationships, setSelectedRelationships] = useState<
     Record<string, SavedObjectRelation[]>
   >({});
+  const [allowedTypes, setAllowedTypes] = useState<SavedObjectManagementTypeInfo[]>([]);
   const [deleteFlyoutOpen, setDeleteFlyoutOpen] = useState(false);
   const [dataViewController] = useState(
     () =>
@@ -155,9 +159,10 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
   }, [selectedDataView, selectedItems]);
 
   const getRelationshipsForSelections = async (selectedViews: RemoveDataViewProps[]) => {
-    const allowedTypes = (await savedObjectsManagement.getAllowedTypes()).map((type) => type.name);
+    const allowedTypeInfo = await savedObjectsManagement.getAllowedTypes();
+    const allowedTypeNames = allowedTypeInfo.map((type) => type.name);
 
-    const relationships: Record<string, unknown> = {};
+    const relationships: Record<string, SavedObjectRelation[]> = {};
 
     const relationshipsArray = await Promise.all(
       selectedViews.map(async (view) => ({
@@ -166,7 +171,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
           await savedObjectsManagement.getRelationships(
             DATA_VIEW_SAVED_OBJECT_TYPE,
             view.id,
-            allowedTypes,
+            allowedTypeNames,
             MAX_DISPLAYED_RELATIONSHIPS
           )
         ).relations,
@@ -178,7 +183,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
       relationships[id] = relations;
     });
 
-    return relationships;
+    return { relationships, allowedTypeInfo };
   };
 
   const renderDeleteButton = () => {
@@ -191,12 +196,11 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
         iconType="trash"
         data-test-subj="delete-data-views-button"
         onClick={async () => {
-          const relationships =
-            ((await getRelationshipsForSelections(selectedItems)) as Record<
-              string,
-              SavedObjectRelation[]
-            >) || {};
+          const { relationships, allowedTypeInfo } = await getRelationshipsForSelections(
+            selectedItems
+          );
           setSelectedRelationships(relationships);
+          setAllowedTypes(allowedTypeInfo);
           setDeleteFlyoutOpen(true);
         }}
       >
@@ -277,12 +281,12 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
         type: 'icon',
         enabled: (dataView: RemoveDataViewProps) => !dataView.managed,
         onClick: async (dataView: RemoveDataViewProps) => {
-          const relationships = (await getRelationshipsForSelections([dataView])) as Record<
-            string,
-            SavedObjectRelation[]
-          >;
+          const { relationships, allowedTypeInfo } = await getRelationshipsForSelections([
+            dataView,
+          ]);
           setSelectedDataView(dataView);
           setSelectedRelationships(relationships);
+          setAllowedTypes(allowedTypeInfo);
           setDeleteFlyoutOpen(true);
         },
         isPrimary: true,
@@ -442,6 +446,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
           dataViewArray={dataViewArray}
           selectedRelationships={selectedRelationships}
           hasSpaces={!!spaces}
+          allowedTypes={allowedTypes}
           onDelete={async () => {
             dataViewController.loadDataViews();
             onDeleteFlyoutClose();

--- a/src/platform/plugins/shared/saved_objects_management/common/types/v1.ts
+++ b/src/platform/plugins/shared/saved_objects_management/common/types/v1.ts
@@ -49,6 +49,7 @@ export interface SavedObjectWithMetadata<T = unknown> {
   updated_at?: string;
   managed?: boolean;
   attributes: T;
+  namespace?: string;
   namespaces?: string[];
   references: SavedObjectReference[];
 }
@@ -65,6 +66,7 @@ export interface SavedObjectRelation {
   meta: SavedObjectMetadata;
   managed: boolean;
   references: SavedObjectReference[];
+  namespaces?: string[];
 }
 
 /**
@@ -159,6 +161,7 @@ export interface RelationshipsQueryHTTP {
 export interface RelationshipsResponseHTTP {
   relations: SavedObjectRelation[];
   invalidRelations: SavedObjectInvalidRelation[];
+  targetNamespaces?: string[];
 }
 
 export interface ScrollCountBodyHTTP {

--- a/src/platform/plugins/shared/saved_objects_management/moon.yml
+++ b/src/platform/plugins/shared/saved_objects_management/moon.yml
@@ -46,6 +46,8 @@ dependsOn:
   - '@kbn/scout'
   - '@kbn/repo-info'
   - '@kbn/core-saved-objects-server'
+  - '@kbn/core-http-browser-mocks'
+  - '@kbn/core-spaces-common'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/saved_objects_management/public/index.ts
+++ b/src/platform/plugins/shared/saved_objects_management/public/index.ts
@@ -24,6 +24,12 @@ export type {
   SavedObjectMetadata,
   SavedObjectManagementTypeInfo,
 } from './types';
+export {
+  RelationshipSpacesCell,
+  SpacesContextWrapper,
+  getRelationshipHref,
+  shouldShowSpacesColumn,
+} from './management_section/objects_table/components/relationship_spaces';
 
 export function plugin(initializerContext: PluginInitializerContext) {
   return new SavedObjectsManagementPlugin();

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
@@ -1,879 +1,891 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Relationships should render dashboards normally 1`] = `
-<EuiFlyout
-  aria-labelledby="generated-id_relationshipsFlyoutTitle"
-  onClose={[MockFunction]}
->
-  <EuiFlyoutHeader
-    hasBorder={true}
+<SpacesContextWrapper>
+  <EuiFlyout
+    aria-labelledby="generated-id_relationshipsFlyoutTitle"
+    onClose={[MockFunction]}
   >
-    <EuiTitle
-      size="m"
+    <EuiFlyoutHeader
+      hasBorder={true}
     >
-      <h2
-        id="generated-id_relationshipsFlyoutTitle"
+      <EuiTitle
+        size="m"
       >
-        <EuiIconTip
-          aria-label="dashboard"
-          content="dashboard"
-          position="top"
-          size="m"
-          type="dashboardApp"
-        />
-          
-        MyDashboard
-      </h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    <EuiCallOut>
-      <p>
-        Here are the saved objects related to MyDashboard. Deleting this dashboard affects its parent objects, but not its children.
-      </p>
-    </EuiCallOut>
-    <EuiSpacer />
-    <EuiInMemoryTable
-      columns={
-        Array [
+        <h2
+          id="generated-id_relationshipsFlyoutTitle"
+        >
+          <EuiIconTip
+            aria-label="dashboard"
+            content="dashboard"
+            position="top"
+            size="m"
+            type="dashboardApp"
+          />
+            
+          MyDashboard
+        </h2>
+      </EuiTitle>
+    </EuiFlyoutHeader>
+    <EuiFlyoutBody>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MyDashboard. Deleting this dashboard affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/app/visualize#/edit/1",
+                  "uiCapabilitiesPath": "visualize_v2.show",
+                },
+                "title": "My Visualization Title 1",
+              },
+              "relationship": "child",
+              "type": "visualization",
+            },
+            Object {
+              "id": "2",
+              "meta": Object {
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/app/visualize#/edit/2",
+                  "uiCapabilitiesPath": "visualize_v2.show",
+                },
+                "title": "My Visualization Title 2",
+              },
+              "relationship": "child",
+              "type": "visualization",
+            },
+          ]
+        }
+        onTableChange={[Function]}
+        pagination={
           Object {
-            "align": "center",
-            "description": "Type of the saved object",
-            "field": "type",
-            "name": "Type",
-            "render": [Function],
-            "sortable": false,
-            "width": "50px",
-          },
+            "pageSize": 10,
+          }
+        }
+        rowProps={[Function]}
+        search={
           Object {
-            "data-test-subj": "directRelationship",
-            "dataType": "string",
-            "field": "relationship",
-            "name": "Direct relationship",
-            "render": [Function],
-            "sortable": false,
-            "width": "125px",
-          },
-          Object {
-            "dataType": "string",
-            "description": "Title of the saved object",
-            "field": "meta.title",
-            "name": "Title",
-            "render": [Function],
-            "sortable": false,
-          },
-          Object {
-            "actions": Array [
+            "filters": Array [
               Object {
-                "available": [Function],
-                "data-test-subj": "relationshipsTableAction-inspect",
-                "description": "Inspect this saved object",
-                "icon": "inspect",
-                "name": "Inspect",
-                "onClick": [Function],
-                "type": "icon",
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "visualization",
+                    "value": "visualization",
+                    "view": "visualization",
+                  },
+                ],
+                "type": "field_value_selection",
               },
             ],
-            "name": "Actions",
-          },
-        ]
-      }
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "meta": Object {
-              "icon": "visualizeApp",
-              "inAppUrl": Object {
-                "path": "/app/visualize#/edit/1",
-                "uiCapabilitiesPath": "visualize_v2.show",
-              },
-              "title": "My Visualization Title 1",
-            },
-            "relationship": "child",
-            "type": "visualization",
-          },
-          Object {
-            "id": "2",
-            "meta": Object {
-              "icon": "visualizeApp",
-              "inAppUrl": Object {
-                "path": "/app/visualize#/edit/2",
-                "uiCapabilitiesPath": "visualize_v2.show",
-              },
-              "title": "My Visualization Title 2",
-            },
-            "relationship": "child",
-            "type": "visualization",
-          },
-        ]
-      }
-      onTableChange={[Function]}
-      pagination={
-        Object {
-          "pageSize": 10,
+          }
         }
-      }
-      rowProps={[Function]}
-      search={
-        Object {
-          "filters": Array [
-            Object {
-              "field": "relationship",
-              "multiSelect": "or",
-              "name": "Direct relationship",
-              "options": Array [
-                Object {
-                  "name": "parent",
-                  "value": "parent",
-                  "view": "Parent",
-                },
-                Object {
-                  "name": "child",
-                  "value": "child",
-                  "view": "Child",
-                },
-              ],
-              "type": "field_value_selection",
-            },
-            Object {
-              "field": "type",
-              "multiSelect": "or",
-              "name": "Type",
-              "options": Array [
-                Object {
-                  "name": "visualization",
-                  "value": "visualization",
-                  "view": "visualization",
-                },
-              ],
-              "type": "field_value_selection",
-            },
-          ],
-        }
-      }
-      searchFormat="eql"
-      tableCaption="Saved objects related to MyDashboard"
-      tableLayout="fixed"
-    />
-  </EuiFlyoutBody>
-</EuiFlyout>
+        searchFormat="eql"
+        tableCaption="Saved objects related to MyDashboard"
+        tableLayout="fixed"
+      />
+    </EuiFlyoutBody>
+  </EuiFlyout>
+</SpacesContextWrapper>
 `;
 
 exports[`Relationships should render errors 1`] = `
-<EuiFlyout
-  aria-labelledby="generated-id_relationshipsFlyoutTitle"
-  onClose={[MockFunction]}
->
-  <EuiFlyoutHeader
-    hasBorder={true}
+<SpacesContextWrapper>
+  <EuiFlyout
+    aria-labelledby="generated-id_relationshipsFlyoutTitle"
+    onClose={[MockFunction]}
   >
-    <EuiTitle
-      size="m"
+    <EuiFlyoutHeader
+      hasBorder={true}
     >
-      <h2
-        id="generated-id_relationshipsFlyoutTitle"
+      <EuiTitle
+        size="m"
       >
-        <EuiIconTip
-          aria-label="dashboard"
-          content="dashboard"
-          position="top"
-          size="m"
-          type="dashboardApp"
-        />
-          
-        MyDashboard
-      </h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    <EuiCallOut
-      color="danger"
-      title={
-        <Memo(MemoizedFormattedMessage)
-          defaultMessage="Error"
-          id="savedObjectsManagement.objectsTable.relationships.renderErrorMessage"
-        />
-      }
-    >
-      foo
-    </EuiCallOut>
-  </EuiFlyoutBody>
-</EuiFlyout>
+        <h2
+          id="generated-id_relationshipsFlyoutTitle"
+        >
+          <EuiIconTip
+            aria-label="dashboard"
+            content="dashboard"
+            position="top"
+            size="m"
+            type="dashboardApp"
+          />
+            
+          MyDashboard
+        </h2>
+      </EuiTitle>
+    </EuiFlyoutHeader>
+    <EuiFlyoutBody>
+      <EuiCallOut
+        color="danger"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Error"
+            id="savedObjectsManagement.objectsTable.relationships.renderErrorMessage"
+          />
+        }
+      >
+        foo
+      </EuiCallOut>
+    </EuiFlyoutBody>
+  </EuiFlyout>
+</SpacesContextWrapper>
 `;
 
 exports[`Relationships should render index patterns normally 1`] = `
-<EuiFlyout
-  aria-labelledby="generated-id_relationshipsFlyoutTitle"
-  onClose={[MockFunction]}
->
-  <EuiFlyoutHeader
-    hasBorder={true}
+<SpacesContextWrapper>
+  <EuiFlyout
+    aria-labelledby="generated-id_relationshipsFlyoutTitle"
+    onClose={[MockFunction]}
   >
-    <EuiTitle
-      size="m"
+    <EuiFlyoutHeader
+      hasBorder={true}
     >
-      <h2
-        id="generated-id_relationshipsFlyoutTitle"
+      <EuiTitle
+        size="m"
       >
-        <EuiIconTip
-          aria-label="index-pattern"
-          content="index-pattern"
-          position="top"
-          size="m"
-          type="indexPatternApp"
-        />
-          
-        MyIndexPattern*
-      </h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    <EuiCallOut>
-      <p>
-        Here are the saved objects related to MyIndexPattern*. Deleting this index-pattern affects its parent objects, but not its children.
-      </p>
-    </EuiCallOut>
-    <EuiSpacer />
-    <EuiInMemoryTable
-      columns={
-        Array [
+        <h2
+          id="generated-id_relationshipsFlyoutTitle"
+        >
+          <EuiIconTip
+            aria-label="index-pattern"
+            content="index-pattern"
+            position="top"
+            size="m"
+            type="indexPatternApp"
+          />
+            
+          MyIndexPattern*
+        </h2>
+      </EuiTitle>
+    </EuiFlyoutHeader>
+    <EuiFlyoutBody>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MyIndexPattern*. Deleting this index-pattern affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "icon": "magnify",
+                "inAppUrl": Object {
+                  "path": "/app/discover#//1",
+                  "uiCapabilitiesPath": "discover_v2.show",
+                },
+                "title": "My Search Title",
+              },
+              "relationship": "parent",
+              "type": "search",
+            },
+            Object {
+              "id": "2",
+              "meta": Object {
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/app/visualize#/edit/2",
+                  "uiCapabilitiesPath": "visualize_v2.show",
+                },
+                "title": "My Visualization Title",
+              },
+              "relationship": "parent",
+              "type": "visualization",
+            },
+          ]
+        }
+        onTableChange={[Function]}
+        pagination={
           Object {
-            "align": "center",
-            "description": "Type of the saved object",
-            "field": "type",
-            "name": "Type",
-            "render": [Function],
-            "sortable": false,
-            "width": "50px",
-          },
+            "pageSize": 10,
+          }
+        }
+        rowProps={[Function]}
+        search={
           Object {
-            "data-test-subj": "directRelationship",
-            "dataType": "string",
-            "field": "relationship",
-            "name": "Direct relationship",
-            "render": [Function],
-            "sortable": false,
-            "width": "125px",
-          },
-          Object {
-            "dataType": "string",
-            "description": "Title of the saved object",
-            "field": "meta.title",
-            "name": "Title",
-            "render": [Function],
-            "sortable": false,
-          },
-          Object {
-            "actions": Array [
+            "filters": Array [
               Object {
-                "available": [Function],
-                "data-test-subj": "relationshipsTableAction-inspect",
-                "description": "Inspect this saved object",
-                "icon": "inspect",
-                "name": "Inspect",
-                "onClick": [Function],
-                "type": "icon",
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "search",
+                    "value": "search",
+                    "view": "search",
+                  },
+                  Object {
+                    "name": "visualization",
+                    "value": "visualization",
+                    "view": "visualization",
+                  },
+                ],
+                "type": "field_value_selection",
               },
             ],
-            "name": "Actions",
-          },
-        ]
-      }
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "meta": Object {
-              "icon": "magnify",
-              "inAppUrl": Object {
-                "path": "/app/discover#//1",
-                "uiCapabilitiesPath": "discover_v2.show",
-              },
-              "title": "My Search Title",
-            },
-            "relationship": "parent",
-            "type": "search",
-          },
-          Object {
-            "id": "2",
-            "meta": Object {
-              "icon": "visualizeApp",
-              "inAppUrl": Object {
-                "path": "/app/visualize#/edit/2",
-                "uiCapabilitiesPath": "visualize_v2.show",
-              },
-              "title": "My Visualization Title",
-            },
-            "relationship": "parent",
-            "type": "visualization",
-          },
-        ]
-      }
-      onTableChange={[Function]}
-      pagination={
-        Object {
-          "pageSize": 10,
+          }
         }
-      }
-      rowProps={[Function]}
-      search={
-        Object {
-          "filters": Array [
-            Object {
-              "field": "relationship",
-              "multiSelect": "or",
-              "name": "Direct relationship",
-              "options": Array [
-                Object {
-                  "name": "parent",
-                  "value": "parent",
-                  "view": "Parent",
-                },
-                Object {
-                  "name": "child",
-                  "value": "child",
-                  "view": "Child",
-                },
-              ],
-              "type": "field_value_selection",
-            },
-            Object {
-              "field": "type",
-              "multiSelect": "or",
-              "name": "Type",
-              "options": Array [
-                Object {
-                  "name": "search",
-                  "value": "search",
-                  "view": "search",
-                },
-                Object {
-                  "name": "visualization",
-                  "value": "visualization",
-                  "view": "visualization",
-                },
-              ],
-              "type": "field_value_selection",
-            },
-          ],
-        }
-      }
-      searchFormat="eql"
-      tableCaption="Saved objects related to MyIndexPattern*"
-      tableLayout="fixed"
-    />
-  </EuiFlyoutBody>
-</EuiFlyout>
+        searchFormat="eql"
+        tableCaption="Saved objects related to MyIndexPattern*"
+        tableLayout="fixed"
+      />
+    </EuiFlyoutBody>
+  </EuiFlyout>
+</SpacesContextWrapper>
 `;
 
 exports[`Relationships should render invalid relations 1`] = `
-<EuiFlyout
-  aria-labelledby="generated-id_relationshipsFlyoutTitle"
-  onClose={[MockFunction]}
->
-  <EuiFlyoutHeader
-    hasBorder={true}
+<SpacesContextWrapper>
+  <EuiFlyout
+    aria-labelledby="generated-id_relationshipsFlyoutTitle"
+    onClose={[MockFunction]}
   >
-    <EuiTitle
-      size="m"
+    <EuiFlyoutHeader
+      hasBorder={true}
     >
-      <h2
-        id="generated-id_relationshipsFlyoutTitle"
+      <EuiTitle
+        size="m"
       >
-        <EuiIconTip
-          aria-label="index-pattern"
-          content="index-pattern"
-          position="top"
-          size="m"
-          type="indexPatternApp"
-        />
-          
-        MyIndexPattern*
-      </h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    <EuiCallOut
-      color="warning"
-      iconType="warning"
-      title="This saved object has some invalid relations."
-    />
-    <EuiSpacer />
-    <EuiInMemoryTable
-      columns={
-        Array [
-          Object {
-            "data-test-subj": "relationshipsObjectType",
-            "description": "Type of the saved object",
-            "field": "type",
-            "name": "Type",
-            "sortable": false,
-            "width": "150px",
-          },
-          Object {
-            "data-test-subj": "relationshipsObjectId",
-            "description": "Id of the saved object",
-            "field": "id",
-            "name": "Id",
-            "sortable": false,
-            "width": "150px",
-          },
-          Object {
-            "data-test-subj": "directRelationship",
-            "dataType": "string",
-            "field": "relationship",
-            "name": "Direct relationship",
-            "render": [Function],
-            "sortable": false,
-            "width": "125px",
-          },
-          Object {
-            "data-test-subj": "relationshipsError",
-            "description": "Error encountered with the relation",
-            "field": "error",
-            "name": "Error",
-            "sortable": false,
-          },
-        ]
-      }
-      items={
-        Array [
-          Object {
-            "error": "Saved object [dashboard/1] not found",
-            "id": "1",
-            "relationship": "child",
-            "type": "dashboard",
-          },
-        ]
-      }
-      pagination={true}
-      rowProps={[Function]}
-      searchFormat="eql"
-      tableCaption="Invalid relationships for MyIndexPattern*"
-      tableLayout="fixed"
-    />
-    <EuiSpacer />
-    <EuiCallOut>
-      <p>
-        Here are the saved objects related to MyIndexPattern*. Deleting this index-pattern affects its parent objects, but not its children.
-      </p>
-    </EuiCallOut>
-    <EuiSpacer />
-    <EuiInMemoryTable
-      columns={
-        Array [
-          Object {
-            "align": "center",
-            "description": "Type of the saved object",
-            "field": "type",
-            "name": "Type",
-            "render": [Function],
-            "sortable": false,
-            "width": "50px",
-          },
-          Object {
-            "data-test-subj": "directRelationship",
-            "dataType": "string",
-            "field": "relationship",
-            "name": "Direct relationship",
-            "render": [Function],
-            "sortable": false,
-            "width": "125px",
-          },
-          Object {
-            "dataType": "string",
-            "description": "Title of the saved object",
-            "field": "meta.title",
-            "name": "Title",
-            "render": [Function],
-            "sortable": false,
-          },
-          Object {
-            "actions": Array [
-              Object {
-                "available": [Function],
-                "data-test-subj": "relationshipsTableAction-inspect",
-                "description": "Inspect this saved object",
-                "icon": "inspect",
-                "name": "Inspect",
-                "onClick": [Function],
-                "type": "icon",
-              },
-            ],
-            "name": "Actions",
-          },
-        ]
-      }
-      items={Array []}
-      onTableChange={[Function]}
-      pagination={
-        Object {
-          "pageSize": 10,
-        }
-      }
-      rowProps={[Function]}
-      search={
-        Object {
-          "filters": Array [
+        <h2
+          id="generated-id_relationshipsFlyoutTitle"
+        >
+          <EuiIconTip
+            aria-label="index-pattern"
+            content="index-pattern"
+            position="top"
+            size="m"
+            type="indexPatternApp"
+          />
+            
+          MyIndexPattern*
+        </h2>
+      </EuiTitle>
+    </EuiFlyoutHeader>
+    <EuiFlyoutBody>
+      <EuiCallOut
+        color="warning"
+        iconType="warning"
+        title="This saved object has some invalid relations."
+      />
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
             Object {
+              "data-test-subj": "relationshipsObjectType",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "sortable": false,
+              "width": "150px",
+            },
+            Object {
+              "data-test-subj": "relationshipsObjectId",
+              "description": "Id of the saved object",
+              "field": "id",
+              "name": "Id",
+              "sortable": false,
+              "width": "150px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
               "field": "relationship",
-              "multiSelect": "or",
               "name": "Direct relationship",
-              "options": Array [
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "data-test-subj": "relationshipsError",
+              "description": "Error encountered with the relation",
+              "field": "error",
+              "name": "Error",
+              "sortable": false,
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "error": "Saved object [dashboard/1] not found",
+              "id": "1",
+              "relationship": "child",
+              "type": "dashboard",
+            },
+          ]
+        }
+        pagination={true}
+        rowProps={[Function]}
+        searchFormat="eql"
+        tableCaption="Invalid relationships for MyIndexPattern*"
+        tableLayout="fixed"
+      />
+      <EuiSpacer />
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MyIndexPattern*. Deleting this index-pattern affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
                 Object {
-                  "name": "parent",
-                  "value": "parent",
-                  "view": "Parent",
-                },
-                Object {
-                  "name": "child",
-                  "value": "child",
-                  "view": "Child",
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
                 },
               ],
-              "type": "field_value_selection",
+              "name": "Actions",
             },
-            Object {
-              "field": "type",
-              "multiSelect": "or",
-              "name": "Type",
-              "options": Array [],
-              "type": "field_value_selection",
-            },
-          ],
+          ]
         }
-      }
-      searchFormat="eql"
-      tableCaption="Saved objects related to MyIndexPattern*"
-      tableLayout="fixed"
-    />
-  </EuiFlyoutBody>
-</EuiFlyout>
+        items={Array []}
+        onTableChange={[Function]}
+        pagination={
+          Object {
+            "pageSize": 10,
+          }
+        }
+        rowProps={[Function]}
+        search={
+          Object {
+            "filters": Array [
+              Object {
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [],
+                "type": "field_value_selection",
+              },
+            ],
+          }
+        }
+        searchFormat="eql"
+        tableCaption="Saved objects related to MyIndexPattern*"
+        tableLayout="fixed"
+      />
+    </EuiFlyoutBody>
+  </EuiFlyout>
+</SpacesContextWrapper>
 `;
 
 exports[`Relationships should render searches normally 1`] = `
-<EuiFlyout
-  aria-labelledby="generated-id_relationshipsFlyoutTitle"
-  onClose={[MockFunction]}
->
-  <EuiFlyoutHeader
-    hasBorder={true}
+<SpacesContextWrapper>
+  <EuiFlyout
+    aria-labelledby="generated-id_relationshipsFlyoutTitle"
+    onClose={[MockFunction]}
   >
-    <EuiTitle
-      size="m"
+    <EuiFlyoutHeader
+      hasBorder={true}
     >
-      <h2
-        id="generated-id_relationshipsFlyoutTitle"
+      <EuiTitle
+        size="m"
       >
-        <EuiIconTip
-          aria-label="search"
-          content="search"
-          position="top"
-          size="m"
-          type="magnify"
-        />
-          
-        MySearch
-      </h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    <EuiCallOut>
-      <p>
-        Here are the saved objects related to MySearch. Deleting this search affects its parent objects, but not its children.
-      </p>
-    </EuiCallOut>
-    <EuiSpacer />
-    <EuiInMemoryTable
-      columns={
-        Array [
+        <h2
+          id="generated-id_relationshipsFlyoutTitle"
+        >
+          <EuiIconTip
+            aria-label="search"
+            content="search"
+            position="top"
+            size="m"
+            type="magnify"
+          />
+            
+          MySearch
+        </h2>
+      </EuiTitle>
+    </EuiFlyoutHeader>
+    <EuiFlyoutBody>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MySearch. Deleting this search affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "editUrl": "/management/kibana/dataViews/dataView/1",
+                "icon": "indexPatternApp",
+                "inAppUrl": Object {
+                  "path": "/app/management/kibana/dataViews/dataView/1",
+                  "uiCapabilitiesPath": "management.kibana.indexPatterns",
+                },
+                "title": "My Index Pattern",
+              },
+              "relationship": "child",
+              "type": "index-pattern",
+            },
+            Object {
+              "id": "2",
+              "meta": Object {
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/app/visualize#/edit/2",
+                  "uiCapabilitiesPath": "visualize_v2.show",
+                },
+                "title": "My Visualization Title",
+              },
+              "relationship": "parent",
+              "type": "visualization",
+            },
+          ]
+        }
+        onTableChange={[Function]}
+        pagination={
           Object {
-            "align": "center",
-            "description": "Type of the saved object",
-            "field": "type",
-            "name": "Type",
-            "render": [Function],
-            "sortable": false,
-            "width": "50px",
-          },
+            "pageSize": 10,
+          }
+        }
+        rowProps={[Function]}
+        search={
           Object {
-            "data-test-subj": "directRelationship",
-            "dataType": "string",
-            "field": "relationship",
-            "name": "Direct relationship",
-            "render": [Function],
-            "sortable": false,
-            "width": "125px",
-          },
-          Object {
-            "dataType": "string",
-            "description": "Title of the saved object",
-            "field": "meta.title",
-            "name": "Title",
-            "render": [Function],
-            "sortable": false,
-          },
-          Object {
-            "actions": Array [
+            "filters": Array [
               Object {
-                "available": [Function],
-                "data-test-subj": "relationshipsTableAction-inspect",
-                "description": "Inspect this saved object",
-                "icon": "inspect",
-                "name": "Inspect",
-                "onClick": [Function],
-                "type": "icon",
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "index-pattern",
+                    "value": "index-pattern",
+                    "view": "index-pattern",
+                  },
+                  Object {
+                    "name": "visualization",
+                    "value": "visualization",
+                    "view": "visualization",
+                  },
+                ],
+                "type": "field_value_selection",
               },
             ],
-            "name": "Actions",
-          },
-        ]
-      }
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "meta": Object {
-              "editUrl": "/management/kibana/dataViews/dataView/1",
-              "icon": "indexPatternApp",
-              "inAppUrl": Object {
-                "path": "/app/management/kibana/dataViews/dataView/1",
-                "uiCapabilitiesPath": "management.kibana.indexPatterns",
-              },
-              "title": "My Index Pattern",
-            },
-            "relationship": "child",
-            "type": "index-pattern",
-          },
-          Object {
-            "id": "2",
-            "meta": Object {
-              "icon": "visualizeApp",
-              "inAppUrl": Object {
-                "path": "/app/visualize#/edit/2",
-                "uiCapabilitiesPath": "visualize_v2.show",
-              },
-              "title": "My Visualization Title",
-            },
-            "relationship": "parent",
-            "type": "visualization",
-          },
-        ]
-      }
-      onTableChange={[Function]}
-      pagination={
-        Object {
-          "pageSize": 10,
+          }
         }
-      }
-      rowProps={[Function]}
-      search={
-        Object {
-          "filters": Array [
-            Object {
-              "field": "relationship",
-              "multiSelect": "or",
-              "name": "Direct relationship",
-              "options": Array [
-                Object {
-                  "name": "parent",
-                  "value": "parent",
-                  "view": "Parent",
-                },
-                Object {
-                  "name": "child",
-                  "value": "child",
-                  "view": "Child",
-                },
-              ],
-              "type": "field_value_selection",
-            },
-            Object {
-              "field": "type",
-              "multiSelect": "or",
-              "name": "Type",
-              "options": Array [
-                Object {
-                  "name": "index-pattern",
-                  "value": "index-pattern",
-                  "view": "index-pattern",
-                },
-                Object {
-                  "name": "visualization",
-                  "value": "visualization",
-                  "view": "visualization",
-                },
-              ],
-              "type": "field_value_selection",
-            },
-          ],
-        }
-      }
-      searchFormat="eql"
-      tableCaption="Saved objects related to MySearch"
-      tableLayout="fixed"
-    />
-  </EuiFlyoutBody>
-</EuiFlyout>
+        searchFormat="eql"
+        tableCaption="Saved objects related to MySearch"
+        tableLayout="fixed"
+      />
+    </EuiFlyoutBody>
+  </EuiFlyout>
+</SpacesContextWrapper>
 `;
 
 exports[`Relationships should render visualizations normally 1`] = `
-<EuiFlyout
-  aria-labelledby="generated-id_relationshipsFlyoutTitle"
-  onClose={[MockFunction]}
->
-  <EuiFlyoutHeader
-    hasBorder={true}
+<SpacesContextWrapper>
+  <EuiFlyout
+    aria-labelledby="generated-id_relationshipsFlyoutTitle"
+    onClose={[MockFunction]}
   >
-    <EuiTitle
-      size="m"
+    <EuiFlyoutHeader
+      hasBorder={true}
     >
-      <h2
-        id="generated-id_relationshipsFlyoutTitle"
+      <EuiTitle
+        size="m"
       >
-        <EuiIconTip
-          aria-label="visualization"
-          content="visualization"
-          position="top"
-          size="m"
-          type="visualizeApp"
-        />
-          
-        MyViz
-      </h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    <EuiCallOut>
-      <p>
-        Here are the saved objects related to MyViz. Deleting this visualization affects its parent objects, but not its children.
-      </p>
-    </EuiCallOut>
-    <EuiSpacer />
-    <EuiInMemoryTable
-      columns={
-        Array [
+        <h2
+          id="generated-id_relationshipsFlyoutTitle"
+        >
+          <EuiIconTip
+            aria-label="visualization"
+            content="visualization"
+            position="top"
+            size="m"
+            type="visualizeApp"
+          />
+            
+          MyViz
+        </h2>
+      </EuiTitle>
+    </EuiFlyoutHeader>
+    <EuiFlyoutBody>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MyViz. Deleting this visualization affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "icon": "dashboardApp",
+                "inAppUrl": Object {
+                  "path": "/app/kibana#/dashboard/1",
+                  "uiCapabilitiesPath": "dashboard_v2.show",
+                },
+                "title": "My Dashboard 1",
+              },
+              "relationship": "parent",
+              "type": "dashboard",
+            },
+            Object {
+              "id": "2",
+              "meta": Object {
+                "icon": "dashboardApp",
+                "inAppUrl": Object {
+                  "path": "/app/kibana#/dashboard/2",
+                  "uiCapabilitiesPath": "dashboard_v2.show",
+                },
+                "title": "My Dashboard 2",
+              },
+              "relationship": "parent",
+              "type": "dashboard",
+            },
+          ]
+        }
+        onTableChange={[Function]}
+        pagination={
           Object {
-            "align": "center",
-            "description": "Type of the saved object",
-            "field": "type",
-            "name": "Type",
-            "render": [Function],
-            "sortable": false,
-            "width": "50px",
-          },
+            "pageSize": 10,
+          }
+        }
+        rowProps={[Function]}
+        search={
           Object {
-            "data-test-subj": "directRelationship",
-            "dataType": "string",
-            "field": "relationship",
-            "name": "Direct relationship",
-            "render": [Function],
-            "sortable": false,
-            "width": "125px",
-          },
-          Object {
-            "dataType": "string",
-            "description": "Title of the saved object",
-            "field": "meta.title",
-            "name": "Title",
-            "render": [Function],
-            "sortable": false,
-          },
-          Object {
-            "actions": Array [
+            "filters": Array [
               Object {
-                "available": [Function],
-                "data-test-subj": "relationshipsTableAction-inspect",
-                "description": "Inspect this saved object",
-                "icon": "inspect",
-                "name": "Inspect",
-                "onClick": [Function],
-                "type": "icon",
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "dashboard",
+                    "value": "dashboard",
+                    "view": "dashboard",
+                  },
+                ],
+                "type": "field_value_selection",
               },
             ],
-            "name": "Actions",
-          },
-        ]
-      }
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "meta": Object {
-              "icon": "dashboardApp",
-              "inAppUrl": Object {
-                "path": "/app/kibana#/dashboard/1",
-                "uiCapabilitiesPath": "dashboard_v2.show",
-              },
-              "title": "My Dashboard 1",
-            },
-            "relationship": "parent",
-            "type": "dashboard",
-          },
-          Object {
-            "id": "2",
-            "meta": Object {
-              "icon": "dashboardApp",
-              "inAppUrl": Object {
-                "path": "/app/kibana#/dashboard/2",
-                "uiCapabilitiesPath": "dashboard_v2.show",
-              },
-              "title": "My Dashboard 2",
-            },
-            "relationship": "parent",
-            "type": "dashboard",
-          },
-        ]
-      }
-      onTableChange={[Function]}
-      pagination={
-        Object {
-          "pageSize": 10,
+          }
         }
-      }
-      rowProps={[Function]}
-      search={
-        Object {
-          "filters": Array [
-            Object {
-              "field": "relationship",
-              "multiSelect": "or",
-              "name": "Direct relationship",
-              "options": Array [
-                Object {
-                  "name": "parent",
-                  "value": "parent",
-                  "view": "Parent",
-                },
-                Object {
-                  "name": "child",
-                  "value": "child",
-                  "view": "Child",
-                },
-              ],
-              "type": "field_value_selection",
-            },
-            Object {
-              "field": "type",
-              "multiSelect": "or",
-              "name": "Type",
-              "options": Array [
-                Object {
-                  "name": "dashboard",
-                  "value": "dashboard",
-                  "view": "dashboard",
-                },
-              ],
-              "type": "field_value_selection",
-            },
-          ],
-        }
-      }
-      searchFormat="eql"
-      tableCaption="Saved objects related to MyViz"
-      tableLayout="fixed"
-    />
-  </EuiFlyoutBody>
-</EuiFlyout>
+        searchFormat="eql"
+        tableCaption="Saved objects related to MyViz"
+        tableLayout="fixed"
+      />
+    </EuiFlyoutBody>
+  </EuiFlyout>
+</SpacesContextWrapper>
 `;

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/relationship_spaces.test.ts
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/relationship_spaces.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
+import type { SavedObjectRelation } from '../../../types';
+import {
+  isStaleRelation,
+  getRelationshipHref,
+  shouldShowSpacesColumn,
+} from './relationship_spaces';
+
+const createRelation = (namespaces?: string[]): SavedObjectRelation => ({
+  id: 'related-id',
+  type: 'dashboard',
+  relationship: 'parent',
+  meta: {},
+  managed: false,
+  references: [],
+  namespaces,
+});
+
+describe('isStaleRelation', () => {
+  it('is not stale when either side has no namespaces', () => {
+    expect(isStaleRelation(undefined, ['space-a'])).toBe(false);
+    expect(isStaleRelation(['space-a'], undefined)).toBe(false);
+  });
+
+  it('is not stale when either side is shared to all spaces', () => {
+    expect(isStaleRelation(['*'], ['space-a'])).toBe(false);
+    expect(isStaleRelation(['space-a'], ['*'])).toBe(false);
+  });
+
+  it('is not stale when the namespaces overlap', () => {
+    expect(isStaleRelation(['space-a', 'space-b'], ['space-b'])).toBe(false);
+  });
+
+  it('is stale when the namespaces do not overlap', () => {
+    expect(isStaleRelation(['space-b'], ['space-a'])).toBe(true);
+  });
+});
+
+describe('getRelationshipHref', () => {
+  it('links to the current space when the relation has no namespaces', () => {
+    const basePath = httpServiceMock.createBasePath({ serverBasePath: '' });
+    basePath.get.mockReturnValue('/s/space-a');
+
+    expect(getRelationshipHref(basePath, undefined, '/app/dashboard#/1')).toBe(
+      '/s/space-a/app/dashboard#/1'
+    );
+  });
+
+  it('links to the current space when the relation is shared into it', () => {
+    const basePath = httpServiceMock.createBasePath({ serverBasePath: '' });
+    basePath.get.mockReturnValue('/s/space-a');
+
+    expect(getRelationshipHref(basePath, ['space-a', 'space-b'], '/app/dashboard#/1')).toBe(
+      '/s/space-a/app/dashboard#/1'
+    );
+  });
+
+  it("links to the relation's own space when it is not the current one", () => {
+    const basePath = httpServiceMock.createBasePath({ serverBasePath: '' });
+    basePath.get.mockReturnValue('/s/space-a');
+
+    expect(getRelationshipHref(basePath, ['space-b'], '/app/dashboard#/1')).toBe(
+      '/s/space-b/app/dashboard#/1'
+    );
+  });
+
+  it('falls back to the current space when the relation is shared to all spaces', () => {
+    const basePath = httpServiceMock.createBasePath({ serverBasePath: '' });
+    basePath.get.mockReturnValue('/s/space-a');
+
+    expect(getRelationshipHref(basePath, ['*'], '/app/dashboard#/1')).toBe(
+      '/s/space-a/app/dashboard#/1'
+    );
+  });
+});
+
+describe('shouldShowSpacesColumn', () => {
+  const basePath = httpServiceMock.createBasePath({ serverBasePath: '' });
+  basePath.get.mockReturnValue('/s/space-a');
+
+  it('is false when the spaces plugin is not available', () => {
+    expect(shouldShowSpacesColumn(undefined, [createRelation(['space-b'])], basePath)).toBe(false);
+  });
+
+  it('is false when every relation is only in the current space', () => {
+    const spacesApi = spacesPluginMock.createStartContract();
+    expect(shouldShowSpacesColumn(spacesApi, [createRelation(['space-a'])], basePath)).toBe(false);
+  });
+
+  it('is true when a relation lives in a different space', () => {
+    const spacesApi = spacesPluginMock.createStartContract();
+    expect(shouldShowSpacesColumn(spacesApi, [createRelation(['space-b'])], basePath)).toBe(true);
+  });
+
+  it('is true when a relation is shared to all spaces', () => {
+    const spacesApi = spacesPluginMock.createStartContract();
+    expect(shouldShowSpacesColumn(spacesApi, [createRelation(['*'])], basePath)).toBe(true);
+  });
+});

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/relationship_spaces.tsx
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/relationship_spaces.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { type PropsWithChildren } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { IBasePath } from '@kbn/core/public';
+import type { SpacesApi } from '@kbn/spaces-plugin/public';
+import { addSpaceIdToPath, getSpaceIdFromPath } from '@kbn/core-spaces-common';
+import type { SavedObjectRelation } from '../../../types';
+
+const ALL_SPACES_ID = '*';
+
+const staleRelationTitle = i18n.translate(
+  'savedObjectsManagement.objectsTable.relationships.spaces.staleTitle',
+  { defaultMessage: 'Possibly stale reference' }
+);
+
+const staleRelationContent = i18n.translate(
+  'savedObjectsManagement.objectsTable.relationships.spaces.staleContent',
+  {
+    defaultMessage:
+      'This object references the saved object, but it is no longer shared into this space.',
+  }
+);
+
+/** Whether a related object's reference points at an object that isn't (or is no longer) shared into any of the spaces the related object lives in. */
+export const isStaleRelation = (
+  relationNamespaces: string[] | undefined,
+  targetNamespaces: string[] | undefined
+): boolean => {
+  if (!relationNamespaces?.length || !targetNamespaces?.length) {
+    return false;
+  }
+  if (relationNamespaces.includes(ALL_SPACES_ID) || targetNamespaces.includes(ALL_SPACES_ID)) {
+    return false;
+  }
+  return !relationNamespaces.some((namespace) => targetNamespaces.includes(namespace));
+};
+
+const getActiveSpaceId = (basePath: IBasePath): string =>
+  getSpaceIdFromPath(basePath.get(), basePath.serverBasePath).spaceId;
+
+/** Picks which space a related object's "open in app" link should point at. */
+const getLinkSpaceId = (
+  relationNamespaces: string[] | undefined,
+  activeSpaceId: string
+): string => {
+  if (!relationNamespaces?.length || relationNamespaces.includes(activeSpaceId)) {
+    return activeSpaceId;
+  }
+  const specificNamespace = relationNamespaces.find((namespace) => namespace !== ALL_SPACES_ID);
+  return specificNamespace ?? activeSpaceId;
+};
+
+export const getRelationshipHref = (
+  basePath: IBasePath,
+  relationNamespaces: string[] | undefined,
+  path: string
+): string => {
+  const activeSpaceId = getActiveSpaceId(basePath);
+  const linkSpaceId = getLinkSpaceId(relationNamespaces, activeSpaceId);
+  return addSpaceIdToPath(basePath.serverBasePath, linkSpaceId, path);
+};
+
+/** Whether the Spaces column is worth showing: only when some relation lives outside the current space. */
+export const shouldShowSpacesColumn = (
+  spacesApi: SpacesApi | undefined,
+  relations: SavedObjectRelation[],
+  basePath: IBasePath
+): boolean => {
+  if (!spacesApi) {
+    return false;
+  }
+  const activeSpaceId = getActiveSpaceId(basePath);
+  return relations.some(
+    (relation) =>
+      relation.namespaces?.includes(ALL_SPACES_ID) ||
+      relation.namespaces?.some((namespace) => namespace !== activeSpaceId)
+  );
+};
+
+/**
+ * `LazySpaceList` reads its data from a `SpacesContextProvider` in React context (via `useSpaces()`);
+ * without one, it throws trying to use an undefined `spacesDataPromise`. Wrap any tree that renders
+ * `RelationshipSpacesCell` with this so it works regardless of whether the caller already set one up.
+ */
+export const SpacesContextWrapper = ({
+  spacesApi,
+  children,
+}: PropsWithChildren<{ spacesApi: SpacesApi | undefined }>) => {
+  if (!spacesApi) {
+    return <>{children}</>;
+  }
+  const Provider = spacesApi.ui.components.getSpacesContextProvider;
+  return <Provider>{children}</Provider>;
+};
+
+export const RelationshipSpacesCell = ({
+  spacesApi,
+  namespaces,
+  targetNamespaces,
+}: {
+  spacesApi: SpacesApi;
+  namespaces: string[] | undefined;
+  targetNamespaces: string[] | undefined;
+}) => {
+  const LazySpaceList = spacesApi.ui.components.getSpaceList;
+
+  return (
+    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <LazySpaceList namespaces={namespaces ?? []} behaviorContext="outside-space" />
+      </EuiFlexItem>
+      {isStaleRelation(namespaces, targetNamespaces) && (
+        <EuiFlexItem grow={false}>
+          <EuiIconTip
+            type="warning"
+            color="warning"
+            title={staleRelationTitle}
+            content={staleRelationContent}
+          />
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+};

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { shallowWithI18nProvider } from '@kbn/test-jest-helpers';
 import { httpServiceMock } from '@kbn/core/public/mocks';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
 import type { SavedObjectManagementTypeInfo } from '../../../../common/types';
 import type { RelationshipsProps } from './relationships';
 import { RelationshipsClass as Relationships } from './relationships';
@@ -396,5 +397,74 @@ describe('Relationships', () => {
 
     expect(props.getRelationships).toHaveBeenCalled();
     expect(component).toMatchSnapshot();
+  });
+
+  it('renders a Spaces column and a space-aware link when a relation lives in another space', async () => {
+    const basePath = httpServiceMock.createBasePath({ serverBasePath: '' });
+    basePath.get.mockReturnValue('/s/space-a');
+    const spacesApi = spacesPluginMock.createStartContract();
+
+    const props: RelationshipsProps = {
+      goInspectObject: () => {},
+      canGoInApp: () => true,
+      basePath,
+      spacesApi,
+      getRelationships: jest.fn().mockImplementation(() => ({
+        relations: [
+          {
+            type: 'dashboard',
+            id: '1',
+            relationship: 'parent',
+            meta: {
+              icon: 'dashboardApp',
+              inAppUrl: {
+                path: '/app/dashboards#/view/1',
+                uiCapabilitiesPath: 'dashboard_v2.show',
+              },
+              title: 'My Dashboard',
+            },
+            namespaces: ['space-b'],
+          },
+        ],
+        invalidRelations: [],
+      })),
+      savedObject: {
+        id: '1',
+        type: 'index-pattern',
+        attributes: {},
+        references: [],
+        namespaces: ['space-a', 'space-b'],
+        meta: {
+          title: 'MyIndexPattern*',
+          icon: 'indexPatternApp',
+          inAppUrl: {
+            path: '/management/kibana/dataViews/dataView/1',
+            uiCapabilitiesPath: 'management.kibana.indexPatterns',
+          },
+        },
+      },
+      allowedTypes,
+      close: jest.fn(),
+    };
+
+    const component = shallowWithI18nProvider(<Relationships {...baseProps} {...props} />);
+    await new Promise((resolve) => process.nextTick(resolve));
+    component.update();
+
+    const columns = component.find('EuiInMemoryTable').prop<Array<Record<string, any>>>('columns');
+    const spacesColumn = columns.find((column) => column.field === 'namespaces');
+    expect(spacesColumn).toBeDefined();
+
+    const relation = { namespaces: ['space-b'] };
+    const spacesCell = shallowWithI18nProvider(spacesColumn!.render(relation.namespaces, relation));
+    const spaceList = spacesCell.find(spacesApi.ui.components.getSpaceList);
+    expect(spaceList.prop('namespaces')).toEqual(['space-b']);
+
+    const titleColumn = columns.find((column) => column.field === 'meta.title');
+    const titleElement = titleColumn!.render('My Dashboard', {
+      meta: { inAppUrl: { path: '/app/dashboards#/view/1' } },
+      namespaces: ['space-b'],
+    });
+    expect(titleElement.props.href).toBe('/s/space-b/app/dashboards#/view/1');
   });
 });

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
@@ -27,6 +27,7 @@ import type { SearchFilterConfig } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { IBasePath } from '@kbn/core/public';
+import type { SpacesApi } from '@kbn/spaces-plugin/public';
 import {
   withEuiTablePersist,
   type EuiTablePersistInjectedProps,
@@ -40,6 +41,12 @@ import type {
   SavedObjectRelation,
   SavedObjectInvalidRelation,
 } from '../../../types';
+import {
+  RelationshipSpacesCell,
+  SpacesContextWrapper,
+  getRelationshipHref,
+  shouldShowSpacesColumn,
+} from './relationship_spaces';
 
 export interface RelationshipsProps {
   basePath: IBasePath;
@@ -50,6 +57,7 @@ export interface RelationshipsProps {
   canGoInApp: (obj: SavedObjectWithMetadata) => boolean;
   allowedTypes: SavedObjectManagementTypeInfo[];
   showPlainSpinner?: boolean;
+  spacesApi?: SpacesApi;
 }
 
 export interface RelationshipsState {
@@ -93,31 +101,33 @@ export class RelationshipsClass extends Component<
 > {
   render() {
     const modalTitleId = htmlIdGenerator()('relationshipsFlyoutTitle');
-    const { close, savedObject, allowedTypes } = this.props;
+    const { close, savedObject, allowedTypes, spacesApi } = this.props;
     const typeLabel = getSavedObjectLabel(savedObject.type, allowedTypes);
 
     return (
-      <EuiFlyout onClose={close} aria-labelledby={modalTitleId}>
-        <EuiFlyoutHeader hasBorder>
-          <EuiTitle size="m">
-            <h2 id={modalTitleId}>
-              <EuiIconTip
-                position="top"
-                content={typeLabel}
-                type={savedObject.meta.icon || 'apps'}
-                size="m"
-                aria-label={typeLabel}
-              />
-              &nbsp;&nbsp;
-              {savedObject.meta.title || getDefaultTitle(savedObject)}
-            </h2>
-          </EuiTitle>
-        </EuiFlyoutHeader>
-        <EuiFlyoutBody>
-          {this.renderInvalidRelationship()}
-          {this.renderRelationshipsTable()}
-        </EuiFlyoutBody>
-      </EuiFlyout>
+      <SpacesContextWrapper spacesApi={spacesApi}>
+        <EuiFlyout onClose={close} aria-labelledby={modalTitleId}>
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="m">
+              <h2 id={modalTitleId}>
+                <EuiIconTip
+                  position="top"
+                  content={typeLabel}
+                  type={savedObject.meta.icon || 'apps'}
+                  size="m"
+                  aria-label={typeLabel}
+                />
+                &nbsp;&nbsp;
+                {savedObject.meta.title || getDefaultTitle(savedObject)}
+              </h2>
+            </EuiTitle>
+          </EuiFlyoutHeader>
+          <EuiFlyoutBody>
+            {this.renderInvalidRelationship()}
+            {this.renderRelationshipsTable()}
+          </EuiFlyoutBody>
+        </EuiFlyout>
+      </SpacesContextWrapper>
     );
   }
 
@@ -271,6 +281,7 @@ export class RelationshipsClass extends Component<
       savedObject,
       allowedTypes,
       showPlainSpinner,
+      spacesApi,
       euiTablePersist: { pageSize, onTableChange },
     } = this.props;
     const { relations, isLoading, error } = this.state;
@@ -335,12 +346,38 @@ export class RelationshipsClass extends Component<
             );
           }
           return (
-            <EuiLink href={basePath.prepend(path)} data-test-subj="relationshipsTitle">
+            <EuiLink
+              href={getRelationshipHref(basePath, object.namespaces, path)}
+              data-test-subj="relationshipsTitle"
+            >
               {title || getDefaultTitle(object)}
             </EuiLink>
           );
         },
       },
+      ...(shouldShowSpacesColumn(spacesApi, relations, basePath)
+        ? [
+            {
+              field: 'namespaces',
+              name: i18n.translate(
+                'savedObjectsManagement.objectsTable.relationships.columnSpacesName',
+                { defaultMessage: 'Spaces' }
+              ),
+              description: i18n.translate(
+                'savedObjectsManagement.objectsTable.relationships.columnSpacesDescription',
+                { defaultMessage: 'The spaces this saved object is shared into' }
+              ),
+              sortable: false,
+              render: (namespaces: string[] | undefined) => (
+                <RelationshipSpacesCell
+                  spacesApi={spacesApi as SpacesApi}
+                  namespaces={namespaces}
+                  targetNamespaces={savedObject.namespaces}
+                />
+              ),
+            },
+          ]
+        : []),
       {
         name: i18n.translate(
           'savedObjectsManagement.objectsTable.relationships.columnActionsName',

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -25,6 +25,7 @@ import type { SavedObjectsTaggingApi } from '@kbn/saved-objects-tagging-oss-plug
 import type { DataViewsContract } from '@kbn/data-views-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { CustomBrandingStart } from '@kbn/core-custom-branding-browser';
+import type { SpacesApi } from '@kbn/spaces-plugin/public';
 import type { Subscription } from 'rxjs';
 import type { SavedObjectManagementTypeInfo, FindQueryHTTP } from '../../../common/types/latest';
 import type { SavedObjectsExportResultDetails } from '../../lib';
@@ -76,6 +77,7 @@ export interface SavedObjectsTableProps {
   canGoInApp: (obj: SavedObjectWithMetadata) => boolean;
   initialQuery?: Query;
   customBranding: CustomBrandingStart;
+  spacesApi?: SpacesApi;
 }
 
 export interface SavedObjectsTableState {
@@ -620,6 +622,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
         canGoInApp={this.props.canGoInApp}
         allowedTypes={this.props.allowedTypes}
         showPlainSpinner={this.state.hasCustomBranding}
+        spacesApi={this.props.spacesApi}
       />
     );
   }

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/saved_objects_table_page.tsx
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/saved_objects_table_page.tsx
@@ -84,6 +84,7 @@ const SavedObjectsTablePage = ({
         actionRegistry={actionRegistry}
         columnRegistry={columnRegistry}
         taggingApi={taggingApi}
+        spacesApi={spacesApi}
         dataViews={dataViewsApi}
         search={dataStart.search}
         http={coreStart.http}

--- a/src/platform/plugins/shared/saved_objects_management/server/lib/find_relationships.test.ts
+++ b/src/platform/plugins/shared/saved_objects_management/server/lib/find_relationships.test.ts
@@ -13,7 +13,11 @@ import { findRelationships } from './find_relationships';
 import { managementMock } from '../services/management.mock';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 
-const createObj = (parts: Partial<SavedObject<any>>): SavedObject<any> => ({
+// `namespace` isn't part of the public `SavedObject` type, but `client.find()` populates it at
+// runtime for single-namespace types in lieu of `namespaces` (see find_relationships.ts).
+const createObj = (
+  parts: Partial<SavedObject<any>> & { namespace?: string }
+): SavedObject<any> & { namespace?: string } => ({
   id: 'id',
   type: 'type',
   attributes: {},
@@ -115,7 +119,142 @@ describe('findRelationships', () => {
       hasReference: { type, id },
       perPage: 20,
       type: referenceTypes,
+      namespaces: ['*'],
     });
+  });
+
+  it('returns the target namespaces alongside the relations', async () => {
+    const type = 'dashboard';
+    const id = 'some-id';
+
+    savedObjectsClient.get.mockResolvedValue(
+      createObj({
+        id,
+        type,
+        namespaces: ['default', 'space-a'],
+      })
+    );
+    savedObjectsClient.bulkGet.mockResolvedValue({ saved_objects: [] });
+    savedObjectsClient.find.mockResolvedValue(createFindResponse([]));
+
+    const { targetNamespaces } = await findRelationships({
+      type,
+      id,
+      size: 20,
+      client: savedObjectsClient,
+      referenceTypes: [],
+      savedObjectsManagement: managementService,
+    });
+
+    expect(targetNamespaces).toEqual(['default', 'space-a']);
+  });
+
+  it('preserves the namespaces of each related object', async () => {
+    const type = 'dashboard';
+    const id = 'some-id';
+    const references = [
+      {
+        type: 'some-type',
+        id: 'ref-1',
+        name: 'ref 1',
+      },
+    ];
+
+    savedObjectsClient.get.mockResolvedValue(
+      createObj({
+        id,
+        type,
+        references,
+      })
+    );
+    savedObjectsClient.bulkGet.mockResolvedValue({
+      saved_objects: [
+        createObj({
+          type: 'some-type',
+          id: 'ref-1',
+          namespaces: ['default'],
+        }),
+      ],
+    });
+    savedObjectsClient.find.mockResolvedValue(
+      createFindResponse([
+        createObj({
+          type: 'parent-type',
+          id: 'parent-id',
+          namespaces: ['space-a'],
+        }),
+      ])
+    );
+
+    const { relations } = await findRelationships({
+      type,
+      id,
+      size: 20,
+      client: savedObjectsClient,
+      referenceTypes: ['some-type', 'parent-type'],
+      savedObjectsManagement: managementService,
+    });
+
+    expect(relations).toEqual([
+      {
+        id: 'ref-1',
+        relationship: 'child',
+        type: 'some-type',
+        meta: expect.any(Object),
+        managed: false,
+        references: [],
+        namespaces: ['default'],
+      },
+      {
+        id: 'parent-id',
+        relationship: 'parent',
+        type: 'parent-type',
+        meta: expect.any(Object),
+        managed: false,
+        references: [],
+        namespaces: ['space-a'],
+      },
+    ]);
+  });
+
+  it('derives namespaces from the singular `namespace` field for single-namespace parent relations', async () => {
+    // client.find() only populates the plural `namespaces` field for multi-namespace types; for
+    // single-namespace types (e.g. dashboards) it returns a singular `namespace` field instead.
+    const type = 'dashboard';
+    const id = 'some-id';
+
+    savedObjectsClient.get.mockResolvedValue(createObj({ id, type }));
+    savedObjectsClient.bulkGet.mockResolvedValue({ saved_objects: [] });
+    savedObjectsClient.find.mockResolvedValue(
+      createFindResponse([
+        createObj({
+          type: 'dashboard',
+          id: 'parent-id',
+          namespace: 'space-b',
+        }),
+      ])
+    );
+
+    const { relations } = await findRelationships({
+      type,
+      id,
+      size: 20,
+      client: savedObjectsClient,
+      referenceTypes: ['dashboard'],
+      savedObjectsManagement: managementService,
+    });
+
+    expect(relations).toEqual([
+      {
+        id: 'parent-id',
+        relationship: 'parent',
+        type: 'dashboard',
+        meta: expect.any(Object),
+        managed: false,
+        references: [],
+        namespaces: ['space-b'],
+      },
+    ]);
   });
 
   it('returns the child and parent references of the object', async () => {

--- a/src/platform/plugins/shared/saved_objects_management/server/lib/find_relationships.ts
+++ b/src/platform/plugins/shared/saved_objects_management/server/lib/find_relationships.ts
@@ -29,7 +29,7 @@ export async function findRelationships({
   referenceTypes: string[];
   savedObjectsManagement: ISavedObjectsManagement;
 }): Promise<v1.RelationshipsResponseHTTP> {
-  const { references = [] } = await client.get(type, id);
+  const { references = [], namespaces: targetNamespaces } = await client.get(type, id);
 
   // Use a map to avoid duplicates, it does happen but have a different "name" in the reference
   const childrenReferences = [
@@ -42,10 +42,13 @@ export async function findRelationships({
     childrenReferences.length > 0
       ? client.bulkGet(childrenReferences)
       : Promise.resolve({ saved_objects: [] }),
+    // Searched across all spaces the user can access: a parent (referencing) object may live in a
+    // different space than the object whose relationships are being requested.
     client.find({
       hasReference: { type, id },
       perPage: size,
       type: referenceTypes,
+      namespaces: ['*'],
     }),
   ]);
 
@@ -79,6 +82,7 @@ export async function findRelationships({
   return {
     relations,
     invalidRelations,
+    targetNamespaces,
   };
 }
 
@@ -89,5 +93,10 @@ function extractCommonProperties(savedObject: SavedObjectWithMetadata) {
     meta: savedObject.meta,
     managed: Boolean(savedObject.managed),
     references: savedObject.references,
+    // `client.find()` only populates the plural `namespaces` field for multi-namespace types; for
+    // single-namespace types (the majority of "parent" relations, e.g. dashboards) it returns the
+    // namespace the object was actually found in as a singular `namespace` field instead.
+    namespaces:
+      savedObject.namespaces ?? (savedObject.namespace ? [savedObject.namespace] : undefined),
   };
 }

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/api/tests/relationships_schema.spec.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/api/tests/relationships_schema.spec.ts
@@ -33,6 +33,7 @@ const relationSchema = schema.object({
   references: schema.arrayOf(
     schema.object({ name: schema.string(), type: schema.string(), id: schema.string() })
   ),
+  namespaces: schema.maybe(schema.arrayOf(schema.string())),
 });
 
 const invalidRelationSchema = schema.object({
@@ -45,6 +46,7 @@ const invalidRelationSchema = schema.object({
 const responseSchema = schema.object({
   relations: schema.arrayOf(relationSchema),
   invalidRelations: schema.arrayOf(invalidRelationSchema),
+  targetNamespaces: schema.maybe(schema.arrayOf(schema.string())),
 });
 
 apiTest.describe(

--- a/src/platform/plugins/shared/saved_objects_management/tsconfig.json
+++ b/src/platform/plugins/shared/saved_objects_management/tsconfig.json
@@ -33,7 +33,9 @@
     "@kbn/content-management-plugin",
     "@kbn/scout",
     "@kbn/repo-info",
-    "@kbn/core-saved-objects-server"
+    "@kbn/core-saved-objects-server",
+    "@kbn/core-http-browser-mocks",
+    "@kbn/core-spaces-common"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -5309,7 +5309,6 @@
     "indexPatternManagement.dataViewTable.createBtn": "Erstellen Sie eine Datenquelle",
     "indexPatternManagement.dataViewTable.dataViewColumnName": "Datenquelle",
     "indexPatternManagement.dataViewTable.deleteButtonLabel": "Löschen {selectedItems, number} {selectedItems, plural, one {Data View} other {Data Views} }",
-    "indexPatternManagement.dataViewTable.deleteConfirmSummary": "Erfolgreich gelöscht {count, number} {count, plural, one {data view} other {data views} }.",
     "indexPatternManagement.dataViewTable.deleteDanger": "Mindestens eine der Datenansichten, die Sie löschen möchten, wird von einem anderen Kibana-Objekt verwendet. Überprüfen Sie die Liste der betroffenen Objekte, um Störungen für andere Kibana-Nutzer zu vermeiden, die auf diese angewiesen sind. Das Löschen von Datenansichten entfernt diese endgültig aus allen Bereichen und kann nicht rückgängig gemacht werden.",
     "indexPatternManagement.dataViewTable.deleteSuccessToast": "{count, number} {count, plural, one {data view} other {data views}} erfolgreich gelöscht.",
     "indexPatternManagement.dataViewTable.deleteWarning": "Wenn Sie eine Datenansicht löschen, wird sie dauerhaft aus allen Bereichen entfernt, so dass sie nicht mehr von Nutzern in einer Kibana-App wie Discover, Dashboards oder Lens verwendet werden kann. Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -5311,7 +5311,6 @@
     "indexPatternManagement.dataViewTable.createBtn": "Créer une vue de données",
     "indexPatternManagement.dataViewTable.dataViewColumnName": "Vue de données",
     "indexPatternManagement.dataViewTable.deleteButtonLabel": "Supprimer {selectedItems, number} {selectedItems, plural, one {Data View} other {Data Views} }",
-    "indexPatternManagement.dataViewTable.deleteConfirmSummary": "Suppression réussie de {count, number} {count, plural, one {data view} other {data views} }.",
     "indexPatternManagement.dataViewTable.deleteDanger": "Au moins une des data views que vous souhaitez supprimer est utilisée par un autre objet Kibana. Consultez la liste des objets concernés pour éviter de perturber les autres utilisateurs de Kibana qui en dépendent. La suppression des vues de données les supprime définitivement de tous les espaces et ne peut pas être annulée.",
     "indexPatternManagement.dataViewTable.deleteSuccessToast": "Suppression réussie de {count, number} {count, plural, one {data view} other {vues de données}}.",
     "indexPatternManagement.dataViewTable.deleteWarning": "La suppression d’une data view l’enlève définitivement de tous les espaces et empêche tous les utilisateurs de l’utiliser dans une application Kibana telle que Discover, les tableaux de bord ou Lens. Cette action ne peut pas être annulée.",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -5328,7 +5328,6 @@
     "indexPatternManagement.dataViewTable.createBtn": "データビューを作成",
     "indexPatternManagement.dataViewTable.dataViewColumnName": "データビュー",
     "indexPatternManagement.dataViewTable.deleteButtonLabel": "{selectedItems, number} {selectedItems, plural, one {Data View} other {Data Views} }を削除",
-    "indexPatternManagement.dataViewTable.deleteConfirmSummary": "{count, number} {count, plural, one {data view} other {data views} }を正常に削除しました",
     "indexPatternManagement.dataViewTable.deleteDanger": "削除するデータビューの少なくとも1つが別のKibanaオブジェクトによって使用されています。影響を受けるオブジェクトのリストを確認し、それらに依存している他のKibanaユーザーに支障が生じないようにしてください。データビューを削除するとすべてのスペースから永久に削除され、元に戻すことはできません。",
     "indexPatternManagement.dataViewTable.deleteSuccessToast": "{count, number} {count, plural, one {data view} other {件のデータビュー}}を正常に削除しました。",
     "indexPatternManagement.dataViewTable.deleteWarning": "データビューを削除すると、すべてのスペースから完全に削除され、すべてのユーザーがDiscover、Dashboards、LensなどのKibanaアプリでデータビューを使用できなくなります。この操作は元に戻すことができません。",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -5326,7 +5326,6 @@
     "indexPatternManagement.dataViewTable.createBtn": "创建数据视图",
     "indexPatternManagement.dataViewTable.dataViewColumnName": "数据视图",
     "indexPatternManagement.dataViewTable.deleteButtonLabel": "删除 {selectedItems, number} {selectedItems, plural, one {Data View} other {Data Views} }",
-    "indexPatternManagement.dataViewTable.deleteConfirmSummary": "已成功删除 {count, number} {count, plural, one {data view} other {data views} }。",
     "indexPatternManagement.dataViewTable.deleteDanger": "您要删除的数据视图中至少有一个被另一个 Kibana 对象使用。请审查受影响对象的列表，以避免对依赖这些对象的其他 Kibana 用户造成任何中断。删除数据视图会将其从所有空间中永久删除，并且无法撤销。",
     "indexPatternManagement.dataViewTable.deleteSuccessToast": "已成功删除 {count, number} 个 {count, plural, one {数据视图} other {数据视图}}。",
     "indexPatternManagement.dataViewTable.deleteWarning": "删除数据视图会将其从所有空间中永久移除，并防止所有用户在 Kibana 应用（如 Discover、仪表板或 Lens）中使用它。此操作无法撤消。",


### PR DESCRIPTION
## Summary

Saved object relationships (in the Data View management "Relationships" flyout, the delete-confirmation table, and the Saved Objects management relationships flyout) now surface and link to related objects that live in a different space than the object being viewed, instead of only showing relations visible from the current space.

**Data view delete modal**
<img src="https://github.com/user-attachments/assets/6e6a45fc-34e2-4277-9738-f2e714c55981" />

**Data view relationships**
<img src="https://github.com/user-attachments/assets/f0aa208d-b895-4a96-a580-7c5016f2c9b5" />

**Saved object relationships**
<img src="https://github.com/user-attachments/assets/24bfb1b8-d32b-468f-91a9-13c7ec0d3112" />

### Why

`findRelationships` on the server previously called `client.find()` without an explicit `namespaces` filter, which scoped the search to the current space. A saved object referenced from a dashboard in another space would simply be invisible in the relationships view, and any link rendered for a relation always pointed into the current space's URL, even when that object didn't actually exist there.

### How it works

- `find_relationships.ts` now searches with `namespaces: ['*']` to find parent relations across all spaces the user can access, and returns each relation's namespaces plus the target object's own `targetNamespaces`.
- A new `relationship_spaces.tsx` module in `saved_objects_management` centralizes the space-aware logic and is exported for reuse:
  - `getRelationshipHref` builds a link into the relation's own space when it differs from the active one.
  - `shouldShowSpacesColumn` only shows a "Spaces" column when some relation actually lives outside the current space.
  - `RelationshipSpacesCell` renders the space list plus a "possibly stale reference" warning icon (`isStaleRelation`) when a relation's namespaces no longer overlap with the target object's.
  - `SpacesContextWrapper` wraps consumers in the Spaces plugin's context provider, since the space list component depends on it being present.
- Both the Saved Objects management relationships flyout and Data View management's relationships table/delete flyout consume these helpers, so the behavior and link logic stay consistent across the two plugins.

### Other changes

- The delete-data-view confirmation table gains a Type icon column (mirroring the main relationships flyout) and passes `allowedTypes` through so labels/icons resolve correctly.
- Removed the redundant "Successfully deleted N data views" message from the delete confirmation content (and its now-unused locale entries), since the outcome is already communicated via toast.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.