### PR TITLE
[9.4] [Security Solution] Add logic to post initialization open api docs (#279526)

### DIFF
--- a/.buildkite/scripts/steps/openapi_bundling/security_solution_openapi_bundling.sh
+++ b/.buildkite/scripts/steps/openapi_bundling/security_solution_openapi_bundling.sh
@@ -27,6 +27,9 @@ echo -e "\n[Security Solution OpenAPI Bundling] Endpoint Exceptions API\n"
 echo -e "\n[Security Solution OpenAPI Bundling] Endpoint Management API\n"
 (cd x-pack/solutions/security/plugins/security_solution && yarn openapi:bundle:endpoint-management)
 
+echo -e "\n[Security Solution OpenAPI Bundling] Initialization API\n"
+(cd x-pack/solutions/security/plugins/security_solution && yarn openapi:bundle:initialization)
+
 echo -e "\n[Security Solution OpenAPI Bundling] Elastic Assistant API\n"
 (cd x-pack/platform/packages/shared/kbn-elastic-assistant-common && yarn openapi:bundle)
 

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -292,6 +292,12 @@ tags:
   - description: Run live queries, manage packs and saved queries.
     name: Security Osquery API
     x-displayName: Security Osquery
+  - description: |
+      Use the initialization API to set up the assets Elastic Security needs to operate in a Kibana space.
+
+      A single request can run one or more initialization flows. Each flow provisions a specific set of assets (for example, list indices, security data views, prebuilt detection rules, endpoint protection, AI prompts, or detection rule monitoring assets). The response reports a per-flow result so you can tell which flows completed and which returned an error.
+    name: Security Solution Initialization API
+    x-displayName: Security solution initialization
   - description: You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.
     name: Security Timeline API
     x-displayName: Security timeline
@@ -47706,6 +47712,83 @@ paths:
       summary: Get prompts
       tags:
         - Security AI Assistant API
+      x-metaTags:
+        - content: Kibana, Elastic Cloud Serverless
+          name: product_name
+  /api/security_solution/initialize:
+    post:
+      description: |
+        **Spaces method and path for this operation:**
+
+        <div><span class="operation-verb post">post</span>&nbsp;<span class="operation-path">/s/{space_id}/api/security_solution/initialize</span></div>
+
+        Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
+
+        Run one or more Security Solution initialization flows for the current space.
+        Each flow provisions a specific set of assets, for example list indices,
+        security data views, prebuilt detection rules, endpoint protection, AI prompts,
+        or detection rule monitoring assets. Only the requested flows are run, and the
+        response reports a result for each one.
+      operationId: InitializeSecuritySolution
+      requestBody:
+        content:
+          application/json:
+            examples:
+              default:
+                value:
+                  flows:
+                    - init-prebuilt-rules
+                    - init-endpoint-protection
+                    - init-ai-prompts
+            schema:
+              type: object
+              properties:
+                flows:
+                  items:
+                    $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowId'
+                  minItems: 1
+                  type: array
+              required:
+                - flows
+        description: The initialization flows to run.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    flows:
+                      init-ai-prompts:
+                        payload:
+                          install_status: installed
+                          name: security_ai_prompts
+                          version: 8.17.1
+                        status: ready
+                      init-endpoint-protection:
+                        payload:
+                          install_status: already_installed
+                          name: endpoint
+                          version: 8.17.1
+                        status: ready
+                      init-prebuilt-rules:
+                        payload:
+                          install_status: installed
+                          name: security_detection_engine
+                          version: 8.17.1
+                        status: ready
+              schema:
+                type: object
+                properties:
+                  flows:
+                    $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowsResult'
+                required:
+                  - flows
+          description: Indicates a successful call. Returns a result for each requested flow.
+      summary: Initialize security solution flows
+      tags:
+        - Security Solution Initialization API
       x-metaTags:
         - content: Kibana, Elastic Cloud Serverless
           name: product_name
@@ -123113,6 +123196,144 @@ components:
     Security_Osquery_API_VersionOrUndefined:
       $ref: '#/components/schemas/Security_Osquery_API_Version'
       nullable: true
+    Security_Solution_Initialization_API_CreateListIndicesReadyResult:
+      type: object
+      properties:
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+    Security_Solution_Initialization_API_DataViewPayload:
+      type: object
+      properties:
+        id:
+          type: string
+        patternList:
+          items:
+            type: string
+          type: array
+        title:
+          type: string
+      required:
+        - id
+        - title
+        - patternList
+    Security_Solution_Initialization_API_InitializationFlowErrorResult:
+      type: object
+      properties:
+        error:
+          nullable: true
+          type: string
+        status:
+          enum:
+            - error
+          type: string
+      required:
+        - status
+        - error
+    Security_Solution_Initialization_API_InitializationFlowId:
+      description: Identifier for an initialization flow.
+      enum:
+        - create-list-indices
+        - security-data-views
+        - init-prebuilt-rules
+        - init-endpoint-protection
+        - init-ai-prompts
+        - init-detection-rule-monitoring
+      type: string
+    Security_Solution_Initialization_API_InitializationFlowsResult:
+      description: Per-flow results. Only requested flows appear in the response, so all properties are optional. Each flow is either a typed ready result or an error result.
+      type: object
+      properties:
+        create-list-indices:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_CreateListIndicesReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        init-ai-prompts:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_PackageInstallReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        init-detection-rule-monitoring:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InstallDetectionEngineRuleMonitoringAssetsReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        init-endpoint-protection:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_PackageInstallReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        init-prebuilt-rules:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_PackageInstallReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        security-data-views:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_SecurityDataViewsReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+    Security_Solution_Initialization_API_InstallDetectionEngineRuleMonitoringAssetsReadyResult:
+      type: object
+      properties:
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+    Security_Solution_Initialization_API_PackageInstallReadyResult:
+      type: object
+      properties:
+        payload:
+          type: object
+          properties:
+            install_status:
+              description: Fleet package installation status (e.g., installed, already_installed).
+              type: string
+            name:
+              type: string
+            version:
+              type: string
+          required:
+            - name
+            - version
+            - install_status
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+        - payload
+    Security_Solution_Initialization_API_SecurityDataViewsReadyResult:
+      type: object
+      properties:
+        payload:
+          type: object
+          properties:
+            alertDataView:
+              $ref: '#/components/schemas/Security_Solution_Initialization_API_DataViewPayload'
+            attackDataView:
+              $ref: '#/components/schemas/Security_Solution_Initialization_API_DataViewPayload'
+            defaultDataView:
+              $ref: '#/components/schemas/Security_Solution_Initialization_API_DataViewPayload'
+            kibanaDataViews:
+              items:
+                $ref: '#/components/schemas/Security_Solution_Initialization_API_DataViewPayload'
+              type: array
+            signalIndexName:
+              type: string
+          required:
+            - defaultDataView
+            - alertDataView
+            - kibanaDataViews
+            - signalIndexName
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+        - payload
     Security_Timeline_API_AssociatedFilterType:
       description: |
         How the note is associated with a Timeline saved object and/or an event (`eventId`). `all`: no association-based restriction from this parameter. `document_only`: document-linked notes (non-empty `eventId`) without timeline association in the API's internal sense; post-filtering drops notes without a usable `eventId`. `saved_object_only`: timeline notes with no linked event (`eventId` empty or absent); post-filtering keeps timeline-only notes. `document_and_saved_object`: notes on a timeline and linked to an event; post-filtering enforces a real `eventId`. `orphan`: not on a timeline and `eventId` is empty (stricter than missing `eventId` in some cases).

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -331,6 +331,12 @@ tags:
   - description: Run live queries, manage packs and saved queries.
     name: Security Osquery API
     x-displayName: Security Osquery
+  - description: |
+      Use the initialization API to set up the assets Elastic Security needs to operate in a Kibana space.
+
+      A single request can run one or more initialization flows. Each flow provisions a specific set of assets (for example, list indices, security data views, prebuilt detection rules, endpoint protection, AI prompts, or detection rule monitoring assets). The response reports a per-flow result so you can tell which flows completed and which returned an error.
+    name: Security Solution Initialization API
+    x-displayName: Security solution initialization
   - description: You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.
     name: Security Timeline API
     x-displayName: Security timeline
@@ -51699,6 +51705,83 @@ paths:
       summary: Get prompts
       tags:
         - Security AI Assistant API
+      x-metaTags:
+        - content: Kibana
+          name: product_name
+  /api/security_solution/initialize:
+    post:
+      description: |
+        **Spaces method and path for this operation:**
+
+        <div><span class="operation-verb post">post</span>&nbsp;<span class="operation-path">/s/{space_id}/api/security_solution/initialize</span></div>
+
+        Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
+
+        Run one or more Security Solution initialization flows for the current space.
+        Each flow provisions a specific set of assets, for example list indices,
+        security data views, prebuilt detection rules, endpoint protection, AI prompts,
+        or detection rule monitoring assets. Only the requested flows are run, and the
+        response reports a result for each one.
+      operationId: InitializeSecuritySolution
+      requestBody:
+        content:
+          application/json:
+            examples:
+              default:
+                value:
+                  flows:
+                    - init-prebuilt-rules
+                    - init-endpoint-protection
+                    - init-ai-prompts
+            schema:
+              type: object
+              properties:
+                flows:
+                  items:
+                    $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowId'
+                  minItems: 1
+                  type: array
+              required:
+                - flows
+        description: The initialization flows to run.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    flows:
+                      init-ai-prompts:
+                        payload:
+                          install_status: installed
+                          name: security_ai_prompts
+                          version: 8.17.1
+                        status: ready
+                      init-endpoint-protection:
+                        payload:
+                          install_status: already_installed
+                          name: endpoint
+                          version: 8.17.1
+                        status: ready
+                      init-prebuilt-rules:
+                        payload:
+                          install_status: installed
+                          name: security_detection_engine
+                          version: 8.17.1
+                        status: ready
+              schema:
+                type: object
+                properties:
+                  flows:
+                    $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowsResult'
+                required:
+                  - flows
+          description: Indicates a successful call. Returns a result for each requested flow.
+      summary: Initialize security solution flows
+      tags:
+        - Security Solution Initialization API
       x-metaTags:
         - content: Kibana
           name: product_name
@@ -134486,6 +134569,144 @@ components:
     Security_Osquery_API_VersionOrUndefined:
       $ref: '#/components/schemas/Security_Osquery_API_Version'
       nullable: true
+    Security_Solution_Initialization_API_CreateListIndicesReadyResult:
+      type: object
+      properties:
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+    Security_Solution_Initialization_API_DataViewPayload:
+      type: object
+      properties:
+        id:
+          type: string
+        patternList:
+          items:
+            type: string
+          type: array
+        title:
+          type: string
+      required:
+        - id
+        - title
+        - patternList
+    Security_Solution_Initialization_API_InitializationFlowErrorResult:
+      type: object
+      properties:
+        error:
+          nullable: true
+          type: string
+        status:
+          enum:
+            - error
+          type: string
+      required:
+        - status
+        - error
+    Security_Solution_Initialization_API_InitializationFlowId:
+      description: Identifier for an initialization flow.
+      enum:
+        - create-list-indices
+        - security-data-views
+        - init-prebuilt-rules
+        - init-endpoint-protection
+        - init-ai-prompts
+        - init-detection-rule-monitoring
+      type: string
+    Security_Solution_Initialization_API_InitializationFlowsResult:
+      description: Per-flow results. Only requested flows appear in the response, so all properties are optional. Each flow is either a typed ready result or an error result.
+      type: object
+      properties:
+        create-list-indices:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_CreateListIndicesReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        init-ai-prompts:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_PackageInstallReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        init-detection-rule-monitoring:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InstallDetectionEngineRuleMonitoringAssetsReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        init-endpoint-protection:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_PackageInstallReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        init-prebuilt-rules:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_PackageInstallReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+        security-data-views:
+          oneOf:
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_SecurityDataViewsReadyResult'
+            - $ref: '#/components/schemas/Security_Solution_Initialization_API_InitializationFlowErrorResult'
+    Security_Solution_Initialization_API_InstallDetectionEngineRuleMonitoringAssetsReadyResult:
+      type: object
+      properties:
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+    Security_Solution_Initialization_API_PackageInstallReadyResult:
+      type: object
+      properties:
+        payload:
+          type: object
+          properties:
+            install_status:
+              description: Fleet package installation status (e.g., installed, already_installed).
+              type: string
+            name:
+              type: string
+            version:
+              type: string
+          required:
+            - name
+            - version
+            - install_status
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+        - payload
+    Security_Solution_Initialization_API_SecurityDataViewsReadyResult:
+      type: object
+      properties:
+        payload:
+          type: object
+          properties:
+            alertDataView:
+              $ref: '#/components/schemas/Security_Solution_Initialization_API_DataViewPayload'
+            attackDataView:
+              $ref: '#/components/schemas/Security_Solution_Initialization_API_DataViewPayload'
+            defaultDataView:
+              $ref: '#/components/schemas/Security_Solution_Initialization_API_DataViewPayload'
+            kibanaDataViews:
+              items:
+                $ref: '#/components/schemas/Security_Solution_Initialization_API_DataViewPayload'
+              type: array
+            signalIndexName:
+              type: string
+          required:
+            - defaultDataView
+            - alertDataView
+            - kibanaDataViews
+            - signalIndexName
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+        - payload
     Security_Timeline_API_AssociatedFilterType:
       description: |
         How the note is associated with a Timeline saved object and/or an event (`eventId`). `all`: no association-based restriction from this parameter. `document_only`: document-linked notes (non-empty `eventId`) without timeline association in the API's internal sense; post-filtering drops notes without a usable `eventId`. `saved_object_only`: timeline notes with no linked event (`eventId` empty or absent); post-filtering keeps timeline-only notes. `document_and_saved_object`: notes on a timeline and linked to an event; post-filtering enforces a real `eventId`. `orphan`: not on a timeline and `eventId` is empty (stricter than missing `eventId` in some cases).

--- a/x-pack/solutions/security/plugins/security_solution/common/api/initialization/initialization.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/initialization/initialization.schema.yaml
@@ -6,10 +6,17 @@ paths:
   /api/security_solution/initialize:
     post:
       summary: Initialize security solution flows
+      description: |
+        Run one or more Security Solution initialization flows for the current space.
+        Each flow provisions a specific set of assets, for example list indices,
+        security data views, prebuilt detection rules, endpoint protection, AI prompts,
+        or detection rule monitoring assets. Only the requested flows are run, and the
+        response reports a result for each one.
       operationId: InitializeSecuritySolution
       x-codegen-enabled: true
       x-labels: [ess, serverless]
       requestBody:
+        description: The initialization flows to run.
         required: true
         content:
           application/json:
@@ -23,9 +30,16 @@ paths:
                   items:
                     $ref: '#/components/schemas/InitializationFlowId'
                   minItems: 1
+            examples:
+              default:
+                value:
+                  flows:
+                    - init-prebuilt-rules
+                    - init-endpoint-protection
+                    - init-ai-prompts
       responses:
         '200':
-          description: OK
+          description: Indicates a successful call. Returns a result for each requested flow.
           content:
             application/json:
               schema:
@@ -35,6 +49,28 @@ paths:
                 properties:
                   flows:
                     $ref: '#/components/schemas/InitializationFlowsResult'
+              examples:
+                default:
+                  value:
+                    flows:
+                      init-prebuilt-rules:
+                        status: ready
+                        payload:
+                          name: security_detection_engine
+                          version: 8.17.1
+                          install_status: installed
+                      init-endpoint-protection:
+                        status: ready
+                        payload:
+                          name: endpoint
+                          version: 8.17.1
+                          install_status: already_installed
+                      init-ai-prompts:
+                        status: ready
+                        payload:
+                          name: security_ai_prompts
+                          version: 8.17.1
+                          install_status: installed
 
 components:
   x-codegen-enabled: true

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -2416,6 +2416,14 @@ Requires the **Timeline and Notes** read privilege (`notes_read`).
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+    * Run one or more Security Solution initialization flows for the current space.
+Each flow provisions a specific set of assets, for example list indices,
+security data views, prebuilt detection rules, endpoint protection, AI prompts,
+or detection rule monitoring assets. Only the requested flows are run, and the
+response reports a result for each one.
+
+    */
   async initializeSecuritySolution(props: InitializeSecuritySolutionProps) {
     this.log.info(`${new Date().toISOString()} Calling API InitializeSecuritySolution`);
     return this.kbnClient

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_initialization_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_initialization_api_2023_10_31.bundled.schema.yaml
@@ -1,0 +1,254 @@
+openapi: 3.0.3
+info:
+  description: Use the initialization API to set up the assets Elastic Security
+    needs to operate in a Kibana space, such as list indices, security data
+    views, prebuilt detection rules, endpoint protection, AI prompts, and
+    detection rule monitoring assets.
+  title: Security Solution Initialization API (Elastic Cloud and self-hosted)
+  version: '2023-10-31'
+servers:
+  - url: http://{kibana_host}:{port}
+    variables:
+      kibana_host:
+        default: localhost
+      port:
+        default: '5601'
+paths:
+  /api/security_solution/initialize:
+    post:
+      description: >
+        Run one or more Security Solution initialization flows for the current
+        space.
+
+        Each flow provisions a specific set of assets, for example list indices,
+
+        security data views, prebuilt detection rules, endpoint protection, AI
+        prompts,
+
+        or detection rule monitoring assets. Only the requested flows are run,
+        and the
+
+        response reports a result for each one.
+      operationId: InitializeSecuritySolution
+      requestBody:
+        content:
+          application/json:
+            examples:
+              default:
+                value:
+                  flows:
+                    - init-prebuilt-rules
+                    - init-endpoint-protection
+                    - init-ai-prompts
+            schema:
+              type: object
+              properties:
+                flows:
+                  items:
+                    $ref: '#/components/schemas/InitializationFlowId'
+                  minItems: 1
+                  type: array
+              required:
+                - flows
+        description: The initialization flows to run.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    flows:
+                      init-ai-prompts:
+                        payload:
+                          install_status: installed
+                          name: security_ai_prompts
+                          version: 8.17.1
+                        status: ready
+                      init-endpoint-protection:
+                        payload:
+                          install_status: already_installed
+                          name: endpoint
+                          version: 8.17.1
+                        status: ready
+                      init-prebuilt-rules:
+                        payload:
+                          install_status: installed
+                          name: security_detection_engine
+                          version: 8.17.1
+                        status: ready
+              schema:
+                type: object
+                properties:
+                  flows:
+                    $ref: '#/components/schemas/InitializationFlowsResult'
+                required:
+                  - flows
+          description: Indicates a successful call. Returns a result for each requested
+            flow.
+      summary: Initialize security solution flows
+      tags:
+        - Security Solution Initialization API
+components:
+  schemas:
+    CreateListIndicesReadyResult:
+      type: object
+      properties:
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+    DataViewPayload:
+      type: object
+      properties:
+        id:
+          type: string
+        patternList:
+          items:
+            type: string
+          type: array
+        title:
+          type: string
+      required:
+        - id
+        - title
+        - patternList
+    InitializationFlowErrorResult:
+      type: object
+      properties:
+        error:
+          nullable: true
+          type: string
+        status:
+          enum:
+            - error
+          type: string
+      required:
+        - status
+        - error
+    InitializationFlowId:
+      description: Identifier for an initialization flow.
+      enum:
+        - create-list-indices
+        - security-data-views
+        - init-prebuilt-rules
+        - init-endpoint-protection
+        - init-ai-prompts
+        - init-detection-rule-monitoring
+      type: string
+    InitializationFlowsResult:
+      description: Per-flow results. Only requested flows appear in the response, so
+        all properties are optional. Each flow is either a typed ready result or
+        an error result.
+      type: object
+      properties:
+        create-list-indices:
+          oneOf:
+            - $ref: '#/components/schemas/CreateListIndicesReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        init-ai-prompts:
+          oneOf:
+            - $ref: '#/components/schemas/PackageInstallReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        init-detection-rule-monitoring:
+          oneOf:
+            - $ref: '#/components/schemas/InstallDetectionEngineRuleMonitoringAssetsReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        init-endpoint-protection:
+          oneOf:
+            - $ref: '#/components/schemas/PackageInstallReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        init-prebuilt-rules:
+          oneOf:
+            - $ref: '#/components/schemas/PackageInstallReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        security-data-views:
+          oneOf:
+            - $ref: '#/components/schemas/SecurityDataViewsReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+    InstallDetectionEngineRuleMonitoringAssetsReadyResult:
+      type: object
+      properties:
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+    PackageInstallReadyResult:
+      type: object
+      properties:
+        payload:
+          type: object
+          properties:
+            install_status:
+              description: Fleet package installation status (e.g., installed,
+                already_installed).
+              type: string
+            name:
+              type: string
+            version:
+              type: string
+          required:
+            - name
+            - version
+            - install_status
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+        - payload
+    SecurityDataViewsReadyResult:
+      type: object
+      properties:
+        payload:
+          type: object
+          properties:
+            alertDataView:
+              $ref: '#/components/schemas/DataViewPayload'
+            attackDataView:
+              $ref: '#/components/schemas/DataViewPayload'
+            defaultDataView:
+              $ref: '#/components/schemas/DataViewPayload'
+            kibanaDataViews:
+              items:
+                $ref: '#/components/schemas/DataViewPayload'
+              type: array
+            signalIndexName:
+              type: string
+          required:
+            - defaultDataView
+            - alertDataView
+            - kibanaDataViews
+            - signalIndexName
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+        - payload
+  securitySchemes:
+    BasicAuth:
+      scheme: basic
+      type: http
+security:
+  - BasicAuth: []
+tags:
+  - description: >
+      Use the initialization API to set up the assets Elastic Security needs to
+      operate in a Kibana space.
+
+
+      A single request can run one or more initialization flows. Each flow
+      provisions a specific set of assets (for example, list indices, security
+      data views, prebuilt detection rules, endpoint protection, AI prompts, or
+      detection rule monitoring assets). The response reports a per-flow result
+      so you can tell which flows completed and which returned an error.
+    name: Security Solution Initialization API
+    x-displayName: Security solution initialization

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_initialization_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_initialization_api_2023_10_31.bundled.schema.yaml
@@ -1,0 +1,254 @@
+openapi: 3.0.3
+info:
+  description: Use the initialization API to set up the assets Elastic Security
+    needs to operate in a Kibana space, such as list indices, security data
+    views, prebuilt detection rules, endpoint protection, AI prompts, and
+    detection rule monitoring assets.
+  title: Security Solution Initialization API (Elastic Cloud Serverless)
+  version: '2023-10-31'
+servers:
+  - url: http://{kibana_host}:{port}
+    variables:
+      kibana_host:
+        default: localhost
+      port:
+        default: '5601'
+paths:
+  /api/security_solution/initialize:
+    post:
+      description: >
+        Run one or more Security Solution initialization flows for the current
+        space.
+
+        Each flow provisions a specific set of assets, for example list indices,
+
+        security data views, prebuilt detection rules, endpoint protection, AI
+        prompts,
+
+        or detection rule monitoring assets. Only the requested flows are run,
+        and the
+
+        response reports a result for each one.
+      operationId: InitializeSecuritySolution
+      requestBody:
+        content:
+          application/json:
+            examples:
+              default:
+                value:
+                  flows:
+                    - init-prebuilt-rules
+                    - init-endpoint-protection
+                    - init-ai-prompts
+            schema:
+              type: object
+              properties:
+                flows:
+                  items:
+                    $ref: '#/components/schemas/InitializationFlowId'
+                  minItems: 1
+                  type: array
+              required:
+                - flows
+        description: The initialization flows to run.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    flows:
+                      init-ai-prompts:
+                        payload:
+                          install_status: installed
+                          name: security_ai_prompts
+                          version: 8.17.1
+                        status: ready
+                      init-endpoint-protection:
+                        payload:
+                          install_status: already_installed
+                          name: endpoint
+                          version: 8.17.1
+                        status: ready
+                      init-prebuilt-rules:
+                        payload:
+                          install_status: installed
+                          name: security_detection_engine
+                          version: 8.17.1
+                        status: ready
+              schema:
+                type: object
+                properties:
+                  flows:
+                    $ref: '#/components/schemas/InitializationFlowsResult'
+                required:
+                  - flows
+          description: Indicates a successful call. Returns a result for each requested
+            flow.
+      summary: Initialize security solution flows
+      tags:
+        - Security Solution Initialization API
+components:
+  schemas:
+    CreateListIndicesReadyResult:
+      type: object
+      properties:
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+    DataViewPayload:
+      type: object
+      properties:
+        id:
+          type: string
+        patternList:
+          items:
+            type: string
+          type: array
+        title:
+          type: string
+      required:
+        - id
+        - title
+        - patternList
+    InitializationFlowErrorResult:
+      type: object
+      properties:
+        error:
+          nullable: true
+          type: string
+        status:
+          enum:
+            - error
+          type: string
+      required:
+        - status
+        - error
+    InitializationFlowId:
+      description: Identifier for an initialization flow.
+      enum:
+        - create-list-indices
+        - security-data-views
+        - init-prebuilt-rules
+        - init-endpoint-protection
+        - init-ai-prompts
+        - init-detection-rule-monitoring
+      type: string
+    InitializationFlowsResult:
+      description: Per-flow results. Only requested flows appear in the response, so
+        all properties are optional. Each flow is either a typed ready result or
+        an error result.
+      type: object
+      properties:
+        create-list-indices:
+          oneOf:
+            - $ref: '#/components/schemas/CreateListIndicesReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        init-ai-prompts:
+          oneOf:
+            - $ref: '#/components/schemas/PackageInstallReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        init-detection-rule-monitoring:
+          oneOf:
+            - $ref: '#/components/schemas/InstallDetectionEngineRuleMonitoringAssetsReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        init-endpoint-protection:
+          oneOf:
+            - $ref: '#/components/schemas/PackageInstallReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        init-prebuilt-rules:
+          oneOf:
+            - $ref: '#/components/schemas/PackageInstallReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+        security-data-views:
+          oneOf:
+            - $ref: '#/components/schemas/SecurityDataViewsReadyResult'
+            - $ref: '#/components/schemas/InitializationFlowErrorResult'
+    InstallDetectionEngineRuleMonitoringAssetsReadyResult:
+      type: object
+      properties:
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+    PackageInstallReadyResult:
+      type: object
+      properties:
+        payload:
+          type: object
+          properties:
+            install_status:
+              description: Fleet package installation status (e.g., installed,
+                already_installed).
+              type: string
+            name:
+              type: string
+            version:
+              type: string
+          required:
+            - name
+            - version
+            - install_status
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+        - payload
+    SecurityDataViewsReadyResult:
+      type: object
+      properties:
+        payload:
+          type: object
+          properties:
+            alertDataView:
+              $ref: '#/components/schemas/DataViewPayload'
+            attackDataView:
+              $ref: '#/components/schemas/DataViewPayload'
+            defaultDataView:
+              $ref: '#/components/schemas/DataViewPayload'
+            kibanaDataViews:
+              items:
+                $ref: '#/components/schemas/DataViewPayload'
+              type: array
+            signalIndexName:
+              type: string
+          required:
+            - defaultDataView
+            - alertDataView
+            - kibanaDataViews
+            - signalIndexName
+        status:
+          enum:
+            - ready
+          type: string
+      required:
+        - status
+        - payload
+  securitySchemes:
+    BasicAuth:
+      scheme: basic
+      type: http
+security:
+  - BasicAuth: []
+tags:
+  - description: >
+      Use the initialization API to set up the assets Elastic Security needs to
+      operate in a Kibana space.
+
+
+      A single request can run one or more initialization flows. Each flow
+      provisions a specific set of assets (for example, list indices, security
+      data views, prebuilt detection rules, endpoint protection, AI prompts, or
+      detection rule monitoring assets). The response reports a per-flow result
+      so you can tell which flows completed and which returned an error.
+    name: Security Solution Initialization API
+    x-displayName: Security solution initialization

--- a/x-pack/solutions/security/plugins/security_solution/package.json
+++ b/x-pack/solutions/security/plugins/security_solution/package.json
@@ -34,6 +34,7 @@
     "openapi:bundle:detections": "node scripts/openapi/bundle_detections",
     "openapi:bundle:timeline": "node scripts/openapi/bundle_timeline",
     "openapi:bundle:entity-analytics": "node scripts/openapi/bundle_entity_analytics",
-    "openapi:bundle:endpoint-management": "node scripts/openapi/bundle_endpoint_management"
+    "openapi:bundle:endpoint-management": "node scripts/openapi/bundle_endpoint_management",
+    "openapi:bundle:initialization": "node scripts/openapi/bundle_initialization"
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_initialization.js
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_initialization.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+require('@kbn/setup-node-env');
+const { bundle } = require('@kbn/openapi-bundler');
+const { join, resolve } = require('path');
+
+const ROOT = resolve(__dirname, '../..');
+
+(async () => {
+  await bundle({
+    sourceGlob: join(ROOT, 'common/api/initialization/**/*.schema.yaml'),
+    outputFilePath: join(
+      ROOT,
+      'docs/openapi/serverless/security_solution_initialization_api_{version}.bundled.schema.yaml'
+    ),
+    options: {
+      includeLabels: ['serverless'],
+      prototypeDocument: join(
+        ROOT,
+        'scripts/openapi/bundle_initialization_info/initialization_serverless.info.yaml'
+      ),
+    },
+  });
+
+  await bundle({
+    sourceGlob: join(ROOT, 'common/api/initialization/**/*.schema.yaml'),
+    outputFilePath: join(
+      ROOT,
+      'docs/openapi/ess/security_solution_initialization_api_{version}.bundled.schema.yaml'
+    ),
+    options: {
+      includeLabels: ['ess'],
+      prototypeDocument: join(
+        ROOT,
+        'scripts/openapi/bundle_initialization_info/initialization_ess.info.yaml'
+      ),
+    },
+  });
+})();

--- a/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_initialization_info/initialization_ess.info.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_initialization_info/initialization_ess.info.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: 'Security Solution Initialization API (Elastic Cloud and self-hosted)'
+  description: 'Use the initialization API to set up the assets Elastic Security needs to operate in a Kibana space, such as list indices, security data views, prebuilt detection rules, endpoint protection, AI prompts, and detection rule monitoring assets.'
+
+tags:
+  - name: 'Security Solution Initialization API'
+    x-displayName: 'Security solution initialization'
+    description: |
+      Use the initialization API to set up the assets Elastic Security needs to operate in a Kibana space.
+
+      A single request can run one or more initialization flows. Each flow provisions a specific set of assets (for example, list indices, security data views, prebuilt detection rules, endpoint protection, AI prompts, or detection rule monitoring assets). The response reports a per-flow result so you can tell which flows completed and which returned an error.

--- a/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_initialization_info/initialization_serverless.info.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_initialization_info/initialization_serverless.info.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: 'Security Solution Initialization API (Elastic Cloud Serverless)'
+  description: 'Use the initialization API to set up the assets Elastic Security needs to operate in a Kibana space, such as list indices, security data views, prebuilt detection rules, endpoint protection, AI prompts, and detection rule monitoring assets.'
+
+tags:
+  - name: 'Security Solution Initialization API'
+    x-displayName: 'Security solution initialization'
+    description: |
+      Use the initialization API to set up the assets Elastic Security needs to operate in a Kibana space.
+
+      A single request can run one or more initialization flows. Each flow provisions a specific set of assets (for example, list indices, security data views, prebuilt detection rules, endpoint protection, AI prompts, or detection rule monitoring assets). The response reports a per-flow result so you can tell which flows completed and which returned an error.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution] Add logic to post initialization open api docs (#279526)](https://github.com/elastic/kibana/pull/279526)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Edgar Santos","email":"edgar.santos@elastic.co"},"sourceCommit":{"committedDate":"2026-07-24T08:28:31Z","message":"[Security Solution] Add logic to post initialization open api docs (#279526)\n\n## Summary\nThis PR allows the the initialization endpoint OpenAPI docs to be\nexposed to our users. The endpoint was added in\nhttps://github.com/elastic/kibana/pull/258891 for 9.4.\n\n## How to test\n\nThese changes wire the already-public `POST\n/api/security_solution/initialize` endpoint into the OpenAPI\ndoc-bundling pipeline so it shows up in the generated API reference.\nVerify it renders correctly.\n\n### Quick check: render the initialization bundle\n\nFrom the repo root, regenerate the bundle:\n\n```bash\ncd x-pack/solutions/security/plugins/security_solution\nyarn openapi:bundle:initialization\n```\n\nThis writes the ESS and Serverless bundles to:\n\n-\n`docs/openapi/ess/security_solution_initialization_api_2023_10_31.bundled.schema.yaml`\n-\n`docs/openapi/serverless/security_solution_initialization_api_2023_10_31.bundled.schema.yaml`\n\nRender either bundle to a standalone HTML page and open it (swap `ess`\nfor `serverless` to check the other variant):\n\n```bash\n# from the repo root\nnode_modules/.bin/redocly build-docs \\\n  x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_initialization_api_2023_10_31.bundled.schema.yaml \\\n  -o /tmp/init_api_docs.html\nopen /tmp/init_api_docs.html\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6fc82d32594a737b4d472f02ea05450038d690dc","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","Team:Detection Engineering","v9.6.0","v9.4.5"],"title":"[Security Solution] Add logic to post initialization open api docs","number":279526,"url":"https://github.com/elastic/kibana/pull/279526","mergeCommit":{"message":"[Security Solution] Add logic to post initialization open api docs (#279526)\n\n## Summary\nThis PR allows the the initialization endpoint OpenAPI docs to be\nexposed to our users. The endpoint was added in\nhttps://github.com/elastic/kibana/pull/258891 for 9.4.\n\n## How to test\n\nThese changes wire the already-public `POST\n/api/security_solution/initialize` endpoint into the OpenAPI\ndoc-bundling pipeline so it shows up in the generated API reference.\nVerify it renders correctly.\n\n### Quick check: render the initialization bundle\n\nFrom the repo root, regenerate the bundle:\n\n```bash\ncd x-pack/solutions/security/plugins/security_solution\nyarn openapi:bundle:initialization\n```\n\nThis writes the ESS and Serverless bundles to:\n\n-\n`docs/openapi/ess/security_solution_initialization_api_2023_10_31.bundled.schema.yaml`\n-\n`docs/openapi/serverless/security_solution_initialization_api_2023_10_31.bundled.schema.yaml`\n\nRender either bundle to a standalone HTML page and open it (swap `ess`\nfor `serverless` to check the other variant):\n\n```bash\n# from the repo root\nnode_modules/.bin/redocly build-docs \\\n  x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_initialization_api_2023_10_31.bundled.schema.yaml \\\n  -o /tmp/init_api_docs.html\nopen /tmp/init_api_docs.html\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6fc82d32594a737b4d472f02ea05450038d690dc"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/280675","number":280675,"state":"MERGED","mergeCommit":{"sha":"142ccd6dd5eb4bd717536f9b928425df38d53da8","message":"[9.5] [Security Solution] Add logic to post initialization open api docs (#279526) (#280675)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Security Solution] Add logic to post initialization open api docs\n(#279526)](https://github.com/elastic/kibana/pull/279526)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Edgar Santos <edgar.santos@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279526","number":279526,"mergeCommit":{"message":"[Security Solution] Add logic to post initialization open api docs (#279526)\n\n## Summary\nThis PR allows the the initialization endpoint OpenAPI docs to be\nexposed to our users. The endpoint was added in\nhttps://github.com/elastic/kibana/pull/258891 for 9.4.\n\n## How to test\n\nThese changes wire the already-public `POST\n/api/security_solution/initialize` endpoint into the OpenAPI\ndoc-bundling pipeline so it shows up in the generated API reference.\nVerify it renders correctly.\n\n### Quick check: render the initialization bundle\n\nFrom the repo root, regenerate the bundle:\n\n```bash\ncd x-pack/solutions/security/plugins/security_solution\nyarn openapi:bundle:initialization\n```\n\nThis writes the ESS and Serverless bundles to:\n\n-\n`docs/openapi/ess/security_solution_initialization_api_2023_10_31.bundled.schema.yaml`\n-\n`docs/openapi/serverless/security_solution_initialization_api_2023_10_31.bundled.schema.yaml`\n\nRender either bundle to a standalone HTML page and open it (swap `ess`\nfor `serverless` to check the other variant):\n\n```bash\n# from the repo root\nnode_modules/.bin/redocly build-docs \\\n  x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_initialization_api_2023_10_31.bundled.schema.yaml \\\n  -o /tmp/init_api_docs.html\nopen /tmp/init_api_docs.html\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6fc82d32594a737b4d472f02ea05450038d690dc"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->