### PR TITLE
[oblt/type-check] Restore GCS build cache for `--project` runs

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/run_type_check_cli.test.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/run_type_check_cli.test.ts
@@ -211,7 +211,7 @@ describe('type_check orchestration', () => {
     });
   });
 
-  describe('smart restore (local, no --project)', () => {
+  describe('smart restore (local)', () => {
     it('calls resolveRestoreStrategy and restores when shouldRestore is true', async () => {
       resolveRestoreStrategy.mockResolvedValueOnce({
         shouldRestore: true,
@@ -265,7 +265,17 @@ describe('type_check orchestration', () => {
       );
     });
 
-    it('skips resolveRestoreStrategy when --project filter is set', async () => {
+    it('still resolves the restore strategy and restores when a --project filter is set', async () => {
+      // A scoped run can face a cold cache too (e.g. a fresh worktree). The
+      // restore decision is repo-wide and project-agnostic, so it must run
+      // regardless of --project; otherwise a heavy closure rebuilds from scratch.
+      resolveRestoreStrategy.mockResolvedValueOnce({
+        shouldRestore: true,
+        bestSha: 'abc123def456',
+        staleProjects: [],
+        cacheServerAvailable: true,
+      });
+
       const log = createLog();
       const procRunner = createProcRunner();
       const flagsReader = makeFlagsReader({
@@ -274,8 +284,13 @@ describe('type_check orchestration', () => {
 
       await runCallback({ log, flagsReader, procRunner });
 
-      expect(resolveRestoreStrategy).not.toHaveBeenCalled();
-      expect(restoreTSBuildArtifacts).not.toHaveBeenCalled();
+      expect(resolveRestoreStrategy).toHaveBeenCalledWith(log, expect.any(Array));
+      expect(restoreTSBuildArtifacts).toHaveBeenCalledWith(log, 'abc123def456', {
+        staleProjects: [],
+        prNumber: undefined,
+        prTipSha: undefined,
+        skipCacheServer: false,
+      });
     });
   });
 

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/run_type_check_cli.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/run_type_check_cli.ts
@@ -130,17 +130,23 @@ run(
     } else {
       await updateRootRefsConfig(log);
 
-      if (!projectFilter) {
-        const strategy = await resolveRestoreStrategy(log, TS_PROJECTS);
-        if (strategy.shouldRestore && strategy.bestSha) {
-          await restoreTSBuildArtifacts(log, strategy.bestSha, {
-            staleProjects: strategy.staleProjects,
-            prNumber: strategy.prNumber,
-            prTipSha: strategy.prTipSha,
-            skipCacheServer: !strategy.cacheServerAvailable,
-          });
-          didRestore = true;
-        }
+      // Restore is decided from repo-wide staleness vs the local artifact state,
+      // independent of which project(s) we ultimately check — so it applies to
+      // `--project` runs too. This matters most for heavy closures (e.g. the
+      // synthetics plugin pulls in ~930 upstream projects): on a cold cache a
+      // scoped run would otherwise build the whole closure from scratch instead
+      // of restoring it from GCS. The HEAD artifacts-state write stays gated on
+      // `!projectFilter` below, so a scoped run never falsely marks every project
+      // fresh.
+      const strategy = await resolveRestoreStrategy(log, TS_PROJECTS);
+      if (strategy.shouldRestore && strategy.bestSha) {
+        await restoreTSBuildArtifacts(log, strategy.bestSha, {
+          staleProjects: strategy.staleProjects,
+          prNumber: strategy.prNumber,
+          prTipSha: strategy.prTipSha,
+          skipCacheServer: !strategy.cacheServerAvailable,
+        });
+        didRestore = true;
       }
     }
 


### PR DESCRIPTION
## Summary

The observability `type_check` CLI (`@kbn/ts-type-check-oblt-cli`) restores prebuilt TypeScript build artifacts from GCS to make incremental checks fast. That restore was gated out whenever a `--project` filter was set — so **scoped runs never used the online cache** and, on a cold cache (e.g. a fresh `git worktree`), rebuilt the project's entire upstream closure from scratch.

That closure can be very large. The **synthetics** plugin transitively references **~930 of the repo's ~1,455 TS projects**, so `--project x-pack/.../synthetics/tsconfig.json` cold-built almost the whole graph (20+ min), while the equivalent full run restored from GCS in 1–2 min.

## What changed

- `run_type_check_cli.ts`: run `resolveRestoreStrategy` (and the GCS restore) regardless of `--project`. The restore decision is computed from repo-wide staleness vs the local artifact state and is independent of which project(s) are ultimately checked, so it's safe for scoped runs.
- The `HEAD` artifacts-state write stays gated on `!projectFilter`, so a scoped run still never marks every project as fresh (verified by the existing `does not write state file when --project filter is used` test).
- Updated the unit test that previously asserted the (now-removed) skip behavior.

## Why it's safe

`resolveRestoreStrategy` already:
- only restores when the effective rebuild count exceeds its threshold and a GCS archive would actually reduce work,
- is a no-op on a warm/fresh local cache,
- invalidates stale `.tsbuildinfo` for correctness.

None of that logic is project-specific. The only thing that must remain full-run-only — writing `HEAD` to the artifacts-state file — is left gated.

## Test plan

- [x] `node scripts/jest .../run_type_check_cli.test.ts` — 18/18 pass
- [x] `node scripts/eslint` on both files — clean
- [x] Type-check of the package (dogfooded through the new CLI) — clean
- [x] Manual, fresh worktree (cold cache): `--project synthetics` now logs a GCS restore and completes in ~2 min instead of 20+.

cc @elastic/observability-ui (package owner)

Made with [Cursor](https://cursor.com)