### PR TITLE
[Security Solution][Flyout] Bring back missing agenty type integration in the isolate host flyout header

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/host_isolation_flyout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/host_isolation_flyout.test.tsx
@@ -11,6 +11,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import {
   HostIsolationFlyout,
   HOST_ISOLATION_FLYOUT_TEST_ID,
+  HOST_ISOLATION_INTEGRATION_TEST_ID,
   HOST_ISOLATION_PANEL_TEST_ID,
   HOST_ISOLATION_TITLE_TEST_ID,
 } from './host_isolation_flyout';
@@ -24,6 +25,10 @@ jest.mock('../../../../hooks/use_app_toasts', () => ({
 
 jest.mock('../..', () => ({
   useWithCaseDetailsRefresh: () => undefined,
+}));
+
+jest.mock('../../../../hooks/endpoint/use_alert_response_actions_support', () => ({
+  useAlertResponseActionsSupport: () => ({ details: { agentType: 'endpoint' } }),
 }));
 
 jest.mock('./host_isolation_panel', () => ({
@@ -97,6 +102,22 @@ describe('<HostIsolationFlyout />', () => {
 
     expect(screen.getByTestId(HOST_ISOLATION_PANEL_TEST_ID)).toBeInTheDocument();
     expect(screen.getByTestId(HOST_ISOLATION_FLYOUT_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('renders the integration line in the header', () => {
+    render(
+      <HostIsolationFlyout
+        hit={hit}
+        detailsData={detailsData}
+        isolateAction="isolateHost"
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId(HOST_ISOLATION_INTEGRATION_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(`${HOST_ISOLATION_INTEGRATION_TEST_ID}-label`)).toHaveTextContent(
+      'Integration'
+    );
   });
 
   it('fires the isolation success toast and calls onClose when form reports success', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/host_isolation_flyout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/host_isolation_flyout.tsx
@@ -7,11 +7,13 @@
 
 import type { FC } from 'react';
 import React, { memo, useCallback } from 'react';
-import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
+import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue, HOST_NAME_FIELD } from '@kbn/discover-utils';
 import { useAppToasts } from '../../../../hooks/use_app_toasts';
+import { useAlertResponseActionsSupport } from '../../../../hooks/endpoint/use_alert_response_actions_support';
+import { AgentTypeIntegration } from '../../agents/agent_type_integration';
 import { useWithCaseDetailsRefresh } from '../..';
 import { HostIsolationPanel } from './host_isolation_panel';
 import { GET_ISOLATION_SUCCESS_MESSAGE, GET_UNISOLATION_SUCCESS_MESSAGE } from '../translations';
@@ -22,6 +24,7 @@ import { PREFIX } from '../../../../../flyout/shared/test_ids';
 const HOST_ISOLATION_TEST_ID = `${PREFIX}HostIsolation` as const;
 export const HOST_ISOLATION_FLYOUT_TEST_ID = `${HOST_ISOLATION_TEST_ID}Flyout` as const;
 export const HOST_ISOLATION_TITLE_TEST_ID = `${HOST_ISOLATION_TEST_ID}Title` as const;
+export const HOST_ISOLATION_INTEGRATION_TEST_ID = `${HOST_ISOLATION_TEST_ID}Integration` as const;
 export const HOST_ISOLATION_PANEL_TEST_ID = `${HOST_ISOLATION_TEST_ID}Panel` as const;
 
 export interface HostIsolationFlyoutProps {
@@ -54,6 +57,9 @@ export const HostIsolationFlyout: FC<HostIsolationFlyoutProps> = memo(
   ({ hit, detailsData, isolateAction, onClose }) => {
     const { addSuccess } = useAppToasts();
     const caseDetailsRefresh = useWithCaseDetailsRefresh();
+    const {
+      details: { agentType },
+    } = useAlertResponseActionsSupport(detailsData);
 
     const title = isolateAction === 'isolateHost' ? ISOLATE_HOST : UNISOLATE_HOST;
     const hostName = getFieldValue(hit, HOST_NAME_FIELD) as string;
@@ -85,6 +91,12 @@ export const HostIsolationFlyout: FC<HostIsolationFlyoutProps> = memo(
               {title}
             </h2>
           </EuiTitle>
+          <EuiSpacer size="s" />
+          <AgentTypeIntegration
+            agentType={agentType}
+            layout="horizontal"
+            data-test-subj={HOST_ISOLATION_INTEGRATION_TEST_ID}
+          />
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
           <div data-test-subj={HOST_ISOLATION_PANEL_TEST_ID}>


### PR DESCRIPTION
## Summary

This PR fixes an issue that was introduced by this previous [PR](https://github.com/elastic/kibana/pull/268658). When we moved to the new flyout system, we mistakenly dropped the agent type integration component from the isolate flyout header. This is now fixed.

| main  | this branch |
| ------------- | ------------- |
| <img width="1494" height="760" alt="Screenshot 2026-07-24 at 9 59 35 AM" src="https://github.com/user-attachments/assets/c747441a-ecd2-4ad7-affd-aa3e9c1eb909" /> | <img width="1494" height="763" alt="Screenshot 2026-07-24 at 10 56 57 AM" src="https://github.com/user-attachments/assets/6e75642a-f0fb-414f-9319-3736953aafe8" /> |

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/279739

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->