### PR TITLE
[Scout] Document Scout test namespaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2198,8 +2198,7 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations @elastic/observability-ui
 
 # QA - AppEx QA
-/docs/extend/scout.md @elastic/appex-qa
-/docs/extend/scout/** @elastic/appex-qa
+/docs/extend/testing/ @elastic/appex-qa
 /x-pack/platform/test/index.d.ts @elastic/appex-qa
 /src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/es/roles.yml @elastic/appex-qa
 /src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/oblt/roles.yml @elastic/appex-qa

--- a/docs/extend/testing/run-scout-tests.md
+++ b/docs/extend/testing/run-scout-tests.md
@@ -9,7 +9,7 @@ The commands below work the same way for both UI and API tests.
 :::::::
 
 ::::::{note}
-The examples use `<plugin-path>/test/scout/ui/playwright.config.ts`. If your plugin organizes tests into [namespaces](./setup-scout.md#scout-namespaces), point at the namespaced config instead — for example `<plugin-path>/test/scout/<namespace>/ui/playwright.config.ts`.
+The examples use `<plugin-path>/test/scout/ui/playwright.config.ts`. If your plugin organizes tests into [namespaces](./setup-scout.md#scout-namespaces), point at the namespaced config instead, for example `<plugin-path>/test/scout/<namespace>/ui/playwright.config.ts`.
 ::::::
 
 ## Local runs [scout-run-tests-local]

--- a/docs/extend/testing/run-scout-tests.md
+++ b/docs/extend/testing/run-scout-tests.md
@@ -8,6 +8,10 @@ navigation_title: Run tests
 The commands below work the same way for both UI and API tests.
 :::::::
 
+::::::{note}
+The examples use `<plugin-path>/test/scout/ui/playwright.config.ts`. If your plugin organizes tests into [namespaces](./setup-scout.md#scout-namespaces), point at the namespaced config instead — for example `<plugin-path>/test/scout/<namespace>/ui/playwright.config.ts`.
+::::::
+
 ## Local runs [scout-run-tests-local]
 
 Scout requires Kibana and Elasticsearch to be running before running tests against a **local deployment**.

--- a/docs/extend/testing/setup-scout.md
+++ b/docs/extend/testing/setup-scout.md
@@ -50,7 +50,7 @@ your-plugin/
 ```
 
 :::::::{tip}
-Large plugins can split tests into per-area [namespaces](#scout-namespaces) instead of placing them directly under the scout root.
+Large plugins can split tests into per-area [namespaces](#scout-namespaces) instead of placing them directly under the Scout root.
 :::::::
 
 ::::::::
@@ -141,7 +141,7 @@ Tweak the new Playwright config(s) and [write UI tests](./write-ui-tests.md) or 
 
 ## Organize large plugins with namespaces [scout-namespaces]
 
-By default, a plugin keeps all of its Scout tests directly under the scout root (`test/scout/{ui,api}/`). Large plugins can instead group tests into **namespaces** — single-level sub-directories named after a functional area:
+By default, a plugin keeps all of its Scout tests directly under the Scout root (`test/scout/{ui,api}/`). Large plugins can instead group tests into **namespaces** — single-level sub-directories named after a functional area:
 
 ```text
 your-plugin/
@@ -155,7 +155,7 @@ your-plugin/
         └── common/              # shared code (optional, reserved name)
 ```
 
-A namespace holds the same layout you'd otherwise place at the scout root, just one level deeper — its own Playwright config(s), fixtures, and tests (for example `test/scout/<namespace>/ui/playwright.config.ts`).
+A namespace holds the same layout you'd otherwise place at the Scout root, just one level deeper — its own Playwright config(s), fixtures, and tests (for example `test/scout/<namespace>/ui/playwright.config.ts`).
 
 **Why use namespaces?**
 
@@ -182,6 +182,6 @@ In interactive mode, if the plugin already uses namespaces, the generator lists 
 
 ::::::{important}
 - **One level only**: use `test/scout/<namespace>/{ui,api}/` — deeper nesting such as `.../<area>/<sub-area>/{ui,api}/` is not supported.
-- **Don't mix layouts**: a scout root is either entirely root-level (`test/scout/{ui,api}/`) or entirely namespace-based. Mixing the two fails the build. To adopt namespaces in an existing plugin, migrate the root-level tests into a namespace first.
+- **Don't mix layouts**: a Scout root is either entirely root-level (`test/scout/{ui,api}/`) or entirely namespace-based. Mixing the two fails the build. To adopt namespaces in an existing plugin, migrate the root-level tests into a namespace first.
 - **Naming**: start with a lowercase letter and use only lowercase letters, digits, and underscores. `ui`, `api`, `.meta`, and `common` are reserved (`common` is a plain shared-utilities directory with no Playwright config).
 ::::::

--- a/docs/extend/testing/setup-scout.md
+++ b/docs/extend/testing/setup-scout.md
@@ -141,7 +141,7 @@ Tweak the new Playwright config(s) and [write UI tests](./write-ui-tests.md) or 
 
 ## Organize large plugins with namespaces [scout-namespaces]
 
-By default, a plugin keeps all of its Scout tests directly under the Scout root (`test/scout/{ui,api}/`). Large plugins can instead group tests into **namespaces** — single-level sub-directories named after a functional area:
+By default, a plugin keeps all of its Scout tests directly under the Scout root (`test/scout/{ui,api}/`). Large plugins can instead group tests into **namespaces** (single-level sub-directories named after a functional area):
 
 ```text
 your-plugin/
@@ -155,13 +155,13 @@ your-plugin/
         └── common/              # shared code (optional, reserved name)
 ```
 
-A namespace holds the same layout you'd otherwise place at the Scout root, one level deeper — its own Playwright config(s), fixtures, and tests (for example `test/scout/<namespace>/ui/playwright.config.ts`).
+A namespace holds the same layout you'd otherwise place at the Scout root, one level deeper, with its own Playwright config(s), fixtures, and tests (for example `test/scout/<namespace>/ui/playwright.config.ts`).
 
 **Why use namespaces?**
 
 - **Scoped ownership**: assign each area to the team that owns it in `.github/CODEOWNERS`, so failures reach the smaller group that maintains that functionality.
 - **Run a focused subset**: point Scout at a single namespace's config to run (or re-run) only that area's tests, instead of the whole plugin's suite.
-- **Independently runnable in CI**: each namespace is discovered as its own config, so selective testing and CI reporting are scoped per area — while all namespaces still share the same [server configuration](./run-scout-tests.md#scout-run-tests-server-config-set).
+- **Independently runnable in CI**: each namespace is discovered as its own config, so selective testing and CI reporting are scoped per area, while all namespaces still share the same [server configuration](./run-scout-tests.md#scout-run-tests-server-config-set).
 
 ### Generate a namespace [scout-namespaces-generate]
 
@@ -182,7 +182,7 @@ In interactive mode, if the plugin already uses namespaces, the generator lists 
 ### Rules [scout-namespaces-rules]
 
 ::::::{important}
-- **One level only**: use `test/scout/<namespace>/{ui,api}/` — deeper nesting such as `.../<area>/<sub-area>/{ui,api}/` is not supported.
+- **One level only**: use `test/scout/<namespace>/{ui,api}/` (deeper nesting such as `.../<area>/<sub-area>/{ui,api}/` is not supported).
 - **Don't mix layouts**: a Scout root is either entirely root-level (`test/scout/{ui,api}/`) or entirely namespace-based. Mixing the two fails the build. To adopt namespaces in an existing plugin, migrate the root-level tests into a namespace first.
 - **Naming**: start with a lowercase letter and use only lowercase letters, digits, and underscores. `ui`, `api`, `.meta`, and `common` are reserved (`common` is a plain shared-utilities directory with no Playwright config).
 ::::::

--- a/docs/extend/testing/setup-scout.md
+++ b/docs/extend/testing/setup-scout.md
@@ -50,7 +50,7 @@ your-plugin/
 ```
 
 :::::::{tip}
-Large plugins can split tests into per-area [namespaces](#scout-namespaces) instead of placing them directly under the Scout root.
+Large plugins often accumulate tests across different functional areas, sometimes owned by different teams. Rather than placing them all directly under the Scout root, group them into functional-area [namespaces](#scout-namespaces) and assign ownership per area.
 :::::::
 
 ::::::::
@@ -155,12 +155,13 @@ your-plugin/
         └── common/              # shared code (optional, reserved name)
 ```
 
-A namespace holds the same layout you'd otherwise place at the Scout root, just one level deeper — its own Playwright config(s), fixtures, and tests (for example `test/scout/<namespace>/ui/playwright.config.ts`).
+A namespace holds the same layout you'd otherwise place at the Scout root, one level deeper — its own Playwright config(s), fixtures, and tests (for example `test/scout/<namespace>/ui/playwright.config.ts`).
 
 **Why use namespaces?**
 
 - **Scoped ownership**: assign each area to the team that owns it in `.github/CODEOWNERS`, so failures reach the smaller group that maintains that functionality.
-- **Independently runnable**: each namespace is discovered as its own config, so selective testing and CI reporting are scoped per area — while all namespaces still share the same [server configuration](./run-scout-tests.md#scout-run-tests-server-config-set).
+- **Run a focused subset**: point Scout at a single namespace's config to run (or re-run) only that area's tests, instead of the whole plugin's suite.
+- **Independently runnable in CI**: each namespace is discovered as its own config, so selective testing and CI reporting are scoped per area — while all namespaces still share the same [server configuration](./run-scout-tests.md#scout-run-tests-server-config-set).
 
 ### Generate a namespace [scout-namespaces-generate]
 

--- a/docs/extend/testing/setup-scout.md
+++ b/docs/extend/testing/setup-scout.md
@@ -49,6 +49,10 @@ your-plugin/
         └── common/  # shared code (optional)
 ```
 
+:::::::{tip}
+Large plugins can split tests into per-area [namespaces](#scout-namespaces) instead of placing them directly under the scout root.
+:::::::
+
 ::::::::
 
 ::::::::{step} Create Playwright config(s)
@@ -134,3 +138,50 @@ Tweak the new Playwright config(s) and [write UI tests](./write-ui-tests.md) or 
 ::::::::::
 
 :::::::::
+
+## Organize large plugins with namespaces [scout-namespaces]
+
+By default, a plugin keeps all of its Scout tests directly under the scout root (`test/scout/{ui,api}/`). Large plugins can instead group tests into **namespaces** — single-level sub-directories named after a functional area:
+
+```text
+your-plugin/
+└── test/
+    └── scout/
+        ├── detection_engine/    # namespace
+        │   ├── ui/
+        │   └── api/
+        ├── entity_analytics/    # namespace
+        │   └── ui/
+        └── common/              # shared code (optional, reserved name)
+```
+
+A namespace holds the same layout you'd otherwise place at the scout root, just one level deeper — its own Playwright config(s), fixtures, and tests (for example `test/scout/<namespace>/ui/playwright.config.ts`).
+
+**Why use namespaces?**
+
+- **Scoped ownership**: assign each area to the team that owns it in `.github/CODEOWNERS`, so failures reach the smaller group that maintains that functionality.
+- **Independently runnable**: each namespace is discovered as its own config, so selective testing and CI reporting are scoped per area — while all namespaces still share the same [server configuration](./run-scout-tests.md#scout-run-tests-server-config-set).
+
+### Generate a namespace [scout-namespaces-generate]
+
+Pass `--namespace` to the [Scout CLI](#scout-setup-cli):
+
+```bash
+node scripts/scout.js generate \
+  --path x-pack/solutions/security/plugins/security_solution \
+  --namespace detection_engine
+```
+
+In interactive mode, if the plugin already uses namespaces, the generator lists the existing ones so you can pick one or create a new one. After scaffolding, it reminds you to set the namespace owner in `.github/CODEOWNERS`:
+
+```text
+/x-pack/solutions/security/plugins/security_solution/test/scout/detection_engine/ @elastic/<team>
+```
+
+### Rules [scout-namespaces-rules]
+
+::::::{important}
+- **One level only**: use `test/scout/<namespace>/{ui,api}/` — deeper nesting such as `.../<area>/<sub-area>/{ui,api}/` is not supported.
+- **Don't mix layouts**: a scout root is either entirely root-level (`test/scout/{ui,api}/`) or entirely namespace-based. Mixing the two fails the build. To adopt namespaces in an existing plugin, migrate the root-level tests into a namespace first.
+- **Naming**: start with a lowercase letter and use only lowercase letters, digits, and underscores. `ui`, `api`, `.meta`, and `common` are reserved (`common` is a plain shared-utilities directory with no Playwright config).
+::::::


### PR DESCRIPTION
This PR updates the Scout public docs so that they cover what Scout test namespaces are, why they exist, and how teams can use them.