### PR TITLE
[ftr] skip FTR tests when changes are scoped to "test/scout/**"

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
@@ -22,7 +22,7 @@ import { getEnabledFtrConfigs } from './ftr_manifests';
 import { discoverJestIntegrationConfigs, discoverJestUnitConfigs } from './jest_configs';
 import { getRunGroup, getRunGroups, labelJestSubgroups } from './run_groups';
 import { shouldSkipFtrTests } from './selective_ftr';
-import { isScoutTestsOnlyDiff } from './selective_scout';
+import { isScoutPathOnlyDiff } from './selective_scout';
 import {
   filterJestIntegrationConfigsByAffected,
   filterJestUnitConfigsByAffected,
@@ -55,12 +55,12 @@ export async function pickTestGroupRunOrder() {
       mergeBase: selectiveTestingMergeBase,
       commit: 'HEAD',
     });
-    if (isScoutTestsOnlyDiff(selectiveChangedFiles)) {
-      console.log('Scout-tests-only diff detected — skipping Jest/FTR test steps');
+    if (isScoutPathOnlyDiff(selectiveChangedFiles)) {
+      console.log('Scout-test-tree-only diff detected — skipping Jest/FTR test steps');
       bk.setAnnotation(
         'selective-testing-scout-tests-only',
         'info',
-        'Selective testing: Scout-tests-only diff — Jest/FTR test steps were skipped.'
+        'Selective testing: Scout-test-tree-only diff — Jest/FTR test steps were skipped.'
       );
       return;
     }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -173,4 +173,22 @@ describe('shouldSkipFtrTests', () => {
   it('returns false for config/serverless.yml', () => {
     expect(shouldSkipFtrTests(new Set(), ['config/serverless.yml'])).toBe(false);
   });
+
+  it('returns true for a Scout-only diff even when the owning module is not excluded', () => {
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/discover-plugin']), [
+        'src/platform/plugins/shared/discover/test/scout/core/api/fixtures/constants.ts',
+        'src/platform/plugins/shared/discover/test/scout/core/ui/tests/foo.spec.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false when a Scout diff is mixed with non-Scout module changes', () => {
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/discover-plugin']), [
+        'src/platform/plugins/shared/discover/test/scout/core/ui/tests/foo.spec.ts',
+        'src/platform/plugins/shared/discover/public/application/main.tsx',
+      ])
+    ).toBe(false);
+  });
 });

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -71,7 +71,7 @@ export const FTR_CRITICAL_PATHS: readonly string[] = [
   '.nvmrc',
 ];
 
-/** Uncategorized-only diffs: skip FTR when every file matches. */
+/** Skip FTR when every changed file matches, regardless of owning module. */
 export const FTR_IRRELEVANT_PATHS: readonly string[] = [
   'docs/**',
   '**/docs/**',
@@ -106,6 +106,8 @@ export const FTR_IRRELEVANT_PATHS: readonly string[] = [
   '**/*.jpg',
   '**/*.jpeg',
   '**/*.webp',
+  // Scout (Playwright) test trees never affect FTR, whichever module owns them.
+  '**/test/scout{_*,}/**',
 ];
 
 /** True when this PR should omit FTR configs. */
@@ -121,6 +123,10 @@ export function shouldSkipFtrTests(
     return false;
   }
 
+  if (allChangedFilesInScope(changedFiles, FTR_IRRELEVANT_PATHS)) {
+    return true;
+  }
+
   if (affectedModules.size > 0) {
     for (const id of affectedModules) {
       if (!FTR_EXCLUDED_MODULES.has(id)) {
@@ -130,5 +136,5 @@ export function shouldSkipFtrTests(
     return true;
   }
 
-  return allChangedFilesInScope(changedFiles, FTR_IRRELEVANT_PATHS);
+  return false;
 }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isScoutTestsOnlyDiff } from './selective_scout';
+import { isScoutTestsOnlyDiff, isScoutPathOnlyDiff } from './selective_scout';
 
 describe('isScoutTestsOnlyDiff', () => {
   it('returns false for an empty diff (no signal)', () => {
@@ -118,6 +118,34 @@ describe('isScoutTestsOnlyDiff', () => {
     expect(
       isScoutTestsOnlyDiff([
         'src/platform/plugins/shared/discover/test/scout_setup/playwright.config.ts',
+      ])
+    ).toBe(false);
+  });
+});
+
+describe('isScoutPathOnlyDiff', () => {
+  it('returns true for fixtures / page objects, unlike isScoutTestsOnlyDiff', () => {
+    expect(
+      isScoutPathOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true when a fixtures change is mixed with in-scope specs', () => {
+    expect(
+      isScoutPathOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/tests/foo.spec.ts',
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false when any non-Scout, non-noise file is present', () => {
+    expect(
+      isScoutPathOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/tests/foo.spec.ts',
+        'src/platform/plugins/shared/discover/public/application/main.tsx',
       ])
     ).toBe(false);
   });

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts
@@ -58,3 +58,17 @@ export function isScoutTestsOnlyDiff(changedFiles: readonly string[]): boolean {
     SCOUT_TESTS_ONLY_EXCLUDE_GLOBS
   );
 }
+
+/**
+ * Returns `true` when every changed file sits inside a Scout test scope
+ * (fixtures included). Unlike `isScoutTestsOnlyDiff`, fixtures aren't
+ * excluded here: Jest/FTR can't consume Scout fixtures either way, so the
+ * tests-only/dependency-tree distinction only matters to Scout's own pipeline.
+ */
+export function isScoutPathOnlyDiff(changedFiles: readonly string[]): boolean {
+  return allChangedFilesInScope(
+    changedFiles,
+    SCOUT_TESTS_ONLY_SCOPE_GLOBS,
+    SCOUT_TESTS_ONLY_IGNORE_PATTERNS
+  );
+}


### PR DESCRIPTION
## Summary

Fixing the issue I found in [CI run](https://buildkite.com/elastic/kibana-pull-request/builds/475407): changes limited to `discover/test/scout/**` (Scout tests) were still triggering full FTR runs, because:

- Any file under a plugin's `test/scout/**` folder is attributed to that plugin's module (e.g. `@kbn/discover-plugin`), so the FTR skip logic saw a "real" module and refused to skip.
- The Scout-tests-only fast path excludes `fixtures/` files (treating them as regular changes), which also blocked the skip when fixtures were touched.

### Fix
- `selective_ftr.ts`: `shouldSkipFtrTests` now skips FTR whenever every changed file matches an irrelevant path (including `**/test/scout{_*,}/**`), regardless of which module owns the directory.
- `selective_scout.ts` / `pick_test_group_run_order.ts`: added `isScoutPathOnlyDiff`, used for the Jest/FTR fast path. It's like `isScoutTestsOnlyDiff` but doesn't `exclude fixtures/`, since Jest/FTR can never consume Scout fixtures anyway — the fixtures distinction only matters for Scout's own test selection.

### Testing
Added unit tests in `selective_ftr.test.ts` and `selective_scout.test.ts` covering Scout-only diffs (with and without fixtures).


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->