### PR TITLE
[Observability] Drop @kbn/cases-plugin TS ref from observability-shared

### DIFF
--- a/src/platform/packages/shared/kbn-cases-components/index.ts
+++ b/src/platform/packages/shared/kbn-cases-components/index.ts
@@ -14,3 +14,4 @@ export { Tooltip } from './src/tooltip/tooltip';
 export type { CaseTooltipProps, CaseTooltipContentProps } from './src/tooltip/types';
 export { UserActionTitleLink, type UserActionTitleLinkProps } from './src/user_action_title_link';
 export { UserActionTitle, type UserActionTitleProps } from './src/user_action_title';
+export { CasesDeepLinkId, type ICasesDeepLinkId } from './src/deep_link_ids';

--- a/src/platform/packages/shared/kbn-cases-components/src/deep_link_ids.ts
+++ b/src/platform/packages/shared/kbn-cases-components/src/deep_link_ids.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Deep link ids for the Cases application. Kept in `@kbn/cases-components` so consumers (e.g. nav
+ * builders in other solutions) can reference these ids without depending on `@kbn/cases-plugin`.
+ */
+export const CasesDeepLinkId = {
+  cases: 'cases',
+  casesCreate: 'cases_create',
+  casesConfigure: 'cases_configure',
+  casesTemplates: 'cases_templates',
+} as const;
+
+export type ICasesDeepLinkId = (typeof CasesDeepLinkId)[keyof typeof CasesDeepLinkId];

--- a/x-pack/platform/plugins/shared/cases/public/common/navigation/deep_links.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/navigation/deep_links.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import type { AppDeepLink } from '@kbn/core/public';
+import { CasesDeepLinkId, type ICasesDeepLinkId } from '@kbn/cases-components';
 import {
   DEFAULT_BASE_PATH,
   getCreateCasePath,
@@ -14,14 +15,7 @@ import {
   getCasesConfigureTemplatesPath,
 } from './paths';
 
-export const CasesDeepLinkId = {
-  cases: 'cases',
-  casesCreate: 'cases_create',
-  casesConfigure: 'cases_configure',
-  casesTemplates: 'cases_templates',
-} as const;
-
-export type ICasesDeepLinkId = (typeof CasesDeepLinkId)[keyof typeof CasesDeepLinkId];
+export { CasesDeepLinkId, type ICasesDeepLinkId };
 
 export const getCasesDeepLinks = <T extends AppDeepLink = AppDeepLink>({
   basePath = DEFAULT_BASE_PATH,

--- a/x-pack/solutions/observability/plugins/observability_shared/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_shared/kibana.jsonc
@@ -23,7 +23,6 @@
       "agentBuilder"
     ],
     "requiredBundles": [
-      "cases",
       "data",
       "inspector",
       "kibanaReact",

--- a/x-pack/solutions/observability/plugins/observability_shared/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_shared/moon.yml
@@ -19,7 +19,7 @@ project:
 dependsOn:
   - '@kbn/core'
   - '@kbn/kibana-react-plugin'
-  - '@kbn/cases-plugin'
+  - '@kbn/cases-components'
   - '@kbn/i18n'
   - '@kbn/shared-ux-page-kibana-template'
   - '@kbn/i18n-react'

--- a/x-pack/solutions/observability/plugins/observability_shared/public/services/update_global_navigation.tsx
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/services/update_global_navigation.tsx
@@ -14,7 +14,7 @@ import type {
   Capabilities,
 } from '@kbn/core/public';
 import { AppStatus, type PricingServiceStart } from '@kbn/core/public';
-import { CasesDeepLinkId } from '@kbn/cases-plugin/public';
+import { CasesDeepLinkId } from '@kbn/cases-components';
 import { casesFeatureId } from '../../common';
 
 /** Capability-based Observability access — pricing tiers do not affect this. */

--- a/x-pack/solutions/observability/plugins/observability_shared/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_shared/tsconfig.json
@@ -15,7 +15,7 @@
   "kbn_references": [
     "@kbn/core",
     "@kbn/kibana-react-plugin",
-    "@kbn/cases-plugin",
+    "@kbn/cases-components",
     "@kbn/i18n",
     "@kbn/shared-ux-page-kibana-template",
     "@kbn/i18n-react",


### PR DESCRIPTION
## Summary

Part of an effort to reduce the observability solution's TS project-reference graph (Phase 1).

`observability_shared` referenced the **entire `@kbn/cases-plugin` TS project (~215 transitive projects / ~2.75M lines)** for a single value import — `CasesDeepLinkId` — used in one nav `switch` statement in `update_global_navigation.tsx`.

This PR relocates `CasesDeepLinkId` / `ICasesDeepLinkId` (a 4-string constant) into the lightweight `@kbn/cases-components` package (closure ~78):

- `@kbn/cases-plugin` re-exports them from `@kbn/cases-components`, so its public API (`@kbn/cases-plugin/public`) is unchanged for all existing consumers.
- `observability_shared` now imports the id from `@kbn/cases-components`, and drops the `@kbn/cases-plugin` TS reference plus the now-unused `cases` `requiredBundle`.

**Type-only / build-graph change — no runtime behavior change.**

### Impact

- `observability_shared` transitive closure: **~802 → ~588 projects**.
- Note: because most obs plugins (apm, synthetics, infra, slo, observability) still reference `@kbn/cases-plugin` directly, the solution-wide closure won't drop until those edges are cut too (subsequent phases). This PR removes one of the 9 direct cases edges in the obs solution and unblocks that work.

## Test plan

- [x] `node scripts/type_check --project src/platform/packages/shared/kbn-cases-components/tsconfig.json`
- [x] `node scripts/type_check --project x-pack/platform/plugins/shared/cases/tsconfig.json`
- [x] `node scripts/type_check --project x-pack/solutions/observability/plugins/observability_shared/tsconfig.json`
- [x] `node scripts/eslint` on changed files
- [ ] CI green

Made with [Cursor](https://cursor.com)