### PR TITLE
[8.19] [CI] Add `failed-test` GitHub issue link in Test Failures annotation (#280527)

### DIFF
--- a/.buildkite/pipeline-utils/test-failures/annotate.test.ts
+++ b/.buildkite/pipeline-utils/test-failures/annotate.test.ts
@@ -48,6 +48,15 @@ describe('Annotate', () => {
         '**Test Failures**<br />\n[[job]](https://buildkite.com/elastic/kibana-pull-request/builds/53#job-id) [[logs]](https://buildkite.com/organizations/elastic/pipelines/kibana-pull-request/builds/53/jobs/job-id/artifacts/artifact-id) OSS CI Group #1 / test should fail'
       );
     });
+
+    it('should create an annotation with issue link if github issue is present', () => {
+      mockFailure.githubIssue = 'https://github.com/elastic/kibana/issues/1234';
+      const annotation = getAnnotation([mockFailure], mockArtifacts);
+
+      expect(annotation).toEqual(
+        '**Test Failures**<br />\n[[job]](https://buildkite.com/elastic/kibana-pull-request/builds/53#job-id) [[logs]](https://buildkite.com/organizations/elastic/pipelines/kibana-pull-request/builds/53/jobs/job-id/artifacts/artifact-id) [[issue]](https://github.com/elastic/kibana/issues/1234) OSS CI Group #1 / test should fail'
+      );
+    });
   });
 
   describe('getSlackMessage', () => {

--- a/.buildkite/pipeline-utils/test-failures/annotate.ts
+++ b/.buildkite/pipeline-utils/test-failures/annotate.ts
@@ -65,8 +65,9 @@ export const getAnnotation = (
             : '';
 
         const logsLink = artifactUrl ? ` [[logs]](${artifactUrl})` : '';
+        const issueLink = failure.githubIssue ? ` [[issue]](${failure.githubIssue})` : '';
 
-        return `[[job]](${jobUrl})${logsLink} ${failure.jobName} / ${failure.name}`;
+        return `[[job]](${jobUrl})${logsLink}${issueLink} ${failure.jobName} / ${failure.name}`;
       })
       .join('<br />\n')
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Add `failed-test` GitHub issue link in Test Failures annotation (#280527)](https://github.com/elastic/kibana/pull/280527)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cesare de Cal","email":"cesare.decal@elastic.co"},"sourceCommit":{"committedDate":"2026-07-24T08:56:18Z","message":"[CI] Add `failed-test` GitHub issue link in Test Failures annotation (#280527)\n\n## Summary\n\nAdds a clickable `[issue]` link to the Buildkite **Test Failures**\nannotation for every failure that has an associated `failed-test` GitHub\nissue.\n\nThe `githubIssue` field is already populated by\n`@kbn/failed-test-reporter-cli` (via the ci-stats lookup) and written\ninto the `target/test_failures/*.json` artifacts the annotator reads.\nPreviously it was only surfaced in the Slack message\n(`getSlackMessage`); now `getAnnotation` renders it too:\n\n```\n[job] [logs] [issue] Job Name / test name\n```\n\nThe link is omitted when a failure has no tracked issue. On PR pipelines\n(`REPORT_FAILED_TESTS_TO_GITHUB` unset), the reporter runs in dry-run,\nso the link only appears for failures that already have a tracked issue\n-- no issues are created or modified.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2ab043b37e5eeb8ad6abebb10ea255d27615c68a","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.6.0"],"title":"[CI] Add `failed-test` GitHub issue link in Test Failures annotation","number":280527,"url":"https://github.com/elastic/kibana/pull/280527","mergeCommit":{"message":"[CI] Add `failed-test` GitHub issue link in Test Failures annotation (#280527)\n\n## Summary\n\nAdds a clickable `[issue]` link to the Buildkite **Test Failures**\nannotation for every failure that has an associated `failed-test` GitHub\nissue.\n\nThe `githubIssue` field is already populated by\n`@kbn/failed-test-reporter-cli` (via the ci-stats lookup) and written\ninto the `target/test_failures/*.json` artifacts the annotator reads.\nPreviously it was only surfaced in the Slack message\n(`getSlackMessage`); now `getAnnotation` renders it too:\n\n```\n[job] [logs] [issue] Job Name / test name\n```\n\nThe link is omitted when a failure has no tracked issue. On PR pipelines\n(`REPORT_FAILED_TESTS_TO_GITHUB` unset), the reporter runs in dry-run,\nso the link only appears for failures that already have a tracked issue\n-- no issues are created or modified.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2ab043b37e5eeb8ad6abebb10ea255d27615c68a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280527","number":280527,"mergeCommit":{"message":"[CI] Add `failed-test` GitHub issue link in Test Failures annotation (#280527)\n\n## Summary\n\nAdds a clickable `[issue]` link to the Buildkite **Test Failures**\nannotation for every failure that has an associated `failed-test` GitHub\nissue.\n\nThe `githubIssue` field is already populated by\n`@kbn/failed-test-reporter-cli` (via the ci-stats lookup) and written\ninto the `target/test_failures/*.json` artifacts the annotator reads.\nPreviously it was only surfaced in the Slack message\n(`getSlackMessage`); now `getAnnotation` renders it too:\n\n```\n[job] [logs] [issue] Job Name / test name\n```\n\nThe link is omitted when a failure has no tracked issue. On PR pipelines\n(`REPORT_FAILED_TESTS_TO_GITHUB` unset), the reporter runs in dry-run,\nso the link only appears for failures that already have a tracked issue\n-- no issues are created or modified.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2ab043b37e5eeb8ad6abebb10ea255d27615c68a"}}]}] BACKPORT-->