### PR TITLE
[CI] skip flaky negative canary suite

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/jest/run_negative.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_negative.test.ts
@@ -97,7 +97,7 @@ describe('NEGATIVE_SCENARIOS', () => {
       'test_timeout',
       'suite_import_error',
       'nonzero_no_failures',
-      'process_exit_zero',
+      // 'process_exit_zero',
       'runner_hang',
     ]);
   });

--- a/src/platform/packages/shared/kbn-test/src/jest/run_negative.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_negative.ts
@@ -102,15 +102,16 @@ export const NEGATIVE_SCENARIOS: NegativeScenario[] = [
     expectedExitCode: NEGATIVE_FAILURE_EXIT_CODE,
     expectedPatterns: [/nonzero_no_failures/, /no individual test failures parsed/],
   },
-  {
-    name: 'process_exit_zero',
-    description: 'test calls process.exit(0), runner falsely reports PASS',
-    configPath: fixtureConfig('process_exit_zero'),
-    // KNOWN BUG elastic/kibana-operations#625: runner trusts the child exit code, so a
-    // mid-run process.exit(0) is reported green even though a failing test never ran.
-    expectedExitCode: 0,
-    expectedPatterns: [/process\.exit called with "0"/, /✅.*process_exit_zero/],
-  },
+  // Skipping, as it's flaky.
+  // {
+  //   name: 'process_exit_zero',
+  //   description: 'test calls process.exit(0), runner falsely reports PASS',
+  //   configPath: fixtureConfig('process_exit_zero'),
+  //   // KNOWN BUG elastic/kibana-operations#625: runner trusts the child exit code, so a
+  //   // mid-run process.exit(0) is reported green even though a failing test never ran.
+  //   expectedExitCode: 0,
+  //   expectedPatterns: [/process\.exit called with "0"/, /✅.*process_exit_zero/],
+  // },
   {
     name: 'runner_hang',
     description: 'test leaves an open handle, runner hangs forever',


### PR DESCRIPTION
## Summary
Introduced negative tests for the jest runner harness in #279867

There's a case about early exit 0 successfully completing the test suite (without running the whole suite of tests) that is appearing flaky for some reason, we'll skip that for now. It highlights a shortcoming in our runner, but it's an obvious one, so we're not really risking anything with quarantining this test for now.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->