### PR TITLE
[One Workflow] Retry transient ES errors in workflow engine

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/moon.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.yml
@@ -38,6 +38,7 @@ dependsOn:
   - '@kbn/usage-api-plugin'
   - '@kbn/logging-mocks'
   - '@kbn/crypto'
+  - '@kbn/core-elasticsearch-server-utils'
   - '@kbn/es-errors'
   - '@kbn/spaces-plugin'
   - '@kbn/core-spaces-common'

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
@@ -50,8 +50,8 @@ export async function setupDependencies(
   // Get ES client from core services (guaranteed to be available at task execution time)
   const internalEsClient = coreStart.elasticsearch.client.asInternalUser;
 
-  const workflowExecutionRepository = new WorkflowExecutionRepository(internalEsClient);
-  const stepExecutionRepository = new StepExecutionRepository(internalEsClient);
+  const workflowExecutionRepository = new WorkflowExecutionRepository(internalEsClient, logger);
+  const stepExecutionRepository = new StepExecutionRepository(internalEsClient, logger);
   const workflowRepository = new WorkflowRepository({
     esClient: internalEsClient,
     logger,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/retry_transient_es_errors.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/retry_transient_es_errors.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { isRetryableEsClientError } from '@kbn/core-elasticsearch-server-utils';
+
+const MAX_ATTEMPTS = 3;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export const retryTransientEsErrors = async <T>(
+  esCall: () => Promise<T>,
+  { logger, attempt = 0 }: { logger: Logger; attempt?: number }
+): Promise<T> => {
+  try {
+    return await esCall();
+  } catch (e) {
+    if (attempt < MAX_ATTEMPTS && isRetryableEsClientError(e)) {
+      const retryCount = attempt + 1;
+      const retryDelaySec = Math.min(Math.pow(2, retryCount), 30); // 2s, 4s, 8s, 16s, 30s
+
+      logger.warn(
+        `Retrying Elasticsearch operation after [${retryDelaySec}s] due to error: ${e.toString()} ${
+          e.stack
+        }`
+      );
+
+      await delay(retryDelaySec * 1000 * Math.random());
+      return retryTransientEsErrors(esCall, { logger, attempt: retryCount });
+    }
+
+    throw e;
+  }
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/task_recovery.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/task_recovery.test.ts
@@ -69,8 +69,8 @@ describe('resolveInterruptedWorkflowRunTask', () => {
 
   beforeEach(() => {
     esClient = elasticsearchServiceMock.createElasticsearchClient();
-    repository = new WorkflowExecutionRepository(esClient);
-    stepExecutionRepository = new StepExecutionRepository(esClient);
+    repository = new WorkflowExecutionRepository(esClient, logger);
+    stepExecutionRepository = new StepExecutionRepository(esClient, logger);
     jest.spyOn(stepExecutionRepository, 'markNonTerminalStepsFailed').mockResolvedValue(undefined);
   });
 
@@ -232,8 +232,8 @@ describe('resolveInterruptedWorkflowResumeTask', () => {
 
   beforeEach(() => {
     esClient = elasticsearchServiceMock.createElasticsearchClient();
-    repository = new WorkflowExecutionRepository(esClient);
-    stepExecutionRepository = new StepExecutionRepository(esClient);
+    repository = new WorkflowExecutionRepository(esClient, logger);
+    stepExecutionRepository = new StepExecutionRepository(esClient, logger);
     jest.spyOn(stepExecutionRepository, 'markNonTerminalStepsFailed').mockResolvedValue(undefined);
   });
 
@@ -390,8 +390,8 @@ describe('resolveExhaustedWorkflowRunTask', () => {
 
   beforeEach(() => {
     esClient = elasticsearchServiceMock.createElasticsearchClient();
-    repository = new WorkflowExecutionRepository(esClient);
-    stepExecutionRepository = new StepExecutionRepository(esClient);
+    repository = new WorkflowExecutionRepository(esClient, logger);
+    stepExecutionRepository = new StepExecutionRepository(esClient, logger);
     jest.spyOn(stepExecutionRepository, 'markNonTerminalStepsFailed').mockResolvedValue(undefined);
     jest.spyOn(logger, 'error').mockImplementation(() => {});
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.test.ts
@@ -63,10 +63,10 @@ describe('checkAndSkipIfExistingScheduledExecution', () => {
     esClient.indices.exists = jest.fn().mockResolvedValue(false) as any;
     esClient.indices.create = jest.fn().mockResolvedValue({}) as any;
     esClient.update = jest.fn().mockResolvedValue({} as any);
-    workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
-    stepExecutionRepository = new StepExecutionRepository(esClient);
-    jest.spyOn(stepExecutionRepository, 'markNonTerminalStepsFailed').mockResolvedValue(undefined);
     logger = loggingSystemMock.create().get();
+    workflowExecutionRepository = new WorkflowExecutionRepository(esClient, logger);
+    stepExecutionRepository = new StepExecutionRepository(esClient, logger);
+    jest.spyOn(stepExecutionRepository, 'markNonTerminalStepsFailed').mockResolvedValue(undefined);
     workflow = {
       id: 'test-workflow-id',
       name: 'Test Workflow',

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -238,8 +238,8 @@ export class WorkflowsExecutionEnginePlugin
               };
 
               const esClient = coreStart.elasticsearch.client.asInternalUser;
-              const workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
-              const stepExecutionRepository = new StepExecutionRepository(esClient);
+              const workflowExecutionRepository = new WorkflowExecutionRepository(esClient, logger);
+              const stepExecutionRepository = new StepExecutionRepository(esClient, logger);
 
               const interruptedOutcome = await resolveInterruptedWorkflowRunTask({
                 workflowExecutionRepository,
@@ -366,8 +366,8 @@ export class WorkflowsExecutionEnginePlugin
               };
 
               const esClient = coreStart.elasticsearch.client.asInternalUser;
-              const workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
-              const stepExecutionRepository = new StepExecutionRepository(esClient);
+              const workflowExecutionRepository = new WorkflowExecutionRepository(esClient, logger);
+              const stepExecutionRepository = new StepExecutionRepository(esClient, logger);
 
               const interruptedOutcome = await resolveInterruptedWorkflowResumeTask({
                 workflowExecutionRepository,
@@ -507,8 +507,8 @@ export class WorkflowsExecutionEnginePlugin
               const esClient = coreStart.elasticsearch.client.asInternalUser;
 
               const workflowRepository = new WorkflowRepository({ esClient, logger });
-              const workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
-              const stepExecutionRepository = new StepExecutionRepository(esClient);
+              const workflowExecutionRepository = new WorkflowExecutionRepository(esClient, logger);
+              const stepExecutionRepository = new StepExecutionRepository(esClient, logger);
 
               const workflow = await workflowRepository.getWorkflow(workflowId, spaceId, {
                 includeGlobal: true,
@@ -681,7 +681,7 @@ export class WorkflowsExecutionEnginePlugin
 
     // Initialize ConcurrencyManager with dependencies
     const workflowTaskManager = new WorkflowTaskManager(plugins.taskManager);
-    const workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
+    const workflowExecutionRepository = new WorkflowExecutionRepository(esClient, this.logger);
     const workflowRepository = new WorkflowRepository({ esClient, logger: this.logger });
     this.concurrencyManager = new ConcurrencyManager(
       workflowTaskManager,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/logs_repository.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/logs_repository.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { loggerMock } from '@kbn/logging-mocks';
 import { LogsRepository } from './logs_repository';
 
 const createDataStreamClientMock = () => ({
@@ -37,7 +38,7 @@ describe('LogsRepository', () => {
   beforeEach(() => {
     dataStreamClient = createDataStreamClientMock();
     (initializeDataStreamClient as jest.Mock).mockResolvedValue(dataStreamClient);
-    repo = new LogsRepository({} as any);
+    repo = new LogsRepository({} as any, loggerMock.create());
   });
 
   describe('createLogs', () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/logs_repository.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/logs_repository.ts
@@ -8,9 +8,11 @@
  */
 
 import type { QueryDslQueryContainer, SortOrder } from '@elastic/elasticsearch/lib/api/types';
+import type { Logger } from '@kbn/core/server';
 import type { DataStreamsStart } from '@kbn/core-data-streams-server';
 import type { ClientSearchRequest } from '@kbn/data-streams';
 import { initializeDataStreamClient, type WorkflowLogEvent } from './data_stream';
+import { retryTransientEsErrors } from '../../lib/retry_transient_es_errors';
 
 export interface LogSearchResult {
   total: number;
@@ -35,13 +37,16 @@ export interface SearchLogsParams {
 }
 
 export class LogsRepository {
-  constructor(private readonly coreDataStreams: DataStreamsStart) {}
+  constructor(
+    private readonly coreDataStreams: DataStreamsStart,
+    private readonly logger: Logger
+  ) {}
 
   public async createLogs(logEvents: WorkflowLogEvent[]): Promise<void> {
     const dataStreamClient = await initializeDataStreamClient(this.coreDataStreams);
 
-    await dataStreamClient.create({
-      documents: logEvents,
+    await retryTransientEsErrors(() => dataStreamClient.create({ documents: logEvents }), {
+      logger: this.logger,
     });
   }
 
@@ -109,11 +114,15 @@ export class LogsRepository {
   private async searchDataStream(query: ClientSearchRequest): Promise<LogSearchResult> {
     const dataStreamClient = await initializeDataStreamClient(this.coreDataStreams);
 
-    const response = await dataStreamClient.search({
-      sort: [{ '@timestamp': { order: 'desc' } }],
-      size: 1000,
-      ...query,
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        dataStreamClient.search({
+          sort: [{ '@timestamp': { order: 'desc' } }],
+          size: 1000,
+          ...query,
+        }),
+      { logger: this.logger }
+    );
 
     return {
       total:

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { loggerMock } from '@kbn/logging-mocks';
 import { StepExecutionRepository } from './step_execution_repository';
 
 describe('StepExecutionRepository', () => {
@@ -30,7 +31,7 @@ describe('StepExecutionRepository', () => {
         create: jest.fn().mockResolvedValue({}),
       },
     };
-    underTest = new StepExecutionRepository(esClient as any);
+    underTest = new StepExecutionRepository(esClient as any, loggerMock.create());
   });
 
   describe('bulkUpsert', () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.ts
@@ -7,18 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ElasticsearchClient } from '@kbn/core/server';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { EsWorkflowStepExecution, SerializedError } from '@kbn/workflows';
 import { ExecutionStatus, isTerminalStatus } from '@kbn/workflows';
 import { getStepExecutionsByWorkflowExecution as getStepExecutionsByWorkflowExecutionShared } from '@kbn/workflows/server';
 import { WORKFLOWS_STEP_EXECUTIONS_INDEX } from '../../common';
+import { retryTransientEsErrors } from '../lib/retry_transient_es_errors';
 
 export type StepExecutionField = keyof EsWorkflowStepExecution;
 
 export class StepExecutionRepository {
   private indexName = WORKFLOWS_STEP_EXECUTIONS_INDEX;
 
-  constructor(private esClient: ElasticsearchClient) {}
+  constructor(private esClient: ElasticsearchClient, private logger: Logger) {}
 
   /**
    * Searches for step executions by workflow execution ID.
@@ -29,14 +30,18 @@ export class StepExecutionRepository {
   public async searchStepExecutionsByExecutionId(
     executionId: string
   ): Promise<EsWorkflowStepExecution[]> {
-    const response = await this.esClient.search<EsWorkflowStepExecution>({
-      index: this.indexName,
-      query: {
-        match: { workflowRunId: executionId },
-      },
-      sort: 'startedAt:desc',
-      size: 10000, // TODO: without it, it returns up to 10 results by default. We should improve this.
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.search<EsWorkflowStepExecution>({
+          index: this.indexName,
+          query: {
+            match: { workflowRunId: executionId },
+          },
+          sort: 'startedAt:desc',
+          size: 10000, // TODO: without it, it returns up to 10 results by default. We should improve this.
+        }),
+      { logger: this.logger }
+    );
 
     return response.hits.hits.map((hit) => hit._source as EsWorkflowStepExecution);
   }
@@ -78,12 +83,16 @@ export class StepExecutionRepository {
     sourceIncludes?: StepExecutionField[],
     sourceExcludes?: StepExecutionField[]
   ): Promise<EsWorkflowStepExecution[]> {
-    const response = await this.esClient.mget<EsWorkflowStepExecution>({
-      index: this.indexName,
-      ids: stepExecutionIds,
-      ...(sourceIncludes?.length ? { _source_includes: sourceIncludes } : {}),
-      ...(sourceExcludes?.length ? { _source_excludes: sourceExcludes } : {}),
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.mget<EsWorkflowStepExecution>({
+          index: this.indexName,
+          ids: stepExecutionIds,
+          ...(sourceIncludes?.length ? { _source_includes: sourceIncludes } : {}),
+          ...(sourceExcludes?.length ? { _source_excludes: sourceExcludes } : {}),
+        }),
+      { logger: this.logger }
+    );
 
     const outputExplicitlyRequested = !!sourceIncludes?.includes('output' as StepExecutionField);
 
@@ -136,14 +145,18 @@ export class StepExecutionRepository {
       }
     });
 
-    const bulkResponse = await this.esClient.bulk({
-      refresh: false, // Performance optimization: documents become searchable after next refresh (~1s)
-      index: this.indexName,
-      body: stepExecutions.flatMap((stepExecution) => [
-        { update: { _id: stepExecution.id } },
-        { doc: stepExecution, doc_as_upsert: true },
-      ]),
-    });
+    const bulkResponse = await retryTransientEsErrors(
+      () =>
+        this.esClient.bulk({
+          refresh: false, // Performance optimization: documents become searchable after next refresh (~1s)
+          index: this.indexName,
+          body: stepExecutions.flatMap((stepExecution) => [
+            { update: { _id: stepExecution.id } },
+            { doc: stepExecution, doc_as_upsert: true },
+          ]),
+        }),
+      { logger: this.logger }
+    );
 
     if (bulkResponse.errors) {
       const erroredDocuments = bulkResponse.items

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/workflow_execution_repository.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/workflow_execution_repository.test.ts
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { loggerMock } from '@kbn/logging-mocks';
 import {
   ConcurrencySlotOccupyingExecutionStatuses,
   ExecutionStatus,
   NonTerminalExecutionStatuses,
 } from '@kbn/workflows';
-import { loggerMock } from '@kbn/logging-mocks';
 import { WorkflowExecutionRepository } from './workflow_execution_repository';
 import { WORKFLOWS_EXECUTIONS_INDEX } from '../../common';
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/workflow_execution_repository.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/workflow_execution_repository.test.ts
@@ -12,6 +12,7 @@ import {
   ExecutionStatus,
   NonTerminalExecutionStatuses,
 } from '@kbn/workflows';
+import { loggerMock } from '@kbn/logging-mocks';
 import { WorkflowExecutionRepository } from './workflow_execution_repository';
 import { WORKFLOWS_EXECUTIONS_INDEX } from '../../common';
 
@@ -40,7 +41,7 @@ describe('WorkflowExecutionRepository', () => {
         create: jest.fn().mockResolvedValue({}),
       },
     };
-    repository = new WorkflowExecutionRepository(esClient as any);
+    repository = new WorkflowExecutionRepository(esClient as any, loggerMock.create());
   });
 
   describe('createWorkflowExecution', () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/workflow_execution_repository.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/workflow_execution_repository.ts
@@ -8,7 +8,7 @@
  */
 
 import type { estypes } from '@elastic/elasticsearch';
-import type { ElasticsearchClient } from '@kbn/core/server';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { EsWorkflowExecution } from '@kbn/workflows';
 import {
   ConcurrencySlotOccupyingExecutionStatuses,
@@ -16,11 +16,12 @@ import {
   NonTerminalExecutionStatuses,
 } from '@kbn/workflows';
 import { WORKFLOWS_EXECUTIONS_INDEX } from '../../common';
+import { retryTransientEsErrors } from '../lib/retry_transient_es_errors';
 
 export class WorkflowExecutionRepository {
   private indexName = WORKFLOWS_EXECUTIONS_INDEX;
 
-  constructor(private esClient: ElasticsearchClient) {}
+  constructor(private esClient: ElasticsearchClient, private logger: Logger) {}
 
   /**
    * Retrieves a workflow execution by its ID from Elasticsearch.
@@ -37,10 +38,14 @@ export class WorkflowExecutionRepository {
     spaceId: string
   ): Promise<EsWorkflowExecution | null> {
     try {
-      const response = await this.esClient.get<EsWorkflowExecution>({
-        index: this.indexName,
-        id: workflowExecutionId,
-      });
+      const response = await retryTransientEsErrors(
+        () =>
+          this.esClient.get<EsWorkflowExecution>({
+            index: this.indexName,
+            id: workflowExecutionId,
+          }),
+        { logger: this.logger }
+      );
 
       const doc = response._source;
       // Verify spaceId matches for security/multi-tenancy
@@ -79,12 +84,16 @@ export class WorkflowExecutionRepository {
       throw new Error('Workflow execution ID is required for creation');
     }
 
-    await this.esClient.index({
-      index: this.indexName,
-      id: workflowExecution.id,
-      refresh: options.refresh ?? false,
-      document: workflowExecution,
-    });
+    await retryTransientEsErrors(
+      () =>
+        this.esClient.index({
+          index: this.indexName,
+          id: workflowExecution.id,
+          refresh: options.refresh ?? false,
+          document: workflowExecution,
+        }),
+      { logger: this.logger }
+    );
   }
 
   /**
@@ -110,11 +119,18 @@ export class WorkflowExecutionRepository {
       }
     });
 
-    const bulkResponse = await this.esClient.bulk({
-      refresh: options.refresh ?? false,
-      index: this.indexName,
-      operations: executions.flatMap((execution) => [{ create: { _id: execution.id } }, execution]),
-    });
+    const bulkResponse = await retryTransientEsErrors(
+      () =>
+        this.esClient.bulk({
+          refresh: options.refresh ?? false,
+          index: this.indexName,
+          operations: executions.flatMap((execution) => [
+            { create: { _id: execution.id } },
+            execution,
+          ]),
+        }),
+      { logger: this.logger }
+    );
 
     return bulkResponse.items.map((item, idx) => {
       const op = item.create ?? item.index;
@@ -146,12 +162,17 @@ export class WorkflowExecutionRepository {
       throw new Error('Workflow execution ID is required for update');
     }
 
-    await this.esClient.update<Partial<EsWorkflowExecution>>({
-      index: this.indexName,
-      id: workflowExecution.id,
-      refresh: options.refresh ?? false,
-      doc: workflowExecution,
-    });
+    const { id } = workflowExecution;
+    await retryTransientEsErrors(
+      () =>
+        this.esClient.update<Partial<EsWorkflowExecution>>({
+          index: this.indexName,
+          id,
+          refresh: options.refresh ?? false,
+          doc: workflowExecution,
+        }),
+      { logger: this.logger }
+    );
   }
 
   /**
@@ -175,11 +196,15 @@ export class WorkflowExecutionRepository {
       }
     });
 
-    const bulkResponse = await this.esClient.bulk({
-      refresh: true,
-      index: this.indexName,
-      body: updates.flatMap((update) => [{ update: { _id: update.id } }, { doc: update }]),
-    });
+    const bulkResponse = await retryTransientEsErrors(
+      () =>
+        this.esClient.bulk({
+          refresh: true,
+          index: this.indexName,
+          body: updates.flatMap((update) => [{ update: { _id: update.id } }, { doc: update }]),
+        }),
+      { logger: this.logger }
+    );
 
     if (bulkResponse.errors) {
       const erroredDocuments = bulkResponse.items
@@ -206,11 +231,15 @@ export class WorkflowExecutionRepository {
    * @returns A promise that resolves to the list of search hits.
    */
   public async searchWorkflowExecutions(query: Record<string, unknown>, size: number = 10) {
-    const response = await this.esClient.search<EsWorkflowExecution>({
-      index: this.indexName,
-      query,
-      size,
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.search<EsWorkflowExecution>({
+          index: this.indexName,
+          query,
+          size,
+        }),
+      { logger: this.logger }
+    );
 
     return response.hits.hits;
   }
@@ -250,18 +279,22 @@ export class WorkflowExecutionRepository {
       filterClauses.push({ term: { triggeredBy } });
     }
 
-    const response = await this.esClient.search<EsWorkflowExecution>({
-      index: this.indexName,
-      size: 0, // Don't need the document, just checking existence
-      terminate_after: 1, // Stop after finding 1 match
-      track_total_hits: true,
-      _source: false, // Don't fetch document content, only check existence
-      query: {
-        bool: {
-          filter: filterClauses, // Filter context = no scoring = faster
-        },
-      },
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.search<EsWorkflowExecution>({
+          index: this.indexName,
+          size: 0, // Don't need the document, just checking existence
+          terminate_after: 1, // Stop after finding 1 match
+          track_total_hits: true,
+          _source: false, // Don't fetch document content, only check existence
+          query: {
+            bool: {
+              filter: filterClauses, // Filter context = no scoring = faster
+            },
+          },
+        }),
+      { logger: this.logger }
+    );
 
     const total = response.hits.total;
     if (total === undefined) {
@@ -300,16 +333,20 @@ export class WorkflowExecutionRepository {
       filterClauses.push({ term: { triggeredBy } });
     }
 
-    const response = await this.esClient.search<EsWorkflowExecution>({
-      index: this.indexName,
-      size: 1,
-      terminate_after: 1, // Stop after finding 1 match
-      query: {
-        bool: {
-          filter: filterClauses, // Filter context = no scoring = faster
-        },
-      },
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.search<EsWorkflowExecution>({
+          index: this.indexName,
+          size: 1,
+          terminate_after: 1, // Stop after finding 1 match
+          query: {
+            bool: {
+              filter: filterClauses, // Filter context = no scoring = faster
+            },
+          },
+        }),
+      { logger: this.logger }
+    );
 
     return response.hits.hits;
   }
@@ -356,20 +393,24 @@ export class WorkflowExecutionRepository {
       });
     }
 
-    const response = await this.esClient.search<Pick<EsWorkflowExecution, 'id'>>({
-      index: this.indexName,
-      query: {
-        bool: {
-          filter: filterClauses, // Filter context = no scoring = faster
-        },
-      },
-      _source: ['id'], // Only fetch ID field for efficiency
-      sort: [
-        { createdAt: { order: 'asc' } },
-        { id: { order: 'asc' } }, // Tie-break for determinism when createdAt collides; not chronological order
-      ],
-      size: Math.min(size, 10000), // Cap at ES default max_result_window for validation
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.search<Pick<EsWorkflowExecution, 'id'>>({
+          index: this.indexName,
+          query: {
+            bool: {
+              filter: filterClauses, // Filter context = no scoring = faster
+            },
+          },
+          _source: ['id'], // Only fetch ID field for efficiency
+          sort: [
+            { createdAt: { order: 'asc' } },
+            { id: { order: 'asc' } }, // Tie-break for determinism when createdAt collides; not chronological order
+          ],
+          size: Math.min(size, 10000), // Cap at ES default max_result_window for validation
+        }),
+      { logger: this.logger }
+    );
 
     return response.hits.hits
       .map((hit) => hit._source?.id ?? hit._id)
@@ -397,14 +438,18 @@ export class WorkflowExecutionRepository {
         },
       });
     }
-    const response = await this.esClient.count({
-      index: this.indexName,
-      query: {
-        bool: {
-          filter: filterClauses,
-        },
-      },
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.count({
+          index: this.indexName,
+          query: {
+            bool: {
+              filter: filterClauses,
+            },
+          },
+        }),
+      { logger: this.logger }
+    );
 
     return response.count;
   }
@@ -416,21 +461,25 @@ export class WorkflowExecutionRepository {
     concurrencyGroupKey: string,
     spaceId: string
   ): Promise<string | null> {
-    const response = await this.esClient.search<Pick<EsWorkflowExecution, 'id'>>({
-      index: this.indexName,
-      size: 1,
-      query: {
-        bool: {
-          filter: [
-            { term: { concurrencyGroupKey } },
-            { term: { spaceId } },
-            { term: { status: ExecutionStatus.QUEUED } },
-          ],
-        },
-      },
-      _source: ['id'],
-      sort: [{ createdAt: { order: 'asc' } }, { id: { order: 'asc' } }],
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.search<Pick<EsWorkflowExecution, 'id'>>({
+          index: this.indexName,
+          size: 1,
+          query: {
+            bool: {
+              filter: [
+                { term: { concurrencyGroupKey } },
+                { term: { spaceId } },
+                { term: { status: ExecutionStatus.QUEUED } },
+              ],
+            },
+          },
+          _source: ['id'],
+          sort: [{ createdAt: { order: 'asc' } }, { id: { order: 'asc' } }],
+        }),
+      { logger: this.logger }
+    );
     const hit = response.hits.hits[0];
     const id = hit?._source?.id ?? hit?._id;
     return typeof id === 'string' ? id : null;
@@ -443,28 +492,32 @@ export class WorkflowExecutionRepository {
     workflowExecutionId: string;
     spaceId: string;
   }): Promise<boolean> {
-    const response = await this.esClient.update({
-      index: this.indexName,
-      id: params.workflowExecutionId,
-      // Near-real-time search must see this doc as PENDING before the next
-      // drain loop iteration counts slot occupancy; otherwise max:1 can double-promote.
-      refresh: 'wait_for',
-      script: {
-        lang: 'painless',
-        source: `
-          if (ctx._source.status == params.queuedStatus && ctx._source.spaceId == params.spaceId) {
-            ctx._source.status = params.pendingStatus;
-          } else {
-            ctx.op = 'noop';
-          }
-        `,
-        params: {
-          queuedStatus: ExecutionStatus.QUEUED,
-          pendingStatus: ExecutionStatus.PENDING,
-          spaceId: params.spaceId,
-        },
-      },
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.update({
+          index: this.indexName,
+          id: params.workflowExecutionId,
+          // Near-real-time search must see this doc as PENDING before the next
+          // drain loop iteration counts slot occupancy; otherwise max:1 can double-promote.
+          refresh: 'wait_for',
+          script: {
+            lang: 'painless',
+            source: `
+              if (ctx._source.status == params.queuedStatus && ctx._source.spaceId == params.spaceId) {
+                ctx._source.status = params.pendingStatus;
+              } else {
+                ctx.op = 'noop';
+              }
+            `,
+            params: {
+              queuedStatus: ExecutionStatus.QUEUED,
+              pendingStatus: ExecutionStatus.PENDING,
+              spaceId: params.spaceId,
+            },
+          },
+        }),
+      { logger: this.logger }
+    );
     return response.result === 'updated';
   }
 
@@ -501,19 +554,23 @@ export class WorkflowExecutionRepository {
 
     const pageSize = Math.min(size, 10000); // Cap at ES default max_result_window
 
-    const response = await this.esClient.search<Pick<EsWorkflowExecution, 'id'>>({
-      index: this.indexName,
-      query: {
-        bool: {
-          filter: filterClauses,
-        },
-      },
-      _source: ['id'],
-      sort: [{ createdAt: { order: 'asc' } }, { id: { order: 'asc' } }],
-      size: pageSize,
-      track_total_hits: true,
-      ...(searchAfter?.length ? { search_after: searchAfter } : {}),
-    });
+    const response = await retryTransientEsErrors(
+      () =>
+        this.esClient.search<Pick<EsWorkflowExecution, 'id'>>({
+          index: this.indexName,
+          query: {
+            bool: {
+              filter: filterClauses,
+            },
+          },
+          _source: ['id'],
+          sort: [{ createdAt: { order: 'asc' } }, { id: { order: 'asc' } }],
+          size: pageSize,
+          track_total_hits: true,
+          ...(searchAfter?.length ? { search_after: searchAfter } : {}),
+        }),
+      { logger: this.logger }
+    );
 
     const hits = response.hits.hits;
     const results = hits

--- a/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/trigger_event_handler.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/trigger_event_handler.ts
@@ -172,7 +172,7 @@ export class TriggerEventHandler {
     this.telemetryClient = new WorkflowExecutionTelemetryClient(coreStart.analytics, deps.logger);
 
     const esClient = coreStart.elasticsearch.client.asInternalUser;
-    this.workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
+    this.workflowExecutionRepository = new WorkflowExecutionRepository(esClient, this.logger);
     this.triggerEventsClientPromise =
       deps.triggerEventsClientPromise ?? initializeTriggerEventsClient(coreStart.dataStreams);
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_event_logger/workflow_event_logger_service.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_event_logger/workflow_event_logger_service.ts
@@ -29,7 +29,7 @@ export class WorkflowEventLoggerService implements IWorkflowEventLoggerService {
     private readonly logger: Logger,
     private readonly enableConsoleLogging: boolean = false
   ) {
-    this.logsRepository = new LogsRepository(dataStreams);
+    this.logsRepository = new LogsRepository(dataStreams, logger);
   }
 
   public createLogger(context: WorkflowEventLoggerContext): IWorkflowEventLogger {

--- a/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
@@ -34,6 +34,7 @@
     "@kbn/usage-api-plugin",
     "@kbn/logging-mocks",
     "@kbn/crypto",
+    "@kbn/core-elasticsearch-server-utils",
     "@kbn/es-errors",
     "@kbn/spaces-plugin",
     "@kbn/core-spaces-common",


### PR DESCRIPTION
All Elasticsearch calls in WorkflowExecutionRepository, StepExecutionRepository, and LogsRepository are now wrapped with retryTransientEsErrors — a helper that retries on NoLivingConnectionsError, ConnectionError, TimeoutError, and common 5xx responses (up to 3 attempts, exponential backoff 2s→4s→8s with jitter).

This addresses the production incident where 1000 concurrent workflow scheduling writes caused ES to drop connections. Previously those errors propagated silently — failed alerts were dropped with only a log line, and subsequent TM task retries produced orphaned 404s. Now transient connectivity failures are retried at the repository level before surfacing as task failures.

The helper follows the same pattern used by the Alerting and SLO plugins, backed by isRetryableEsClientError from @kbn/core-elasticsearch-server-utils.