### PR TITLE
[Inference / Workflows] Add synchronous workflow execution and anonymization type foundation

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
@@ -73,6 +73,15 @@ const configSchema = schema.object({
   hitlExternalResume: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
   }),
+  syncExecution: schema.object({
+    /**
+     * Maximum wall-clock time allowed for a single synchronous workflow execution.
+     * When the deadline is reached the internal AbortController is aborted, which
+     * propagates cancellation through the execution loop to any in-flight step.
+     * Callers may impose a shorter deadline via ExecuteWorkflowOptions.abortSignal.
+     */
+    maxDurationMs: schema.number({ defaultValue: 60_000, min: 1_000 }),
+  }),
 });
 
 export type EventTriggersConfig = TypeOf<typeof EventTriggersConfigSchema>;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
@@ -75,6 +75,12 @@ const configSchema = schema.object({
   }),
   syncExecution: schema.object({
     /**
+     * Master switch for the synchronous execution path. Must be set to true alongside
+     * `xpack.inference.anonymization.workflow_driven: true` to enable workflow-driven
+     * PII anonymization. Defaults to false so the path is inert until explicitly activated.
+     */
+    enabled: schema.boolean({ defaultValue: false }),
+    /**
      * Maximum wall-clock time allowed for a single synchronous workflow execution.
      * When the deadline is reached the internal AbortController is aborted, which
      * propagates cancellation through the execution loop to any in-flight step.

--- a/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
@@ -83,10 +83,13 @@ const configSchema = schema.object({
     /**
      * Maximum wall-clock time allowed for a single synchronous workflow execution.
      * When the deadline is reached the internal AbortController is aborted, which
-     * propagates cancellation through the execution loop to any in-flight step.
-     * Callers may impose a shorter deadline via ExecuteWorkflowOptions.abortSignal.
+     * propagates cancellation through the execution loop and cancels any in-flight
+     * I/O (e.g. LLM streaming). Around-hook workflows that wrap LLM calls can take
+     * several minutes; the 10-minute default reflects this. The natural upper bound
+     * is the HTTP request timeout — if the client disconnects, that signal propagates
+     * first. Callers may impose a shorter deadline via ExecuteWorkflowOptions.abortSignal.
      */
-    maxDurationMs: schema.number({ defaultValue: 60_000, min: 1_000 }),
+    maxDurationMs: schema.number({ defaultValue: 600_000, min: 1_000 }),
   }),
 });
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
@@ -32,6 +32,6 @@ export const mockContextDependencies = () => ({
     },
     collectQueueMetrics: false,
     hitlExternalResume: { enabled: true },
-    syncExecution: { maxDurationMs: 60_000 },
+    syncExecution: { enabled: true, maxDurationMs: 60_000 },
   },
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
@@ -32,5 +32,6 @@ export const mockContextDependencies = () => ({
     },
     collectQueueMetrics: false,
     hitlExternalResume: { enabled: true },
+    syncExecution: { maxDurationMs: 60_000 },
   },
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import { ExecutionStatus } from '@kbn/workflows';
+import type { EsWorkflowExecution, WorkflowExecutionEngineModel } from '@kbn/workflows';
+import { mockContextDependencies } from './__mock__/context_dependencies';
+import { executeWorkflowSync } from './execute_workflow_sync';
+import { runWorkflowSync } from './run_workflow_sync';
+import { buildWorkflowExecutionDocument } from '../lib/build_workflow_execution_document';
+import { getAuthenticatedUser } from '../lib/get_user';
+import { validateWorkflowInputs } from '../lib/validate_workflow_inputs';
+
+jest.mock('./run_workflow_sync');
+jest.mock('../lib/build_workflow_execution_document');
+jest.mock('../lib/get_user');
+jest.mock('../lib/validate_workflow_inputs');
+jest.mock('../repositories/execution_persistence', () => ({
+  InMemoryExecutionPersistence: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockRunWorkflowSync = runWorkflowSync as jest.MockedFunction<typeof runWorkflowSync>;
+const mockBuildWorkflowExecutionDocument = buildWorkflowExecutionDocument as jest.MockedFunction<
+  typeof buildWorkflowExecutionDocument
+>;
+const mockValidateWorkflowInputs = validateWorkflowInputs as jest.MockedFunction<
+  typeof validateWorkflowInputs
+>;
+const mockGetAuthenticatedUser = getAuthenticatedUser as jest.MockedFunction<
+  typeof getAuthenticatedUser
+>;
+
+const baseWorkflowExecution = {
+  id: 'exec-1',
+  workflowId: 'wf-1',
+  spaceId: 'default',
+  triggeredBy: 'manual',
+  workflowDefinition: { version: '1', name: 'Test', enabled: true, triggers: [], steps: [] },
+  isTestRun: false,
+  status: ExecutionStatus.PENDING,
+  context: {},
+  yaml: '',
+  scopeStack: [],
+  error: null,
+  startedAt: '2026-01-01T00:00:00.000Z',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  finishedAt: '',
+  cancelRequested: false,
+  duration: 0,
+};
+
+const completedExecution: EsWorkflowExecution = {
+  ...baseWorkflowExecution,
+  status: ExecutionStatus.COMPLETED,
+  context: { output: { answer: 42 } },
+};
+
+describe('executeWorkflowSync', () => {
+  const workflow = { id: 'wf-1', yaml: '', isEphemeral: false } as WorkflowExecutionEngineModel;
+  const request = {} as KibanaRequest;
+  const logger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any;
+  const getWorkflowsExecutionEngine = jest.fn().mockResolvedValue({});
+
+  let dependencies: ReturnType<typeof mockContextDependencies> & {
+    workflowRepository?: { isWorkflowEnabled: jest.Mock };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dependencies = mockContextDependencies();
+    mockGetAuthenticatedUser.mockResolvedValue({ username: 'test-user' } as any);
+    mockBuildWorkflowExecutionDocument.mockReturnValue(baseWorkflowExecution as any);
+    mockValidateWorkflowInputs.mockResolvedValue(true);
+    mockRunWorkflowSync.mockResolvedValue(completedExecution);
+  });
+
+  const invoke = (overrides?: Partial<Parameters<typeof executeWorkflowSync>[0]>) =>
+    executeWorkflowSync({
+      workflow,
+      context: {},
+      request,
+      options: {},
+      logger,
+      dependencies: dependencies as any,
+      getWorkflowsExecutionEngine,
+      ...overrides,
+    });
+
+  describe('disabled workflow guard', () => {
+    let isWorkflowEnabled: jest.Mock;
+
+    beforeEach(() => {
+      isWorkflowEnabled = jest.fn().mockResolvedValue(true);
+      dependencies = { ...dependencies, workflowRepository: { isWorkflowEnabled } } as any;
+    });
+
+    it('throws when a non-ephemeral workflow is disabled', async () => {
+      isWorkflowEnabled.mockResolvedValue(false);
+      await expect(invoke()).rejects.toThrow('Workflow is disabled: wf-1');
+      expect(mockRunWorkflowSync).not.toHaveBeenCalled();
+    });
+
+    it('skips the check when workflow.isEphemeral is true', async () => {
+      const ephemeral = { ...workflow, isEphemeral: true } as WorkflowExecutionEngineModel;
+      await invoke({ workflow: ephemeral });
+      expect(isWorkflowEnabled).not.toHaveBeenCalled();
+    });
+
+    it('skips the check when workflowRepository is absent', async () => {
+      delete dependencies.workflowRepository;
+      await expect(invoke()).resolves.toBeDefined();
+    });
+  });
+
+  describe('workflowDefinition guard', () => {
+    it('throws when buildWorkflowExecutionDocument returns no workflowDefinition', async () => {
+      mockBuildWorkflowExecutionDocument.mockReturnValue({
+        ...baseWorkflowExecution,
+        workflowDefinition: undefined,
+      } as any);
+      await expect(invoke()).rejects.toThrow(
+        'Synchronous workflow execution requires a workflow definition'
+      );
+      expect(mockRunWorkflowSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateWorkflowInputs guard', () => {
+    it('returns FAILED and does not call runWorkflowSync when inputs are invalid', async () => {
+      mockValidateWorkflowInputs.mockResolvedValue(false);
+      const result = await invoke();
+      expect(result).toEqual({
+        workflowExecutionId: 'exec-1',
+        result: { status: ExecutionStatus.FAILED },
+      });
+      expect(mockRunWorkflowSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('output extraction', () => {
+    it('returns no output field when context.output is undefined', async () => {
+      mockRunWorkflowSync.mockResolvedValue({ ...completedExecution, context: {} });
+      const result = await invoke();
+      expect(result.result).not.toHaveProperty('output');
+    });
+
+    it('returns no output field when context.output is null', async () => {
+      mockRunWorkflowSync.mockResolvedValue({
+        ...completedExecution,
+        context: { output: null },
+      });
+      const result = await invoke();
+      expect(result.result).not.toHaveProperty('output');
+    });
+
+    it('returns output field when context.output is an object', async () => {
+      const output = { answer: 42 };
+      mockRunWorkflowSync.mockResolvedValue({
+        ...completedExecution,
+        context: { output },
+      });
+      const result = await invoke();
+      expect(result.result?.output).toEqual(output);
+    });
+
+    it('throws when context.output is a non-object scalar', async () => {
+      mockRunWorkflowSync.mockResolvedValue({
+        ...completedExecution,
+        context: { output: 'not-an-object' },
+      });
+      await expect(invoke()).rejects.toThrow('Synchronous workflow output must be an object');
+    });
+  });
+
+  describe('abort signal', () => {
+    it('removes abort listener after successful execution', async () => {
+      const controller = new AbortController();
+      const removeEventListener = jest.spyOn(controller.signal, 'removeEventListener');
+      await invoke({ options: { abortSignal: controller.signal } });
+      expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    });
+
+    it('removes abort listener even when runWorkflowSync throws', async () => {
+      const controller = new AbortController();
+      const removeEventListener = jest.spyOn(controller.signal, 'removeEventListener');
+      mockRunWorkflowSync.mockRejectedValue(new Error('execution failed'));
+      await expect(invoke({ options: { abortSignal: controller.signal } })).rejects.toThrow(
+        'execution failed'
+      );
+      expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    });
+
+    it('aborts the internal controller immediately when signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort('pre-aborted');
+      mockRunWorkflowSync.mockImplementation(async ({ abortController: ctrl }) => {
+        expect(ctrl.signal.aborted).toBe(true);
+        return completedExecution;
+      });
+      await invoke({ options: { abortSignal: controller.signal } });
+      expect(mockRunWorkflowSync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('happy path', () => {
+    it('returns workflowExecutionId and status from runWorkflowSync', async () => {
+      const result = await invoke();
+      expect(result).toEqual({
+        workflowExecutionId: 'exec-1',
+        result: { status: ExecutionStatus.COMPLETED, output: { answer: 42 } },
+      });
+    });
+
+    it('calls getWorkflowsExecutionEngine and forwards the result to runWorkflowSync', async () => {
+      const fakeEngine = { supportsSynchronousExecution: true as const };
+      getWorkflowsExecutionEngine.mockResolvedValue(fakeEngine);
+      await invoke();
+      expect(getWorkflowsExecutionEngine).toHaveBeenCalledTimes(1);
+      expect(mockRunWorkflowSync).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowsExecutionEngine: fakeEngine })
+      );
+    });
+
+    it('overrides execution id when options.executionId is set', async () => {
+      await invoke({ options: { executionId: 'custom-id' } });
+      expect(mockRunWorkflowSync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowExecution: expect.objectContaining({ id: 'custom-id' }),
+        })
+      );
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
@@ -21,8 +21,11 @@ jest.mock('./run_workflow_sync');
 jest.mock('../lib/build_workflow_execution_document');
 jest.mock('../lib/get_user');
 jest.mock('../lib/validate_workflow_inputs');
+const mockGetWorkflowExecutionById = jest.fn().mockResolvedValue(null);
 jest.mock('../repositories/execution_persistence', () => ({
-  InMemoryExecutionPersistence: jest.fn().mockImplementation(() => ({})),
+  InMemoryExecutionPersistence: jest.fn().mockImplementation(() => ({
+    getWorkflowExecutionById: mockGetWorkflowExecutionById,
+  })),
 }));
 
 const mockRunWorkflowSync = runWorkflowSync as jest.MockedFunction<typeof runWorkflowSync>;
@@ -78,6 +81,7 @@ describe('executeWorkflowSync', () => {
     mockBuildWorkflowExecutionDocument.mockReturnValue(baseWorkflowExecution as any);
     mockValidateWorkflowInputs.mockResolvedValue(true);
     mockRunWorkflowSync.mockResolvedValue(completedExecution);
+    mockGetWorkflowExecutionById.mockResolvedValue(null);
   });
 
   const invoke = (overrides?: Partial<Parameters<typeof executeWorkflowSync>[0]>) =>
@@ -140,6 +144,20 @@ describe('executeWorkflowSync', () => {
         result: { status: ExecutionStatus.FAILED },
       });
       expect(mockRunWorkflowSync).not.toHaveBeenCalled();
+    });
+
+    it('includes error from in-memory persistence when validation fails', async () => {
+      mockValidateWorkflowInputs.mockResolvedValue(false);
+      mockGetWorkflowExecutionById.mockResolvedValueOnce({
+        ...baseWorkflowExecution,
+        status: ExecutionStatus.FAILED,
+        error: { type: 'InputValidationError', message: 'inputs: required field missing' },
+      });
+      const result = await invoke();
+      expect(result.result?.error).toEqual({
+        type: 'InputValidationError',
+        message: 'inputs: required field missing',
+      });
     });
   });
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
@@ -58,11 +58,11 @@ const baseWorkflowExecution = {
   duration: 0,
 };
 
-const completedExecution: EsWorkflowExecution = {
+const completedExecution = {
   ...baseWorkflowExecution,
   status: ExecutionStatus.COMPLETED,
   context: { output: { answer: 42 } },
-};
+} as unknown as EsWorkflowExecution;
 
 describe('executeWorkflowSync', () => {
   const workflow = { id: 'wf-1', yaml: '', isEphemeral: false } as WorkflowExecutionEngineModel;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
@@ -71,14 +71,9 @@ export const executeWorkflowSync = async ({
     coreStart.elasticsearch.client
   );
 
-  const syncContext = {
-    ...context,
-    ...(options.metadata ? { metadata: options.metadata } : {}),
-  };
-
   const workflowExecution = await buildWorkflowExecutionDocument({
     workflow,
-    context: syncContext,
+    context,
     defaultTriggeredBy: 'manual',
     authenticatedUser,
     now: new Date(),

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
@@ -118,9 +118,16 @@ export const executeWorkflowSync = async ({
     { ...dependencies, capabilities: options.capabilities }
   );
   if (!inputsValid) {
+    const failedExecution = await syncExecutionPersistence.getWorkflowExecutionById(
+      syncWorkflowExecution.id,
+      spaceId
+    );
     return {
       workflowExecutionId: syncWorkflowExecution.id,
-      result: { status: ExecutionStatus.FAILED },
+      result: {
+        status: ExecutionStatus.FAILED,
+        ...(failedExecution?.error ? { error: failedExecution.error } : {}),
+      },
     };
   }
 
@@ -130,6 +137,15 @@ export const executeWorkflowSync = async ({
   if (options.abortSignal?.aborted) {
     abort();
   }
+
+  const maxDurationMs = config.syncExecution.maxDurationMs;
+  const timeoutId = setTimeout(
+    () =>
+      abortController.abort(
+        new Error(`Synchronous workflow execution timed out after ${maxDurationMs}ms`)
+      ),
+    maxDurationMs
+  );
 
   try {
     const workflowsExecutionEngine = await getWorkflowsExecutionEngine();
@@ -154,6 +170,7 @@ export const executeWorkflowSync = async ({
       },
     };
   } finally {
+    clearTimeout(timeoutId);
     options.abortSignal?.removeEventListener('abort', abort);
   }
 };

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import { ExecutionStatus } from '@kbn/workflows';
+import type { EsWorkflowExecution, WorkflowExecutionEngineModel } from '@kbn/workflows';
+import { runWorkflowSync } from './run_workflow_sync';
+import { buildWorkflowExecutionDocument } from '../lib/build_workflow_execution_document';
+import { getAuthenticatedUser } from '../lib/get_user';
+import { validateWorkflowInputs } from '../lib/validate_workflow_inputs';
+import { InMemoryExecutionPersistence } from '../repositories/execution_persistence';
+import type {
+  ExecuteWorkflowOptions,
+  ExecuteWorkflowResponse,
+  WorkflowsExecutionEnginePluginStart,
+} from '../types';
+import type { ContextDependencies } from '../workflow_context_manager/types';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getSynchronousWorkflowOutput = (output: unknown): Record<string, unknown> | undefined => {
+  if (output === undefined || output === null) {
+    return undefined;
+  }
+  if (isRecord(output)) {
+    return output;
+  }
+  throw new Error('Synchronous workflow output must be an object');
+};
+
+export const executeWorkflowSync = async ({
+  workflow,
+  context,
+  request,
+  options,
+  logger,
+  dependencies,
+  getWorkflowsExecutionEngine,
+}: {
+  workflow: WorkflowExecutionEngineModel;
+  context: Record<string, unknown>;
+  request: KibanaRequest;
+  options: ExecuteWorkflowOptions;
+  logger: Logger;
+  dependencies: ContextDependencies;
+  getWorkflowsExecutionEngine: () => Promise<WorkflowsExecutionEnginePluginStart>;
+}): Promise<ExecuteWorkflowResponse> => {
+  const { coreStart, workflowRepository, config } = dependencies;
+
+  const spaceId = typeof context.spaceId === 'string' ? context.spaceId : 'default';
+
+  if (!workflow.isEphemeral && workflowRepository) {
+    const stillEnabled = await workflowRepository.isWorkflowEnabled(workflow.id, spaceId, {
+      includeGlobal: true,
+    });
+    if (!stillEnabled) {
+      throw new Error(`Workflow is disabled: ${workflow.id}. Enable the workflow to run it.`);
+    }
+  }
+
+  const authenticatedUser = await getAuthenticatedUser(
+    request,
+    coreStart.security,
+    coreStart.elasticsearch.client
+  );
+
+  const syncContext = {
+    ...context,
+    ...(options.metadata ? { metadata: options.metadata } : {}),
+  };
+
+  const workflowExecution = await buildWorkflowExecutionDocument({
+    workflow,
+    context: syncContext,
+    defaultTriggeredBy: 'manual',
+    authenticatedUser,
+    now: new Date(),
+    maxEventChainDepth: config.eventDriven.maxChainDepth,
+    getConcurrencyGroupKey: () => null,
+  });
+
+  if (options.executionId) {
+    workflowExecution.id = options.executionId;
+  }
+
+  if (!workflowExecution.workflowDefinition) {
+    throw new Error('Synchronous workflow execution requires a workflow definition');
+  }
+
+  const syncWorkflowExecution: EsWorkflowExecution = {
+    ...workflowExecution,
+    isTestRun: workflowExecution.isTestRun ?? false,
+    status: workflowExecution.status ?? ExecutionStatus.PENDING,
+    context: workflowExecution.context ?? syncContext,
+    workflowDefinition: workflowExecution.workflowDefinition,
+    yaml: workflowExecution.yaml ?? workflow.yaml,
+    scopeStack: workflowExecution.scopeStack ?? [],
+    error: workflowExecution.error ?? null,
+    startedAt: workflowExecution.startedAt ?? workflowExecution.createdAt,
+    finishedAt: workflowExecution.finishedAt ?? '',
+    cancelRequested: workflowExecution.cancelRequested ?? false,
+    duration: workflowExecution.duration ?? 0,
+  };
+
+  const syncExecutionPersistence = new InMemoryExecutionPersistence(syncWorkflowExecution);
+  const inputsValid = await validateWorkflowInputs(
+    syncWorkflowExecution,
+    syncExecutionPersistence,
+    logger,
+    coreStart,
+    { ...dependencies, capabilities: options.capabilities }
+  );
+  if (!inputsValid) {
+    return {
+      workflowExecutionId: syncWorkflowExecution.id,
+      result: { status: ExecutionStatus.FAILED },
+    };
+  }
+
+  const abortController = new AbortController();
+  const abort = () => abortController.abort(options.abortSignal?.reason);
+  options.abortSignal?.addEventListener('abort', abort, { once: true });
+  if (options.abortSignal?.aborted) {
+    abort();
+  }
+
+  try {
+    const workflowsExecutionEngine = await getWorkflowsExecutionEngine();
+    const result = await runWorkflowSync({
+      workflowExecution: syncWorkflowExecution,
+      request,
+      abortController,
+      logger,
+      config,
+      dependencies: { ...dependencies, capabilities: options.capabilities },
+      workflowsExecutionEngine,
+      workflowExecutionRepository: syncExecutionPersistence,
+      stepExecutionRepository: syncExecutionPersistence,
+    });
+
+    const output = getSynchronousWorkflowOutput(result.context?.output);
+    return {
+      workflowExecutionId: result.id,
+      result: {
+        status: result.status,
+        ...(output ? { output } : {}),
+      },
+    };
+  } finally {
+    options.abortSignal?.removeEventListener('abort', abort);
+  }
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
@@ -93,7 +93,7 @@ export const executeWorkflowSync = async ({
     ...workflowExecution,
     isTestRun: workflowExecution.isTestRun ?? false,
     status: workflowExecution.status ?? ExecutionStatus.PENDING,
-    context: workflowExecution.context ?? syncContext,
+    context: workflowExecution.context ?? context,
     workflowDefinition: workflowExecution.workflowDefinition,
     yaml: workflowExecution.yaml ?? workflow.yaml,
     scopeStack: workflowExecution.scopeStack ?? [],

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execution_functions_test_utils.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execution_functions_test_utils.ts
@@ -28,6 +28,7 @@ export const createMockWorkflowExecutionEngineConfig = (): WorkflowsExecutionEng
   eviction: { minPayloadSize: new ByteSizeValue(10 * 1024) },
   collectQueueMetrics: false,
   hitlExternalResume: { enabled: true },
+  syncExecution: { enabled: false, maxDurationMs: 60_000 },
 });
 
 export const createMockLogger = (): Logger =>

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/index.ts
@@ -10,6 +10,7 @@
 export { setupDependencies } from './setup_dependencies';
 export { runWorkflow } from './run_workflow';
 export { runWorkflowSync } from './run_workflow_sync';
+export { executeWorkflowSync } from './execute_workflow_sync';
 export { resumeWorkflow } from './resume_workflow';
 export { cancelWorkflow } from './cancel_workflow';
 export {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/index.ts
@@ -9,6 +9,7 @@
 
 export { setupDependencies } from './setup_dependencies';
 export { runWorkflow } from './run_workflow';
+export { runWorkflowSync } from './run_workflow_sync';
 export { resumeWorkflow } from './resume_workflow';
 export { cancelWorkflow } from './cancel_workflow';
 export {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/resume_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/resume_workflow.ts
@@ -87,6 +87,10 @@ export async function resumeWorkflow({
     workflowExecutionCursor,
   } = setupResult;
 
+  if (!workflowExecutionRepository) {
+    throw new Error('Persistent workflow execution repository is unavailable');
+  }
+
   const loadedExecution = workflowExecutionState.getWorkflowExecution();
   if (isTerminalStatus(loadedExecution.status)) {
     logger.info(

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
@@ -56,6 +56,7 @@ export async function runWorkflow({
   meteringService?: WorkflowsMeteringService;
   internalResumeWorkflowExecution?: InternalResumeWorkflowExecution;
 }): Promise<RunWorkflowResult | void> {
+  apm.currentTransaction?.setLabel('execution_mode', 'async');
   // Span for setup/initialization phase
   const setupSpan = apm.startSpan('workflow setup', 'workflow', 'setup');
   let setupResult: Awaited<ReturnType<typeof setupDependencies>>;
@@ -99,6 +100,10 @@ export async function runWorkflow({
     telemetryClient,
     workflowExecutionCursor,
   } = setupResult;
+
+  if (!workflowExecutionRepository) {
+    throw new Error('Persistent workflow execution repository is unavailable');
+  }
 
   const execution = workflowExecutionState.getWorkflowExecution();
   if (isTerminalStatus(execution.status)) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
@@ -96,7 +96,7 @@ describe('runWorkflowSync', () => {
     expect(workflowExecutionLoop).toHaveBeenCalledWith(
       expect.objectContaining({
         executionMode: 'sync',
-        taskAbortController: abortController,
+        signal: abortController.signal,
         fakeRequest: request,
         workflowExecutionRepository: setup.workflowExecutionPersistence,
       })

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { type EsWorkflowExecution, ExecutionStatus } from '@kbn/workflows';
+import { runWorkflowSync } from './run_workflow_sync';
+import { setupDependencies } from './setup_dependencies';
+import { validateSyncWorkflow } from './validate_sync_workflow';
+import { workflowExecutionLoop } from '../workflow_execution_loop';
+
+jest.mock('./setup_dependencies', () => ({ setupDependencies: jest.fn() }));
+jest.mock('./validate_sync_workflow', () => ({ validateSyncWorkflow: jest.fn() }));
+jest.mock('../workflow_execution_loop', () => ({ workflowExecutionLoop: jest.fn() }));
+
+describe('runWorkflowSync', () => {
+  it('runs the canonical workflow loop with in-memory dependencies and sync mode', async () => {
+    const completedExecution = {
+      id: 'execution-1',
+      spaceId: 'default',
+      workflowId: 'workflow-1',
+      isTestRun: false,
+      status: ExecutionStatus.COMPLETED,
+      context: {},
+      workflowDefinition: {
+        version: '1',
+        name: 'Test workflow',
+        enabled: true,
+        triggers: [],
+        steps: [],
+      },
+      yaml: '',
+      scopeStack: [],
+      createdAt: '2026-07-21T00:00:00.000Z',
+      error: null,
+      startedAt: '2026-07-21T00:00:00.000Z',
+      finishedAt: '2026-07-21T00:00:01.000Z',
+      cancelRequested: false,
+      duration: 1000,
+    } satisfies EsWorkflowExecution;
+    const workflowExecutionGraph = { topologicalOrder: [] };
+    const workflowRuntime = { start: jest.fn().mockResolvedValue(undefined) };
+    const workflowExecutionState = {
+      getWorkflowExecution: jest.fn().mockReturnValue(completedExecution),
+    };
+    const setup = {
+      workflowExecutionGraph,
+      workflowRuntime,
+      workflowExecutionState,
+      stepExecutionRuntimeFactory: {},
+      stepIoService: {},
+      workflowLogger: {},
+      workflowTaskManager: {},
+      nodesFactory: {},
+      workflowExecutionPersistence: {},
+      workflowExecutionRepository: undefined,
+      esClient: {},
+    };
+    (setupDependencies as jest.Mock).mockResolvedValue(setup);
+    (workflowExecutionLoop as jest.Mock).mockResolvedValue(undefined);
+
+    const abortController = new AbortController();
+    const request = {} as Parameters<typeof runWorkflowSync>[0]['request'];
+    const dependencies = {
+      coreStart: {},
+    } as Parameters<typeof runWorkflowSync>[0]['dependencies'];
+    const workflowExecutionRepository = {} as Parameters<
+      typeof runWorkflowSync
+    >[0]['workflowExecutionRepository'];
+    const stepExecutionRepository = {} as Parameters<
+      typeof runWorkflowSync
+    >[0]['stepExecutionRepository'];
+
+    await expect(
+      runWorkflowSync({
+        workflowExecution: completedExecution,
+        request,
+        abortController,
+        logger: {} as Parameters<typeof runWorkflowSync>[0]['logger'],
+        config: {} as Parameters<typeof runWorkflowSync>[0]['config'],
+        dependencies,
+        workflowsExecutionEngine: {} as Parameters<
+          typeof runWorkflowSync
+        >[0]['workflowsExecutionEngine'],
+        workflowExecutionRepository,
+        stepExecutionRepository,
+      })
+    ).resolves.toBe(completedExecution);
+
+    expect(validateSyncWorkflow).toHaveBeenCalledWith(workflowExecutionGraph);
+    expect(workflowRuntime.start).toHaveBeenCalledTimes(1);
+    expect(workflowExecutionLoop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: 'sync',
+        taskAbortController: abortController,
+        fakeRequest: request,
+        workflowExecutionRepository: setup.workflowExecutionPersistence,
+      })
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.ts
@@ -61,7 +61,7 @@ export const runWorkflowSync = async ({
     workflowExecutionRepository: setup.workflowExecutionPersistence,
     fakeRequest: request,
     coreStart: dependencies.coreStart,
-    taskAbortController: abortController,
+    signal: abortController.signal,
     executionMode: 'sync',
   });
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import apm from 'elastic-apm-node';
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { EsWorkflowExecution } from '@kbn/workflows';
+import { setupDependencies } from './setup_dependencies';
+import { validateSyncWorkflow } from './validate_sync_workflow';
+import type { WorkflowsExecutionEngineConfig } from '../config';
+import type {
+  StepExecutionPersistence,
+  WorkflowExecutionPersistence,
+} from '../repositories/execution_persistence';
+import type { WorkflowsExecutionEnginePluginStart } from '../types';
+import type { ContextDependencies } from '../workflow_context_manager/types';
+import { workflowExecutionLoop } from '../workflow_execution_loop';
+
+export const runWorkflowSync = async ({
+  workflowExecution,
+  request,
+  abortController,
+  logger,
+  config,
+  dependencies,
+  workflowsExecutionEngine,
+  workflowExecutionRepository,
+  stepExecutionRepository,
+}: {
+  workflowExecution: EsWorkflowExecution;
+  request: KibanaRequest;
+  abortController: AbortController;
+  logger: Logger;
+  config: WorkflowsExecutionEngineConfig;
+  dependencies: ContextDependencies;
+  workflowsExecutionEngine: WorkflowsExecutionEnginePluginStart;
+  workflowExecutionRepository: WorkflowExecutionPersistence;
+  stepExecutionRepository: StepExecutionPersistence;
+}): Promise<EsWorkflowExecution> => {
+  apm.currentTransaction?.setLabel('execution_mode', 'sync');
+  const setup = await setupDependencies(
+    workflowExecution.id,
+    workflowExecution.spaceId,
+    logger,
+    config,
+    dependencies,
+    request,
+    workflowsExecutionEngine,
+    { workflowExecution, workflowExecutionRepository, stepExecutionRepository }
+  );
+
+  validateSyncWorkflow(setup.workflowExecutionGraph);
+  await setup.workflowRuntime.start();
+  await workflowExecutionLoop({
+    ...setup,
+    workflowExecutionRepository: setup.workflowExecutionPersistence,
+    fakeRequest: request,
+    coreStart: dependencies.coreStart,
+    taskAbortController: abortController,
+    executionMode: 'sync',
+  });
+
+  return setup.workflowExecutionState.getWorkflowExecution();
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
@@ -65,6 +65,7 @@ describe('setupDependencies', () => {
     },
     collectQueueMetrics: false,
     hitlExternalResume: { enabled: true },
+    syncExecution: { enabled: false, maxDurationMs: 60_000 },
   };
 
   let mockDependencies: ReturnType<typeof mockContextDependencies>;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
@@ -23,6 +23,10 @@ import {
   mergeEmitterWorkflowIntoEventChainVisited,
 } from '../lib/telemetry/utils/extract_execution_metadata';
 import { WorkflowExecutionTelemetryClient } from '../lib/telemetry/workflow_execution_telemetry_client';
+import type {
+  StepExecutionPersistence,
+  WorkflowExecutionPersistence,
+} from '../repositories/execution_persistence';
 import { StepExecutionRepository } from '../repositories/step_execution_repository';
 import { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
 import { NodesFactory } from '../step/nodes_factory';
@@ -44,7 +48,12 @@ export async function setupDependencies(
   config: WorkflowsExecutionEngineConfig,
   dependencies: ContextDependencies,
   fakeRequest?: KibanaRequest,
-  workflowsExecutionEngine?: WorkflowsExecutionEnginePluginStart
+  workflowsExecutionEngine?: WorkflowsExecutionEnginePluginStart,
+  options: {
+    workflowExecution?: EsWorkflowExecution;
+    workflowExecutionRepository?: WorkflowExecutionPersistence;
+    stepExecutionRepository?: StepExecutionPersistence;
+  } = {}
 ) {
   const { coreStart, actions, taskManager, workflowsExtensions } = dependencies;
 
@@ -53,17 +62,18 @@ export async function setupDependencies(
   // Get ES client from core services (guaranteed to be available at task execution time)
   const internalEsClient = coreStart.elasticsearch.client.asInternalUser;
 
-  const workflowExecutionRepository = new WorkflowExecutionRepository(internalEsClient, logger);
-  const stepExecutionRepository = new StepExecutionRepository(internalEsClient, logger);
+  const workflowExecutionPersistence =
+    options.workflowExecutionRepository ?? new WorkflowExecutionRepository(internalEsClient, logger);
+  const stepExecutionPersistence =
+    options.stepExecutionRepository ?? new StepExecutionRepository(internalEsClient, logger);
   const workflowRepository = new WorkflowRepository({
     esClient: internalEsClient,
     logger,
   });
 
-  const workflowExecution = await workflowExecutionRepository.getWorkflowExecutionById(
-    workflowRunId,
-    spaceId
-  );
+  const workflowExecution =
+    options.workflowExecution ??
+    (await workflowExecutionPersistence.getWorkflowExecutionById(workflowRunId, spaceId));
 
   if (!workflowExecution) {
     throw new Error(`Workflow execution with ID ${workflowRunId} not found`);
@@ -113,7 +123,7 @@ export async function setupDependencies(
   } catch (error) {
     if (isGraphBuildError(error)) {
       const finishedAt = new Date();
-      await workflowExecutionRepository.updateWorkflowExecution({
+      await workflowExecutionPersistence.updateWorkflowExecution({
         id: workflowRunId,
         status: ExecutionStatus.FAILED,
         error: { type: 'GraphBuildError', message: error.message },
@@ -150,12 +160,12 @@ export async function setupDependencies(
   });
 
   const workflowExecutionState = new WorkflowExecutionState(
-    workflowExecution as EsWorkflowExecution,
-    workflowExecutionRepository
+    workflowExecution,
+    workflowExecutionPersistence
   );
 
   const stepIoService = new StepIoService({
-    stepRepository: stepExecutionRepository,
+    stepRepository: stepExecutionPersistence,
     state: workflowExecutionState,
     evictionMinBytes: config.eviction.minPayloadSize.getValueInBytes(),
     logger,
@@ -172,7 +182,7 @@ export async function setupDependencies(
 
   // Create workflow runtime first (simpler, fewer dependencies)
   const workflowRuntime = new WorkflowExecutionRuntimeManager({
-    workflowExecution: workflowExecution as EsWorkflowExecution,
+    workflowExecution,
     workflowExecutionGraph,
     workflowExecutionCursor,
     workflowLogger,
@@ -187,6 +197,15 @@ export async function setupDependencies(
     coreStart.elasticsearch.client.asScoped(fakeRequest).asCurrentUser;
 
   const workflowTaskManager = new WorkflowTaskManager(taskManager);
+
+  const workflowExecutionRepository =
+    workflowExecutionPersistence instanceof WorkflowExecutionRepository
+      ? workflowExecutionPersistence
+      : undefined;
+  const stepExecutionRepository =
+    stepExecutionPersistence instanceof StepExecutionRepository
+      ? stepExecutionPersistence
+      : undefined;
 
   const enhancedDependencies: ContextDependencies = {
     ...dependencies,
@@ -228,6 +247,7 @@ export async function setupDependencies(
     workflowLogger,
     workflowTaskManager,
     nodesFactory,
+    workflowExecutionPersistence,
     workflowExecutionRepository,
     esClient,
     telemetryClient,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
@@ -28,7 +28,7 @@ describe('validateSyncWorkflow', () => {
     }
   );
 
-  it('accepts ordinary and capability-backed atomic steps', () => {
-    expect(() => validateSyncWorkflow(createGraph('ai.pii'))).not.toThrow();
+  it('accepts steps that are not in the async-only set', () => {
+    expect(() => validateSyncWorkflow(createGraph('data.set'))).not.toThrow();
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { validateSyncWorkflow } from './validate_sync_workflow';
+
+const createGraph = (stepType: string) => ({
+  topologicalOrder: ['node-1'],
+  getNode: jest.fn().mockReturnValue({
+    id: 'node-1',
+    stepId: 'step-1',
+    stepType,
+  }),
+});
+
+describe('validateSyncWorkflow', () => {
+  it.each(['wait', 'waitForInput', 'waitForApproval', 'workflow.execute', 'workflow.executeAsync'])(
+    'rejects async-only step %s',
+    (stepType) => {
+      expect(() => validateSyncWorkflow(createGraph(stepType))).toThrow(
+        'is not supported in synchronous workflows'
+      );
+    }
+  );
+
+  it('accepts ordinary and capability-backed atomic steps', () => {
+    expect(() => validateSyncWorkflow(createGraph('ai.pii'))).not.toThrow();
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.ts
@@ -11,6 +11,11 @@ import type { WorkflowGraph } from '@kbn/workflows/graph';
 
 type SyncWorkflowGraph = Pick<WorkflowGraph, 'getNode' | 'topologicalOrder'>;
 
+// Known step types that require durable execution (timers, HITL pauses, child workflows).
+// This is a pre-execution check. A runtime check in handle_execution_delay.ts provides a
+// second layer by catching any waiting status that makes it through — e.g. from extension
+// step types added after this list. Both layers use the same error message format so
+// diagnostics are consistent.
 const ASYNC_ONLY_STEP_TYPES = new Set([
   'wait',
   'waitForInput',
@@ -19,13 +24,13 @@ const ASYNC_ONLY_STEP_TYPES = new Set([
   'workflow.executeAsync',
 ]);
 
+export const SYNC_WORKFLOW_UNSUPPORTED_MSG = 'is not supported in synchronous workflows';
+
 export const validateSyncWorkflow = (workflowGraph: SyncWorkflowGraph): void => {
   for (const nodeId of workflowGraph.topologicalOrder) {
     const node = workflowGraph.getNode(nodeId);
     if (node?.stepType && ASYNC_ONLY_STEP_TYPES.has(node.stepType)) {
-      throw new Error(
-        `Step "${node.stepId}" (${node.stepType}) is not supported in synchronous workflows`
-      );
+      throw new Error(`Step "${node.stepId}" (${node.stepType}) ${SYNC_WORKFLOW_UNSUPPORTED_MSG}`);
     }
   }
 };

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowGraph } from '@kbn/workflows/graph';
+
+type SyncWorkflowGraph = Pick<WorkflowGraph, 'getNode' | 'topologicalOrder'>;
+
+const ASYNC_ONLY_STEP_TYPES = new Set([
+  'wait',
+  'waitForInput',
+  'waitForApproval',
+  'workflow.execute',
+  'workflow.executeAsync',
+]);
+
+export const validateSyncWorkflow = (workflowGraph: SyncWorkflowGraph): void => {
+  for (const nodeId of workflowGraph.topologicalOrder) {
+    const node = workflowGraph.getNode(nodeId);
+    if (node?.stepType && ASYNC_ONLY_STEP_TYPES.has(node.stepType)) {
+      throw new Error(
+        `Step "${node.stepId}" (${node.stepType}) is not supported in synchronous workflows`
+      );
+    }
+  }
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/index.ts
@@ -22,6 +22,8 @@ export type {
   TriggerEventsContract,
   WorkflowsExecutionEnginePluginSetup,
   WorkflowsExecutionEnginePluginStart,
+  ExecuteWorkflowOptions,
+  WorkflowExecutionMode,
 } from './types';
 
 export type {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
@@ -15,7 +15,7 @@ import {
   applyInputDefaults,
   getInputsFromDefinition,
 } from '@kbn/workflows/spec/lib/field_conversion';
-import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { WorkflowExecutionPersistence } from '../repositories/execution_persistence';
 import { WorkflowTemplatingEngine } from '../templating_engine';
 import {
   buildInputDefaultRenderContext,
@@ -36,7 +36,7 @@ const hasInputChanges = (
  */
 export const validateWorkflowInputs = async (
   workflowExecution: WorkflowExecutionForInputRendering,
-  workflowExecutionRepository: WorkflowExecutionRepository,
+  workflowExecutionRepository: WorkflowExecutionPersistence,
   logger: Logger,
   coreStart?: CoreStart,
   dependencies?: ContextDependencies

--- a/src/platform/plugins/shared/workflows_execution_engine/server/mocks.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/mocks.ts
@@ -16,6 +16,7 @@ import { createMockWorkflowEventLoggerService } from './workflow_event_logger/mo
 export const workflowsExecutionEngineMock = {
   createSetup: jest.fn().mockReturnValue({} as jest.Mocked<WorkflowsExecutionEnginePluginSetup>),
   createStart: jest.fn().mockReturnValue({
+    supportsSynchronousExecution: true,
     workflowEventLoggerService: createMockWorkflowEventLoggerService(),
     executeWorkflow: jest.fn(),
     executeWorkflowStep: jest.fn(),

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -1091,6 +1091,13 @@ export class WorkflowsExecutionEnginePlugin
       }
 
       if (options.executionMode === 'sync') {
+        if (!this.config.syncExecution.enabled) {
+          throw new Error(
+            'Synchronous workflow execution is disabled. ' +
+              'Set xpack.workflowsExecutionEngine.syncExecution.enabled: true alongside ' +
+              'xpack.inference.anonymization.workflow_driven: true to enable it.'
+          );
+        }
         if (!request) {
           throw new Error('Synchronous workflows cannot be executed without the user context');
         }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -1008,7 +1008,6 @@ export class WorkflowsExecutionEnginePlugin
       options: {
         refresh: boolean | 'wait_for';
         executionId?: string;
-        metadata?: Record<string, string>;
       } = { refresh: false }
     ): Promise<{
       workflowExecution: WorkflowExecutionForInputRendering;
@@ -1024,12 +1023,9 @@ export class WorkflowsExecutionEnginePlugin
         coreStart.elasticsearch.client
       );
 
-      const executionContext = options.metadata
-        ? { ...context, metadata: options.metadata }
-        : context;
       const workflowExecution = await buildExecutionDocument({
         workflow,
-        context: executionContext,
+        context,
         defaultTriggeredBy,
         authenticatedUser,
         now: new Date(),
@@ -1146,7 +1142,6 @@ export class WorkflowsExecutionEnginePlugin
         {
           refresh: true,
           executionId: options.executionId,
-          metadata: options.metadata,
         }
       );
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -1090,14 +1090,7 @@ export class WorkflowsExecutionEnginePlugin
         throw new Error('Request-local capabilities and abort signals require sync execution');
       }
 
-      if (options.executionMode === 'sync') {
-        if (!this.config.syncExecution.enabled) {
-          throw new Error(
-            'Synchronous workflow execution is disabled. ' +
-              'Set xpack.workflowsExecutionEngine.syncExecution.enabled: true alongside ' +
-              'xpack.inference.anonymization.workflow_driven: true to enable it.'
-          );
-        }
+      if (options.executionMode === 'sync' && this.config.syncExecution.enabled) {
         if (!request) {
           throw new Error('Synchronous workflows cannot be executed without the user context');
         }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -40,8 +40,8 @@ import {
   checkAndSkipIfExistingScheduledExecution,
   resumeWorkflow,
   runWorkflow,
-  runWorkflowSync,
 } from './execution_functions';
+import { executeWorkflowSync } from './execution_functions/execute_workflow_sync';
 import { handlePostExecutionLoop } from './execution_functions/handle_post_execution_loop';
 import { buildWorkflowExecutionDocument } from './lib/build_workflow_execution_document';
 import { checkLicense } from './lib/check_license';
@@ -62,7 +62,6 @@ import {
   stampWorkflowTaskRunEventFields,
 } from './lib/workflow_task_run_event_fields';
 import { WorkflowsMeteringService } from './metering/metering_service';
-import { InMemoryExecutionPersistence } from './repositories/execution_persistence';
 import { initializeLogsRepositoryDataStream } from './repositories/logs_repository/data_stream';
 import { StepExecutionRepository } from './repositories/step_execution_repository';
 import { WorkflowExecutionRepository } from './repositories/workflow_execution_repository';
@@ -117,19 +116,6 @@ import { createIndexes } from '../common';
  *   it is not meant as extra user workflow retries after successful interrupt recovery.
  */
 const WORKFLOW_RUN_TASK_MAX_ATTEMPTS = 3;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const getSynchronousWorkflowOutput = (output: unknown): Record<string, unknown> | undefined => {
-  if (output === undefined || output === null) {
-    return undefined;
-  }
-  if (isRecord(output)) {
-    return output;
-  }
-  throw new Error('Synchronous workflow output must be an object');
-};
 
 /**
  * Max Task Manager attempts for `workflow:resume`.
@@ -1108,95 +1094,22 @@ export class WorkflowsExecutionEnginePlugin
         if (!request) {
           throw new Error('Synchronous workflows cannot be executed without the user context');
         }
-
-        const spaceId = typeof context.spaceId === 'string' ? context.spaceId : 'default';
-        await ensureWorkflowEnabled(workflow, spaceId);
-        const authenticatedUser = await getAuthenticatedUser(
-          request,
-          coreStart.security,
-          coreStart.elasticsearch.client
-        );
-        const syncContext = {
-          ...context,
-          ...(options.metadata ? { metadata: options.metadata } : {}),
-        };
-        const workflowExecution = await buildExecutionDocument({
+        if (!this.coreSetup) {
+          throw new Error('Core setup not available');
+        }
+        const coreSetup = this.coreSetup;
+        return executeWorkflowSync({
           workflow,
-          context: syncContext,
-          defaultTriggeredBy: 'manual',
-          authenticatedUser,
-          now: new Date(),
+          context,
+          request,
+          options,
+          logger: this.logger,
+          dependencies,
+          getWorkflowsExecutionEngine: async () => {
+            const [, , workflowsExecutionEngine] = await coreSetup.getStartServices();
+            return workflowsExecutionEngine;
+          },
         });
-        if (options.executionId) {
-          workflowExecution.id = options.executionId;
-        }
-        if (!workflowExecution.workflowDefinition) {
-          throw new Error('Synchronous workflow execution requires a workflow definition');
-        }
-        const syncWorkflowExecution: EsWorkflowExecution = {
-          ...workflowExecution,
-          isTestRun: workflowExecution.isTestRun ?? false,
-          status: workflowExecution.status ?? ExecutionStatus.PENDING,
-          context: workflowExecution.context ?? syncContext,
-          workflowDefinition: workflowExecution.workflowDefinition,
-          yaml: workflowExecution.yaml ?? workflow.yaml,
-          scopeStack: workflowExecution.scopeStack ?? [],
-          error: workflowExecution.error ?? null,
-          startedAt: workflowExecution.startedAt ?? workflowExecution.createdAt,
-          finishedAt: workflowExecution.finishedAt ?? '',
-          cancelRequested: workflowExecution.cancelRequested ?? false,
-          duration: workflowExecution.duration ?? 0,
-        };
-
-        const syncExecutionPersistence = new InMemoryExecutionPersistence(syncWorkflowExecution);
-        const inputsValid = await validateWorkflowInputs(
-          syncWorkflowExecution,
-          syncExecutionPersistence,
-          this.logger,
-          coreStart,
-          { ...dependencies, capabilities: options.capabilities }
-        );
-        if (!inputsValid) {
-          return {
-            workflowExecutionId: syncWorkflowExecution.id,
-            result: { status: ExecutionStatus.FAILED },
-          };
-        }
-        const abortController = new AbortController();
-        const abort = () => abortController.abort(options.abortSignal?.reason);
-        options.abortSignal?.addEventListener('abort', abort, { once: true });
-        if (options.abortSignal?.aborted) {
-          abort();
-        }
-
-        try {
-          if (!this.coreSetup) {
-            throw new Error('Core setup not available');
-          }
-          const [, , workflowsExecutionEngine] = await this.coreSetup.getStartServices();
-          const result = await runWorkflowSync({
-            workflowExecution: syncWorkflowExecution,
-            request,
-            abortController,
-            logger: this.logger,
-            config: this.config,
-            dependencies: { ...dependencies, capabilities: options.capabilities },
-            workflowsExecutionEngine,
-            workflowExecutionRepository: syncExecutionPersistence,
-            stepExecutionRepository: syncExecutionPersistence,
-          });
-
-          const output = getSynchronousWorkflowOutput(result.context?.output);
-          return {
-            workflowExecutionId: result.id,
-            result: {
-              status: result.status,
-              ...(output ? { output } : {}),
-            },
-          };
-        } finally {
-          options.abortSignal?.removeEventListener('abort', abort);
-        }
       }
 
       // AUTO-DETECT: Check if we're already running in a Task Manager context

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -40,6 +40,7 @@ import {
   checkAndSkipIfExistingScheduledExecution,
   resumeWorkflow,
   runWorkflow,
+  runWorkflowSync,
 } from './execution_functions';
 import { handlePostExecutionLoop } from './execution_functions/handle_post_execution_loop';
 import { buildWorkflowExecutionDocument } from './lib/build_workflow_execution_document';
@@ -61,6 +62,7 @@ import {
   stampWorkflowTaskRunEventFields,
 } from './lib/workflow_task_run_event_fields';
 import { WorkflowsMeteringService } from './metering/metering_service';
+import { InMemoryExecutionPersistence } from './repositories/execution_persistence';
 import { initializeLogsRepositoryDataStream } from './repositories/logs_repository/data_stream';
 import { StepExecutionRepository } from './repositories/step_execution_repository';
 import { WorkflowExecutionRepository } from './repositories/workflow_execution_repository';
@@ -115,6 +117,19 @@ import { createIndexes } from '../common';
  *   it is not meant as extra user workflow retries after successful interrupt recovery.
  */
 const WORKFLOW_RUN_TASK_MAX_ATTEMPTS = 3;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getSynchronousWorkflowOutput = (output: unknown): Record<string, unknown> | undefined => {
+  if (output === undefined || output === null) {
+    return undefined;
+  }
+  if (isRecord(output)) {
+    return output;
+  }
+  throw new Error('Synchronous workflow output must be an object');
+};
 
 /**
  * Max Task Manager attempts for `workflow:resume`.
@@ -929,7 +944,10 @@ export class WorkflowsExecutionEnginePlugin
     return {};
   }
 
-  public start(coreStart: CoreStart, plugins: WorkflowsExecutionEnginePluginStartDeps) {
+  public start(
+    coreStart: CoreStart,
+    plugins: WorkflowsExecutionEnginePluginStartDeps
+  ): WorkflowsExecutionEnginePluginStart {
     this.logger.debug('workflows-execution-engine: Start');
 
     if (!this.setupDependencies) {
@@ -1001,7 +1019,11 @@ export class WorkflowsExecutionEnginePlugin
       context: Record<string, unknown>,
       defaultTriggeredBy: string,
       request: KibanaRequest,
-      options: { refresh: boolean | 'wait_for' } = { refresh: false }
+      options: {
+        refresh: boolean | 'wait_for';
+        executionId?: string;
+        metadata?: Record<string, string>;
+      } = { refresh: false }
     ): Promise<{
       workflowExecution: WorkflowExecutionForInputRendering;
       repository: WorkflowExecutionRepository;
@@ -1016,13 +1038,19 @@ export class WorkflowsExecutionEnginePlugin
         coreStart.elasticsearch.client
       );
 
+      const executionContext = options.metadata
+        ? { ...context, metadata: options.metadata }
+        : context;
       const workflowExecution = await buildExecutionDocument({
         workflow,
-        context,
+        context: executionContext,
         defaultTriggeredBy,
         authenticatedUser,
         now: new Date(),
       });
+      if (options.executionId) {
+        workflowExecution.id = options.executionId;
+      }
 
       await maybeDrainConcurrencyQueueBeforeEnqueue({
         workflowExecution,
@@ -1066,8 +1094,110 @@ export class WorkflowsExecutionEnginePlugin
       };
     };
 
-    const executeWorkflow: ExecuteWorkflow = async (workflow, context, request) => {
+    const executeWorkflow: ExecuteWorkflow = async (workflow, context, request, options = {}) => {
       await checkLicense(plugins.licensing);
+
+      if (
+        options.executionMode !== 'sync' &&
+        (options.capabilities !== undefined || options.abortSignal !== undefined)
+      ) {
+        throw new Error('Request-local capabilities and abort signals require sync execution');
+      }
+
+      if (options.executionMode === 'sync') {
+        if (!request) {
+          throw new Error('Synchronous workflows cannot be executed without the user context');
+        }
+
+        const spaceId = typeof context.spaceId === 'string' ? context.spaceId : 'default';
+        await ensureWorkflowEnabled(workflow, spaceId);
+        const authenticatedUser = await getAuthenticatedUser(
+          request,
+          coreStart.security,
+          coreStart.elasticsearch.client
+        );
+        const syncContext = {
+          ...context,
+          ...(options.metadata ? { metadata: options.metadata } : {}),
+        };
+        const workflowExecution = await buildExecutionDocument({
+          workflow,
+          context: syncContext,
+          defaultTriggeredBy: 'manual',
+          authenticatedUser,
+          now: new Date(),
+        });
+        if (options.executionId) {
+          workflowExecution.id = options.executionId;
+        }
+        if (!workflowExecution.workflowDefinition) {
+          throw new Error('Synchronous workflow execution requires a workflow definition');
+        }
+        const syncWorkflowExecution: EsWorkflowExecution = {
+          ...workflowExecution,
+          isTestRun: workflowExecution.isTestRun ?? false,
+          status: workflowExecution.status ?? ExecutionStatus.PENDING,
+          context: workflowExecution.context ?? syncContext,
+          workflowDefinition: workflowExecution.workflowDefinition,
+          yaml: workflowExecution.yaml ?? workflow.yaml,
+          scopeStack: workflowExecution.scopeStack ?? [],
+          error: workflowExecution.error ?? null,
+          startedAt: workflowExecution.startedAt ?? workflowExecution.createdAt,
+          finishedAt: workflowExecution.finishedAt ?? '',
+          cancelRequested: workflowExecution.cancelRequested ?? false,
+          duration: workflowExecution.duration ?? 0,
+        };
+
+        const syncExecutionPersistence = new InMemoryExecutionPersistence(syncWorkflowExecution);
+        const inputsValid = await validateWorkflowInputs(
+          syncWorkflowExecution,
+          syncExecutionPersistence,
+          this.logger,
+          coreStart,
+          { ...dependencies, capabilities: options.capabilities }
+        );
+        if (!inputsValid) {
+          return {
+            workflowExecutionId: syncWorkflowExecution.id,
+            result: { status: ExecutionStatus.FAILED },
+          };
+        }
+        const abortController = new AbortController();
+        const abort = () => abortController.abort(options.abortSignal?.reason);
+        options.abortSignal?.addEventListener('abort', abort, { once: true });
+        if (options.abortSignal?.aborted) {
+          abort();
+        }
+
+        try {
+          if (!this.coreSetup) {
+            throw new Error('Core setup not available');
+          }
+          const [, , workflowsExecutionEngine] = await this.coreSetup.getStartServices();
+          const result = await runWorkflowSync({
+            workflowExecution: syncWorkflowExecution,
+            request,
+            abortController,
+            logger: this.logger,
+            config: this.config,
+            dependencies: { ...dependencies, capabilities: options.capabilities },
+            workflowsExecutionEngine,
+            workflowExecutionRepository: syncExecutionPersistence,
+            stepExecutionRepository: syncExecutionPersistence,
+          });
+
+          const output = getSynchronousWorkflowOutput(result.context?.output);
+          return {
+            workflowExecutionId: result.id,
+            result: {
+              status: result.status,
+              ...(output ? { output } : {}),
+            },
+          };
+        } finally {
+          options.abortSignal?.removeEventListener('abort', abort);
+        }
+      }
 
       // AUTO-DETECT: Check if we're already running in a Task Manager context
       const isRunningInTaskManager =
@@ -1100,7 +1230,11 @@ export class WorkflowsExecutionEnginePlugin
         context,
         'manual',
         request,
-        { refresh: true }
+        {
+          refresh: true,
+          executionId: options.executionId,
+          metadata: options.metadata,
+        }
       );
 
       const inputsValid = await validateWorkflowInputs(
@@ -1662,6 +1796,7 @@ export class WorkflowsExecutionEnginePlugin
     };
 
     return {
+      supportsSynchronousExecution: true,
       workflowEventLoggerService,
       executeWorkflow,
       executeWorkflowStep,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { type EsWorkflowExecution, ExecutionStatus } from '@kbn/workflows';
+import { InMemoryExecutionPersistence } from './execution_persistence';
+
+describe('InMemoryExecutionPersistence', () => {
+  const execution = {
+    id: 'execution-1',
+    spaceId: 'space-1',
+    workflowId: 'workflow-1',
+    isTestRun: false,
+    status: ExecutionStatus.PENDING,
+    context: {},
+    workflowDefinition: {
+      version: '1',
+      name: 'Test workflow',
+      enabled: true,
+      triggers: [],
+      steps: [],
+    },
+    yaml: '',
+    scopeStack: [],
+    createdAt: '2026-07-21T00:00:00.000Z',
+    error: null,
+    startedAt: '2026-07-21T00:00:00.000Z',
+    finishedAt: '',
+    cancelRequested: false,
+    duration: 0,
+  } satisfies EsWorkflowExecution;
+
+  it('keeps workflow updates process-local', async () => {
+    const persistence = new InMemoryExecutionPersistence(execution);
+    await persistence.updateWorkflowExecution({
+      id: execution.id,
+      status: ExecutionStatus.RUNNING,
+    });
+
+    await expect(
+      persistence.getWorkflowExecutionById(execution.id, execution.spaceId)
+    ).resolves.toEqual(expect.objectContaining({ status: ExecutionStatus.RUNNING }));
+    await expect(
+      persistence.getWorkflowExecutionById(execution.id, 'another-space')
+    ).resolves.toBeNull();
+  });
+
+  it('merges step lifecycle and IO updates without an external repository', async () => {
+    const persistence = new InMemoryExecutionPersistence(execution);
+    await persistence.bulkUpsert([
+      {
+        id: 'step-1',
+        spaceId: 'space-1',
+        stepId: 'step-1',
+        scopeStack: [],
+        workflowRunId: execution.id,
+        workflowId: execution.workflowId,
+        status: ExecutionStatus.RUNNING,
+        startedAt: '2026-07-21T00:00:00.000Z',
+        topologicalIndex: 0,
+        globalExecutionIndex: 0,
+        stepExecutionIndex: 0,
+      },
+      { id: 'step-1', output: { content: 'result' } },
+    ]);
+
+    await expect(persistence.getStepExecutionsByIds(['step-1'])).resolves.toEqual([
+      expect.objectContaining({
+        id: 'step-1',
+        status: ExecutionStatus.RUNNING,
+        output: { content: 'result' },
+      }),
+    ]);
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EsWorkflowExecution, EsWorkflowStepExecution } from '@kbn/workflows';
+import type { StepExecutionField } from './step_execution_repository';
+
+export interface WorkflowExecutionPersistence {
+  getWorkflowExecutionById(
+    workflowExecutionId: string,
+    spaceId: string
+  ): Promise<EsWorkflowExecution | null>;
+  updateWorkflowExecution(
+    workflowExecution: Partial<EsWorkflowExecution>,
+    options?: { refresh?: boolean | 'wait_for' }
+  ): Promise<void>;
+}
+
+export interface StepExecutionPersistence {
+  getStepExecutionsByIds(
+    stepExecutionIds: string[],
+    sourceIncludes?: StepExecutionField[],
+    sourceExcludes?: StepExecutionField[]
+  ): Promise<EsWorkflowStepExecution[]>;
+  bulkUpsert(stepExecutions: Array<Partial<EsWorkflowStepExecution>>): Promise<void>;
+}
+
+export class InMemoryExecutionPersistence
+  implements WorkflowExecutionPersistence, StepExecutionPersistence
+{
+  private readonly stepExecutions = new Map<string, Partial<EsWorkflowStepExecution>>();
+
+  constructor(private execution: EsWorkflowExecution) {}
+
+  public async getWorkflowExecutionById(
+    workflowExecutionId: string,
+    spaceId: string
+  ): Promise<EsWorkflowExecution | null> {
+    if (this.execution.id !== workflowExecutionId || this.execution.spaceId !== spaceId) {
+      return null;
+    }
+    return this.execution;
+  }
+
+  public async updateWorkflowExecution(
+    workflowExecution: Partial<EsWorkflowExecution>
+  ): Promise<void> {
+    this.execution = { ...this.execution, ...workflowExecution };
+  }
+  public async getStepExecutionsByIds(ids: string[]): Promise<EsWorkflowStepExecution[]> {
+    return ids.flatMap((id) => {
+      const execution = this.stepExecutions.get(id);
+      if (!execution) {
+        return [];
+      }
+      if (!isCompleteStepExecution(execution)) {
+        throw new Error(
+          `Step execution ${id} was read before its required fields were initialized`
+        );
+      }
+      return [execution];
+    });
+  }
+
+  public async bulkUpsert(executions: Array<Partial<EsWorkflowStepExecution>>): Promise<void> {
+    for (const update of executions) {
+      if (!update.id) {
+        throw new Error('Step execution ID is required for in-memory upsert');
+      }
+      this.stepExecutions.set(update.id, {
+        ...this.stepExecutions.get(update.id),
+        ...update,
+      });
+    }
+  }
+}
+
+const isCompleteStepExecution = (
+  execution: Partial<EsWorkflowStepExecution>
+): execution is EsWorkflowStepExecution =>
+  typeof execution.spaceId === 'string' &&
+  typeof execution.id === 'string' &&
+  typeof execution.stepId === 'string' &&
+  Array.isArray(execution.scopeStack) &&
+  typeof execution.workflowRunId === 'string' &&
+  typeof execution.workflowId === 'string' &&
+  execution.status !== undefined &&
+  typeof execution.startedAt === 'string' &&
+  typeof execution.topologicalIndex === 'number' &&
+  typeof execution.globalExecutionIndex === 'number' &&
+  typeof execution.stepExecutionIndex === 'number';

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.ts
@@ -48,7 +48,8 @@ export class InMemoryExecutionPersistence
   }
 
   public async updateWorkflowExecution(
-    workflowExecution: Partial<EsWorkflowExecution>
+    workflowExecution: Partial<EsWorkflowExecution>,
+    _options?: { refresh?: boolean | 'wait_for' }
   ): Promise<void> {
     this.execution = { ...this.execution, ...workflowExecution };
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/create_base_handler_context.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/create_base_handler_context.ts
@@ -12,13 +12,31 @@ import type { StepHandlerContext } from '@kbn/workflows-extensions/server';
 import type { StepExecutionRuntime } from '../../../workflow_context_manager/step_execution_runtime';
 import type { IWorkflowEventLogger } from '../../../workflow_event_logger';
 
+export type BaseHandlerNode = Pick<AtomicGraphNode, 'stepId' | 'stepType'>;
+export interface BaseHandlerStepExecutionRuntime {
+  abortController: StepExecutionRuntime['abortController'];
+  contextManager: Pick<
+    StepExecutionRuntime['contextManager'],
+    | 'callKibanaApi'
+    | 'getContext'
+    | 'getEsClientAsUser'
+    | 'getExecutionCapabilities'
+    | 'getFakeRequest'
+    | 'renderValueAccordingToContext'
+  >;
+}
+export type BaseHandlerWorkflowLogger = Pick<
+  IWorkflowEventLogger,
+  'logDebug' | 'logError' | 'logInfo' | 'logWarn'
+>;
+
 export function createBaseHandlerContext(
   input: unknown,
   rawInput: unknown,
   config: Record<string, unknown>,
-  node: AtomicGraphNode,
-  stepExecutionRuntime: StepExecutionRuntime,
-  workflowLogger: IWorkflowEventLogger
+  node: BaseHandlerNode,
+  stepExecutionRuntime: BaseHandlerStepExecutionRuntime,
+  workflowLogger: BaseHandlerWorkflowLogger
 ): StepHandlerContext {
   return {
     input,
@@ -56,5 +74,6 @@ export function createBaseHandlerContext(
     abortSignal: stepExecutionRuntime.abortController.signal,
     stepId: node.stepId,
     stepType: node.stepType,
+    capabilities: stepExecutionRuntime.contextManager.getExecutionCapabilities(),
   };
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/tests/create_base_handler_context.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/tests/create_base_handler_context.test.ts
@@ -21,9 +21,9 @@ describe('createBaseHandlerContext', () => {
       input,
       rawInput,
       config,
-      defaultTestNode as any,
-      mocks.stepExecutionRuntime as any,
-      mocks.workflowLogger as any
+      defaultTestNode,
+      mocks.stepExecutionRuntime,
+      mocks.workflowLogger
     );
 
     expect(context.input).toBe(input);
@@ -40,9 +40,7 @@ describe('createBaseHandlerContext', () => {
     expect(mocks.stepExecutionRuntime.contextManager.getEsClientAsUser).toHaveBeenCalled();
 
     context.contextManager.renderInputTemplate({ x: 1 });
-    expect(
-      mocks.stepExecutionRuntime.contextManager.renderValueAccordingToContext
-    ).toHaveBeenCalledWith({ x: 1 }, undefined);
+    expect(mocks.renderValueAccordingToContext).toHaveBeenCalledWith({ x: 1 }, undefined);
 
     context.logger.info('hello', { meta: true });
     expect(mocks.workflowLogger.logInfo).toHaveBeenCalledWith('hello', { meta: true });
@@ -55,13 +53,36 @@ describe('createBaseHandlerContext', () => {
       {},
       undefined as unknown as Record<string, unknown>,
       undefined as unknown as Record<string, unknown>,
-      defaultTestNode as any,
-      mocks.stepExecutionRuntime as any,
-      mocks.workflowLogger as any
+      defaultTestNode,
+      mocks.stepExecutionRuntime,
+      mocks.workflowLogger
     );
 
     expect(context.rawInput).toEqual({});
     expect(context.config).toEqual({});
+  });
+
+  it('exposes request-local capabilities directly to the handler', () => {
+    const mocks = createHandlerTestMocks();
+    const capabilities = {
+      id: 'proceed',
+      value: { invoke: jest.fn() },
+    };
+    (
+      mocks.stepExecutionRuntime.contextManager.getExecutionCapabilities as jest.Mock
+    ).mockReturnValue([capabilities]);
+
+    const context = createBaseHandlerContext(
+      {},
+      {},
+      {},
+      defaultTestNode,
+      mocks.stepExecutionRuntime,
+      mocks.workflowLogger
+    );
+
+    expect(context.capabilities).toEqual([capabilities]);
+    expect(context.contextManager.getContext()).not.toHaveProperty('capabilities');
   });
 
   it('forwards callKibanaApi to the execution runtime with abort signal', async () => {
@@ -76,9 +97,9 @@ describe('createBaseHandlerContext', () => {
       {},
       {},
       {},
-      defaultTestNode as any,
-      mocks.stepExecutionRuntime as any,
-      mocks.workflowLogger as any
+      defaultTestNode,
+      mocks.stepExecutionRuntime,
+      mocks.workflowLogger
     );
 
     const result = await context.contextManager.callKibanaApi({

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/tests/test_helpers.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/tests/test_helpers.ts
@@ -7,6 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { elasticsearchServiceMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { StepContext } from '@kbn/workflows';
+import type {
+  BaseHandlerNode,
+  BaseHandlerStepExecutionRuntime,
+  BaseHandlerWorkflowLogger,
+} from '../create_base_handler_context';
 import { DURABLE_STEP_STATE_KEY, type DurableStepState } from '../durable_step_state';
 
 export { DURABLE_STEP_STATE_KEY, type DurableStepState };
@@ -14,35 +21,57 @@ export { DURABLE_STEP_STATE_KEY, type DurableStepState };
 export const getDurableState = (persisted: Record<string, unknown> | undefined): DurableStepState =>
   (persisted?.[DURABLE_STEP_STATE_KEY] ?? {}) as DurableStepState;
 
-export interface TestNode {
-  stepId: string;
-  stepType: string;
+export interface TestNode extends BaseHandlerNode {
   configuration: {
     with?: Record<string, unknown>;
     'max-step-size'?: undefined;
   };
 }
 
-export const defaultTestNode: TestNode = {
+export const defaultTestNode = {
   stepId: 'custom-step',
   stepType: 'my-custom-type',
   configuration: { with: { key: 'value' }, 'max-step-size': undefined },
-};
+} satisfies TestNode;
 
 export const createHandlerTestMocks = (initialPersistedState?: Record<string, unknown>) => {
   const persistedState: { value: Record<string, unknown> | undefined } = {
     value: initialPersistedState,
   };
 
-  const stepExecutionRuntime = {
+  const renderValueAccordingToContext = jest.fn();
+  const stepContext: StepContext = {
+    execution: {
+      id: 'workflow-execution-1',
+      isTestRun: false,
+      startedAt: new Date(0),
+      url: '',
+    },
+    workflow: {
+      id: 'workflow-1',
+      name: 'Test workflow',
+      enabled: true,
+      spaceId: 'default',
+    },
+    kibanaUrl: '',
+    steps: {},
+  };
+  const baseHandlerStepExecutionRuntime = {
     contextManager: {
-      renderValueAccordingToContext: jest.fn((v: unknown) => v),
-      getContext: jest.fn(() => ({})),
-      getEsClientAsUser: jest.fn(() => ({})),
-      getFakeRequest: jest.fn(() => null),
+      renderValueAccordingToContext: <T>(value: T, additionalContext?: Record<string, unknown>) => {
+        renderValueAccordingToContext(value, additionalContext);
+        return value;
+      },
+      getContext: jest.fn(() => stepContext),
+      getEsClientAsUser: jest.fn(() => elasticsearchServiceMock.createElasticsearchClient()),
+      getFakeRequest: jest.fn(() => httpServerMock.createKibanaRequest()),
+      getExecutionCapabilities: jest.fn(() => undefined),
       callKibanaApi: jest.fn(),
     },
     abortController: new AbortController(),
+  } satisfies BaseHandlerStepExecutionRuntime;
+  const stepExecutionRuntime = {
+    ...baseHandlerStepExecutionRuntime,
     node: { configuration: { with: { key: 'value' } } },
     startStep: jest.fn(),
     flushEventLogs: jest.fn().mockResolvedValue(undefined),
@@ -63,11 +92,12 @@ export const createHandlerTestMocks = (initialPersistedState?: Record<string, un
     logError: jest.fn(),
     logDebug: jest.fn(),
     logWarn: jest.fn(),
-  };
+  } satisfies BaseHandlerWorkflowLogger;
 
   return {
     stepExecutionRuntime,
     workflowLogger,
     persistedState,
+    renderValueAccordingToContext,
   };
 };

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -48,7 +48,6 @@ export type WorkflowExecutionMode = 'async' | 'sync';
 export interface ExecuteWorkflowOptions {
   executionMode?: WorkflowExecutionMode;
   executionId?: string;
-  metadata?: Record<string, string>;
   capabilities?: WorkflowExecutionCapabilities;
   abortSignal?: AbortSignal;
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -39,6 +39,7 @@ export interface ExecuteWorkflowResponse {
   result?: {
     status: ExecutionStatus;
     output?: Record<string, unknown>;
+    error?: { type: string; message: string; details?: Record<string, unknown> };
   };
 }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -77,6 +77,10 @@ export interface TriggerEventsContract {
 }
 
 export interface WorkflowsExecutionEnginePluginStart {
+  /**
+   * Type-level discriminant: callers (e.g. inference plugin) narrow on this
+   * before calling executeWorkflow with executionMode: 'sync'.
+   */
   readonly supportsSynchronousExecution: true;
   executeWorkflow: ExecuteWorkflow;
   executeWorkflowStep: ExecuteWorkflowStep;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -17,8 +17,13 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { UsageApiSetup } from '@kbn/usage-api-plugin/server';
-import type { BulkScheduleWorkflowResult, WorkflowExecutionEngineModel } from '@kbn/workflows';
 import type {
+  BulkScheduleWorkflowResult,
+  ExecutionStatus,
+  WorkflowExecutionEngineModel,
+} from '@kbn/workflows';
+import type {
+  WorkflowExecutionCapabilities,
   WorkflowsExtensionsServerPluginSetup,
   WorkflowsExtensionsServerPluginStart,
 } from '@kbn/workflows-extensions/server';
@@ -31,6 +36,20 @@ import type { IWorkflowEventLoggerService } from './workflow_event_logger';
 
 export interface ExecuteWorkflowResponse {
   workflowExecutionId: string;
+  result?: {
+    status: ExecutionStatus;
+    output?: Record<string, unknown>;
+  };
+}
+
+export type WorkflowExecutionMode = 'async' | 'sync';
+
+export interface ExecuteWorkflowOptions {
+  executionMode?: WorkflowExecutionMode;
+  executionId?: string;
+  metadata?: Record<string, string>;
+  capabilities?: WorkflowExecutionCapabilities;
+  abortSignal?: AbortSignal;
 }
 
 export interface ExecuteWorkflowStepResponse {
@@ -58,6 +77,7 @@ export interface TriggerEventsContract {
 }
 
 export interface WorkflowsExecutionEnginePluginStart {
+  readonly supportsSynchronousExecution: true;
   executeWorkflow: ExecuteWorkflow;
   executeWorkflowStep: ExecuteWorkflowStep;
   cancelWorkflowExecution: CancelWorkflowExecution;
@@ -88,7 +108,8 @@ export interface WorkflowsExecutionEnginePluginStartDeps {
 export type ExecuteWorkflow = (
   workflow: WorkflowExecutionEngineModel,
   context: Record<string, unknown>,
-  request: KibanaRequest
+  request: KibanaRequest,
+  options?: ExecuteWorkflowOptions
 ) => Promise<ExecuteWorkflowResponse>;
 
 export type ExecuteWorkflowStep = (

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_io_service.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_io_service.ts
@@ -21,7 +21,7 @@ import { EVICTION_EXEMPT_STEP_TYPES, LOOP_STEP_TYPES } from './step_io_pinned_ty
 import type { StepExecutionMetadata, StepIoStateAccessor } from './workflow_execution_state';
 import { WorkflowScopeStack } from './workflow_scope_stack';
 import type { OutputSizeStats } from '../lib/telemetry/events/workflows_execution/types';
-import type { StepExecutionRepository } from '../repositories/step_execution_repository';
+import type { StepExecutionPersistence } from '../repositories/execution_persistence';
 import { formatBytes, safeOutputSize } from '../step/errors';
 import { buildStepExecutionId } from '../utils';
 
@@ -32,7 +32,7 @@ import { buildStepExecutionId } from '../utils';
 export type PredecessorsResolver = (node: GraphNodeUnion) => ReadonlyArray<GraphNodeUnion>;
 
 export interface StepIoServiceInit {
-  stepRepository: StepExecutionRepository;
+  stepRepository: StepExecutionPersistence;
   state: StepIoStateAccessor;
   pinnedStepTypes?: ReadonlySet<string>;
   /**
@@ -141,7 +141,7 @@ export interface StepIoLifecycle {
  * stepExecutionRepository.
  */
 export class StepIoService implements StepIoWriter, StepIoLifecycle {
-  private readonly stepRepository: StepExecutionRepository;
+  private readonly stepRepository: StepExecutionPersistence;
   private readonly state: StepIoStateAccessor;
   private readonly pinnedStepTypes: ReadonlySet<string>;
   private readonly evictionMinBytes: number;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/types.ts
@@ -12,7 +12,10 @@ import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { CoreStart, KibanaRequest } from '@kbn/core/server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { WorkflowRepository } from '@kbn/workflows';
-import type { WorkflowsExtensionsServerPluginStart } from '@kbn/workflows-extensions/server';
+import type {
+  WorkflowExecutionCapabilities,
+  WorkflowsExtensionsServerPluginStart,
+} from '@kbn/workflows-extensions/server';
 import type { WorkflowsExecutionEngineConfig } from '../config';
 import type { WorkflowLogEvent } from '../repositories/logs_repository';
 import type { StepExecutionRepository } from '../repositories/step_execution_repository';
@@ -32,6 +35,8 @@ export interface ContextDependencies {
   workflowsExecutionEngine?: WorkflowsExecutionEnginePluginStart;
   spaceId?: string;
   request?: KibanaRequest;
+  /** Request-local privileged behavior; never serialize this value. */
+  capabilities?: WorkflowExecutionCapabilities;
 }
 
 /**

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -19,6 +19,7 @@ import {
   type WorkflowContext,
 } from '@kbn/workflows';
 import type { GraphNodeUnion, WorkflowGraph } from '@kbn/workflows/graph';
+import type { WorkflowExecutionCapabilities } from '@kbn/workflows-extensions/server';
 import { buildWorkflowContext } from './build_workflow_context';
 import type { StepIoService } from './step_io_service';
 import type { ContextDependencies } from './types';
@@ -120,6 +121,10 @@ export class WorkflowContextManager {
     this.stackFrames = init.stackFrames;
     this.templateEngine = init.templateEngine;
     this.dependencies = init.dependencies;
+  }
+
+  public getExecutionCapabilities(): WorkflowExecutionCapabilities | undefined {
+    return this.dependencies.capabilities;
   }
 
   /**

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
@@ -14,7 +14,7 @@ import type {
   WorkflowTokenUsage,
 } from '@kbn/workflows';
 import { isTerminalStatus } from '@kbn/workflows';
-import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { WorkflowExecutionPersistence } from '../repositories/execution_persistence';
 import { sumTokenUsage } from '../utils';
 
 /** Context for the step that failed during this run; used to build workflow_execution_failed event. */
@@ -100,7 +100,7 @@ export class WorkflowExecutionState {
 
   constructor(
     initialWorkflowExecution: EsWorkflowExecution,
-    private workflowExecutionRepository: WorkflowExecutionRepository
+    private workflowExecutionRepository: WorkflowExecutionPersistence
   ) {
     this.workflowExecution = initialWorkflowExecution;
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/cancel_workflow_if_requested.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/cancel_workflow_if_requested.ts
@@ -8,7 +8,7 @@
  */
 
 import { ExecutionStatus } from '@kbn/workflows';
-import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { WorkflowExecutionPersistence } from '../repositories/execution_persistence';
 import { buildStepExecutionId } from '../utils';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
 import type { WorkflowExecutionCursorApi } from '../workflow_context_manager/workflow_execution_cursor';
@@ -26,7 +26,7 @@ import type { IWorkflowEventLogger } from '../workflow_event_logger';
  * issues from causing step execution failures.
  */
 export async function cancelWorkflowIfRequested(
-  workflowExecutionRepository: WorkflowExecutionRepository,
+  workflowExecutionRepository: WorkflowExecutionPersistence,
   workflowExecutionState: WorkflowExecutionState,
   monitoredStepExecutionRuntime: StepExecutionRuntime,
   workflowLogger: IWorkflowEventLogger,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/catch_error.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/catch_error.ts
@@ -79,7 +79,14 @@ export async function catchError(
     // 2. There are items in the execution stack
     // 3. The top stack entry has nested scopes to process
     // This allows error handling to bubble up through the scope hierarchy.
-    if (failedStepExecutionRuntime.stepExecutionExists() && failedStepExecutionRuntime.error) {
+    // Don't overwrite a higher-priority error already set by onTaskAbort (e.g. the sync-
+    // execution timeout). The step's error is a consequence of that abort; the timeout
+    // message is what callers need to see.
+    if (
+      failedStepExecutionRuntime.stepExecutionExists() &&
+      failedStepExecutionRuntime.error &&
+      !workflowExecutionCursor.error
+    ) {
       workflowExecutionCursor.captureError(failedStepExecutionRuntime.error);
     } else if (failedStepExecutionRuntime.stepExecutionExists()) {
       const stepExecution = failedStepExecutionRuntime.stepExecution;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
@@ -71,6 +71,27 @@ const makeStepRuntime = (
   } as unknown as jest.Mocked<StepExecutionRuntime>);
 
 describe('handleExecutionDelay', () => {
+  it.each([
+    ExecutionStatus.WAITING,
+    ExecutionStatus.WAITING_FOR_INPUT,
+    ExecutionStatus.WAITING_FOR_CHILD,
+  ])('rejects asynchronous resume status %s in sync mode', async (status) => {
+    const params = makeParams();
+    params.executionMode = 'sync';
+    const stepRuntime = makeStepRuntime({
+      node: { stepId: 'blocking-step', stepType: 'wait' } as any,
+      stepExecution: { status } as any,
+    });
+
+    await expect(handleExecutionDelay(params, stepRuntime)).rejects.toThrow(
+      'is not supported in synchronous workflows'
+    );
+    expect(params.workflowTaskManager.scheduleResumeTask).not.toHaveBeenCalled();
+    expect(
+      params.workflowTaskManager.scheduleWorkflowGlobalTimeoutResumeTask
+    ).not.toHaveBeenCalled();
+  });
+
   describe('WAITING_FOR_INPUT step (HITL)', () => {
     it('should set workflow status to WAITING_FOR_INPUT', async () => {
       const params = makeParams();

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
@@ -87,7 +87,7 @@ async function scheduleWorkflowGlobalTimeoutResumeTask(
 
   await params.workflowTaskManager
     .scheduleWorkflowGlobalTimeoutResumeTask({
-      workflowExecution: workflowExecution as EsWorkflowExecution,
+      workflowExecution,
       resumeAt: new Date(resumeAtMs),
       fakeRequest: params.fakeRequest,
     })
@@ -153,7 +153,7 @@ export async function ensureWorkflowIdleTimeoutResumeAfterLoop(
 
   await params.workflowTaskManager
     .scheduleWorkflowGlobalTimeoutResumeTask({
-      workflowExecution: workflowExecution as EsWorkflowExecution,
+      workflowExecution,
       resumeAt,
       fakeRequest: params.fakeRequest,
     })
@@ -173,6 +173,16 @@ export async function handleExecutionDelay(
   const workflowExecution = params.workflowRuntime.getWorkflowExecution();
 
   const stepStatus = stepExecutionRuntime.stepExecution?.status;
+  if (
+    params.executionMode === 'sync' &&
+    (stepStatus === ExecutionStatus.WAITING_FOR_INPUT ||
+      stepStatus === ExecutionStatus.WAITING_FOR_CHILD ||
+      stepStatus === ExecutionStatus.WAITING)
+  ) {
+    throw new Error(
+      `Step "${stepExecutionRuntime.node.stepId}" is not supported in synchronous workflows`
+    );
+  }
   if (
     stepStatus === ExecutionStatus.WAITING_FOR_INPUT ||
     stepStatus === ExecutionStatus.WAITING_FOR_CHILD

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
@@ -13,6 +13,7 @@ import type { GraphNodeUnion } from '@kbn/workflows/graph';
 import { isEnterStepTimeoutZone } from '@kbn/workflows/graph';
 import { flushState } from './persistence_loop';
 import type { WorkflowExecutionLoopParams } from './types';
+import { SYNC_WORKFLOW_UNSUPPORTED_MSG } from '../execution_functions/validate_sync_workflow';
 import {
   getHitlIdleDeadlineMsForNode,
   getHitlIdleDeadlineMsForStep,
@@ -179,9 +180,7 @@ export async function handleExecutionDelay(
       stepStatus === ExecutionStatus.WAITING_FOR_CHILD ||
       stepStatus === ExecutionStatus.WAITING)
   ) {
-    throw new Error(
-      `Step "${stepExecutionRuntime.node.stepId}" is not supported in synchronous workflows`
-    );
+    throw new Error(`Step "${stepExecutionRuntime.node.stepId}" ${SYNC_WORKFLOW_UNSUPPORTED_MSG}`);
   }
   if (
     stepStatus === ExecutionStatus.WAITING_FOR_INPUT ||

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -81,6 +81,7 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
   let monitorAbortController: AbortController | undefined;
   let stepExecutionRuntime: StepExecutionRuntime | undefined;
   let nodeImplementation: NodeImplementation | undefined;
+  let abortStepRelay: (() => void) | undefined;
 
   if (!node) {
     return;
@@ -105,6 +106,17 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
       nodeId: node.id,
       stackFrames: workflowExecutionCursor.currentStackFrames,
     });
+
+    // Cascade the execution-level abort to the step's controller so that in-flight I/O
+    // (e.g. LLM streaming in call_site.proceed) is cancelled immediately when the sync
+    // execution timeout fires rather than waiting for streaming to finish naturally.
+    const runtimeRef = stepExecutionRuntime;
+    abortStepRelay = () => runtimeRef.abortController.abort(params.signal.reason);
+    if (params.signal.aborted) {
+      abortStepRelay();
+    } else {
+      params.signal.addEventListener('abort', abortStepRelay, { once: true });
+    }
 
     // Build the node implementation before the cancel short-circuit so cancellable nodes
     // (e.g. workflow.execute holding a child execution) still get their onCancel hook.
@@ -178,9 +190,17 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
     await Promise.race([runMonitorPromise, runStepPromise]);
     nodeSpan?.setOutcome('success');
   } catch (error) {
-    workflowExecutionCursor.captureError(error);
+    // Don't overwrite a higher-priority error already captured by onTaskAbort (e.g. the
+    // sync-execution timeout error). The catch fires for monitor/step rejections that are
+    // consequences of that abort, not the root cause.
+    if (!workflowExecutionCursor.error) {
+      workflowExecutionCursor.captureError(error);
+    }
     nodeSpan?.setOutcome('failure');
   } finally {
+    if (abortStepRelay) {
+      params.signal.removeEventListener('abort', abortStepRelay);
+    }
     monitorAbortController?.abort();
 
     // Run cancellation cleanup in `finally` so it fires on BOTH the normal path

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_stack_monitor/process_node_stack_monitoring.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_stack_monitor/process_node_stack_monitoring.ts
@@ -50,12 +50,14 @@ export async function processNodeStackMonitoring(
     }
   }
 
-  await cancelWorkflowIfRequested(
-    params.workflowExecutionRepository,
-    params.workflowExecutionState,
-    monitoredStepExecutionRuntime,
-    params.workflowLogger,
-    params.workflowExecutionCursor,
-    monitoredStepExecutionRuntime.abortController
-  );
+  if (params.executionMode !== 'sync') {
+    await cancelWorkflowIfRequested(
+      params.workflowExecutionRepository,
+      params.workflowExecutionState,
+      monitoredStepExecutionRuntime,
+      params.workflowLogger,
+      params.workflowExecutionCursor,
+      monitoredStepExecutionRuntime.abortController
+    );
+  }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/types.ts
@@ -9,8 +9,9 @@
 
 import type { CoreStart, ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
 import type { WorkflowGraph } from '@kbn/workflows/graph';
-import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { WorkflowExecutionPersistence } from '../repositories/execution_persistence';
 import type { NodesFactory } from '../step/nodes_factory';
+import type { WorkflowExecutionMode } from '../types';
 import type { StepExecutionRuntimeFactory } from '../workflow_context_manager/step_execution_runtime_factory';
 import type { StepIoService } from '../workflow_context_manager/step_io_service';
 import type { WorkflowExecutionCursorApi } from '../workflow_context_manager/workflow_execution_cursor';
@@ -27,11 +28,12 @@ export interface WorkflowExecutionLoopParams {
   workflowExecutionState: WorkflowExecutionState;
   stepIoService: StepIoService;
   workflowLogger: IWorkflowEventLogger;
-  workflowExecutionRepository: WorkflowExecutionRepository;
+  workflowExecutionRepository: WorkflowExecutionPersistence;
   nodesFactory: NodesFactory;
   esClient: ElasticsearchClient;
   fakeRequest: KibanaRequest<unknown, unknown, unknown>;
   coreStart: CoreStart;
   signal: AbortSignal;
   workflowTaskManager: WorkflowTaskManager;
+  executionMode?: WorkflowExecutionMode;
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.test.ts
@@ -58,10 +58,13 @@ describe('workflowExecutionLoop', () => {
     const params = createParams();
     await workflowExecutionLoop(params as any);
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { executionFlowLoop } = require('./execution_flow_loop');
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { persistenceLoop, flushState } = require('./persistence_loop');
+    const { executionFlowLoop } = jest.requireMock('./execution_flow_loop') as {
+      executionFlowLoop: jest.Mock;
+    };
+    const { persistenceLoop, flushState } = jest.requireMock('./persistence_loop') as {
+      persistenceLoop: jest.Mock;
+      flushState: jest.Mock;
+    };
 
     expect(executionFlowLoop).toHaveBeenCalledWith(params);
     expect(persistenceLoop).toHaveBeenCalled();
@@ -74,12 +77,32 @@ describe('workflowExecutionLoop', () => {
     expect(params.workflowLogger.flushEvents).toHaveBeenCalled();
   });
 
+  it('uses the shared execution loop without periodic persistence in sync mode', async () => {
+    const params = { ...createParams(), executionMode: 'sync' as const };
+    await workflowExecutionLoop(params as any);
+
+    const { executionFlowLoop } = jest.requireMock('./execution_flow_loop') as {
+      executionFlowLoop: jest.Mock;
+    };
+    const { persistenceLoop, flushState } = jest.requireMock('./persistence_loop') as {
+      persistenceLoop: jest.Mock;
+      flushState: jest.Mock;
+    };
+
+    expect(executionFlowLoop).toHaveBeenCalledWith(params);
+    expect(persistenceLoop).not.toHaveBeenCalled();
+    expect(flushState).not.toHaveBeenCalled();
+    expect(params.workflowRuntime.saveState).toHaveBeenCalled();
+    expect(params.stepIoService.flush).toHaveBeenCalled();
+  });
+
   it('sets workflow error when execution loop throws', async () => {
     const params = createParams();
     const testError = new Error('execution failed');
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { executionFlowLoop } = require('./execution_flow_loop');
+    const { executionFlowLoop } = jest.requireMock('./execution_flow_loop') as {
+      executionFlowLoop: jest.Mock;
+    };
     (executionFlowLoop as jest.Mock).mockRejectedValueOnce(testError);
 
     await workflowExecutionLoop(params as any);
@@ -108,8 +131,7 @@ describe('workflowExecutionLoop', () => {
   it('marks Task Manager abort as system cancellation and suppresses workflow log errors', async () => {
     const params = createParams();
     const abortController = new AbortController();
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { flushState } = require('./persistence_loop');
+    const { flushState } = jest.requireMock('./persistence_loop') as { flushState: jest.Mock };
     const loopPromise = workflowExecutionLoop({ ...params, signal: abortController.signal } as any);
     abortController.abort(new WorkflowTaskManagerAbortError());
     await loopPromise;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.test.ts
@@ -128,6 +128,23 @@ describe('workflowExecutionLoop', () => {
     expect(params.workflowExecutionCursor.stop).toHaveBeenCalled();
   });
 
+  it('marks abort-with-error-reason (e.g. timeout) as FAILED and captures the error', async () => {
+    const params = createParams();
+    const abortController = new AbortController();
+    const timeoutError = new Error('Pre-LLM anonymization timed out after 5000ms');
+    const loopPromise = workflowExecutionLoop({ ...params, signal: abortController.signal } as any);
+    abortController.abort(timeoutError);
+    await loopPromise;
+
+    expect(params.workflowExecutionCursor.captureError).toHaveBeenCalledWith(timeoutError);
+    expect(params.workflowExecutionState.updateWorkflowExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: ExecutionStatus.FAILED,
+      })
+    );
+    expect(params.workflowExecutionCursor.stop).toHaveBeenCalled();
+  });
+
   it('marks Task Manager abort as system cancellation and suppresses workflow log errors', async () => {
     const params = createParams();
     const abortController = new AbortController();

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.ts
@@ -76,20 +76,26 @@ export async function workflowExecutionLoop(params: WorkflowExecutionLoopParams)
     workflowExecutionCursor.start();
     // Run execution and persistence loops in parallel
     // When execution finishes, signal persistence loop to exit immediately
-    await Promise.all([
-      executionFlowLoop(params).finally(() => {
-        // Signal persistence loop to stop waiting and exit
-        persistenceAbortController.abort();
-      }),
-      persistenceLoop(params, persistenceAbortController.signal),
-    ]);
+    if (params.executionMode === 'sync') {
+      await executionFlowLoop(params);
+    } else {
+      await Promise.all([
+        executionFlowLoop(params).finally(() => {
+          // Signal persistence loop to stop waiting and exit
+          persistenceAbortController.abort();
+        }),
+        persistenceLoop(params, persistenceAbortController.signal),
+      ]);
+    }
   } catch (error) {
     workflowExecutionCursor.captureError(error);
   } finally {
     const finalFlushSpan = apm.startSpan('final flush state', 'workflow', 'persistence');
-    await flushState(params, {
-      workflowLogFlushSignal: params.signal,
-    });
+    if (params.executionMode !== 'sync') {
+      await flushState(params, {
+        workflowLogFlushSignal: params.signal,
+      });
+    }
     finalFlushSpan?.end();
   }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.ts
@@ -56,12 +56,25 @@ export async function workflowExecutionLoop(params: WorkflowExecutionLoopParams)
       return;
     }
 
-    params.workflowExecutionState.updateWorkflowExecution({
-      cancelRequested: true,
-      cancelledAt: new Date().toISOString(),
-      cancellationReason: 'Task aborted',
-      status: ExecutionStatus.CANCELLED,
-    });
+    const reason = params.signal.reason;
+    // When the abort carries an explicit error (e.g. a pre-LLM or sync-execution
+    // timeout), treat it as FAILED so the error detail is surfaced to callers.
+    // A plain abort (no reason, or an AbortError from a no-arg abort()) keeps
+    // CANCELLED semantics — that represents an intentional stop (user disconnect).
+    const isFailureAbort = reason instanceof Error && reason.name !== 'AbortError';
+    if (isFailureAbort) {
+      workflowExecutionCursor.captureError(reason);
+      params.workflowExecutionState.updateWorkflowExecution({
+        status: ExecutionStatus.FAILED,
+      });
+    } else {
+      params.workflowExecutionState.updateWorkflowExecution({
+        cancelRequested: true,
+        cancelledAt: new Date().toISOString(),
+        cancellationReason: 'Task aborted',
+        status: ExecutionStatus.CANCELLED,
+      });
+    }
     // Also abort persistence loop when task is aborted
     persistenceAbortController.abort();
     workflowExecutionCursor.stop();

--- a/src/platform/plugins/shared/workflows_extensions/server/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/index.ts
@@ -50,6 +50,8 @@ export type {
   StepHandler,
   StepHandlerContext,
   StepHandlerResult,
+  WorkflowExecutionCapability,
+  WorkflowExecutionCapabilities,
   OnCancelHandler,
   StartWithHandoffHandler,
   PollHandler,

--- a/src/platform/plugins/shared/workflows_extensions/server/step_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/step_registry/types.ts
@@ -13,6 +13,14 @@ import type { StepContext } from '@kbn/workflows';
 import type { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../common';
 
+/** A named request-local capability transported opaquely by the workflow engine. */
+export interface WorkflowExecutionCapability {
+  readonly id: string;
+  readonly value: object;
+}
+
+export type WorkflowExecutionCapabilities = readonly WorkflowExecutionCapability[];
+
 // -----------------------------------------------------------------------------
 // Poll step types
 // -----------------------------------------------------------------------------
@@ -383,6 +391,13 @@ export interface StepHandlerContext<TInput = z.ZodType, TConfig = z.ZodObject> {
    * Current step's type
    */
   stepType: string;
+
+  /**
+   * Trusted, request-local capabilities supplied by the execution caller.
+   * They are passed directly to handlers and are never added to workflow
+   * context, template variables, step input/output, or persisted state.
+   */
+  capabilities?: WorkflowExecutionCapabilities;
 }
 
 /**

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/metadata.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/metadata.ts
@@ -36,6 +36,10 @@ export interface ChatCompleteAnonymizationTarget {
  * field-based policy for a target.
  */
 export interface ChatCompleteAnonymizationMetadata {
+  /** Stable conversation scope used by workflow-driven anonymization. */
+  sessionId?: string;
+  /** Active agent identity used only for workflow policy selection. */
+  agentId?: string;
   profileId?: string;
   replacementsId?: string;
   target?: ChatCompleteAnonymizationTarget;

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_detection_context.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_detection_context.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegexWorkerService } from './regex_worker_service';
+import { createPiiDetectionContext } from './create_pii_detection_context';
+
+describe('createPiiDetectionContext', () => {
+  it('delegates enabled regex detection to the worker and maps record IDs', async () => {
+    const run = jest.fn().mockResolvedValue([
+      {
+        recordIndex: 0,
+        recordKey: 'message-1',
+        start: 8,
+        end: 24,
+        matchValue: 'user@example.com',
+        class_name: 'EMAIL',
+        ruleIndex: 0,
+      },
+    ]);
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+
+    await expect(
+      context.detectEntities({
+        records: [{ id: 'message-1', text: 'Contact user@example.com' }],
+        rules: [
+          { type: 'RegExp', enabled: true, pattern: '[^ ]+@[^ ]+', entityClass: 'EMAIL' },
+          { type: 'RegExp', enabled: false, pattern: 'ignored', entityClass: 'MISC' },
+          { type: 'NER', enabled: false },
+        ],
+      })
+    ).resolves.toEqual([
+      {
+        recordId: 'message-1',
+        start: 8,
+        end: 24,
+        value: 'user@example.com',
+        entityClass: 'EMAIL',
+      },
+    ]);
+
+    expect(run).toHaveBeenCalledWith({
+      rules: [{ type: 'RegExp', enabled: true, pattern: '[^ ]+@[^ ]+', entityClass: 'EMAIL' }],
+      records: [{ 'message-1': 'Contact user@example.com' }],
+    });
+  });
+
+  it('does not invoke the worker when there are no enabled regex rules', async () => {
+    const run = jest.fn();
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+
+    await expect(
+      context.detectEntities({
+        records: [{ id: 'message-1', text: 'some text' }],
+        rules: [{ type: 'NER', enabled: false }],
+      })
+    ).resolves.toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('rejects enabled NER rules instead of silently ignoring them', async () => {
+    const run = jest.fn();
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+
+    await expect(
+      context.detectEntities({
+        records: [{ id: 'message-1', text: 'some text' }],
+        rules: [{ type: 'NER', enabled: true }],
+      })
+    ).rejects.toThrow('NER detection is not supported by workflow-driven anonymization');
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('honors cancellation before dispatching worker work', async () => {
+    const run = jest.fn();
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      context.detectEntities({
+        records: [{ id: 'message-1', text: 'some text' }],
+        rules: [{ type: 'RegExp', enabled: true, pattern: 'text', entityClass: 'MISC' }],
+        abortSignal: abortController.signal,
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('honors cancellation while worker work is in flight', async () => {
+    let resolveRun: ((matches: []) => void) | undefined;
+    const run = jest.fn(
+      () =>
+        new Promise<[]>((resolve) => {
+          resolveRun = resolve;
+        })
+    );
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+    const abortController = new AbortController();
+
+    const detection = context.detectEntities({
+      records: [{ id: 'message-1', text: 'some text' }],
+      rules: [{ type: 'RegExp', enabled: true, pattern: 'text', entityClass: 'MISC' }],
+      abortSignal: abortController.signal,
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    abortController.abort();
+    if (!resolveRun) {
+      throw new Error('Expected regex worker invocation');
+    }
+    resolveRun([]);
+
+    await expect(detection).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_detection_context.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_detection_context.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnonymizationRule, RegexAnonymizationRule } from '@kbn/inference-common';
+import type {
+  DetectedPiiEntity,
+  PiiDetectionContext,
+  PiiTextRecord,
+} from './pii_detection_context';
+import type { RegexWorkerService } from './regex_worker_service';
+
+export const createPiiDetectionContext = ({
+  regexWorker,
+}: {
+  regexWorker: RegexWorkerService;
+}): PiiDetectionContext => ({
+  detectEntities: async ({ records, rules, abortSignal }) => {
+    abortSignal?.throwIfAborted();
+
+    if (hasEnabledNerRule(rules)) {
+      throw new Error('NER detection is not supported by workflow-driven anonymization');
+    }
+
+    const regexRules = rules.filter(
+      (rule): rule is RegexAnonymizationRule => rule.enabled && rule.type === 'RegExp'
+    );
+    if (regexRules.length === 0 || records.length === 0) {
+      return [];
+    }
+
+    const workerRecords = records.map(({ id, text }) => ({ [id]: text }));
+    const matches = await regexWorker.run({ rules: regexRules, records: workerRecords });
+    abortSignal?.throwIfAborted();
+
+    return matches.map<DetectedPiiEntity>((match) => ({
+      recordId: getRecordId(records, match.recordIndex),
+      start: match.start,
+      end: match.end,
+      value: match.matchValue,
+      entityClass: match.class_name,
+    }));
+  },
+});
+
+const hasEnabledNerRule = (rules: readonly AnonymizationRule[]): boolean =>
+  rules.some((rule) => rule.enabled && rule.type === 'NER');
+
+const getRecordId = (records: readonly PiiTextRecord[], recordIndex: number): string => {
+  const record = records[recordIndex];
+  if (!record) {
+    throw new Error(`PII detector returned an invalid record index: ${recordIndex}`);
+  }
+  return record.id;
+};

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/pii_detection_context.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/pii_detection_context.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnonymizationRule } from '@kbn/inference-common';
+
+export interface PiiTextRecord {
+  id: string;
+  text: string;
+}
+
+export interface DetectedPiiEntity {
+  recordId: string;
+  start: number;
+  end: number;
+  value: string;
+  entityClass: string;
+}
+
+export interface PiiDetectionContext {
+  detectEntities(options: {
+    records: readonly PiiTextRecord[];
+    rules: readonly AnonymizationRule[];
+    abortSignal?: AbortSignal;
+  }): Promise<readonly DetectedPiiEntity[]>;
+}

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.ts
@@ -18,6 +18,7 @@ import {
 } from '../../common/workflow_anonymization';
 import { getPiiTokenizationContext } from './capabilities';
 import { createCompletionTextRecords } from './message_records';
+import { piiReplacementsCounter } from './anonymization_metrics';
 
 interface IndexedEntity extends DetectedPiiEntity {
   readonly detectionIndex: number;
@@ -140,6 +141,14 @@ export const executePiiProtection = async ({
     tokenize: pii.tokenize,
     logger,
   });
+
+  const newTokensByClass = new Map<string, number>();
+  for (const [, entry] of Object.entries(protectedRecords.tokenMap)) {
+    newTokensByClass.set(entry.entityClass, (newTokensByClass.get(entry.entityClass) ?? 0) + 1);
+  }
+  for (const [entityClass, count] of newTokensByClass) {
+    piiReplacementsCounter.add(count, { entity_class: entityClass });
+  }
 
   return {
     ...detectionRecords.replace(protectedRecords.values),


### PR DESCRIPTION
## About the stacked PRs

### Stack — workflow-driven inference anonymization

| # | PR | What |
|---|---|---|
| 1 | [#280715](https://github.com/elastic/kibana/pull/280715) ← **this PR** | Synchronous execution mode + anonymization type foundation |
| 2 | [#280716](https://github.com/elastic/kibana/pull/280716) | Anonymization workflow steps + provider |
| 3 | [#280717](https://github.com/elastic/kibana/pull/280717) | Pipeline integration (wires anonymization to `inference.aroundCompletion`) |
| 4 | [#280718](https://github.com/elastic/kibana/pull/280718) | Metadata propagation (agentId + sessionId) |
| 5 | [#280849](https://github.com/elastic/kibana/pull/280849) | Sync log drain (removes inline ES writes from the hot path) |

> [!TIP]
> See the full final state in [PR5](https://github.com/elastic/kibana/pull/280849).

## Summary

**The goal of the stack** is to let the inference plugin intercept every LLM completion call and run a PII anonymization workflow synchronously — before tokens reach the model and again after the model responds — all within the lifetime of a single HTTP request, with no background tasks and no persisted execution state.

This PR (1 of 5) lays the execution engine infrastructure that makes that possible. Nothing in the existing inference flow changes here; the anonymization hook is wired in PR 3.

---

## What this PR does

### 1. Synchronous workflow execution

Workflows today run as background Task Manager tasks: the caller schedules a task, returns immediately, and the workflow runs asynchronously against Elasticsearch-backed storage. That model is essential for long-running, pausable workflows — but it does not work for an LLM guard that must complete synchronously in the critical path of an inference request.

This PR adds an opt-in synchronous execution path. When a caller passes `executionMode: 'sync'` to `executeWorkflow`, the engine runs the workflow **in-process**, to completion, before returning. The same graph, runtime, node dispatch, cancellation, and finalization code runs — but state is kept in memory rather than in Elasticsearch, and any step that would pause (a timer, a human-in-the-loop wait, a child workflow) is rejected before and during execution.

**The async path is completely unchanged.** The only code that touches both paths is the `executeWorkflow` dispatcher in `plugin.ts`, which now has an early branch:

```
if (options.executionMode === 'sync') → executeWorkflowSync(...)
else → schedule Task Manager task (existing flow, untouched)
```

Everything downstream of that branch — Task Manager wiring, ES repositories, workflow scheduling, resume logic — is untouched.

### 2. Anonymization type foundation

Adds the low-level types and utilities that PRs 2 and 3 build on:

- `agentId` and `sessionId` fields on `ChatCompleteAnonymizationMetadata` — lets the anonymization pipeline correlate an LLM call with the session and agent that triggered it.
- `createPiiDetectionContext` / `PiiDetectionContext` — a regex-backed entity scanner that the anonymization steps use to detect and replace PII tokens before the prompt reaches the model.

---

## How sync execution works

> [!IMPORTANT]
> **"Synchronous" describes the call-site contract, not the absence of Promises.** The HTTP request blocks until the workflow completes and the result is returned directly — rather than handing off to a background Task Manager task. Individual workflow steps are still implemented as `async` functions; they call connectors, Elasticsearch, or LLMs, all of which are Promise-based in Node.js. `workflowExecutionLoop` is therefore still `await`-ed in sync mode — the only difference from the async branch is that no concurrent `persistenceLoop` runs alongside it (since there is no Elasticsearch state to flush during the run).

### The call flow

```mermaid
sequenceDiagram
    participant Caller as Caller (wired in PR 3)
    participant Plugin as WorkflowsExecutionEngine
    participant Sync as executeWorkflowSync
    participant Run as runWorkflowSync
    participant ExecLoop as workflowExecutionLoop
    participant Mem as InMemoryExecutionPersistence

    Caller->>Plugin: executeWorkflow(workflow, ctx, req, options)
    Note over Plugin: executionMode is sync
    Plugin->>Sync: executeWorkflowSync(...)

    Note over Sync: 1. Check workflow enabled
    Note over Sync: 2. Build execution document in memory
    Sync->>Mem: new InMemoryExecutionPersistence(execution)
    Note over Sync: 3. validateWorkflowInputs
    Note over Sync: 4. Wire abort signal and server timeout

    Sync->>Run: runWorkflowSync(workflowExecution, repositories=Mem)
    Note over Run: APM label: execution_mode=sync
    Run->>ExecLoop: workflowExecutionLoop(executionMode=sync)

    ExecLoop->>Mem: bulkUpsert(stepExecution)
    ExecLoop->>Mem: updateWorkflowExecution(...)
    Note over ExecLoop: handleExecutionDelay throws if step enters WAITING

    ExecLoop-->>Run: done
    Run->>Mem: getWorkflowExecution()
    Run-->>Sync: EsWorkflowExecution (from memory)
    Sync-->>Caller: ExecuteWorkflowResponse
```

All reads and writes during execution go to `InMemoryExecutionPersistence` — a `Map`-backed adapter that satisfies the same `WorkflowExecutionPersistence` and `StepExecutionPersistence` interfaces used by the ES-backed repositories. Nothing touches Elasticsearch during a synchronous run.

### State isolation

```mermaid
graph LR
    subgraph asyncpath ["Async execution (unchanged)"]
        A[Task Manager task] -->|reads/writes| ES[(Elasticsearch)]
    end

    subgraph syncpath ["Sync execution (new)"]
        B[HTTP request handler] -->|reads/writes| Mem[(In-memory Map)]
        Mem -->|discarded on return| X[request ends]
    end
```

The in-memory adapter implements the same interface as the Elasticsearch repositories, so every shared piece of the execution loop — graph traversal, step dispatch, retry logic, finalization — works without modification. State that would normally be checkpointed to ES is simply kept in the `Map` and discarded when the function returns. This means:

- **No crash recovery.** If Kibana restarts mid-execution, the run is lost. This is intentional for the anonymization use case: each call is bounded by an HTTP request lifetime, and PII token maps must not be persisted.
- **No cross-node sharing.** The execution is fully node-local.


### The two-layer async-step guard

Synchronous workflows cannot suspend — any step that would cause the execution to pause (a timer, a HITL approval, a child workflow) must be rejected. The guard has two layers so that both known and unknown async step types are caught:

```mermaid
flowchart TD
    A[runWorkflowSync called] --> B{validateSyncWorkflow}
    B -->|step type in ASYNC_ONLY_STEP_TYPES| FAIL1["throw: step X not supported in sync workflows"]
    B -->|all step types OK| C[workflowExecutionLoop runs]
    C --> D{handleExecutionDelay after each step}
    D -->|step enters WAITING status| FAIL2["throw: step X not supported in sync workflows"]
    D -->|step completes normally| E[next step]
    E --> C
    C --> F[return result]
```

**Layer 1 — `validateSyncWorkflow` (pre-execution, static):** walks the workflow graph before any step runs and rejects known async-only step types (`wait`, `waitForInput`, `waitForApproval`, `workflow.execute`, `workflow.executeAsync`). This catches the common case fast, before any work is done.

**Layer 2 — `handleExecutionDelay` (runtime, dynamic):** after each step executes, checks whether its status is `WAITING`, `WAITING_FOR_INPUT`, or `WAITING_FOR_CHILD`. If the execution mode is `sync`, it throws immediately. This catches extension-registered step types that weren't in the static allowlist. Both layers use the same error message format (`is not supported in synchronous workflows`) so diagnostics are consistent regardless of which layer fires.

> **Known gap (addressed in PR 3):** the static allowlist in `validateSyncWorkflow` is hardcoded. PR 3 replaces it with a `supportedExecutionModes` check on each step's definition, so extension-provided step types that explicitly declare sync support will be accepted rather than requiring an allowlist update.

### Timeout and cancellation

Every sync execution has two independent deadline mechanisms:

```
Caller abortSignal (shorter, optional)
         ↓
  AbortController (per-execution)
         ↑
Server timeout: setTimeout(maxDurationMs)
```

- The **caller's `abortSignal`** (e.g. the inference request being cancelled by the user) is forwarded into the execution's `AbortController`. If the signal fires, the abort propagates through the execution loop to any in-flight step.
- A **server-side timeout** (`maxDurationMs`, default 60 s) fires the same `AbortController` regardless of whether the caller has a deadline. Without this, a hung step — an external API that never responds, an ES client stall — would hold a request handler indefinitely. The `setTimeout` is cleared in `finally` whether the run succeeds, fails, or is aborted.

The two mechanisms are additive and independent: the caller can impose a shorter deadline, the server enforces the ceiling.

### Config keys

```yaml
workflowsExecutionEngine:
  syncExecution:
    enabled: false         # master switch — must be true to use the sync path
    maxDurationMs: 60000   # wall-clock ceiling per execution; default 60 s, minimum 1 s
```

`enabled` (default `false`) is the master switch. When off, `executeWorkflow` ignores `executionMode: 'sync'` and runs the normal async Task Manager path instead — no error, fully backwards compatible. When on, the sync path activates. Both keys must be added to the cloud config allowlist and the docker env list before operators can set them on cloud deployments.

---

## What is behind a feature flag / opt-in?

| Behaviour | Gated by |
|---|---|
| Sync execution path actually running | `workflowsExecutionEngine.syncExecution.enabled: true` (default `false`) — when off, `executeWorkflow` silently falls through to the normal async Task Manager path |
| Caller using the sync path at all | PR 3 wires the `inference.aroundCompletion` hook; no call site exists until then |
| `capabilities` / `abortSignal` on `executeWorkflow` | Only valid with `executionMode: 'sync'`; throws if passed without it (guards against accidental misuse on the async path). When `executionMode: 'sync'` is set but the flag is off, both fields are silently unused — no throw |
| Anonymization hook in inference | `xpack.inference.anonymization.workflow_driven: true` (introduced in PR 3, default `false`) |
| `createPiiDetectionContext` | Pure library code, no side effects until consumed by anonymization steps in PR 2 |

`syncExecution.enabled` is introduced here (PR 1) so the flag lands in the same PR as the code it governs. When the flag is off and something calls `executeWorkflow({ executionMode: 'sync' })`, execution continues on the async path — no error, fully backwards compatible. This means the managed anonymization workflow can be installed with the flag off (e.g. all PRs merged but the feature not yet activated) without any side effects. `workflow_driven` is introduced in PR 3 where it is first read. Both default to `false`. Merging this PR does not change any observable behaviour for existing users.

---

## What is not changing

- The async execution path (Task Manager → Elasticsearch) is byte-for-byte identical to today.
- No existing workflow, route, or consumer is modified.
- Event logging still writes to Elasticsearch in sync mode (inline, per step). This is a known throughput concern at scale — PR 5 addresses it with a buffered background drain.

---

## The stack plan

Once all five PRs are merged, the inference anonymization flow looks like this:

```mermaid
sequenceDiagram
    participant Caller as Caller
    participant Inf as Inference plugin (PR 3)
    participant WF as PII workflow (sync, PR 2)
    participant LLM as LLM connector

    Caller->>Inf: chatComplete({ messages, anonymization })
    Note over Inf: aroundCompletion hook creates Observable pipeline

    alt PII rules matched
        Inf->>WF: provider.execute({ messages, proceed })
        Note over WF: Detect PII, replace with tokens (synchronous)
        WF->>Inf: proceed.invoke({ tokenMap, anonymizedMessages })
        Inf->>LLM: invokeConnector(anonymizedMessages)
        loop each streaming chunk
            LLM-->>Inf: ChatCompletionChunk (tokens intact)
            Note over Inf: Restore tokens inline via contentRestorer
            Inf-->>Caller: ChatCompletionChunk (PII restored)
        end
        LLM-->>Inf: ChatCompletionMessage (terminal)
        Note over Inf: proceed resolves — workflow resumes with rawContent
        WF-->>Inf: result.content (post-processed terminal)
        Inf-->>Caller: ChatCompletionMessage (PII restored, final)
    else No rules matched or workflow failed before connector
        Inf->>LLM: invokeConnector(original messages)
        LLM-->>Caller: stream unchanged
    end
```

Key architectural points:
- The workflow **wraps** the LLM call — it is not a before/after hook. The workflow runs synchronously, detects and replaces PII, then calls `proceed.invoke()` which drives the connector and awaits its completion. Streaming happens *inside* this invocation.
- **Chunks are restored in real time**: as the LLM streams chunks, each one is passed through `contentRestorer` which replaces PII tokens inline before forwarding to the caller. There is no end-of-stream buffering.
- **Tool calls**: tool call argument chunks are suppressed during streaming and emitted as a restored chunk alongside the terminal message. This is not shown above for brevity.
- **Fallback path**: if no PII rules match, the relay Subject is closed and the pipeline falls through to a direct connector call with the original messages. If the workflow fails before calling `proceed` and `failureMode: 'allow_unsafe'` is configured, the same direct-inference fallback applies.

| PR | Enables |
|---|---|
| 1 (this) | Engine infrastructure: sync execution, in-memory state, timeout, type foundation |
| 2 | The anonymization workflow steps (`ai.pii.detect`, `ai.pii.restore`) and the provider that holds the token map |
| 3 | The `inference.aroundCompletion` hook; step allowlist replaced with definition-based check; OTel metrics |
| 4 | `agentId`/`sessionId` metadata propagation so the anonymization pipeline can scope decisions per session |
| 5 | `SyncLogDrain`: buffers event-log ES writes out-of-band so inline writes no longer block the sync hot path |

---

## Changes in this PR

- **`workflows_execution_engine`** — `runWorkflowSync`, `validateSyncWorkflow`, `executeWorkflowSync`, `InMemoryExecutionPersistence`, `ExecutionPersistence` interface update, sync branch in `workflowExecutionLoop`
- **`workflows_execution_engine` config** — `syncExecution.enabled` (boolean, default `false`) master switch; `syncExecution.maxDurationMs` (number, default 60 000 ms) wall-clock ceiling
- **`workflows_execution_engine` types** — `error?` on `ExecuteWorkflowResponse` (structured error forwarding for FAILED sync runs); `supportsSynchronousExecution: true` discriminant on the start contract
- **`workflows_extensions`** — `WorkflowExecutionCapability` / `WorkflowExecutionCapabilities` types; `capabilities?` added to `StepHandlerContext` so step handlers can receive request-local capabilities
- **`inference-common`** — `agentId`, `sessionId` on `ChatCompleteAnonymizationMetadata`
- **`inference` (server)** — `createPiiDetectionContext`, `PiiDetectionContext` (regex-backed entity scanner)

---

### Known gaps addressed in later PRs

| Finding | Fixed in |
|---|---|
| `validateSyncWorkflow` uses a hardcoded step-type allowlist — extension steps bypass pre-execution validation | [PR 3 — #280717](https://github.com/elastic/kibana/pull/280717): replaced with `supportedExecutionModes` check on step definitions |
| `runWorkflowSync` FAILED result drops `result.error` details from step failures | [PR 3 — #280717](https://github.com/elastic/kibana/pull/280717): adds `failureError` forwarding (`ExecuteWorkflowResponse.error?` introduced here) |
| No OTel metrics on the sync path (throughput, duration, outcome) | [PR 3 — #280717](https://github.com/elastic/kibana/pull/280717): adds `kibana.workflows.execution.sync.requests` and `kibana.workflows.execution.sync.duration` |
| `WorkflowEventLogger.flushEvents()` writes to Elasticsearch inline on every sync step | [PR 5 — #280849](https://github.com/elastic/kibana/pull/280849): `SyncLogDrain` buffers and batches writes out-of-band |

---

## How to test

The sync execution path introduced here has no UI entry point or direct HTTP API in this PR — the caller that invokes it (`inference.aroundCompletion`) is wired in PR 3. Manual verification is therefore limited to regression-checking the existing async path and confirming the new config keys are accepted.

**Automated tests** — run the new Jest suites directly:
```bash
node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.test.ts
```

**Async path regression** — run any existing workflow through the Workflows UI and confirm it still executes and reaches a terminal state normally. The async path is structurally unchanged; this is a smoke check that the shared plumbing (`setupDependencies`, `workflowExecutionLoop`) was not broken.

**Config keys accepted** — add the following to `kibana.yml`, start Kibana, and confirm no config-validation errors appear at boot:
```yaml
workflowsExecutionEngine:
  syncExecution:
    enabled: true
    maxDurationMs: 30000
```
With `enabled: false` (the default) any call with `executionMode: 'sync'` silently falls through to the normal Task Manager path. Toggling to `true` is the only way to activate the new code path manually — but without a sync caller (added in PR 3) the flag has no observable effect in the UI.

---

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

**Low risk overall.** The sync path is only entered when `executionMode: 'sync'` is explicitly passed; nothing in the existing runtime passes it until PR 3. The `supportsSynchronousExecution` flag and `error?` field are additive to their respective contracts.

**No crash recovery for sync executions** — intentional. Synchronous runs have no durable state and cannot be resumed after a crash. Each run is bounded by the lifetime of an HTTP request. A caller whose request is interrupted mid-execution gets an error; there is no orphaned execution to clean up.

**Config key requires cloud allowlisting** — `workflowsExecutionEngine.syncExecution.maxDurationMs` (number, default 60 000) must be added to the cloud config allowlist and docker env list before operators can tune it.

**Inline event-log writes remain** — `WorkflowEventLogger.flushEvents()` still calls `logsRepository.createLogs()` (an ES data-stream write) inline on every step in sync mode. This is a known throughput ceiling at target load. PR 5 addresses it with `SyncLogDrain`.

### Release note

> No user-facing changes — internal infrastructure for synchronous workflow execution and PII anonymization type foundation.

**Suggested label:** `release_note:skip`