### PR TITLE
[9.5] Improve legacy js-yaml legacy consumers list (#280720)

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -20,39 +20,66 @@
 const { USES_STYLED_COMPONENTS } = require('@kbn/babel-preset/styled_components_files');
 
 /**
+ * Compile an exact, kibana-root-relative file path (forward slashes) into an
+ * anchored regex. A regex is required because the `module_migration` rule matches
+ * each `exclude` with `RegExp.test()` against a path that uses the OS-native
+ * separator, so each `/` is matched as `[\/\\]` to also work on Windows.
+ */
+const exactFilePathMatcher = (relativePath) =>
+  new RegExp(
+    `^${relativePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\//g, '[\\/\\\\]')}$`
+  );
+
+/**
  * Files that already import js-yaml. New js-yaml imports must not be added here;
  * this list is expected to shrink as consumers migrate to the `yaml` package.
- * Each entry is an anchored regex tested against the kibana-root-relative file path.
+ * Each entry is an exact file path, so adding a new js-yaml import (even in an
+ * already-listed directory) is flagged until that file is migrated or added here.
  * The `module_migration` rule evaluates each mapping independently, so this list
  * does not interact with other allowlists (e.g. AXIOS_LEGACY_CONSUMERS in .eslintrc.js).
  */
 const JS_YAML_LEGACY_CONSUMERS = [
-  /^packages[\/\\]kbn-rspack-optimizer[\/\\]/,
-  /^src[\/\\]platform[\/\\]kbn-ui[\/\\]_tooling[\/\\]/,
-  /^src[\/\\]platform[\/\\]packages[\/\\]private[\/\\]kbn-gen-ai-functional-testing[\/\\]/,
-  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-connector-cli[\/\\]/,
-  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-edot-collector[\/\\]/,
-  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-otel-demo[\/\\]/,
-  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-scout[\/\\]/,
-  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-synthtrace[\/\\]src[\/\\]cli[\/\\]/,
-  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-test[\/\\]src[\/\\]functional_test_runner[\/\\]/,
-  /^src[\/\\]platform[\/\\]plugins[\/\\]private[\/\\]interactive_setup[\/\\]server[\/\\]/,
-  /^x-pack[\/\\]packages[\/\\]kbn-synthetics-private-location[\/\\]/,
-  /^x-pack[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-data-forge[\/\\]/,
-  /^x-pack[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]response-ops[\/\\]alerting-v2-rule-form[\/\\]/,
-  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]agent_builder[\/\\]server[\/\\]services[\/\\]/,
-  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]/,
-  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]inference[\/\\]scripts[\/\\]/,
-  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]rule_registry[\/\\]scripts[\/\\]/,
-  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]streams[\/\\]scripts[\/\\]/,
-  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]packages[\/\\]synthetics-test-data[\/\\]/,
-  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]apm[\/\\]scripts[\/\\]/,
-  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]apm[\/\\]server[\/\\]routes[\/\\]fleet[\/\\]/,
-  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]observability_ai_assistant_app[\/\\]scripts[\/\\]/,
-  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]observability_onboarding[\/\\]server[\/\\]routes[\/\\]flow[\/\\]/,
-  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]synthetics[\/\\]public[\/\\]/,
-  /^x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]cloud_defend[\/\\]/,
-];
+  'packages/kbn-rspack-optimizer/src/limits.ts',
+  'src/platform/kbn-ui/_tooling/affected_packages.ts',
+  'src/platform/packages/private/kbn-gen-ai-functional-testing/src/connectors.ts',
+  'src/platform/packages/shared/kbn-connector-cli/src/create_connectors/manifest_loader.ts',
+  'src/platform/packages/shared/kbn-edot-collector/src/get_edot_collector_configuration.ts',
+  'src/platform/packages/shared/kbn-edot-collector/src/read_kibana_config.ts',
+  'src/platform/packages/shared/kbn-otel-demo/src/demos/aws_retail_store/manifests.ts',
+  'src/platform/packages/shared/kbn-otel-demo/src/demos/bank_of_anthos/manifests.ts',
+  'src/platform/packages/shared/kbn-otel-demo/src/demos/quarkus_super_heroes/manifests.ts',
+  'src/platform/packages/shared/kbn-otel-demo/src/demos/rust_k8s_demo/manifests.ts',
+  'src/platform/packages/shared/kbn-otel-demo/src/get_edot_k8s_collector_config.ts',
+  'src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts',
+  'src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/agent_builder_smoke/stateful/classic.stateful.config.ts',
+  'src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts',
+  'src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.ts',
+  'src/platform/packages/shared/kbn-synthtrace/src/cli/utils/read_kibana_config.ts',
+  'src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts',
+  'src/platform/plugins/private/interactive_setup/server/kibana_config_writer.ts',
+  'x-pack/packages/kbn-synthetics-private-location/src/lib/parse_cli_options.ts',
+  'x-pack/platform/packages/shared/kbn-data-forge/src/lib/create_config.ts',
+  'x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.test.ts',
+  'x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.ts',
+  'x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/yaml_rule_form.test.tsx',
+  'x-pack/platform/plugins/shared/agent_builder/server/services/plugins/utils/parsing/parse_skill_file.ts',
+  'x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx',
+  'x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/component_config_tab.tsx',
+  'x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/yaml_viewer.test.tsx',
+  'x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/yaml_viewer.tsx',
+  'x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts',
+  'x-pack/platform/plugins/shared/inference/scripts/util/read_kibana_config.ts',
+  'x-pack/platform/plugins/shared/rule_registry/scripts/generate_ecs_fieldmap/index.js',
+  'x-pack/solutions/observability/packages/synthetics-test-data/src/e2e/tasks/read_kibana_config.ts',
+  'x-pack/solutions/observability/plugins/apm/scripts/shared/read_kibana_config.ts',
+  'x-pack/solutions/observability/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts',
+  'x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/read_kibana_config.ts',
+  'x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/generate_agent_config.test.ts',
+  'x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/generate_agent_config.ts',
+  'x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_inspect.tsx',
+  'x-pack/solutions/security/plugins/cloud_defend/common/utils/helpers.ts',
+  'x-pack/solutions/security/plugins/cloud_defend/public/components/control_general_view/index.test.tsx',
+].map(exactFilePathMatcher);
 
 const USES_ELASTIC_APM_AGENT = [
   // Core platform APM integration & agent infrastructure


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Improve legacy js-yaml legacy consumers list (#280720)](https://github.com/elastic/kibana/pull/280720)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-24T12:05:08Z","message":"Improve legacy js-yaml legacy consumers list (#280720)\n\n## Summary\n\nThis PR updates the legacy js-yaml consumers list to be file-specific.\nThe previous list was too broad and allowed teams to begin\nre-introducing js-yaml references.","sha":"d078c9f004cc750a3ff5c50188b0bc92e86a7e3b","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.6.0"],"title":"Improve js-yaml legacy consumers list","number":280720,"url":"https://github.com/elastic/kibana/pull/280720","mergeCommit":{"message":"Improve legacy js-yaml legacy consumers list (#280720)\n\n## Summary\n\nThis PR updates the legacy js-yaml consumers list to be file-specific.\nThe previous list was too broad and allowed teams to begin\nre-introducing js-yaml references.","sha":"d078c9f004cc750a3ff5c50188b0bc92e86a7e3b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280720","number":280720,"mergeCommit":{"message":"Improve legacy js-yaml legacy consumers list (#280720)\n\n## Summary\n\nThis PR updates the legacy js-yaml consumers list to be file-specific.\nThe previous list was too broad and allowed teams to begin\nre-introducing js-yaml references.","sha":"d078c9f004cc750a3ff5c50188b0bc92e86a7e3b"}}]}] BACKPORT-->