### PR TITLE
[9.3] [Agent Builder] Prevent conversation overwrite via auto-create (#280189)

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/client/client.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/client/client.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, ElasticsearchClient } from '@kbn/core/server';
+import { loggerMock } from '@kbn/logging-mocks';
+import { createClient, type ConversationClient } from './client';
+import { createStorage } from './storage';
+import type { Document } from './converters';
+
+jest.mock('./storage');
+
+const createStorageMock = createStorage as jest.MockedFunction<typeof createStorage>;
+
+const user = { id: 'user-1', username: 'user-1-name' };
+
+const createConversationDocument = ({
+  userId = user.id,
+  username = user.username,
+}: { userId?: string; username?: string } = {}): Document => ({
+  _id: 'conversation-1',
+  _seq_no: 1,
+  _primary_term: 1,
+  _source: {
+    agent_id: 'agent-1',
+    user_id: userId,
+    user_name: username,
+    space: 'default',
+    title: 'Conversation 1',
+    created_at: '2024-09-04T06:44:17.944Z',
+    updated_at: '2024-09-04T06:44:17.944Z',
+    conversation_rounds: [],
+    attachments: [],
+  },
+});
+
+describe('ConversationClient', () => {
+  let mockEsClient: {
+    search: jest.Mock;
+    index: jest.Mock;
+    delete: jest.Mock;
+  };
+  let logger: Logger;
+  let client: ConversationClient;
+
+  beforeEach(() => {
+    mockEsClient = {
+      search: jest.fn(),
+      index: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    createStorageMock.mockReturnValue({
+      getClient: () => mockEsClient,
+    } as unknown as ReturnType<typeof createStorage>);
+
+    logger = loggerMock.create();
+
+    client = createClient({
+      space: 'default',
+      logger,
+      esClient: {} as unknown as ElasticsearchClient,
+      user,
+    });
+  });
+
+  describe('exists', () => {
+    it('returns true when the document exists, even when owned by another user', async () => {
+      mockEsClient.search.mockResolvedValue({
+        hits: {
+          hits: [createConversationDocument({ userId: 'other-user-id', username: 'other-user' })],
+        },
+      });
+
+      await expect(client.exists('conversation-1')).resolves.toBe(true);
+    });
+
+    it('returns false when no document exists', async () => {
+      mockEsClient.search.mockResolvedValue({
+        hits: {
+          hits: [],
+        },
+      });
+
+      await expect(client.exists('conversation-1')).resolves.toBe(false);
+    });
+  });
+
+  describe('create', () => {
+    beforeEach(() => {
+      mockEsClient.index.mockResolvedValue({ result: 'created' });
+      mockEsClient.search.mockResolvedValue({
+        hits: {
+          hits: [createConversationDocument()],
+        },
+      });
+    });
+
+    it('indexes with op_type create so existing conversations are never overwritten', async () => {
+      await client.create({
+        id: 'conversation-1',
+        title: 'Conversation 1',
+        agent_id: 'agent-1',
+        rounds: [],
+      });
+
+      expect(mockEsClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'conversation-1',
+          op_type: 'create',
+        })
+      );
+    });
+
+    it('throws a not found error and does not overwrite when the id already exists', async () => {
+      const conflictError = Object.assign(new Error('version conflict'), { statusCode: 409 });
+      mockEsClient.index.mockRejectedValueOnce(conflictError);
+
+      await expect(
+        client.create({
+          id: 'conversation-1',
+          title: 'Conversation 1',
+          agent_id: 'agent-1',
+          rounds: [],
+        })
+      ).rejects.toMatchObject({
+        message: 'Conversation conversation-1 not found',
+      });
+
+      expect(mockEsClient.search).not.toHaveBeenCalled();
+    });
+
+    it('propagates non-conflict index failures', async () => {
+      const error = new Error('index unavailable');
+      mockEsClient.index.mockRejectedValueOnce(error);
+
+      await expect(
+        client.create({
+          id: 'conversation-1',
+          title: 'Conversation 1',
+          agent_id: 'agent-1',
+          rounds: [],
+        })
+      ).rejects.toBe(error);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/client/client.ts
@@ -113,12 +113,15 @@ class ConversationClientImpl implements ConversationClient {
     return fromEs(document);
   }
 
+  /**
+   * Reports whether a conversation document physically exists. Callers must not
+   * treat this as an access check; it does not verify the current user owns the
+   * conversation, only that a document with the given id is present.
+   */
   async exists(conversationId: string): Promise<boolean> {
     const document = await this._get(conversationId);
-    if (!document) {
-      return false;
-    }
-    return hasAccess({ conversation: document, user: this.user });
+
+    return document !== undefined;
   }
 
   async create(conversation: ConversationCreateRequest): Promise<Conversation> {
@@ -132,10 +135,20 @@ class ConversationClientImpl implements ConversationClient {
       space: this.space,
     });
 
-    await this.storage.getClient().index({
-      id,
-      document: attributes,
-    });
+    try {
+      await this.storage.getClient().index({
+        id,
+        document: attributes,
+        // never overwrite an existing conversation, e.g. one owned by another user
+        op_type: 'create',
+      });
+    } catch (error) {
+      if (error?.statusCode === 409) {
+        throw createConversationNotFoundError({ conversationId: id });
+      }
+
+      throw error;
+    }
 
     return this.get(id);
   }

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/client/client.ts
@@ -113,11 +113,6 @@ class ConversationClientImpl implements ConversationClient {
     return fromEs(document);
   }
 
-  /**
-   * Reports whether a conversation document physically exists. Callers must not
-   * treat this as an access check; it does not verify the current user owns the
-   * conversation, only that a document with the given id is present.
-   */
   async exists(conversationId: string): Promise<boolean> {
     const document = await this._get(conversationId);
 
@@ -139,7 +134,6 @@ class ConversationClientImpl implements ConversationClient {
       await this.storage.getClient().index({
         id,
         document: attributes,
-        // never overwrite an existing conversation, e.g. one owned by another user
         op_type: 'create',
       });
     } catch (error) {


### PR DESCRIPTION
# Backport

This is a **manual** backport of the following commit from `main` to `9.3`:
- [[Agent Builder] Prevent conversation overwrite via auto-create (#280189)](https://github.com/elastic/kibana/pull/280189)

The automatic backport failed with merge conflicts because on `9.3` the plugin is still named `onechat` (not `agent_builder`) and it uses the older `hasAccess`-based conversation client. The fix was adapted by hand to that older client: `exists()` now reports physical document existence, and `create()` indexes with `op_type: 'create' so an existing conversation can no longer be overwritten. Unit tests in `client.test.ts` were added/updated to cover the new behavior.

Security fix — please review carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":280189,"url":"https://github.com/elastic/kibana/pull/280189","title":"[Agent Builder] Prevent conversation overwrite via auto-create"},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"sourceCommit":{"sha":"cdd9880b6f33e11520f46be61a3733e43509c8fe"}}] BACKPORT-->