### PR TITLE
[Chrome Next] Make Discover's title actions always visible, make `borderless` internal to discover 

### DIFF
--- a/src/core/packages/chrome/app-header/README.md
+++ b/src/core/packages/chrome/app-header/README.md
@@ -38,7 +38,8 @@ primitive behind the React APIs.
 Discover uses `DiscoverAppHeader` from `@kbn/app-header/discover` to place its UnifiedTabs bar beside
 the title. This is a Discover-specific layout exception; other apps should use the structured
 `tabs` or `badges` props on `AppHeader`. The public header components discard undeclared props, so
-this internal title slot cannot be forced through a type suppression.
+this internal title slot cannot be forced through a type suppression. When the tabs bar is present,
+it owns the bottom separator and title actions remain visible without hovering.
 
 ## Editable titles
 

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
@@ -356,7 +356,7 @@ describe('AppHeaderView', () => {
     });
   });
 
-  describe('borderless flag', () => {
+  describe('bottom border', () => {
     it('renders a bottom border by default', () => {
       renderAppHeader(<AppHeaderView title="Dashboard" />);
 
@@ -366,8 +366,8 @@ describe('AppHeaderView', () => {
       );
     });
 
-    it('omits the bottom border when borderless is set', () => {
-      renderAppHeader(<AppHeaderView title="Dashboard" borderless />);
+    it('omits the bottom border for Discover tabs', () => {
+      renderAppHeader(<DiscoverAppHeader title="Discover" tabsBar={<div>Tabs</div>} />);
 
       expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.root)).not.toHaveStyleRule(
         'border-bottom',

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
@@ -55,15 +55,11 @@ export interface AppHeaderViewProps {
   spacing?: AppHeaderSpacing;
   docLink?: string;
   showAddIntegrations?: boolean;
-  /**
-   * Omits the header's bottom border. Used when the content rendered below the header owns the
-   * separating line instead (e.g. Discover using UnifiedTabs).
-   */
-  borderless?: boolean;
 }
 
 interface AppHeaderViewInternalProps extends AppHeaderViewProps {
   titleAppend?: ReactNode;
+  borderless?: boolean;
 }
 
 const getPublicAppHeaderViewProps = ({
@@ -78,7 +74,6 @@ const getPublicAppHeaderViewProps = ({
   spacing,
   docLink,
   showAddIntegrations,
-  borderless,
 }: AppHeaderViewProps): AppHeaderViewProps => ({
   title,
   back,
@@ -91,7 +86,6 @@ const getPublicAppHeaderViewProps = ({
   spacing,
   docLink,
   showAddIntegrations,
-  borderless,
 });
 
 const AppHeaderViewInternal = React.memo<AppHeaderViewInternalProps>(
@@ -210,6 +204,7 @@ export const DiscoverAppHeader = React.memo<DiscoverAppHeaderProps>(({ tabsBar, 
     {...getPublicAppHeaderViewProps(props)}
     title={props.title}
     titleAppend={tabsBar}
+    borderless={tabsBar != null}
   />
 ));
 

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_shell.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_shell.tsx
@@ -204,8 +204,8 @@ const useHeaderStyles = (
       flex-shrink: 0;
       align-items: center;
       gap: ${euiTheme.size.xs};
-      opacity: 0;
-      pointer-events: none;
+      opacity: ${hasTitleAppend ? 1 : 0};
+      pointer-events: ${hasTitleAppend ? 'auto' : 'none'};
       transition: opacity ${euiTheme.animation.fast} ease;
     `;
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/chrome_app_header/chrome_app_header.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chrome_app_header/chrome_app_header.tsx
@@ -21,10 +21,9 @@ import { useIsChromeNextProjectHeader } from './use_is_chrome_next_project_heade
 interface ChromeAppHeaderProps {
   menu?: AppMenuConfig;
   tabsBar?: ReactNode;
-  hasTabs?: boolean;
 }
 
-export const ChromeAppHeader = ({ menu, tabsBar, hasTabs = false }: ChromeAppHeaderProps) => {
+export const ChromeAppHeader = ({ menu, tabsBar }: ChromeAppHeaderProps) => {
   const { embeddableEditor } = useDiscoverServices();
   const isChromeNextProjectHeader = useIsChromeNextProjectHeader();
   const persistedDiscoverSession = useInternalStateSelector(
@@ -86,7 +85,6 @@ export const ChromeAppHeader = ({ menu, tabsBar, hasTabs = false }: ChromeAppHea
         sticky={false}
         spacing="compact"
         tabsBar={tabsBar}
-        borderless={hasTabs}
       />
     </div>
   );

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
@@ -74,9 +74,7 @@ export const TabsView = (props: SingleTabViewProps) => {
 
   const wrapTabsBar = useMemo((): UnifiedTabsProps['wrapTabsBar'] => {
     if (isChromeNextProjectHeader) {
-      return (tabsBar) => (
-        <ChromeAppHeader menu={topNavMenuItems} hasTabs={Boolean(tabsBar)} tabsBar={tabsBar} />
-      );
+      return (tabsBar) => <ChromeAppHeader menu={topNavMenuItems} tabsBar={tabsBar} />;
     }
   }, [isChromeNextProjectHeader, topNavMenuItems]);
 


### PR DESCRIPTION
## Summary


We [discussed](https://elastic.slack.com/archives/C0ANQ2123J4/p1784200389560379) that hover actions do not work well for Discover because of the tabs. There is odd spacing. I think it makes sense to make Discover an exception again and always show "share" without hover.


**Before: Share only on hover, but there is always weird space left**
<img width="1542" height="910" alt="Screenshot 2026-07-24 at 13 31 38" src="https://github.com/user-attachments/assets/b282ad37-3d4d-43d4-aca2-af00337c8fbd" />

**After: share always shown**
<img width="1542" height="910" alt="Screenshot 2026-07-24 at 13 31 16" src="https://github.com/user-attachments/assets/94019e56-41d7-4116-99d9-e616b7783ea6" />

