### PR TITLE
[9.4] [Discover] fix delete Dataview flyout relationships link (#280145)

### DIFF
--- a/src/platform/plugins/shared/data_view_management/moon.yml
+++ b/src/platform/plugins/shared/data_view_management/moon.yml
@@ -61,6 +61,7 @@ dependsOn:
   - '@kbn/cps-utils'
   - '@kbn/cps'
   - '@kbn/scout'
+  - '@kbn/core-http-browser-mocks'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.test.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.test.tsx
@@ -7,15 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/public';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import {
   DeleteModalContent,
   relationshipCalloutText,
   spacesWarningText,
 } from './delete_data_view_flyout_content';
 import type { RemoveDataViewProps } from '../edit_index_pattern';
+import { mockManagementPlugin } from '../../mocks';
 
 const mockViews: RemoveDataViewProps[] = [
   {
@@ -53,100 +57,71 @@ describe('DeleteModalContent', () => {
     setReviewedItems = jest.fn();
   });
 
-  it('renders warning callout when no relationships', () => {
+  const renderContent = (
+    overrides: Partial<React.ComponentProps<typeof DeleteModalContent>> = {},
+    context = mockManagementPlugin.createIndexPatternManagmentContext()
+  ) =>
     render(
       <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={{ '1': [], '2': [] }}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
+        <KibanaContextProvider services={context}>
+          <DeleteModalContent
+            views={mockViews}
+            hasSpaces={true}
+            relationships={mockRelationships}
+            reviewedItems={reviewedItems}
+            setReviewedItems={setReviewedItems}
+            {...overrides}
+          />
+        </KibanaContextProvider>
       </IntlProvider>
     );
-    expect(screen.getByText(spacesWarningText)).toBeInTheDocument();
-    expect(screen.getByText(/Successfully deleted 2 data views/i)).toBeInTheDocument();
+
+  it('renders warning callout when no relationships', () => {
+    renderContent({ relationships: { '1': [], '2': [] } });
+    expect(screen.getByText(spacesWarningText)).toBeVisible();
+    expect(screen.getByText(/Successfully deleted 2 data views/i)).toBeVisible();
   });
 
   it('renders danger callout when relationships exist', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
-    );
-    expect(screen.getByText(relationshipCalloutText)).toBeInTheDocument();
+    renderContent();
+    expect(screen.getByText(relationshipCalloutText)).toBeVisible();
   });
 
   it('renders table with data view names and spaces', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
-    );
-    expect(screen.getByText('Data View 1')).toBeInTheDocument();
-    expect(screen.getByText('Data View 2')).toBeInTheDocument();
-    expect(screen.getByText('all')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
+    renderContent();
+    expect(screen.getByText('Data View 1')).toBeVisible();
+    expect(screen.getByText('Data View 2')).toBeVisible();
+    expect(screen.getByText('all')).toBeVisible();
+    expect(screen.getByText('1')).toBeVisible();
   });
 
   it('shows "Review" button for views with relationships', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
-    );
+    renderContent();
     expect(screen.getAllByText('Review').length).toBe(1);
   });
 
-  it('expands relationship details when "Review" is clicked', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={true}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
-    );
-    const reviewBtn = screen.getByRole('button', { name: /Expand/i });
-    fireEvent.click(reviewBtn);
-    expect(screen.getByText('Dashboard 1')).toBeInTheDocument();
+  it('expands relationship details when "Review" is clicked', async () => {
+    renderContent();
+    await userEvent.click(screen.getByRole('button', { name: /Expand/i }));
+    expect(screen.getByText('Dashboard 1')).toBeVisible();
     expect(setReviewedItems).toHaveBeenCalled();
   });
 
-  it('renders without spaces column if hasSpaces is false', () => {
-    render(
-      <IntlProvider>
-        <DeleteModalContent
-          views={mockViews}
-          hasSpaces={false}
-          relationships={mockRelationships}
-          reviewedItems={reviewedItems}
-          setReviewedItems={setReviewedItems}
-        />
-      </IntlProvider>
+  it('renders related object links with the current space basePath', async () => {
+    const context = mockManagementPlugin.createIndexPatternManagmentContext();
+    context.http = httpServiceMock.createStartContract({ basePath: '/s/space-a' });
+
+    renderContent({}, context);
+    await userEvent.click(screen.getByRole('button', { name: /Expand/i }));
+
+    expect(screen.getByText('Dashboard 1').closest('a')).toHaveAttribute(
+      'href',
+      '/s/space-a/app/dashboards#/view/rel-1'
     );
+  });
+
+  it('renders without spaces column if hasSpaces is false', () => {
+    renderContent({ hasSpaces: false });
     expect(screen.queryByText('Spaces')).not.toBeInTheDocument();
   });
 });

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
@@ -24,8 +24,10 @@ import type { SavedObjectRelation } from '@kbn/saved-objects-management-plugin/p
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useState, type ReactNode } from 'react';
 import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { RemoveDataViewProps } from '../edit_index_pattern';
 import { MAX_DISPLAYED_RELATIONSHIPS } from '../../constants';
