### PR TITLE
[9.4] [CI] Add Jest runner negative testing for scripts/jest_all (#279867)

### DIFF
--- a/.buildkite/scripts/steps/checks/jest_negative.sh
+++ b/.buildkite/scripts/steps/checks/jest_negative.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
+echo --- Jest Runner Negative Testing
+# Feeds deliberately-failing canary configs to scripts/jest_all and inverts the result:
+# the runner must report each failure. Exits non-zero if any canary is not caught.
+node scripts/jest_negative

--- a/.buildkite/scripts/steps/checks/quick_checks.json
+++ b/.buildkite/scripts/steps/checks/quick_checks.json
@@ -99,5 +99,8 @@
   {
     "script": ".buildkite/scripts/steps/checks/verify_moon_projects.sh",
     "mayChangeFiles": true
+  },
+  {
+    "script": ".buildkite/scripts/steps/checks/jest_negative.sh"
   }
 ]

--- a/.eslintignore
+++ b/.eslintignore
@@ -32,6 +32,7 @@ snapshots.js
 /packages/kbn-generate/templates
 /src/platform/packages/shared/kbn-test/src/functional_test_runner/__tests__/fixtures/
 /src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/__tests__/fixtures/
+/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/
 /src/platform/packages/shared/kbn-flot-charts/lib
 /src/platform/packages/shared/kbn-monaco/src/**/antlr
 /src/platform/packages/shared/kbn-workflows/spec/elasticsearch/generated/**

--- a/scripts/jest_negative.js
+++ b/scripts/jest_negative.js
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+require('@kbn/setup-node-env');
+require('@kbn/test').runJestNegative();

--- a/src/platform/packages/shared/kbn-test/index.ts
+++ b/src/platform/packages/shared/kbn-test/index.ts
@@ -76,6 +76,13 @@ export type { JestConfigResult, JestValidationResult } from './src/jest/run_cont
 
 export { runJestAll } from './src/jest/run_all';
 
+export { runJestNegative, NEGATIVE_SCENARIOS, evaluateScenario } from './src/jest/run_negative';
+export type {
+  NegativeScenario,
+  ScenarioEvaluation,
+  ScenarioOutcome,
+} from './src/jest/run_negative';
+
 export {
   runJestViaMoon,
   parseMoonJestOutput,

--- a/src/platform/packages/shared/kbn-test/src/jest/configs/get_jest_configs.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/configs/get_jest_configs.test.ts
@@ -110,6 +110,22 @@ describe('getJestConfigs', () => {
     expect(result.duplicateTestFiles).toHaveLength(0);
   });
 
+  it('excludes __fixtures__ from auto-discovery', async () => {
+    let capturedCmd = '';
+    mockExecResponder = (cmd: string) => {
+      capturedCmd = cmd;
+      if (cmd.includes('*.test.ts') && cmd.includes('jest.config')) {
+        return { stdout: 'pkg/a/foo.test.ts\npkg/a/jest.config.js' };
+      }
+      return { stdout: '' };
+    };
+
+    const { getJestConfigs } = await import('./get_jest_configs');
+    await getJestConfigs();
+
+    expect(capturedCmd).toContain(':(glob,exclude)**/__fixtures__/**');
+  });
+
   it('should handle provided config paths', async () => {
     const configPaths = ['pkg/a/jest.config.js'];
 

--- a/src/platform/packages/shared/kbn-test/src/jest/configs/get_jest_configs.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/configs/get_jest_configs.ts
@@ -59,9 +59,12 @@ export async function getJestConfigs(configPaths?: string[]): Promise<{
         .map((file) => resolve(REPO_ROOT, file))
         .filter((file) => existsSync(file));
     } else {
-      // Merge both git commands into one for better performance
+      // Merge both git commands into one for better performance.
+      // Exclude __fixtures__ so fixture tests/configs (e.g. the negative-testing
+      // canaries) are never treated as real tests or orphaned. This mirrors CI's
+      // discoverJestUnitConfigs, which already ignores **/__fixtures__/**.
       const combinedResult = await execAsync(
-        `git ls-files -- '*.test.ts' '*.test.tsx' '**/jest.config.js' '**/*/jest.config.js' '**/jest.integration.config.js' '**/*/jest.integration.config.js'`,
+        `git ls-files -- '*.test.ts' '*.test.tsx' '**/jest.config.js' '**/*/jest.config.js' '**/jest.integration.config.js' '**/*/jest.integration.config.js' ':(glob,exclude)**/__fixtures__/**'`,
         { cwd: REPO_ROOT, maxBuffer: 1024 * 1024 * 10 }
       );
 

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/assertion_failure/assertion_failure.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/assertion_failure/assertion_failure.test.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Canary: a plain assertion failure. The runner must report this config as failed.
+describe('negative canary: assertion failure', () => {
+  it('fails a basic assertion', () => {
+    expect(1 + 1).toBe(3);
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/assertion_failure/jest.config.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/assertion_failure/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Negative-testing canary config. It lives under __fixtures__ so normal discovery
+// (CI run order, orphan check, package runs) never picks it up; it is only run
+// explicitly by scripts/jest_negative, which expects it to fail. Kept minimal and
+// standalone (no shared preset) so the canary fails for its own reason and is not
+// affected by the preset's __fixtures__ ignore or its jsdom/enzyme setup files.
+module.exports = {
+  rootDir: '../../../../../../../../../..',
+  roots: [
+    '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/assertion_failure',
+  ],
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(js|mjs|tsx?)$':
+      '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+};

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/log_buffer_overload/jest.config.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/log_buffer_overload/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Negative-testing canary config. It lives under __fixtures__ so normal discovery
+// (CI run order, orphan check, package runs) never picks it up; it is only run
+// explicitly by scripts/jest_negative, which expects it to fail. Kept minimal and
+// standalone (no shared preset) so the canary fails for its own reason and is not
+// affected by the preset's __fixtures__ ignore or its jsdom/enzyme setup files.
+module.exports = {
+  rootDir: '../../../../../../../../../..',
+  roots: [
+    '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/log_buffer_overload',
+  ],
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(js|mjs|tsx?)$':
+      '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+};

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/log_buffer_overload/log_buffer_overload.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/log_buffer_overload/log_buffer_overload.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Canary: emit more output than a single V8 string can hold (~512MB). A runner that
+// accumulates child output into a JS string (`buffer += ...`) overflows with
+// "RangeError: Invalid string length" and must surface that as a failure rather than
+// a pass. Writes are backpressure-aware so the bytes actually reach the runner.
+// Tracks elastic/kibana-operations#624; remove this canary once the buffer is fixed.
+describe('negative canary: log buffer overload', () => {
+  it('emits more than a JS string can hold', async () => {
+    const oneMb = 'x'.repeat(1024 * 1024);
+    const targetMb = Number(process.env.NEGATIVE_LOG_MB ?? 600);
+
+    for (let i = 0; i < targetMb; i++) {
+      if (!process.stdout.write(oneMb)) {
+        await new Promise((resolve) => process.stdout.once('drain', resolve));
+      }
+    }
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/nonzero_no_failures/jest.config.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/nonzero_no_failures/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Negative-testing canary config. It lives under __fixtures__ so normal discovery
+// (CI run order, orphan check, package runs) never picks it up; it is only run
+// explicitly by scripts/jest_negative, which expects it to fail. Kept minimal and
+// standalone (no shared preset) so the canary fails for its own reason and is not
+// affected by the preset's __fixtures__ ignore or its jsdom/enzyme setup files.
+module.exports = {
+  rootDir: '../../../../../../../../../..',
+  roots: [
+    '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/nonzero_no_failures',
+  ],
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(js|mjs|tsx?)$':
+      '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+};

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/nonzero_no_failures/nonzero_no_failures.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/nonzero_no_failures/nonzero_no_failures.test.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Canary: the process exits non-zero during module evaluation, before Jest can
+// collect or report any test result. The runner must still treat the non-zero
+// exit as a failure even though there are no parseable test-failure lines.
+process.exit(7);
+
+describe('negative canary: non-zero exit without failures', () => {
+  it('is never reached', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/process_exit_zero/jest.config.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/process_exit_zero/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Negative-testing canary config. It lives under __fixtures__ so normal discovery
+// (CI run order, orphan check, package runs) never picks it up; it is only run
+// explicitly by scripts/jest_negative, which expects it to fail. Kept minimal and
+// standalone (no shared preset) so the canary fails for its own reason and is not
+// affected by the preset's __fixtures__ ignore or its jsdom/enzyme setup files.
+module.exports = {
+  rootDir: '../../../../../../../../../..',
+  roots: [
+    '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/process_exit_zero',
+  ],
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(js|mjs|tsx?)$':
+      '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+};

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/process_exit_zero/process_exit_zero.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/process_exit_zero/process_exit_zero.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Canary: a test calls process.exit(0) mid-run. With --runInBand tests execute in
+// the Jest main process, so this terminates the child with exit code 0 before the
+// failing test below ever runs and before Jest prints a summary. A runner that
+// trusts the exit code alone will mark this config as PASSED.
+// Tracks elastic/kibana-operations#625; update this canary once the runner detects
+// incomplete Jest runs.
+describe('negative canary: process exit zero', () => {
+  it('exits the process with 0 before failures can run', () => {
+    process.exit(0);
+  });
+
+  it('would fail, but never runs', () => {
+    expect('process_exit_zero').toBe('caught');
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/runner_hang/jest.config.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/runner_hang/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Negative-testing canary config. It lives under __fixtures__ so normal discovery
+// (CI run order, orphan check, package runs) never picks it up; it is only run
+// explicitly by scripts/jest_negative, which expects it to fail. Kept minimal and
+// standalone (no shared preset) so the canary fails for its own reason and is not
+// affected by the preset's __fixtures__ ignore or its jsdom/enzyme setup files.
+module.exports = {
+  rootDir: '../../../../../../../../../..',
+  roots: [
+    '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/runner_hang',
+  ],
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(js|mjs|tsx?)$':
+      '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+};

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/runner_hang/runner_hang.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/runner_hang/runner_hang.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Canary: the test passes but leaves an open handle (a referenced interval), so the
+// Jest child process (run without --forceExit) never exits. A runner with no
+// per-config timeout waits on the child's 'exit' event forever and hangs.
+// Tracks elastic/kibana-operations#626; update this canary once the runner enforces
+// a per-config timeout.
+describe('negative canary: runner hang', () => {
+  it('passes but leaves the event loop alive', () => {
+    setInterval(() => {}, 60_000);
+    expect('runner_hang').toBeTruthy();
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/suite_import_error/jest.config.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/suite_import_error/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Negative-testing canary config. It lives under __fixtures__ so normal discovery
+// (CI run order, orphan check, package runs) never picks it up; it is only run
+// explicitly by scripts/jest_negative, which expects it to fail. Kept minimal and
+// standalone (no shared preset) so the canary fails for its own reason and is not
+// affected by the preset's __fixtures__ ignore or its jsdom/enzyme setup files.
+module.exports = {
+  rootDir: '../../../../../../../../../..',
+  roots: [
+    '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/suite_import_error',
+  ],
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(js|mjs|tsx?)$':
+      '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+};

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/suite_import_error/suite_import_error.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/suite_import_error/suite_import_error.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import './this_module_does_not_exist';
+
+// Canary: the suite fails to load because of an unresolvable import, before any
+// assertion runs. The runner must report the suite-load failure.
+describe('negative canary: suite import error', () => {
+  it('never runs because the import above fails', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/test_timeout/jest.config.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/test_timeout/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Negative-testing canary config. It lives under __fixtures__ so normal discovery
+// (CI run order, orphan check, package runs) never picks it up; it is only run
+// explicitly by scripts/jest_negative, which expects it to fail. Kept minimal and
+// standalone (no shared preset) so the canary fails for its own reason and is not
+// affected by the preset's __fixtures__ ignore or its jsdom/enzyme setup files.
+module.exports = {
+  rootDir: '../../../../../../../../../..',
+  roots: [
+    '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/test_timeout',
+  ],
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(js|mjs|tsx?)$':
+      '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+};

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/test_timeout/test_timeout.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/test_timeout/test_timeout.test.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Canary: a test that never resolves within its timeout. The runner must report
+// the timeout as a failure.
+describe('negative canary: test timeout', () => {
+  it('never resolves within the timeout', async () => {
+    await new Promise(() => {});
+  }, 50);
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/worker_oom/jest.config.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/worker_oom/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Negative-testing canary config. It lives under __fixtures__ so normal discovery
+// (CI run order, orphan check, package runs) never picks it up; it is only run
+// explicitly by scripts/jest_negative, which expects it to fail. Kept minimal and
+// standalone (no shared preset) so the canary fails for its own reason and is not
+// affected by the preset's __fixtures__ ignore or its jsdom/enzyme setup files.
+module.exports = {
+  rootDir: '../../../../../../../../../..',
+  roots: [
+    '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/worker_oom',
+  ],
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(js|mjs|tsx?)$':
+      '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+};

--- a/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/worker_oom/worker_oom.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__/worker_oom/worker_oom.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Canary: exhaust the V8 heap so the test process is OOM-killed. scripts/jest_negative
+// runs this with a small --max-old-space-size so it crashes quickly and deterministically.
+// The runner must surface the crash as a failure rather than a pass.
+describe('negative canary: out of memory', () => {
+  it('exhausts the heap', () => {
+    const blocks: string[] = [];
+    for (;;) {
+      blocks.push('x'.repeat(10 * 1024 * 1024));
+    }
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/run_negative.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_negative.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { evaluateScenario, NEGATIVE_SCENARIOS, type NegativeScenario } from './run_negative';
+
+const scenario: NegativeScenario = {
+  name: 'example',
+  description: 'example canary',
+  configPath: 'path/to/jest.config.js',
+  expectedExitCode: 10,
+  expectedPatterns: [/example/, /FAILED/],
+};
+
+describe('evaluateScenario', () => {
+  it('passes when the runner fails with the expected exit code and all patterns match', () => {
+    const result = evaluateScenario(scenario, 10, 'example config FAILED');
+
+    expect(result.passedAsExpected).toBe(true);
+    expect(result.exitCodeMatched).toBe(true);
+    expect(result.missingPatterns).toHaveLength(0);
+  });
+
+  it('fails when the runner unexpectedly succeeds (exit 0)', () => {
+    const result = evaluateScenario(scenario, 0, 'example config FAILED');
+
+    expect(result.passedAsExpected).toBe(false);
+    expect(result.exitCodeMatched).toBe(false);
+  });
+
+  it('fails when the exit code is non-zero but not the expected one', () => {
+    const result = evaluateScenario(scenario, 1, 'example config FAILED');
+
+    expect(result.passedAsExpected).toBe(false);
+    expect(result.exitCodeMatched).toBe(false);
+  });
+
+  it('fails when the failure signature is missing (failed for the wrong reason)', () => {
+    const result = evaluateScenario(scenario, 10, 'some unrelated output');
+
+    expect(result.passedAsExpected).toBe(false);
+    expect(result.exitCodeMatched).toBe(true);
+    expect(result.missingPatterns).toEqual([/example/, /FAILED/]);
+  });
+
+  it('matches a runner crash by its exact exit code (1)', () => {
+    const crashScenario: NegativeScenario = {
+      ...scenario,
+      expectedExitCode: 1,
+      expectedPatterns: [/boom/],
+    };
+
+    expect(evaluateScenario(crashScenario, 1, 'boom').passedAsExpected).toBe(true);
+    expect(evaluateScenario(crashScenario, 10, 'boom').passedAsExpected).toBe(false);
+    expect(evaluateScenario(crashScenario, 0, 'boom').passedAsExpected).toBe(false);
+  });
+
+  it("matches a runner hang only when the scenario expects 'timeout'", () => {
+    const hangScenario: NegativeScenario = {
+      ...scenario,
+      expectedExitCode: 'timeout',
+      expectedPatterns: [/Starting/],
+    };
+
+    expect(evaluateScenario(hangScenario, 'timeout', 'Starting cfg').passedAsExpected).toBe(true);
+    expect(evaluateScenario(hangScenario, 10, 'Starting cfg').passedAsExpected).toBe(false);
+    expect(evaluateScenario(scenario, 'timeout', 'example FAILED').passedAsExpected).toBe(false);
+  });
+
+  it('matches a known-bug false pass by exit 0 plus its signature', () => {
+    const falsePassScenario: NegativeScenario = {
+      ...scenario,
+      expectedExitCode: 0,
+      expectedPatterns: [/process\.exit called with "0"/],
+    };
+
+    const goodRun = evaluateScenario(falsePassScenario, 0, 'process.exit called with "0"');
+    expect(goodRun.passedAsExpected).toBe(true);
+
+    // Once the runner catches the abuse (exits 10), the pinned bug is fixed → canary flips
+    const fixedRunner = evaluateScenario(falsePassScenario, 10, 'process.exit called with "0"');
+    expect(fixedRunner.passedAsExpected).toBe(false);
+  });
+});
+
+describe('NEGATIVE_SCENARIOS', () => {
+  it('covers the documented failure modes', () => {
+    expect(NEGATIVE_SCENARIOS.map((s) => s.name)).toEqual([
+      'assertion_failure',
+      'worker_oom',
+      'log_buffer_overload',
+      'test_timeout',
+      'suite_import_error',
+      'nonzero_no_failures',
+      'process_exit_zero',
+      'runner_hang',
+    ]);
+  });
+
+  it('gives every canary an output signature and a fixture config', () => {
+    for (const s of NEGATIVE_SCENARIOS) {
+      expect(s.expectedPatterns.length).toBeGreaterThan(0);
+      expect(s.configPath).toContain('__fixtures__');
+    }
+  });
+
+  it('only known-bug canaries may expect a pass or a hang', () => {
+    // process_exit_zero pins elastic/kibana-operations#625 (false PASS);
+    // runner_hang pins elastic/kibana-operations#626 (no per-config timeout).
+    const knownBugCanaries = ['process_exit_zero', 'runner_hang'];
+    for (const s of NEGATIVE_SCENARIOS) {
+      if (!knownBugCanaries.includes(s.name)) {
+        expect(typeof s.expectedExitCode).toBe('number');
+        expect(s.expectedExitCode).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/run_negative.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_negative.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Path from 'path';
+
+import execa from 'execa';
+import Table from 'cli-table3';
+import { ToolingLog } from '@kbn/tooling-log';
+import { REPO_ROOT } from '@kbn/repo-info';
+
+/**
+ * Negative testing for `scripts/jest_all`: each scenario feeds a deliberately-failing
+ * Jest config to the runner and inverts the result — it passes only if the runner
+ * surfaces the expected failure. Scenarios tagged with a tracking issue pin a known
+ * runner bug and go red once it's fixed (the signal to update them).
+ */
+
+const NEGATIVE_FAILURE_EXIT_CODE = 10; // scripts/jest_all's "a config failed" code
+const DEFAULT_SCENARIO_TIMEOUT_MS = 10 * 60 * 1000;
+
+export interface NegativeScenario {
+  name: string;
+  description: string;
+  /** REPO_ROOT-relative path to the canary Jest config. */
+  configPath: string;
+  /** Exit code the runner must produce; `'timeout'` means we expect it to hang and kill it. */
+  expectedExitCode: number | 'timeout';
+  /** All must appear in the runner output for the scenario to pass. */
+  expectedPatterns: RegExp[];
+  env?: Record<string, string>;
+  timeoutMs?: number;
+}
+
+export interface ScenarioEvaluation {
+  exitCodeMatched: boolean;
+  missingPatterns: RegExp[];
+  passedAsExpected: boolean;
+}
+
+export interface ScenarioOutcome extends ScenarioEvaluation {
+  scenario: NegativeScenario;
+  exitCode: number | 'timeout';
+  durationMs: number;
+}
+
+const fixtureConfig = (scenario: string) =>
+  Path.join(
+    'src/platform/packages/shared/kbn-test/src/jest/negative/__fixtures__',
+    scenario,
+    'jest.config.js'
+  );
+
+export const NEGATIVE_SCENARIOS: NegativeScenario[] = [
+  {
+    name: 'assertion_failure',
+    description: 'a plain failing assertion',
+    configPath: fixtureConfig('assertion_failure'),
+    expectedExitCode: NEGATIVE_FAILURE_EXIT_CODE,
+    expectedPatterns: [/assertion_failure/, /Expected/, /Received/],
+  },
+  {
+    name: 'worker_oom',
+    description: 'test process is OOM-killed',
+    configPath: fixtureConfig('worker_oom'),
+    expectedExitCode: NEGATIVE_FAILURE_EXIT_CODE,
+    env: { NODE_OPTIONS: '--max-old-space-size=256' },
+    expectedPatterns: [/worker_oom/, /heap out of memory|out of memory|FATAL ERROR/i],
+  },
+  {
+    name: 'log_buffer_overload',
+    description: 'output larger than a JS string (~512MB)',
+    configPath: fixtureConfig('log_buffer_overload'),
+    // KNOWN BUG elastic/kibana-operations#624: runner buffers child output into a JS
+    // string and crashes with an uncaught "Invalid string length" (exit 1).
+    expectedExitCode: 1,
+    expectedPatterns: [/Invalid string length/],
+  },
+  {
+    name: 'test_timeout',
+    description: 'a test that never resolves within its timeout',
+    configPath: fixtureConfig('test_timeout'),
+    expectedExitCode: NEGATIVE_FAILURE_EXIT_CODE,
+    expectedPatterns: [/test_timeout/, /Exceeded timeout|timeout/i],
+  },
+  {
+    name: 'suite_import_error',
+    description: 'suite fails to load (unresolvable import)',
+    configPath: fixtureConfig('suite_import_error'),
+    expectedExitCode: NEGATIVE_FAILURE_EXIT_CODE,
+    expectedPatterns: [/suite_import_error/, /Cannot find module|find module/i],
+  },
+  {
+    name: 'nonzero_no_failures',
+    description: 'process exits non-zero with no parseable failures',
+    configPath: fixtureConfig('nonzero_no_failures'),
+    expectedExitCode: NEGATIVE_FAILURE_EXIT_CODE,
+    expectedPatterns: [/nonzero_no_failures/, /no individual test failures parsed/],
+  },
+  {
+    name: 'process_exit_zero',
+    description: 'test calls process.exit(0), runner falsely reports PASS',
+    configPath: fixtureConfig('process_exit_zero'),
+    // KNOWN BUG elastic/kibana-operations#625: runner trusts the child exit code, so a
+    // mid-run process.exit(0) is reported green even though a failing test never ran.
+    expectedExitCode: 0,
+    expectedPatterns: [/process\.exit called with "0"/, /✅.*process_exit_zero/],
+  },
+  {
+    name: 'runner_hang',
+    description: 'test leaves an open handle, runner hangs forever',
+    configPath: fixtureConfig('runner_hang'),
+    // KNOWN BUG elastic/kibana-operations#626: no per-config timeout, so a child that
+    // never exits hangs the runner until this scenario's timeoutMs kills it.
+    expectedExitCode: 'timeout',
+    expectedPatterns: [/Starting .*runner_hang/],
+    timeoutMs: 90_000,
+  },
+];
+
+/** Entry point for `scripts/jest_negative`. */
+export const runJestNegative = async () => {
+  const log = new ToolingLog({ level: 'info', writeTo: process.stdout });
+
+  log.info(
+    `Negative testing ${NEGATIVE_SCENARIOS.length} canaries against scripts/jest_all; ` +
+      `each must produce its expected failure mode.`
+  );
+
+  const outcomes: ScenarioOutcome[] = [];
+  for (const scenario of NEGATIVE_SCENARIOS) {
+    outcomes.push(await runScenario(scenario, log));
+  }
+
+  writeSummary(outcomes, log);
+
+  const unexpected = outcomes.filter((outcome) => !outcome.passedAsExpected);
+  if (unexpected.length > 0) {
+    log.error(
+      `${unexpected.length} canary/canaries did not behave as expected: ${unexpected
+        .map((outcome) => outcome.scenario.name)
+        .join(', ')}. Either the Jest runner stopped surfacing a failure, or a known bug ` +
+        `pinned by a canary was fixed (see the scenario's tracking issue).`
+    );
+    process.exit(1);
+  }
+
+  log.success(`All ${outcomes.length} canaries behaved as expected.`);
+  process.exit(0);
+};
+
+export const evaluateScenario = (
+  scenario: NegativeScenario,
+  exitCode: number | 'timeout',
+  output: string
+): ScenarioEvaluation => {
+  const exitCodeMatched = exitCode === scenario.expectedExitCode;
+  const missingPatterns = scenario.expectedPatterns.filter((pattern) => !pattern.test(output));
+
+  return {
+    exitCodeMatched,
+    missingPatterns,
+    passedAsExpected: exitCodeMatched && missingPatterns.length === 0,
+  };
+};
+
+const runScenario = async (
+  scenario: NegativeScenario,
+  log: ToolingLog
+): Promise<ScenarioOutcome> => {
+  log.write(`--- Negative canary: ${scenario.name} (${scenario.description})`);
+
+  // Strip BUILDKITE so jest_all's checkpoint/resume can't skip a canary on a step
+  // retry: process_exit_zero exits 0 by design, gets marked "done", and would then be
+  // skipped on the next attempt — dropping the output this canary asserts on.
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    JEST_WARMUP_DELAY_MS: '0',
+    ...scenario.env,
+  };
+  delete childEnv.BUILDKITE;
+
+  const started = Date.now();
+  const subprocess = execa('node', ['scripts/jest_all', '--configs', scenario.configPath], {
+    cwd: REPO_ROOT,
+    reject: false,
+    all: true,
+    detached: true, // detached=true: own process group so a timeout can SIGKILL the whole tree
+    env: childEnv,
+  });
+
+  let timedOut = false;
+  const killTimer = setTimeout(() => {
+    timedOut = true;
+    try {
+      process.kill(-subprocess.pid!, 'SIGKILL');
+    } catch {
+      // process group already gone
+    }
+  }, scenario.timeoutMs ?? DEFAULT_SCENARIO_TIMEOUT_MS);
+
+  const result = await subprocess;
+  clearTimeout(killTimer);
+
+  const durationMs = Date.now() - started;
+  const exitCode = timedOut ? 'timeout' : result.exitCode ?? 1;
+  const output = result.all ?? `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+
+  const evaluation = evaluateScenario(scenario, exitCode, output);
+
+  if (evaluation.passedAsExpected) {
+    log.success(`${scenario.name}: behaved as expected (exit ${exitCode})`);
+  } else {
+    log.error(`${scenario.name}: did NOT behave as expected (exit ${exitCode})`);
+    if (!evaluation.exitCodeMatched) {
+      log.error(`  expected exit ${scenario.expectedExitCode}, got ${exitCode}`);
+    }
+    for (const pattern of evaluation.missingPatterns) {
+      log.error(`  missing expected output pattern: ${pattern}`);
+    }
+    log.write(output);
+  }
+
+  return { scenario, exitCode, durationMs, ...evaluation };
+};
+
+const writeSummary = (outcomes: ScenarioOutcome[], log: ToolingLog) => {
+  const table = new Table({
+    head: ['Canary', 'Expected', 'Exit', 'Result', 'Duration'],
+    colAligns: ['left', 'left', 'right', 'center', 'right'],
+    style: { head: ['cyan', 'bold'], border: ['gray'] },
+  });
+
+  for (const outcome of outcomes) {
+    table.push([
+      outcome.scenario.name,
+      outcome.scenario.description,
+      String(outcome.exitCode),
+      outcome.passedAsExpected ? 'PASS' : 'FAIL',
+      `${Math.round(outcome.durationMs / 1000)}s`,
+    ]);
+  }
+
+  log.write('+++ Negative testing summary');
+  log.info(table.toString());
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[CI] Add Jest runner negative testing for scripts/jest_all (#279867)](https://github.com/elastic/kibana/pull/279867)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-07-23T16:35:47Z","message":"[CI] Add Jest runner negative testing for scripts/jest_all (#279867)\n\n## Summary\nAdds negative testing for the `scripts/jest_all` runner: 8 canary\nconfigs that deliberately fail in specific ways, an inverting runner\n(`scripts/jest_negative`) that verifies each failure is surfaced, and a\ngating PR pipeline step. Canary fixtures live under `__fixtures__` and\nare excluded from normal Jest discovery.\n\nCanaries cover: assertion failure, worker OOM, log buffer overflow\n(`RangeError: Invalid string length`), test timeout, suite import error,\nnon-zero exit with no parseable failures, plus two known runner bugs\npinned for future fixes (`process.exit(0)` false pass, open-handle\nhang).\n\nCloses elastic/kibana-operations#621\n\nRelated:\n- elastic/kibana#269289 — prior buffer fix (merged, then reverted)\n- elastic/kibana-operations#624 — log buffer overflow bug\n- elastic/kibana-operations#625 — `process.exit(0)` false pass bug\n- elastic/kibana-operations#626 — no per-config timeout / runner hang\nbug\n\n## Test plan\n- [x] `node scripts/jest_negative` — all 8 canaries pass (~2m20s)\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-test/src/jest/run_negative.test.ts`\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-test/tsconfig.json`\n\nMade with [Cursor](https://cursor.com)","sha":"e901b73e367b68fbdc67d7250bfee0d803a84e24","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:version","v9.5.0","v9.6.0","v9.4.5"],"title":"[CI] Add Jest runner negative testing for scripts/jest_all","number":279867,"url":"https://github.com/elastic/kibana/pull/279867","mergeCommit":{"message":"[CI] Add Jest runner negative testing for scripts/jest_all (#279867)\n\n## Summary\nAdds negative testing for the `scripts/jest_all` runner: 8 canary\nconfigs that deliberately fail in specific ways, an inverting runner\n(`scripts/jest_negative`) that verifies each failure is surfaced, and a\ngating PR pipeline step. Canary fixtures live under `__fixtures__` and\nare excluded from normal Jest discovery.\n\nCanaries cover: assertion failure, worker OOM, log buffer overflow\n(`RangeError: Invalid string length`), test timeout, suite import error,\nnon-zero exit with no parseable failures, plus two known runner bugs\npinned for future fixes (`process.exit(0)` false pass, open-handle\nhang).\n\nCloses elastic/kibana-operations#621\n\nRelated:\n- elastic/kibana#269289 — prior buffer fix (merged, then reverted)\n- elastic/kibana-operations#624 — log buffer overflow bug\n- elastic/kibana-operations#625 — `process.exit(0)` false pass bug\n- elastic/kibana-operations#626 — no per-config timeout / runner hang\nbug\n\n## Test plan\n- [x] `node scripts/jest_negative` — all 8 canaries pass (~2m20s)\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-test/src/jest/run_negative.test.ts`\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-test/tsconfig.json`\n\nMade with [Cursor](https://cursor.com)","sha":"e901b73e367b68fbdc67d7250bfee0d803a84e24"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/280567","number":280567,"state":"MERGED","mergeCommit":{"sha":"5a9f625db1b356d06aabd70de4cdcd3615655b5e","message":"[9.5] [CI] Add Jest runner negative testing for scripts/jest_all (#279867) (#280567)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[CI] Add Jest runner negative testing for scripts/jest_all\n(#279867)](https://github.com/elastic/kibana/pull/279867)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279867","number":279867,"mergeCommit":{"message":"[CI] Add Jest runner negative testing for scripts/jest_all (#279867)\n\n## Summary\nAdds negative testing for the `scripts/jest_all` runner: 8 canary\nconfigs that deliberately fail in specific ways, an inverting runner\n(`scripts/jest_negative`) that verifies each failure is surfaced, and a\ngating PR pipeline step. Canary fixtures live under `__fixtures__` and\nare excluded from normal Jest discovery.\n\nCanaries cover: assertion failure, worker OOM, log buffer overflow\n(`RangeError: Invalid string length`), test timeout, suite import error,\nnon-zero exit with no parseable failures, plus two known runner bugs\npinned for future fixes (`process.exit(0)` false pass, open-handle\nhang).\n\nCloses elastic/kibana-operations#621\n\nRelated:\n- elastic/kibana#269289 — prior buffer fix (merged, then reverted)\n- elastic/kibana-operations#624 — log buffer overflow bug\n- elastic/kibana-operations#625 — `process.exit(0)` false pass bug\n- elastic/kibana-operations#626 — no per-config timeout / runner hang\nbug\n\n## Test plan\n- [x] `node scripts/jest_negative` — all 8 canaries pass (~2m20s)\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-test/src/jest/run_negative.test.ts`\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-test/tsconfig.json`\n\nMade with [Cursor](https://cursor.com)","sha":"e901b73e367b68fbdc67d7250bfee0d803a84e24"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->