### PR TITLE
[Security Solution] Render user profile avatars on notes

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/notes/components/notes_details_content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/notes/components/notes_details_content.test.tsx
@@ -22,6 +22,10 @@ import type { State } from '../../../../../common/store';
 jest.mock('../../../../../common/components/user_privileges');
 const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
 
+jest.mock('../../../../../common/components/user_profiles/use_suggest_users', () => ({
+  useSuggestUsers: () => ({ isLoading: false, data: [] }),
+}));
+
 const mockAddError = jest.fn();
 jest.mock('../../../../../common/hooks/use_app_toasts', () => ({
   useAppToasts: () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/note_avatar.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/note_avatar.test.tsx
@@ -41,7 +41,8 @@ describe('NoteAvatar', () => {
 
     const avatar = getByTestId(TEST_ID);
     expect(avatar).toBeInTheDocument();
-    expect(avatar.querySelector('img')).toHaveAttribute('src', 'my-image-url');
+    // EuiAvatar renders the profile image as a CSS background, not an <img> element
+    expect(avatar).toHaveStyle('background-image: url(my-image-url)');
   });
 
   it('should render the profile initials and color when the matching user profile has them', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/note_avatar.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/note_avatar.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { NoteAvatar } from './note_avatar';
+import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
+
+jest.mock('../../common/components/user_profiles/use_suggest_users');
+
+const TEST_ID = 'note-avatar';
+
+describe('NoteAvatar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSuggestUsers as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: [
+        {
+          uid: '1',
+          user: { username: 'elastic', full_name: 'Elastic User' },
+          data: { avatar: { imageUrl: 'my-image-url' } },
+        },
+        {
+          uid: '2',
+          user: { username: 'test' },
+          data: { avatar: { initials: 'TU', color: '#09e8ca' } },
+        },
+      ],
+    });
+  });
+
+  it('should render the profile image when the matching user profile has one', () => {
+    const { getByTestId } = render(
+      <NoteAvatar displayName={'Elastic User'} size="l" data-test-subj={TEST_ID} />
+    );
+
+    const avatar = getByTestId(TEST_ID);
+    expect(avatar).toBeInTheDocument();
+    expect(avatar.querySelector('img')).toHaveAttribute('src', 'my-image-url');
+  });
+
+  it('should render the profile initials and color when the matching user profile has them', () => {
+    const { getByTestId, getByText } = render(
+      <NoteAvatar displayName={'test'} size="l" data-test-subj={TEST_ID} />
+    );
+
+    expect(getByTestId(TEST_ID)).toBeInTheDocument();
+    expect(getByText('TU')).toBeInTheDocument();
+  });
+
+  it('should fall back to a default avatar when no user profile matches', () => {
+    const { getByTestId, getByText } = render(
+      <NoteAvatar displayName={'unknown user'} size="l" data-test-subj={TEST_ID} />
+    );
+
+    expect(getByTestId(TEST_ID)).toBeInTheDocument();
+    expect(getByText('uu')).toBeInTheDocument();
+  });
+
+  it('should render ? when the display name is missing', () => {
+    const { getByText } = render(
+      <NoteAvatar displayName={undefined} size="l" data-test-subj={TEST_ID} />
+    );
+
+    expect(getByText('?')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/note_avatar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/note_avatar.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo } from 'react';
+import { EuiAvatar } from '@elastic/eui';
+import type { EuiAvatarProps } from '@elastic/eui';
+import { UserAvatar, getUserDisplayName } from '@kbn/user-profile-components';
+import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
+
+export interface NoteAvatarProps {
+  /**
+   * The display name saved on the note (createdBy/updatedBy), which the server stores
+   * as the user's full_name || email || username at the time the note was saved
+   */
+  displayName: string | null | undefined;
+  /**
+   * Size of the avatar
+   */
+  size: EuiAvatarProps['size'];
+  /**
+   * Data test subject string for testing
+   */
+  ['data-test-subj']?: string;
+}
+
+/**
+ * Renders the avatar for a note author.
+ * Notes only persist the author's display name, so we look up the matching user profile
+ * to render the avatar (image, initials and color) configured in the user's profile.
+ * Falls back to a default initials avatar when no matching profile is found.
+ */
+export const NoteAvatar = memo(
+  ({ displayName, size, 'data-test-subj': dataTestSubj }: NoteAvatarProps) => {
+    const { data: userProfiles } = useSuggestUsers({ searchTerm: '' });
+
+    const userProfile = useMemo(
+      () => (userProfiles ?? []).find(({ user }) => getUserDisplayName(user) === displayName),
+      [userProfiles, displayName]
+    );
+
+    if (userProfile) {
+      return (
+        <UserAvatar
+          data-test-subj={dataTestSubj}
+          user={userProfile.user}
+          avatar={userProfile.data.avatar}
+          size={size}
+        />
+      );
+    }
+
+    return <EuiAvatar data-test-subj={dataTestSubj} size={size} name={displayName || '?'} />;
+  }
+);
+
+NoteAvatar.displayName = 'NoteAvatar';

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/notes_list.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/notes_list.test.tsx
@@ -20,11 +20,14 @@ import { ReqStatus } from '../store/notes.slice';
 import { useUserPrivileges } from '../../common/components/user_privileges';
 import type { Note } from '../../../common/api/timeline';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
+import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
 
 jest.mock('../../common/hooks/use_experimental_features');
 
 jest.mock('../../common/components/user_privileges');
 const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
+
+jest.mock('../../common/components/user_profiles/use_suggest_users');
 
 const mockNote: Note = {
   eventId: '1',
@@ -47,6 +50,11 @@ describe('NotesList', () => {
       timelinePrivileges: { read: true },
       notesPrivileges: { crud: true, read: true },
     });
+
+    (useSuggestUsers as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: [],
+    });
   });
 
   it('should render a note as a comment', () => {
@@ -61,6 +69,28 @@ describe('NotesList', () => {
     expect(getByTestId(`${DELETE_NOTE_BUTTON_TEST_ID}-0`)).toBeInTheDocument();
     expect(getByTestId(`${OPEN_TIMELINE_BUTTON_TEST_ID}-0`)).toBeInTheDocument();
     expect(getByTestId(`${NOTE_AVATAR_TEST_ID}-0`)).toBeInTheDocument();
+  });
+
+  it('should render the user profile image in the avatar when a profile matches the user', () => {
+    (useSuggestUsers as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: [
+        {
+          uid: '1',
+          user: { username: 'elastic' },
+          data: { avatar: { imageUrl: 'my-image-url' } },
+        },
+      ],
+    });
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <NotesList notes={[mockNote]} />
+      </TestProviders>
+    );
+
+    const avatar = getByTestId(`${NOTE_AVATAR_TEST_ID}-0`);
+    expect(avatar.querySelector('img')).toHaveAttribute('src', 'my-image-url');
   });
 
   it('should render ? in avatar is user is missing', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/notes_list.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/notes_list.test.tsx
@@ -90,7 +90,8 @@ describe('NotesList', () => {
     );
 
     const avatar = getByTestId(`${NOTE_AVATAR_TEST_ID}-0`);
-    expect(avatar.querySelector('img')).toHaveAttribute('src', 'my-image-url');
+    // EuiAvatar renders the profile image as a CSS background, not an <img> element
+    expect(avatar).toHaveStyle('background-image: url(my-image-url)');
   });
 
   it('should render ? in avatar is user is missing', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/notes_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/notes_list.tsx
@@ -6,13 +6,14 @@
  */
 
 import React, { memo } from 'react';
-import { EuiAvatar, EuiComment, EuiCommentList, EuiLoadingElastic } from '@elastic/eui';
+import { EuiComment, EuiCommentList, EuiLoadingElastic } from '@elastic/eui';
 import { useSelector } from 'react-redux-v7';
 import { FormattedRelative } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { OpenFlyoutButtonIcon } from './open_flyout_button';
 import { OpenTimelineButtonIcon } from './open_timeline_button';
 import { DeleteNoteButtonIcon } from './delete_note_button';
+import { NoteAvatar } from './note_avatar';
 import { MarkdownRenderer } from '../../common/components/markdown_editor';
 import { ADD_NOTE_LOADING_TEST_ID, NOTE_AVATAR_TEST_ID, NOTES_COMMENT_TEST_ID } from './test_ids';
 import type { State } from '../../common/store';
@@ -80,10 +81,10 @@ export const NotesList = memo(({ notes, options }: NotesListProps) => {
               </>
             }
             timelineAvatar={
-              <EuiAvatar
+              <NoteAvatar
                 data-test-subj={`${NOTE_AVATAR_TEST_ID}-${index}`}
                 size="l"
-                name={note.updatedBy || '?'}
+                displayName={note.updatedBy}
               />
             }
           >

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/pages/note_management_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/pages/note_management_page.tsx
@@ -8,7 +8,6 @@
 import React, { useCallback, useMemo, useEffect } from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import {
-  EuiAvatar,
   EuiBasicTable,
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -49,6 +48,7 @@ import * as i18n from './translations';
 import { OpenFlyoutButtonIcon } from '../components/open_flyout_button';
 import { OpenTimelineButtonIcon } from '../components/open_timeline_button';
 import { NoteContent } from '../components/note_content';
+import { NoteAvatar } from '../components/note_avatar';
 import { useLicense } from '../../common/hooks/use_license';
 
 const columns: Array<EuiBasicTableColumn<Note>> = [
@@ -93,7 +93,7 @@ const columns: Array<EuiBasicTableColumn<Note>> = [
   {
     field: 'createdBy',
     name: i18n.CREATED_BY_COLUMN,
-    render: (createdBy: Note['createdBy']) => <EuiAvatar name={createdBy || ''} size="s" />,
+    render: (createdBy: Note['createdBy']) => <NoteAvatar displayName={createdBy} size="s" />,
     width: '100px',
     align: 'center',
   },

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/notes/participants.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/notes/participants.test.tsx
@@ -16,6 +16,10 @@ import {
   TIMELINE_PARTICIPANT_TITLE_TEST_ID,
 } from './test_ids';
 
+jest.mock('../../../common/components/user_profiles/use_suggest_users', () => ({
+  useSuggestUsers: () => ({ isLoading: false, data: [] }),
+}));
+
 const mockNote: Note = {
   eventId: '1',
   noteId: '1',

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/notes/participants.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/notes/participants.tsx
@@ -7,7 +7,6 @@
 
 import { filter, uniqBy } from 'lodash/fp';
 import {
-  EuiAvatar,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -26,6 +25,7 @@ import {
   TIMELINE_PARTICIPANT_TITLE_TEST_ID,
 } from './test_ids';
 import { type Note } from '../../../../common/api/timeline';
+import { NoteAvatar } from '../../../notes/components/note_avatar';
 
 export const PARTICIPANTS = i18n.translate(
   'xpack.securitySolution.timeline.notes.participantsTitle',
@@ -66,7 +66,7 @@ const UsernameWithAvatar: React.FC<UsernameWithAvatar> = React.memo(
         data-test-subj={dataTestSubj}
       >
         <EuiFlexItem grow={false}>
-          <EuiAvatar data-test-subj="avatar" name={username} size="l" />
+          <NoteAvatar data-test-subj="avatar" displayName={username} size="l" />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiText

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
@@ -47,6 +47,10 @@ jest.mock('./hooks/use_delete_note');
 
 jest.mock('../../../../common/components/user_privileges');
 
+jest.mock('../../../../common/components/user_profiles/use_suggest_users', () => ({
+  useSuggestUsers: () => ({ isLoading: false, data: [] }),
+}));
+
 const deleteMutateMock = jest.fn();
 
 describe('NotePreviews', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
@@ -7,7 +7,6 @@
 
 import { uniqBy } from 'lodash/fp';
 import {
-  EuiAvatar,
   EuiButtonIcon,
   EuiCommentList,
   EuiScreenReaderOnly,
@@ -20,6 +19,7 @@ import styled from 'styled-components';
 import { useDispatch } from 'react-redux-v7';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { userSelectedNotesForDeletion } from '../../../../notes';
+import { NoteAvatar } from '../../../../notes/components/note_avatar';
 import { PageScope } from '../../../../data_view_manager/constants';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -226,11 +226,7 @@ export const NotePreviews = React.memo<NotePreviewsProps>(
                 ),
                 children: <EuiText size="s">{timeline.description}</EuiText>,
                 timelineAvatar: (
-                  <EuiAvatar
-                    data-test-subj="avatar"
-                    name={timeline.updatedBy != null ? timeline.updatedBy : '?'}
-                    size="l"
-                  />
+                  <NoteAvatar data-test-subj="avatar" displayName={timeline.updatedBy} size="l" />
                 ),
                 actions: null,
               },
@@ -277,11 +273,7 @@ export const NotePreviews = React.memo<NotePreviewsProps>(
               />
             ),
             timelineAvatar: (
-              <EuiAvatar
-                data-test-subj="avatar"
-                name={note.updatedBy != null ? note.updatedBy : '?'}
-                size="l"
-              />
+              <NoteAvatar data-test-subj="avatar" displayName={note.updatedBy} size="l" />
             ),
           };
         }),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/notes/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/notes/index.test.tsx
@@ -22,6 +22,10 @@ import type { State } from '../../../../../common/store';
 
 jest.mock('../../../../../common/components/user_privileges');
 
+jest.mock('../../../../../common/components/user_profiles/use_suggest_users', () => ({
+  useSuggestUsers: () => ({ isLoading: false, data: [] }),
+}));
+
 const mockAddError = jest.fn();
 jest.mock('../../../../../common/hooks/use_app_toasts', () => ({
   useAppToasts: () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/notes/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/notes/index.tsx
@@ -7,7 +7,6 @@
 
 import React, { useCallback, useEffect, useMemo } from 'react';
 import {
-  EuiAvatar,
   EuiComment,
   EuiFlexGroup,
   EuiFlexItem,
@@ -43,6 +42,7 @@ import {
 import type { Note } from '../../../../../../common/api/timeline';
 import { TimelineStatusEnum } from '../../../../../../common/api/timeline';
 import { NotesList } from '../../../../../notes/components/notes_list';
+import { NoteAvatar } from '../../../../../notes/components/note_avatar';
 import { Participants } from '../../../notes/participants';
 import { NOTES } from '../../../notes/translations';
 import { useShallowEqualSelector } from '../../../../../common/hooks/use_selector';
@@ -146,7 +146,7 @@ const NotesTabContentComponent: React.FC<NotesTabContentProps> = React.memo(({ t
             </>
           }
           event={ADDED_A_DESCRIPTION}
-          timelineAvatar={<EuiAvatar size="l" name={timeline.updatedBy || '?'} />}
+          timelineAvatar={<NoteAvatar size="l" displayName={timeline.updatedBy} />}
           data-test-subj={TIMELINE_DESCRIPTION_COMMENT_TEST_ID}
         >
           <EuiText size="s">{timeline.description}</EuiText>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/users/suggest_user_profiles_route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/users/suggest_user_profiles_route.test.ts
@@ -60,6 +60,17 @@ describe('suggestUserProfilesRoute', () => {
       expect(response.body).toEqual(expectedBody);
     });
 
+    test('requests the maximum number of user profiles the security plugin allows', async () => {
+      const request = buildRequest();
+      await server.inject(request, requestContextMock.convertContext(context));
+
+      // Without an explicit size the security plugin only returns 10 profiles, which is not
+      // enough for consumers that match a stored display name against all known profiles.
+      expect(mockSecurityStart.userProfiles.suggest).toHaveBeenCalledWith(
+        expect.objectContaining({ size: 100 })
+      );
+    });
+
     test('returns 500 if `security.userProfiles.suggest` throws error', async () => {
       mockSecurityStart.userProfiles.suggest.mockRejectedValue(new Error('something went wrong'));
       const request = buildRequest();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/users/suggest_user_profiles_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/users/suggest_user_profiles_route.ts
@@ -16,6 +16,15 @@ import { buildSiemResponse } from '../utils';
 import type { StartPlugins } from '../../../../plugin';
 import { SuggestUserProfilesRequestQuery } from '../../../../../common/api/detection_engine/users';
 
+/**
+ * Number of user profiles to request from the security plugin.
+ * Without an explicit size, `userProfiles.suggest` defaults to 10, which is too few for
+ * consumers that match an existing name against the full set of profiles (e.g. note avatars)
+ * rather than searching interactively. 100 is the maximum the security plugin accepts;
+ * requesting more makes it throw.
+ */
+const MAX_USER_PROFILES = 100;
+
 export const suggestUserProfilesRoute = (
   router: SecuritySolutionPluginRouter,
   getStartServices: StartServicesAccessor<StartPlugins>
@@ -49,6 +58,7 @@ export const suggestUserProfilesRoute = (
         try {
           const users = await security.userProfiles.suggest({
             name: searchTerm,
+            size: MAX_USER_PROFILES,
             dataPath: 'avatar',
             requiredPrivileges: {
               spaceId,


### PR DESCRIPTION
## Summary

Addresses #280901.

Note author avatars in the Security Solution were rendered with a bare `<EuiAvatar name={displayName} />`, so they showed auto-generated initials in an auto-assigned color and ignored the avatar the user had configured in their Kibana user profile. The same person appeared with their real profile image in Cases and the user menu, but with generated initials on their notes.

This PR adds a shared `NoteAvatar` component that resolves the note's stored display name back to a user profile and renders `UserAvatar` from `@kbn/user-profile-components` (image if set, otherwise the profile's own initials and color), falling back to the previous generated avatar when no profile matches — deleted users, imported notes, unauthenticated writes.

Call sites switched over:

| Surface | File |
| --- | --- |
| Notes list (flyout + timeline Notes tab) | `public/notes/components/notes_list.tsx` |
| Note management page, "Created by" column | `public/notes/pages/note_management_page.tsx` |
| Timeline participants | `public/timelines/components/notes/participants.tsx` |
| Note previews (open timeline) | `public/timelines/components/open_timeline/note_previews/index.tsx` |
| Timeline description comment | `public/timelines/components/timeline/tabs/notes/index.tsx` |

## Why matching is done on the display name

Notes do not persist a user profile identifier. The server stores only a display string:

```ts
// server/lib/timeline/saved_object/notes/saved_object.ts
savedNote.createdBy = userInfo ? getUserDisplayName(userInfo) : UNAUTHENTICATED_USER;
savedNote.updatedBy = userInfo ? getUserDisplayName(userInfo) : UNAUTHENTICATED_USER;
```

With no `uid` on the note, the client has nothing to look up by, so `NoteAvatar` matches `getUserDisplayName(profile.user) === note.updatedBy` against the profiles returned by the existing `useSuggestUsers` hook.

## Second commit: raising the suggestion cap

While verifying the first commit against a real stack I found it only worked for very small deployments. `useSuggestUsers({ searchTerm: '' })` calls `GET /internal/detection_engine/users/_find`, and that route called `security.userProfiles.suggest()` **without a `size`** — which defaults to `DEFAULT_SUGGESTIONS_COUNT = 10`. Measured on a 9.4.4 stack with two users holding profile images and three notes between them:

| Activated user profiles | Profiles returned by `suggestUsers('')` | Notes resolving to a profile avatar |
| --- | --- | --- |
| 2 | 2 | 3 / 3 |
| 16 | 10 | 1 / 3 |

At 16 users the author of two of the three notes fell outside the 10 returned profiles and kept the buggy fallback. The second commit passes an explicit `size: 100` (`MAX_SUGGESTIONS_COUNT`, the ceiling the security plugin enforces — above it `suggest` throws).

**Reviewers please note this is a mitigation, not a cure**, and it has two consequences worth weighing:

- The cliff moves from 10 users to 100; deployments above that still show fallback avatars for some authors, and which authors is effectively arbitrary since the suggest ordering is neither stable nor authorship-aware.
- `/internal/detection_engine/users/_find` is shared with alert assignee suggestions. Because the route passes `requiredPrivileges`, the security plugin fetches `max(size * 2, …)` profiles and then privilege-filters them, so this raises that request from 20 to 200 profiles per call. The result is cached client-side with `staleTime: Infinity`, but it is a real increase per fresh fetch.

Two further limits are inherent to name matching and not fixed here: users sharing a display name are indistinguishable, and because the note stores whatever `getUserDisplayName` returned *at write time*, later changing a user's `full_name` silently breaks the match for their existing notes.

The durable fix is to persist the author's profile `uid` on the note saved object and resolve it with `bulkGetUserProfiles`, keeping name matching only as a fallback for notes written before that change. That needs a saved-object model version and server-side work, so it is left for a follow-up — happy to take direction on whether this should wait for it.

## Third commit: fixing two assertions that could never pass

The `NoteAvatar` and `NotesList` tests added in the first commit both asserted the profile image like this:

```ts
expect(avatar.querySelector('img')).toHaveAttribute('src', 'my-image-url');
```

`EuiAvatar` renders `imageUrl` as a CSS `background-image` and never emits an `<img>` element, so `querySelector('img')` is always `null` and both tests fail. They now assert on the background image, matching how `kbn-user-profile-components` tests the same component. The component code was correct — only the assertions were wrong.

## Testing

- Added unit tests for `NoteAvatar`: profile image, profile initials + color, fallback when no profile matches, and `?` when the display name is missing.
- Added a route test asserting the explicit `size` is passed to `userProfiles.suggest`.

![Uploading image.png…]()


Run locally against this branch:

| Suite | Result |
| --- | --- |
| `public/notes` (incl. `note_avatar`, `notes_list`) | 13 suites, 113 tests passed |
| `public/timelines` (participants, note previews, notes tab) | 8 suites, 43 tests passed |
| `suggest_user_profiles_route` | passed |
| `type_check --project .../security_solution` | `tsc` exited 0 |

End-to-end verification: built Kibana 9.6.0 from this branch against a version-matched ES 9.6.0-SNAPSHOT on a trial license, with two users holding uploaded profile images and three notes between them. The notes management page "Created by" column, the timeline Notes tab, and the "Created by" / "Participants" panels all render the real profile images; on 9.4.4 the same scenario renders generated letter avatars (`E`, `SC`). Screenshots below.

## Checklist

- [x] Unit tests added for the new component and the route change
- [x] Unit tests and type check run locally
- [x] Verified end-to-end in a running Kibana built from this branch
- [ ] Verified in CI
