### PR TITLE
[One Workflow] Add generic `request` action to all v2 spec connectors

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -25,6 +25,23 @@ export {
 export { getConnectorSpec } from './src/get_connector_spec';
 export { isToolAction, TEST_CONNECTOR_SUB_ACTION } from './src/connector_spec';
 export {
+  GENERIC_REQUEST_SUB_ACTION,
+  GENERIC_REQUEST_METHODS,
+  DEFAULT_GENERIC_REQUEST_DESCRIPTION,
+  GenericRequestInputSchema,
+  GenericRequestUrlOnlyInputSchema,
+  getGenericRequestInputSchema,
+  GenericRequestOutputSchema,
+  buildGenericRequestHandler,
+  resolveGenericRequestUrl,
+} from './src/generic_request';
+export type {
+  GetBaseUrl,
+  GenericRequestInput,
+  GenericRequestMethod,
+  GenericRequestOutput,
+} from './src/generic_request';
+export {
   getConnectorActionErrorMeta,
   setConnectorActionErrorMeta,
   getFinitePositiveNumber,

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -26,6 +26,7 @@ import type { Logger } from '@kbn/logging';
 import type { CustomHostSettings, ProxySettings, SSLSettings } from '@kbn/actions-utils';
 import type { LicenseType } from '@kbn/licensing-types';
 import type { AxiosHeaderValue, AxiosInstance } from 'axios';
+import type { GetBaseUrl } from './generic_request';
 
 export { UISchemas } from './connector_spec_ui';
 
@@ -326,6 +327,34 @@ export interface ConnectorSpec {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- record of actions with different input types (contravariance)
   actions: Record<string, ActionDefinition<any, any, any>>;
+
+  /**
+   * Resolves the connector's API base URL from the action context. Used by the
+   * framework-synthesized `request` action to support relative `path` requests,
+   * and can be reused by the connector's own action handlers as the single
+   * source of truth for the base URL. Leave the API version segment out of the
+   * base and keep it in per-action paths (e.g. base `https://api.zoom.us`, path
+   * `/v2/users/me`).
+   *
+   * Optional: multi-host connectors may omit it, in which case their `request`
+   * action only accepts an absolute `url`.
+   */
+  getBaseUrl?: GetBaseUrl;
+
+  /**
+   * Opt out of the framework-synthesized generic `request` action. Set this for
+   * connectors that do not expose a plain HTTP/REST surface (e.g. MCP connectors
+   * that only speak JSON-RPC), where a raw method/path/url request is
+   * meaningless.
+   */
+  disableGenericRequest?: boolean;
+
+  /**
+   * Overrides the human-readable description of the synthesized generic `request`
+   * action (surfaced in authoring UIs). Defaults to
+   * {@link DEFAULT_GENERIC_REQUEST_DESCRIPTION} when omitted.
+   */
+  genericRequestDescription?: string;
 
   test?: ConnectorTest;
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -237,6 +237,16 @@ export interface ActionContext {
   connectorUsageCollector?: unknown;
   log: Logger;
   secrets?: Record<string, unknown>;
+  /**
+   * Validates that a request target URL is permitted by the Kibana Actions
+   * `allowedHosts` allowlist, throwing when it is not. Provided by the executor
+   * so handlers that build request URLs from user-controlled input (e.g. the
+   * framework-synthesized generic `request` action) can guard against sending
+   * the connector's credentials to arbitrary hosts (SSRF / credential
+   * exfiltration). Optional so specs can be exercised in isolation without the
+   * full Actions plumbing.
+   */
+  ensureUriAllowed?: (uri: string) => void;
 }
 
 // ============================================================================

--- a/src/platform/packages/shared/kbn-connector-specs/src/generic_request.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/generic_request.test.ts
@@ -210,5 +210,45 @@ describe('generic_request', () => {
         url: 'https://api.example.com/v0/things',
       });
     });
+
+    describe('allowedHosts enforcement', () => {
+      it('validates the resolved absolute url against the allowlist before requesting', async () => {
+        const ctx = createCtx({ status: 200, headers: {}, data: {} });
+        const ensureUriAllowed = jest.fn();
+        ctx.ensureUriAllowed = ensureUriAllowed;
+        const handler = buildGenericRequestHandler(() => 'https://api.example.com');
+
+        await handler(ctx, { method: 'get', url: 'https://other.example.com/raw' });
+
+        expect(ensureUriAllowed).toHaveBeenCalledWith('https://other.example.com/raw');
+        expect(ctx.client.request as jest.Mock).toHaveBeenCalled();
+      });
+
+      it('validates the resolved base-url + path against the allowlist', async () => {
+        const ctx = createCtx({ status: 200, headers: {}, data: {} });
+        const ensureUriAllowed = jest.fn();
+        ctx.ensureUriAllowed = ensureUriAllowed;
+        const handler = buildGenericRequestHandler(() => 'https://api.example.com');
+
+        await handler(ctx, { method: 'get', path: '/v0/things' });
+
+        expect(ensureUriAllowed).toHaveBeenCalledWith('https://api.example.com/v0/things');
+      });
+
+      it('does not send the request when the host is not allowed', async () => {
+        const ctx = createCtx({ status: 200, headers: {}, data: {} });
+        ctx.ensureUriAllowed = jest.fn(() => {
+          throw new Error(
+            'target url "https://evil.example.com/steal" is not added to the Kibana config'
+          );
+        });
+        const handler = buildGenericRequestHandler(() => 'https://api.example.com');
+
+        await expect(
+          handler(ctx, { method: 'get', url: 'https://evil.example.com/steal' })
+        ).rejects.toThrow('is not added to the Kibana config');
+        expect(ctx.client.request as jest.Mock).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-connector-specs/src/generic_request.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/generic_request.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActionContext } from './connector_spec';
+import {
+  GENERIC_REQUEST_SUB_ACTION,
+  GenericRequestInputSchema,
+  GenericRequestUrlOnlyInputSchema,
+  getGenericRequestInputSchema,
+  buildGenericRequestHandler,
+  resolveGenericRequestUrl,
+} from './generic_request';
+
+describe('generic_request', () => {
+  describe('GENERIC_REQUEST_SUB_ACTION', () => {
+    it('is "request"', () => {
+      expect(GENERIC_REQUEST_SUB_ACTION).toBe('request');
+    });
+  });
+
+  describe('GenericRequestInputSchema', () => {
+    it('defaults method to "get" and allows a path', () => {
+      const parsed = GenericRequestInputSchema.parse({ path: '/v0/foo' });
+      expect(parsed).toEqual({ method: 'get', path: '/v0/foo' });
+    });
+
+    it('allows an absolute url instead of a path', () => {
+      const parsed = GenericRequestInputSchema.parse({ url: 'https://api.example.com/v0/foo' });
+      expect(parsed).toEqual({ method: 'get', url: 'https://api.example.com/v0/foo' });
+    });
+
+    it('accepts body, headers and query', () => {
+      const input = {
+        method: 'post' as const,
+        path: '/v0/foo',
+        body: { a: 1 },
+        headers: { 'X-Test': 'yes' },
+        query: { limit: 10, active: true, name: 'x' },
+      };
+      expect(GenericRequestInputSchema.parse(input)).toEqual(input);
+    });
+
+    it('rejects unknown properties', () => {
+      expect(() =>
+        GenericRequestInputSchema.parse({ path: '/v0/foo', unexpected: true })
+      ).toThrow();
+    });
+
+    it('rejects an unsupported method', () => {
+      expect(() =>
+        GenericRequestInputSchema.parse({ method: 'options', path: '/v0/foo' })
+      ).toThrow();
+    });
+
+    it('allows neither path nor url at the schema level (enforced at resolution time)', () => {
+      expect(() => GenericRequestInputSchema.parse({ method: 'get' })).not.toThrow();
+    });
+  });
+
+  describe('GenericRequestUrlOnlyInputSchema', () => {
+    it('requires an absolute url', () => {
+      const parsed = GenericRequestUrlOnlyInputSchema.parse({
+        url: 'https://api.example.com/foo',
+      });
+      expect(parsed).toEqual({ method: 'get', url: 'https://api.example.com/foo' });
+    });
+
+    it('rejects a path', () => {
+      expect(() =>
+        GenericRequestUrlOnlyInputSchema.parse({ path: '/foo', url: 'https://api.example.com' })
+      ).toThrow();
+    });
+
+    it('rejects a missing url', () => {
+      expect(() => GenericRequestUrlOnlyInputSchema.parse({ method: 'get' })).toThrow();
+    });
+  });
+
+  describe('getGenericRequestInputSchema', () => {
+    it('returns the path-capable schema when the connector has a base URL', () => {
+      expect(getGenericRequestInputSchema(true)).toBe(GenericRequestInputSchema);
+    });
+
+    it('returns the url-only schema when the connector has no base URL', () => {
+      expect(getGenericRequestInputSchema(false)).toBe(GenericRequestUrlOnlyInputSchema);
+    });
+  });
+
+  describe('resolveGenericRequestUrl', () => {
+    const ctx = { config: { baseUrl: 'https://api.example.com' } } as unknown as ActionContext;
+    const getBaseUrl = (c: ActionContext) => (c.config as { baseUrl: string }).baseUrl;
+
+    it('uses url verbatim when provided, overriding path and base URL', () => {
+      expect(
+        resolveGenericRequestUrl(
+          ctx,
+          { url: 'https://other.example.com/x', path: '/v0/ignored' },
+          getBaseUrl
+        )
+      ).toBe('https://other.example.com/x');
+    });
+
+    it('joins base URL and path when only a path is provided', () => {
+      expect(resolveGenericRequestUrl(ctx, { path: '/v0/things' }, getBaseUrl)).toBe(
+        'https://api.example.com/v0/things'
+      );
+    });
+
+    it('normalizes a leading-slash-less path and trailing base slashes', () => {
+      expect(
+        resolveGenericRequestUrl(ctx, { path: 'v0/things' }, () => 'https://api.example.com///')
+      ).toBe('https://api.example.com/v0/things');
+    });
+
+    it('throws when neither url nor path is provided', () => {
+      expect(() => resolveGenericRequestUrl(ctx, {}, getBaseUrl)).toThrow(/Either "url" or "path"/);
+    });
+
+    it('throws when a path is provided but the connector has no getBaseUrl', () => {
+      expect(() => resolveGenericRequestUrl(ctx, { path: '/v0/things' }, undefined)).toThrow(
+        /does not support relative "path"/
+      );
+    });
+
+    it('allows url on a connector without getBaseUrl', () => {
+      expect(resolveGenericRequestUrl(ctx, { url: 'https://api.example.com/x' }, undefined)).toBe(
+        'https://api.example.com/x'
+      );
+    });
+  });
+
+  describe('buildGenericRequestHandler', () => {
+    const createCtx = (requestResult: unknown): ActionContext => {
+      const request = jest.fn().mockResolvedValue(requestResult);
+      return {
+        client: { request } as unknown as ActionContext['client'],
+        config: { baseUrl: 'https://api.example.com' },
+        log: { debug: jest.fn(), error: jest.fn() } as unknown as ActionContext['log'],
+      } as ActionContext;
+    };
+
+    it('joins base URL and path, forwards method/body/headers/query, and shapes the output', async () => {
+      const ctx = createCtx({
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+        data: { id: 'abc' },
+      });
+      const handler = buildGenericRequestHandler((c) => (c.config as { baseUrl: string }).baseUrl);
+
+      const output = await handler(ctx, {
+        method: 'post',
+        path: '/v0/things',
+        body: { name: 'x' },
+        headers: { 'X-Test': '1' },
+        query: { limit: 5 },
+      });
+
+      expect(ctx.client.request as jest.Mock).toHaveBeenCalledWith({
+        method: 'post',
+        url: 'https://api.example.com/v0/things',
+        data: { name: 'x' },
+        headers: { 'X-Test': '1' },
+        params: { limit: 5 },
+      });
+      expect(output).toEqual({
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+        data: { id: 'abc' },
+      });
+    });
+
+    it('uses an absolute url verbatim', async () => {
+      const ctx = createCtx({ status: 200, headers: {}, data: {} });
+      const handler = buildGenericRequestHandler((c) => (c.config as { baseUrl: string }).baseUrl);
+
+      await handler(ctx, { method: 'get', url: 'https://other.example.com/raw' });
+
+      expect(ctx.client.request as jest.Mock).toHaveBeenCalledWith({
+        method: 'get',
+        url: 'https://other.example.com/raw',
+      });
+    });
+
+    it('works with a url even when the connector has no getBaseUrl', async () => {
+      const ctx = createCtx({ status: 200, headers: {}, data: {} });
+      const handler = buildGenericRequestHandler(undefined);
+
+      await handler(ctx, { method: 'get', url: 'https://api.example.com/raw' });
+
+      expect(ctx.client.request as jest.Mock).toHaveBeenCalledWith({
+        method: 'get',
+        url: 'https://api.example.com/raw',
+      });
+    });
+
+    it('omits data/headers/params when not provided', async () => {
+      const ctx = createCtx({ status: 200, headers: {}, data: {} });
+      const handler = buildGenericRequestHandler(() => 'https://api.example.com');
+
+      await handler(ctx, { method: 'get', path: '/v0/things' });
+
+      expect(ctx.client.request as jest.Mock).toHaveBeenCalledWith({
+        method: 'get',
+        url: 'https://api.example.com/v0/things',
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/generic_request.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/generic_request.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { ActionContext } from './connector_spec';
+
+/**
+ * Reserved sub-action key for the framework-synthesized generic request action.
+ *
+ * Every v2 connector spec gets a `request` sub-action out of the box. It lets
+ * workflows (and other consumers) call arbitrary endpoints of the connector's
+ * API while reusing the connector's already-configured authentication and error
+ * handling. No secrets are ever exposed to the caller.
+ *
+ * The target endpoint is resolved as follows:
+ * - When `url` is provided it is used verbatim (overriding `path` and the
+ *   connector's base URL).
+ * - Otherwise `path` is appended to the connector's base URL, which a spec
+ *   exposes via {@link ConnectorSpec.getBaseUrl}. A connector without a
+ *   `getBaseUrl` (e.g. multi-host connectors) can only be called with `url`.
+ */
+export const GENERIC_REQUEST_SUB_ACTION = 'request';
+
+export const GENERIC_REQUEST_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'] as const;
+
+export type GenericRequestMethod = (typeof GENERIC_REQUEST_METHODS)[number];
+
+/**
+ * Default human-readable description for the synthesized generic request action.
+ * A spec can override it via {@link ConnectorSpec.genericRequestDescription}.
+ */
+export const DEFAULT_GENERIC_REQUEST_DESCRIPTION =
+  "Send a custom HTTP request to any of the connector's API endpoints, reusing its " +
+  'configured authentication. Provide a relative `path` (resolved against the connector base URL) ' +
+  'or an absolute `url`, plus optional `method`, `body`, `headers`, and `query`.';
+
+/**
+ * Resolves a connector's base URL from the action context (config/secrets). The
+ * generic request `path` is appended to this value. The API version segment is
+ * intentionally left out of the base and kept in the `path` (e.g. base
+ * `https://api.zoom.us`, path `/v2/users/me`).
+ */
+export type GetBaseUrl = (ctx: ActionContext) => string;
+
+const methodField = z
+  .enum(GENERIC_REQUEST_METHODS)
+  .describe('The HTTP method to use for the request.')
+  .default('get');
+
+const bodyField = z.unknown().optional().describe('The request body. Sent as JSON.');
+
+const headersField = z
+  .record(z.string(), z.string())
+  .optional()
+  .describe('Additional request headers merged with the connector-configured headers.');
+
+const queryField = z
+  .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+  .optional()
+  .describe('Query string parameters appended to the request URL.');
+
+/**
+ * Input schema for the generic request action of a connector that exposes a
+ * base URL (via {@link ConnectorSpec.getBaseUrl}). Accepts a relative `path`
+ * (resolved against the base URL) or an absolute `url` that overrides it.
+ */
+export const GenericRequestInputSchema = z
+  .object({
+    method: methodField,
+    path: z
+      .string()
+      .optional()
+      .describe(
+        'The path appended to the connector-configured base URL (leading slash optional). Ignored when `url` is provided.'
+      ),
+    url: z
+      .string()
+      .optional()
+      .describe(
+        'An absolute URL. When provided it is used verbatim, overriding `path` and the connector-configured base URL.'
+      ),
+    body: bodyField,
+    headers: headersField,
+    query: queryField,
+  })
+  .strict();
+
+/**
+ * Input schema for the generic request action of a connector that does NOT
+ * expose a base URL (e.g. multi-host connectors). Only an absolute `url` is
+ * supported; `path` is intentionally omitted because it could never resolve.
+ */
+export const GenericRequestUrlOnlyInputSchema = z
+  .object({
+    method: methodField,
+    url: z
+      .string()
+      .describe(
+        'An absolute URL. This connector targets multiple hosts, so a full URL is required.'
+      ),
+    body: bodyField,
+    headers: headersField,
+    query: queryField,
+  })
+  .strict();
+
+export type GenericRequestInput = z.infer<typeof GenericRequestInputSchema>;
+
+/**
+ * Returns the appropriate generic request input schema for a connector based on
+ * whether it exposes a base URL. Connectors without a base URL cannot resolve a
+ * relative `path`, so they get the `url`-only schema.
+ */
+export const getGenericRequestInputSchema = (hasBaseUrl: boolean) =>
+  hasBaseUrl ? GenericRequestInputSchema : GenericRequestUrlOnlyInputSchema;
+
+export const GenericRequestOutputSchema = z.object({
+  status: z.number().describe('The HTTP status code of the response.'),
+  headers: z.record(z.string(), z.unknown()).describe('The response headers.'),
+  data: z.unknown().describe('The response body.'),
+});
+
+export type GenericRequestOutput = z.infer<typeof GenericRequestOutputSchema>;
+
+const joinUrl = (baseUrl: string, path: string): string => {
+  const trimmedBase = baseUrl.replace(/\/+$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${trimmedBase}${normalizedPath}`;
+};
+
+/**
+ * Resolves the target URL for a generic request. `url` wins over `path`; when
+ * neither `url` nor a resolvable base URL is available, an error is thrown.
+ */
+export const resolveGenericRequestUrl = (
+  ctx: ActionContext,
+  input: Pick<GenericRequestInput, 'path' | 'url'>,
+  getBaseUrl?: GetBaseUrl
+): string => {
+  const { url, path } = input;
+  if (url) {
+    return url;
+  }
+  if (path === undefined) {
+    throw new Error('Either "url" or "path" must be provided for the request action.');
+  }
+  if (!getBaseUrl) {
+    throw new Error(
+      'This connector does not support relative "path" requests; provide an absolute "url" instead.'
+    );
+  }
+  return joinUrl(getBaseUrl(ctx), path);
+};
+
+/**
+ * Builds the handler for the synthesized generic request action. The handler
+ * relies on the connector's authenticated axios client (`ctx.client`) so
+ * authentication and error handling stay on the connector side.
+ */
+export const buildGenericRequestHandler =
+  (getBaseUrl?: GetBaseUrl) =>
+  async (ctx: ActionContext, input: GenericRequestInput): Promise<GenericRequestOutput> => {
+    const { method, body, headers, query } = input;
+    const url = resolveGenericRequestUrl(ctx, input, getBaseUrl);
+    const response = await ctx.client.request({
+      method,
+      url,
+      ...(body !== undefined ? { data: body } : {}),
+      ...(headers !== undefined ? { headers } : {}),
+      ...(query !== undefined ? { params: query } : {}),
+    });
+    return {
+      status: response.status,
+      headers: response.headers as Record<string, unknown>,
+      data: response.data,
+    };
+  };

--- a/src/platform/packages/shared/kbn-connector-specs/src/generic_request.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/generic_request.ts
@@ -168,6 +168,12 @@ export const buildGenericRequestHandler =
   async (ctx: ActionContext, input: GenericRequestInput): Promise<GenericRequestOutput> => {
     const { method, body, headers, query } = input;
     const url = resolveGenericRequestUrl(ctx, input, getBaseUrl);
+    // The resolved URL can be author-controlled (an absolute `url`, or a `path`
+    // joined onto the base URL). Enforce the Actions `allowedHosts` allowlist
+    // before sending the connector's authenticated client at it, so a workflow
+    // author cannot exfiltrate the connector's credentials or drive SSRF to
+    // arbitrary/internal hosts.
+    ctx.ensureUriAllowed?.(url);
     const response = await ctx.client.request({
       method,
       url,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/abuseipdb/abuseipdb.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/abuseipdb/abuseipdb.ts
@@ -23,6 +23,11 @@ import { z, lazySchema } from '@kbn/zod/v4';
 import { i18n } from '@kbn/i18n';
 import type { ConnectorSpec } from '../../connector_spec';
 
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The version segment stays in paths.
+const getBaseUrl = (): string => 'https://api.abuseipdb.com';
+const ABUSEIPDB_API_V2 = `${getBaseUrl()}/api/v2`;
+
 export const AbuseIPDBConnector: ConnectorSpec = {
   metadata: {
     id: '.abuseipdb',
@@ -56,7 +61,7 @@ export const AbuseIPDBConnector: ConnectorSpec = {
       ),
       handler: async (ctx, input) => {
         const typedInput = input as { ipAddress: string; maxAgeInDays?: number };
-        const response = await ctx.client.get('https://api.abuseipdb.com/api/v2/check', {
+        const response = await ctx.client.get(`${ABUSEIPDB_API_V2}/check`, {
           params: {
             ipAddress: typedInput.ipAddress,
             maxAgeInDays: typedInput.maxAgeInDays || 90,
@@ -85,7 +90,7 @@ export const AbuseIPDBConnector: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput = input as { ip: string; categories: number[]; comment?: string };
         const response = await ctx.client.post(
-          'https://api.abuseipdb.com/api/v2/report',
+          `${ABUSEIPDB_API_V2}/report`,
           new URLSearchParams({
             ip: typedInput.ip,
             categories: typedInput.categories.join(','),
@@ -113,7 +118,7 @@ export const AbuseIPDBConnector: ConnectorSpec = {
       ),
       handler: async (ctx, input) => {
         const typedInput = input as { ipAddress: string };
-        const response = await ctx.client.get('https://api.abuseipdb.com/api/v2/check', {
+        const response = await ctx.client.get(`${ABUSEIPDB_API_V2}/check`, {
           params: {
             ipAddress: typedInput.ipAddress,
             verbose: true,
@@ -150,7 +155,7 @@ export const AbuseIPDBConnector: ConnectorSpec = {
       ),
       handler: async (ctx, input) => {
         const typedInput = input as { network: string; maxAgeInDays?: number };
-        const response = await ctx.client.get('https://api.abuseipdb.com/api/v2/check-block', {
+        const response = await ctx.client.get(`${ABUSEIPDB_API_V2}/check-block`, {
           params: {
             network: typedInput.network,
             maxAgeInDays: typedInput.maxAgeInDays || 30,
@@ -165,9 +170,11 @@ export const AbuseIPDBConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     handler: async (ctx) => {
-      await ctx.client.get('https://api.abuseipdb.com/api/v2/check', {
+      await ctx.client.get(`${ABUSEIPDB_API_V2}/check`, {
         params: { ipAddress: '8.8.8.8' },
       });
       return {};

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/alienvault_otx/alienvault_otx.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/alienvault_otx/alienvault_otx.ts
@@ -23,6 +23,11 @@ import { z, lazySchema } from '@kbn/zod/v4';
 import { i18n } from '@kbn/i18n';
 import type { ConnectorSpec } from '../../connector_spec';
 
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The version segment stays in paths.
+const getBaseUrl = (): string => 'https://otx.alienvault.com';
+const OTX_API_V1 = `${getBaseUrl()}/api/v1`;
+
 export const AlienVaultOTXConnector: ConnectorSpec = {
   metadata: {
     id: '.alienvault-otx',
@@ -63,7 +68,7 @@ export const AlienVaultOTXConnector: ConnectorSpec = {
         const typedInput = input as { indicatorType: string; indicator: string; section?: string };
         const section = typedInput.section || 'general';
         const response = await ctx.client.get(
-          `https://otx.alienvault.com/api/v1/indicators/${typedInput.indicatorType}/${typedInput.indicator}/${section}`
+          `${OTX_API_V1}/indicators/${typedInput.indicatorType}/${typedInput.indicator}/${section}`
         );
         return {
           indicator: typedInput.indicator,
@@ -91,16 +96,13 @@ export const AlienVaultOTXConnector: ConnectorSpec = {
       ),
       handler: async (ctx, input) => {
         const typedInput = input as { query?: string; page?: number; limit?: number };
-        const response = await ctx.client.get(
-          'https://otx.alienvault.com/api/v1/pulses/subscribed',
-          {
-            params: {
-              ...(typedInput.query && { q: typedInput.query }),
-              page: typedInput.page || 1,
-              limit: typedInput.limit || 20,
-            },
-          }
-        );
+        const response = await ctx.client.get(`${OTX_API_V1}/pulses/subscribed`, {
+          params: {
+            ...(typedInput.query && { q: typedInput.query }),
+            page: typedInput.page || 1,
+            limit: typedInput.limit || 20,
+          },
+        });
         return {
           count: response.data.count,
           results: response.data.results,
@@ -118,9 +120,7 @@ export const AlienVaultOTXConnector: ConnectorSpec = {
       ),
       handler: async (ctx, input) => {
         const typedInput = input as { pulseId: string };
-        const response = await ctx.client.get(
-          `https://otx.alienvault.com/api/v1/pulses/${typedInput.pulseId}`
-        );
+        const response = await ctx.client.get(`${OTX_API_V1}/pulses/${typedInput.pulseId}`);
         return {
           id: response.data.id,
           name: response.data.name,
@@ -156,7 +156,7 @@ export const AlienVaultOTXConnector: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput = input as { indicatorType: string; indicator: string };
         const response = await ctx.client.get(
-          `https://otx.alienvault.com/api/v1/indicators/${typedInput.indicatorType}/${typedInput.indicator}/pulses`
+          `${OTX_API_V1}/indicators/${typedInput.indicatorType}/${typedInput.indicator}/pulses`
         );
         return {
           indicator: typedInput.indicator,
@@ -167,10 +167,12 @@ export const AlienVaultOTXConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     handler: async (ctx) => {
       try {
-        await ctx.client.get('https://otx.alienvault.com/api/v1/pulses/subscribed', {
+        await ctx.client.get(`${OTX_API_V1}/pulses/subscribed`, {
           params: { limit: 1 },
         });
         return {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/confluence_cloud/confluence.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/confluence_cloud/confluence.ts
@@ -26,7 +26,7 @@ const ATLASSIAN_NET_SUFFIX = '.atlassian.net';
  * Validates and normalizes subdomain: trims, strips optional .atlassian.net suffix,
  * rejects empty, full hostnames (containing '.'), and invalid characters.
  */
-const buildBaseUrl = (ctx: ActionContext): string => {
+const getBaseUrl = (ctx: ActionContext): string => {
   let sub = String(ctx.config?.subdomain ?? '').trim();
   if (sub === '') {
     throw new Error('Confluence Cloud subdomain is required');
@@ -127,7 +127,7 @@ export const ConfluenceCloudConnector: ConnectorSpec = {
       isTool: true,
       input: ListPagesInputSchema,
       handler: async (ctx, input: ListPagesInput) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const params: Record<string, unknown> = {
           limit: input.limit ?? DEFAULT_LIST_LIMIT,
         };
@@ -153,7 +153,7 @@ export const ConfluenceCloudConnector: ConnectorSpec = {
       isTool: true,
       input: GetPageInputSchema,
       handler: async (ctx, input: GetPageInput) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const params: Record<string, unknown> = {};
         if (input.bodyFormat != null) params['body-format'] = input.bodyFormat;
         const response = await ctx.client.get(
@@ -169,7 +169,7 @@ export const ConfluenceCloudConnector: ConnectorSpec = {
       isTool: true,
       input: ListSpacesInputSchema,
       handler: async (ctx, input: ListSpacesInput) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const params: Record<string, unknown> = {
           limit: input.limit ?? DEFAULT_LIST_LIMIT,
         };
@@ -195,7 +195,7 @@ export const ConfluenceCloudConnector: ConnectorSpec = {
       isTool: true,
       input: GetSpaceInputSchema,
       handler: async (ctx, input: GetSpaceInput) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const response = await ctx.client.get(
           `${baseUrl}${CONFLUENCE_V2_PREFIX}/spaces/${encodeURIComponent(input.id)}`
         );
@@ -203,6 +203,8 @@ export const ConfluenceCloudConnector: ConnectorSpec = {
       },
     },
   },
+  getBaseUrl,
+
   skill: [
     'Typical pattern: listSpaces → listPages (with spaceId) → getPage (with bodyFormat) to retrieve full page content.',
   ].join('\n'),
@@ -212,7 +214,7 @@ export const ConfluenceCloudConnector: ConnectorSpec = {
     }),
     handler: async (ctx) => {
       try {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const response = await ctx.client.get(`${baseUrl}${CONFLUENCE_V2_PREFIX}/spaces`, {
           params: { limit: 1 },
         });

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
@@ -25,7 +25,7 @@ import {
 } from './types';
 import type { ActionContext, ConnectorSpec } from '../../../..';
 
-const buildBaseUrl = (ctx: ActionContext): string => {
+const getBaseUrl = (ctx: ActionContext): string => {
   if (ctx.secrets?.authType === 'oauth_authorization_code') {
     const cloudId = String(ctx.config?.cloudId ?? '').trim();
     if (cloudId === '') {
@@ -144,7 +144,7 @@ export const JiraConnector: ConnectorSpec = {
           maxResults?: number;
           nextPageToken?: string;
         };
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const response = await ctx.client.post(`${baseUrl}/rest/api/3/search/jql`, typedInput);
         return response.data;
       },
@@ -158,7 +158,7 @@ export const JiraConnector: ConnectorSpec = {
         const typedInput = input as {
           issueId: string;
         };
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const response = await ctx.client.get(`${baseUrl}/rest/api/3/issue/${typedInput.issueId}`);
         return response.data;
       },
@@ -174,7 +174,7 @@ export const JiraConnector: ConnectorSpec = {
           startAt?: number;
           query?: string;
         };
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const response = await ctx.client.get(`${baseUrl}/rest/api/3/project/search`, {
           params: typedInput,
         });
@@ -190,7 +190,7 @@ export const JiraConnector: ConnectorSpec = {
         const typedInput = input as {
           projectId: string;
         };
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const response = await ctx.client.get(
           `${baseUrl}/rest/api/3/project/${typedInput.projectId}`
         );
@@ -211,7 +211,7 @@ export const JiraConnector: ConnectorSpec = {
           maxResults?: number;
           property?: string;
         };
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = getBaseUrl(ctx);
         const response = await ctx.client.get(`${baseUrl}/rest/api/3/user/search`, {
           params: typedInput,
         });
@@ -219,6 +219,8 @@ export const JiraConnector: ConnectorSpec = {
       },
     },
   },
+  getBaseUrl,
+
   skill: [
     'Typical patterns:',
     '- Discovery: getProjects → getProject (by key) → searchIssuesWithJql (scoped to project)',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/azure_blob/azure_blob.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/azure_blob/azure_blob.ts
@@ -334,6 +334,8 @@ export const AzureBlob: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   skill: [
     'Use this connector to explore and retrieve content from Azure Blob Storage.',
     '',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/bigquery/bigquery.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/bigquery/bigquery.ts
@@ -23,7 +23,11 @@ import {
   RunQueryInputSchema,
 } from './types';
 
-const BIGQUERY_API_BASE = 'https://bigquery.googleapis.com/bigquery/v2';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/v2` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://bigquery.googleapis.com';
+const BIGQUERY_API_V2 = `${getBaseUrl()}/bigquery/v2`;
 const DEFAULT_LOCATION = 'US';
 const DEFAULT_MAX_RESULTS = 1000;
 const BIGQUERY_USER_AGENT = 'Kibana-BigQuery-Connector/1.0';
@@ -201,7 +205,7 @@ const submitQuery = async (
 
   try {
     const response = await ctx.client.post<BigQueryQueryResponse>(
-      `${BIGQUERY_API_BASE}/projects/${encodeURIComponent(projectId)}/queries`,
+      `${BIGQUERY_API_V2}/projects/${encodeURIComponent(projectId)}/queries`,
       body
     );
     return normalizeQueryResponse(response.data);
@@ -318,7 +322,7 @@ export const BigQuery: ConnectorSpec = {
 
         try {
           const response = await ctx.client.get<BigQueryQueryResponse>(
-            `${BIGQUERY_API_BASE}/projects/${encodeURIComponent(
+            `${BIGQUERY_API_V2}/projects/${encodeURIComponent(
               projectId
             )}/queries/${encodeURIComponent(input.jobId)}`,
             { params }
@@ -344,7 +348,7 @@ export const BigQuery: ConnectorSpec = {
 
         try {
           const response = await ctx.client.get(
-            `${BIGQUERY_API_BASE}/projects/${encodeURIComponent(projectId)}/datasets`,
+            `${BIGQUERY_API_V2}/projects/${encodeURIComponent(projectId)}/datasets`,
             { params }
           );
           return response.data;
@@ -381,6 +385,8 @@ export const BigQuery: ConnectorSpec = {
       }
     },
   },
+
+  getBaseUrl,
 
   skill: [
     '## BigQuery Connector',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/box/box.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/box/box.ts
@@ -120,6 +120,10 @@ export const Box: ConnectorSpec = {
     fields: ['serverUrl'],
   },
 
+  // MCP connector: talks to an MCP server over JSON-RPC, so a generic HTTP
+  // request (method/path/url) is meaningless. Opt out of the synthesized action.
+  disableGenericRequest: true,
+
   actions: {
     whoAmI: {
       isTool: true,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/brave_search/brave_search.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/brave_search/brave_search.ts
@@ -23,6 +23,11 @@ import type { ConnectorSpec } from '../../connector_spec';
 const DEFAULT_COUNT = 10;
 const DEFAULT_OFFSET = 0;
 
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The version segment stays in paths.
+const getBaseUrl = (): string => 'https://api.search.brave.com';
+const BRAVE_API_V1 = `${getBaseUrl()}/res/v1`;
+
 export const BraveSearchConnector: ConnectorSpec = {
   metadata: {
     id: '.brave-search',
@@ -84,7 +89,7 @@ export const BraveSearchConnector: ConnectorSpec = {
           offset: typedInput.offset || DEFAULT_OFFSET,
         };
 
-        const response = await ctx.client.get('https://api.search.brave.com/res/v1/web/search', {
+        const response = await ctx.client.get(`${BRAVE_API_V1}/web/search`, {
           params,
           headers: {
             Accept: 'application/json',
@@ -101,11 +106,13 @@ export const BraveSearchConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     handler: async (ctx) => {
       try {
         // Perform a simple test search
-        await ctx.client.get('https://api.search.brave.com/res/v1/web/search', {
+        await ctx.client.get(`${BRAVE_API_V1}/web/search`, {
           params: {
             q: 'test',
             count: 1,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/dropbox/dropbox.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/dropbox/dropbox.ts
@@ -99,6 +99,10 @@ export const Dropbox: ConnectorSpec = {
     fields: ['serverUrl'],
   },
 
+  // MCP connector: talks to an MCP server over JSON-RPC, so a generic HTTP
+  // request (method/path/url) is meaningless. Opt out of the synthesized action.
+  disableGenericRequest: true,
+
   actions: {
     whoAmI: {
       isTool: true,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/figma/figma.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/figma/figma.ts
@@ -11,7 +11,11 @@ import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ConnectorSpec } from '../../connector_spec';
 import type * as Figma from './types';
-const FIGMA_API_BASE = 'https://api.figma.com';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/v1` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://api.figma.com';
+const FIGMA_API_BASE = getBaseUrl();
 
 const FILE_PATH_PREFIXES = ['design', 'file', 'board', 'proto', 'slides'] as const;
 const FILE_PATH_PREFIX_SET: Set<string> = new Set(FILE_PATH_PREFIXES);
@@ -240,6 +244,8 @@ export const FigmaConnector: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   skill: [
     'Use whoAmI to confirm which Figma account is connected before performing other actions.',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/firecrawl/firecrawl.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/firecrawl/firecrawl.ts
@@ -18,7 +18,11 @@ import {
   CrawlAndWaitInputSchema,
   GetCrawlStatusInputSchema,
 } from './types';
-const FIRECRAWL_API_BASE = 'https://api.firecrawl.dev';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/v2` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://api.firecrawl.dev';
+const FIRECRAWL_API_BASE = getBaseUrl();
 
 /** Max characters of markdown to include per page in crawlAndWait output. */
 const MARKDOWN_SNIPPET_LENGTH = 500;
@@ -225,6 +229,8 @@ export const FirecrawlConnector: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   skill: [
     'Common pattern: **map** a site to find relevant URLs, then **scrape** the specific ones you need.',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/github/github.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/github/github.ts
@@ -132,6 +132,10 @@ export const GithubConnector: ConnectorSpec = {
     fields: ['serverUrl'],
   },
 
+  // MCP connector: talks to an MCP server over JSON-RPC, so a generic HTTP
+  // request (method/path/url) is meaningless. Opt out of the synthesized action.
+  disableGenericRequest: true,
+
   actions: {
     getMe: {
       isTool: true,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/gmail/gmail.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/gmail/gmail.ts
@@ -10,7 +10,11 @@
 import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ConnectorSpec } from '../../connector_spec';
-const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/gmail/v1/users/me` path stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://gmail.googleapis.com';
+const GMAIL_API = `${getBaseUrl()}/gmail/v1/users/me`;
 const DEFAULT_MAX_RESULTS = 10;
 const MAX_PAGE_SIZE = 100;
 
@@ -112,7 +116,7 @@ export const GmailConnector: ConnectorSpec = {
         if (typedInput.query) params.q = typedInput.query;
         if (typedInput.pageToken) params.pageToken = typedInput.pageToken;
         try {
-          const response = await ctx.client.get(`${GMAIL_API_BASE}/messages`, { params });
+          const response = await ctx.client.get(`${GMAIL_API}/messages`, { params });
           return {
             messages: response.data.messages ?? [],
             nextPageToken: response.data.nextPageToken,
@@ -148,12 +152,9 @@ export const GmailConnector: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput = input as { messageId: string; format?: string };
         try {
-          const response = await ctx.client.get(
-            `${GMAIL_API_BASE}/messages/${typedInput.messageId}`,
-            {
-              params: { format: typedInput.format ?? 'minimal' },
-            }
-          );
+          const response = await ctx.client.get(`${GMAIL_API}/messages/${typedInput.messageId}`, {
+            params: { format: typedInput.format ?? 'minimal' },
+          });
           return response.data;
         } catch (error: unknown) {
           throwGmailError(error);
@@ -185,7 +186,7 @@ export const GmailConnector: ConnectorSpec = {
         const typedInput = input as { messageId: string; attachmentId: string };
         try {
           const response = await ctx.client.get(
-            `${GMAIL_API_BASE}/messages/${typedInput.messageId}/attachments/${typedInput.attachmentId}`
+            `${GMAIL_API}/messages/${typedInput.messageId}/attachments/${typedInput.attachmentId}`
           );
           return response.data;
         } catch (error: unknown) {
@@ -231,7 +232,7 @@ export const GmailConnector: ConnectorSpec = {
         if (typedInput.pageToken) params.pageToken = typedInput.pageToken;
         if (typedInput.labelIds?.length) params.labelIds = typedInput.labelIds;
         try {
-          const response = await ctx.client.get(`${GMAIL_API_BASE}/messages`, { params });
+          const response = await ctx.client.get(`${GMAIL_API}/messages`, { params });
           return {
             messages: response.data.messages ?? [],
             nextPageToken: response.data.nextPageToken,
@@ -245,12 +246,14 @@ export const GmailConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     description: 'Verifies Gmail connection by fetching user profile',
     handler: async (ctx) => {
       ctx.log.debug('Gmail test handler');
       try {
-        const response = await ctx.client.get(`${GMAIL_API_BASE}/profile`);
+        const response = await ctx.client.get(`${GMAIL_API}/profile`);
         if (response.status !== 200) {
           return {
             ok: false,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/google_calendar.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/google_calendar.ts
@@ -22,8 +22,11 @@ import type {
   ListEventsInput,
   FreeBusyInput,
 } from './types';
-// Google Calendar API constants
-const GOOGLE_CALENDAR_API_BASE = 'https://www.googleapis.com/calendar/v3';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/calendar/v3` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://www.googleapis.com';
+const GOOGLE_CALENDAR_API_V3 = `${getBaseUrl()}/calendar/v3`;
 const DEFAULT_MAX_RESULTS = 50;
 const MAX_RESULTS_LIMIT = 2500;
 
@@ -107,7 +110,7 @@ export const GoogleCalendar: ConnectorSpec = {
 
         try {
           const response = await ctx.client.get(
-            `${GOOGLE_CALENDAR_API_BASE}/calendars/${calendarId}/events`,
+            `${GOOGLE_CALENDAR_API_V3}/calendars/${calendarId}/events`,
             { params }
           );
 
@@ -130,7 +133,7 @@ export const GoogleCalendar: ConnectorSpec = {
 
         try {
           const response = await ctx.client.get(
-            `${GOOGLE_CALENDAR_API_BASE}/calendars/${calendarId}/events/${eventId}`
+            `${GOOGLE_CALENDAR_API_V3}/calendars/${calendarId}/events/${eventId}`
           );
 
           return response.data;
@@ -153,10 +156,9 @@ export const GoogleCalendar: ConnectorSpec = {
         }
 
         try {
-          const response = await ctx.client.get(
-            `${GOOGLE_CALENDAR_API_BASE}/users/me/calendarList`,
-            { params }
-          );
+          const response = await ctx.client.get(`${GOOGLE_CALENDAR_API_V3}/users/me/calendarList`, {
+            params,
+          });
 
           return response.data;
         } catch (error: unknown) {
@@ -191,7 +193,7 @@ export const GoogleCalendar: ConnectorSpec = {
 
         try {
           const response = await ctx.client.get(
-            `${GOOGLE_CALENDAR_API_BASE}/calendars/${calendarId}/events`,
+            `${GOOGLE_CALENDAR_API_V3}/calendars/${calendarId}/events`,
             { params }
           );
 
@@ -220,7 +222,7 @@ export const GoogleCalendar: ConnectorSpec = {
         }
 
         try {
-          const response = await ctx.client.post(`${GOOGLE_CALENDAR_API_BASE}/freeBusy`, body);
+          const response = await ctx.client.post(`${GOOGLE_CALENDAR_API_V3}/freeBusy`, body);
 
           return response.data;
         } catch (error: unknown) {
@@ -240,13 +242,15 @@ export const GoogleCalendar: ConnectorSpec = {
     'Availability: Prefer freeBusy over listEvents when you only need to know whether someone is free or busy — it is more token-efficient.',
   ].join('\n'),
 
+  getBaseUrl,
+
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.googleCalendar.test.description', {
       defaultMessage: 'Verifies Google Calendar connection by fetching calendar list',
     }),
     handler: async (ctx) => {
       try {
-        const response = await ctx.client.get(`${GOOGLE_CALENDAR_API_BASE}/users/me/calendarList`, {
+        const response = await ctx.client.get(`${GOOGLE_CALENDAR_API_V3}/users/me/calendarList`, {
           params: {
             maxResults: 1,
           },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/google_drive/google_drive.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/google_drive/google_drive.ts
@@ -15,8 +15,11 @@ import {
   getEstimatedBase64OutputBytes,
 } from '../../connector_utils';
 import type { ConnectorSpec } from '../../connector_spec';
-// Google Drive API constants
-const GOOGLE_DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/drive/v3` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://www.googleapis.com';
+const GOOGLE_DRIVE_API_V3 = `${getBaseUrl()}/drive/v3`;
 const DEFAULT_PAGE_SIZE = 250;
 const MAX_PAGE_SIZE = 1000;
 const DEFAULT_FOLDER_ID = 'root';
@@ -223,7 +226,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
         }
 
         try {
-          const response = await ctx.client.get(`${GOOGLE_DRIVE_API_BASE}/files`, {
+          const response = await ctx.client.get(`${GOOGLE_DRIVE_API_V3}/files`, {
             params,
           });
 
@@ -302,7 +305,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
         }
 
         try {
-          const response = await ctx.client.get(`${GOOGLE_DRIVE_API_BASE}/files`, {
+          const response = await ctx.client.get(`${GOOGLE_DRIVE_API_V3}/files`, {
             params,
           });
 
@@ -356,7 +359,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
         try {
           // First, get file metadata to determine if it's a Google Workspace document
           const metadataResponse = await ctx.client.get(
-            `${GOOGLE_DRIVE_API_BASE}/files/${typedInput.fileId}`,
+            `${GOOGLE_DRIVE_API_V3}/files/${typedInput.fileId}`,
             {
               params: {
                 fields: 'id, name, mimeType, size',
@@ -379,7 +382,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
               typedInput.responseType
             );
             contentResponse = await ctx.client.get(
-              `${GOOGLE_DRIVE_API_BASE}/files/${typedInput.fileId}/export`,
+              `${GOOGLE_DRIVE_API_V3}/files/${typedInput.fileId}/export`,
               {
                 params: {
                   mimeType: resolvedMimeType,
@@ -392,7 +395,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
             // fall back to base64 for binary types even when text was requested.
             useTextResponse &&= !!fileMetadata.mimeType?.startsWith('text/');
             contentResponse = await ctx.client.get(
-              `${GOOGLE_DRIVE_API_BASE}/files/${typedInput.fileId}`,
+              `${GOOGLE_DRIVE_API_V3}/files/${typedInput.fileId}`,
               {
                 params: {
                   alt: 'media',
@@ -479,7 +482,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
           const results = await Promise.all(
             typedInput.fileIds.map(async (fileId) => {
               try {
-                const response = await ctx.client.get(`${GOOGLE_DRIVE_API_BASE}/files/${fileId}`, {
+                const response = await ctx.client.get(`${GOOGLE_DRIVE_API_V3}/files/${fileId}`, {
                   params: { fields: metadataFields, supportsAllDrives: true },
                 });
                 return response.data;
@@ -531,6 +534,8 @@ export const GoogleDriveConnector: ConnectorSpec = {
     'For reading document content, prefer responseType "text" to avoid oversized base64 payloads.',
   ].join('\n'),
 
+  getBaseUrl,
+
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.googleDrive.test.description', {
       defaultMessage: 'Verifies Google Drive connection by fetching user information',
@@ -538,7 +543,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
     handler: async (ctx) => {
       ctx.log.debug('Google Drive test handler');
       try {
-        const response = await ctx.client.get(`${GOOGLE_DRIVE_API_BASE}/about`, {
+        const response = await ctx.client.get(`${GOOGLE_DRIVE_API_V3}/about`, {
           params: {
             fields: 'user',
           },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/greynoise/greynoise.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/greynoise/greynoise.ts
@@ -23,6 +23,12 @@ import { z, lazySchema } from '@kbn/zod/v4';
 import { i18n } from '@kbn/i18n';
 import type { ConnectorSpec } from '../../connector_spec';
 
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/v2` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://api.greynoise.io';
+const GREYNOISE_API_V2 = `${getBaseUrl()}/v2`;
+
 const IpInputSchema = lazySchema(() =>
   z.object({
     ip: z.ipv4().describe('IP address'),
@@ -50,9 +56,7 @@ export const GreyNoiseConnector: ConnectorSpec = {
       input: IpInputSchema,
       handler: async (ctx, input) => {
         const typedInput = input as { ip: string };
-        const response = await ctx.client.get(
-          `https://api.greynoise.io/v2/noise/context/${typedInput.ip}`
-        );
+        const response = await ctx.client.get(`${GREYNOISE_API_V2}/noise/context/${typedInput.ip}`);
         return {
           ip: response.data.ip,
           seen: response.data.seen,
@@ -70,9 +74,7 @@ export const GreyNoiseConnector: ConnectorSpec = {
       input: IpInputSchema,
       handler: async (ctx, input) => {
         const typedInput = input as { ip: string };
-        const response = await ctx.client.get(
-          `https://api.greynoise.io/v2/noise/quick/${typedInput.ip}`
-        );
+        const response = await ctx.client.get(`${GREYNOISE_API_V2}/noise/quick/${typedInput.ip}`);
         return {
           ip: typedInput.ip,
           noise: response.data.noise,
@@ -87,7 +89,7 @@ export const GreyNoiseConnector: ConnectorSpec = {
       input: IpInputSchema,
       handler: async (ctx, input) => {
         const typedInput = input as { ip: string };
-        const response = await ctx.client.get('https://api.greynoise.io/v2/meta/metadata', {
+        const response = await ctx.client.get(`${GREYNOISE_API_V2}/meta/metadata`, {
           params: { ip: typedInput.ip },
         });
         return {
@@ -107,7 +109,7 @@ export const GreyNoiseConnector: ConnectorSpec = {
       input: IpInputSchema,
       handler: async (ctx, input) => {
         const typedInput = input as { ip: string };
-        const response = await ctx.client.get(`https://api.greynoise.io/v2/riot/${typedInput.ip}`);
+        const response = await ctx.client.get(`${GREYNOISE_API_V2}/riot/${typedInput.ip}`);
         return {
           ip: typedInput.ip,
           riot: response.data.riot,
@@ -121,10 +123,12 @@ export const GreyNoiseConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     handler: async (ctx) => {
       try {
-        await ctx.client.get('https://api.greynoise.io/v2/noise/quick/8.8.8.8');
+        await ctx.client.get(`${GREYNOISE_API_V2}/noise/quick/8.8.8.8`);
         return {
           ok: true,
           message: 'Successfully connected to GreyNoise API',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/kubernetes/kubernetes.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/kubernetes/kubernetes.ts
@@ -227,15 +227,19 @@ const normalizeK8sError = (error: unknown): Error => {
   return error instanceof Error ? error : new Error(String(error));
 };
 
+const getBaseUrl = (ctx: ActionContext): string => {
+  const { apiUrl } = ctx.config as { apiUrl: string };
+  return apiUrl;
+};
+
 /** Central request helper: resolves the URL, applies headers, normalizes errors. */
 const k8sRequest = async (ctx: ActionContext, options: K8sRequestOptions): Promise<unknown> => {
   assertPathAllowed(options.path);
-  const { apiUrl } = ctx.config as { apiUrl: string };
   const client = ctx.client as AxiosInstance;
   try {
     const response = await client.request({
       method: options.method,
-      url: `${apiUrl}${options.path}`,
+      url: `${getBaseUrl(ctx)}${options.path}`,
       ...(options.params ? { params: options.params } : {}),
       ...(options.data !== undefined ? { data: options.data } : {}),
       ...(options.contentType ? { headers: { 'Content-Type': options.contentType } } : {}),
@@ -413,6 +417,11 @@ export const KubernetesConnector: ConnectorSpec = {
         }),
     })
   ),
+
+  // Kubernetes ships its own richer `request` action (with contentType and
+  // strategic-merge-patch handling), so opt out of the framework-synthesized
+  // generic request to avoid clashing with the reserved `request` key.
+  disableGenericRequest: true,
 
   actions: {
     request: {
@@ -697,6 +706,8 @@ export const KubernetesConnector: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   skill: [
     'Kubernetes connector — usage guidance for LLMs.',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/microsoft_teams/microsoft_teams.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/microsoft_teams/microsoft_teams.ts
@@ -33,6 +33,11 @@ import type {
  */
 const userPath = (userId?: string): string => (userId ? `/users/${userId}` : '/me');
 
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The version segment stays in paths.
+const getBaseUrl = (): string => 'https://graph.microsoft.com';
+const GRAPH_API_V1 = `${getBaseUrl()}/v1.0`;
+
 const GraphCollectionOutputSchema = lazySchema(() =>
   z.object({
     value: z.array(z.any()).describe('Array of items returned from the API'),
@@ -186,14 +191,11 @@ export const MicrosoftTeams: ConnectorSpec = {
         }
         const base = userPath(input?.userId);
         ctx.log.debug('Microsoft Teams listing joined teams');
-        const response = await ctx.client.get(
-          `https://graph.microsoft.com/v1.0${base}/joinedTeams`,
-          {
-            params: {
-              $select: 'id,displayName,description,isArchived,tenantId',
-            },
-          }
-        );
+        const response = await ctx.client.get(`${GRAPH_API_V1}${base}/joinedTeams`, {
+          params: {
+            $select: 'id,displayName,description,isArchived,tenantId',
+          },
+        });
         return response.data;
       },
     },
@@ -207,14 +209,11 @@ export const MicrosoftTeams: ConnectorSpec = {
       output: GraphCollectionOutputSchema,
       handler: async (ctx, input: ListChannelsInput) => {
         ctx.log.debug(`Microsoft Teams listing channels for team ${input.teamId}`);
-        const response = await ctx.client.get(
-          `https://graph.microsoft.com/v1.0/teams/${input.teamId}/channels`,
-          {
-            params: {
-              $select: 'id,displayName,description,createdDateTime,membershipType,webUrl',
-            },
-          }
-        );
+        const response = await ctx.client.get(`${GRAPH_API_V1}/teams/${input.teamId}/channels`, {
+          params: {
+            $select: 'id,displayName,description,createdDateTime,membershipType,webUrl',
+          },
+        });
         return response.data;
       },
     },
@@ -231,7 +230,7 @@ export const MicrosoftTeams: ConnectorSpec = {
           `Microsoft Teams listing messages for channel ${input.channelId} in team ${input.teamId}`
         );
         const response = await ctx.client.get(
-          `https://graph.microsoft.com/v1.0/teams/${input.teamId}/channels/${input.channelId}/messages`,
+          `${GRAPH_API_V1}/teams/${input.teamId}/channels/${input.channelId}/messages`,
           {
             params: {
               ...(input.top !== undefined && { $top: input.top }),
@@ -258,7 +257,7 @@ export const MicrosoftTeams: ConnectorSpec = {
         }
         const base = userPath(input.userId);
         ctx.log.debug('Microsoft Teams listing chats');
-        const response = await ctx.client.get(`https://graph.microsoft.com/v1.0${base}/chats`, {
+        const response = await ctx.client.get(`${GRAPH_API_V1}${base}/chats`, {
           params: {
             $select: 'id,topic,createdDateTime,lastUpdatedDateTime,chatType,webUrl',
             ...(input.top !== undefined && { $top: input.top }),
@@ -277,14 +276,11 @@ export const MicrosoftTeams: ConnectorSpec = {
       output: GraphCollectionOutputSchema,
       handler: async (ctx, input: ListChatMessagesInput) => {
         ctx.log.debug(`Microsoft Teams listing messages for chat ${input.chatId}`);
-        const response = await ctx.client.get(
-          `https://graph.microsoft.com/v1.0/chats/${input.chatId}/messages`,
-          {
-            params: {
-              ...(input.top !== undefined && { $top: input.top }),
-            },
-          }
-        );
+        const response = await ctx.client.get(`${GRAPH_API_V1}/chats/${input.chatId}/messages`, {
+          params: {
+            ...(input.top !== undefined && { $top: input.top }),
+          },
+        });
         return response.data;
       },
     },
@@ -336,14 +332,13 @@ export const MicrosoftTeams: ConnectorSpec = {
         };
 
         ctx.log.debug('Microsoft Teams searching messages');
-        const response = await ctx.client.post(
-          'https://graph.microsoft.com/v1.0/search/query',
-          searchRequest
-        );
+        const response = await ctx.client.post(`${GRAPH_API_V1}/search/query`, searchRequest);
         return response.data;
       },
     },
   },
+
+  getBaseUrl,
 
   skill: [
     'Microsoft Teams connector — usage guidance:',
@@ -367,9 +362,7 @@ export const MicrosoftTeams: ConnectorSpec = {
 
       try {
         const isAppOnly = ctx.secrets?.authType === 'oauth_client_credentials';
-        const url = isAppOnly
-          ? 'https://graph.microsoft.com/v1.0/teams'
-          : 'https://graph.microsoft.com/v1.0/me/joinedTeams'; // bearer and oauth_authorization_code use delegated /me path
+        const url = isAppOnly ? `${GRAPH_API_V1}/teams` : `${GRAPH_API_V1}/me/joinedTeams`; // bearer and oauth_authorization_code use delegated /me path
 
         const response = await ctx.client.get(url, {
           params: { $select: 'id,displayName' },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/notion/notion.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/notion/notion.ts
@@ -10,6 +10,13 @@ import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ConnectorSpec } from '../../connector_spec';
 import type * as Notion from './types';
+
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/v1` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://api.notion.com';
+const NOTION_API_V1 = `${getBaseUrl()}/v1`;
+
 export const NotionConnector: ConnectorSpec = {
   metadata: {
     id: '.notion',
@@ -79,7 +86,7 @@ export const NotionConnector: ConnectorSpec = {
         })
       ),
       handler: async (ctx, input: Notion.SearchByTitleInput) => {
-        const response = await ctx.client.post('https://api.notion.com/v1/search', {
+        const response = await ctx.client.post(`${NOTION_API_V1}/search`, {
           query: input.query,
           filter: {
             value: input.queryObjectType,
@@ -108,10 +115,7 @@ export const NotionConnector: ConnectorSpec = {
         })
       ),
       handler: async (ctx, input: Notion.GetPageInput) => {
-        const response = await ctx.client.get(
-          `https://api.notion.com/v1/pages/${input.pageId}`,
-          {}
-        );
+        const response = await ctx.client.get(`${NOTION_API_V1}/pages/${input.pageId}`, {});
         return response.data;
       },
     },
@@ -132,7 +136,7 @@ export const NotionConnector: ConnectorSpec = {
       ),
       handler: async (ctx, input: Notion.GetDataSourceInput) => {
         const response = await ctx.client.get(
-          `https://api.notion.com/v1/data_sources/${input.dataSourceId}`,
+          `${NOTION_API_V1}/data_sources/${input.dataSourceId}`,
           {}
         );
         return response.data;
@@ -190,7 +194,7 @@ export const NotionConnector: ConnectorSpec = {
         }
 
         const response = await ctx.client.post(
-          `https://api.notion.com/v1/data_sources/${input.dataSourceId}/query`,
+          `${NOTION_API_V1}/data_sources/${input.dataSourceId}/query`,
           requestData
         );
         return response.data;
@@ -220,6 +224,8 @@ export const NotionConnector: ConnectorSpec = {
     'Use pageSize to control results per page; maximum allowed by Notion is 100.',
   ].join('\n'),
 
+  getBaseUrl,
+
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.notion.test.description', {
       defaultMessage: 'Verifies Notion connection by fetching metadata about given data source',
@@ -230,7 +236,7 @@ export const NotionConnector: ConnectorSpec = {
       ctx.log.debug('Notion test handler');
 
       try {
-        const response = await ctx.client.get('https://api.notion.com/v1/users');
+        const response = await ctx.client.get(`${NOTION_API_V1}/users`);
         const numOfUsers = response.data.results.length;
         return {
           ok: true,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/one_drive/one_drive.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/one_drive/one_drive.ts
@@ -44,6 +44,11 @@ const SEARCH_SELECT = `${COMMON_SELECT},parentReference`;
 const FILE_METADATA_SELECT = `${COMMON_SELECT},parentReference,@microsoft.graph.downloadUrl`;
 const REMOTE_ITEMS_SELECT = `${COMMON_SELECT},remoteItem`;
 
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The version segment stays in paths.
+const getBaseUrl = (): string => 'https://graph.microsoft.com';
+const GRAPH_API_V1 = `${getBaseUrl()}/v1.0`;
+
 export const OneDrive: ConnectorSpec = {
   metadata: {
     id: '.one_drive',
@@ -103,7 +108,7 @@ export const OneDrive: ConnectorSpec = {
         'identify which account is connected.',
       input: lazySchema(() => z.object({})),
       handler: async (ctx) => {
-        const response = await ctx.client.get('https://graph.microsoft.com/v1.0/me', {
+        const response = await ctx.client.get(`${GRAPH_API_V1}/me`, {
           params: { $select: 'id,displayName,mail,userPrincipalName' },
         });
         return response.data;
@@ -118,7 +123,7 @@ export const OneDrive: ConnectorSpec = {
         'orient the agent before browsing files.',
       input: lazySchema(() => z.object({})),
       handler: async (ctx) => {
-        const response = await ctx.client.get('https://graph.microsoft.com/v1.0/me/drive', {
+        const response = await ctx.client.get(`${GRAPH_API_V1}/me/drive`, {
           params: { $select: 'id,name,driveType,quota,owner' },
         });
         return response.data;
@@ -137,8 +142,8 @@ export const OneDrive: ConnectorSpec = {
       handler: async (ctx, input: GetItemChildrenInput) => {
         const url =
           input.itemId && input.itemId !== ''
-            ? `https://graph.microsoft.com/v1.0/me/drive/items/${input.itemId}/children`
-            : 'https://graph.microsoft.com/v1.0/me/drive/root/children';
+            ? `${GRAPH_API_V1}/me/drive/items/${input.itemId}/children`
+            : `${GRAPH_API_V1}/me/drive/root/children`;
 
         const response = await ctx.client.get(url, {
           params: {
@@ -163,10 +168,10 @@ export const OneDrive: ConnectorSpec = {
       input: SearchInputSchema,
       handler: async (ctx, input: SearchInput) => {
         const url = input.query
-          ? `https://graph.microsoft.com/v1.0/me/drive/root/search(q='${encodeURIComponent(
+          ? `${GRAPH_API_V1}/me/drive/root/search(q='${encodeURIComponent(
               input.query.replace(/'/g, "''")
             )}')`
-          : 'https://graph.microsoft.com/v1.0/me/drive/root/search';
+          : `${GRAPH_API_V1}/me/drive/root/search`;
         const response = await ctx.client.get(url, {
           params: {
             $select: SEARCH_SELECT,
@@ -191,8 +196,8 @@ export const OneDrive: ConnectorSpec = {
       input: GetFileMetadataInputSchema,
       handler: async (ctx, input: GetFileMetadataInput) => {
         const itemUrl = input.driveId
-          ? `https://graph.microsoft.com/v1.0/drives/${input.driveId}/items/${input.itemId}`
-          : `https://graph.microsoft.com/v1.0/me/drive/items/${input.itemId}`;
+          ? `${GRAPH_API_V1}/drives/${input.driveId}/items/${input.itemId}`
+          : `${GRAPH_API_V1}/me/drive/items/${input.itemId}`;
         const response = await ctx.client.get(itemUrl, {
           params: {
             $select: FILE_METADATA_SELECT,
@@ -215,8 +220,8 @@ export const OneDrive: ConnectorSpec = {
       input: GetFileContentInputSchema,
       handler: async (ctx, input: GetFileContentInput) => {
         const itemUrl = input.driveId
-          ? `https://graph.microsoft.com/v1.0/drives/${input.driveId}/items/${input.itemId}/content`
-          : `https://graph.microsoft.com/v1.0/me/drive/items/${input.itemId}/content`;
+          ? `${GRAPH_API_V1}/drives/${input.driveId}/items/${input.itemId}/content`
+          : `${GRAPH_API_V1}/me/drive/items/${input.itemId}/content`;
         const response = await ctx.client.get(itemUrl, { responseType: 'arraybuffer' });
         const buffer = Buffer.from(response.data);
         const rawContentType = String(response.headers?.['content-type'] ?? '');
@@ -241,15 +246,12 @@ export const OneDrive: ConnectorSpec = {
         'If the response contains a nextPageToken field, pass it as pageToken to fetch the next page.',
       input: ListSharedWithMeInputSchema,
       handler: async (ctx, input: ListSharedWithMeInput) => {
-        const response = await ctx.client.get(
-          'https://graph.microsoft.com/v1.0/me/drive/sharedWithMe',
-          {
-            params: {
-              $select: REMOTE_ITEMS_SELECT,
-              ...(input.pageToken ? { $skiptoken: input.pageToken } : {}),
-            },
-          }
-        );
+        const response = await ctx.client.get(`${GRAPH_API_V1}/me/drive/sharedWithMe`, {
+          params: {
+            $select: REMOTE_ITEMS_SELECT,
+            ...(input.pageToken ? { $skiptoken: input.pageToken } : {}),
+          },
+        });
         return withNextPageToken(response.data);
       },
     },
@@ -264,7 +266,7 @@ export const OneDrive: ConnectorSpec = {
         'If the response contains a nextPageToken field, pass it as pageToken to fetch the next page.',
       input: ListRecentFilesInputSchema,
       handler: async (ctx, input: ListRecentFilesInput) => {
-        const response = await ctx.client.get('https://graph.microsoft.com/v1.0/me/drive/recent', {
+        const response = await ctx.client.get(`${GRAPH_API_V1}/me/drive/recent`, {
           params: {
             $select: REMOTE_ITEMS_SELECT,
             $top: 25,
@@ -276,6 +278,8 @@ export const OneDrive: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.oneDrive.test.description', {
       defaultMessage:
@@ -283,7 +287,7 @@ export const OneDrive: ConnectorSpec = {
     }),
     handler: async (ctx) => {
       try {
-        const response = await ctx.client.get('https://graph.microsoft.com/v1.0/me', {
+        const response = await ctx.client.get(`${GRAPH_API_V1}/me`, {
           params: { $select: 'displayName,mail' },
         });
         const { displayName, mail } = response.data as { displayName: string; mail: string };

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/one_password/one_password.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/one_password/one_password.ts
@@ -10,7 +10,11 @@ import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ConnectorSpec } from '../../connector_spec';
 
-const BASE_URL = 'https://api.1password.com/v1beta1';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/v1beta1` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://api.1password.com';
+const ONE_PASSWORD_API_V1BETA1 = `${getBaseUrl()}/v1beta1`;
 
 // So we get something like: 1Password API error (403): {"code":7,"message":"no_owner_remain","details":[]}
 const throwWithApiError = (error: unknown): never => {
@@ -45,7 +49,7 @@ export const OnePasswordConnector: ConnectorSpec = {
       {
         type: 'oauth_client_credentials',
         defaults: {
-          tokenUrl: `${BASE_URL}/users/oauth2/token`,
+          tokenUrl: `${ONE_PASSWORD_API_V1BETA1}/users/oauth2/token`,
           scope: 'openid',
           tokenEndpointAuthMethod: 'client_secret_basic',
         },
@@ -102,13 +106,16 @@ export const OnePasswordConnector: ConnectorSpec = {
         const { accountUuid } = ctx.config as { accountUuid: string };
 
         try {
-          const response = await ctx.client.get(`${BASE_URL}/accounts/${accountUuid}/users`, {
-            params: {
-              ...(typedInput.filter && { filter: typedInput.filter }),
-              ...(typedInput.maxPageSize && { maxPageSize: typedInput.maxPageSize }),
-              ...(typedInput.pageToken && { pageToken: typedInput.pageToken }),
-            },
-          });
+          const response = await ctx.client.get(
+            `${ONE_PASSWORD_API_V1BETA1}/accounts/${accountUuid}/users`,
+            {
+              params: {
+                ...(typedInput.filter && { filter: typedInput.filter }),
+                ...(typedInput.maxPageSize && { maxPageSize: typedInput.maxPageSize }),
+                ...(typedInput.pageToken && { pageToken: typedInput.pageToken }),
+              },
+            }
+          );
           return response.data;
         } catch (error) {
           throwWithApiError(error);
@@ -133,7 +140,7 @@ export const OnePasswordConnector: ConnectorSpec = {
 
         try {
           const response = await ctx.client.get(
-            `${BASE_URL}/accounts/${accountUuid}/users/${uuid}`
+            `${ONE_PASSWORD_API_V1BETA1}/accounts/${accountUuid}/users/${uuid}`
           );
           return response.data;
         } catch (error) {
@@ -162,7 +169,7 @@ export const OnePasswordConnector: ConnectorSpec = {
 
         try {
           const response = await ctx.client.post(
-            `${BASE_URL}/accounts/${accountUuid}/users/${uuid}:suspend`
+            `${ONE_PASSWORD_API_V1BETA1}/accounts/${accountUuid}/users/${uuid}:suspend`
           );
           return response.data;
         } catch (error) {
@@ -188,7 +195,7 @@ export const OnePasswordConnector: ConnectorSpec = {
 
         try {
           const response = await ctx.client.post(
-            `${BASE_URL}/accounts/${accountUuid}/users/${uuid}:reactivate`
+            `${ONE_PASSWORD_API_V1BETA1}/accounts/${accountUuid}/users/${uuid}:reactivate`
           );
           return response.data;
         } catch (error) {
@@ -197,6 +204,8 @@ export const OnePasswordConnector: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.onePassword.test.description', {
@@ -207,9 +216,12 @@ export const OnePasswordConnector: ConnectorSpec = {
       const { accountUuid } = ctx.config as { accountUuid: string };
 
       try {
-        const response = await ctx.client.get(`${BASE_URL}/accounts/${accountUuid}/users`, {
-          params: { maxPageSize: 1 },
-        });
+        const response = await ctx.client.get(
+          `${ONE_PASSWORD_API_V1BETA1}/accounts/${accountUuid}/users`,
+          {
+            params: { maxPageSize: 1 },
+          }
+        );
 
         if (response.status === 200) {
           return { ok: true, message: 'Successfully connected to 1Password Users API' };

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/outlook/outlook.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/outlook/outlook.ts
@@ -29,7 +29,11 @@ import type {
   ListFoldersInput,
 } from './types';
 
-const GRAPH_BASE = 'https://graph.microsoft.com/v1.0';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/v1.0` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://graph.microsoft.com';
+const GRAPH_BASE = `${getBaseUrl()}/v1.0`;
 
 const GraphCollectionOutputSchema = z.object({
   value: z.array(z.any()).describe('Array of items returned from the API'),
@@ -229,6 +233,8 @@ export const Outlook: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.outlook.test.description', {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/pagerduty/pagerduty.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/pagerduty/pagerduty.ts
@@ -109,6 +109,10 @@ export const PagerdutyConnector: ConnectorSpec = {
     fields: ['serverUrl'],
   },
 
+  // MCP connector: talks to an MCP server over JSON-RPC, so a generic HTTP
+  // request (method/path/url) is meaningless. Opt out of the synthesized action.
+  disableGenericRequest: true,
+
   actions: {
     getUserData: {
       isTool: true,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/salesforce.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/salesforce.ts
@@ -8,11 +8,11 @@
  */
 import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
-import type { ConnectorSpec } from '../../connector_spec';
+import type { ActionContext, ConnectorSpec } from '../../connector_spec';
 const SALESFORCE_API_VERSION = 'v66.0';
 
 /** Derive instance base URL from the full token URL (strip /services/oauth2/token and any path). */
-function getBaseUrl(tokenUrl: string | undefined): string {
+function resolveBaseUrlFromTokenUrl(tokenUrl: string | undefined): string {
   if (!tokenUrl || tokenUrl.trim() === '') {
     throw new Error(
       'Salesforce connector is not configured: tokenUrl (OAuth token endpoint) is required.'
@@ -23,6 +23,15 @@ function getBaseUrl(tokenUrl: string | undefined): string {
     : tokenUrl;
   return base.replace(/\/+$/, '');
 }
+
+/**
+ * Base URL for the framework-synthesized `request` action and the single source
+ * of truth reused by the handlers below. Salesforce derives the instance origin
+ * from the OAuth token URL in secrets; the `/services/data/<version>` API prefix
+ * stays in the per-action paths.
+ */
+const getBaseUrl = (ctx: ActionContext): string =>
+  resolveBaseUrlFromTokenUrl(ctx.secrets?.tokenUrl as string | undefined);
 
 /** Resolve Salesforce nextRecordsUrl (relative path) to a full URL. */
 function createPaginationUrl(baseUrl: string, nextRecordsUrl: string): string {
@@ -100,7 +109,7 @@ export const SalesforceConnector: ConnectorSpec = {
       ),
       handler: async (ctx, input) => {
         const typedInput = input as { soql: string; nextRecordsUrl?: string };
-        const baseUrl = getBaseUrl(ctx.secrets?.tokenUrl as string | undefined);
+        const baseUrl = getBaseUrl(ctx);
         if (typedInput.nextRecordsUrl) {
           const url = createPaginationUrl(baseUrl, typedInput.nextRecordsUrl);
           const response = await ctx.client.get(url, {});
@@ -133,7 +142,7 @@ export const SalesforceConnector: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput = input as { sobjectName: string; recordId: string };
         validateSobjectName(typedInput.sobjectName);
-        const baseUrl = getBaseUrl(ctx.secrets?.tokenUrl as string | undefined);
+        const baseUrl = getBaseUrl(ctx);
         const sobjectSegment = encodeURIComponent(typedInput.sobjectName.trim());
         const recordIdSegment = encodeURIComponent(typedInput.recordId);
         const response = await ctx.client.get(
@@ -162,7 +171,7 @@ export const SalesforceConnector: ConnectorSpec = {
           limit: number;
           nextRecordsUrl?: string;
         };
-        const baseUrl = getBaseUrl(ctx.secrets?.tokenUrl as string | undefined);
+        const baseUrl = getBaseUrl(ctx);
         if (typedInput.nextRecordsUrl) {
           const url = createPaginationUrl(baseUrl, typedInput.nextRecordsUrl);
           const response = await ctx.client.get(url, {});
@@ -202,7 +211,7 @@ export const SalesforceConnector: ConnectorSpec = {
           returning: string;
           nextRecordsUrl?: string;
         };
-        const baseUrl = getBaseUrl(ctx.secrets?.tokenUrl as string);
+        const baseUrl = getBaseUrl(ctx);
         if (typedInput.nextRecordsUrl) {
           const url = createPaginationUrl(baseUrl, typedInput.nextRecordsUrl);
           const response = await ctx.client.get(url, {});
@@ -233,7 +242,7 @@ export const SalesforceConnector: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput = input as { sobjectName: string };
         validateSobjectName(typedInput.sobjectName);
-        const baseUrl = getBaseUrl(ctx.secrets?.tokenUrl as string | undefined);
+        const baseUrl = getBaseUrl(ctx);
         const sobjectSegment = encodeURIComponent(typedInput.sobjectName.trim());
         const response = await ctx.client.get(
           `${baseUrl}/services/data/${SALESFORCE_API_VERSION}/sobjects/${sobjectSegment}/describe`,
@@ -258,7 +267,7 @@ export const SalesforceConnector: ConnectorSpec = {
       ),
       handler: async (ctx, input) => {
         const typedInput = input as { contentVersionId: string };
-        const baseUrl = getBaseUrl(ctx.secrets?.tokenUrl as string | undefined);
+        const baseUrl = getBaseUrl(ctx);
         const id = encodeURIComponent(typedInput.contentVersionId.trim());
         const url = `${baseUrl}/services/data/${SALESFORCE_API_VERSION}/sobjects/ContentVersion/${id}/VersionData`;
         const response = await ctx.client.get(url, { responseType: 'arraybuffer' });
@@ -271,6 +280,8 @@ export const SalesforceConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.salesforce.test.description', {
       defaultMessage: 'Verifies Salesforce connection by running a simple query',
@@ -279,7 +290,7 @@ export const SalesforceConnector: ConnectorSpec = {
       ctx.log.debug('Salesforce test handler');
 
       try {
-        const baseUrl = getBaseUrl(ctx.secrets?.tokenUrl as string | undefined);
+        const baseUrl = getBaseUrl(ctx);
         await ctx.client.get(`${baseUrl}/services/data/${SALESFORCE_API_VERSION}/query`, {
           params: { q: 'SELECT Id FROM User LIMIT 1' },
         });

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/servicenow_search/servicenow_search.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/servicenow_search/servicenow_search.ts
@@ -22,7 +22,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
-import type { ConnectorSpec } from '../../connector_spec';
+import type { ActionContext, ConnectorSpec } from '../../connector_spec';
 import {
   SearchInputSchema,
   GetRecordInputSchema,
@@ -43,6 +43,14 @@ import type {
   GetAttachmentInput,
   DescribeTableInput,
 } from './types';
+
+const getBaseUrl = (ctx: ActionContext): string => {
+  const { instanceUrl } = ctx.config as { instanceUrl: string };
+  return instanceUrl;
+};
+
+const SERVICENOW_API_PREFIX = '/api/now';
+
 export const ServicenowSearch: ConnectorSpec = {
   metadata: {
     id: '.servicenow_search',
@@ -108,8 +116,7 @@ export const ServicenowSearch: ConnectorSpec = {
       description: 'Search ServiceNow records using full-text search across a given table',
       input: SearchInputSchema,
       handler: async (ctx, input: SearchInput) => {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
-        const url = `${instanceUrl}/api/now/table/${input.table}`;
+        const url = `${getBaseUrl(ctx)}${SERVICENOW_API_PREFIX}/table/${input.table}`;
         const limit = input.limit ?? 20;
 
         // GOTO123TEXTQUERY321 is ServiceNow's undocumented full-text search parameter
@@ -138,8 +145,9 @@ export const ServicenowSearch: ConnectorSpec = {
         'For knowledge articles (kb_knowledge table), request fields: sys_id,number,short_description,text,topic,category,author,sys_created_on,sys_updated_on,workflow_state,kb_knowledge_base,kb_category',
       input: GetRecordInputSchema,
       handler: async (ctx, input: GetRecordInput) => {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
-        const url = `${instanceUrl}/api/now/table/${input.table}/${input.sysId}`;
+        const url = `${getBaseUrl(ctx)}${SERVICENOW_API_PREFIX}/table/${input.table}/${
+          input.sysId
+        }`;
 
         const response = await ctx.client.get(url, {
           params: {
@@ -157,8 +165,7 @@ export const ServicenowSearch: ConnectorSpec = {
       description: 'List records from a ServiceNow table with optional encoded query filter',
       input: ListRecordsInputSchema,
       handler: async (ctx, input: ListRecordsInput) => {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
-        const url = `${instanceUrl}/api/now/table/${input.table}`;
+        const url = `${getBaseUrl(ctx)}${SERVICENOW_API_PREFIX}/table/${input.table}`;
         const limit = input.limit ?? 20;
 
         const response = await ctx.client.get(url, {
@@ -182,8 +189,7 @@ export const ServicenowSearch: ConnectorSpec = {
         'List available ServiceNow tables with their labels and descriptions. Use this to discover what tables exist in the instance before querying them.',
       input: ListTablesInputSchema,
       handler: async (ctx, input: ListTablesInput) => {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
-        const url = `${instanceUrl}/api/now/table/sys_db_object`;
+        const url = `${getBaseUrl(ctx)}${SERVICENOW_API_PREFIX}/table/sys_db_object`;
         const limit = input.limit ?? 50;
 
         const response = await ctx.client.get(url, {
@@ -208,8 +214,7 @@ export const ServicenowSearch: ConnectorSpec = {
         'List available ServiceNow knowledge bases with their titles and descriptions. Use this to discover what knowledge bases exist before searching for articles.',
       input: ListKnowledgeBasesInputSchema,
       handler: async (ctx, input: ListKnowledgeBasesInput) => {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
-        const url = `${instanceUrl}/api/now/table/kb_knowledge_base`;
+        const url = `${getBaseUrl(ctx)}${SERVICENOW_API_PREFIX}/table/kb_knowledge_base`;
         const limit = input.limit ?? 20;
 
         const response = await ctx.client.get(url, {
@@ -233,8 +238,7 @@ export const ServicenowSearch: ConnectorSpec = {
         'Returns journal entries in chronological order. Call this after retrieving a record to understand its history.',
       input: GetCommentsInputSchema,
       handler: async (ctx, input: GetCommentsInput) => {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
-        const url = `${instanceUrl}/api/now/table/sys_journal_field`;
+        const url = `${getBaseUrl(ctx)}${SERVICENOW_API_PREFIX}/table/sys_journal_field`;
         const limit = input.limit ?? 20;
 
         const response = await ctx.client.get(url, {
@@ -266,18 +270,18 @@ export const ServicenowSearch: ConnectorSpec = {
         })
       ),
       handler: async (ctx, input: GetAttachmentInput) => {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
+        const baseUrl = getBaseUrl(ctx);
 
         // First get attachment metadata
         const metaResponse = await ctx.client.get(
-          `${instanceUrl}/api/now/attachment/${input.sysId}`,
+          `${baseUrl}${SERVICENOW_API_PREFIX}/attachment/${input.sysId}`,
           {}
         );
         const { file_name: fileName, content_type: contentType } = metaResponse.data.result;
 
         // Then download the content
         const contentResponse = await ctx.client.get(
-          `${instanceUrl}/api/now/attachment/${input.sysId}/file`,
+          `${baseUrl}${SERVICENOW_API_PREFIX}/attachment/${input.sysId}/file`,
           { responseType: 'arraybuffer' }
         );
         const buffer = Buffer.from(contentResponse.data);
@@ -298,10 +302,9 @@ export const ServicenowSearch: ConnectorSpec = {
         'querying it — for example, to know which fields to request or filter on.',
       input: DescribeTableInputSchema,
       handler: async (ctx, input: DescribeTableInput) => {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
         // The /api/now/doc/table/schema endpoint returns the full flattened schema
         // including inherited fields from parent tables, and is accessible to non-admin users.
-        const url = `${instanceUrl}/api/now/doc/table/schema/${input.table}`;
+        const url = `${getBaseUrl(ctx)}${SERVICENOW_API_PREFIX}/doc/table/schema/${input.table}`;
 
         const response = await ctx.client.get(url, {});
 
@@ -309,6 +312,8 @@ export const ServicenowSearch: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   skill: [
     'ServiceNow connector — cross-action usage guidance for LLMs.',
@@ -335,16 +340,18 @@ export const ServicenowSearch: ConnectorSpec = {
     }),
     handler: async (ctx) => {
       try {
-        const { instanceUrl } = ctx.config as { instanceUrl: string };
         // Fetch the authenticated user's own record — readable by any authenticated user
         // regardless of role. Avoids relying on admin-only tables like sys_properties.
-        const response = await ctx.client.get(`${instanceUrl}/api/now/table/sys_user`, {
-          params: {
-            sysparm_query: 'sys_created_on!=NULL',
-            sysparm_limit: 1,
-            sysparm_fields: 'sys_id',
-          },
-        });
+        const response = await ctx.client.get(
+          `${getBaseUrl(ctx)}${SERVICENOW_API_PREFIX}/table/sys_user`,
+          {
+            params: {
+              sysparm_query: 'sys_created_on!=NULL',
+              sysparm_limit: 1,
+              sysparm_fields: 'sys_id',
+            },
+          }
+        );
         const results = response.data?.result ?? [];
         if (results.length > 0) {
           return {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sharepoint_server/sharepoint_server.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sharepoint_server/sharepoint_server.ts
@@ -23,7 +23,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
-import type { ConnectorSpec } from '../../connector_spec';
+import type { ActionContext, ConnectorSpec } from '../../connector_spec';
 import { normalizeUrl } from '../../connector_utils';
 import {
   CallRestApiInputSchema,
@@ -38,6 +38,13 @@ import {
 } from './types';
 
 const ODATA_HEADERS = { Accept: 'application/json;odata=nometadata' };
+
+const getBaseUrl = (ctx: ActionContext): string => {
+  const { siteUrl } = ctx.config as { siteUrl: string };
+  return normalizeUrl(siteUrl);
+};
+
+const SHAREPOINT_API_PREFIX = '/_api';
 
 export const SharepointServer: ConnectorSpec = {
   metadata: {
@@ -74,9 +81,8 @@ export const SharepointServer: ConnectorSpec = {
       input: z.object({}).optional(),
       output: z.any(),
       handler: async (ctx) => {
-        const { siteUrl } = ctx.config as { siteUrl: string };
         ctx.log.debug('SharePoint Server getting web info');
-        const response = await ctx.client.get(`${normalizeUrl(siteUrl)}/_api/web`, {
+        const response = await ctx.client.get(`${getBaseUrl(ctx)}${SHAREPOINT_API_PREFIX}/web`, {
           headers: ODATA_HEADERS,
         });
         return response.data;
@@ -90,16 +96,18 @@ export const SharepointServer: ConnectorSpec = {
       input: z.object({}).optional(),
       output: ODataCollectionOutputSchema,
       handler: async (ctx) => {
-        const { siteUrl } = ctx.config as { siteUrl: string };
         ctx.log.debug('SharePoint Server getting lists');
-        const response = await ctx.client.get(`${normalizeUrl(siteUrl)}/_api/web/lists`, {
-          headers: ODATA_HEADERS,
-          params: {
-            $select:
-              'Id,Title,ItemCount,Description,Created,LastItemModifiedDate,RootFolder/ServerRelativeUrl',
-            $expand: 'RootFolder',
-          },
-        });
+        const response = await ctx.client.get(
+          `${getBaseUrl(ctx)}${SHAREPOINT_API_PREFIX}/web/lists`,
+          {
+            headers: ODATA_HEADERS,
+            params: {
+              $select:
+                'Id,Title,ItemCount,Description,Created,LastItemModifiedDate,RootFolder/ServerRelativeUrl',
+              $expand: 'RootFolder',
+            },
+          }
+        );
         return response.data;
       },
     },
@@ -112,11 +120,12 @@ export const SharepointServer: ConnectorSpec = {
       output: ODataCollectionOutputSchema,
       handler: async (ctx, input) => {
         const { listTitle } = input as { listTitle: string };
-        const { siteUrl } = ctx.config as { siteUrl: string };
         ctx.log.debug(`SharePoint Server getting items of list "${listTitle}"`);
         const escapedListTitle = listTitle.replace(/'/g, "''");
         const response = await ctx.client.get(
-          `${normalizeUrl(siteUrl)}/_api/web/lists/GetByTitle('${escapedListTitle}')/items`,
+          `${getBaseUrl(
+            ctx
+          )}${SHAREPOINT_API_PREFIX}/web/lists/GetByTitle('${escapedListTitle}')/items`,
           {
             headers: ODATA_HEADERS,
           }
@@ -133,20 +142,16 @@ export const SharepointServer: ConnectorSpec = {
       output: GetFolderContentsOutputSchema,
       handler: async (ctx, input) => {
         const { path } = input as { path: string };
-        const { siteUrl } = ctx.config as { siteUrl: string };
         ctx.log.debug(`SharePoint Server getting folder contents at "${path}"`);
         const escapedPath = path.replace(/'/g, "''");
+        const baseUrl = getBaseUrl(ctx);
         const [filesResponse, foldersResponse] = await Promise.all([
           ctx.client.get(
-            `${normalizeUrl(
-              siteUrl
-            )}/_api/web/GetFolderByServerRelativeUrl('${escapedPath}')/Files`,
+            `${baseUrl}${SHAREPOINT_API_PREFIX}/web/GetFolderByServerRelativeUrl('${escapedPath}')/Files`,
             { headers: ODATA_HEADERS }
           ),
           ctx.client.get(
-            `${normalizeUrl(
-              siteUrl
-            )}/_api/web/GetFolderByServerRelativeUrl('${escapedPath}')/Folders`,
+            `${baseUrl}${SHAREPOINT_API_PREFIX}/web/GetFolderByServerRelativeUrl('${escapedPath}')/Folders`,
             { headers: ODATA_HEADERS }
           ),
         ]);
@@ -165,11 +170,12 @@ export const SharepointServer: ConnectorSpec = {
       output: DownloadFileOutputSchema,
       handler: async (ctx, input) => {
         const { path } = input as { path: string };
-        const { siteUrl } = ctx.config as { siteUrl: string };
         ctx.log.debug(`SharePoint Server downloading file at "${path}"`);
         const escapedPath = path.replace(/'/g, "''");
         const response = await ctx.client.get(
-          `${normalizeUrl(siteUrl)}/_api/web/GetFileByServerRelativeUrl('${escapedPath}')/$value`,
+          `${getBaseUrl(
+            ctx
+          )}${SHAREPOINT_API_PREFIX}/web/GetFileByServerRelativeUrl('${escapedPath}')/$value`,
           { responseType: 'arraybuffer' }
         );
         const buffer = Buffer.from(response.data);
@@ -189,10 +195,11 @@ export const SharepointServer: ConnectorSpec = {
       output: z.any(),
       handler: async (ctx, input) => {
         const { pageId } = input as { pageId: number };
-        const { siteUrl } = ctx.config as { siteUrl: string };
         ctx.log.debug(`SharePoint Server getting site page contents for page ID ${pageId}`);
         const response = await ctx.client.get(
-          `${normalizeUrl(siteUrl)}/_api/web/lists/GetByTitle('Site Pages')/items(${pageId})`,
+          `${getBaseUrl(
+            ctx
+          )}${SHAREPOINT_API_PREFIX}/web/lists/GetByTitle('Site Pages')/items(${pageId})`,
           {
             headers: ODATA_HEADERS,
             params: {
@@ -212,16 +219,18 @@ export const SharepointServer: ConnectorSpec = {
       output: z.any(),
       handler: async (ctx, input) => {
         const { query, from, size } = input as { query: string; from?: number; size?: number };
-        const { siteUrl } = ctx.config as { siteUrl: string };
         ctx.log.debug(`SharePoint Server search: "${query}"`);
-        const response = await ctx.client.get(`${normalizeUrl(siteUrl)}/_api/search/query`, {
-          headers: ODATA_HEADERS,
-          params: {
-            querytext: `'${query.replace(/'/g, "''")}'`,
-            ...(from !== undefined && { startRow: from }),
-            ...(size !== undefined && { rowLimit: size }),
-          },
-        });
+        const response = await ctx.client.get(
+          `${getBaseUrl(ctx)}${SHAREPOINT_API_PREFIX}/search/query`,
+          {
+            headers: ODATA_HEADERS,
+            params: {
+              querytext: `'${query.replace(/'/g, "''")}'`,
+              ...(from !== undefined && { startRow: from }),
+              ...(size !== undefined && { rowLimit: size }),
+            },
+          }
+        );
         return response.data;
       },
     },
@@ -238,8 +247,7 @@ export const SharepointServer: ConnectorSpec = {
           path: string;
           body?: unknown;
         };
-        const { siteUrl } = ctx.config as { siteUrl: string };
-        const url = `${normalizeUrl(siteUrl)}/${path}`;
+        const url = `${getBaseUrl(ctx)}/${path}`;
         ctx.log.debug(`SharePoint Server callRestApi ${method} ${url}`);
         const response = await ctx.client.request({
           method,
@@ -256,6 +264,8 @@ export const SharepointServer: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   skill: [
     'SharePoint Server connector — usage guidance for LLM agents.',
@@ -300,10 +310,12 @@ export const SharepointServer: ConnectorSpec = {
     handler: async (ctx) => {
       ctx.log.debug('SharePoint Server test handler');
       try {
-        const { siteUrl } = ctx.config as { siteUrl: string };
-        const response = await ctx.client.get(`${normalizeUrl(siteUrl)}/_api/web/title`, {
-          headers: ODATA_HEADERS,
-        });
+        const response = await ctx.client.get(
+          `${getBaseUrl(ctx)}${SHAREPOINT_API_PREFIX}/web/title`,
+          {
+            headers: ODATA_HEADERS,
+          }
+        );
         const title = response.data?.value ?? 'Unknown';
         return {
           ok: true,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/shodan/shodan.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/shodan/shodan.ts
@@ -23,6 +23,11 @@ import { z, lazySchema } from '@kbn/zod/v4';
 import { i18n } from '@kbn/i18n';
 import type { ConnectorSpec } from '../../connector_spec';
 
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below.
+const getBaseUrl = (): string => 'https://api.shodan.io';
+const SHODAN_API_BASE = getBaseUrl();
+
 export const ShodanConnector: ConnectorSpec = {
   metadata: {
     id: '.shodan',
@@ -50,7 +55,7 @@ export const ShodanConnector: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput = input as { query: string; page?: number };
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
-        const response = await ctx.client.get('https://api.shodan.io/shodan/host/search', {
+        const response = await ctx.client.get(`${SHODAN_API_BASE}/shodan/host/search`, {
           params: {
             query: typedInput.query,
             page: typedInput.page || 1,
@@ -75,12 +80,9 @@ export const ShodanConnector: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput = input as { ip: string };
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
-        const response = await ctx.client.get(
-          `https://api.shodan.io/shodan/host/${typedInput.ip}`,
-          {
-            params: { key: apiKey },
-          }
-        );
+        const response = await ctx.client.get(`${SHODAN_API_BASE}/shodan/host/${typedInput.ip}`, {
+          params: { key: apiKey },
+        });
         return {
           ip: response.data.ip_str,
           ports: response.data.ports,
@@ -104,7 +106,7 @@ export const ShodanConnector: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput = input as { query: string; facets?: string };
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
-        const response = await ctx.client.get('https://api.shodan.io/shodan/host/count', {
+        const response = await ctx.client.get(`${SHODAN_API_BASE}/shodan/host/count`, {
           params: {
             query: typedInput.query,
             ...(typedInput.facets && { facets: typedInput.facets }),
@@ -123,7 +125,7 @@ export const ShodanConnector: ConnectorSpec = {
       input: lazySchema(() => z.object({})),
       handler: async (ctx) => {
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
-        const response = await ctx.client.get('https://api.shodan.io/shodan/services', {
+        const response = await ctx.client.get(`${SHODAN_API_BASE}/shodan/services`, {
           params: { key: apiKey },
         });
         return {
@@ -133,11 +135,13 @@ export const ShodanConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     handler: async (ctx) => {
       try {
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
-        await ctx.client.get('https://api.shodan.io/shodan/host/8.8.8.8', {
+        await ctx.client.get(`${SHODAN_API_BASE}/shodan/host/8.8.8.8`, {
           params: { key: apiKey },
         });
         return {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
@@ -52,7 +52,10 @@ import {
   type SlackWhoAmIInput,
 } from './types';
 
-const SLACK_API_BASE = 'https://slack.com/api';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below.
+const getBaseUrl = (): string => 'https://slack.com/api';
+const SLACK_API_BASE = getBaseUrl();
 
 const SLACK_RETRY_DEFAULT_BASE_DELAY_MS = 1000;
 const SLACK_RETRY_JITTER_MAX_MS = 250;
@@ -1100,6 +1103,8 @@ export const Slack: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.slack.test.description', {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/snowflake/snowflake.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/snowflake/snowflake.ts
@@ -71,6 +71,11 @@ const SNOWFLAKE_SQL_API_PATH = '/api/v2/statements';
 const SNOWFLAKE_REST_API_V2 = '/api/v2';
 const SNOWFLAKE_USER_AGENT = 'Kibana-Snowflake-Connector/1.0';
 
+const getBaseUrl = (ctx: ActionContext): string => {
+  const { accountUrl } = ctx.config as { accountUrl: string };
+  return normalizeUrl(accountUrl);
+};
+
 const buildListParams = (input: {
   like?: string;
   startsWith?: string;
@@ -137,13 +142,11 @@ const submitStatement = async (
   input: ExecuteStatementInput | RunQueryInput
 ): Promise<unknown> => {
   const {
-    accountUrl,
     warehouse: defaultWarehouse,
     database: defaultDatabase,
     defaultSchema,
     role: defaultRole,
   } = ctx.config as {
-    accountUrl: string;
     warehouse?: string;
     database?: string;
     defaultSchema?: string;
@@ -180,7 +183,7 @@ const submitStatement = async (
     };
   }
 
-  const url = `${normalizeUrl(accountUrl)}${SNOWFLAKE_SQL_API_PATH}`;
+  const url = `${getBaseUrl(ctx)}${SNOWFLAKE_SQL_API_PATH}`;
 
   const response = await ctx.client.post(url, body, {
     params: { async: true },
@@ -391,12 +394,10 @@ export const Snowflake: ConnectorSpec = {
         'Check the status of a previously submitted SQL statement and retrieve results if execution is complete. Returns HTTP 200 with a ResultSet when finished, or HTTP 202 with a QueryStatus if still running. Use the statementHandle returned by runQuery. For large result sets, use the partition parameter to page through data.',
       input: GetStatementStatusInputSchema,
       handler: async (ctx, input: GetStatementStatusInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
-
         const params: Record<string, unknown> = {};
         if (input.partition !== undefined) params.partition = input.partition;
 
-        const url = `${normalizeUrl(accountUrl)}${SNOWFLAKE_SQL_API_PATH}/${input.statementHandle}`;
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_SQL_API_PATH}/${input.statementHandle}`;
 
         const response = await ctx.client.get(url, {
           params,
@@ -413,11 +414,7 @@ export const Snowflake: ConnectorSpec = {
         'Cancel a running SQL statement in Snowflake. Use the statementHandle returned by runQuery. Returns a confirmation with the cancellation status. Only works on statements that are still executing.',
       input: CancelStatementInputSchema,
       handler: async (ctx, input: CancelStatementInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
-
-        const url = `${normalizeUrl(accountUrl)}${SNOWFLAKE_SQL_API_PATH}/${
-          input.statementHandle
-        }/cancel`;
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_SQL_API_PATH}/${input.statementHandle}/cancel`;
 
         const response = await ctx.client.post(
           url,
@@ -437,11 +434,10 @@ export const Snowflake: ConnectorSpec = {
         'List Snowflake databases visible to the connector\'s role. Returns JSON objects (not SQL row arrays) with name, kind, owner, comment, created_on, and other metadata. Does not require a warehouse. Use this as the starting point for data discovery when the target database is unknown. Supports case-insensitive name filtering via "like" (SQL wildcards) and case-sensitive prefix filtering via "startsWith".',
       input: ListDatabasesInputSchema,
       handler: async (ctx, input: ListDatabasesInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
         const params = buildListParams(input);
         if (input.history !== undefined) params.history = input.history;
 
-        const url = `${normalizeUrl(accountUrl)}${SNOWFLAKE_REST_API_V2}/databases`;
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_REST_API_V2}/databases`;
         const response = await ctx.client.get(url, { params });
         return response.data;
       },
@@ -453,12 +449,11 @@ export const Snowflake: ConnectorSpec = {
         'List schemas inside a Snowflake database. Returns JSON objects with name, database_name, owner, comment, and other metadata. Does not require a warehouse. Use after listDatabases to narrow down the target before listing tables or views. Database name is case-sensitive and must match exactly what listDatabases returned.',
       input: ListSchemasInputSchema,
       handler: async (ctx, input: ListSchemasInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
         const params = buildListParams(input);
 
-        const url = `${normalizeUrl(
-          accountUrl
-        )}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(input.database)}/schemas`;
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
+          input.database
+        )}/schemas`;
         const response = await ctx.client.get(url, { params });
         return response.data;
       },
@@ -470,13 +465,10 @@ export const Snowflake: ConnectorSpec = {
         'List tables inside a Snowflake schema. Returns JSON objects with name, database_name, schema_name, kind, rows, bytes, cluster_by, comment, and other metadata. Does not require a warehouse. Use after listSchemas to find the specific table to describe or query. Database and schema names are case-sensitive. Optional: "history" to include dropped tables.',
       input: ListTablesInputSchema,
       handler: async (ctx, input: ListTablesInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
         const params = buildListParams(input);
         if (input.history !== undefined) params.history = input.history;
 
-        const url = `${normalizeUrl(
-          accountUrl
-        )}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
           input.database
         )}/schemas/${encodeURIComponent(input.schema)}/tables`;
         const response = await ctx.client.get(url, { params });
@@ -490,12 +482,9 @@ export const Snowflake: ConnectorSpec = {
         "List views inside a Snowflake schema. Returns JSON objects with name, database_name, schema_name, owner, comment, and other metadata. Does not require a warehouse. Database and schema names are case-sensitive. Use describeView to retrieve a view's columns and underlying query text.",
       input: ListViewsInputSchema,
       handler: async (ctx, input: ListViewsInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
         const params = buildListParams(input);
 
-        const url = `${normalizeUrl(
-          accountUrl
-        )}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
           input.database
         )}/schemas/${encodeURIComponent(input.schema)}/views`;
         const response = await ctx.client.get(url, { params });
@@ -509,11 +498,7 @@ export const Snowflake: ConnectorSpec = {
         'Get the full definition of a Snowflake table, including columns (name, type, nullable, default, comment), clustering keys, row count, size in bytes, owner, and other metadata. Returns a clean JSON Table object (not SQL row arrays). Does not require a warehouse. Use this before runQuery to build correct SELECT or JOIN queries against the table. Database, schema, and table names are all case-sensitive.',
       input: DescribeTableInputSchema,
       handler: async (ctx, input: DescribeTableInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
-
-        const url = `${normalizeUrl(
-          accountUrl
-        )}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
           input.database
         )}/schemas/${encodeURIComponent(input.schema)}/tables/${encodeURIComponent(input.name)}`;
         const response = await ctx.client.get(url);
@@ -527,11 +512,7 @@ export const Snowflake: ConnectorSpec = {
         'Get the full definition of a Snowflake view, including columns, the underlying SELECT query text, owner, comment, and other metadata. Returns a clean JSON View object. Does not require a warehouse. Use to understand what a view exposes before querying it or building dependent logic. Database, schema, and view names are all case-sensitive.',
       input: DescribeViewInputSchema,
       handler: async (ctx, input: DescribeViewInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
-
-        const url = `${normalizeUrl(
-          accountUrl
-        )}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
           input.database
         )}/schemas/${encodeURIComponent(input.schema)}/views/${encodeURIComponent(input.name)}`;
         const response = await ctx.client.get(url);
@@ -545,12 +526,9 @@ export const Snowflake: ConnectorSpec = {
         'List Cortex Search services defined in a Snowflake schema. Cortex Search provides semantic + lexical search over indexed text columns. Returns JSON objects with name, database_name, schema_name, target_lag, warehouse, comment, and the underlying source query. Use before cortexSearch to discover what search services are available. Database and schema names are case-sensitive.',
       input: ListCortexSearchServicesInputSchema,
       handler: async (ctx, input: ListCortexSearchServicesInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
         const params = buildListParams(input);
 
-        const url = `${normalizeUrl(
-          accountUrl
-        )}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
           input.database
         )}/schemas/${encodeURIComponent(input.schema)}/cortex-search-services`;
         const response = await ctx.client.get(url, { params });
@@ -564,16 +542,12 @@ export const Snowflake: ConnectorSpec = {
         'Run a natural-language query against a Snowflake Cortex Search service. Cortex Search performs hybrid semantic + lexical matching over the service\'s indexed search column and returns ranked results as JSON. Use for unstructured text retrieval (support docs, product catalogs, chat logs) — much better than LIKE or CONTAINS in SQL. Supports additional attribute filtering via the "filter" DSL (@eq, @contains, @gte, @lte, @and, @or, @not). Example filter: {"@and": [{"@eq": {"REGION": "US"}}, {"@gte": {"YEAR": 2024}}]}. Prefer limit<=20 to keep LLM context small.',
       input: CortexSearchInputSchema,
       handler: async (ctx, input: CortexSearchInput) => {
-        const { accountUrl } = ctx.config as { accountUrl: string };
-
         const body: Record<string, unknown> = { query: input.query };
         if (input.columns !== undefined) body.columns = input.columns;
         if (input.filter !== undefined) body.filter = input.filter;
         if (input.limit !== undefined) body.limit = input.limit;
 
-        const url = `${normalizeUrl(
-          accountUrl
-        )}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
+        const url = `${getBaseUrl(ctx)}${SNOWFLAKE_REST_API_V2}/databases/${encodeURIComponent(
           input.database
         )}/schemas/${encodeURIComponent(input.schema)}/cortex-search-services/${encodeURIComponent(
           input.serviceName
@@ -590,8 +564,7 @@ export const Snowflake: ConnectorSpec = {
         'Verifies connection to Snowflake by executing SELECT CURRENT_VERSION() and returning the result.',
     }),
     handler: async (ctx) => {
-      const { accountUrl } = ctx.config as { accountUrl: string };
-      const url = `${normalizeUrl(accountUrl)}${SNOWFLAKE_SQL_API_PATH}`;
+      const url = `${getBaseUrl(ctx)}${SNOWFLAKE_SQL_API_PATH}`;
 
       const response = await ctx.client.post(
         url,
@@ -616,6 +589,8 @@ export const Snowflake: ConnectorSpec = {
       };
     },
   },
+
+  getBaseUrl,
 
   skill: [
     '## Snowflake Connector',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sublime_security/sublime_security.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sublime_security/sublime_security.ts
@@ -556,6 +556,11 @@ Gotchas:
     },
   },
 
+  // Base URL for the framework-synthesized `request` action (and the single
+  // source of truth reused by the handlers above). The `/v0` API version stays
+  // in the per-action paths.
+  getBaseUrl,
+
   test: {
     enabled: true,
     description: i18n.translate('core.kibanaConnectorSpecs.sublimeSecurity.test.description', {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/tavily/tavily.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/tavily/tavily.ts
@@ -71,6 +71,10 @@ export const TavilyConnector: ConnectorSpec = {
     fields: ['serverUrl'],
   },
 
+  // MCP connector: talks to an MCP server over JSON-RPC, so a generic HTTP
+  // request (method/path/url) is meaningless. Opt out of the synthesized action.
+  disableGenericRequest: true,
+
   actions: {
     tavilySearch: {
       isTool: true,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/urlvoid/urlvoid.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/urlvoid/urlvoid.ts
@@ -24,6 +24,10 @@ import { i18n } from '@kbn/i18n';
 
 import type { ConnectorSpec } from '../../connector_spec';
 
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The version segment stays in paths.
+const getBaseUrl = (): string => 'https://api.urlvoid.com';
+
 export const URLVoidConnector: ConnectorSpec = {
   metadata: {
     id: '.urlvoid',
@@ -51,7 +55,7 @@ export const URLVoidConnector: ConnectorSpec = {
         const typedInput = input as { domain: string };
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
         const response = await ctx.client.get(
-          `https://api.urlvoid.com/api1000/${apiKey}/host/${typedInput.domain}`
+          `${getBaseUrl()}/api1000/${apiKey}/host/${typedInput.domain}`
         );
         return {
           domain: typedInput.domain,
@@ -73,9 +77,7 @@ export const URLVoidConnector: ConnectorSpec = {
         const typedInput = input as { url: string };
         const domain = new URL(typedInput.url).hostname;
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
-        const response = await ctx.client.get(
-          `https://api.urlvoid.com/api1000/${apiKey}/host/${domain}`
-        );
+        const response = await ctx.client.get(`${getBaseUrl()}/api1000/${apiKey}/host/${domain}`);
         return {
           url: typedInput.url,
           domain,
@@ -97,7 +99,7 @@ export const URLVoidConnector: ConnectorSpec = {
         const typedInput = input as { domain: string };
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
         const response = await ctx.client.get(
-          `https://api.urlvoid.com/api1000/${apiKey}/host/${typedInput.domain}`
+          `${getBaseUrl()}/api1000/${apiKey}/host/${typedInput.domain}`
         );
         return {
           domain: typedInput.domain,
@@ -116,9 +118,7 @@ export const URLVoidConnector: ConnectorSpec = {
       input: lazySchema(() => z.object({})),
       handler: async (ctx) => {
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
-        const response = await ctx.client.get(
-          `https://api.urlvoid.com/api1000/${apiKey}/stats/remained`
-        );
+        const response = await ctx.client.get(`${getBaseUrl()}/api1000/${apiKey}/stats/remained`);
         return {
           queriesRemaining: response.data.queries_remaining,
           queriesUsed: response.data.queries_used,
@@ -128,11 +128,13 @@ export const URLVoidConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     handler: async (ctx) => {
       try {
         const apiKey = ctx.secrets?.authType === 'api_key_header' ? ctx.secrets['X-Api-Key'] : '';
-        await ctx.client.get(`https://api.urlvoid.com/api1000/${apiKey}/stats/remained`);
+        await ctx.client.get(`${getBaseUrl()}/api1000/${apiKey}/stats/remained`);
         return {
           ok: true,
           message: 'Successfully connected to URLVoid API',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/virustotal/virustotal.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/virustotal/virustotal.ts
@@ -24,7 +24,11 @@ import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ConnectorSpec } from '../../connector_spec';
 
-const VIRUSTOTAL_API_BASE_URL = 'https://www.virustotal.com/api/v3';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/api/v3` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://www.virustotal.com';
+const VIRUSTOTAL_API_V3 = `${getBaseUrl()}/api/v3`;
 const VIRUSTOTAL_RESOURCE_TYPES = ['analysis', 'url', 'domain', 'ip', 'file'] as const;
 const VIRUSTOTAL_DOMAIN_REGEX = z.regexes.domain;
 const VIRUSTOTAL_DOMAIN_SCHEMA = z.string().regex(VIRUSTOTAL_DOMAIN_REGEX);
@@ -182,7 +186,7 @@ export const VirusTotalConnector: ConnectorSpec = {
         const typedInput = input as { hash: string; failOnError?: boolean };
         try {
           const response = await ctx.client.get(
-            `${VIRUSTOTAL_API_BASE_URL}/files/${encodeURIComponent(typedInput.hash)}`
+            `${VIRUSTOTAL_API_V3}/files/${encodeURIComponent(typedInput.hash)}`
           );
           return {
             id: response.data.data.id,
@@ -220,7 +224,7 @@ export const VirusTotalConnector: ConnectorSpec = {
 
           if (isValidDomain(url)) {
             const response = await ctx.client.get(
-              `${VIRUSTOTAL_API_BASE_URL}/domains/${encodeURIComponent(normalizeDomain(url))}`
+              `${VIRUSTOTAL_API_V3}/domains/${encodeURIComponent(normalizeDomain(url))}`
             );
             return {
               id: response.data.data.id,
@@ -232,7 +236,7 @@ export const VirusTotalConnector: ConnectorSpec = {
           }
 
           const submitResponse = await ctx.client.post(
-            `${VIRUSTOTAL_API_BASE_URL}/urls`,
+            `${VIRUSTOTAL_API_V3}/urls`,
             new URLSearchParams({ url }),
             {
               headers: {
@@ -242,7 +246,7 @@ export const VirusTotalConnector: ConnectorSpec = {
           );
           const analysisId = submitResponse.data.data.id;
           const analysisResponse = await ctx.client.get(
-            `${VIRUSTOTAL_API_BASE_URL}/analyses/${encodeURIComponent(analysisId)}`
+            `${VIRUSTOTAL_API_V3}/analyses/${encodeURIComponent(analysisId)}`
           );
           return {
             id: analysisId,
@@ -290,7 +294,7 @@ export const VirusTotalConnector: ConnectorSpec = {
 
         try {
           const response = await ctx.client.get(
-            `${VIRUSTOTAL_API_BASE_URL}/${getVirusTotalResourcePath(resourceType, typedInput.id)}`
+            `${VIRUSTOTAL_API_V3}/${getVirusTotalResourcePath(resourceType, typedInput.id)}`
           );
           const attributes = response.data.data.attributes;
           return {
@@ -333,7 +337,7 @@ export const VirusTotalConnector: ConnectorSpec = {
           const formData = new FormData();
           formData.append('file', new Blob([buffer]), typedInput.filename || 'file');
 
-          const response = await ctx.client.post(`${VIRUSTOTAL_API_BASE_URL}/files`, formData);
+          const response = await ctx.client.post(`${VIRUSTOTAL_API_V3}/files`, formData);
           return {
             id: response.data.data.id,
             type: response.data.data.type,
@@ -367,7 +371,7 @@ export const VirusTotalConnector: ConnectorSpec = {
         const typedInput = input as { ip: string; failOnError?: boolean };
         try {
           const response = await ctx.client.get(
-            `${VIRUSTOTAL_API_BASE_URL}/ip_addresses/${encodeURIComponent(typedInput.ip)}`
+            `${VIRUSTOTAL_API_V3}/ip_addresses/${encodeURIComponent(typedInput.ip)}`
           );
           return {
             id: response.data.data.id,
@@ -386,10 +390,12 @@ export const VirusTotalConnector: ConnectorSpec = {
     },
   },
 
+  getBaseUrl,
+
   test: {
     handler: async (ctx) => {
       try {
-        await ctx.client.get(`${VIRUSTOTAL_API_BASE_URL}/ip_addresses/8.8.8.8`);
+        await ctx.client.get(`${VIRUSTOTAL_API_V3}/ip_addresses/8.8.8.8`);
         return {
           ok: true,
           message: 'Successfully connected to VirusTotal API',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/zendesk/zendesk.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/zendesk/zendesk.ts
@@ -10,8 +10,11 @@
 import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ActionContext, ConnectorSpec } from '../../connector_spec';
-const buildBaseUrl = (ctx: ActionContext): string =>
-  `https://${String((ctx.config?.subdomain as string) ?? '').trim()}.zendesk.com/api/v2`;
+
+const getBaseUrl = (ctx: ActionContext): string =>
+  `https://${String((ctx.config?.subdomain as string) ?? '').trim()}.zendesk.com`;
+
+const ZENDESK_API_V2 = '/api/v2';
 
 export const ZendeskConnector: ConnectorSpec = {
   metadata: {
@@ -115,7 +118,7 @@ export const ZendeskConnector: ConnectorSpec = {
         })
       ),
       handler: async (ctx, input) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = `${getBaseUrl(ctx)}${ZENDESK_API_V2}`;
         const params: Record<string, string | number | undefined> = {
           query: input.query,
           ...(input.sortBy && { sort_by: input.sortBy }),
@@ -150,7 +153,7 @@ export const ZendeskConnector: ConnectorSpec = {
         })
       ),
       handler: async (ctx, input) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = `${getBaseUrl(ctx)}${ZENDESK_API_V2}`;
         const params: Record<string, string | number | undefined> = {};
         if (input.page !== undefined && input.page !== null) params.page = input.page;
         if (input.perPage !== undefined && input.perPage !== null) params.per_page = input.perPage;
@@ -170,7 +173,7 @@ export const ZendeskConnector: ConnectorSpec = {
         })
       ),
       handler: async (ctx, input) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = `${getBaseUrl(ctx)}${ZENDESK_API_V2}`;
         const response = await ctx.client.get(`${baseUrl}/tickets/${input.ticketId}.json`, {
           params: { include: 'comment_count' },
         });
@@ -206,7 +209,7 @@ export const ZendeskConnector: ConnectorSpec = {
         })
       ),
       handler: async (ctx, input) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = `${getBaseUrl(ctx)}${ZENDESK_API_V2}`;
         const params: Record<string, string | number | boolean | undefined> = {};
         if (input.page !== undefined && input.page !== null) params.page = input.page;
         if (input.perPage !== undefined && input.perPage !== null) params.per_page = input.perPage;
@@ -227,12 +230,14 @@ export const ZendeskConnector: ConnectorSpec = {
         'Get the currently authenticated Zendesk user. Returns the user record for the API credentials in use. Useful for verifying which account is connected or resolving your own agent/user ID.',
       input: lazySchema(() => z.object({})),
       handler: async (ctx) => {
-        const baseUrl = buildBaseUrl(ctx);
+        const baseUrl = `${getBaseUrl(ctx)}${ZENDESK_API_V2}`;
         const response = await ctx.client.get(`${baseUrl}/users/me.json`);
         return response.data;
       },
     },
   },
+
+  getBaseUrl,
 
   skill: [
     'Zendesk connector — usage guidance for LLMs.',
@@ -256,7 +261,7 @@ export const ZendeskConnector: ConnectorSpec = {
       defaultMessage: 'Verifies Zendesk connection by listing current user',
     }),
     handler: async (ctx) => {
-      const baseUrl = buildBaseUrl(ctx);
+      const baseUrl = `${getBaseUrl(ctx)}${ZENDESK_API_V2}`;
       try {
         const response = await ctx.client.get(`${baseUrl}/users/me.json`);
         const user = response.data?.user;

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/zoom/zoom.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/zoom/zoom.ts
@@ -74,7 +74,11 @@ import {
   pickUserProfile,
 } from './types';
 
-const ZOOM_API_BASE = 'https://api.zoom.us/v2';
+// Base URL for the framework-synthesized `request` action and the single source
+// of truth reused by the handlers below. The `/v2` API version stays in the
+// per-action paths.
+const getBaseUrl = (): string => 'https://api.zoom.us';
+const ZOOM_API_V2 = `${getBaseUrl()}/v2`;
 
 /**
  * Zoom UUIDs that begin with `/` or contain `//` must be double-encoded
@@ -131,7 +135,7 @@ export const Zoom: ConnectorSpec = {
       output: ZoomUserProfileSchema,
       handler: async (ctx) => {
         ctx.log.debug('Zoom whoAmI — fetching /users/me');
-        const { data } = await ctx.client.get(`${ZOOM_API_BASE}/users/me`);
+        const { data } = await ctx.client.get(`${ZOOM_API_V2}/users/me`);
         return pickUserProfile(data);
       },
     },
@@ -153,7 +157,7 @@ export const Zoom: ConnectorSpec = {
         );
 
         const response = await ctx.client.get(
-          `${ZOOM_API_BASE}/users/${encodeURIComponent(typedInput.userId)}/meetings`,
+          `${ZOOM_API_V2}/users/${encodeURIComponent(typedInput.userId)}/meetings`,
           {
             params: {
               type: typedInput.type,
@@ -204,7 +208,7 @@ export const Zoom: ConnectorSpec = {
         const encodedId = encodeZoomId(typedInput.meetingId);
         ctx.log.debug(`Zoom getting meeting details for ${typedInput.meetingId}`);
 
-        const { data } = await ctx.client.get(`${ZOOM_API_BASE}/meetings/${encodedId}`);
+        const { data } = await ctx.client.get(`${ZOOM_API_V2}/meetings/${encodedId}`);
         return {
           uuid: data.uuid,
           id: data.id,
@@ -245,7 +249,7 @@ export const Zoom: ConnectorSpec = {
         const encodedId = encodeZoomId(typedInput.meetingId);
         ctx.log.debug(`Zoom getting past meeting details for ${typedInput.meetingId}`);
 
-        const { data } = await ctx.client.get(`${ZOOM_API_BASE}/past_meetings/${encodedId}`);
+        const { data } = await ctx.client.get(`${ZOOM_API_V2}/past_meetings/${encodedId}`);
         return {
           uuid: data.uuid,
           id: data.id,
@@ -280,7 +284,7 @@ export const Zoom: ConnectorSpec = {
         const encodedId = encodeZoomId(typedInput.meetingId);
         ctx.log.debug(`Zoom getting recordings for meeting ${typedInput.meetingId}`);
 
-        const { data } = await ctx.client.get(`${ZOOM_API_BASE}/meetings/${encodedId}/recordings`);
+        const { data } = await ctx.client.get(`${ZOOM_API_V2}/meetings/${encodedId}/recordings`);
         return {
           topic: data.topic,
           start_time: data.start_time,
@@ -315,7 +319,7 @@ export const Zoom: ConnectorSpec = {
         ctx.log.debug(`Zoom listing recordings for user ${typedInput.userId}`);
 
         const { data } = await ctx.client.get(
-          `${ZOOM_API_BASE}/users/${encodeURIComponent(typedInput.userId)}/recordings`,
+          `${ZOOM_API_V2}/users/${encodeURIComponent(typedInput.userId)}/recordings`,
           {
             params: {
               ...(typedInput.from && { from: typedInput.from }),
@@ -389,7 +393,7 @@ export const Zoom: ConnectorSpec = {
         ctx.log.debug(`Zoom listing participants for past meeting ${typedInput.meetingId}`);
 
         const { data } = await ctx.client.get(
-          `${ZOOM_API_BASE}/past_meetings/${encodedId}/participants`,
+          `${ZOOM_API_V2}/past_meetings/${encodedId}/participants`,
           {
             params: {
               ...(typedInput.pageSize !== undefined && { page_size: typedInput.pageSize }),
@@ -422,16 +426,13 @@ export const Zoom: ConnectorSpec = {
         const encodedId = encodeZoomId(typedInput.meetingId);
         ctx.log.debug(`Zoom listing registrants for meeting ${typedInput.meetingId}`);
 
-        const { data } = await ctx.client.get(
-          `${ZOOM_API_BASE}/meetings/${encodedId}/registrants`,
-          {
-            params: {
-              ...(typedInput.status && { status: typedInput.status }),
-              ...(typedInput.pageSize !== undefined && { page_size: typedInput.pageSize }),
-              ...(typedInput.nextPageToken && { next_page_token: typedInput.nextPageToken }),
-            },
-          }
-        );
+        const { data } = await ctx.client.get(`${ZOOM_API_V2}/meetings/${encodedId}/registrants`, {
+          params: {
+            ...(typedInput.status && { status: typedInput.status }),
+            ...(typedInput.pageSize !== undefined && { page_size: typedInput.pageSize }),
+            ...(typedInput.nextPageToken && { next_page_token: typedInput.nextPageToken }),
+          },
+        });
         return {
           page_size: data.page_size,
           next_page_token: data.next_page_token,
@@ -441,6 +442,8 @@ export const Zoom: ConnectorSpec = {
       },
     },
   },
+
+  getBaseUrl,
 
   skill: [
     'Recordings — two strategies:',
@@ -459,7 +462,7 @@ export const Zoom: ConnectorSpec = {
       ctx.log.debug('Zoom test handler — checking /users/me');
 
       try {
-        const response = await ctx.client.get(`${ZOOM_API_BASE}/users/me`);
+        const response = await ctx.client.get(`${ZOOM_API_V2}/users/me`);
         const displayName =
           `${response.data.first_name ?? ''} ${response.data.last_name ?? ''}`.trim() ||
           response.data.email ||

--- a/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
@@ -17,7 +17,11 @@ import {
   XSOARRunActionParamsSchema,
   XSOARRunActionResponseSchema,
 } from '@kbn/connector-schemas/xsoar';
-import { connectorsSpecs } from '@kbn/connector-specs';
+import {
+  connectorsSpecs,
+  GENERIC_REQUEST_SUB_ACTION,
+  getGenericRequestInputSchema,
+} from '@kbn/connector-specs';
 import { i18n } from '@kbn/i18n';
 import type { BaseConnectorContract } from '@kbn/workflows';
 import { FetcherConfigSchema, KibanaHttpMethodSchema, KibanaStepMetaSchema } from '@kbn/workflows';
@@ -132,12 +136,26 @@ import {
 export const ConnectorSpecsInputSchemas = new Map<string, Record<string, z.ZodSchema>>(
   Object.values(connectorsSpecs).map((connectorSpec) => [
     connectorSpec.metadata.id,
-    Object.fromEntries(
-      Object.entries(connectorSpec.actions).map(([actionName, action]) => [
-        actionName,
-        action.input,
-      ])
-    ),
+    {
+      ...Object.fromEntries(
+        Object.entries(connectorSpec.actions).map(([actionName, action]) => [
+          actionName,
+          action.input,
+        ])
+      ),
+      // Every v2 connector gets the framework-synthesized generic request action
+      // (see create_connector_from_spec.ts) unless it opts out, so
+      // `{connector}.request` gets typed authoring support instead of the
+      // passthrough fallback. Connectors without a base URL only accept an
+      // absolute `url` (no `path`).
+      ...(connectorSpec.disableGenericRequest
+        ? {}
+        : {
+            [GENERIC_REQUEST_SUB_ACTION]: getGenericRequestInputSchema(
+              Boolean(connectorSpec.getBaseUrl)
+            ),
+          }),
+    },
   ])
 );
 

--- a/src/platform/plugins/shared/workflows_management/common/connector_sub_actions_map.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_sub_actions_map.ts
@@ -56,7 +56,7 @@ import {
   SUB_ACTION as XSOAR_SUB_ACTION,
 } from '@kbn/connector-schemas/xsoar/constants';
 
-import { connectorsSpecs } from '@kbn/connector-specs';
+import { connectorsSpecs, GENERIC_REQUEST_SUB_ACTION } from '@kbn/connector-specs';
 
 // Helper function to format sub-action names for display
 function formatSubActionName(action: string): string {
@@ -147,7 +147,14 @@ function createSubActionsMapping() {
   });
 
   Object.values(connectorsSpecs).forEach((connectorSpec) => {
-    mapping[connectorSpec.metadata.id] = Object.keys(connectorSpec.actions).map((action) => ({
+    // Every v2 connector gets the framework-synthesized generic request action
+    // (see create_connector_from_spec.ts) unless it opts out, so
+    // `{connector}.request` shows up in step-type autocomplete.
+    const actionNames = [
+      ...Object.keys(connectorSpec.actions),
+      ...(connectorSpec.disableGenericRequest ? [] : [GENERIC_REQUEST_SUB_ACTION]),
+    ];
+    mapping[connectorSpec.metadata.id] = actionNames.map((action) => ({
       name: action,
       displayName: formatSubActionName(action),
     }));

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/index.ts
@@ -13,6 +13,7 @@ export { BaseMonacoConnectorHandler } from './base_monaco_connector_handler';
 // Specific connector handlers
 export { ElasticsearchMonacoConnectorHandler } from './elasticsearch_connector_handler';
 export { KibanaMonacoConnectorHandler } from './kibana_monaco_connector_handler';
+export { SpecConnectorMonacoHandler } from './spec_connector_handler';
 export { GenericMonacoConnectorHandler } from './generic_monaco_connector_handler';
 export { HttpMonacoConnectorStepHandler } from './http_connector_step_handler';
 export { WorkflowExecuteMonacoConnectorHandler } from './workflow_execute_handler';

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/spec_connector_handler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/spec_connector_handler.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { DEFAULT_GENERIC_REQUEST_DESCRIPTION } from '@kbn/connector-specs';
+import { SpecConnectorMonacoHandler } from './spec_connector_handler';
+import { createMockHoverContext, createMockStepContext } from './test_utils/mock_factories';
+import { setMockStabilityBadgeThemeForTests } from '../stability/set_mock_stability_badge_theme_for_tests';
+
+jest.mock('../../../../../common/schema', () => ({
+  getCachedAllConnectorsMap: jest.fn(() => new Map()),
+}));
+
+jest.mock('../connectors_cache', () => ({
+  getCachedAllConnectors: jest.fn(() => []),
+}));
+
+describe('SpecConnectorMonacoHandler', () => {
+  let handler: SpecConnectorMonacoHandler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockStabilityBadgeThemeForTests();
+    handler = new SpecConnectorMonacoHandler();
+  });
+
+  describe('canHandle', () => {
+    it('handles a known connector-spec action', () => {
+      expect(handler.canHandle('zoom.whoAmI')).toBe(true);
+    });
+
+    it('handles the synthesized request action', () => {
+      expect(handler.canHandle('zoom.request')).toBe(true);
+    });
+
+    it('does not handle unknown connector types', () => {
+      expect(handler.canHandle('kibana.createSpace')).toBe(false);
+      expect(handler.canHandle('not-a-connector')).toBe(false);
+      expect(handler.canHandle('unknownspec.request')).toBe(false);
+    });
+  });
+
+  describe('generateHoverContent', () => {
+    it("renders a defined action's real description", async () => {
+      const context = createMockHoverContext(
+        'zoom.whoAmI',
+        createMockStepContext({ stepType: 'zoom.whoAmI' })
+      );
+
+      const result = await handler.generateHoverContent(context);
+
+      expect(result).not.toBeNull();
+      expect(result!.value).toContain('**Connector**: `Zoom`');
+      expect(result!.value).toContain('**Action**: `whoAmI`');
+      expect(result!.value).toContain('profile of the currently authenticated Zoom user');
+    });
+
+    it('renders the default generic request description for the request action', async () => {
+      const context = createMockHoverContext(
+        'zoom.request',
+        createMockStepContext({ stepType: 'zoom.request' })
+      );
+
+      const result = await handler.generateHoverContent(context);
+
+      expect(result).not.toBeNull();
+      expect(result!.value).toContain('**Action**: `request`');
+      expect(result!.value).toContain(DEFAULT_GENERIC_REQUEST_DESCRIPTION);
+    });
+
+    it('shows the resolved base URL for a constant-host connector request', async () => {
+      const context = createMockHoverContext(
+        'zoom.request',
+        createMockStepContext({ stepType: 'zoom.request' })
+      );
+
+      const result = await handler.generateHoverContent(context);
+
+      expect(result!.value).toContain('**Base URL**');
+      expect(result!.value).toContain('`https://api.zoom.us`');
+    });
+
+    it('notes a config-derived base URL cannot be resolved at authoring time', async () => {
+      const context = createMockHoverContext(
+        'zendesk.request',
+        createMockStepContext({ stepType: 'zendesk.request' })
+      );
+
+      const result = await handler.generateHoverContent(context);
+
+      expect(result!.value).toContain('**Base URL**');
+      expect(result!.value).toContain('resolved from the connector configuration');
+      expect(result!.value).not.toContain('.zendesk.com');
+    });
+
+    it('notes url-only for a multi-host connector without a base URL', async () => {
+      const context = createMockHoverContext(
+        'amazon_s3.request',
+        createMockStepContext({ stepType: 'amazon_s3.request' })
+      );
+
+      const result = await handler.generateHoverContent(context);
+
+      expect(result!.value).toContain('**Base URL**');
+      expect(result!.value).toContain('absolute `url`');
+    });
+
+    it('does not show a base URL line for non-request actions', async () => {
+      const context = createMockHoverContext(
+        'zoom.whoAmI',
+        createMockStepContext({ stepType: 'zoom.whoAmI' })
+      );
+
+      const result = await handler.generateHoverContent(context);
+
+      expect(result!.value).not.toContain('**Base URL**');
+    });
+
+    it('returns null when there is no step context', async () => {
+      const context = createMockHoverContext('zoom.whoAmI');
+
+      const result = await handler.generateHoverContent(context);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for an unknown action on a known connector', async () => {
+      const context = createMockHoverContext(
+        'zoom.definitelyNotAnAction',
+        createMockStepContext({ stepType: 'zoom.definitelyNotAnAction' })
+      );
+
+      const result = await handler.generateHoverContent(context);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/spec_connector_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/spec_connector_handler.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActionContext, ConnectorSpec } from '@kbn/connector-specs';
+import {
+  connectorsSpecs,
+  DEFAULT_GENERIC_REQUEST_DESCRIPTION,
+  GENERIC_REQUEST_SUB_ACTION,
+} from '@kbn/connector-specs';
+import type { monaco } from '@kbn/monaco';
+import { BaseMonacoConnectorHandler } from './base_monaco_connector_handler';
+import type { ConnectorExamples, HoverContext } from '../monaco_providers/provider_interfaces';
+
+/**
+ * Builds a lookup of v2 connector-spec connectors keyed by their workflow
+ * connector-type name (the spec `metadata.id` without the leading dot, e.g.
+ * `.slack` -> `slack`).
+ */
+const buildSpecsByTypeName = (): Map<string, ConnectorSpec> => {
+  const map = new Map<string, ConnectorSpec>();
+  for (const spec of Object.values(connectorsSpecs) as ConnectorSpec[]) {
+    const id = spec?.metadata?.id;
+    if (typeof id === 'string' && id.length > 0) {
+      map.set(id.replace(/^\./, ''), spec);
+    }
+  }
+  return map;
+};
+
+/**
+ * Monaco hover handler for v2 connector-spec connectors. Surfaces the real
+ * per-action description from the connector spec (including the synthesized
+ * generic `request` action) instead of the keyword-based generic fallback.
+ */
+export class SpecConnectorMonacoHandler extends BaseMonacoConnectorHandler {
+  private readonly specsByTypeName: Map<string, ConnectorSpec>;
+
+  constructor() {
+    // Above the generic fallback (priority 1), below the dedicated
+    // elasticsearch/kibana handlers.
+    super('SpecConnectorMonacoHandler', 50, []);
+    this.specsByTypeName = buildSpecsByTypeName();
+  }
+
+  /**
+   * Split a workflow connector type (`{typeName}.{action}`) into its spec and
+   * action parts, if it maps to a known connector spec.
+   */
+  private resolve(
+    connectorType: string
+  ): { spec: ConnectorSpec; typeName: string; actionName: string } | null {
+    const separatorIndex = connectorType.indexOf('.');
+    if (separatorIndex <= 0) {
+      return null;
+    }
+    const typeName = connectorType.slice(0, separatorIndex);
+    const actionName = connectorType.slice(separatorIndex + 1);
+    const spec = this.specsByTypeName.get(typeName);
+    if (!spec || !actionName) {
+      return null;
+    }
+    return { spec, typeName, actionName };
+  }
+
+  canHandle(connectorType: string): boolean {
+    return this.resolve(connectorType) !== null;
+  }
+
+  async generateHoverContent(context: HoverContext): Promise<monaco.IMarkdownString | null> {
+    try {
+      const { connectorType, stepContext } = context;
+      if (!stepContext) {
+        return null;
+      }
+
+      const resolved = this.resolve(connectorType);
+      if (!resolved) {
+        return null;
+      }
+      const { spec, actionName } = resolved;
+
+      const description = this.getActionDescription(spec, actionName);
+      if (!description) {
+        return null;
+      }
+
+      const bodyLines = [
+        `**Connector**: \`${spec.metadata.displayName}\``,
+        '',
+        `**Action**: \`${actionName}\``,
+        '',
+        description,
+      ];
+
+      // For the generic request action, surface the base URL that a relative
+      // `path` resolves against so authors know what to prefix.
+      if (actionName === GENERIC_REQUEST_SUB_ACTION && !spec.disableGenericRequest) {
+        bodyLines.push('', this.getBaseUrlHint(spec));
+      }
+
+      bodyLines.push(
+        '',
+        '_💡 Tip: Use Ctrl+Space for parameter autocomplete in the `with` block._'
+      );
+
+      return this.createMarkdownContent(
+        this.prependStabilityBadgeToContent(
+          this.getConnectorStabilityFromCache(connectorType),
+          bodyLines
+        )
+      );
+    } catch (error) {
+      return null;
+    }
+  }
+
+  getExamples(): ConnectorExamples | null {
+    return null;
+  }
+
+  /**
+   * Resolves the human-readable description for an action, falling back to the
+   * generic request description for the framework-synthesized `request` action.
+   */
+  private getActionDescription(spec: ConnectorSpec, actionName: string): string | null {
+    const definedDescription = spec.actions?.[actionName]?.description;
+    if (definedDescription) {
+      return definedDescription;
+    }
+    if (actionName === GENERIC_REQUEST_SUB_ACTION && !spec.disableGenericRequest) {
+      return spec.genericRequestDescription ?? DEFAULT_GENERIC_REQUEST_DESCRIPTION;
+    }
+    return null;
+  }
+
+  /**
+   * Builds the base-URL hint line for the request action. Constant-host specs
+   * resolve to a literal (their `getBaseUrl` ignores the context); config- or
+   * secret-derived specs cannot be resolved at authoring time, so we show a note
+   * instead. Specs without `getBaseUrl` (multi-host) only accept an absolute
+   * `url`.
+   */
+  private getBaseUrlHint(spec: ConnectorSpec): string {
+    if (!spec.getBaseUrl) {
+      return '**Base URL**: _not available — provide an absolute `url` (this connector targets multiple hosts)._';
+    }
+    const staticBaseUrl = this.tryResolveStaticBaseUrl(spec);
+    if (staticBaseUrl) {
+      return `**Base URL** (\`path\` is appended to this): \`${staticBaseUrl}\``;
+    }
+    return '**Base URL**: resolved from the connector configuration at run time; `path` is appended to it.';
+  }
+
+  /**
+   * Attempts to resolve a connector's base URL without a runtime context.
+   * Only resolves for specs whose `getBaseUrl` is context-independent (constant
+   * hosts); returns null when resolution would depend on config/secrets, so we
+   * never surface a misleading, partially-interpolated URL.
+   */
+  private tryResolveStaticBaseUrl(spec: ConnectorSpec): string | null {
+    const { getBaseUrl } = spec;
+    if (!getBaseUrl || getBaseUrl.length > 0 || this.usesContext(getBaseUrl)) {
+      // `getBaseUrl.length > 0` means it declares a parameter (i.e. uses ctx).
+      return null;
+    }
+    try {
+      const resolved = getBaseUrl({} as ActionContext);
+      return typeof resolved === 'string' && resolved.length > 0 ? resolved : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Heuristic: whether a `getBaseUrl` implementation references the action
+   * context (config/secrets), in which case it can't be resolved at authoring
+   * time.
+   */
+  private usesContext(getBaseUrl: NonNullable<ConnectorSpec['getBaseUrl']>): boolean {
+    const source = Function.prototype.toString.call(getBaseUrl);
+    return /\b(ctx|config|secrets)\b/.test(source);
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -95,6 +95,7 @@ import {
   GenericMonacoConnectorHandler,
   HttpMonacoConnectorStepHandler,
   KibanaMonacoConnectorHandler,
+  SpecConnectorMonacoHandler,
   WorkflowExecuteMonacoConnectorHandler,
 } from '../lib/monaco_connectors';
 import { CustomMonacoStepHandler } from '../lib/monaco_connectors/custom_monaco_step_handler';
@@ -451,6 +452,12 @@ export const WorkflowYAMLEditor = ({
 
         const customHandler = new CustomMonacoStepHandler();
         registerMonacoConnectorHandler(customHandler);
+
+        // Handles v2 connector-spec connectors (e.g. `.slack`, `.zoom`) using
+        // their real per-action descriptions, including the synthesized
+        // `request` action. Sits above the keyword-based generic fallback.
+        const specConnectorHandler = new SpecConnectorMonacoHandler();
+        registerMonacoConnectorHandler(specConnectorHandler);
 
         const genericHandler = new GenericMonacoConnectorHandler();
         registerMonacoConnectorHandler(genericHandler);

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.test.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ConnectorSpec } from '@kbn/connector-specs';
-import { TEST_CONNECTOR_SUB_ACTION } from '@kbn/connector-specs';
+import { TEST_CONNECTOR_SUB_ACTION, GENERIC_REQUEST_SUB_ACTION } from '@kbn/connector-specs';
 import { ACTION_TYPE_SOURCES } from '@kbn/actions-types';
 import { z as z4 } from '@kbn/zod/v4';
 import { createConnectorTypeFromSpec } from './create_connector_from_spec';
@@ -127,7 +127,7 @@ describe('createConnectorTypeFromSpec', () => {
     expect(connectorType.source).toBe(ACTION_TYPE_SOURCES.spec);
   });
 
-  it('throws an error if the actions are empty', () => {
+  it('produces a usable connector even when the spec defines no explicit actions', () => {
     const spec = createMockSpec({
       metadata: {
         id: 'workflows-multi-feature-connector-no-actions',
@@ -139,10 +139,17 @@ describe('createConnectorTypeFromSpec', () => {
       actions: {},
     });
 
-    // This should throw an error because generateParamsSchema requires actions
-    expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).toThrow(
-      'No actions defined'
-    );
+    // The framework always synthesizes a generic `request` action, so there is
+    // always at least one executable action.
+    const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+    expect(connectorType.executor).toBeDefined();
+    expect(connectorType.validate.params).toBeDefined();
+
+    const requestParams = {
+      subAction: GENERIC_REQUEST_SUB_ACTION,
+      subActionParams: { method: 'get', url: 'https://api.example.com/v0/foo' },
+    };
+    expect(() => connectorType.validate.params!.schema.parse(requestParams)).not.toThrow();
   });
 
   it('always includes config and secrets validators', () => {
@@ -386,9 +393,14 @@ describe('createConnectorTypeFromSpec', () => {
         test: { handler: testHandler },
       });
 
-      expect(() =>
-        createConnectorTypeFromSpec(specWithOnlyDisabledTest, mockActionsPlugin)
-      ).toThrow('No actions defined');
+      // Even with no explicit actions and a disabled test, the synthesized
+      // `request` action keeps the connector usable but not testable.
+      const disabledTestConnector = createConnectorTypeFromSpec(
+        specWithOnlyDisabledTest,
+        mockActionsPlugin
+      );
+      expect(disabledTestConnector.isTestable).toBe(false);
+      expect(disabledTestConnector.executor).toBeDefined();
 
       const specWithActions = createMockSpec({
         test: { handler: testHandler },
@@ -496,6 +508,185 @@ describe('createConnectorTypeFromSpec', () => {
 
       const testParams = { subAction: TEST_CONNECTOR_SUB_ACTION, subActionParams: {} };
       expect(() => connectorType.validate.params!.schema.parse(testParams)).not.toThrow();
+    });
+  });
+
+  describe('generic request action', () => {
+    it('synthesizes a url-only request action for a spec without getBaseUrl', () => {
+      const spec = createMockSpec();
+      const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+
+      const urlParams = {
+        subAction: GENERIC_REQUEST_SUB_ACTION,
+        subActionParams: { method: 'post', url: 'https://api.example.com/v0/foo', body: { a: 1 } },
+      };
+      expect(() => connectorType.validate.params!.schema.parse(urlParams)).not.toThrow();
+
+      // Without a base URL, a relative `path` can never resolve, so it is not a
+      // valid parameter.
+      const pathParams = {
+        subAction: GENERIC_REQUEST_SUB_ACTION,
+        subActionParams: { method: 'get', path: '/v0/foo' },
+      };
+      expect(() => connectorType.validate.params!.schema.parse(pathParams)).toThrow();
+    });
+
+    it('accepts a relative path in the params schema when getBaseUrl is present', () => {
+      const spec = createMockSpec({ getBaseUrl: () => 'https://api.example.com' });
+      const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+
+      const requestParams = {
+        subAction: GENERIC_REQUEST_SUB_ACTION,
+        subActionParams: { method: 'get', path: '/v0/foo' },
+      };
+      expect(() => connectorType.validate.params!.schema.parse(requestParams)).not.toThrow();
+    });
+
+    it('routes a path-based request through the connector axios client using getBaseUrl', async () => {
+      const requestFn = jest
+        .fn()
+        .mockResolvedValue({ status: 200, headers: { 'x-h': '1' }, data: { ok: true } });
+      mockGetAxiosInstanceWithAuth.mockResolvedValue({ request: requestFn });
+
+      const spec = createMockSpec({
+        actions: {},
+        getBaseUrl: (ctx) => (ctx.config as { baseUrl: string }).baseUrl,
+      });
+      const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+
+      const result = await connectorType.executor!({
+        actionId: 'connector-id',
+        config: { baseUrl: 'https://api.example.com' },
+        secrets: {},
+        params: {
+          subAction: GENERIC_REQUEST_SUB_ACTION,
+          subActionParams: { method: 'get', path: '/v0/foo' },
+        },
+        services: {} as never,
+        logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() } as never,
+        configurationUtilities: mockActionsConfigUtils,
+        connectorUsageCollector: {} as never,
+      });
+
+      expect(requestFn).toHaveBeenCalledWith({
+        method: 'get',
+        url: 'https://api.example.com/v0/foo',
+      });
+      expect(result).toEqual({
+        status: 'ok',
+        data: { status: 200, headers: { 'x-h': '1' }, data: { ok: true } },
+        actionId: 'connector-id',
+      });
+    });
+
+    it('routes a url-based request verbatim even without getBaseUrl', async () => {
+      const requestFn = jest
+        .fn()
+        .mockResolvedValue({ status: 200, headers: {}, data: { ok: true } });
+      mockGetAxiosInstanceWithAuth.mockResolvedValue({ request: requestFn });
+
+      const spec = createMockSpec({ actions: {} });
+      const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+
+      const result = await connectorType.executor!({
+        actionId: 'connector-id',
+        config: {},
+        secrets: {},
+        params: {
+          subAction: GENERIC_REQUEST_SUB_ACTION,
+          subActionParams: { method: 'get', url: 'https://api.example.com/raw' },
+        },
+        services: {} as never,
+        logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() } as never,
+        configurationUtilities: mockActionsConfigUtils,
+        connectorUsageCollector: {} as never,
+      });
+
+      expect(requestFn).toHaveBeenCalledWith({
+        method: 'get',
+        url: 'https://api.example.com/raw',
+      });
+      expect(result.status).toBe('ok');
+    });
+
+    it('errors when a path is used on a connector without getBaseUrl', async () => {
+      mockGetAxiosInstanceWithAuth.mockResolvedValue({ request: jest.fn() });
+
+      const spec = createMockSpec({ actions: {} });
+      const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+
+      const result = await connectorType.executor!({
+        actionId: 'connector-id',
+        config: {},
+        secrets: {},
+        params: {
+          subAction: GENERIC_REQUEST_SUB_ACTION,
+          subActionParams: { method: 'get', path: '/v0/foo' },
+        },
+        services: {} as never,
+        logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() } as never,
+        configurationUtilities: mockActionsConfigUtils,
+        connectorUsageCollector: {} as never,
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.message).toMatch(/does not support relative "path"/);
+    });
+
+    it('throws when spec.actions contains the reserved request key', () => {
+      const spec = createMockSpec({
+        actions: {
+          [GENERIC_REQUEST_SUB_ACTION]: {
+            input: z4.object({ test: z4.string() }),
+            handler: jest.fn(),
+          },
+        },
+      });
+
+      expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).toThrow(
+        GENERIC_REQUEST_SUB_ACTION
+      );
+    });
+
+    it('does not synthesize a request action when the spec opts out', () => {
+      const spec = createMockSpec({ disableGenericRequest: true });
+      const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+
+      const requestParams = {
+        subAction: GENERIC_REQUEST_SUB_ACTION,
+        subActionParams: { method: 'get', url: 'https://api.example.com/foo' },
+      };
+      expect(() => connectorType.validate.params!.schema.parse(requestParams)).toThrow();
+    });
+
+    it('allows a spec to define its own request action when it opts out', () => {
+      const ownRequestHandler = jest.fn();
+      const spec = createMockSpec({
+        disableGenericRequest: true,
+        actions: {
+          [GENERIC_REQUEST_SUB_ACTION]: {
+            input: z4.object({ path: z4.string() }),
+            handler: ownRequestHandler,
+          },
+        },
+      });
+
+      expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).not.toThrow();
+
+      const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+      const requestParams = {
+        subAction: GENERIC_REQUEST_SUB_ACTION,
+        subActionParams: { path: '/custom' },
+      };
+      expect(() => connectorType.validate.params!.schema.parse(requestParams)).not.toThrow();
+    });
+
+    it('produces no executor when a spec opts out and has no other actions or test', () => {
+      const spec = createMockSpec({ actions: {}, disableGenericRequest: true });
+      const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+
+      expect(connectorType.executor).toBeUndefined();
+      expect(connectorType.validate.params).toBeUndefined();
     });
   });
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
@@ -6,7 +6,14 @@
  */
 
 import type { ConnectorSpec } from '@kbn/connector-specs';
-import { TEST_CONNECTOR_SUB_ACTION } from '@kbn/connector-specs';
+import {
+  TEST_CONNECTOR_SUB_ACTION,
+  GENERIC_REQUEST_SUB_ACTION,
+  DEFAULT_GENERIC_REQUEST_DESCRIPTION,
+  getGenericRequestInputSchema,
+  GenericRequestOutputSchema,
+  buildGenericRequestHandler,
+} from '@kbn/connector-specs';
 import { ACTION_TYPE_SOURCES } from '@kbn/actions-types';
 import { z as z4 } from '@kbn/zod/v4';
 
@@ -30,19 +37,46 @@ const buildExecutableActions = (spec: ConnectorSpec): ConnectorSpec['actions'] =
     );
   }
 
-  const baseActions = spec.actions ?? {};
-
-  if (!spec.test?.enabled) {
-    return baseActions;
+  // `request` is reserved for the framework-synthesized generic request action.
+  // Specs that opt out (`disableGenericRequest`) may define their own richer
+  // `request` action (e.g. Kubernetes), so only guard the key when we would
+  // actually synthesize the generic one.
+  if (!spec.disableGenericRequest && spec.actions?.[GENERIC_REQUEST_SUB_ACTION]) {
+    throw new Error(
+      `Connector spec "${spec.metadata.id}" defines a reserved action key "${GENERIC_REQUEST_SUB_ACTION}".`
+    );
   }
 
-  return {
-    ...baseActions,
-    [TEST_CONNECTOR_SUB_ACTION]: {
-      handler: spec.test.handler,
-      input: z4.unknown().optional(),
-    },
-  };
+  let actions: ConnectorSpec['actions'] = { ...(spec.actions ?? {}) };
+
+  // Every v2 connector gets a generic `request` action out of the box, unless it
+  // opts out (e.g. MCP connectors with no plain HTTP surface). It reaches
+  // arbitrary endpoints of the connector's API while reusing its authentication
+  // and error handling. `getBaseUrl` (when present) enables relative `path`
+  // requests; connectors without it can only be called with an absolute `url`.
+  if (!spec.disableGenericRequest) {
+    actions = {
+      ...actions,
+      [GENERIC_REQUEST_SUB_ACTION]: {
+        input: getGenericRequestInputSchema(Boolean(spec.getBaseUrl)),
+        output: GenericRequestOutputSchema,
+        handler: buildGenericRequestHandler(spec.getBaseUrl),
+        description: spec.genericRequestDescription ?? DEFAULT_GENERIC_REQUEST_DESCRIPTION,
+      },
+    };
+  }
+
+  if (spec.test?.enabled) {
+    actions = {
+      ...actions,
+      [TEST_CONNECTOR_SUB_ACTION]: {
+        handler: spec.test.handler,
+        input: z4.unknown().optional(),
+      },
+    };
+  }
+
+  return actions;
 };
 
 export const createConnectorTypeFromSpec = (
@@ -51,10 +85,8 @@ export const createConnectorTypeFromSpec = (
 ): ActionType<ActionTypeConfig, ActionTypeSecrets, ActionTypeParams, unknown> => {
   const configUtils = actions.getActionsConfigurationUtilities();
 
-  const hasTest = Boolean(spec.test?.enabled);
-  const hasActions = Boolean(spec.actions);
   const executableActions = buildExecutableActions(spec);
-  const hasExecutableActions = hasActions || hasTest;
+  const hasExecutableActions = Object.keys(executableActions).length > 0;
 
   const executor = hasExecutableActions
     ? generateExecutorFunction({

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
@@ -92,6 +92,7 @@ export const createConnectorTypeFromSpec = (
     ? generateExecutorFunction({
         actions: executableActions,
         getAxiosInstanceWithAuth: actions.getAxiosInstanceWithAuth,
+        configurationUtilities: configUtils,
       })
     : undefined;
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
@@ -10,6 +10,7 @@ import type { MockedLogger } from '@kbn/logging-mocks';
 import { generateExecutorFunction } from './generate_executor_function';
 import { setConnectorActionErrorMeta, TEST_CONNECTOR_SUB_ACTION } from '@kbn/connector-specs';
 import type { ConnectorSpec } from '@kbn/connector-specs';
+import { actionsConfigMock } from '../../actions_config.mock';
 import type { GetAxiosInstanceWithAuthFn } from '../get_axios_instance';
 
 describe('generateExecutorFunction', () => {
@@ -19,6 +20,7 @@ describe('generateExecutorFunction', () => {
   let mockGetAxiosInstanceWithAuth: jest.MockedFunction<GetAxiosInstanceWithAuthFn>;
   let mockAxiosInstance: object;
   let mockHandler: jest.Mock;
+  const configurationUtilities = actionsConfigMock.create();
 
   const makeExecOptions = (params: Record<string, unknown>) =>
     ({
@@ -59,6 +61,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -72,6 +75,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const subActionParams = { message: 'hello', count: 3 };
@@ -87,14 +91,42 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const opts = makeExecOptions({ subAction: 'testAction', subActionParams: {} });
       await executor({ ...opts, config, secrets });
 
       expect(mockHandler).toHaveBeenCalledWith(
-        { log: logger, client: mockAxiosInstance, config, secrets },
+        {
+          log: logger,
+          client: mockAxiosInstance,
+          config,
+          secrets,
+          ensureUriAllowed: expect.any(Function),
+        },
         {}
+      );
+    });
+
+    it('exposes an ensureUriAllowed helper that delegates to the allowedHosts allowlist', async () => {
+      let capturedEnsureUriAllowed: ((uri: string) => void) | undefined;
+      mockHandler.mockImplementation((ctx) => {
+        capturedEnsureUriAllowed = ctx.ensureUriAllowed;
+        return { result: 'ok' };
+      });
+
+      const executor = generateExecutorFunction({
+        actions: makeActions(),
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
+      });
+
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+
+      capturedEnsureUriAllowed?.('https://allowed.example.com/x');
+      expect(configurationUtilities.ensureUriAllowed).toHaveBeenCalledWith(
+        'https://allowed.example.com/x'
       );
     });
 
@@ -104,6 +136,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -119,6 +152,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -138,6 +172,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       await executor({
@@ -164,6 +199,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       await executor(
@@ -187,6 +223,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       await expect(
@@ -202,6 +239,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       await expect(
@@ -219,6 +257,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -242,6 +281,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -273,6 +313,7 @@ describe('generateExecutorFunction', () => {
           },
         },
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -301,6 +342,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -324,6 +366,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
@@ -337,6 +380,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -356,6 +400,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       await expect(
@@ -378,6 +423,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions,
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -404,6 +450,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions,
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result = await executor(
@@ -431,6 +478,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions,
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        configurationUtilities,
       });
 
       const result1 = await executor(

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -11,6 +11,7 @@ import {
   getFinitePositiveNumber,
   getHeaderValue,
 } from '@kbn/connector-specs';
+import type { ActionsConfigurationUtilities } from '../../actions_config';
 import type { ExecutorParams } from '../../sub_action_framework/types';
 import type {
   ActionTypeExecutorOptions as ConnectorTypeExecutorOptions,
@@ -65,9 +66,11 @@ const getErrorMeta = ({
 export const generateExecutorFunction = ({
   actions,
   getAxiosInstanceWithAuth,
+  configurationUtilities,
 }: {
   actions: ConnectorSpec['actions'];
   getAxiosInstanceWithAuth: GetAxiosInstanceWithAuthFn;
+  configurationUtilities: ActionsConfigurationUtilities;
 }) =>
   async function (
     execOptions: ConnectorTypeExecutorOptions<RecordUnknown, RecordUnknown, RecordUnknown>
@@ -112,6 +115,10 @@ export const generateExecutorFunction = ({
       client: axiosInstance,
       secrets,
       config,
+      // Handlers that build request URLs from user-controlled input use this to
+      // enforce the Actions `allowedHosts` allowlist before sending the
+      // authenticated client at a host (e.g. the generic `request` action).
+      ensureUriAllowed: (uri: string) => configurationUtilities.ensureUriAllowed(uri),
     };
 
     try {


### PR DESCRIPTION
## Summary

Every v2 connector-spec connector now gets a framework-synthesized generic `request` action out of the box, letting workflows call any endpoint of the connector's API while reusing its configured authentication and error handling. This removes the need to stand up a separate generic HTTP connector (and re-enter secrets) just to reach an endpoint that isn't covered by a dedicated sub-action.

- **`getBaseUrl` on `ConnectorSpec`**: added and backfilled across specs (host only; the API version segment stays in per-action paths). Handlers reuse it as the single source of truth for the base URL, so the final URLs are byte-for-byte identical to before.
- **Synthesized `request` action**: added in `buildExecutableActions`. Its input schema is `path` + optional `url` when a base URL exists, and `url`-only for multi-host connectors that can't resolve a relative `path`. An absolute `url` always overrides `path` + base URL.
- **`disableGenericRequest` opt-out**: for connectors with no plain HTTP surface — MCP connectors (GitHub, Tavily, Box, Dropbox, PagerDuty), Kubernetes (which ships its own richer `request`), and multi-host connectors that shouldn't accept arbitrary URLs.
- **`genericRequestDescription` override** + `DEFAULT_GENERIC_REQUEST_DESCRIPTION` for the authoring-time description.
- **Authoring support**: a new `SpecConnectorMonacoHandler` surfaces each action's real description in the YAML editor hover (including the synthesized `request` action), plus a base-URL hint. The synthesized action is also wired into the workflows autocomplete/schema maps.

## Testing

- New unit tests for the generic request schema/handler (`generic_request.test.ts`), the connector synthesis (`create_connector_from_spec.test.ts`), and the hover handler (`spec_connector_handler.test.ts`).
- Type-check and jest pass for the affected packages.

## Release note

Workflow authors can now use a generic `request` action on any v2 connector to call API endpoints that don't yet have a dedicated action, reusing the connector's configured authentication.