+import type { IndexPatternManagmentContext } from '../../types';
 
 const all = i18n.translate('indexPatternManagement.dataViewTable.spaceCountAll', {
   defaultMessage: 'all',
@@ -84,6 +86,8 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
   reviewedItems,
   setReviewedItems,
 }) => {
+  const { http } = useKibana<IndexPatternManagmentContext>().services;
+
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<Record<string, ReactNode>>(
     {}
   );
@@ -103,7 +107,7 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
           }),
           render: (meta: SavedObjectRelation['meta']) => {
             return meta.inAppUrl ? (
-              <EuiLink target="_blank" href={meta.inAppUrl.path}>
+              <EuiLink target="_blank" href={http.basePath.prepend(meta.inAppUrl.path)}>
                 {meta.title}
               </EuiLink>
             ) : (

--- a/src/platform/plugins/shared/data_view_management/tsconfig.json
+++ b/src/platform/plugins/shared/data_view_management/tsconfig.json
@@ -48,7 +48,6 @@
     "@kbn/saved-objects-tagging-oss-plugin",
     "@kbn/cps-utils",
     "@kbn/cps",
-    "@kbn/discover-utils",
     "@kbn/scout",
     "@kbn/core-http-browser-mocks",
   ],

--- a/src/platform/plugins/shared/data_view_management/tsconfig.json
+++ b/src/platform/plugins/shared/data_view_management/tsconfig.json
@@ -48,7 +48,9 @@
     "@kbn/saved-objects-tagging-oss-plugin",
     "@kbn/cps-utils",
     "@kbn/cps",
-    "@kbn/scout"
+    "@kbn/discover-utils",
+    "@kbn/scout",
+    "@kbn/core-http-browser-mocks",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Discover] fix delete Dataview flyout relationships link (#280145)](https://github.com/elastic/kibana/pull/280145)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastian Delle Donne","email":"sebastian.delledonne@elastic.co"},"sourceCommit":{"committedDate":"2026-07-24T07:33:24Z","message":"[Discover] fix delete Dataview flyout relationships link (#280145)\n\n- Closes https://github.com/elastic/kibana/issues/274785\n## Summary\nDataView relationship links were not built correctly within spaces and\nlead to a 404 page.\n\n**Steps to reproduce**\n- Create a custom Kibana Space (e.g. space-a) and ensure it has access\nto Stack Management → Data Views.\n- In space-a, create or share a Data View that is used by at least one\nsaved object in that space (e.g. a saved search or dashboard).\n- Navigate to Stack Management → Data Views while in space-a (URL should\ninclude /s/space-a/).\n- Open the Data View and confirm on the Relationships tab that related\nobjects link correctly (hover a link — URL includes /s/space-a/).\n- Initiate deletion of the Data View (from the detail page or the list\npage).\n- In the Delete Data View flyout, expand Review for the Data View and\nhover a related object link.\n\n### After fix\n<img width=\"1713\" height=\"871\" alt=\"dataview2\"\nsrc=\"https://github.com/user-attachments/assets/88b6cc14-06c2-4bce-a3cc-ef83ac797a7a\"\n/>\n\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"32cdd6d8762a750208506f70dd363b4cf94e5fa1","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","Team:DataDiscovery","backport:version","v9.5.0","v9.6.0","v9.4.5"],"title":"[Discover] fix delete Dataview flyout relationships link","number":280145,"url":"https://github.com/elastic/kibana/pull/280145","mergeCommit":{"message":"[Discover] fix delete Dataview flyout relationships link (#280145)\n\n- Closes https://github.com/elastic/kibana/issues/274785\n## Summary\nDataView relationship links were not built correctly within spaces and\nlead to a 404 page.\n\n**Steps to reproduce**\n- Create a custom Kibana Space (e.g. space-a) and ensure it has access\nto Stack Management → Data Views.\n- In space-a, create or share a Data View that is used by at least one\nsaved object in that space (e.g. a saved search or dashboard).\n- Navigate to Stack Management → Data Views while in space-a (URL should\ninclude /s/space-a/).\n- Open the Data View and confirm on the Relationships tab that related\nobjects link correctly (hover a link — URL includes /s/space-a/).\n- Initiate deletion of the Data View (from the detail page or the list\npage).\n- In the Delete Data View flyout, expand Review for the Data View and\nhover a related object link.\n\n### After fix\n<img width=\"1713\" height=\"871\" alt=\"dataview2\"\nsrc=\"https://github.com/user-attachments/assets/88b6cc14-06c2-4bce-a3cc-ef83ac797a7a\"\n/>\n\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"32cdd6d8762a750208506f70dd363b4cf94e5fa1"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/280661","number":280661,"state":"MERGED","mergeCommit":{"sha":"fe3ee5f8da852795e21f013e1c8de24819c80c6f","message":"[9.5] [Discover] fix delete Dataview flyout relationships link (#280145) (#280661)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Discover] fix delete Dataview flyout relationships link\n(#280145)](https://github.com/elastic/kibana/pull/280145)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sebastian Delle Donne <sebastian.delledonne@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280145","number":280145,"mergeCommit":{"message":"[Discover] fix delete Dataview flyout relationships link (#280145)\n\n- Closes https://github.com/elastic/kibana/issues/274785\n## Summary\nDataView relationship links were not built correctly within spaces and\nlead to a 404 page.\n\n**Steps to reproduce**\n- Create a custom Kibana Space (e.g. space-a) and ensure it has access\nto Stack Management → Data Views.\n- In space-a, create or share a Data View that is used by at least one\nsaved object in that space (e.g. a saved search or dashboard).\n- Navigate to Stack Management → Data Views while in space-a (URL should\ninclude /s/space-a/).\n- Open the Data View and confirm on the Relationships tab that related\nobjects link correctly (hover a link — URL includes /s/space-a/).\n- Initiate deletion of the Data View (from the detail page or the list\npage).\n- In the Delete Data View flyout, expand Review for the Data View and\nhover a related object link.\n\n### After fix\n<img width=\"1713\" height=\"871\" alt=\"dataview2\"\nsrc=\"https://github.com/user-attachments/assets/88b6cc14-06c2-4bce-a3cc-ef83ac797a7a\"\n/>\n\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"32cdd6d8762a750208506f70dd363b4cf94e5fa1"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->