### PR TITLE
[Alerting][v2] Stop updateRule from toggling a rule's enabled state

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.test.ts
@@ -944,19 +944,14 @@ describe('updateRuleDataSchema', () => {
     expect(nullArtifacts).toMatchObject({ artifacts: null });
   });
 
-  it('accepts an enabled field set to true', () => {
-    const result = updateRuleDataSchema.parse({ enabled: true });
-    expect(result).toEqual({ enabled: true });
+  it('rejects enabled: true (enabled is not writable via update)', () => {
+    const result = updateRuleDataSchema.safeParse({ enabled: true });
+    expect(result.success).toBe(false);
   });
 
-  it('accepts an enabled field set to false', () => {
-    const result = updateRuleDataSchema.parse({ enabled: false });
-    expect(result).toEqual({ enabled: false });
-  });
-
-  it('omits enabled when not provided', () => {
-    const result = updateRuleDataSchema.parse({});
-    expect(result).not.toHaveProperty('enabled');
+  it('rejects enabled: false (enabled is not writable via update)', () => {
+    const result = updateRuleDataSchema.safeParse({ enabled: false });
+    expect(result.success).toBe(false);
   });
 
   it('accepts a state_transition object', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -538,7 +538,6 @@ export const updateRuleDataSchema = z
     state_transition: stateTransitionSchema.nullable(),
     grouping: groupingSchema.optional().nullable(),
     artifacts: z.array(artifactSchema).max(100).optional().nullable(),
-    enabled: z.boolean().optional().describe('Whether the rule is enabled.'),
   })
   .strict()
   .check((ctx) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout_container.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout_container.tsx
@@ -63,7 +63,9 @@ export const RuleSummaryFlyoutContainer = ({ ruleId, onClose, onEdit, onClone }:
         onEdit={onEdit}
         onClone={onClone}
         onDelete={(r) => setRuleToDelete(r)}
-        onToggleEnabled={(r) => toggleRuleEnabled({ id: r.id, enabled: !r.enabled })}
+        onToggleEnabled={(r) =>
+          toggleRuleEnabled({ id: r.id, enabled: !r.enabled, name: r.metadata.name })
+        }
       />
       {ruleToDelete && (
         <DeleteConfirmationModal

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.test.tsx
@@ -255,7 +255,11 @@ describe('RuleDetailPage', () => {
     const toggle = await screen.findByTestId('ruleDetailsEnabledSwitch');
     expect(toggle).toBeChecked();
     fireEvent.click(toggle);
-    expect(mockToggleRuleEnabled).toHaveBeenCalledWith({ id: 'rule-1', enabled: false });
+    expect(mockToggleRuleEnabled).toHaveBeenCalledWith({
+      id: 'rule-1',
+      enabled: false,
+      name: 'Test Signal Rule',
+    });
   });
 
   it('renders an unchecked enabled switch for disabled rules and enables the rule when toggled on', async () => {
@@ -263,7 +267,11 @@ describe('RuleDetailPage', () => {
     const toggle = await screen.findByTestId('ruleDetailsEnabledSwitch');
     expect(toggle).not.toBeChecked();
     fireEvent.click(toggle);
-    expect(mockToggleRuleEnabled).toHaveBeenCalledWith({ id: 'rule-1', enabled: true });
+    expect(mockToggleRuleEnabled).toHaveBeenCalledWith({
+      id: 'rule-1',
+      enabled: true,
+      name: 'Test Signal Rule',
+    });
   });
 
   it('disables the switch while the toggle mutation is in flight', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
@@ -161,9 +161,9 @@ export const RuleDetailPage: React.FunctionComponent = () => {
 
   const handleToggleEnabled = React.useCallback(
     (enabled: boolean) => {
-      toggleRuleEnabled({ id: rule.id, enabled });
+      toggleRuleEnabled({ id: rule.id, enabled, name: rule.metadata.name });
     },
-    [toggleRuleEnabled, rule.id]
+    [toggleRuleEnabled, rule.id, rule.metadata.name]
   );
 
   const onEdit = React.useCallback(() => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_toggle_rule_enabled.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_toggle_rule_enabled.test.ts
@@ -11,7 +11,7 @@ import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { useToggleRuleEnabled } from './use_toggle_rule_enabled';
 import { useService, CoreStart } from '@kbn/core-di-browser';
 import { RulesApi } from '../services/rules_api';
-import type { RuleResponse } from '@kbn/alerting-v2-schemas';
+import type { BulkResponse } from '@kbn/alerting-v2-schemas';
 
 jest.mock('@kbn/core-di-browser');
 jest.mock('../services/rules_api');
@@ -19,23 +19,7 @@ jest.mock('../services/rules_api');
 const mockUseService = useService as jest.MockedFunction<typeof useService>;
 const mockCoreStart = CoreStart as jest.MockedFunction<typeof CoreStart>;
 
-const mockEnabledRuleResponse: RuleResponse = {
-  id: 'rule-1',
-  kind: 'signal',
-  enabled: true,
-  metadata: {
-    name: 'My CPU Alert',
-    description: '',
-    tags: [],
-  },
-  time_field: '@timestamp',
-  schedule: { every: '1m', lookback: '5m' },
-  query: { format: 'standalone', breach: { query: 'FROM logs-*' } },
-  createdBy: 'test-user',
-  createdAt: '2026-01-01T00:00:00.000Z',
-  updatedBy: 'test-user',
-  updatedAt: '2026-01-01T00:00:00.000Z',
-};
+const successResponse: BulkResponse = { affected_count: 1, errors: [] };
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -49,7 +33,8 @@ const createWrapper = () => {
 };
 
 describe('useToggleRuleEnabled', () => {
-  const mockUpdateRule = jest.fn();
+  const mockBulkEnableRules = jest.fn();
+  const mockBulkDisableRules = jest.fn();
   const mockAddSuccess = jest.fn();
   const mockAddDanger = jest.fn();
 
@@ -60,7 +45,10 @@ describe('useToggleRuleEnabled', () => {
 
     mockUseService.mockImplementation((service: unknown) => {
       if (service === RulesApi) {
-        return { updateRule: mockUpdateRule } as any;
+        return {
+          bulkEnableRules: mockBulkEnableRules,
+          bulkDisableRules: mockBulkDisableRules,
+        } as any;
       }
       if (service === 'notifications') {
         return { toasts: { addSuccess: mockAddSuccess, addDanger: mockAddDanger } } as any;
@@ -69,37 +57,54 @@ describe('useToggleRuleEnabled', () => {
     });
   });
 
-  it('should show an enabled toast with the rule name when enabling', async () => {
-    mockUpdateRule.mockResolvedValue(mockEnabledRuleResponse);
+  it('calls bulkEnableRules and shows an enabled toast with the rule name when enabling', async () => {
+    mockBulkEnableRules.mockResolvedValue(successResponse);
     const { result } = renderHook(() => useToggleRuleEnabled(), { wrapper: createWrapper() });
 
-    result.current.mutate({ id: 'rule-1', enabled: true });
+    result.current.mutate({ id: 'rule-1', enabled: true, name: 'My CPU Alert' });
 
     await waitFor(() => {
-      expect(mockUpdateRule).toHaveBeenCalledWith('rule-1', { enabled: true });
+      expect(mockBulkEnableRules).toHaveBeenCalledWith({ ids: ['rule-1'] });
+      expect(mockBulkDisableRules).not.toHaveBeenCalled();
       expect(mockAddSuccess).toHaveBeenCalledWith('Rule "My CPU Alert" enabled');
       expect(mockAddDanger).not.toHaveBeenCalled();
     });
   });
 
-  it('should show a disabled toast with the rule name when disabling', async () => {
-    mockUpdateRule.mockResolvedValue({ ...mockEnabledRuleResponse, enabled: false });
+  it('calls bulkDisableRules and shows a disabled toast with the rule name when disabling', async () => {
+    mockBulkDisableRules.mockResolvedValue(successResponse);
     const { result } = renderHook(() => useToggleRuleEnabled(), { wrapper: createWrapper() });
 
-    result.current.mutate({ id: 'rule-1', enabled: false });
+    result.current.mutate({ id: 'rule-1', enabled: false, name: 'My CPU Alert' });
 
     await waitFor(() => {
-      expect(mockUpdateRule).toHaveBeenCalledWith('rule-1', { enabled: false });
+      expect(mockBulkDisableRules).toHaveBeenCalledWith({ ids: ['rule-1'] });
+      expect(mockBulkEnableRules).not.toHaveBeenCalled();
       expect(mockAddSuccess).toHaveBeenCalledWith('Rule "My CPU Alert" disabled');
       expect(mockAddDanger).not.toHaveBeenCalled();
     });
   });
 
-  it('should show a danger toast when the toggle fails', async () => {
-    mockUpdateRule.mockRejectedValue(new Error('toggle failed'));
+  it('shows a danger toast when the toggle request rejects', async () => {
+    mockBulkEnableRules.mockRejectedValue(new Error('toggle failed'));
     const { result } = renderHook(() => useToggleRuleEnabled(), { wrapper: createWrapper() });
 
-    result.current.mutate({ id: 'rule-1', enabled: true });
+    result.current.mutate({ id: 'rule-1', enabled: true, name: 'My CPU Alert' });
+
+    await waitFor(() => {
+      expect(mockAddDanger).toHaveBeenCalledWith(expect.any(String));
+      expect(mockAddSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  it('shows a danger toast when the bulk response reports a per-rule error', async () => {
+    mockBulkEnableRules.mockResolvedValue({
+      affected_count: 0,
+      errors: [{ id: 'rule-1', error: { code: 'RULE_NOT_FOUND', message: 'not found' } }],
+    } satisfies BulkResponse);
+    const { result } = renderHook(() => useToggleRuleEnabled(), { wrapper: createWrapper() });
+
+    result.current.mutate({ id: 'rule-1', enabled: true, name: 'My CPU Alert' });
 
     await waitFor(() => {
       expect(mockAddDanger).toHaveBeenCalledWith(expect.any(String));
@@ -108,7 +113,7 @@ describe('useToggleRuleEnabled', () => {
   });
 
   it('stays in a loading state until the invalidated queries have refetched', async () => {
-    mockUpdateRule.mockResolvedValue(mockEnabledRuleResponse);
+    mockBulkEnableRules.mockResolvedValue(successResponse);
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
@@ -125,7 +130,7 @@ describe('useToggleRuleEnabled', () => {
 
     const { result } = renderHook(() => useToggleRuleEnabled(), { wrapper });
 
-    result.current.mutate({ id: 'rule-1', enabled: true });
+    result.current.mutate({ id: 'rule-1', enabled: true, name: 'My CPU Alert' });
 
     // The success toast fires synchronously before invalidation is awaited, so once
     // it has been called we know the mutation is now blocked on the invalidation promise.

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_toggle_rule_enabled.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_toggle_rule_enabled.ts
@@ -5,30 +5,52 @@
  * 2.0.
  */
 
+import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
 import { useService, CoreStart } from '@kbn/core-di-browser';
 import { RulesApi } from '../services/rules_api';
 import { ruleKeys } from './query_key_factory';
 
+interface ToggleRuleEnabledVariables {
+  id: string;
+  enabled: boolean;
+  name: string;
+}
+
 export const useToggleRuleEnabled = () => {
   const rulesApi = useService(RulesApi);
   const { toasts } = useService(CoreStart('notifications'));
   const queryClient = useQueryClient();
 
+  const showErrorToast = useCallback(
+    () =>
+      toasts.addDanger(
+        i18n.translate('xpack.alertingV2.hooks.useToggleRuleEnabled.errorMessage', {
+          defaultMessage: 'Failed to update rule status',
+        })
+      ),
+    [toasts]
+  );
+
   return useMutation({
-    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
-      rulesApi.updateRule(id, { enabled }),
+    mutationFn: ({ id, enabled }: ToggleRuleEnabledVariables) =>
+      enabled ? rulesApi.bulkEnableRules({ ids: [id] }) : rulesApi.bulkDisableRules({ ids: [id] }),
     onSuccess: async (data, variables) => {
+      if (data.errors.length > 0) {
+        showErrorToast();
+        return;
+      }
+
       toasts.addSuccess(
         variables.enabled
           ? i18n.translate('xpack.alertingV2.hooks.useToggleRuleEnabled.enabledMessage', {
               defaultMessage: 'Rule "{ruleName}" enabled',
-              values: { ruleName: data.metadata.name },
+              values: { ruleName: variables.name },
             })
           : i18n.translate('xpack.alertingV2.hooks.useToggleRuleEnabled.disabledMessage', {
               defaultMessage: 'Rule "{ruleName}" disabled',
-              values: { ruleName: data.metadata.name },
+              values: { ruleName: variables.name },
             })
       );
 
@@ -38,11 +60,7 @@ export const useToggleRuleEnabled = () => {
       ]);
     },
     onError: () => {
-      toasts.addDanger(
-        i18n.translate('xpack.alertingV2.hooks.useToggleRuleEnabled.errorMessage', {
-          defaultMessage: 'Failed to update rule status',
-        })
-      );
+      showErrorToast();
     },
   });
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
@@ -1010,7 +1010,11 @@ describe('RulesListPage', () => {
     // Click the switch for the enabled rule (rule-1) — should disable it
     fireEvent.click(screen.getByTestId('ruleEnabledSwitch-rule-1'));
 
-    expect(mockToggleEnabledMutate).toHaveBeenCalledWith({ id: 'rule-1', enabled: false });
+    expect(mockToggleEnabledMutate).toHaveBeenCalledWith({
+      id: 'rule-1',
+      enabled: false,
+      name: 'Rule One',
+    });
   });
 
   it('shows "Clone" action in the context menu', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.test.tsx
@@ -225,7 +225,11 @@ describe('RulesListTableContainer', () => {
 
       fireEvent.click(screen.getByTestId('ruleEnabledSwitch-rule-1'));
 
-      expect(mockToggleEnabledMutate).toHaveBeenCalledWith({ id: 'rule-1', enabled: false });
+      expect(mockToggleEnabledMutate).toHaveBeenCalledWith({
+        id: 'rule-1',
+        enabled: false,
+        name: 'Rule One',
+      });
     });
 
     it('shows a spinner in place of the switch for the rule being toggled', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
@@ -155,7 +155,9 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
         onEdit={(r) => onEditInFlyout(r)}
         onClone={(r) => onCloneInFlyout(r)}
         onDelete={(r) => setRuleToDelete(r)}
-        onToggleEnabled={(r) => toggleEnabledMutation.mutate({ id: r.id, enabled: !r.enabled })}
+        onToggleEnabled={(r) =>
+          toggleEnabledMutation.mutate({ id: r.id, enabled: !r.enabled, name: r.metadata.name })
+        }
         togglingRuleId={
           toggleEnabledMutation.isLoading ? toggleEnabledMutation.variables?.id : undefined
         }
@@ -180,7 +182,9 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
             onCloneInFlyout(r);
           }}
           onDelete={(r) => setRuleToDelete(r)}
-          onToggleEnabled={(r) => toggleEnabledMutation.mutate({ id: r.id, enabled: !r.enabled })}
+          onToggleEnabled={(r) =>
+            toggleEnabledMutation.mutate({ id: r.id, enabled: !r.enabled, name: r.metadata.name })
+          }
         />
       ) : null}
       {ruleToDelete ? (

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -276,6 +276,31 @@ describe('RulesClient', () => {
       });
     });
 
+    it('does not schedule the executor task when updating a disabled rule', async () => {
+      const client = createClient();
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        attributes: { ...baseSoAttrs, enabled: false },
+        version: 'WzEsMV0=',
+        id: 'rule-id-disabled',
+      });
+
+      await client.updateRule({
+        id: 'rule-id-disabled',
+        data: { schedule: { every: '5m' } },
+      });
+
+      // A disabled rule must never be re-armed by an unrelated property edit —
+      // lifecycle transitions are owned exclusively by enableRule/disableRule.
+      expect(ensureRuleExecutorTaskScheduledMock).not.toHaveBeenCalled();
+      // The stored (disabled) state is still persisted.
+      expect(rulesSavedObjectService.update).toHaveBeenCalledWith({
+        id: 'rule-id-disabled',
+        attrs: expect.objectContaining({ enabled: false }),
+        version: 'WzEsMV0=',
+      });
+    });
+
     it('updates the description of a rule', async () => {
       const client = createClient();
 
@@ -1958,59 +1983,17 @@ describe('RulesClient', () => {
         expect(ruleEventPublisher.emitRuleDisabled).not.toHaveBeenCalled();
       });
 
-      it('emits only ruleUpdated for an enable-only PATCH (no lifecycle event via the update path)', async () => {
+      it('emits only ruleUpdated for a content update on a disabled rule (no lifecycle event via the update path)', async () => {
         const client = createClient();
         mockGetExistingRule('rule-id-wf-3', { ...workflowSoAttrs, enabled: false });
 
-        await client.updateRule({ id: 'rule-id-wf-3', data: { enabled: true } });
+        await client.updateRule({
+          id: 'rule-id-wf-3',
+          data: { metadata: { name: 'renamed' } },
+        });
 
         expect(ruleEventPublisher.emitRuleUpdated).toHaveBeenCalledWith(request, [
           { id: 'rule-id-wf-3', spaceId: 'space-1' },
-        ]);
-        expect(ruleEventPublisher.emitRuleEnabled).not.toHaveBeenCalled();
-        expect(ruleEventPublisher.emitRuleDisabled).not.toHaveBeenCalled();
-      });
-
-      it('emits only ruleUpdated for a disable-only PATCH (no lifecycle event via the update path)', async () => {
-        const client = createClient();
-        mockGetExistingRule('rule-id-wf-3b');
-
-        await client.updateRule({ id: 'rule-id-wf-3b', data: { enabled: false } });
-
-        expect(ruleEventPublisher.emitRuleUpdated).toHaveBeenCalledWith(request, [
-          { id: 'rule-id-wf-3b', spaceId: 'space-1' },
-        ]);
-        expect(ruleEventPublisher.emitRuleEnabled).not.toHaveBeenCalled();
-        expect(ruleEventPublisher.emitRuleDisabled).not.toHaveBeenCalled();
-      });
-
-      it('emits only ruleUpdated when content and enabled change together', async () => {
-        const client = createClient();
-        mockGetExistingRule('rule-id-wf-3c', { ...workflowSoAttrs, enabled: false });
-
-        await client.updateRule({
-          id: 'rule-id-wf-3c',
-          data: { metadata: { name: 'renamed' }, enabled: true },
-        });
-
-        expect(ruleEventPublisher.emitRuleUpdated).toHaveBeenCalledWith(request, [
-          { id: 'rule-id-wf-3c', spaceId: 'space-1' },
-        ]);
-        expect(ruleEventPublisher.emitRuleEnabled).not.toHaveBeenCalled();
-        expect(ruleEventPublisher.emitRuleDisabled).not.toHaveBeenCalled();
-      });
-
-      it('emits ruleUpdated only when enabled is set but unchanged in the PATCH', async () => {
-        const client = createClient();
-        mockGetExistingRule('rule-id-wf-3d');
-
-        await client.updateRule({
-          id: 'rule-id-wf-3d',
-          data: { enabled: true, metadata: { name: 'renamed' } },
-        });
-
-        expect(ruleEventPublisher.emitRuleUpdated).toHaveBeenCalledWith(request, [
-          { id: 'rule-id-wf-3d', spaceId: 'space-1' },
         ]);
         expect(ruleEventPublisher.emitRuleEnabled).not.toHaveBeenCalled();
         expect(ruleEventPublisher.emitRuleDisabled).not.toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
@@ -389,11 +389,18 @@ export class RulesClient {
       checkLimit: existingAttrs.enabled,
     });
 
-    await this.scheduleRuleExecutorTask({
-      ruleId: id,
-      spaceId,
-      scheduleEvery: nextAttrs.schedule.every,
-    });
+    // updateRule NEVER changes whether a rule runs — it only re-syncs the
+    // schedule interval of an already-enabled rule (Task Manager's
+    // `ensureScheduled` updates the interval of the existing task on conflict).
+    // Turning the run loop on/off stays exclusively with enableRule/disableRule,
+    // so a disabled rule is never resurrected by an unrelated property edit.
+    if (existingAttrs.enabled) {
+      await this.scheduleRuleExecutorTask({
+        ruleId: id,
+        spaceId,
+        scheduleEvery: nextAttrs.schedule.every,
+      });
+    }
 
     const { version: newVersion } = await this.writeRuleAttrs({
       id,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
@@ -194,7 +194,9 @@ export function buildUpdateRuleAttributes(
     // `null` → clear (undefined). SO schema uses `maybe()` without `nullable()`.
     grouping: nullToUndefined(updateData.grouping, existingAttrs.grouping),
     artifacts: nullToEmptyArray(updateData.artifacts, existingAttrs.artifacts),
-    enabled: updateData.enabled ?? existingAttrs.enabled,
+    // `enabled` is never writable via update — lifecycle transitions are owned
+    // exclusively by enableRule/disableRule, so the stored value is preserved.
+    enabled: existingAttrs.enabled,
     // Server-managed fields — preserved as-is except timestamps and user.
     createdBy: existingAttrs.createdBy,
     createdAt: existingAttrs.createdAt,

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/update_rule.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/update_rule.spec.ts
@@ -65,18 +65,23 @@ apiTest.describe('Update rule API', { tag: '@local-stateful-classic' }, () => {
     }
   );
 
-  apiTest('update: should toggle the enabled field', async ({ apiClient, apiServices }) => {
-    const created = await apiServices.alertingV2.rules.create(
-      buildCreateRuleData({ metadata: { name: 'rule-to-disable' } })
-    );
-    expect(created.enabled).toBe(true);
-    const response = await apiClient.patch(getRuleUrl(created.id), {
-      headers: writerHeaders,
-      body: { enabled: false },
-    });
-    expect(response).toHaveStatusCode(200);
-    expect(response.body.enabled).toBe(false);
-  });
+  apiTest(
+    'update: should reject a body containing enabled and never toggle lifecycle',
+    async ({ apiClient, apiServices }) => {
+      const created = await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({ metadata: { name: 'rule-to-disable' } })
+      );
+      expect(created.enabled).toBe(true);
+      const response = await apiClient.patch(getRuleUrl(created.id), {
+        headers: writerHeaders,
+        body: { enabled: false },
+      });
+      expect(response).toHaveStatusCode(400);
+
+      const stored = await apiServices.alertingV2.rules.get(created.id);
+      expect(stored.enabled).toBe(true);
+    }
+  );
 
   apiTest(
     'update: should update schedule.lookback while preserving schedule.every',


### PR DESCRIPTION
## Summary

Closes elastic/kibana#280581

In Alerting v2, a rule's on/off lifecycle lives in two synced places: the `enabled` boolean on the rule Saved Object, and the existence of the rule's Task Manager executor task. Enabling/disabling is a **state transition with side effects** (schedule/remove the TM task, emit `ruleEnabled`/`ruleDisabled` events), so it must go **only** through the dedicated `enableRule`/`disableRule` paths  and never through the generic update method. This PR fixes this.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->