### PR TITLE
Add scoped session metrics for exploratory tester

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/.agents/scripts/session-token-usage.py
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/scripts/session-token-usage.py
@@ -28,77 +28,8 @@ Consumers:
 Shared across both skills to avoid drift on transcript parsing and edge-case handling.
 """
 
-import json
-import os
 import sys
-from pathlib import Path
-
-
-def resolve_transcript(explicit_path=None):
-    """Return the path to the JSONL transcript, or None if not found."""
-    if explicit_path:
-        p = Path(explicit_path)
-        return p if p.is_file() else None
-
-    session_id = os.environ.get('CLAUDE_CODE_SESSION_ID', '').strip()
-    if not session_id:
-        return None
-
-    # cwd slug: replace '/' with '-' (leading '/' becomes leading '-')
-    cwd_slug = os.getcwd().replace('/', '-')
-    transcript = Path.home() / '.claude' / 'projects' / cwd_slug / f'{session_id}.jsonl'
-    if transcript.is_file():
-        return transcript
-
-    # Session ID was set but the specific file wasn't found — don't guess with a
-    # different session's transcript; return None so the caller writes "not available".
-    return None
-
-
-def sum_tokens(transcript_path):
-    """
-    Sum token fields across all lines in the JSONL transcript.
-
-    Each line may be a JSON object with a top-level 'usage' key (older format)
-    or a 'message' key whose value has a 'usage' sub-key (newer format).
-    Unrecognised or unparseable lines are silently skipped.
-    """
-    totals = {
-        'input_tokens': 0,
-        'output_tokens': 0,
-        'cache_creation_input_tokens': 0,
-        'cache_read_input_tokens': 0,
-    }
-    usage_blocks = 0
-
-    with open(transcript_path, encoding='utf-8') as fh:
-        for raw in fh:
-            raw = raw.strip()
-            if not raw:
-                continue
-            try:
-                obj = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-
-            # Try 'message.usage' first (Claude Code ≥ 2025 format)
-            usage = None
-            msg = obj.get('message')
-            if isinstance(msg, dict):
-                usage = msg.get('usage')
-            # Fall back to top-level 'usage'
-            if not isinstance(usage, dict):
-                usage = obj.get('usage')
-            if not isinstance(usage, dict):
-                continue
-
-            usage_blocks += 1
-            for key in totals:
-                v = usage.get(key, 0)
-                if isinstance(v, (int, float)):
-                    totals[key] += int(v)
-
-    return totals, usage_blocks
+from session_metrics import format_legacy_usage, parse_transcript, resolve_transcript
 
 
 def main():
@@ -109,25 +40,11 @@ def main():
         # Not Claude Code or transcript missing — caller writes "not available"
         sys.exit(1)
 
-    try:
-        t, usage_blocks = sum_tokens(transcript)
-    except OSError:
+    result = parse_transcript(transcript)
+    if result.status != "available" or result.totals is None:
         sys.exit(1)
 
-    if usage_blocks == 0:
-        # Transcript exists but contains no usage blocks — format unrecognised or
-        # session ended before any exchange was recorded. Treat as unreadable so
-        # the caller writes "not available" rather than a misleading "total 0".
-        sys.exit(1)
-
-    total = sum(t.values())
-    print(
-        f"input={t['input_tokens']} "
-        f"output={t['output_tokens']} "
-        f"cache_create={t['cache_creation_input_tokens']} "
-        f"cache_read={t['cache_read_input_tokens']} "
-        f"total={total}"
-    )
+    print(format_legacy_usage(result.totals))
     sys.exit(0)
 
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/scripts/session_metrics.py
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/scripts/session_metrics.py
@@ -8,7 +8,7 @@ import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 
 TOKEN_FIELDS = (
@@ -17,6 +17,18 @@ TOKEN_FIELDS = (
     "cache_creation_input_tokens",
     "cache_read_input_tokens",
 )
+ALLOWED_SCOPES = frozenset(("orchestrator", "worker"))
+ALLOWED_ARTIFACT_KINDS = frozenset(
+    (
+        "findings",
+        "report",
+        "screenshot",
+        "video",
+        "configuration",
+        "detector_source",
+    )
+)
+PAYLOAD_FIELDS = ("tool_input", "tool_output", "browser_events")
 
 
 @dataclass(frozen=True)
@@ -67,6 +79,19 @@ class TranscriptResult:
     status: str
     totals: TokenTotals | None
     usage_blocks: int
+
+
+@dataclass(frozen=True)
+class ManifestTranscript:
+    path: str
+    scope: str = "orchestrator"
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class ManifestArtifact:
+    path: str
+    kind: str
 
 
 def resolve_transcript(explicit_path: str | None) -> Path | None:
@@ -166,3 +191,236 @@ def format_legacy_usage(totals: TokenTotals) -> str:
         f"cache_read={totals.cache_read_input_tokens} "
         f"total={totals.total}"
     )
+
+
+def load_manifest(path: Path) -> dict[str, object]:
+    """Load and validate the versioned session metrics manifest."""
+    try:
+        with path.open(encoding="utf-8") as manifest_file:
+            manifest = json.load(manifest_file)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Unable to read metrics manifest: {path}") from exc
+
+    if not isinstance(manifest, dict) or manifest.get("version") != 1:
+        raise ValueError("Metrics manifest must be an object with version 1")
+    return manifest
+
+
+def _resolve_manifest_path(root: Path, relative_path: str) -> Path:
+    if not isinstance(relative_path, str) or not relative_path:
+        raise ValueError("Manifest paths must be non-empty strings")
+
+    candidate = (root / relative_path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Manifest path escapes session root: {relative_path}") from exc
+    return candidate
+
+
+def _manifest_transcripts(
+    manifest: Mapping[str, object],
+) -> list[ManifestTranscript]:
+    raw_transcripts = manifest.get("transcripts", [])
+    if not isinstance(raw_transcripts, list):
+        raise ValueError("Manifest transcripts must be a list")
+
+    transcripts: list[ManifestTranscript] = []
+    for raw_transcript in raw_transcripts:
+        if not isinstance(raw_transcript, dict):
+            raise ValueError("Manifest transcript entries must be objects")
+        path = raw_transcript.get("path")
+        scope = raw_transcript.get("scope", "orchestrator")
+        name = raw_transcript.get("name")
+        if not isinstance(path, str) or not isinstance(scope, str):
+            raise ValueError("Manifest transcript path and scope must be strings")
+        if scope not in ALLOWED_SCOPES:
+            raise ValueError(f"Unsupported transcript scope: {scope}")
+        if name is not None and not isinstance(name, str):
+            raise ValueError("Manifest transcript name must be a string")
+        transcripts.append(ManifestTranscript(path, scope, name))
+    return transcripts
+
+
+def _manifest_artifacts(
+    manifest: Mapping[str, object],
+) -> list[ManifestArtifact]:
+    raw_artifacts = manifest.get("artifacts", [])
+    if not isinstance(raw_artifacts, list):
+        raise ValueError("Manifest artifacts must be a list")
+
+    artifacts: list[ManifestArtifact] = []
+    for raw_artifact in raw_artifacts:
+        if not isinstance(raw_artifact, dict):
+            raise ValueError("Manifest artifact entries must be objects")
+        path = raw_artifact.get("path")
+        kind = raw_artifact.get("kind")
+        if not isinstance(path, str) or not isinstance(kind, str):
+            raise ValueError("Manifest artifact path and kind must be strings")
+        if kind not in ALLOWED_ARTIFACT_KINDS:
+            raise ValueError(f"Unsupported artifact kind: {kind}")
+        artifacts.append(ManifestArtifact(path, kind))
+    return artifacts
+
+
+def _session_dir_artifacts(session_dir: Path) -> list[ManifestArtifact]:
+    artifacts: list[ManifestArtifact] = []
+    artifacts.extend(
+        ManifestArtifact(path.name, "findings")
+        for path in session_dir.glob("findings-flow-*.md")
+        if path.is_file()
+    )
+    for name, kind in (("report.md", "report"), ("config.json", "configuration")):
+        path = session_dir / name
+        if path.is_file():
+            artifacts.append(ManifestArtifact(name, kind))
+
+    screenshot_extensions = {".jpg", ".jpeg", ".png", ".webp"}
+    video_extensions = {".mov", ".mp4", ".webm"}
+    for directory, extensions, kind in (
+        ("screenshots", screenshot_extensions, "screenshot"),
+        ("videos", video_extensions, "video"),
+    ):
+        root = session_dir / directory
+        if not root.is_dir():
+            continue
+        artifacts.extend(
+            ManifestArtifact(str(path.relative_to(session_dir)), kind)
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix.lower() in extensions
+        )
+    return artifacts
+
+
+def _artifact_metrics(
+    root: Path,
+    manifest_artifacts: list[ManifestArtifact],
+    session_dir: Path | None,
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    artifacts = list(manifest_artifacts)
+    if session_dir is not None:
+        artifacts.extend(_session_dir_artifacts(session_dir))
+
+    by_kind: dict[str, dict[str, int]] = {}
+    sources: list[dict[str, object]] = []
+    counted_paths: set[Path] = set()
+    for artifact in artifacts:
+        path = _resolve_manifest_path(root, artifact.path)
+        source = {"kind": "artifact", "path": str(path), "artifact_kind": artifact.kind}
+        if not path.is_file():
+            source["status"] = "missing"
+            sources.append(source)
+            continue
+        if path in counted_paths:
+            continue
+        counted_paths.add(path)
+        stats = by_kind.setdefault(artifact.kind, {"files": 0, "bytes": 0})
+        stats["files"] += 1
+        stats["bytes"] += path.stat().st_size
+        source["status"] = "available"
+        source["bytes"] = path.stat().st_size
+        sources.append(source)
+
+    status = "available" if by_kind else "not_available"
+    return {"status": status, "by_kind": by_kind}, sources
+
+
+def _payload_metrics(manifest: Mapping[str, object]) -> dict[str, object]:
+    raw_payload = manifest.get("payload_bytes")
+    if not isinstance(raw_payload, dict):
+        return {"status": "not_available"}
+
+    values: dict[str, int] = {}
+    for field in PAYLOAD_FIELDS:
+        value = _as_non_negative_integer(raw_payload.get(field))
+        if value is None:
+            return {"status": "not_available"}
+        values[field] = value
+    return {"status": "available", **values}
+
+
+def _token_metrics(
+    results: list[TranscriptResult],
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    by_scope: dict[str, TokenTotals] = {}
+    sources: list[dict[str, object]] = []
+    for result in results:
+        source = {
+            "kind": "transcript",
+            "path": result.source,
+            "scope": result.scope,
+            "status": result.status,
+            "usage_blocks": result.usage_blocks,
+        }
+        sources.append(source)
+        if result.status != "available" or result.totals is None:
+            continue
+        by_scope[result.scope] = by_scope.get(result.scope, TokenTotals()) + result.totals
+
+    aggregate = TokenTotals()
+    serialized_by_scope: dict[str, dict[str, int]] = {}
+    for scope, totals in sorted(by_scope.items()):
+        serialized_by_scope[scope] = totals.as_dict()
+        aggregate += totals
+
+    status = "available" if serialized_by_scope else "not_available"
+    return (
+        {
+            "status": status,
+            "by_scope": serialized_by_scope,
+            "aggregate": aggregate.as_dict() if serialized_by_scope else None,
+        },
+        sources,
+    )
+
+
+def build_session_metrics(
+    manifest_path: Path | None,
+    explicit_transcript: Path | None,
+    session_dir: Path | None,
+) -> dict[str, object]:
+    """Build deterministic scoped token, payload, and artifact metrics."""
+    manifest: dict[str, object] = {}
+    manifest_root = session_dir.resolve() if session_dir is not None else None
+    if manifest_path is not None and manifest_path.is_file():
+        manifest = load_manifest(manifest_path)
+        raw_root = manifest.get("session_root", ".")
+        if not isinstance(raw_root, str):
+            raise ValueError("Manifest session_root must be a string")
+        manifest_root = (manifest_path.parent / raw_root).resolve()
+    if manifest_root is None:
+        manifest_root = Path.cwd().resolve()
+
+    transcript_results: list[TranscriptResult] = []
+    if manifest:
+        for entry in _manifest_transcripts(manifest):
+            path = _resolve_manifest_path(manifest_root, entry.path)
+            transcript_results.append(parse_transcript(path, entry.scope))
+    elif explicit_transcript is not None:
+        transcript_results.append(parse_transcript(explicit_transcript))
+    else:
+        auto_transcript = resolve_transcript(None)
+        if auto_transcript is not None:
+            transcript_results.append(parse_transcript(auto_transcript))
+
+    if explicit_transcript is not None and manifest:
+        transcript_results.append(parse_transcript(explicit_transcript))
+
+    tokens, token_sources = _token_metrics(transcript_results)
+    artifacts, artifact_sources = _artifact_metrics(
+        manifest_root,
+        _manifest_artifacts(manifest) if manifest else [],
+        session_dir,
+    )
+    return {
+        "schema_version": 1,
+        "tokens": tokens,
+        "payload_bytes": _payload_metrics(manifest),
+        "artifacts": artifacts,
+        "sources": token_sources + artifact_sources,
+    }
+
+
+def render_json_metrics(metrics: Mapping[str, object]) -> str:
+    """Render metrics with stable key ordering for fixture comparisons."""
+    return json.dumps(metrics, sort_keys=True)

--- a/x-pack/solutions/security/plugins/security_solution/.agents/scripts/session_metrics.py
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/scripts/session_metrics.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Pure parsing and formatting primitives for exploratory-tester session metrics."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+TOKEN_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+
+
+@dataclass(frozen=True)
+class TokenTotals:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+    @property
+    def total(self) -> int:
+        return sum(
+            (
+                self.input_tokens,
+                self.output_tokens,
+                self.cache_creation_input_tokens,
+                self.cache_read_input_tokens,
+            )
+        )
+
+    def __add__(self, other: "TokenTotals") -> "TokenTotals":
+        return TokenTotals(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            cache_creation_input_tokens=(
+                self.cache_creation_input_tokens
+                + other.cache_creation_input_tokens
+            ),
+            cache_read_input_tokens=(
+                self.cache_read_input_tokens + other.cache_read_input_tokens
+            ),
+        )
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_creation_input_tokens": self.cache_creation_input_tokens,
+            "cache_read_input_tokens": self.cache_read_input_tokens,
+            "total": self.total,
+        }
+
+
+@dataclass(frozen=True)
+class TranscriptResult:
+    source: str
+    scope: str
+    status: str
+    totals: TokenTotals | None
+    usage_blocks: int
+
+
+def resolve_transcript(explicit_path: str | None) -> Path | None:
+    """Return the explicit or current Claude Code transcript, if it exists."""
+    if explicit_path:
+        path = Path(explicit_path)
+        return path if path.is_file() else None
+
+    session_id = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
+    if not session_id:
+        return None
+
+    cwd_slug = os.getcwd().replace("/", "-")
+    transcript = Path.home() / ".claude" / "projects" / cwd_slug / f"{session_id}.jsonl"
+    return transcript if transcript.is_file() else None
+
+
+def _as_non_negative_integer(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(value) or value < 0:
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        return None
+    return int(value)
+
+
+def _extract_usage(obj: Any) -> dict[str, Any] | None:
+    if not isinstance(obj, dict):
+        return None
+
+    message = obj.get("message")
+    if isinstance(message, dict) and isinstance(message.get("usage"), dict):
+        return message["usage"]
+
+    usage = obj.get("usage")
+    return usage if isinstance(usage, dict) else None
+
+
+def parse_transcript(
+    path: Path,
+    scope: str = "orchestrator",
+) -> TranscriptResult:
+    """Parse supported JSONL usage blocks from one transcript."""
+    source = str(path)
+    if not path.is_file():
+        return TranscriptResult(source, scope, "missing", None, 0)
+
+    totals = TokenTotals()
+    usage_blocks = 0
+
+    try:
+        with path.open(encoding="utf-8") as transcript:
+            for raw in transcript:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                usage = _extract_usage(obj)
+                if usage is None:
+                    continue
+
+                values = {
+                    field: _as_non_negative_integer(usage.get(field))
+                    for field in TOKEN_FIELDS
+                }
+                if not any(value is not None for value in values.values()):
+                    continue
+
+                usage_blocks += 1
+                totals += TokenTotals(
+                    input_tokens=values["input_tokens"] or 0,
+                    output_tokens=values["output_tokens"] or 0,
+                    cache_creation_input_tokens=(
+                        values["cache_creation_input_tokens"] or 0
+                    ),
+                    cache_read_input_tokens=values["cache_read_input_tokens"] or 0,
+                )
+    except OSError:
+        return TranscriptResult(source, scope, "unreadable", None, 0)
+
+    if usage_blocks == 0:
+        return TranscriptResult(source, scope, "empty", None, 0)
+    return TranscriptResult(source, scope, "available", totals, usage_blocks)
+
+
+def format_legacy_usage(totals: TokenTotals) -> str:
+    """Render the stable one-line format used by existing skill consumers."""
+    return (
+        f"input={totals.input_tokens} "
+        f"output={totals.output_tokens} "
+        f"cache_create={totals.cache_creation_input_tokens} "
+        f"cache_read={totals.cache_read_input_tokens} "
+        f"total={totals.total}"
+    )

--- a/x-pack/solutions/security/plugins/security_solution/.agents/scripts/test_session_metrics.py
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/scripts/test_session_metrics.py
@@ -12,8 +12,10 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from session_metrics import (  # noqa: E402
     TokenTotals,
+    build_session_metrics,
     format_legacy_usage,
     parse_transcript,
+    render_json_metrics,
     resolve_transcript,
 )
 
@@ -87,6 +89,142 @@ class SessionMetricsParserTests(unittest.TestCase):
             finally:
                 if previous_session_id is not None:
                     os.environ["CLAUDE_CODE_SESSION_ID"] = previous_session_id
+
+    def test_build_session_metrics_aggregates_scoped_transcripts_and_artifacts(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            (root / "orchestrator.jsonl").write_text(
+                '{"message":{"usage":{"input_tokens":2,"output_tokens":3,'
+                '"cache_creation_input_tokens":5,"cache_read_input_tokens":7}}}\n',
+                encoding="utf-8",
+            )
+            (root / "worker-1.jsonl").write_text(
+                '{"message":{"usage":{"input_tokens":11,"output_tokens":13,'
+                '"cache_creation_input_tokens":17,"cache_read_input_tokens":19}}}\n',
+                encoding="utf-8",
+            )
+            (root / "findings-flow-1.md").write_text("abc", encoding="utf-8")
+            (root / "screenshots").mkdir()
+            (root / "screenshots/step.png").write_bytes(b"1234")
+            (root / "detectors.js").write_bytes(b"12345")
+            manifest = root / "metrics.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "session_root": ".",
+                        "transcripts": [
+                            {
+                                "path": "orchestrator.jsonl",
+                                "scope": "orchestrator",
+                            },
+                            {
+                                "path": "worker-1.jsonl",
+                                "scope": "worker",
+                                "name": "flow-1",
+                            },
+                        ],
+                        "artifacts": [
+                            {
+                                "path": "findings-flow-1.md",
+                                "kind": "findings",
+                            },
+                            {
+                                "path": "screenshots/step.png",
+                                "kind": "screenshot",
+                            },
+                            {
+                                "path": "detectors.js",
+                                "kind": "detector_source",
+                            },
+                        ],
+                        "payload_bytes": {
+                            "tool_input": 101,
+                            "tool_output": 202,
+                            "browser_events": 303,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            metrics = build_session_metrics(manifest, None, None)
+
+            self.assertEqual(metrics["schema_version"], 1)
+            self.assertEqual(
+                metrics["tokens"]["by_scope"]["worker"]["output_tokens"],
+                13,
+            )
+            self.assertEqual(
+                metrics["artifacts"]["by_kind"]["screenshot"]["bytes"],
+                4,
+            )
+            self.assertEqual(
+                metrics["payload_bytes"],
+                {
+                    "status": "available",
+                    "tool_input": 101,
+                    "tool_output": 202,
+                    "browser_events": 303,
+                },
+            )
+            self.assertEqual(
+                json.loads(render_json_metrics(metrics)),
+                metrics,
+            )
+
+    def test_build_session_metrics_marks_unavailable_payloads(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            manifest = root / "metrics.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "session_root": ".",
+                        "transcripts": [],
+                        "artifacts": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            metrics = build_session_metrics(manifest, None, None)
+
+            self.assertEqual(
+                metrics["payload_bytes"],
+                {"status": "not_available"},
+            )
+            self.assertEqual(metrics["tokens"]["status"], "not_available")
+            self.assertEqual(metrics["artifacts"]["status"], "not_available")
+
+    def test_manifest_cannot_read_paths_outside_session_root(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            outside = root.parent / "outside-metrics-fixture.txt"
+            outside.write_text("secret", encoding="utf-8")
+            manifest = root / "metrics.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "session_root": ".",
+                        "transcripts": [],
+                        "artifacts": [
+                            {
+                                "path": "../outside-metrics-fixture.txt",
+                                "kind": "report",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                build_session_metrics(manifest, None, None)
+
+            outside.unlink()
 
 
 if __name__ == "__main__":

--- a/x-pack/solutions/security/plugins/security_solution/.agents/scripts/test_session_metrics.py
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/scripts/test_session_metrics.py
@@ -1,0 +1,93 @@
+import json
+import math
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from session_metrics import (  # noqa: E402
+    TokenTotals,
+    format_legacy_usage,
+    parse_transcript,
+    resolve_transcript,
+)
+
+
+class SessionMetricsParserTests(unittest.TestCase):
+    def test_parse_transcript_supports_message_and_top_level_usage(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            transcript = Path(raw_dir) / "session.jsonl"
+            transcript.write_text(
+                '{"message":{"usage":{"input_tokens":2,"output_tokens":3,'
+                '"cache_creation_input_tokens":5,"cache_read_input_tokens":7}}}\n'
+                '{"usage":{"input_tokens":11,"output_tokens":13,'
+                '"cache_creation_input_tokens":17,"cache_read_input_tokens":19}}\n',
+                encoding="utf-8",
+            )
+
+            result = parse_transcript(transcript)
+
+            self.assertEqual(result.status, "available")
+            self.assertEqual(result.totals, TokenTotals(13, 16, 22, 26))
+            self.assertEqual(
+                format_legacy_usage(result.totals),
+                "input=13 output=16 cache_create=22 cache_read=26 total=77",
+            )
+
+    def test_parse_transcript_ignores_malformed_and_invalid_usage_values(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            transcript = Path(raw_dir) / "session.jsonl"
+            transcript.write_text(
+                "not-json\n"
+                + json.dumps(
+                    {
+                        "message": {
+                            "usage": {
+                                "input_tokens": -1,
+                                "output_tokens": math.inf,
+                                "cache_creation_input_tokens": "not-a-number",
+                                "cache_read_input_tokens": 4,
+                            }
+                        }
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = parse_transcript(transcript)
+
+            self.assertEqual(result.status, "available")
+            self.assertEqual(result.totals, TokenTotals(0, 0, 0, 4))
+
+    def test_parse_transcript_reports_empty_and_missing_sources(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            empty = Path(raw_dir) / "empty.jsonl"
+            empty.write_text('{"message":{"content":[]}}\n', encoding="utf-8")
+
+            self.assertEqual(parse_transcript(empty).status, "empty")
+            self.assertEqual(
+                parse_transcript(Path(raw_dir) / "missing.jsonl").status,
+                "missing",
+            )
+
+    def test_explicit_transcript_resolution_takes_precedence(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            explicit = Path(raw_dir) / "explicit.jsonl"
+            explicit.write_text("{}", encoding="utf-8")
+            previous_session_id = os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+            try:
+                self.assertEqual(resolve_transcript(str(explicit)), explicit)
+                self.assertIsNone(resolve_transcript(None))
+            finally:
+                if previous_session_id is not None:
+                    os.environ["CLAUDE_CODE_SESSION_ID"] = previous_session_id
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract reusable transcript parsing while preserving the legacy token-usage output.
- Aggregate orchestrator and worker token totals from a versioned manifest.
- Measure allowlisted session artifacts and optional sanitized payload byte counters.
- Enforce manifest path safety and report unavailable sources explicitly.

Addresses elastic/security-team#18592

## Test plan
- [x] `python3 x-pack/solutions/security/plugins/security_solution/.agents/scripts/test_session_metrics.py -v`
- [x] ReadLints on the changed Python files
- [x] `git diff --check`
- [x] Confirmed no `docs/superpowers` files are included

Made with [Cursor](https://cursor.com)