### PR TITLE
[9.5] [Entity Analytics] Check privilges before trying to install or init ES V2 (#280251)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -121970,35 +121970,41 @@ components:
       properties:
         has_all_required:
           type: boolean
+        has_install_permissions:
+          type: boolean
         has_read_permissions:
           type: boolean
         has_write_permissions:
           type: boolean
+        install_privileges:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityAnalyticsPrivilegesDetail'
         privileges:
-          type: object
-          properties:
-            elasticsearch:
-              type: object
-              properties:
-                cluster:
-                  additionalProperties:
-                    type: boolean
-                  type: object
-                index:
-                  additionalProperties:
-                    additionalProperties:
-                      type: boolean
-                    type: object
-                  type: object
-            kibana:
-              additionalProperties:
-                type: boolean
-              type: object
-          required:
-            - elasticsearch
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityAnalyticsPrivilegesDetail'
       required:
         - has_all_required
         - privileges
+    Security_Entity_Analytics_API_EntityAnalyticsPrivilegesDetail:
+      type: object
+      properties:
+        elasticsearch:
+          type: object
+          properties:
+            cluster:
+              additionalProperties:
+                type: boolean
+              type: object
+            index:
+              additionalProperties:
+                additionalProperties:
+                  type: boolean
+                type: object
+              type: object
+        kibana:
+          additionalProperties:
+            type: boolean
+          type: object
+      required:
+        - elasticsearch
     Security_Entity_Analytics_API_EntityRiskLevels:
       enum:
         - Unknown

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -135246,35 +135246,41 @@ components:
       properties:
         has_all_required:
           type: boolean
+        has_install_permissions:
+          type: boolean
         has_read_permissions:
           type: boolean
         has_write_permissions:
           type: boolean
+        install_privileges:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityAnalyticsPrivilegesDetail'
         privileges:
-          type: object
-          properties:
-            elasticsearch:
-              type: object
-              properties:
-                cluster:
-                  additionalProperties:
-                    type: boolean
-                  type: object
-                index:
-                  additionalProperties:
-                    additionalProperties:
-                      type: boolean
-                    type: object
-                  type: object
-            kibana:
-              additionalProperties:
-                type: boolean
-              type: object
-          required:
-            - elasticsearch
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityAnalyticsPrivilegesDetail'
       required:
         - has_all_required
         - privileges
+    Security_Entity_Analytics_API_EntityAnalyticsPrivilegesDetail:
+      type: object
+      properties:
+        elasticsearch:
+          type: object
+          properties:
+            cluster:
+              additionalProperties:
+                type: boolean
+              type: object
+            index:
+              additionalProperties:
+                additionalProperties:
+                  type: boolean
+                type: object
+              type: object
+        kibana:
+          additionalProperties:
+            type: boolean
+          type: object
+      required:
+        - elasticsearch
     Security_Entity_Analytics_API_EntityRiskLevels:
       enum:
         - Unknown

--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -44978,7 +44978,6 @@
     "xpack.securitySolution.riskScore.entityDashboardWarningPanelBody": "Wir haben keine Risiko-Score-Daten für {entityType} gefunden. Überprüfen Sie, ob Sie globale Filter in der globalen KQL-Suchleiste haben. Falls Sie gerade das Risikomodul {entityType} aktiviert haben, könnte die Risiko-Engine bis zu einer Stunde benötigen, um die Risikobewertungsdaten {entityType} zu generieren und in diesem Panel anzuzeigen.",
     "xpack.securitySolution.riskScore.entityDashboardWarningPanelTitle": "Keine {entityType} Risiko-Score-Daten zur Anzeige verfügbar",
     "xpack.securitySolution.riskScore.errorPanel.errors": "Fehler",
-    "xpack.securitySolution.riskScore.errorPanel.message": "Der Status der Risiko-Engine konnte nicht geändert werden. Beheben Sie die folgenden Probleme und versuchen Sie es erneut:",
     "xpack.securitySolution.riskScore.errorPanel.title": "Es ist ein Fehler aufgetreten",
     "xpack.securitySolution.riskScore.failSearchDescription": "Suche nach Risiko-Score konnte nicht ausgeführt werden",
     "xpack.securitySolution.riskScore.includeClosedAlertsDescription": "Aktivieren Sie diese Option, um sowohl offene als auch geschlossene Alerts in die Berechnungen der Risiko-Engine einzubeziehen. Die Einbeziehung geschlossener Alerts hilft, eine umfassendere Risikobewertung basierend auf früheren Vorfällen zu ermöglichen, was zu einer genaueren Bewertung und präziseren Einblicken führt.",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -44828,7 +44828,6 @@
     "xpack.securitySolution.riskScore.entityDashboardWarningPanelBody": "Nous n’avons pas trouvé de données de score de risque du {entityType}. Vérifiez si vous avez des filtres globaux dans la barre de recherche KQL globale. Si vous venez d’activer le module de risque du {entityType}, le moteur de risque peut mettre une heure à générer les données de score de risque du {entityType} et à les afficher dans ce panneau.",
     "xpack.securitySolution.riskScore.entityDashboardWarningPanelTitle": "Aucune donnée de score de risque du {entityType} ne peut être affichée",
     "xpack.securitySolution.riskScore.errorPanel.errors": "Erreurs",
-    "xpack.securitySolution.riskScore.errorPanel.message": "Le statut du moteur à risque n'a pas pu être changé. Résoudre les problèmes suivants et réessayer :",
     "xpack.securitySolution.riskScore.errorPanel.title": "Une erreur est survenue",
     "xpack.securitySolution.riskScore.failSearchDescription": "Impossible de lancer une recherche sur le score de risque",
     "xpack.securitySolution.riskScore.includeClosedAlertsDescription": "Activez cette option pour considérer les alertes ouvertes et fermées dans les calculs du moteur de risque. Inclure les alertes fermées vous aide à obtenir une évaluation de risque plus complète en fonction des incidents passés, ce qui donne des scores et des informations plus précises.",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -45150,7 +45150,6 @@
     "xpack.securitySolution.riskScore.entityDashboardWarningPanelBody": "{entityType}リスクスコアデータが見つかりません。グローバルKQL検索バーにグローバルフィルターがあるかどうかを確認してください。{entityType}リスクモジュールを有効にしたばかりの場合は、リスクエンジンが{entityType}リスクスコアデータを生成し、このパネルに表示するまでに1時間かかることがあります。",
     "xpack.securitySolution.riskScore.entityDashboardWarningPanelTitle": "表示する{entityType}リスクスコアデータがありません",
     "xpack.securitySolution.riskScore.errorPanel.errors": "エラー",
-    "xpack.securitySolution.riskScore.errorPanel.message": "リスクエンジンステータスを変更できませんでした。次の項目を修正して、再試行してください。",
     "xpack.securitySolution.riskScore.errorPanel.title": "エラーが発生しました",
     "xpack.securitySolution.riskScore.failSearchDescription": "リスクスコアで検索を実行できませんでした",
     "xpack.securitySolution.riskScore.includeClosedAlertsDescription": "このオプションを有効にすると、オープン中およびクローズ済みのアラートがリスクエンジンの計算で考慮されます。クローズ済みのアラートを含めることで、過去のインシデントに基づくより包括的なリスク評価が可能になり、より正確なスコアリングと分析につながります。",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -45143,7 +45143,6 @@
     "xpack.securitySolution.riskScore.entityDashboardWarningPanelBody": "找不到任何 {entityType} 风险分数数据。检查全局 KQL 搜索栏中是否具有任何全局筛选。如果刚刚启用了 {entityType} 风险模块，风险引擎可能需要一小时才能生成并在此面板中显示 {entityType} 风险分数数据。",
     "xpack.securitySolution.riskScore.entityDashboardWarningPanelTitle": "没有可显示的 {entityType} 风险分数数据",
     "xpack.securitySolution.riskScore.errorPanel.errors": "错误",
-    "xpack.securitySolution.riskScore.errorPanel.message": "无法更改风险引擎状态。修复以下问题，然后重试：",
     "xpack.securitySolution.riskScore.errorPanel.title": "有错误",
     "xpack.securitySolution.riskScore.failSearchDescription": "无法对风险分数执行搜索",
     "xpack.securitySolution.riskScore.includeClosedAlertsDescription": "启用此选项可将未决和已关闭告警都纳入风险引擎计算。包括已关闭告警有助于根据过去的事件提供更全面的风险评估，从而获取更准确的评分和洞见。",

--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -24,6 +24,14 @@ export const PLUGIN_NAME = 'Entity Store';
 
 export const FF_ENABLE_ENTITY_STORE_V2 = 'securitySolution:entityStoreEnableV2';
 
+export {
+  ENTITY_STORE_SOURCE_INDICES_PRIVILEGES,
+  ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
+  ENTITY_STORE_CLUSTER_PRIVILEGES,
+  ENGINE_DESCRIPTOR_TYPE_NAME,
+  ENGINE_DESCRIPTOR_CREATE_PRIVILEGE,
+} from './privileges';
+
 export type EntityStoreStatus = z.infer<typeof EntityStoreStatus>;
 export const EntityStoreStatus = z.enum([
   'not_installed',

--- a/x-pack/solutions/security/plugins/entity_store/common/privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/privileges.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Privilege lists enforced by Entity Store install / maintainers-init
+ * (`AssetManagerClient.getPrivileges` → `enforceEntityStorePrivileges`)
+ */
+
+export const ENTITY_STORE_SOURCE_INDICES_PRIVILEGES = ['read', 'view_index_metadata'];
+export const ENTITY_STORE_TARGET_INDICES_PRIVILEGES = ['read', 'manage'];
+// Install creates index templates + component templates (manage_index_templates) and the
+// latest/metadata ingest pipelines (manage_ingest_pipelines). Both are enforced as the
+// requesting user, so both must be part of the enable-store privilege check.
+export const ENTITY_STORE_CLUSTER_PRIVILEGES = [
+  'manage_index_templates',
+  'manage_ingest_pipelines',
+];
+
+/**
+ * Saved object type registered for Entity Store engines. Install/stop privilege checks use
+ * create on this type (`security.authz.actions.savedObject.get(type, 'create')`).
+ */
+export const ENGINE_DESCRIPTOR_TYPE_NAME = 'entity-engine-descriptor-v2';
+
+/**
+ * Kibana privilege string for creating/updating engine descriptors. Matches the shape produced
+ * by `actions.savedObject.get(ENGINE_DESCRIPTOR_TYPE_NAME, 'create')` and returned under
+ * `install_privileges.kibana` from check_privileges.
+ */
+export const ENGINE_DESCRIPTOR_CREATE_PRIVILEGE =
+  `saved_object:${ENGINE_DESCRIPTOR_TYPE_NAME}/create` as const;

--- a/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.test.tsx
+++ b/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.test.tsx
@@ -27,14 +27,26 @@ const createMockServices = (): MockServices => ({
 
 const asServices = (mock: MockServices): Services => mock as unknown as Services;
 
-// The hook reads status and (only when it might auto-install) the preferences, both via http.get.
-// Route the two GETs by path so tests can set the status and the autoInstall preference independently.
+// The hook reads status, privileges (before any write), and (only when it might
+// auto-install) preferences — all via http.get. Route GETs by path so tests can
+// set each independently.
 const mockHttpGet = (
   mockServices: MockServices,
-  { status, autoInstall = true }: { status: EntityStoreStatus; autoInstall?: boolean }
+  {
+    status,
+    autoInstall = true,
+    hasInstallPermissions = true,
+  }: {
+    status: EntityStoreStatus;
+    autoInstall?: boolean;
+    hasInstallPermissions?: boolean;
+  }
 ) => {
   mockServices.http.get.mockImplementation((opts: { path: string }) => {
     if (opts.path === ENTITY_STORE_ROUTES.public.STATUS) return Promise.resolve({ status });
+    if (opts.path === ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES) {
+      return Promise.resolve({ has_install_permissions: hasInstallPermissions });
+    }
     if (opts.path === ENTITY_STORE_ROUTES.internal.PREFERENCES) {
       return Promise.resolve({ autoInstall });
     }
@@ -63,6 +75,9 @@ describe('useInstallEntityStoreV2', () => {
       method: 'GET',
       query: { type: 'entity-engine-status', per_page: 0 },
     });
+    expect(mockServices.http.get).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES })
+    );
     expect(mockServices.http.post).not.toHaveBeenCalled();
   });
 
@@ -152,6 +167,10 @@ describe('useInstallEntityStoreV2', () => {
       path: ENTITY_STORE_ROUTES.public.STATUS,
       query: { include_components: false },
     });
+    expect(mockServices.http.get).toHaveBeenCalledWith({
+      path: ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES,
+      query: { apiVersion: '2' },
+    });
     expect(mockServices.http.post).toHaveBeenCalledWith({
       path: ENTITY_STORE_ROUTES.public.INSTALL,
       body: JSON.stringify({}),
@@ -206,5 +225,52 @@ describe('useInstallEntityStoreV2', () => {
     expect(mockServices.http.get).not.toHaveBeenCalledWith(
       expect.objectContaining({ path: ENTITY_STORE_ROUTES.internal.PREFERENCES })
     );
+  });
+
+  it('should not POST /install when the user lacks install privileges', async () => {
+    const mockServices = createMockServices();
+
+    mockServices.spaces.getActiveSpace.mockResolvedValue({ id: 'default' });
+    mockHttpGet(mockServices, {
+      status: EntityStoreStatusEnum.enum.not_installed,
+      hasInstallPermissions: false,
+    });
+
+    renderHook(() => useInstallEntityStoreV2(asServices(mockServices)));
+
+    await waitFor(() => {
+      expect(mockServices.http.get).toHaveBeenCalledWith({
+        path: ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES,
+        query: { apiVersion: '2' },
+      });
+    });
+
+    expect(mockServices.http.get).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: ENTITY_STORE_ROUTES.internal.PREFERENCES })
+    );
+    expect(mockServices.http.post).not.toHaveBeenCalled();
+    expect(mockServices.logger.error).not.toHaveBeenCalled();
+  });
+
+  it('should not POST entity_maintainers/init when the user lacks install privileges', async () => {
+    const mockServices = createMockServices();
+
+    mockServices.spaces.getActiveSpace.mockResolvedValue({ id: 'default' });
+    mockHttpGet(mockServices, {
+      status: EntityStoreStatusEnum.enum.running,
+      hasInstallPermissions: false,
+    });
+
+    renderHook(() => useInstallEntityStoreV2(asServices(mockServices)));
+
+    await waitFor(() => {
+      expect(mockServices.http.get).toHaveBeenCalledWith({
+        path: ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES,
+        query: { apiVersion: '2' },
+      });
+    });
+
+    expect(mockServices.http.post).not.toHaveBeenCalled();
+    expect(mockServices.logger.error).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
+++ b/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
@@ -48,6 +48,11 @@ const getPreferencesRequest: HttpFetchOptionsWithPath = {
   query: { apiVersion: '2' },
 };
 
+const getPrivilegesRequest: HttpFetchOptionsWithPath = {
+  path: ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES,
+  query: { apiVersion: '2' },
+};
+
 // Detects whether the legacy v1 Entity Store was installed in this space by
 // looking up the legacy `entity-engine-status` saved object. Used to decide
 // whether to auto-install v2 in non-default spaces (only for users who had v1).
@@ -57,6 +62,15 @@ export const isEntityStoreV1Installed = async (http: HttpSetup): Promise<boolean
     query: { type: LEGACY_ENTITY_ENGINE_SO_TYPE, per_page: 0 },
   });
   return response.total > 0;
+};
+
+// Gate auto-install / maintainers-init on the same privilege set the install and
+// entity_maintainers/init routes enforce server-side (read + manage on the target
+// alias, manage_index_templates cluster, saved-object create, and read/
+// view_index_metadata on source indices) — surfaced as `has_install_permissions`.
+const hasEntityStoreInstallPrivileges = async (http: HttpSetup): Promise<boolean> => {
+  const privileges = await http.get<{ has_install_permissions?: boolean }>(getPrivilegesRequest);
+  return privileges.has_install_permissions === true;
 };
 
 /**
@@ -75,6 +89,7 @@ export const useInstallEntityStoreV2 = (services: Services) => {
 
         // Entity store already installed → init entity maintainers only.
         if (isEntityStoreV2Installed) {
+          if (!(await hasEntityStoreInstallPrivileges(services.http))) return;
           await services.http.post(initEntityMaintainersRequest);
           return;
         }
@@ -85,6 +100,9 @@ export const useInstallEntityStoreV2 = (services: Services) => {
           const hadV1 = await isEntityStoreV1Installed(services.http);
           if (!hadV1) return;
         }
+
+        // Skip preferences + install for users without install privileges
+        if (!(await hasEntityStoreInstallPrivileges(services.http))) return;
 
         const { autoInstall } = await services.http.get<{ autoInstall: boolean }>(
           getPreferencesRequest

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
@@ -77,6 +77,8 @@ describe('AssetManagerClient', () => {
   const namespace = 'default';
 
   let client: AssetManagerClient;
+  let mockUserEsClient: jest.Mocked<ElasticsearchClient>;
+  let mockInternalEsClient: jest.Mocked<ElasticsearchClient>;
   let mockEngineDescriptorClient: {
     getAll: jest.Mock;
     init: jest.Mock;
@@ -124,9 +126,13 @@ describe('AssetManagerClient', () => {
       delete: jest.fn().mockResolvedValue(undefined),
     };
 
+    mockUserEsClient = {} as jest.Mocked<ElasticsearchClient>;
+    mockInternalEsClient = {} as jest.Mocked<ElasticsearchClient>;
+
     client = new AssetManagerClient({
       logger: loggerMock.create(),
-      esClient: {} as jest.Mocked<ElasticsearchClient>,
+      esClient: mockUserEsClient,
+      internalEsClient: mockInternalEsClient,
       taskManager: {} as jest.Mocked<TaskManagerStartContract>,
       engineDescriptorClient:
         mockEngineDescriptorClient as unknown as import('../saved_objects').EngineDescriptorClient,
@@ -157,6 +163,24 @@ describe('AssetManagerClient', () => {
     expect(mockScheduleExtractEntityTask).toHaveBeenCalledTimes(2);
   });
 
+  it('runs v1 cleanup and stored-script setup as the internal user', async () => {
+    await client.init({} as KibanaRequest, ['host', 'user']);
+
+    // Legacy v1 cleanup and managed stored scripts must not require the enabling user to hold
+    // transform/enrich/cluster-manage privileges, so they run as the internal/system user.
+    // Reference-equality (toBe) matters here: both mock clients are `{}` and would be
+    // structurally equal under objectContaining.
+    expect(mockStopAndRemoveV1).toHaveBeenCalled();
+    mockStopAndRemoveV1.mock.calls.forEach(([arg]) => {
+      expect(arg.esClient).toBe(mockInternalEsClient);
+      expect(arg.esClient).not.toBe(mockUserEsClient);
+    });
+    expect(mockInstallEuidStoredScripts).toHaveBeenCalled();
+    mockInstallEuidStoredScripts.mock.calls.forEach(([arg]) => {
+      expect(arg.esClient).toBe(mockInternalEsClient);
+    });
+  });
+
   it('does not recreate shared indices or data streams during per-type install', async () => {
     const installed = await client.install('host');
 
@@ -178,6 +202,7 @@ describe('AssetManagerClient', () => {
       getPrivilegesClient = new AssetManagerClient({
         logger: loggerMock.create(),
         esClient: {} as jest.Mocked<ElasticsearchClient>,
+        internalEsClient: {} as jest.Mocked<ElasticsearchClient>,
         taskManager: {} as jest.Mocked<TaskManagerStartContract>,
         engineDescriptorClient:
           mockEngineDescriptorClient as unknown as import('../saved_objects').EngineDescriptorClient,
@@ -228,6 +253,38 @@ describe('AssetManagerClient', () => {
       expect(indexKeys).toContain('.entities.entities-default');
       expect(indexKeys).not.toContain('-logs-cloud_security_posture.*');
       expect(indexKeys).not.toContain('-logs-excluded-*');
+    });
+
+    it('checks the cluster + target assets that install creates as the requesting user', async () => {
+      // The updates data stream is also returned as an extraction source.
+      getLocalIndexPatternsMock.mockResolvedValue([
+        'logs-*',
+        '.entities.v2.updates.security_default',
+      ]);
+
+      await getPrivilegesClient.getPrivileges({} as KibanaRequest);
+
+      const [calledWith] = checkPrivilegesWithRequestMock.mock.calls[0];
+
+      // Ingest pipelines + templates are both created during install.
+      expect(calledWith.elasticsearch.cluster).toEqual(
+        expect.arrayContaining(['manage_index_templates', 'manage_ingest_pipelines'])
+      );
+
+      // The concrete latest index + its alias, and the updates/metadata data streams.
+      const indexKeys = Object.keys(calledWith.elasticsearch.index);
+      expect(indexKeys).toContain('entities-latest-default');
+      expect(indexKeys).toContain('.entities.v2.latest.security_default-*');
+      expect(indexKeys).toContain('.entities.v2.updates.security_default');
+      expect(indexKeys).toContain('.entities.v2.metadata.security_default');
+      expect(calledWith.elasticsearch.index['.entities.v2.latest.security_default-*']).toEqual(
+        expect.arrayContaining(['manage'])
+      );
+      // Updates data stream is both a target (manage) and a source (view_index_metadata);
+      // privileges must be unioned, not overwritten.
+      expect(calledWith.elasticsearch.index['.entities.v2.updates.security_default']).toEqual(
+        expect.arrayContaining(['manage', 'view_index_metadata'])
+      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -16,6 +16,11 @@ import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { CheckPrivilegesResponse } from '@kbn/security-plugin-types-server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { EntityType } from '../../../common';
+import {
+  ENTITY_STORE_CLUSTER_PRIVILEGES,
+  ENTITY_STORE_SOURCE_INDICES_PRIVILEGES,
+  ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
+} from '../../../common';
 import { scheduleExtractEntityTask, stopExtractEntityTask } from '../../tasks/extract_entity_task';
 import {
   scheduleHistorySnapshotTasks,
@@ -32,13 +37,7 @@ import {
   LogExtractionConfig,
 } from '../saved_objects';
 import type { HistorySnapshotBodyParams, LogExtractionInstallParams } from '../../routes/constants';
-import {
-  ENGINE_STATUS,
-  ENTITY_STORE_CLUSTER_PRIVILEGES,
-  ENTITY_STORE_SOURCE_INDICES_PRIVILEGES,
-  ENTITY_STORE_STATUS,
-  ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
-} from '../constants';
+import { ENGINE_STATUS, ENTITY_STORE_STATUS } from '../constants';
 import type {
   EntityStoreStatus,
   EngineComponentStatus,
@@ -50,11 +49,13 @@ import {
   getEntitiesAlias,
   ENTITY_LATEST,
   getLatestEntitiesIndexName,
+  getLatestEntityIndexPattern,
 } from '../../../common/domain/entity_index';
 import { getLatestIndexTemplateId } from './latest_index_template';
 import { getUpdatesIndexTemplateId } from './updates_index_template';
 import { getComponentTemplateName, getUpdatesComponentTemplateName } from './component_templates';
 import { getUpdatesEntitiesDataStreamName } from './updates_data_stream';
+import { getMetadataEntitiesDataStreamName } from './metadata_data_stream';
 import type { LogsExtractionClient } from '../logs_extraction';
 import type { RemoteLogExtractionStateClient } from '../saved_objects/remote_log_extraction_state';
 import type { ManagedEntityDefinition } from '../../../common/domain/definitions/entity_schema';
@@ -72,6 +73,7 @@ import { stopAndRemoveV1, stopAndRemoveV1SharedTasks } from '../../infra/remove_
 interface AssetManagerDependencies {
   logger: Logger;
   esClient: ElasticsearchClient;
+  internalEsClient: ElasticsearchClient;
   taskManager: TaskManagerStartContract;
   engineDescriptorClient: EngineDescriptorClient;
   globalStateClient: EntityStoreGlobalStateClient;
@@ -87,6 +89,7 @@ interface AssetManagerDependencies {
 export class AssetManagerClient {
   private readonly logger: Logger;
   private readonly esClient: ElasticsearchClient;
+  private readonly internalEsClient: ElasticsearchClient;
   private readonly taskManager: TaskManagerStartContract;
   private readonly engineDescriptorClient: EngineDescriptorClient;
   private readonly globalStateClient: EntityStoreGlobalStateClient;
@@ -101,6 +104,7 @@ export class AssetManagerClient {
   constructor(deps: AssetManagerDependencies) {
     this.logger = deps.logger;
     this.esClient = deps.esClient;
+    this.internalEsClient = deps.internalEsClient;
     this.taskManager = deps.taskManager;
     this.engineDescriptorClient = deps.engineDescriptorClient;
     this.globalStateClient = deps.globalStateClient;
@@ -131,12 +135,14 @@ export class AssetManagerClient {
       await Promise.all([
         this.globalStateClient.init({ historySnapshot, logsExtraction }),
 
+        // V1 cleanup is legacy migration work — run it as the internal user so enabling the
+        // entity store does not require the user to hold transform/enrich/index admin on v1 assets.
         ...entityTypes.map((type) =>
           stopAndRemoveV1({
             type,
             namespace: this.namespace,
             logger: this.logger,
-            esClient: this.esClient,
+            esClient: this.internalEsClient,
             taskManager: this.taskManager,
             savedObjectsClient: this.savedObjectsClient,
           })
@@ -173,8 +179,11 @@ export class AssetManagerClient {
           request,
         }),
 
+        // Stored scripts are managed assets with no granular ES privilege (only `manage`/`all`),
+        // so create them as the internal user rather than forcing the enabling user to hold
+        // broad cluster `manage`.
         installEuidStoredScripts({
-          esClient: this.esClient,
+          esClient: this.internalEsClient,
           logger: this.logger,
         }),
       ]);
@@ -252,6 +261,9 @@ export class AssetManagerClient {
             logger: this.logger.get(type),
             namespace: this.namespace,
           }),
+          // Deletion must run as the requesting user: kibana_system holds the raw
+          // `cluster:admin/script/put` action (so managed installs work) but NOT
+          // `cluster:admin/script/delete`, which is only granted by cluster `manage`/`all`.
           deleteEuidStoredScripts({
             esClient: this.esClient,
             logger: this.logger,
@@ -351,23 +363,32 @@ export class AssetManagerClient {
       'create'
     );
 
-    // _has_privileges treats a leading `-` as a literal index name, not an exclusion.
-    // Negative patterns are a query-time directive and have no meaning here.
-    const sourceIndexPrivileges = Object.fromEntries(
-      sourceIndexPatterns
-        .filter((idx) => !idx.startsWith('-'))
-        .map((idx) => [idx, ENTITY_STORE_SOURCE_INDICES_PRIVILEGES])
-    );
-
-    const targetIndexPrivileges = {
-      [getEntitiesAlias(ENTITY_LATEST, this.namespace)]: ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
+    // Install creates the concrete `.entities.v2.*` latest index (+ alias) and the
+    // updates/metadata data streams as the requesting user, so each needs `read` + `manage`.
+    // The updates data stream is also an extraction source (`view_index_metadata`), so we
+    // merge privileges into one map. Patterns starting with `-` are stripped: `_has_privileges`
+    // treats them as literal index names, not exclusions.
+    const index: Record<string, string[]> = {};
+    const unionPrivileges = (name: string, privileges: string[]) => {
+      index[name] = Array.from(new Set([...(index[name] ?? []), ...privileges]));
     };
+
+    [
+      getEntitiesAlias(ENTITY_LATEST, this.namespace),
+      getLatestEntityIndexPattern(this.namespace),
+      getUpdatesEntitiesDataStreamName(this.namespace),
+      getMetadataEntitiesDataStreamName(this.namespace),
+    ].forEach((name) => unionPrivileges(name, ENTITY_STORE_TARGET_INDICES_PRIVILEGES));
+
+    sourceIndexPatterns
+      .filter((idx) => !idx.startsWith('-'))
+      .forEach((idx) => unionPrivileges(idx, ENTITY_STORE_SOURCE_INDICES_PRIVILEGES));
 
     return checkPrivileges({
       kibana: [kibanaPrivileges],
       elasticsearch: {
         cluster: ENTITY_STORE_CLUSTER_PRIVILEGES,
-        index: { ...targetIndexPrivileges, ...sourceIndexPrivileges },
+        index,
       },
     });
   }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/constants.ts
@@ -10,10 +10,6 @@ import type { EntityStoreStatus } from './types';
 
 export const ECS_MAPPINGS_COMPONENT_TEMPLATE = 'ecs@mappings';
 
-export const ENTITY_STORE_SOURCE_INDICES_PRIVILEGES = ['read', 'view_index_metadata'];
-export const ENTITY_STORE_TARGET_INDICES_PRIVILEGES = ['read', 'manage'];
-export const ENTITY_STORE_CLUSTER_PRIVILEGES = ['manage_index_templates'];
-
 export const ENGINE_STATUS: Record<Uppercase<EngineStatus>, EngineStatus> = {
   INSTALLING: 'installing',
   STARTED: 'started',

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/engine_descriptor/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/engine_descriptor/types.ts
@@ -8,8 +8,9 @@
 import type { SavedObjectsFullModelVersion } from '@kbn/core-saved-objects-server';
 import type { SavedObjectsType } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
+import { ENGINE_DESCRIPTOR_TYPE_NAME } from '../../../../common/privileges';
 
-export const EngineDescriptorTypeName = 'entity-engine-descriptor-v2';
+export const EngineDescriptorTypeName = ENGINE_DESCRIPTOR_TYPE_NAME;
 
 export const EngineDescriptorTypeMappings: SavedObjectsType['mappings'] = {
   dynamic: false,

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/remove_v1.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/remove_v1.ts
@@ -15,6 +15,9 @@ interface StopAndRemoveV1Params {
   type: EntityType;
   namespace: string;
   logger: Logger;
+  // Must be the internal/system ES client. V1 cleanup performs privileged transform, enrich, and
+  // index/template/pipeline admin plus a raw `.kibana` delete — legacy migration work the user
+  // enabling the entity store is not (and should not be) required to be authorized for.
   esClient: ElasticsearchClient;
   taskManager: TaskManagerStartContract;
   savedObjectsClient: SavedObjectsClientContract;

--- a/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
@@ -138,6 +138,7 @@ export async function createRequestHandlerContext({
     assetManagerClient: new AssetManagerClient({
       logger,
       esClient: core.elasticsearch.client.asCurrentUser,
+      internalEsClient: core.elasticsearch.client.asInternalUser,
       taskManager: taskManagerStart,
       engineDescriptorClient,
       globalStateClient,

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/check_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/check_privileges.ts
@@ -10,7 +10,10 @@ import { API_VERSIONS, ENTITY_STORE_ROUTES } from '../../../common';
 import { DEFAULT_ENTITY_STORE_PERMISSIONS } from '../constants';
 import type { EntityStorePluginRouter } from '../../types';
 import { wrapMiddlewares } from '../middleware';
-import { checkEntityStoreIndexPrivileges } from './utils/check_and_format_privileges';
+import {
+  checkEntityStoreIndexPrivileges,
+  formatPrivileges,
+} from './utils/check_and_format_privileges';
 
 export function registerCheckPrivileges(router: EntityStorePluginRouter) {
   router.versioned
@@ -41,16 +44,27 @@ export function registerCheckPrivileges(router: EntityStorePluginRouter) {
         const entityStoreCtx = await ctx.entityStore;
         const security = entityStoreCtx.security;
         const spaceId = entityStoreCtx.namespace;
+        const assetManager = entityStoreCtx.assetManagerClient;
 
-        const response = await checkEntityStoreIndexPrivileges({
-          request: req,
-          security,
-          spaceId,
-          includeMetadataPrivileges: true,
-        });
+        const [response, installPrivileges] = await Promise.all([
+          checkEntityStoreIndexPrivileges({
+            request: req,
+            security,
+            spaceId,
+            includeMetadataPrivileges: true,
+          }),
+          // Mirror the exact server-side enforcement used by the install and
+          // entity_maintainers/init routes (`enforceEntityStorePrivileges`), so clients can
+          // gate write POSTs on the same aggregate check the routes perform.
+          assetManager.getPrivileges(req),
+        ]);
 
         return res.ok({
-          body: response,
+          body: {
+            ...response,
+            has_install_permissions: installPrivileges.hasAllRequested,
+            install_privileges: formatPrivileges(installPrivileges.privileges),
+          },
         });
       })
     );

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/examples/entity_store_check_privileges.yaml
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/examples/entity_store_check_privileges.yaml
@@ -18,6 +18,21 @@ responses:
               has_all_required: true
               has_read_permissions: true
               has_write_permissions: true
+              has_install_permissions: true
+              install_privileges:
+                elasticsearch:
+                  cluster:
+                    manage_index_templates: true
+                    manage_ingest_pipelines: true
+                  index:
+                    "entities-latest-default":
+                      read: true
+                      manage: true
+                    ".entities.v2.latest.security_default-*":
+                      read: true
+                      manage: true
+                kibana:
+                  "saved_object:entity-engine-descriptor-v2/create": true
           missingPrivilegesExample:
             summary: "Missing privileges"
             description: "The current user is missing write privileges on the entity index."
@@ -32,6 +47,21 @@ responses:
               has_all_required: false
               has_read_permissions: true
               has_write_permissions: false
+              has_install_permissions: false
+              install_privileges:
+                elasticsearch:
+                  cluster:
+                    manage_index_templates: true
+                    manage_ingest_pipelines: false
+                  index:
+                    "entities-latest-default":
+                      read: true
+                      manage: true
+                    ".entities.v2.latest.security_default-*":
+                      read: true
+                      manage: true
+                kibana:
+                  "saved_object:entity-engine-descriptor-v2/create": true
 x-codeSamples:
   - lang: curl
     source: |

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.ts
@@ -19,19 +19,23 @@ import {
   ENTITY_LATEST,
 } from '../../../../common';
 
+const PrivilegesDetail = z.object({
+  elasticsearch: z.object({
+    cluster: z.object({}).catchall(z.boolean()).optional(),
+    index: z.object({}).catchall(z.object({}).catchall(z.boolean())).optional(),
+  }),
+  kibana: z.object({}).catchall(z.boolean()).optional(),
+});
+
 export type Privileges = z.infer<typeof Privileges>;
 export const Privileges = z.object({
   has_all_required: z.boolean(),
   has_read_permissions: z.boolean().optional(),
   has_write_permissions: z.boolean().optional(),
+  has_install_permissions: z.boolean().optional(),
   has_kibana_feature_access: z.boolean().optional(),
-  privileges: z.object({
-    elasticsearch: z.object({
-      cluster: z.object({}).catchall(z.boolean()).optional(),
-      index: z.object({}).catchall(z.object({}).catchall(z.boolean())).optional(),
-    }),
-    kibana: z.object({}).catchall(z.boolean()).optional(),
-  }),
+  privileges: PrivilegesDetail,
+  install_privileges: PrivilegesDetail.optional(),
 });
 
 const groupPrivilegesByName = <PrivilegeName extends string>(

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/factories.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/factories.ts
@@ -121,6 +121,7 @@ export async function createAssetManagerClient({
     assetManagerClient: new AssetManagerClient({
       logger,
       esClient,
+      internalEsClient: coreStart.elasticsearch.client.asInternalUser,
       taskManager: pluginsStart.taskManager,
       engineDescriptorClient,
       globalStateClient,

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/check_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/check_privileges.spec.ts
@@ -42,6 +42,15 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
       has_all_required: true,
       has_read_permissions: true,
       has_write_permissions: true,
+      has_install_permissions: true,
+      install_privileges: {
+        elasticsearch: {
+          cluster: {
+            manage_index_templates: true,
+            manage_ingest_pipelines: true,
+          },
+        },
+      },
     });
   });
 
@@ -86,6 +95,7 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
         has_all_required: false,
         has_read_permissions: false,
         has_write_permissions: false,
+        has_install_permissions: false,
       });
     }
   );
@@ -117,6 +127,7 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
         has_all_required: false,
         has_read_permissions: false,
         has_write_permissions: false,
+        has_install_permissions: false,
       });
     }
   );
@@ -153,6 +164,7 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
         has_all_required: false,
         has_read_permissions: true,
         has_write_permissions: false,
+        has_install_permissions: false,
       });
     }
   );
@@ -190,6 +202,7 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
         has_all_required: false,
         has_read_permissions: true,
         has_write_permissions: false,
+        has_install_permissions: false,
       });
     }
   );
@@ -226,6 +239,8 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
         has_all_required: false,
         has_read_permissions: true,
         has_write_permissions: true,
+        // write-only is not install-eligible (install needs manage + cluster + SO + source).
+        has_install_permissions: false,
       });
     }
   );

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_store_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_store_privileges.spec.ts
@@ -13,18 +13,24 @@ import {
   ENTITY_STORE_CLUSTER_PRIVILEGES,
   ENTITY_STORE_SOURCE_INDICES_PRIVILEGES,
   ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
-} from '../../../../server/domain/constants';
-import { getEntitiesAlias, ENTITY_LATEST } from '../../../../common/domain/entity_index';
+  ENGINE_DESCRIPTOR_CREATE_PRIVILEGE,
+  FF_ENABLE_ENTITY_STORE_V2,
+} from '../../../../common';
+import {
+  getEntitiesAlias,
+  ENTITY_LATEST,
+  getLatestEntityIndexPattern,
+} from '../../../../common/domain/entity_index';
 import { PUBLIC_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
-import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
 import { clearEntityStoreIndices } from '../fixtures/helpers';
 import { getUpdatesEntitiesDataStreamName } from '../../../../server/domain/asset_manager/updates_data_stream';
+import { getMetadataEntitiesDataStreamName } from '../../../../server/domain/asset_manager/metadata_data_stream';
 
 apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, () => {
   const TARGET_INDEX_LATEST = getEntitiesAlias(ENTITY_LATEST, 'default');
+  const TARGET_INDEX_LATEST_PATTERN = getLatestEntityIndexPattern('default');
   const TARGET_INDEX_UPDATES = getUpdatesEntitiesDataStreamName('default');
-
-  const SAVED_OBJECT_PRIVILEGE = 'saved_object:entity-engine-descriptor-v2/create';
+  const TARGET_INDEX_METADATA = getMetadataEntitiesDataStreamName('default');
 
   interface RoleOptions {
     withTargetIndex?: boolean;
@@ -41,8 +47,15 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
     ];
 
     if (withTargetIndex) {
+      // Install creates the concrete latest index (+ alias) and the updates/metadata data
+      // streams, all as the requesting user, so `manage` is required on each.
       indices.push({
-        names: [TARGET_INDEX_LATEST],
+        names: [
+          TARGET_INDEX_LATEST,
+          TARGET_INDEX_LATEST_PATTERN,
+          TARGET_INDEX_UPDATES,
+          TARGET_INDEX_METADATA,
+        ],
         privileges: ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
       });
     }
@@ -54,7 +67,7 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
         {
           application: 'kibana-.kibana',
           privileges: withSavedObjectCreate
-            ? ['feature_siem.all', SAVED_OBJECT_PRIVILEGE]
+            ? ['feature_siem.all', ENGINE_DESCRIPTOR_CREATE_PRIVILEGE]
             : ['feature_siem.all'],
           resources: ['*'],
         },
@@ -132,15 +145,17 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
       });
 
       expect(response.statusCode).toBe(403);
+      // Install creates several target assets, so a role missing target privileges reports
+      // more than one missing index; assert the latest target is among them.
       expect(response.body.attributes).toMatchObject({
         missing_elasticsearch_privileges: {
           cluster: [],
-          index: [
-            {
+          index: expect.arrayContaining([
+            expect.objectContaining({
               index: TARGET_INDEX_LATEST,
               privileges: expect.arrayContaining(ENTITY_STORE_TARGET_INDICES_PRIVILEGES),
-            },
-          ],
+            }),
+          ]),
         },
       });
     }
@@ -161,7 +176,7 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
 
       expect(response.statusCode).toBe(403);
       expect(response.body.attributes).toMatchObject({
-        missing_kibana_privileges: [SAVED_OBJECT_PRIVILEGE],
+        missing_kibana_privileges: [ENGINE_DESCRIPTOR_CREATE_PRIVILEGE],
       });
     }
   );
@@ -208,15 +223,17 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
       });
 
       expect(response.statusCode).toBe(403);
+      // Install creates several target assets, so a role missing target privileges reports
+      // more than one missing index; assert the latest target is among them.
       expect(response.body.attributes).toMatchObject({
         missing_elasticsearch_privileges: {
           cluster: [],
-          index: [
-            {
+          index: expect.arrayContaining([
+            expect.objectContaining({
               index: TARGET_INDEX_LATEST,
               privileges: expect.arrayContaining(ENTITY_STORE_TARGET_INDICES_PRIVILEGES),
-            },
-          ],
+            }),
+          ]),
         },
       });
     }
@@ -237,7 +254,7 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
 
       expect(response.statusCode).toBe(403);
       expect(response.body.attributes).toMatchObject({
-        missing_kibana_privileges: [SAVED_OBJECT_PRIVILEGE],
+        missing_kibana_privileges: [ENGINE_DESCRIPTOR_CREATE_PRIVILEGE],
       });
     }
   );

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/common/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/common/common.gen.ts
@@ -18,18 +18,25 @@ import { z, lazySchema } from '@kbn/zod/v4';
 
 import { AssetCriticalityLevel } from '../asset_criticality/common.gen';
 
+export const EntityAnalyticsPrivilegesDetail = lazySchema(() =>
+  z.object({
+    elasticsearch: z.object({
+      cluster: z.object({}).catchall(z.boolean()).optional(),
+      index: z.object({}).catchall(z.object({}).catchall(z.boolean())).optional(),
+    }),
+    kibana: z.object({}).catchall(z.boolean()).optional(),
+  })
+);
+export type EntityAnalyticsPrivilegesDetail = z.infer<typeof EntityAnalyticsPrivilegesDetail>;
+
 export const EntityAnalyticsPrivileges = lazySchema(() =>
   z.object({
     has_all_required: z.boolean(),
     has_read_permissions: z.boolean().optional(),
     has_write_permissions: z.boolean().optional(),
-    privileges: z.object({
-      elasticsearch: z.object({
-        cluster: z.object({}).catchall(z.boolean()).optional(),
-        index: z.object({}).catchall(z.object({}).catchall(z.boolean())).optional(),
-      }),
-      kibana: z.object({}).catchall(z.boolean()).optional(),
-    }),
+    has_install_permissions: z.boolean().optional(),
+    privileges: EntityAnalyticsPrivilegesDetail,
+    install_privileges: EntityAnalyticsPrivilegesDetail.optional(),
   })
 );
 export type EntityAnalyticsPrivileges = z.infer<typeof EntityAnalyticsPrivileges>;

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/common/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/common/common.schema.yaml
@@ -15,31 +15,37 @@ components:
           type: boolean
         has_write_permissions:
           type: boolean
+        has_install_permissions:
+          type: boolean
         privileges:
-          type: object
-          properties:
-            elasticsearch:
-              type: object
-              properties:
-                cluster:
-                  type: object
-                  additionalProperties:
-                    type: boolean
-                index:
-                  type: object
-                  additionalProperties:
-                    type: object
-                    additionalProperties:
-                      type: boolean
-            kibana:
-              type: object
-              additionalProperties:
-                type: boolean
-          required:
-            - elasticsearch
+          $ref: "#/components/schemas/EntityAnalyticsPrivilegesDetail"
+        install_privileges:
+          $ref: "#/components/schemas/EntityAnalyticsPrivilegesDetail"
       required:
         - has_all_required
         - privileges
+    EntityAnalyticsPrivilegesDetail:
+      type: object
+      properties:
+        elasticsearch:
+          type: object
+          properties:
+            cluster:
+              type: object
+              additionalProperties:
+                type: boolean
+            index:
+              type: object
+              additionalProperties:
+                type: object
+                additionalProperties:
+                  type: boolean
+        kibana:
+          type: object
+          additionalProperties:
+            type: boolean
+      required:
+        - elasticsearch
     EntityAfterKey:
       type: object
       additionalProperties:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1947,35 +1947,41 @@ components:
       properties:
         has_all_required:
           type: boolean
+        has_install_permissions:
+          type: boolean
         has_read_permissions:
           type: boolean
         has_write_permissions:
           type: boolean
+        install_privileges:
+          $ref: '#/components/schemas/EntityAnalyticsPrivilegesDetail'
         privileges:
-          type: object
-          properties:
-            elasticsearch:
-              type: object
-              properties:
-                cluster:
-                  additionalProperties:
-                    type: boolean
-                  type: object
-                index:
-                  additionalProperties:
-                    additionalProperties:
-                      type: boolean
-                    type: object
-                  type: object
-            kibana:
-              additionalProperties:
-                type: boolean
-              type: object
-          required:
-            - elasticsearch
+          $ref: '#/components/schemas/EntityAnalyticsPrivilegesDetail'
       required:
         - has_all_required
         - privileges
+    EntityAnalyticsPrivilegesDetail:
+      type: object
+      properties:
+        elasticsearch:
+          type: object
+          properties:
+            cluster:
+              additionalProperties:
+                type: boolean
+              type: object
+            index:
+              additionalProperties:
+                additionalProperties:
+                  type: boolean
+                type: object
+              type: object
+        kibana:
+          additionalProperties:
+            type: boolean
+          type: object
+      required:
+        - elasticsearch
     EntityRiskLevels:
       enum:
         - Unknown

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1947,35 +1947,41 @@ components:
       properties:
         has_all_required:
           type: boolean
+        has_install_permissions:
+          type: boolean
         has_read_permissions:
           type: boolean
         has_write_permissions:
           type: boolean
+        install_privileges:
+          $ref: '#/components/schemas/EntityAnalyticsPrivilegesDetail'
         privileges:
-          type: object
-          properties:
-            elasticsearch:
-              type: object
-              properties:
-                cluster:
-                  additionalProperties:
-                    type: boolean
-                  type: object
-                index:
-                  additionalProperties:
-                    additionalProperties:
-                      type: boolean
-                    type: object
-                  type: object
-            kibana:
-              additionalProperties:
-                type: boolean
-              type: object
-          required:
-            - elasticsearch
+          $ref: '#/components/schemas/EntityAnalyticsPrivilegesDetail'
       required:
         - has_all_required
         - privileges
+    EntityAnalyticsPrivilegesDetail:
+      type: object
+      properties:
+        elasticsearch:
+          type: object
+          properties:
+            cluster:
+              additionalProperties:
+                type: boolean
+              type: object
+            index:
+              additionalProperties:
+                additionalProperties:
+                  type: boolean
+                type: object
+              type: object
+        kibana:
+          additionalProperties:
+            type: boolean
+          type: object
+      required:
+        - elasticsearch
     EntityRiskLevels:
       enum:
         - Unknown

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { userHasRiskEngineReadPermissions } from './user_has_risk_engine_read_permissions';
+export { userHasEntityStoreStopPrivileges } from './user_has_entity_store_stop_privileges';
 export type { SnakeToCamelCase } from './utils';
 export {
   RISK_SCORE_RANGES,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/user_has_entity_store_stop_privileges.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/user_has_entity_store_stop_privileges.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { userHasEntityStoreStopPrivileges } from './user_has_entity_store_stop_privileges';
+import { ENGINE_DESCRIPTOR_CREATE_PRIVILEGE } from '@kbn/entity-store/common';
+
+describe('userHasEntityStoreStopPrivileges', () => {
+  it('returns false when privileges are undefined', () => {
+    expect(userHasEntityStoreStopPrivileges(undefined)).toBe(false);
+  });
+
+  it('returns false when install_privileges.kibana is missing', () => {
+    expect(
+      userHasEntityStoreStopPrivileges({
+        has_all_required: false,
+        privileges: { elasticsearch: {}, kibana: {} },
+      })
+    ).toBe(false);
+  });
+
+  it('returns true when engine descriptor create is authorized', () => {
+    expect(
+      userHasEntityStoreStopPrivileges({
+        has_all_required: false,
+        has_install_permissions: false,
+        privileges: { elasticsearch: {}, kibana: {} },
+        install_privileges: {
+          elasticsearch: {},
+          kibana: {
+            [ENGINE_DESCRIPTOR_CREATE_PRIVILEGE]: true,
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when engine descriptor create is not authorized', () => {
+    expect(
+      userHasEntityStoreStopPrivileges({
+        has_all_required: false,
+        has_install_permissions: false,
+        privileges: { elasticsearch: {}, kibana: {} },
+        install_privileges: {
+          elasticsearch: {},
+          kibana: {
+            [ENGINE_DESCRIPTOR_CREATE_PRIVILEGE]: false,
+          },
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/user_has_entity_store_stop_privileges.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/user_has_entity_store_stop_privileges.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ENGINE_DESCRIPTOR_CREATE_PRIVILEGE } from '@kbn/entity-store/common';
+import type { EntityAnalyticsPrivileges } from '../../../common/api/entity_analytics';
+
+/**
+ * Stop updates engine descriptors as the requesting user, so it needs SO write on
+ * entity-engine-descriptor-v2 (Security `all`). That is a subset of install privileges —
+ * missing ES manage/cluster does not block stop.
+ *
+ * Privilege key comes from `@kbn/entity-store/common` so it stays aligned with
+ * `AssetManagerClient.getPrivileges` / the SO type registration.
+ */
+export const userHasEntityStoreStopPrivileges = (privileges?: EntityAnalyticsPrivileges): boolean =>
+  privileges?.install_privileges?.kibana?.[ENGINE_DESCRIPTOR_CREATE_PRIVILEGE] === true;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_toggle.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_toggle.test.tsx
@@ -90,7 +90,8 @@ describe('EntityAnalyticsErrorPanel', () => {
 
 describe('EntityAnalyticsToggle', () => {
   const defaultProps = {
-    hasAllRequiredPrivileges: true,
+    hasEnablementPrivileges: true,
+    hasStopPrivileges: true,
     isPrivilegesLoading: false,
     selectedSettingsMatchSavedSettings: true,
     onSaveSettings: jest.fn().mockResolvedValue(undefined),
@@ -148,10 +149,10 @@ describe('EntityAnalyticsToggle', () => {
     expect(toggle).toBeDisabled();
   });
 
-  it('disables the switch when privileges are missing', () => {
+  it('disables the switch when enablement privileges are missing and the toggle is off', () => {
     const props = {
       ...defaultProps,
-      hasAllRequiredPrivileges: false,
+      hasEnablementPrivileges: false,
     };
 
     render(<EntityAnalyticsToggle {...props} />, { wrapper: Wrapper });
@@ -159,7 +160,39 @@ describe('EntityAnalyticsToggle', () => {
     expect(toggle).toBeDisabled();
   });
 
-  it('disables the switch when privileges are still loading', () => {
+  // OFF only needs SO write on the engine descriptor. Missing that (not full install) disables
+  // the switch when on — otherwise stop fails server-side on the user-scoped SO update.
+  it('disables the switch when stop privileges are missing and the toggle is on', () => {
+    mockUseToggleReturn.status = 'enabled';
+    const props = {
+      ...defaultProps,
+      hasEnablementPrivileges: false,
+      hasStopPrivileges: false,
+    };
+
+    render(<EntityAnalyticsToggle {...props} />, { wrapper: Wrapper });
+    const toggle = screen.getByTestId(ENTITY_ANALYTICS_SWITCH_TEST_ID);
+    expect(toggle).toBeChecked();
+    expect(toggle).toBeDisabled();
+  });
+
+  it('keeps an enabled switch usable when stop privileges exist but enablement privileges do not', () => {
+    mockUseToggleReturn.status = 'enabled';
+    const props = {
+      ...defaultProps,
+      hasEnablementPrivileges: false,
+      hasStopPrivileges: true,
+    };
+
+    render(<EntityAnalyticsToggle {...props} />, { wrapper: Wrapper });
+    const toggle = screen.getByTestId(ENTITY_ANALYTICS_SWITCH_TEST_ID);
+    expect(toggle).toBeChecked();
+    expect(toggle).not.toBeDisabled();
+    fireEvent.click(toggle);
+    expect(mockToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the switch when privileges are still loading and the toggle is off', () => {
     const props = {
       ...defaultProps,
       isPrivilegesLoading: true,
@@ -170,7 +203,7 @@ describe('EntityAnalyticsToggle', () => {
     expect(toggle).toBeDisabled();
   });
 
-  it('renders checked and disabled when enabled but privileges are loading', () => {
+  it('disables an enabled switch while privileges are loading', () => {
     mockUseToggleReturn.status = 'enabled';
     const props = { ...defaultProps, isPrivilegesLoading: true };
     render(<EntityAnalyticsToggle {...props} />, { wrapper: Wrapper });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_toggle.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_toggle.tsx
@@ -76,7 +76,8 @@ export const EntityAnalyticsErrorPanel: React.FC<{
 };
 
 interface EntityAnalyticsToggleProps {
-  hasAllRequiredPrivileges: boolean;
+  hasEnablementPrivileges: boolean;
+  hasStopPrivileges: boolean;
   isPrivilegesLoading: boolean;
   selectedSettingsMatchSavedSettings: boolean;
   onSaveSettings: () => Promise<void>;
@@ -84,7 +85,8 @@ interface EntityAnalyticsToggleProps {
 }
 
 export const EntityAnalyticsToggle: React.FC<EntityAnalyticsToggleProps> = ({
-  hasAllRequiredPrivileges,
+  hasEnablementPrivileges,
+  hasStopPrivileges,
   isPrivilegesLoading,
   selectedSettingsMatchSavedSettings,
   onSaveSettings,
@@ -96,14 +98,18 @@ export const EntityAnalyticsToggle: React.FC<EntityAnalyticsToggleProps> = ({
     isSavingSettings,
   });
 
+  const isChecked = status === 'enabled';
+
+  // Turning the toggle ON installs/starts the Entity Store and inits/enables the risk score
+  // maintainer, so it requires the full enablement privilege set. Turning it OFF stops engines
+  // via user-scoped SO updates on entity-engine-descriptor-v2,
+  // so it requires SO write privileges, but not the full ES/cluster install set.
   const isDisabled =
     isPrivilegesLoading ||
-    !hasAllRequiredPrivileges ||
     isStatusLoading ||
     status === 'enabling' ||
-    status === 'error';
-
-  const isChecked = status === 'enabled';
+    status === 'error' ||
+    (isChecked ? !hasStopPrivileges : !hasEnablementPrivileges);
 
   return (
     <>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.test.tsx
@@ -50,6 +50,7 @@ const defaultProps = {
 
 const allEntityEnginePrivileges: EntityAnalyticsPrivileges = {
   has_all_required: true,
+  has_install_permissions: true,
   privileges: {
     elasticsearch: {
       cluster: { manage_enrich: true },
@@ -61,6 +62,7 @@ const allEntityEnginePrivileges: EntityAnalyticsPrivileges = {
 
 const missingEntityEnginePrivileges: EntityAnalyticsPrivileges = {
   has_all_required: false,
+  has_install_permissions: false,
   privileges: {
     elasticsearch: {
       cluster: { manage_enrich: false },
@@ -168,6 +170,49 @@ describe('EnablementConfirmationModal', () => {
 
       render(<EnablementConfirmationModal {...defaultProps} />, { wrapper: Wrapper });
       expect(screen.queryByTestId('enablement-modal-test')).toBeInTheDocument();
+    });
+  });
+
+  // The toggle enables both the risk score maintainer and the Entity Store in one action, so the
+  // confirm button requires both privilege sets — a user privileged for only one half must not be
+  // able to confirm (otherwise the missing half fails server-side with a 500).
+  describe('with only Entity Store privileges (missing risk engine)', () => {
+    beforeEach(() => {
+      mockUseEntityEnginePrivileges.mockReturnValue({
+        data: allEntityEnginePrivileges,
+        isLoading: false,
+      });
+      mockUseMissingRiskEnginePrivileges.mockReturnValue(missingRiskEnginePrivileges);
+    });
+
+    it('renders the enable button disabled', () => {
+      render(<EnablementConfirmationModal {...defaultProps} />, { wrapper: Wrapper });
+      expect(screen.getByTestId('entityAnalyticsEnablementConfirmButton')).toBeDisabled();
+    });
+
+    it('shows the risk engine missing privileges callout', () => {
+      render(<EnablementConfirmationModal {...defaultProps} />, { wrapper: Wrapper });
+      expect(screen.getByTestId('callout-missing-risk-engine-privileges')).toBeInTheDocument();
+    });
+  });
+
+  describe('with only risk engine privileges (missing Entity Store)', () => {
+    beforeEach(() => {
+      mockUseEntityEnginePrivileges.mockReturnValue({
+        data: missingEntityEnginePrivileges,
+        isLoading: false,
+      });
+      mockUseMissingRiskEnginePrivileges.mockReturnValue(allRiskEnginePrivileges);
+    });
+
+    it('renders the enable button disabled', () => {
+      render(<EnablementConfirmationModal {...defaultProps} />, { wrapper: Wrapper });
+      expect(screen.getByTestId('entityAnalyticsEnablementConfirmButton')).toBeDisabled();
+    });
+
+    it('shows the entity engine missing privileges callout', () => {
+      render(<EnablementConfirmationModal {...defaultProps} />, { wrapper: Wrapper });
+      expect(screen.getByTestId('callout-missing-privileges-callout')).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
@@ -48,10 +48,14 @@ export const EnablementConfirmationModal: React.FC<EnablementConfirmationModalPr
 
   const hasRiskScorePrivileges =
     !riskEnginePrivileges.isLoading && riskEnginePrivileges.hasAllRequiredPrivileges;
+  // Enabling runs the install / maintainers-init routes, which enforce the install privilege set
+  // (has_install_permissions), not entity-index read+write (has_all_required).
   const hasEntityStorePrivileges =
-    !isLoadingEntityEnginePrivileges && entityEnginePrivileges?.has_all_required;
+    !isLoadingEntityEnginePrivileges && entityEnginePrivileges?.has_install_permissions;
 
-  const isConfirmDisabled = !hasRiskScorePrivileges && !hasEntityStorePrivileges;
+  // Confirm enables BOTH the risk score maintainer and the Entity Store, so require both privilege
+  // sets (disable if either is missing) to avoid a partial-failure 500 on the half the user can't do.
+  const isConfirmDisabled = !hasRiskScorePrivileges || !hasEntityStorePrivileges;
 
   if (!visible) {
     return null;
@@ -93,7 +97,7 @@ export const EnablementConfirmationModal: React.FC<EnablementConfirmationModalPr
               <RiskEnginePrivilegesCallOut privileges={riskEnginePrivileges} />
             </EuiFlexItem>
           )}
-          {entityEnginePrivileges && !entityEnginePrivileges.has_all_required && (
+          {entityEnginePrivileges && !entityEnginePrivileges.has_install_permissions && (
             <EuiFlexItem>
               <EntityStoreMissingPrivilegesCallout privileges={entityEnginePrivileges} />
             </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/entity_store_missing_stop_privileges_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/entity_store_missing_stop_privileges_callout.tsx
@@ -10,22 +10,27 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { EntityAnalyticsPrivileges } from '../../../../../common/api/entity_analytics';
 import { MissingPrivilegesCallout } from '../../missing_privileges_callout';
 
-export const EntityStoreMissingPrivilegesCallout = ({
+/**
+ * Shown when Entity Analytics is on but the user does not have the necessary privileges to stop it.
+ */
+export const EntityStoreMissingStopPrivilegesCallout = ({
   privileges,
 }: {
   privileges: EntityAnalyticsPrivileges;
 }) => (
   <MissingPrivilegesCallout
-    // Enabling the Entity Store enforces the install privilege set (manage/cluster/SO/source),
-    // not entity-index read+write, so surface that breakdown when the server provides it.
     privileges={{
-      ...privileges,
-      privileges: privileges.install_privileges ?? privileges.privileges,
+      has_all_required: false,
+      privileges: {
+        elasticsearch: {},
+        // Stop only needs the Kibana SO write checked under install_privileges. see `userHasEntityStoreStopPrivileges` for more details.
+        kibana: privileges.install_privileges?.kibana ?? {},
+      },
     }}
     title={
       <FormattedMessage
-        id="xpack.securitySolution.riskEngine.missingPrivilegesCallOut.title"
-        defaultMessage="Insufficient privileges to enable the Entity Store"
+        id="xpack.securitySolution.entityAnalytics.missingStopPrivilegesCallOut.title"
+        defaultMessage="Insufficient privileges to turn off Entity Analytics"
       />
     }
   />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.test.tsx
@@ -13,6 +13,7 @@ import { Route } from '@kbn/shared-ux-router';
 import { EntityAnalyticsManagementPage } from './entity_analytics_management_page';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { ENTITY_ANALYTICS_MANAGEMENT_PATH } from '../../../common/constants';
+import { ENGINE_DESCRIPTOR_CREATE_PRIVILEGE } from '@kbn/entity-store/common';
 
 import {
   ENTITY_ANALYTICS_MANAGEMENT_PAGE_TITLE_TEST_ID,
@@ -39,8 +40,11 @@ jest.mock('../api/api', () => ({
   }),
 }));
 
+const mockUseMissingRiskEnginePrivileges = jest
+  .fn()
+  .mockReturnValue({ isLoading: false, hasAllRequiredPrivileges: true });
 jest.mock('../hooks/use_missing_risk_engine_privileges', () => ({
-  useMissingRiskEnginePrivileges: () => ({ isLoading: false, hasAllRequiredPrivileges: true }),
+  useMissingRiskEnginePrivileges: () => mockUseMissingRiskEnginePrivileges(),
 }));
 
 const mockUseIsExperimentalFeatureEnabled = jest.fn().mockReturnValue(false);
@@ -109,8 +113,23 @@ jest.mock('../components/entity_store/hooks/use_entity_store', () => ({
   useDeleteEntityStoreMutation: (...args: unknown[]) => mockUseDeleteEntityStoreMutation(...args),
 }));
 
+const withStopPrivileges = {
+  install_privileges: {
+    kibana: { [ENGINE_DESCRIPTOR_CREATE_PRIVILEGE]: true },
+  },
+};
+const withoutStopPrivileges = {
+  install_privileges: {
+    kibana: { [ENGINE_DESCRIPTOR_CREATE_PRIVILEGE]: false },
+  },
+};
+
 const mockUseEntityEnginePrivileges = jest.fn().mockReturnValue({
-  data: { has_all_required: true },
+  data: {
+    has_all_required: true,
+    has_install_permissions: true,
+    ...withStopPrivileges,
+  },
 });
 jest.mock('../components/entity_store/hooks/use_entity_engine_privileges', () => ({
   useEntityEnginePrivileges: (...args: unknown[]) => mockUseEntityEnginePrivileges(...args),
@@ -132,6 +151,17 @@ jest.mock('../components/entity_store/components/entity_store_missing_privileges
   ),
 }));
 
+jest.mock(
+  '../components/entity_store/components/entity_store_missing_stop_privileges_callout',
+  () => ({
+    EntityStoreMissingStopPrivilegesCallout: () => (
+      <span data-test-subj="entity-store-missing-stop-privileges">
+        {'Entity store missing stop privileges'}
+      </span>
+    ),
+  })
+);
+
 jest.mock('../components/entity_store/components/clear_entity_data_button', () => ({
   ClearEntityDataButton: () => (
     <span data-test-subj="clear-entity-data-button">{'Clear Entity Data'}</span>
@@ -151,8 +181,17 @@ jest.mock(
 );
 
 jest.mock('../components/entity_analytics_toggle', () => ({
-  EntityAnalyticsToggle: () => (
-    <span data-test-subj="mock-entity-analytics-toggle">{'Entity analytics toggle'}</span>
+  EntityAnalyticsToggle: (props: {
+    hasEnablementPrivileges: boolean;
+    hasStopPrivileges: boolean;
+  }) => (
+    <span
+      data-test-subj="mock-entity-analytics-toggle"
+      data-has-enablement-privileges={String(props.hasEnablementPrivileges)}
+      data-has-stop-privileges={String(props.hasStopPrivileges)}
+    >
+      {'Entity analytics toggle'}
+    </span>
   ),
 }));
 
@@ -237,7 +276,15 @@ describe('EntityAnalyticsManagementPage', () => {
       data: { status: 'not_installed', engines: [] },
     });
     mockUseEntityEnginePrivileges.mockReturnValue({
-      data: { has_all_required: true },
+      data: {
+        has_all_required: true,
+        has_install_permissions: true,
+        ...withStopPrivileges,
+      },
+    });
+    mockUseMissingRiskEnginePrivileges.mockReturnValue({
+      isLoading: false,
+      hasAllRequiredPrivileges: true,
     });
     mockUseDeleteEntityStoreMutation.mockReturnValue({
       isLoading: false,
@@ -355,7 +402,11 @@ describe('EntityAnalyticsManagementPage', () => {
       data: { status: 'running', engines: [{ type: 'host' }] },
     });
     mockUseEntityEnginePrivileges.mockReturnValue({
-      data: { has_all_required: true },
+      data: {
+        has_all_required: true,
+        has_install_permissions: true,
+        ...withStopPrivileges,
+      },
     });
 
     render(pageComponent());
@@ -369,11 +420,64 @@ describe('EntityAnalyticsManagementPage', () => {
 
   it('shows entity store missing privileges callout when privileges are insufficient', () => {
     mockUseEntityEnginePrivileges.mockReturnValue({
-      data: { has_all_required: false },
+      data: {
+        has_all_required: false,
+        has_install_permissions: false,
+        ...withoutStopPrivileges,
+      },
     });
 
     render(pageComponent());
     expect(screen.getByTestId('entity-store-missing-privileges')).toBeInTheDocument();
+  });
+
+  it('hides the enable privileges callout when Entity Analytics is already on', () => {
+    mockUseEntityStoreStatus.mockReturnValue({
+      data: { status: 'running', engines: [{ type: 'host' }] },
+    });
+    mockUseEntityEnginePrivileges.mockReturnValue({
+      data: {
+        has_all_required: false,
+        has_install_permissions: false,
+        ...withoutStopPrivileges,
+      },
+    });
+
+    render(pageComponent());
+    expect(screen.queryByTestId('entity-store-missing-privileges')).not.toBeInTheDocument();
+    expect(screen.getByTestId('entity-store-missing-stop-privileges')).toBeInTheDocument();
+  });
+
+  it('shows stop privileges callout when Entity Analytics is on but stop privileges are missing', () => {
+    mockUseEntityStoreStatus.mockReturnValue({
+      data: { status: 'running', engines: [{ type: 'host' }] },
+    });
+    mockUseEntityEnginePrivileges.mockReturnValue({
+      data: {
+        has_all_required: false,
+        has_install_permissions: false,
+        ...withoutStopPrivileges,
+      },
+    });
+
+    render(pageComponent());
+    expect(screen.getByTestId('entity-store-missing-stop-privileges')).toBeInTheDocument();
+  });
+
+  it('does not show stop privileges callout when Entity Analytics is on and stop privileges exist', () => {
+    mockUseEntityStoreStatus.mockReturnValue({
+      data: { status: 'running', engines: [{ type: 'host' }] },
+    });
+    mockUseEntityEnginePrivileges.mockReturnValue({
+      data: {
+        has_all_required: false,
+        has_install_permissions: false,
+        ...withStopPrivileges,
+      },
+    });
+
+    render(pageComponent());
+    expect(screen.queryByTestId('entity-store-missing-stop-privileges')).not.toBeInTheDocument();
   });
 
   it('shows the Clear Entity Data button when entity store is installed with privileges', () => {
@@ -381,7 +485,11 @@ describe('EntityAnalyticsManagementPage', () => {
       data: { status: 'running', engines: [{ type: 'host' }] },
     });
     mockUseEntityEnginePrivileges.mockReturnValue({
-      data: { has_all_required: true },
+      data: {
+        has_all_required: true,
+        has_install_permissions: true,
+        ...withStopPrivileges,
+      },
     });
 
     render(pageComponent());
@@ -413,5 +521,100 @@ describe('EntityAnalyticsManagementPage', () => {
     render(pageComponent());
     fireEvent.click(screen.getByTestId(WATCHLISTS_TAB_TEST_ID));
     expect(screen.getByTestId('mock-watchlists-tab')).toBeInTheDocument();
+  });
+
+  // The toggle enables both the risk score maintainer and the Entity Store in one action, so
+  // enablement requires BOTH privilege sets (an OR would let an install-only user flip it and then
+  // hit a risk engine 500). OFF derives stop privileges from install_privileges.kibana (SO write), not full install.
+  describe('Entity Analytics toggle gating', () => {
+    const missingRiskEnginePrivileges = {
+      isLoading: false,
+      hasAllRequiredPrivileges: false,
+      missingPrivileges: {
+        clusterPrivileges: { enable: [], run: [] },
+        indexPrivileges: [],
+      },
+    };
+
+    it('grants enablement when the user has both risk engine and entity store install privileges', () => {
+      mockUseMissingRiskEnginePrivileges.mockReturnValue({
+        isLoading: false,
+        hasAllRequiredPrivileges: true,
+      });
+      mockUseEntityEnginePrivileges.mockReturnValue({
+        data: {
+          has_all_required: false,
+          has_install_permissions: true,
+          ...withStopPrivileges,
+        },
+      });
+      render(pageComponent());
+      expect(screen.getByTestId('mock-entity-analytics-toggle')).toHaveAttribute(
+        'data-has-enablement-privileges',
+        'true'
+      );
+      expect(screen.getByTestId('mock-entity-analytics-toggle')).toHaveAttribute(
+        'data-has-stop-privileges',
+        'true'
+      );
+    });
+
+    it('denies enablement when the user has entity store install privileges but is missing risk engine privileges', () => {
+      mockUseMissingRiskEnginePrivileges.mockReturnValue(missingRiskEnginePrivileges);
+      mockUseEntityEnginePrivileges.mockReturnValue({
+        data: {
+          has_all_required: false,
+          has_install_permissions: true,
+          ...withStopPrivileges,
+        },
+      });
+      render(pageComponent());
+      expect(screen.getByTestId('mock-entity-analytics-toggle')).toHaveAttribute(
+        'data-has-enablement-privileges',
+        'false'
+      );
+      expect(screen.getByTestId('mock-entity-analytics-toggle')).toHaveAttribute(
+        'data-has-stop-privileges',
+        'true'
+      );
+    });
+
+    it('denies enablement when the user has risk engine privileges but is missing entity store install privileges', () => {
+      mockUseMissingRiskEnginePrivileges.mockReturnValue({
+        isLoading: false,
+        hasAllRequiredPrivileges: true,
+      });
+      mockUseEntityEnginePrivileges.mockReturnValue({
+        data: {
+          has_all_required: false,
+          has_install_permissions: false,
+          ...withStopPrivileges,
+        },
+      });
+      render(pageComponent());
+      expect(screen.getByTestId('mock-entity-analytics-toggle')).toHaveAttribute(
+        'data-has-enablement-privileges',
+        'false'
+      );
+      expect(screen.getByTestId('mock-entity-analytics-toggle')).toHaveAttribute(
+        'data-has-stop-privileges',
+        'true'
+      );
+    });
+
+    it('denies stop privileges when engine descriptor write is missing', () => {
+      mockUseEntityEnginePrivileges.mockReturnValue({
+        data: {
+          has_all_required: false,
+          has_install_permissions: false,
+          ...withoutStopPrivileges,
+        },
+      });
+      render(pageComponent());
+      expect(screen.getByTestId('mock-entity-analytics-toggle')).toHaveAttribute(
+        'data-has-stop-privileges',
+        'false'
+      );
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
@@ -28,6 +28,7 @@ import { AssetCriticalityTab } from '../components/asset_criticality/asset_criti
 import { WatchlistsTab } from '../components/watchlists/watchlists_tab';
 import { EntityResolutionTab } from '../components/entity_resolution';
 import { EntityStoreMissingPrivilegesCallout } from '../components/entity_store/components/entity_store_missing_privileges_callout';
+import { EntityStoreMissingStopPrivilegesCallout } from '../components/entity_store/components/entity_store_missing_stop_privileges_callout';
 import { EngineStatus } from '../components/entity_store/components/engines_status';
 import { ClearEntityDataButton } from '../components/entity_store/components/clear_entity_data_button';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
@@ -38,7 +39,11 @@ import {
 } from '../components/entity_store/hooks/use_entity_store';
 import { useEntityEnginePrivileges } from '../components/entity_store/hooks/use_entity_engine_privileges';
 import { ENTITY_ANALYTICS_MANAGEMENT_PATH } from '../../../common/constants';
-import { userHasRiskEngineReadPermissions, safeErrorMessage } from '../common';
+import {
+  userHasRiskEngineReadPermissions,
+  userHasEntityStoreStopPrivileges,
+  safeErrorMessage,
+} from '../common';
 import {
   ENTITY_ANALYTICS_MANAGEMENT_PAGE_TEST_ID,
   ENTITY_ANALYTICS_MANAGEMENT_PAGE_TITLE_TEST_ID,
@@ -100,8 +105,16 @@ export const EntityAnalyticsManagementPage = () => {
     'hasAllRequiredPrivileges' in riskEnginePrivileges &&
     riskEnginePrivileges.hasAllRequiredPrivileges;
 
-  const userHasEntityStorePrivileges = entityEnginePrivileges?.has_all_required ?? false;
-  const hasAllRequiredPrivileges = userHasRiskEnginePrivileges || userHasEntityStorePrivileges;
+  const userHasEntityStoreInstallPrivileges =
+    entityEnginePrivileges?.has_install_permissions ?? false;
+
+  const hasStopPrivileges = userHasEntityStoreStopPrivileges(entityEnginePrivileges);
+
+  // Turning ON enables BOTH the risk score maintainer and the Entity Store in one action (see
+  // useToggleEntityAnalytics), so enablement requires both privilege sets. With an OR the toggle
+  // would look enabled while the half the user isn't privileged for fails server-side.
+  const hasEnablementPrivileges =
+    userHasRiskEnginePrivileges && userHasEntityStoreInstallPrivileges;
 
   const canRunEngine =
     (!riskEnginePrivileges.isLoading &&
@@ -152,6 +165,14 @@ export const EntityAnalyticsManagementPage = () => {
 
   const deleteError = safeErrorMessage(deleteEntityStoreMutation.error);
 
+  const isEntityAnalyticsOn = entityStoreStatus.data?.status === 'running' || false;
+  const showEntityStoreEnablementCallout =
+    !isEntityAnalyticsOn &&
+    !!entityEnginePrivileges &&
+    !entityEnginePrivileges.has_install_permissions;
+  const showStopPrivilegesCallout =
+    isEntityAnalyticsOn && !isLoadingPrivileges && !hasStopPrivileges;
+
   return (
     <>
       <RiskEnginePrivilegesCallOut privileges={riskEnginePrivileges} />
@@ -172,8 +193,9 @@ export const EntityAnalyticsManagementPage = () => {
                   selectedSettingsMatchSavedSettings={selectedSettingsMatchSavedSettings}
                   onSaveSettings={handleSaveToggleSettings}
                   isSavingSettings={saveSelectedSettingsMutation.isLoading}
-                  hasAllRequiredPrivileges={hasAllRequiredPrivileges}
-                  isPrivilegesLoading={riskEnginePrivileges.isLoading}
+                  hasEnablementPrivileges={hasEnablementPrivileges}
+                  hasStopPrivileges={hasStopPrivileges}
+                  isPrivilegesLoading={riskEnginePrivileges.isLoading || isLoadingPrivileges}
                 />
               </EuiFlexGroup>
             </EuiFlexItem>
@@ -181,10 +203,18 @@ export const EntityAnalyticsManagementPage = () => {
         }
       />
 
-      {!entityEnginePrivileges || entityEnginePrivileges.has_all_required ? null : (
+      {showEntityStoreEnablementCallout && (
         <>
           <EuiSpacer size="l" />
           <EntityStoreMissingPrivilegesCallout privileges={entityEnginePrivileges} />
+          <EuiSpacer size="l" />
+        </>
+      )}
+
+      {showStopPrivilegesCallout && entityEnginePrivileges && (
+        <>
+          <EuiSpacer size="l" />
+          <EntityStoreMissingStopPrivilegesCallout privileges={entityEnginePrivileges} />
           <EuiSpacer size="l" />
         </>
       )}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/translations.ts
@@ -140,10 +140,10 @@ export const ERROR_PANEL_TITLE = i18n.translate(
 );
 
 export const ERROR_PANEL_MESSAGE = i18n.translate(
-  'xpack.securitySolution.riskScore.errorPanel.message',
+  'xpack.securitySolution.entityAnalytics.errorPanel.message',
   {
     defaultMessage:
-      'The risk score maintainer status could not be changed. Fix the following and try again:',
+      'Entity Analytics status could not be changed. Fix the following and try again:',
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/entity_analytics/api/tests/maintainers/entity_maintainers.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/entity_analytics/api/tests/maintainers/entity_maintainers.spec.ts
@@ -11,7 +11,15 @@ import { expect } from '@kbn/scout-security/api';
 import {
   FF_ENABLE_ENTITY_STORE_V2,
   getEntitiesAlias,
+  getEntityIndexPattern,
+  getLatestEntityIndexPattern,
   ENTITY_LATEST,
+  ENTITY_METADATA,
+  ENTITY_SCHEMA_VERSION_V2,
+  ENTITY_STORE_SOURCE_INDICES_PRIVILEGES,
+  ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
+  ENTITY_STORE_CLUSTER_PRIVILEGES,
+  ENGINE_DESCRIPTOR_CREATE_PRIVILEGE,
 } from '@kbn/entity-store/common';
 
 import {
@@ -23,13 +31,14 @@ import {
 } from '../../fixtures/maintainers/constants';
 import { clearEntityStoreIndices } from '../../fixtures/maintainers/helpers';
 
-const ENTITY_STORE_SOURCE_INDICES_PRIVILEGES = ['read', 'view_index_metadata'];
-const ENTITY_STORE_TARGET_INDICES_PRIVILEGES = ['read', 'manage'];
-const ENTITY_STORE_CLUSTER_PRIVILEGES = ['manage_index_templates'];
-
 const TARGET_INDEX_LATEST = getEntitiesAlias(ENTITY_LATEST, 'default');
+const TARGET_INDEX_LATEST_PATTERN = getLatestEntityIndexPattern('default');
 const TARGET_INDEX_UPDATES = UPDATES_INDEX;
-const SAVED_OBJECT_PRIVILEGE = 'saved_object:entity-engine-descriptor-v2/create';
+const TARGET_INDEX_METADATA = getEntityIndexPattern({
+  schemaVersion: ENTITY_SCHEMA_VERSION_V2,
+  dataset: ENTITY_METADATA,
+  namespace: 'default',
+});
 
 interface RoleOptions {
   withTargetIndex?: boolean;
@@ -46,8 +55,15 @@ const buildRoleDescriptor = ({
   ];
 
   if (withTargetIndex) {
+    // Install creates the concrete latest index (+ alias) and the updates/metadata data
+    // streams, all as the requesting user, so read+manage is required on each.
     indices.push({
-      names: [TARGET_INDEX_LATEST],
+      names: [
+        TARGET_INDEX_LATEST,
+        TARGET_INDEX_LATEST_PATTERN,
+        TARGET_INDEX_UPDATES,
+        TARGET_INDEX_METADATA,
+      ],
       privileges: ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
     });
   }
@@ -59,7 +75,7 @@ const buildRoleDescriptor = ({
       {
         application: 'kibana-.kibana',
         privileges: withSavedObjectCreate
-          ? ['feature_siem.all', SAVED_OBJECT_PRIVILEGE]
+          ? ['feature_siem.all', ENGINE_DESCRIPTOR_CREATE_PRIVILEGE]
           : ['feature_siem.all'],
         resources: ['*'],
       },
@@ -115,15 +131,17 @@ apiTest.describe('Entity Store entity maintainers', { tag: ENTITY_STORE_TAGS }, 
       });
 
       expect(response.statusCode).toBe(403);
+      // Install creates several target assets, so a role missing target privileges reports
+      // more than one missing index; assert the latest target is among them.
       expect(response.body.attributes).toMatchObject({
         missing_elasticsearch_privileges: {
           cluster: [],
-          index: [
-            {
+          index: expect.arrayContaining([
+            expect.objectContaining({
               index: TARGET_INDEX_LATEST,
               privileges: expect.arrayContaining(ENTITY_STORE_TARGET_INDICES_PRIVILEGES),
-            },
-          ],
+            }),
+          ]),
         },
       });
     }
@@ -144,7 +162,7 @@ apiTest.describe('Entity Store entity maintainers', { tag: ENTITY_STORE_TAGS }, 
 
       expect(response.statusCode).toBe(403);
       expect(response.body.attributes).toMatchObject({
-        missing_kibana_privileges: [SAVED_OBJECT_PRIVILEGE],
+        missing_kibana_privileges: [ENGINE_DESCRIPTOR_CREATE_PRIVILEGE],
       });
     }
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Entity Analytics] Check privilges before trying to install or init ES V2 (#280251)](https://github.com/elastic/kibana/pull/280251)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"tcalopes","email":"tatiana.lopes@elastic.co"},"sourceCommit":{"committedDate":"2026-07-24T13:11:25Z","message":"[Entity Analytics] Check privilges before trying to install or init ES V2 (#280251)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/278587\n\n**Issue:**\n\nWhen a read-only user (e.g. `feature_siemV5.read` + cases read, no\nEntity Store index privileges) loads Security Solution,\n`useInstallEntityStoreV2` auto-POSTs\n`/api/security/entity_store/install` (or `/entity_maintainers/init` when\nthe store is already installed). The server correctly returns 403, but\neach session load records a failed write in audit logs.\n\n**Fix:**\n~Before either write POST, call `GET\n/internal/security/entity_store/check_privileges` and skip install /\nmaintainers-init when `has_write_permissions` is not true.~\n\nGate auto-install / maintainers-init on `has_install_permissions` from\n`GET /internal/security/entity_store/check_privileges` — the same\nprivilege set install and maintainers-init enforce server-side — so\nread-only users never fire those write POSTs.\n- `has_write_permissions` is data-plane write on entity indices. Install\nenforces a different set via `AssetManagerClient.getPrivileges()`\n(`read`+`manage` on targets, cluster template/pipeline privileges, SO\ncreate, source read). Gating on write could both false-negative and\nfalse-positive vs the server.\n\n**Other changes**\n\n- **`check_privileges` API:** adds `has_install_permissions` and\n`install_privileges`\n- **`getPrivileges()`:** checks the concrete latest index (+ alias),\nupdates/metadata data streams, and `manage_ingest_pipelines`\n- **Install side effects:** V1 cleanup and EUID script **create** run as\nthe internal ES user; EUID script **delete** on uninstall stays as the\nrequesting user (`kibana_system` can put scripts but not delete them)\n- **Enablement UI:** management toggle, enablement modal, and\nmissing-privileges callout use `has_install_permissions` /\n`install_privileges`\n- Toggle **ON** requires risk-engine **and** entity-store install\nprivileges\n- Toggle **OFF** requires SO write on `entity-engine-descriptor-v2`, not\nfull install ES privileges\n- When On and stop privileges are missing: disable the switch and show\n`EntityStoreMissingStopPrivilegesCallout` and hides the enable/install\ncallout while On\n- **Shared constants:** install privilege lists live in\n`@kbn/entity-store/common` so Scout specs don’t duplicate them\n\n## How to test\n\n1. As admin, uninstall Entity Store and re-enable auto-install:\n```\nPOST api/security/entity_store/uninstall {}\nPUT /internal/security/entity_store/preferences { \"autoInstall\": true }\n```\n2. Create a read-only role/user with Kibana `feature_siemV5.read` and no\nentity-store index privileges.\n3. Log in as that user, open the security solution (`/app/security`),\nand watch Network.\n4. Expect: `check_privileges`. Do **not** expect `POST .../install`.\n5. Repeat with the store already installed (`running`/`stopped`): do\n**not** expect `POST .../entity_maintainers/init`.\n6. As a privileged user with write access and `autoInstall: true`,\nconfirm auto-install still works as before.\n7. With Entity Analytics already On, log in as a user with Security\n`all` + SO create but without install ES `manage`/cluster: confirm\ntoggle can turn Off.\n8. As Security `read` only (no SO create): with store On, confirm toggle\nis disabled and the stop-privileges callout appears (enable callout does\nnot).\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/d998ed33-199b-4f0b-9a6c-1541139136da\n\n### After\n\n\nhttps://github.com/user-attachments/assets/c82b14de-09b9-40a7-8add-287292d23780\n\n---------\n\nCo-authored-by: Paulo Silva <paulo.henrique@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6d84ba23d8b6ba322409c7b967acf2dc4f84fc1f","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Entity Analytics","backport:version","v9.5.0","reviewer:scout","v9.6.0"],"title":"[Entity Analytics] Check privilges before trying to install or init ES V2","number":280251,"url":"https://github.com/elastic/kibana/pull/280251","mergeCommit":{"message":"[Entity Analytics] Check privilges before trying to install or init ES V2 (#280251)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/278587\n\n**Issue:**\n\nWhen a read-only user (e.g. `feature_siemV5.read` + cases read, no\nEntity Store index privileges) loads Security Solution,\n`useInstallEntityStoreV2` auto-POSTs\n`/api/security/entity_store/install` (or `/entity_maintainers/init` when\nthe store is already installed). The server correctly returns 403, but\neach session load records a failed write in audit logs.\n\n**Fix:**\n~Before either write POST, call `GET\n/internal/security/entity_store/check_privileges` and skip install /\nmaintainers-init when `has_write_permissions` is not true.~\n\nGate auto-install / maintainers-init on `has_install_permissions` from\n`GET /internal/security/entity_store/check_privileges` — the same\nprivilege set install and maintainers-init enforce server-side — so\nread-only users never fire those write POSTs.\n- `has_write_permissions` is data-plane write on entity indices. Install\nenforces a different set via `AssetManagerClient.getPrivileges()`\n(`read`+`manage` on targets, cluster template/pipeline privileges, SO\ncreate, source read). Gating on write could both false-negative and\nfalse-positive vs the server.\n\n**Other changes**\n\n- **`check_privileges` API:** adds `has_install_permissions` and\n`install_privileges`\n- **`getPrivileges()`:** checks the concrete latest index (+ alias),\nupdates/metadata data streams, and `manage_ingest_pipelines`\n- **Install side effects:** V1 cleanup and EUID script **create** run as\nthe internal ES user; EUID script **delete** on uninstall stays as the\nrequesting user (`kibana_system` can put scripts but not delete them)\n- **Enablement UI:** management toggle, enablement modal, and\nmissing-privileges callout use `has_install_permissions` /\n`install_privileges`\n- Toggle **ON** requires risk-engine **and** entity-store install\nprivileges\n- Toggle **OFF** requires SO write on `entity-engine-descriptor-v2`, not\nfull install ES privileges\n- When On and stop privileges are missing: disable the switch and show\n`EntityStoreMissingStopPrivilegesCallout` and hides the enable/install\ncallout while On\n- **Shared constants:** install privilege lists live in\n`@kbn/entity-store/common` so Scout specs don’t duplicate them\n\n## How to test\n\n1. As admin, uninstall Entity Store and re-enable auto-install:\n```\nPOST api/security/entity_store/uninstall {}\nPUT /internal/security/entity_store/preferences { \"autoInstall\": true }\n```\n2. Create a read-only role/user with Kibana `feature_siemV5.read` and no\nentity-store index privileges.\n3. Log in as that user, open the security solution (`/app/security`),\nand watch Network.\n4. Expect: `check_privileges`. Do **not** expect `POST .../install`.\n5. Repeat with the store already installed (`running`/`stopped`): do\n**not** expect `POST .../entity_maintainers/init`.\n6. As a privileged user with write access and `autoInstall: true`,\nconfirm auto-install still works as before.\n7. With Entity Analytics already On, log in as a user with Security\n`all` + SO create but without install ES `manage`/cluster: confirm\ntoggle can turn Off.\n8. As Security `read` only (no SO create): with store On, confirm toggle\nis disabled and the stop-privileges callout appears (enable callout does\nnot).\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/d998ed33-199b-4f0b-9a6c-1541139136da\n\n### After\n\n\nhttps://github.com/user-attachments/assets/c82b14de-09b9-40a7-8add-287292d23780\n\n---------\n\nCo-authored-by: Paulo Silva <paulo.henrique@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6d84ba23d8b6ba322409c7b967acf2dc4f84fc1f"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280251","number":280251,"mergeCommit":{"message":"[Entity Analytics] Check privilges before trying to install or init ES V2 (#280251)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/278587\n\n**Issue:**\n\nWhen a read-only user (e.g. `feature_siemV5.read` + cases read, no\nEntity Store index privileges) loads Security Solution,\n`useInstallEntityStoreV2` auto-POSTs\n`/api/security/entity_store/install` (or `/entity_maintainers/init` when\nthe store is already installed). The server correctly returns 403, but\neach session load records a failed write in audit logs.\n\n**Fix:**\n~Before either write POST, call `GET\n/internal/security/entity_store/check_privileges` and skip install /\nmaintainers-init when `has_write_permissions` is not true.~\n\nGate auto-install / maintainers-init on `has_install_permissions` from\n`GET /internal/security/entity_store/check_privileges` — the same\nprivilege set install and maintainers-init enforce server-side — so\nread-only users never fire those write POSTs.\n- `has_write_permissions` is data-plane write on entity indices. Install\nenforces a different set via `AssetManagerClient.getPrivileges()`\n(`read`+`manage` on targets, cluster template/pipeline privileges, SO\ncreate, source read). Gating on write could both false-negative and\nfalse-positive vs the server.\n\n**Other changes**\n\n- **`check_privileges` API:** adds `has_install_permissions` and\n`install_privileges`\n- **`getPrivileges()`:** checks the concrete latest index (+ alias),\nupdates/metadata data streams, and `manage_ingest_pipelines`\n- **Install side effects:** V1 cleanup and EUID script **create** run as\nthe internal ES user; EUID script **delete** on uninstall stays as the\nrequesting user (`kibana_system` can put scripts but not delete them)\n- **Enablement UI:** management toggle, enablement modal, and\nmissing-privileges callout use `has_install_permissions` /\n`install_privileges`\n- Toggle **ON** requires risk-engine **and** entity-store install\nprivileges\n- Toggle **OFF** requires SO write on `entity-engine-descriptor-v2`, not\nfull install ES privileges\n- When On and stop privileges are missing: disable the switch and show\n`EntityStoreMissingStopPrivilegesCallout` and hides the enable/install\ncallout while On\n- **Shared constants:** install privilege lists live in\n`@kbn/entity-store/common` so Scout specs don’t duplicate them\n\n## How to test\n\n1. As admin, uninstall Entity Store and re-enable auto-install:\n```\nPOST api/security/entity_store/uninstall {}\nPUT /internal/security/entity_store/preferences { \"autoInstall\": true }\n```\n2. Create a read-only role/user with Kibana `feature_siemV5.read` and no\nentity-store index privileges.\n3. Log in as that user, open the security solution (`/app/security`),\nand watch Network.\n4. Expect: `check_privileges`. Do **not** expect `POST .../install`.\n5. Repeat with the store already installed (`running`/`stopped`): do\n**not** expect `POST .../entity_maintainers/init`.\n6. As a privileged user with write access and `autoInstall: true`,\nconfirm auto-install still works as before.\n7. With Entity Analytics already On, log in as a user with Security\n`all` + SO create but without install ES `manage`/cluster: confirm\ntoggle can turn Off.\n8. As Security `read` only (no SO create): with store On, confirm toggle\nis disabled and the stop-privileges callout appears (enable callout does\nnot).\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/d998ed33-199b-4f0b-9a6c-1541139136da\n\n### After\n\n\nhttps://github.com/user-attachments/assets/c82b14de-09b9-40a7-8add-287292d23780\n\n---------\n\nCo-authored-by: Paulo Silva <paulo.henrique@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6d84ba23d8b6ba322409c7b967acf2dc4f84fc1f"}}]}] BACKPORT-->