### PR TITLE
[AlertingV2][POC] Add execution end marker event to prevent processing events of executions that have yet finished

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/partial_execution_visibility.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/partial_execution_visibility.test.ts
@@ -1,0 +1,290 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Reproduces https://github.com/elastic/rna-program/issues/437
+ *
+ * The rule executor writes alert events in streaming batches with
+ * `refresh: false`. Index auto-refresh can make an earlier batch searchable
+ * while a later batch of the SAME execution is still unwritten/unsearchable.
+ * If a dispatcher cycle runs inside that window, it sees a partial set of
+ * episodes, dispatches an aggregate group built from them, and records a
+ * `notified` action for the group. When the remaining episodes become
+ * visible, they resolve to the same deterministic action group id and
+ * throttling suppresses them — the notification for those episodes is lost.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import {
+  createRootWithCorePlugins,
+  createTestServers,
+  type TestElasticsearchUtils,
+} from '@kbn/core-test-helpers-kbn-server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import {
+  ALERT_ACTIONS_DATA_STREAM,
+  type AlertAction,
+} from '../../../resources/datastreams/alert_actions';
+import {
+  ALERT_EVENTS_DATA_STREAM,
+  type AlertEvent,
+} from '../../../resources/datastreams/alert_events';
+import { getDataStreamResourceDefinitions } from '../../../resources/datastreams/register';
+import type { ActionPolicySavedObjectAttributes } from '../../../saved_objects';
+import { DatastreamInitializer } from '../../services/resource_service/datastream_initializer';
+import { createActionPolicySavedObjectService } from '../../services/action_policy_saved_object_service/action_policy_saved_object_service.mock';
+import { createLoggerService } from '../../services/logger_service/logger_service.mock';
+import { QueryService } from '../../services/query_service/query_service';
+import { createRulesSavedObjectService } from '../../services/rules_saved_object_service/rules_saved_object_service.mock';
+import { StorageService } from '../../services/storage_service/storage_service';
+import { createRuleSoAttributes } from '../../test_utils';
+import { DispatcherService } from '../dispatcher';
+import { DispatcherPipeline } from '../execution_pipeline';
+import {
+  ApplySuppressionStep,
+  ApplyThrottlingStep,
+  BuildGroupsStep,
+  DispatchStep,
+  EvaluateMatchersStep,
+  FetchEpisodesStep,
+  FetchPoliciesStep,
+  FetchRulesStep,
+  FetchSuppressionsStep,
+  StoreActionsStep,
+} from '../steps';
+import type { ActionPolicyWorkflowPayload } from '../types';
+
+const RULE_ID = 'rule-437';
+const POLICY_ID = 'policy-all-mode';
+const WORKFLOW_ID = 'workflow-437';
+
+const GROUP_HASH_HOST_A = 'group-hash-host-a';
+const GROUP_HASH_HOST_B = 'group-hash-host-b';
+const GROUP_HASH_HOST_C = 'group-hash-host-c';
+
+function createAlertEvent(params: {
+  timestamp: string;
+  groupHash: string;
+  host: string;
+  episodeId: string;
+}): AlertEvent {
+  return {
+    '@timestamp': params.timestamp,
+    rule: { id: RULE_ID, version: 1 },
+    group_hash: params.groupHash,
+    data: { 'host.name': params.host },
+    status: 'breached',
+    source: 'internal',
+    type: 'alert',
+    episode: { id: params.episodeId, status: 'active' },
+    space_id: 'default',
+  };
+}
+
+function createAllModePolicyAttributes(): ActionPolicySavedObjectAttributes {
+  return {
+    name: 'All-mode policy',
+    description: 'Groups every matched episode into a single notification',
+    enabled: true,
+    destinations: [{ type: 'workflow', id: WORKFLOW_ID }],
+    groupingMode: 'all',
+    throttle: { strategy: 'time_interval', interval: '1h' },
+    auth: { apiKey: 'test-api-key', owner: 'elastic', createdByUser: false },
+    createdBy: null,
+    updatedBy: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('dispatcher: partial visibility of a rule execution (issue #437)', () => {
+  jest.setTimeout(300_000);
+
+  let manageES: TestElasticsearchUtils;
+  let root: ReturnType<typeof createRootWithCorePlugins>;
+  let esClient: ElasticsearchClient;
+  let storageService: StorageService;
+  let dispatcherService: DispatcherService;
+  let scheduleWorkflow: jest.Mock;
+
+  beforeAll(async () => {
+    // A fixed non-default port avoids colliding with dev/Scout clusters that
+    // occupy the default test ES port (9220).
+    const esPort = 9260;
+    const { startES } = createTestServers({
+      adjustTimeout: jest.setTimeout,
+      settings: { es: { port: esPort } },
+    });
+    manageES = await startES();
+
+    root = createRootWithCorePlugins(
+      {
+        elasticsearch: {
+          hosts: [`http://localhost:${esPort}`],
+          username: manageES.username,
+          password: manageES.password,
+        },
+      },
+      { oss: true }
+    );
+    await root.preboot();
+    await root.setup();
+    const coreStart = await root.start();
+    esClient = coreStart.elasticsearch.client.asInternalUser;
+  });
+
+  afterAll(async () => {
+    await root?.shutdown().catch(() => {});
+    await manageES?.stop().catch(() => {});
+  });
+
+  beforeEach(async () => {
+    // Reset the data streams so each test starts from empty indices — a
+    // leftover `notified` record from a previous test would trip throttling.
+    for (const definition of getDataStreamResourceDefinitions()) {
+      await esClient.indices
+        .deleteDataStream({ name: definition.dataStreamName })
+        .catch(() => {});
+    }
+    const logger = loggingSystemMock.createLogger();
+    for (const definition of getDataStreamResourceDefinitions()) {
+      await new DatastreamInitializer(logger, esClient, definition).initialize();
+    }
+
+    const { loggerService } = createLoggerService();
+
+    const queryService = new QueryService(esClient, loggerService);
+    storageService = new StorageService(esClient, loggerService);
+
+    const rulesMock = createRulesSavedObjectService();
+    rulesMock.mockFindByIds.mockResolvedValue([
+      { id: RULE_ID, attributes: createRuleSoAttributes(), namespaces: ['default'] },
+    ]);
+
+    const policiesMock = createActionPolicySavedObjectService();
+    policiesMock.mockFindAllDecrypted.mockResolvedValue([
+      { id: POLICY_ID, attributes: createAllModePolicyAttributes(), namespaces: ['default'] },
+    ]);
+
+    scheduleWorkflow = jest.fn().mockResolvedValue('workflow-execution-1');
+    const workflowsManagement = {
+      getWorkflow: jest.fn().mockResolvedValue({
+        id: WORKFLOW_ID,
+        name: 'Notify workflow',
+        enabled: true,
+        yaml: 'steps: []',
+        definition: undefined,
+      }),
+      scheduleWorkflow,
+    } as unknown as WorkflowsServerPluginSetup['management'];
+
+    const pipeline = new DispatcherPipeline(loggerService, [
+      new FetchEpisodesStep(queryService),
+      new FetchSuppressionsStep(queryService),
+      new ApplySuppressionStep(),
+      new FetchRulesStep(rulesMock.rulesSavedObjectService),
+      new FetchPoliciesStep(policiesMock.actionPolicySavedObjectService),
+      new EvaluateMatchersStep(loggerService),
+      new BuildGroupsStep(),
+      new ApplyThrottlingStep(queryService, loggerService),
+      new DispatchStep(loggerService, workflowsManagement),
+      new StoreActionsStep(storageService),
+    ]);
+    dispatcherService = new DispatcherService(pipeline);
+  });
+
+  /** Writes alert events the way the rule executor does (`refresh: false`). */
+  async function writeAlertEventsBatch(events: AlertEvent[]): Promise<void> {
+    const result = await storageService.bulkIndexDocs({
+      index: ALERT_EVENTS_DATA_STREAM,
+      docs: events,
+    });
+    expect(result.errors).toHaveLength(0);
+  }
+
+  async function refresh(index: string): Promise<void> {
+    await esClient.indices.refresh({ index });
+  }
+
+  async function fetchActions(): Promise<AlertAction[]> {
+    const response = await esClient.search<AlertAction>({
+      index: ALERT_ACTIONS_DATA_STREAM,
+      size: 100,
+      query: { match_all: {} },
+    });
+    return response.hits.hits.map((hit) => hit._source!);
+  }
+
+  function dispatchedGroupHashes(): string[] {
+    return scheduleWorkflow.mock.calls.flatMap((call) => {
+      const { payload } = call[2] as { payload: ActionPolicyWorkflowPayload };
+      return payload.episodes.map((episode) => episode.group_hash);
+    });
+  }
+
+  it('delivers every episode of an execution even when the dispatcher observes the execution partially', async () => {
+    const now = Date.now();
+    const eventTimestamp = new Date(now - 5_000).toISOString();
+    const lateEventTimestamp = new Date(now - 4_000).toISOString();
+    const previousStartedAt = new Date(now - 60_000);
+
+    // The rule execution produces three alert events (one per host), written
+    // in two streaming batches. Batch 1 becomes searchable via auto-refresh.
+    await writeAlertEventsBatch([
+      createAlertEvent({
+        timestamp: eventTimestamp,
+        groupHash: GROUP_HASH_HOST_A,
+        host: 'host-a',
+        episodeId: 'episode-host-a',
+      }),
+      createAlertEvent({
+        timestamp: eventTimestamp,
+        groupHash: GROUP_HASH_HOST_B,
+        host: 'host-b',
+        episodeId: 'episode-host-b',
+      }),
+    ]);
+    await refresh(ALERT_EVENTS_DATA_STREAM);
+
+    // Dispatcher cycle 1 runs before batch 2 is searchable: it only sees
+    // E1 (host-a) and E2 (host-b).
+    await dispatcherService.run({ previousStartedAt });
+
+    expect(scheduleWorkflow).toHaveBeenCalledTimes(1);
+    expect(dispatchedGroupHashes().sort()).toEqual([GROUP_HASH_HOST_A, GROUP_HASH_HOST_B]);
+
+    // The dispatcher's own writes become searchable before the next cycle.
+    await refresh(ALERT_ACTIONS_DATA_STREAM);
+
+    // Batch 2 (E3, host-c) lands and the executor's final explicit refresh
+    // makes it searchable.
+    await writeAlertEventsBatch([
+      createAlertEvent({
+        timestamp: lateEventTimestamp,
+        groupHash: GROUP_HASH_HOST_C,
+        host: 'host-c',
+        episodeId: 'episode-host-c',
+      }),
+    ]);
+    await refresh(ALERT_EVENTS_DATA_STREAM);
+
+    // Dispatcher cycle 2 picks up E3. It belongs to the same logical
+    // execution, so it must reach the user — not be throttled away because
+    // the group built from the partial view was already notified.
+    await dispatcherService.run({ previousStartedAt });
+
+    const hashes = dispatchedGroupHashes();
+    expect(hashes).toContain(GROUP_HASH_HOST_C);
+
+    await refresh(ALERT_ACTIONS_DATA_STREAM);
+    const suppressActionsForHostC = (await fetchActions()).filter(
+      (action) => action.action_type === 'suppress' && action.group_hash === GROUP_HASH_HOST_C
+    );
+    expect(suppressActionsForHostC).toHaveLength(0);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/partial_execution_visibility.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/partial_execution_visibility.test.ts
@@ -6,16 +6,19 @@
  */
 
 /**
- * Reproduces https://github.com/elastic/rna-program/issues/437
+ * Verifies the fix for https://github.com/elastic/rna-program/issues/437
  *
  * The rule executor writes alert events in streaming batches with
- * `refresh: false`. Index auto-refresh can make an earlier batch searchable
- * while a later batch of the SAME execution is still unwritten/unsearchable.
- * If a dispatcher cycle runs inside that window, it sees a partial set of
- * episodes, dispatches an aggregate group built from them, and records a
- * `notified` action for the group. When the remaining episodes become
- * visible, they resolve to the same deterministic action group id and
- * throttling suppresses them — the notification for those episodes is lost.
+ * `refresh: false`, so index auto-refresh can make an earlier batch searchable
+ * while a later batch of the SAME execution is still unsearchable. Without a
+ * guard, a dispatcher cycle running inside that window would act on a partial
+ * set of episodes and later suppress the remaining ones as already-notified.
+ *
+ * The fix has the executor write an `execution_end_marker` document as the last
+ * write of each execution, and the dispatcher only processes an execution's
+ * episodes once that marker is visible. This test asserts the resulting
+ * behavior: a partially-visible execution produces no notification, and once
+ * the marker lands every episode is delivered together in a single dispatch.
  */
 
 import type { ElasticsearchClient } from '@kbn/core/server';
@@ -68,6 +71,7 @@ const GROUP_HASH_HOST_B = 'group-hash-host-b';
 const GROUP_HASH_HOST_C = 'group-hash-host-c';
 
 function createAlertEvent(params: {
+  execution: { uuid: string };
   timestamp: string;
   groupHash: string;
   host: string;
@@ -75,6 +79,7 @@ function createAlertEvent(params: {
 }): AlertEvent {
   return {
     '@timestamp': params.timestamp,
+    execution: params.execution,
     rule: { id: RULE_ID, version: 1 },
     group_hash: params.groupHash,
     data: { 'host.name': params.host },
@@ -83,6 +88,17 @@ function createAlertEvent(params: {
     type: 'alert',
     episode: { id: params.episodeId, status: 'active' },
     space_id: 'default',
+  };
+}
+
+function createExecutionEndMarkerEvent(params: {
+  execution: { uuid: string };
+  timestamp: string;
+}): Partial<AlertEvent> {
+  return {
+    '@timestamp': params.timestamp,
+    execution: params.execution,
+    type: 'execution_end_marker',
   };
 }
 
@@ -199,7 +215,7 @@ describe('dispatcher: partial visibility of a rule execution (issue #437)', () =
   });
 
   /** Writes alert events the way the rule executor does (`refresh: false`). */
-  async function writeAlertEventsBatch(events: AlertEvent[]): Promise<void> {
+  async function writeAlertEventsBatch(events: Partial<AlertEvent>[]): Promise<void> {
     const result = await storageService.bulkIndexDocs({
       index: ALERT_EVENTS_DATA_STREAM,
       docs: events,
@@ -228,6 +244,7 @@ describe('dispatcher: partial visibility of a rule execution (issue #437)', () =
   }
 
   it('delivers every episode of an execution even when the dispatcher observes the execution partially', async () => {
+    const execution: { uuid: string } = { uuid: 'execution-1' };
     const now = Date.now();
     const eventTimestamp = new Date(now - 5_000).toISOString();
     const lateEventTimestamp = new Date(now - 4_000).toISOString();
@@ -237,12 +254,14 @@ describe('dispatcher: partial visibility of a rule execution (issue #437)', () =
     // in two streaming batches. Batch 1 becomes searchable via auto-refresh.
     await writeAlertEventsBatch([
       createAlertEvent({
+        execution,
         timestamp: eventTimestamp,
         groupHash: GROUP_HASH_HOST_A,
         host: 'host-a',
         episodeId: 'episode-host-a',
       }),
       createAlertEvent({
+        execution,
         timestamp: eventTimestamp,
         groupHash: GROUP_HASH_HOST_B,
         host: 'host-b',
@@ -251,35 +270,39 @@ describe('dispatcher: partial visibility of a rule execution (issue #437)', () =
     ]);
     await refresh(ALERT_EVENTS_DATA_STREAM);
 
-    // Dispatcher cycle 1 runs before batch 2 is searchable: it only sees
-    // E1 (host-a) and E2 (host-b).
+    // Dispatcher cycle 1 sees E1 (host-a) and E2 (host-b) but no marker yet, so
+    // the execution is treated as incomplete and nothing is dispatched.
     await dispatcherService.run({ previousStartedAt });
 
-    expect(scheduleWorkflow).toHaveBeenCalledTimes(1);
-    expect(dispatchedGroupHashes().sort()).toEqual([GROUP_HASH_HOST_A, GROUP_HASH_HOST_B]);
+    expect(scheduleWorkflow).toHaveBeenCalledTimes(0);
 
     // The dispatcher's own writes become searchable before the next cycle.
     await refresh(ALERT_ACTIONS_DATA_STREAM);
 
-    // Batch 2 (E3, host-c) lands and the executor's final explicit refresh
-    // makes it searchable.
+    // Batch 2 (E3, host-c) lands, followed by the execution-end marker as the
+    // last write of the execution.
     await writeAlertEventsBatch([
       createAlertEvent({
+        execution,
         timestamp: lateEventTimestamp,
         groupHash: GROUP_HASH_HOST_C,
         host: 'host-c',
         episodeId: 'episode-host-c',
       }),
+      createExecutionEndMarkerEvent({ execution, timestamp: lateEventTimestamp }),
     ]);
     await refresh(ALERT_EVENTS_DATA_STREAM);
 
-    // Dispatcher cycle 2 picks up E3. It belongs to the same logical
-    // execution, so it must reach the user — not be throttled away because
-    // the group built from the partial view was already notified.
+    // Dispatcher cycle 2 sees the marker, so the whole execution is now
+    // eligible and all three episodes are dispatched together — no episode is
+    // lost to throttling from a partial notification.
     await dispatcherService.run({ previousStartedAt });
 
-    const hashes = dispatchedGroupHashes();
-    expect(hashes).toContain(GROUP_HASH_HOST_C);
+    expect(dispatchedGroupHashes().sort()).toEqual([
+      GROUP_HASH_HOST_A,
+      GROUP_HASH_HOST_B,
+      GROUP_HASH_HOST_C,
+    ]);
 
     await refresh(ALERT_ACTIONS_DATA_STREAM);
     const suppressActionsForHostC = (await fetchActions()).filter(

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
@@ -21,15 +21,23 @@ import type { AlertEpisode, ActionGroupId } from './types';
 // without the explicit DROP it rides through the INLINE STATS buffer and can exceed ~16.8 MB.
 export const getDispatchableAlertEventsQuery = (): EsqlRequest => {
   const alertEventType: AlertEventType = 'alert';
+  const executionEndMarkerType: AlertEventType = 'execution_end_marker';
+
+  // Now - 6 mins
+  const fallbackCutoff = new Date(Date.now() - 6 * 60 * 1000).toISOString();
 
   return esql`FROM ${ALERT_EVENTS_DATA_STREAM},${ALERT_ACTIONS_DATA_STREAM} METADATA _source
-      | WHERE type IS NULL OR type == ${alertEventType}
+      | WHERE type IS NULL OR type == ${alertEventType} OR type == ${executionEndMarkerType}
       | EVAL
+          execution_uuid = execution.uuid,
           rule_id = COALESCE(rule.id, rule_id),
           episode_id = COALESCE(episode.id, episode_id),
           episode_status = episode.status,
           data_json = CASE(type IS NOT NULL, JSON_EXTRACT(_source, "$.data"), NULL)
-      | DROP episode.id, rule.id, episode.status, _source
+      | DROP episode.id, rule.id, episode.status, _source, execution.uuid
+      | INLINE STATS execution_end_marker_timestamp = MAX(@timestamp) WHERE type == "execution_end_marker" BY execution_uuid
+      | WHERE type IS NULL OR type == ${alertEventType}
+      | WHERE type is NULL or execution_end_marker_timestamp IS NOT NULL OR @timestamp < ${fallbackCutoff}::datetime
       | INLINE STATS last_fired = max(last_series_event_timestamp) WHERE action_type == "fire" OR action_type == "suppress" OR action_type == "unmatched" BY rule_id, group_hash
       | WHERE last_fired IS NULL OR last_fired < @timestamp
       | STATS

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/build_alert_events.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/build_alert_events.ts
@@ -160,6 +160,7 @@ export function createAlertEventsBatchBuilder({
 
       const doc = buildRuleEventDocument({
         '@timestamp': wroteAt,
+        execution: { uuid: executionUuid },
         scheduled_timestamp: scheduledTimestamp,
         rule: { id: ruleId, version: ruleVersion },
         group_hash: groupHash,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.test.ts
@@ -18,6 +18,7 @@ import {
 } from './test_utils';
 import { createMetricCollectorFactory } from './metrics/metric_collector_factory.mock';
 import { createMockRuleExecutorEventPublisher } from '../events/rule_executor_event_publisher/rule_executor_event_publisher.mock';
+import { createMockStorageServiceContract } from '../services/storage_service/storage_service.mock';
 import { MetricsMiddleware } from './metrics/metrics_middleware';
 import { EmittedCountersRecorder } from './metrics/recorders/emitted_counters_recorder';
 import { RULE_EXECUTION_COUNTERS } from './metrics/counters';
@@ -54,7 +55,8 @@ describe('RuleExecutionPipeline', () => {
         [step1, step2, step3],
         [],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput();
 
@@ -95,7 +97,8 @@ describe('RuleExecutionPipeline', () => {
         [step1, step2, step3],
         [],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput();
 
@@ -136,7 +139,8 @@ describe('RuleExecutionPipeline', () => {
         [step1, step2, step3],
         [],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput();
 
@@ -177,7 +181,8 @@ describe('RuleExecutionPipeline', () => {
         [step1, step2],
         [],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput();
 
@@ -191,7 +196,8 @@ describe('RuleExecutionPipeline', () => {
         [],
         [],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput();
 
@@ -246,7 +252,8 @@ describe('RuleExecutionPipeline', () => {
         [step1],
         [middleware1, middleware2],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput();
 
@@ -280,7 +287,8 @@ describe('RuleExecutionPipeline', () => {
         [step],
         [],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput();
 
@@ -306,7 +314,8 @@ describe('RuleExecutionPipeline', () => {
         [step],
         [],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput({ abortSignal: abortController.signal });
 
@@ -343,7 +352,8 @@ describe('RuleExecutionPipeline', () => {
         [step1],
         [errorMiddleware],
         createMetricCollectorFactory(),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
       const input = createRuleExecutionPipelineInput();
 
@@ -385,7 +395,8 @@ describe('RuleExecutionPipeline', () => {
         [],
         [],
         createMetricCollectorFactory({ startedAt }),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
 
       const result = await pipeline.execute(createRuleExecutionPipelineInput());
@@ -415,7 +426,8 @@ describe('RuleExecutionPipeline', () => {
         [step1, step2],
         [createMetricsMiddleware(loggerService)],
         createMetricCollectorFactory({ startedAt }),
-        createMockRuleExecutorEventPublisher()
+        createMockRuleExecutorEventPublisher(),
+        createMockStorageServiceContract()
       );
 
       const result = await pipeline.execute(createRuleExecutionPipelineInput());
@@ -445,7 +457,8 @@ describe('RuleExecutionPipeline', () => {
         [ruleStep, storeStep],
         [createMetricsMiddleware(loggerService)],
         createMetricCollectorFactory({ startedAt }),
-        eventPublisher
+        eventPublisher,
+        createMockStorageServiceContract()
       );
 
       const input = createRuleExecutionPipelineInput({
@@ -480,7 +493,8 @@ describe('RuleExecutionPipeline', () => {
         [ruleStep],
         [createMetricsMiddleware(loggerService)],
         createMetricCollectorFactory({ startedAt }),
-        eventPublisher
+        eventPublisher,
+        createMockStorageServiceContract()
       );
 
       await pipeline.execute(createRuleExecutionPipelineInput());
@@ -502,7 +516,8 @@ describe('RuleExecutionPipeline', () => {
         [],
         [createMetricsMiddleware(loggerService)],
         createMetricCollectorFactory({ startedAt }),
-        eventPublisher
+        eventPublisher,
+        createMockStorageServiceContract()
       );
 
       await pipeline.execute(createRuleExecutionPipelineInput());
@@ -525,7 +540,8 @@ describe('RuleExecutionPipeline', () => {
         [step],
         [createMetricsMiddleware(loggerService)],
         createMetricCollectorFactory({ startedAt }),
-        eventPublisher
+        eventPublisher,
+        createMockStorageServiceContract()
       );
 
       await expect(
@@ -551,7 +567,8 @@ describe('RuleExecutionPipeline', () => {
         [ruleStep],
         [createMetricsMiddleware(loggerService)],
         createMetricCollectorFactory({ startedAt }),
-        eventPublisher
+        eventPublisher,
+        createMockStorageServiceContract()
       );
 
       await pipeline.execute(createRuleExecutionPipelineInput());
@@ -573,7 +590,8 @@ describe('RuleExecutionPipeline', () => {
         [ruleStep, step2],
         [createMetricsMiddleware(loggerService)],
         createMetricCollectorFactory({ startedAt }),
-        eventPublisher
+        eventPublisher,
+        createMockStorageServiceContract()
       );
 
       const result = await pipeline.execute(createRuleExecutionPipelineInput());

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.ts
@@ -34,6 +34,7 @@ import {
 import { StorageServiceInternalToken } from '../services/storage_service/tokens';
 import type { StorageServiceContract } from '../services/storage_service/storage_service';
 import { ALERT_EVENTS_DATA_STREAM, AlertEvent } from '../../resources/datastreams/alert_events';
+import { buildExecutionUuid } from './build_alert_events';
 
 /**
  * Raw input from the task runner.
@@ -119,9 +120,20 @@ export class RuleExecutionPipeline implements RuleExecutionPipelineContract {
       // monotonic auto-refresh therefore guarantees: marker visible =>
       // every event of this execution visible. The dispatcher gates on this so
       // it never acts on a partially-written execution (rna-program#437).
+      // Must match the uuid the alert-event builder stamps on `execution.uuid`
+      // (deterministic from ruleId/spaceId/scheduledAt), NOT the Task Manager
+      // run uuid in `rawInput.executionUuid` — otherwise the dispatcher's gate
+      // groups the marker and the events under different uuids and never
+      // correlates them.
       await writeExecutionEndMarkerDoc({
         params: {
-          execution: { uuid: rawInput.executionUuid },
+          execution: {
+            uuid: buildExecutionUuid({
+              ruleId: rawInput.ruleId,
+              spaceId: rawInput.spaceId,
+              scheduledTimestamp: rawInput.scheduledAt,
+            }),
+          },
           timestamp: new Date().toISOString(),
           rule: { id: rawInput.ruleId },
           spaceId: rawInput.spaceId,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.ts
@@ -31,6 +31,9 @@ import {
   RuleExecutorEventPublisher,
   type RuleExecutorEventPublisherContract,
 } from '../events/rule_executor_event_publisher/rule_executor_event_publisher';
+import { StorageServiceInternalToken } from '../services/storage_service/tokens';
+import type { StorageServiceContract } from '../services/storage_service/storage_service';
+import { ALERT_EVENTS_DATA_STREAM, AlertEvent } from '../../resources/datastreams/alert_events';
 
 /**
  * Raw input from the task runner.
@@ -65,8 +68,10 @@ export class RuleExecutionPipeline implements RuleExecutionPipelineContract {
     @inject(MetricCollectorFactoryToken)
     private readonly metricCollectorFactory: MetricCollectorFactoryContract,
     @inject(RuleExecutorEventPublisher)
-    private readonly eventPublisher: RuleExecutorEventPublisherContract
-  ) {}
+    private readonly eventPublisher: RuleExecutorEventPublisherContract,
+    @inject(StorageServiceInternalToken)
+    private readonly storageService: StorageServiceContract
+  ) { }
 
   public async execute(rawInput: RuleExecutionPipelineInput): Promise<RuleExecutionPipelineResult> {
     const executionContext = createExecutionContext(rawInput.abortSignal);
@@ -108,6 +113,22 @@ export class RuleExecutionPipeline implements RuleExecutionPipelineContract {
       }
 
       const snapshot = collector.finalize();
+
+      // Written strictly after every per-batch StoreAlertEventsStep write has
+      // completed, so the marker is the last document of this execution. A
+      // monotonic auto-refresh therefore guarantees: marker visible =>
+      // every event of this execution visible. The dispatcher gates on this so
+      // it never acts on a partially-written execution (rna-program#437).
+      await writeExecutionEndMarkerDoc({
+        params: {
+          execution: { uuid: rawInput.executionUuid },
+          timestamp: new Date().toISOString(),
+          rule: { id: rawInput.ruleId },
+          spaceId: rawInput.spaceId,
+        },
+        deps: { storageService: this.storageService },
+      });
+
       this.publishExecutionSucceeded(rawInput, collector, pipelineState, snapshot);
       return {
         completed: true,
@@ -173,9 +194,8 @@ export class RuleExecutionPipeline implements RuleExecutionPipelineContract {
       });
     } catch (error) {
       this.logger.warn({
-        message: `[rule_executor] Failed to publish rule.execution.succeeded event: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        message: `[rule_executor] Failed to publish rule.execution.succeeded event: ${error instanceof Error ? error.message : String(error)
+          }`,
       });
     }
   }
@@ -188,10 +208,51 @@ export class RuleExecutionPipeline implements RuleExecutionPipelineContract {
       });
     } catch (publishError) {
       this.logger.warn({
-        message: `[rule_executor] Failed to publish rule.execution.failed event: ${
-          publishError instanceof Error ? publishError.message : String(publishError)
-        }`,
+        message: `[rule_executor] Failed to publish rule.execution.failed event: ${publishError instanceof Error ? publishError.message : String(publishError)
+          }`,
       });
     }
   }
 }
+
+/**
+ * Writes a single execution-end marker document to `.rule-events`.
+ *
+ * Called once, after the pipeline stream has drained, so it is the last write
+ * of the execution. Combined with Elasticsearch's monotonic refresh, this lets
+ * the dispatcher treat "marker visible" as "all events of this execution
+ * visible" and avoid acting on a partially-written execution (rna-program#437).
+ *
+ * Uses the default `refresh: false`; the guarantee comes from write ordering,
+ * not a synchronous refresh (which was intentionally removed in #274008).
+ */
+const writeExecutionEndMarkerDoc = async ({
+  params,
+  deps,
+}: {
+  params: {
+    execution: { uuid: string };
+    timestamp: string;
+    rule: { id: string };
+    spaceId: string;
+  };
+  deps: {
+    storageService: StorageServiceContract;
+  };
+}): Promise<void> => {
+
+  const doc: Partial<AlertEvent> = {
+    '@timestamp': params.timestamp,
+    type: 'execution_end_marker',
+    execution: { uuid: params.execution.uuid },
+    rule: { id: params.rule.id, version: 1 },
+    space_id: params.spaceId,
+  };
+
+  await deps.storageService.bulkIndexDocs({
+    index: ALERT_EVENTS_DATA_STREAM,
+    docs: [
+      doc,
+    ],
+  });
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_events.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_events.ts
@@ -51,7 +51,7 @@ const mappings: MappingsDefinition = {
 };
 
 const alertEventStatusSchema = z.enum(['breached', 'recovered', 'no_data']);
-const alertEventTypeSchema = z.enum(['signal', 'alert']);
+const alertEventTypeSchema = z.enum(['signal', 'alert', 'execution_end_marker']);
 const alertEpisodeStatusSchema = z.enum(['inactive', 'pending', 'active', 'recovering']);
 const alertEpisodeStatusCountSchema = z.number().int().optional();
 const alertEventSeveritySchema = z.enum(['info', 'low', 'medium', 'high', 'critical']);
@@ -65,7 +65,7 @@ export const alertEventSchema = z.object({
   '@timestamp': z.string(),
   execution: z.object({
     uuid: z.string(),
-  }),
+  }).optional(),
   scheduled_timestamp: z.string().optional(),
   rule: z.object({
     id: z.string(),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_events.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_events.ts
@@ -10,7 +10,7 @@ import { z } from '@kbn/zod/v4';
 import type { ResourceDefinition } from './types';
 
 export const ALERT_EVENTS_DATA_STREAM = '.rule-events';
-export const ALERT_EVENTS_DATA_STREAM_VERSION = 5;
+export const ALERT_EVENTS_DATA_STREAM_VERSION = 6;
 export const ALERT_EVENTS_BACKING_INDEX = '.ds-.rule-events-*';
 
 const mappings: MappingsDefinition = {
@@ -18,6 +18,12 @@ const mappings: MappingsDefinition = {
   properties: {
     // Document '_id' is used as the unique alert event identifier
     '@timestamp': { type: 'date' },
+    execution: {
+      type: 'object',
+      properties: {
+        uuid: { type: 'keyword' },
+      },
+    },
     scheduled_timestamp: { type: 'date' },
     rule: {
       type: 'object',
@@ -57,6 +63,9 @@ export const alertEventSeverity = alertEventSeveritySchema.enum;
 
 export const alertEventSchema = z.object({
   '@timestamp': z.string(),
+  execution: z.object({
+    uuid: z.string(),
+  }),
   scheduled_timestamp: z.string().optional(),
   rule: z.object({
     id: z.string(),


### PR DESCRIPTION
# POC: Prevent notification loss from partially-visible executions ([#437](https://github.com/elastic/rna-program/issues/437))

## Problem & context

The rule executor writes an execution's alert events to `.rule-events` in
streaming batches with `refresh: false`. Elasticsearch auto-refresh (~1s) can
make an earlier batch searchable while a later batch of the **same execution**
is still unsearchable.

The dispatcher runs independently (every ~5s) and can query inside that window,
seeing only a partial set of episodes. In `all` / `per_field` grouping modes
this is harmful: the dispatcher builds an aggregate group from the partial set,
dispatches it, and writes a `notified` record keyed by a deterministic
`action_group_id`. When the remaining episodes become visible, they resolve to
that same `action_group_id`, and throttling suppresses them as already-notified.

Result: the user gets an incomplete notification (e.g. 2 of 3 hosts), and the
missing episodes are silently dropped — with `time_interval` throttling, for up
to the whole throttle window.

The removal of the synchronous refresh (#274008) did not cause this — the race
exists with or without it, because auto-refresh exposes partial state either
way. The PR's assumption that the dispatcher "never reads events from the
current execution cycle" is only true by timing, not by construction.

## Fix proposed in the POC

Make execution completeness explicit, so the dispatcher never acts on a
partially-written execution:

1. **`execution.uuid` on alert events** — stamped on each event (already
   computed internally for `group_hash` fallback). Added to the `.rule-events`
   mapping/schema so it is queryable.

2. **Execution-end marker** — the executor writes one `execution_end_marker`
   document to `.rule-events` as the **last write** of the execution
   (`writeExecutionEndMarkerDoc`, after the pipeline stream drains, `refresh:
   false`). Because refreshes are monotonic, "marker visible" implies "all
   events of that execution visible" — no synchronous refresh needed, so the
   #274008 perf win is preserved.

3. **Dispatcher gate** — `getDispatchableAlertEventsQuery` computes, per
   `execution.uuid`, whether a marker is visible (`INLINE STATS`), then keeps an
   alert event only if its execution has a marker **or** the event is older than
   a fallback cutoff. Incomplete executions are excluded until complete;
   crashed executions are released after the fallback.

Validated end-to-end by an integration test against a real ES:
`partial_execution_visibility.test.ts` — a partial execution produces no
notification, and once the marker lands all episodes dispatch together.

## TBD / ToDo

- **Stamp `execution.uuid` on all event builders** — currently only `breached`.
  Recovery / no-data / continued-breach events don't carry it, so they fall into
  the `null` execution group and the gate delays them until the fallback. Make
  the field required once every builder sets it (centralize via
  `buildRuleEventDocument`).
- **Fallback cutoff constant** — replace the hardcoded `6 * 60 * 1000` with a
  documented constant tied to the rule executor task `timeout` (5m) and kept
  below the dispatcher `LOOKBACK_WINDOW_MINUTES` (10m).
- **Deterministic cutoff** — derive it from `input.startedAt` instead of
  `Date.now()` so the crash-path (fallback) case is unit-testable.
- **Marker on halts** — decide whether an execution that halts after writing
  some events should still emit a marker (otherwise those events wait for the
  fallback).
- **Data-stream version bump** — finalize the `.rule-events` version bump for
  migration once the mapping change is settled.
- **Tests** — unit tests for the gate and marker; a deterministic crash-path
  integration test (events without a marker released by age).
- **Audit other readers** — confirm no other query / the Director treats
  `execution_end_marker` documents as alert events.

## Alternative considered: reuse rule-execution-history events (#463)

#463 adds rule execution history via the shared `event_log` plugin
(`.kibana-event-log-ds`): an `execute-start` doc at task pickup and an `execute`
doc after the pipeline completes, correlated by an `execution.uuid`. The `execute`
doc is a natural "execution finished" signal, so the dispatcher could gate on it
instead of on a marker written to `.rule-events`.

**Pros**

- Reuses existing infrastructure (bulk writer, ILM, RBAC, REST/`IEventLogClient`).
- No extra document type polluting `.rule-events`.
- Richer metadata already captured (outcome, duration, batches, lag).
- Run correlation via `execution.uuid` is already part of the design.
- Aligns with the dispatcher's own action-history approach (same provider).

**Cons (why it does not work as a correctness gate)**

- **Cross-index visibility has no ordering guarantee.** The marker approach is
  safe because it is co-located in `.rule-events` and refreshes are monotonic
  within an index: marker visible ⇒ all events visible. The `execute` doc lives
  in a *different* index with an independent refresh cycle, so it can become
  visible *before* the last `.rule-events` batch is refreshed — the dispatcher
  would see "complete" while still missing events. That is the exact race we are
  fixing, reintroduced.
- **event_log is best-effort.** #463 states its writes are async-buffered and
  `logEvent` is fire-and-forget. A delayed or dropped `execute` doc would strand
  an execution's episodes (until the fallback, or indefinitely without one).
  A correctness gate should not depend on an observability channel.
- **Wrong tool for the job.** #463 answers observability questions ("how many
  runs failed / are lagging"); best-effort is fine there. Overloading it for
  control-flow gating couples the two and inherits its best-effort semantics.
- **`execution.uuid` mismatch.** #463 generates the uuid at task pickup; the
  executor's existing `executionUuid` is deterministic
  (`sha256(ruleId|spaceId|scheduledTimestamp)`). Correlating would require
  aligning on one.

**Making it work would require** either a synchronous `.rule-events` refresh
before emitting `execute` (regressing the #274008 perf win) or a
safety-margin watermark (still probabilistic) — neither clean.

**Conclusion:** this POC uses the co-located execution-end marker as the
correctness gate.

## Related

- [#437 ](https://github.com/elastic/rna-program/issues/437)— this bug (dispatcher side).
- [#456 ](https://github.com/elastic/rna-program/issues/456)— same partial-visibility family: frozen per-execution `@timestamp`.
- [#760](https://github.com/elastic/rna-program/issues/760) Separate executor bug found while investigating: per-batch false `recovered`
  events (`create_recovery_events_step.ts` computes recovery against only the
  current batch). Tracked separately.
