### PR TITLE
[Chrome Next] Gate Add integrations button with permissions

### DIFF
--- a/src/core/packages/chrome/app-header/moon.yml
+++ b/src/core/packages/chrome/app-header/moon.yml
@@ -17,6 +17,7 @@ project:
   owner: '@elastic/appex-sharedux'
   sourceRoot: src/core/packages/chrome/app-header
 dependsOn:
+  - '@kbn/core-capabilities-common'
   - '@kbn/core-chrome-app-menu-components'
   - '@kbn/core-chrome-browser'
   - '@kbn/core-chrome-browser-context'

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
@@ -22,6 +22,12 @@ import type { AppHeaderMetadataItems } from '../types';
 import { AppHeaderView, DiscoverAppHeader } from './app_header';
 import { APP_HEADER_TEST_SUBJECTS } from './test_subjects';
 
+const createChromeWithIntegrationsAccess = (canAccessIntegrations: boolean) => {
+  const chrome = chromeServiceMock.createStartContract();
+  chrome.componentDeps.capabilities.navLinks.integrations = canAccessIntegrations;
+  return chrome;
+};
+
 const renderAppHeader = (
   ui: React.ReactElement,
   chrome: InternalChromeStart = chromeServiceMock.createStartContract()
@@ -124,10 +130,47 @@ describe('AppHeaderView', () => {
   });
 
   it('renders when the only content is a static app menu item', async () => {
-    renderAppHeader(<AppHeaderView showAddIntegrations />);
+    renderAppHeader(
+      <AppHeaderView showAddIntegrations />,
+      createChromeWithIntegrationsAccess(true)
+    );
 
     expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.root)).toBeInTheDocument();
     expect(await screen.findByTestId(APP_MENU_TEST_SUBJECTS.root)).toBeInTheDocument();
+  });
+
+  it('shows Add integrations when capabilities.navLinks.integrations is true', async () => {
+    renderAppHeader(
+      <AppHeaderView title="Workflows" showAddIntegrations />,
+      createChromeWithIntegrationsAccess(true)
+    );
+
+    fireEvent.click(await screen.findByTestId(APP_MENU_TEST_SUBJECTS.overflowButton));
+    expect(await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.menuAddIntegrations)).toHaveAttribute(
+      'href',
+      '/app/integrations/browse'
+    );
+  });
+
+  it('hides Add integrations when capabilities.navLinks.integrations is false', async () => {
+    renderAppHeader(
+      <AppHeaderView title="Workflows" showAddIntegrations docLink="https://example.com/docs" />,
+      createChromeWithIntegrationsAccess(false)
+    );
+
+    fireEvent.click(await screen.findByTestId(APP_MENU_TEST_SUBJECTS.overflowButton));
+    expect(
+      screen.queryByTestId(APP_HEADER_TEST_SUBJECTS.menuAddIntegrations)
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render when Add integrations is the only content and access is denied', () => {
+    renderAppHeader(
+      <AppHeaderView showAddIntegrations />,
+      createChromeWithIntegrationsAccess(false)
+    );
+
+    expect(screen.queryByTestId(APP_HEADER_TEST_SUBJECTS.root)).not.toBeInTheDocument();
   });
 
   it('renders Discover tabs beside the title', () => {

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
@@ -27,7 +27,7 @@ import { TitleArea } from './title_area';
 import { TitleActions } from './title_actions';
 import { AppMenu } from './app_menu';
 import { AppHeaderMetadata } from './app_header_metadata';
-import { useResolvedBadges, useShareAction } from './hooks';
+import { useCanAccessIntegrations, useResolvedBadges, useShareAction } from './hooks';
 
 export interface AppHeaderViewProps {
   title?: AppHeaderTitle;
@@ -113,6 +113,8 @@ const AppHeaderViewInternal = React.memo<AppHeaderViewInternalProps>(
     const hasLegacyActionMenu = useHasLegacyActionMenu();
     const shareAction = useShareAction(menu);
     const resolvedBadges = useResolvedBadges(badges);
+    const canAccessIntegrations = useCanAccessIntegrations();
+    const showIntegrations = !!showAddIntegrations && canAccessIntegrations;
 
     // Sparse legacy states (only a back and/or overflow-menu button, no title or other content) look
     // too tall at the standard height, so default them to the shorter `compact` spacing. An explicit
@@ -141,7 +143,7 @@ const AppHeaderViewInternal = React.memo<AppHeaderViewInternalProps>(
       !!favorite ||
       !!metadata?.length ||
       !!docLink ||
-      !!showAddIntegrations ||
+      showIntegrations ||
       hasLegacyActionMenu;
 
     if (!show) {

--- a/src/core/packages/chrome/app-header/src/app_header/hooks/chrome.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/hooks/chrome.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Capabilities } from '@kbn/core-capabilities-common';
 import type { IBasePath } from '@kbn/core-http-browser';
 import type { MountPoint } from '@kbn/core-mount-utils-browser';
 import { useObservable } from '@kbn/use-observable';
@@ -16,6 +17,18 @@ import { useChromeService } from '@kbn/core-chrome-browser-context';
 // Chrome-owned dependencies that are not part of the public plugin contract.
 export function useBasePath(): IBasePath {
   return useChromeService().componentDeps.basePath;
+}
+
+export function useCapabilities(): Capabilities {
+  return useChromeService().componentDeps.capabilities;
+}
+
+/**
+ * True when the current user can access the Integrations app.
+ * Same signal used by Home and NoDataCard (`capabilities.navLinks.integrations`).
+ */
+export function useCanAccessIntegrations(): boolean {
+  return useCapabilities().navLinks.integrations === true;
 }
 
 export function useLegacyActionMenu(): MountPoint | undefined {

--- a/src/core/packages/chrome/app-header/src/app_header/hooks/index.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/hooks/index.ts
@@ -7,7 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { useBasePath, useLegacyActionMenu, useHasLegacyActionMenu } from './chrome';
+export {
+  useBasePath,
+  useCanAccessIntegrations,
+  useCapabilities,
+  useLegacyActionMenu,
+  useHasLegacyActionMenu,
+} from './chrome';
 export { useBackNavTargets } from './use_back_navigation';
 export type { BackNavigation } from './use_back_navigation';
 export { useResolvedBadges } from './use_app_badges';

--- a/src/core/packages/chrome/app-header/src/app_header/hooks/use_app_header_menu.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/hooks/use_app_header_menu.ts
@@ -14,7 +14,7 @@ import { useChromeService } from '@kbn/core-chrome-browser-context';
 import { useObservable } from '@kbn/use-observable';
 import { i18n } from '@kbn/i18n';
 
-import { useBasePath } from './chrome';
+import { useBasePath, useCanAccessIntegrations } from './chrome';
 import { APP_HEADER_TEST_SUBJECTS } from '../test_subjects';
 
 const createIntegrationsMenuItem = (href: string): AppMenuStaticItem => ({
@@ -61,6 +61,7 @@ export const useAppHeaderStaticItems = ({
 }): AppMenuStaticItem[] => {
   const chrome = useChromeService();
   const basePath = useBasePath();
+  const canAccessIntegrations = useCanAccessIntegrations();
   const feedbackHandler = useObservable(chrome.next.getFeedbackHandler$(), undefined);
   const helpExtension = useObservable(chrome.getHelpExtension$(), undefined);
 
@@ -82,13 +83,19 @@ export const useAppHeaderStaticItems = ({
       staticItems.push(createDocumentationMenuItem(docLink));
     }
 
-    if (showAddIntegrations) {
-      // FIXME: https://github.com/elastic/kibana/issues/271295 - handle edge case where fleet is not enabled or user doesn't have permissions to view it
+    if (showAddIntegrations && canAccessIntegrations) {
       staticItems.push(createIntegrationsMenuItem(basePath.prepend('/app/integrations/browse')));
     }
 
     return staticItems;
-  }, [basePath, explicitDocLink, helpExtension, showAddIntegrations, feedbackHandler]);
+  }, [
+    basePath,
+    canAccessIntegrations,
+    explicitDocLink,
+    helpExtension,
+    showAddIntegrations,
+    feedbackHandler,
+  ]);
 };
 
 export interface ShareAction {

--- a/src/core/packages/chrome/app-header/tsconfig.json
+++ b/src/core/packages/chrome/app-header/tsconfig.json
@@ -7,6 +7,7 @@
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["target/**/*"],
   "kbn_references": [
+    "@kbn/core-capabilities-common",
     "@kbn/core-chrome-app-menu-components",
     "@kbn/core-chrome-browser",
     "@kbn/core-chrome-browser-context",

--- a/src/core/packages/chrome/browser-internal-types/index.ts
+++ b/src/core/packages/chrome/browser-internal-types/index.ts
@@ -9,6 +9,7 @@
 
 import type { ReactNode } from 'react';
 import type { Observable } from 'rxjs';
+import type { Capabilities } from '@kbn/core-capabilities-common';
 import type { IBasePath } from '@kbn/core-http-browser';
 import type { MountPoint } from '@kbn/core-mount-utils-browser';
 import type {
@@ -44,6 +45,7 @@ export interface InternalChromeStart extends ChromeStart {
   componentDeps: {
     readonly basePath: IBasePath;
     readonly legacyActionMenu$: Observable<MountPoint | undefined>;
+    readonly capabilities: Capabilities;
   };
 
   sideNav: ChromeStart['sideNav'] & {

--- a/src/core/packages/chrome/browser-internal-types/moon.yml
+++ b/src/core/packages/chrome/browser-internal-types/moon.yml
@@ -17,6 +17,7 @@ project:
   owner: '@elastic/appex-sharedux'
   sourceRoot: src/core/packages/chrome/browser-internal-types
 dependsOn:
+  - '@kbn/core-capabilities-common'
   - '@kbn/core-chrome-browser'
   - '@kbn/core-http-browser'
   - '@kbn/core-mount-utils-browser'

--- a/src/core/packages/chrome/browser-internal-types/tsconfig.json
+++ b/src/core/packages/chrome/browser-internal-types/tsconfig.json
@@ -11,6 +11,7 @@
     "target/**/*"
   ],
   "kbn_references": [
+    "@kbn/core-capabilities-common",
     "@kbn/core-chrome-browser",
     "@kbn/core-http-browser",
     "@kbn/core-mount-utils-browser",

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -192,6 +192,7 @@ export class ChromeService {
       componentDeps: {
         basePath: http.basePath,
         legacyActionMenu$: application.currentActionMenu$,
+        capabilities: application.capabilities,
       },
     });
 

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.tsx
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.tsx
@@ -63,6 +63,11 @@ const createStartContractMock = () => {
       legacyActionMenu$: new BehaviorSubject<MountPoint | undefined>(
         undefined
       ) as unknown as DeeplyMockedKeys<Observable<MountPoint | undefined>>,
+      capabilities: lazyObject({
+        navLinks: {},
+        management: {},
+        catalogue: {},
+      }),
     }),
     sidebar: lazyObject(sidebar),
     navLinks: lazyObject({

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.storybook_mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.storybook_mock.ts
@@ -23,6 +23,7 @@ type ChromeStorybookStart = Pick<
   componentDeps: {
     basePath: Pick<InternalChromeStart['componentDeps']['basePath'], 'get' | 'prepend'>;
     legacyActionMenu$: InternalChromeStart['componentDeps']['legacyActionMenu$'];
+    capabilities: Pick<InternalChromeStart['componentDeps']['capabilities'], 'navLinks'>;
   };
 };
 
@@ -31,8 +32,8 @@ type ChromeStorybookStart = Pick<
  *
  * Unlike {@link chromeServiceMock}, this does not use `jest`, so it can run in the Storybook
  * runtime. It implements only the surface Chrome-owned React components read when rendered
- * under `ChromeServiceProvider` (base path, the legacy action menu, the feedback handler,
- * and the badge/help observables); everything else is intentionally omitted behind a
+ * under `ChromeServiceProvider` (base path, the legacy action menu, capabilities, the feedback
+ * handler, and the badge/help observables); everything else is intentionally omitted behind a
  * single cast.
  */
 export const createChromeStorybookStart = (): InternalChromeStart => {
@@ -43,6 +44,9 @@ export const createChromeStorybookStart = (): InternalChromeStart => {
         prepend: (path: string) => path,
       },
       legacyActionMenu$: new BehaviorSubject(undefined),
+      capabilities: {
+        navLinks: { integrations: true },
+      },
     },
     next: {
       getFeedbackHandler$: () => new BehaviorSubject<(() => void) | undefined>(undefined),


### PR DESCRIPTION
## Summary

This PR adds permission checks to `Add integrations` static item in app menu.

Closes: https://github.com/elastic/kibana/issues/271295

