### PR TITLE
[One Workflow] Add "Build a request from cURL" to the workflow YAML editor

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/connector_supports_generic_request.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/connector_supports_generic_request.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ConnectorSpec } from '@kbn/connector-specs';
+import { connectorsSpecs } from '@kbn/connector-specs';
+
+/**
+ * Whether a connector type (e.g. `.slack`) is a v2 connector spec that exposes
+ * the framework-synthesized generic `request` action. Connectors that opt out
+ * via `disableGenericRequest` (e.g. MCP connectors) do not, so the "Build one"
+ * footer should not be offered for them.
+ */
+export const connectorSupportsGenericRequest = (connectorType: string): boolean => {
+  const dotted = connectorType.startsWith('.') ? connectorType : `.${connectorType}`;
+  const spec = (Object.values(connectorsSpecs) as ConnectorSpec[]).find(
+    (candidate) => candidate?.metadata?.id === dotted
+  );
+  return Boolean(spec) && !spec!.disableGenericRequest;
+};

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/use_display_options.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/use_display_options.test.ts
@@ -70,6 +70,31 @@ describe('buildDisplayOptions', () => {
     expect(result[0].data?.menuItem).toEqual({ kind: 'action', action: options[0] });
   });
 
+  it('appends "Build one" footer rows inside a request-capable connector group', () => {
+    const options = [makeAction('slack.postMessage', 'Post message')];
+    const result = buildDisplayOptions({
+      ...base,
+      options,
+      currentPath: ['external', 'slack'],
+      buildRequestConnectorType: '.slack',
+    });
+    const buildItems = result.filter((o) => o.data?.menuItem?.kind === 'buildRequest');
+    expect(buildItems).toHaveLength(2);
+    expect(buildItems.map((o) => (o.data?.menuItem as { mode: string }).mode)).toEqual([
+      'scratch',
+      'curl',
+    ]);
+    expect(
+      buildItems.every((o) => (o.data?.menuItem as { connectorType: string }).connectorType === '.slack')
+    ).toBe(true);
+  });
+
+  it('does not append footer rows when no request-capable connector is active', () => {
+    const options = [makeAction('a', 'A')];
+    const result = buildDisplayOptions({ ...base, options, currentPath: ['group1'] });
+    expect(result.some((o) => o.data?.menuItem?.kind === 'buildRequest')).toBe(false);
+  });
+
   describe('hash mode (#)', () => {
     it('shows only jump entries when search starts with #', () => {
       const result = buildDisplayOptions({ ...base, searchTerm: '#' });

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/use_display_options.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/use_display_options.test.ts
@@ -85,7 +85,9 @@ describe('buildDisplayOptions', () => {
       'curl',
     ]);
     expect(
-      buildItems.every((o) => (o.data?.menuItem as { connectorType: string }).connectorType === '.slack')
+      buildItems.every(
+        (o) => (o.data?.menuItem as { connectorType: string }).connectorType === '.slack'
+      )
     ).toBe(true);
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/use_display_options.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/use_display_options.ts
@@ -25,6 +25,12 @@ interface UseDisplayOptionsArgs {
   commands?: EditorCommand[];
   jumpToStepEntries?: JumpToStepEntry[];
   currentPath: string[];
+  /**
+   * The connector type of the group the user has drilled into (e.g. `.slack`),
+   * when it supports the generic `request` action. Used to append the
+   * "Build one" footer inside that connector's submenu.
+   */
+  buildRequestConnectorType?: string;
 }
 
 export function useDisplayOptions({
@@ -33,6 +39,7 @@ export function useDisplayOptions({
   commands,
   jumpToStepEntries,
   currentPath,
+  buildRequestConnectorType,
 }: UseDisplayOptionsArgs): MenuSelectableOption[] {
   return useMemo(
     () =>
@@ -42,9 +49,34 @@ export function useDisplayOptions({
         commands,
         jumpToStepEntries,
         currentPath,
+        buildRequestConnectorType,
       }),
-    [options, searchTerm, commands, jumpToStepEntries, currentPath]
+    [options, searchTerm, commands, jumpToStepEntries, currentPath, buildRequestConnectorType]
   );
+}
+
+/**
+ * Builds the "Couldn't find your action? Build one" footer rows shown inside a
+ * connector's submenu (from scratch / from cURL). Only relevant for connectors
+ * that expose the generic `request` action.
+ */
+function buildRequestFooterOptions(connectorType: string): MenuSelectableOption[] {
+  return [
+    {
+      label: i18n.translate('workflows.actionsMenu.buildFromScratch', {
+        defaultMessage: "Couldn't find your action? Build one from scratch",
+      }),
+      className: 'compactOption',
+      data: { menuItem: { kind: 'buildRequest', connectorType, mode: 'scratch' } },
+    },
+    {
+      label: i18n.translate('workflows.actionsMenu.buildFromCurl', {
+        defaultMessage: 'Build a request from a cURL command',
+      }),
+      className: 'compactOption',
+      data: { menuItem: { kind: 'buildRequest', connectorType, mode: 'curl' } },
+    },
+  ];
 }
 
 export function buildDisplayOptions({
@@ -53,6 +85,7 @@ export function buildDisplayOptions({
   commands,
   jumpToStepEntries,
   currentPath,
+  buildRequestConnectorType,
 }: UseDisplayOptionsArgs): MenuSelectableOption[] {
   const result: MenuSelectableOption[] = [];
   const term = searchTerm.trim().toLowerCase();
@@ -63,6 +96,9 @@ export function buildDisplayOptions({
   if (currentPath.length > 0) {
     for (const opt of options) {
       result.push({ label: opt.label, data: { menuItem: { kind: 'action', action: opt } } });
+    }
+    if (buildRequestConnectorType) {
+      result.push(...buildRequestFooterOptions(buildRequestConnectorType));
     }
     return result;
   }

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/types.ts
@@ -23,11 +23,18 @@ export interface JumpToStepEntry {
   lineStart: number;
 }
 
+/**
+ * How to build a fresh `request` step for a connector: either an empty
+ * skeleton, or one prefilled from a pasted cURL command.
+ */
+export type BuildRequestMode = 'scratch' | 'curl';
+
 export type MenuItemData =
   | { kind: 'action'; action: ActionOptionData }
   | { kind: 'command'; command: EditorCommand }
   | { kind: 'jump'; entry: JumpToStepEntry }
-  | { kind: 'nav'; target: 'viewAll' | 'viewExisting' };
+  | { kind: 'nav'; target: 'viewAll' | 'viewExisting' }
+  | { kind: 'buildRequest'; connectorType: string; mode: BuildRequestMode };
 
 /**
  * Options passed to EuiSelectable carry MenuItemData inside the standard

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/ui/actions_menu.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/ui/actions_menu.tsx
@@ -28,10 +28,12 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '../../../hooks/use_kibana';
 import { StepIcon } from '../../../shared/ui/step_icons/step_icon';
+import { connectorSupportsGenericRequest } from '../lib/connector_supports_generic_request';
 import { flattenOptions, getActionOptions } from '../lib/get_action_options';
 import { STEPS_PREFIX, useDisplayOptions } from '../lib/use_display_options';
 import {
   type ActionOptionData,
+  type BuildRequestMode,
   type EditorCommand,
   getMenuItemData,
   isActionConnectorGroup,
@@ -49,6 +51,37 @@ export interface ActionsMenuProps {
   jumpToStepEntries?: JumpToStepEntry[];
   onCommandSelected?: (commandId: string) => void;
   onJumpToStep?: (lineNumber: number) => void;
+  onBuildRequestSelected?: (connectorType: string, mode: BuildRequestMode) => void;
+}
+
+/**
+ * Walks the drill-in path against the option tree and, if the user is currently
+ * inside a connector group that supports the generic `request` action, returns
+ * that connector's type (e.g. `.slack`) so the "Build one" footer can be shown.
+ */
+function getBuildRequestConnectorType(
+  defaultOptions: ActionOptionData[],
+  currentPath: string[]
+): string | undefined {
+  if (currentPath.length === 0) {
+    return undefined;
+  }
+  let options = defaultOptions;
+  let current: ActionOptionData | undefined;
+  for (const id of currentPath) {
+    current = options.find((o) => o.id === id);
+    if (current && isActionGroup(current)) {
+      options = current.options;
+    } else {
+      return undefined;
+    }
+  }
+  if (current && isActionConnectorGroup(current)) {
+    return connectorSupportsGenericRequest(current.connectorType)
+      ? current.connectorType
+      : undefined;
+  }
+  return undefined;
 }
 
 export function ActionsMenu({
@@ -57,6 +90,7 @@ export function ActionsMenu({
   jumpToStepEntries,
   onCommandSelected,
   onJumpToStep,
+  onBuildRequestSelected,
 }: ActionsMenuProps) {
   const styles = useMemoCss(componentStyles);
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -88,12 +122,18 @@ export function ActionsMenu({
     }
   }, [defaultOptions, currentPath]);
 
+  const buildRequestConnectorType = useMemo(
+    () => getBuildRequestConnectorType(defaultOptions, currentPath),
+    [defaultOptions, currentPath]
+  );
+
   const displayOptions = useDisplayOptions({
     options,
     searchTerm,
     commands,
     jumpToStepEntries,
     currentPath,
+    buildRequestConnectorType,
   });
 
   const renderActionOption = (rawOption: EuiSelectableOption, searchValue: string) => {
@@ -127,6 +167,26 @@ export function ActionsMenu({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiIcon type="arrowRight" size="s" color="primary" aria-hidden={true} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    }
+
+    if (itemData?.kind === 'buildRequest') {
+      return (
+        <EuiFlexGroup alignItems="center" gutterSize="xs" css={styles.viewAllLink}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon
+              type={itemData.mode === 'curl' ? 'editorCodeBlock' : 'plusInCircle'}
+              size="s"
+              color="primary"
+              aria-hidden={true}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="primary">
+              {rawOption.label}
+            </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       );
@@ -223,6 +283,10 @@ export function ActionsMenu({
     }
     if (itemData?.kind === 'jump') {
       onJumpToStep?.(itemData.entry.lineStart);
+      return;
+    }
+    if (itemData?.kind === 'buildRequest') {
+      onBuildRequestSelected?.(itemData.connectorType, itemData.mode);
       return;
     }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/ui/actions_menu_popover.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/ui/actions_menu_popover.tsx
@@ -22,6 +22,7 @@ export const ActionsMenuPopover = React.memo(function ActionsMenuPopover({
   jumpToStepEntries,
   onCommandSelected,
   onJumpToStep,
+  onBuildRequestSelected,
   ...props
 }: ActionsMenuPopoverProps) {
   return (
@@ -41,6 +42,7 @@ export const ActionsMenuPopover = React.memo(function ActionsMenuPopover({
         jumpToStepEntries={jumpToStepEntries}
         onCommandSelected={onCommandSelected}
         onJumpToStep={onJumpToStep}
+        onBuildRequestSelected={onBuildRequestSelected}
       />
     </EuiPopover>
   );

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/connector_specs/resolve_static_base_url.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/connector_specs/resolve_static_base_url.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActionContext, ConnectorSpec } from '@kbn/connector-specs';
+import { connectorsSpecs } from '@kbn/connector-specs';
+
+/**
+ * Heuristic: whether a `getBaseUrl` implementation references the action
+ * context (config/secrets), in which case it can't be resolved at authoring
+ * time (there is no runtime context on the client).
+ */
+const usesContext = (getBaseUrl: NonNullable<ConnectorSpec['getBaseUrl']>): boolean => {
+  const source = Function.prototype.toString.call(getBaseUrl);
+  return /\b(ctx|config|secrets)\b/.test(source);
+};
+
+/**
+ * Attempts to resolve a connector's base URL without a runtime context. Only
+ * resolves for specs whose `getBaseUrl` is context-independent (constant hosts);
+ * returns `null` when resolution would depend on config/secrets, so callers
+ * never surface or rely on a misleading, partially-interpolated URL.
+ */
+export const resolveStaticBaseUrl = (spec: ConnectorSpec): string | null => {
+  const { getBaseUrl } = spec;
+  // `getBaseUrl.length > 0` means it declares a parameter (i.e. uses ctx).
+  if (!getBaseUrl || getBaseUrl.length > 0 || usesContext(getBaseUrl)) {
+    return null;
+  }
+  try {
+    const resolved = getBaseUrl({} as ActionContext);
+    return typeof resolved === 'string' && resolved.length > 0 ? resolved : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Looks up a v2 connector spec by its workflow connector-type id, accepting
+ * either the dotted form (`.slack`) or the bare form (`slack`).
+ */
+export const getConnectorSpecByType = (connectorType: string): ConnectorSpec | undefined => {
+  const dotted = connectorType.startsWith('.') ? connectorType : `.${connectorType}`;
+  for (const spec of Object.values(connectorsSpecs) as ConnectorSpec[]) {
+    if (spec?.metadata?.id === dotted) {
+      return spec;
+    }
+  }
+  return undefined;
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/curl/curl_to_request_step.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/curl/curl_to_request_step.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { curlToRequestStep } from './curl_to_request_step';
+
+const unwrap = (connectorType: string, curl: string) => {
+  const result = curlToRequestStep(connectorType, curl);
+  if (!result.ok) {
+    throw new Error(`Expected mapping to succeed, got: ${result.error}`);
+  }
+  return result;
+};
+
+describe('curlToRequestStep', () => {
+  it('uses a relative path when the URL matches the connector base URL', () => {
+    // Zoom has a static base URL of https://api.zoom.us.
+    const result = unwrap('.zoom', 'curl -X POST https://api.zoom.us/v2/users/me');
+    expect(result.stepType).toBe('zoom.request');
+    expect(result.snippet).toContain('type: zoom.request');
+    expect(result.snippet).toContain('method: post');
+    expect(result.snippet).toContain('path: /v2/users/me');
+    expect(result.snippet).not.toContain('url:');
+    expect(result.notes.join(' ')).toContain('relative `path`');
+  });
+
+  it('keeps the query string on the path', () => {
+    const result = unwrap('.zoom', 'curl "https://api.zoom.us/v2/users?status=active"');
+    expect(result.snippet).toContain('path: /v2/users?status=active');
+  });
+
+  it('falls back to an absolute url when the host does not match the base URL', () => {
+    const result = unwrap('.zoom', 'curl https://example.com/other/endpoint');
+    expect(result.snippet).toContain('url: https://example.com/other/endpoint');
+    expect(result.snippet).not.toContain('path:');
+    expect(result.notes.join(' ')).toContain('absolute `url`');
+  });
+
+  it('uses an absolute url for connectors without a static base URL', () => {
+    // amazon_s3 is multi-host: no resolvable static base URL.
+    const result = unwrap('.amazon_s3', 'curl https://my-bucket.s3.amazonaws.com/key');
+    expect(result.snippet).toContain('url: https://my-bucket.s3.amazonaws.com/key');
+    expect(result.snippet).not.toContain('path:');
+  });
+
+  it('includes non-auth headers and the parsed body', () => {
+    const result = unwrap(
+      '.zoom',
+      `curl -X POST https://api.zoom.us/v2/chat -H 'Content-Type: application/json' -d '{"message":"hi"}'`
+    );
+    expect(result.snippet).toContain('Content-Type: application/json');
+    expect(result.snippet).toContain('message: hi');
+  });
+
+  it('strips auth headers and notes it', () => {
+    const result = unwrap(
+      '.zoom',
+      `curl https://api.zoom.us/v2/users/me -H 'Authorization: Bearer secret'`
+    );
+    expect(result.snippet).not.toContain('Authorization');
+    expect(result.snippet).not.toContain('secret');
+    expect(result.notes.join(' ')).toContain('Removed authentication');
+  });
+
+  it('returns an error for a cURL command with no URL', () => {
+    const result = curlToRequestStep('.zoom', 'curl -X GET -H "Accept: application/json"');
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns an error for empty input', () => {
+    const result = curlToRequestStep('.zoom', '   ');
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/curl/curl_to_request_step.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/curl/curl_to_request_step.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { stringify, type ToStringOptions } from 'yaml';
+import { GENERIC_REQUEST_SUB_ACTION } from '@kbn/connector-specs';
+import { parseCurl, type ParsedCurl } from './parse_curl';
+import {
+  getConnectorSpecByType,
+  resolveStaticBaseUrl,
+} from '../connector_specs/resolve_static_base_url';
+
+export interface CurlToRequestStepResult {
+  ok: true;
+  /** The full workflow step type, e.g. `slack.request`. */
+  stepType: string;
+  /** YAML for a single step-sequence item (leading `- name:` … block). */
+  snippet: string;
+  /** Human-readable notes to surface in the UI (stripped auth, path vs url, …). */
+  notes: string[];
+}
+
+export interface CurlToRequestStepError {
+  ok: false;
+  error: string;
+}
+
+const YAML_OPTIONS: ToStringOptions = { indent: 2, lineWidth: 0 };
+
+/**
+ * Splits an absolute URL into the `path` (path + query + hash, relative to the
+ * base URL) actually appended to a connector base URL. Returns `null` when the
+ * URL does not sit under `baseUrl`, in which case the caller should fall back to
+ * an absolute `url`.
+ */
+const toRelativePath = (absoluteUrl: string, baseUrl: string): string | null => {
+  let base: URL;
+  let target: URL;
+  try {
+    base = new URL(baseUrl);
+    target = new URL(absoluteUrl);
+  } catch {
+    return null;
+  }
+  if (base.origin !== target.origin) {
+    return null;
+  }
+  const basePath = base.pathname.replace(/\/+$/, '');
+  if (basePath && !target.pathname.startsWith(basePath)) {
+    return null;
+  }
+  const remainder = target.pathname.slice(basePath.length) || '/';
+  const path = remainder.startsWith('/') ? remainder : `/${remainder}`;
+  return `${path}${target.search}${target.hash}`;
+};
+
+/**
+ * Builds the ordered `with` block for the generic request action. `url` and
+ * `path` are mutually exclusive by construction here (path wins when the URL
+ * resolves against a known base URL).
+ */
+const buildWithBlock = (
+  parsed: ParsedCurl,
+  relativePath: string | null
+): Record<string, unknown> => {
+  const withBlock: Record<string, unknown> = { method: parsed.method };
+  if (relativePath !== null) {
+    withBlock.path = relativePath;
+  } else {
+    withBlock.url = parsed.url;
+  }
+  if (parsed.body !== undefined) {
+    withBlock.body = parsed.body;
+  }
+  if (Object.keys(parsed.headers).length > 0) {
+    withBlock.headers = parsed.headers;
+  }
+  return withBlock;
+};
+
+const buildNotes = (parsed: ParsedCurl, relativePath: string | null): string[] => {
+  const notes: string[] = [];
+  const strippedNames = [...parsed.strippedAuth.headerNames];
+  if (parsed.strippedAuth.hadUserFlag) {
+    strippedNames.push('basic auth (-u)');
+  }
+  if (strippedNames.length > 0) {
+    notes.push(
+      `Removed authentication (${strippedNames.join(
+        ', '
+      )}) — the connector supplies its own credentials.`
+    );
+  }
+  if (relativePath !== null) {
+    notes.push('Matched the connector base URL, so a relative `path` was used.');
+  } else {
+    notes.push('Could not match a connector base URL, so an absolute `url` was used.');
+  }
+  return notes;
+};
+
+/**
+ * Converts a raw cURL command into a workflow `request`-step snippet for the
+ * given connector. When the connector exposes a statically resolvable base URL
+ * and the pasted URL sits under it, the step uses a relative `path`; otherwise
+ * it falls back to an absolute `url`. Auth headers are stripped (the connector
+ * injects its own credentials).
+ */
+export const curlToRequestStep = (
+  connectorType: string,
+  rawCurl: string
+): CurlToRequestStepResult | CurlToRequestStepError => {
+  const parseResult = parseCurl(rawCurl);
+  if (!parseResult.ok) {
+    return { ok: false, error: parseResult.error };
+  }
+  const parsed = parseResult.value;
+
+  const spec = getConnectorSpecByType(connectorType);
+  const baseUrl = spec ? resolveStaticBaseUrl(spec) : null;
+  const relativePath = baseUrl ? toRelativePath(parsed.url, baseUrl) : null;
+
+  const stepType = `${connectorType.replace(/^\./, '')}.${GENERIC_REQUEST_SUB_ACTION}`;
+  const withBlock = buildWithBlock(parsed, relativePath);
+
+  const step = [
+    {
+      name: `${stepType.replaceAll('.', '_')}_step`,
+      type: stepType,
+      'connector-id': '# Enter connector UUID here',
+      with: withBlock,
+    },
+  ];
+
+  const snippet = stringify(step, YAML_OPTIONS);
+
+  return {
+    ok: true,
+    stepType,
+    snippet,
+    notes: buildNotes(parsed, relativePath),
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/curl/parse_curl.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/curl/parse_curl.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { parseCurl } from './parse_curl';
+
+const unwrap = (input: string) => {
+  const result = parseCurl(input);
+  if (!result.ok) {
+    throw new Error(`Expected parse to succeed, got: ${result.error}`);
+  }
+  return result.value;
+};
+
+describe('parseCurl', () => {
+  it('parses a simple GET with just a URL', () => {
+    const parsed = unwrap('curl https://api.example.com/v2/users');
+    expect(parsed.method).toBe('get');
+    expect(parsed.url).toBe('https://api.example.com/v2/users');
+    expect(parsed.headers).toEqual({});
+    expect(parsed.body).toBeUndefined();
+  });
+
+  it('reads an explicit method (case-insensitive)', () => {
+    expect(unwrap('curl -X POST https://api.example.com/x').method).toBe('post');
+    expect(unwrap('curl --request delete https://api.example.com/x').method).toBe('delete');
+  });
+
+  it('defaults to POST when a body is present without an explicit method', () => {
+    const parsed = unwrap(`curl https://api.example.com/x -d '{"a":1}'`);
+    expect(parsed.method).toBe('post');
+    expect(parsed.body).toEqual({ a: 1 });
+    expect(parsed.isJsonBody).toBe(true);
+  });
+
+  it('keeps a non-JSON body as a raw string', () => {
+    const parsed = unwrap(`curl https://api.example.com/x --data 'hello=world'`);
+    expect(parsed.body).toBe('hello=world');
+    expect(parsed.isJsonBody).toBe(false);
+  });
+
+  it('collects non-auth headers and preserves their casing', () => {
+    const parsed = unwrap(
+      `curl https://api.example.com/x -H 'Content-Type: application/json' -H 'X-Custom: 42'`
+    );
+    expect(parsed.headers).toEqual({
+      'Content-Type': 'application/json',
+      'X-Custom': '42',
+    });
+  });
+
+  it('strips Authorization and other auth headers from headers', () => {
+    const parsed = unwrap(
+      `curl https://api.example.com/x -H 'Authorization: Bearer secret' -H 'x-api-key: k' -H 'Accept: application/json'`
+    );
+    expect(parsed.headers).toEqual({ Accept: 'application/json' });
+    expect(parsed.strippedAuth.headerNames).toEqual(
+      expect.arrayContaining(['Authorization', 'x-api-key'])
+    );
+  });
+
+  it('strips -u/--user basic auth and records it', () => {
+    const parsed = unwrap('curl -u user:pass https://api.example.com/x');
+    expect(parsed.strippedAuth.hadUserFlag).toBe(true);
+  });
+
+  it('supports --header=value and --request=value equals syntax', () => {
+    const parsed = unwrap(
+      `curl --request=PUT --header='Content-Type: application/json' https://api.example.com/x`
+    );
+    expect(parsed.method).toBe('put');
+    expect(parsed.headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+
+  it('handles multi-line commands with backslash continuations', () => {
+    const parsed = unwrap(`curl -X POST \\
+      https://api.example.com/v2/messages \\
+      -H 'Content-Type: application/json' \\
+      -d '{"text":"hi"}'`);
+    expect(parsed.method).toBe('post');
+    expect(parsed.url).toBe('https://api.example.com/v2/messages');
+    expect(parsed.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(parsed.body).toEqual({ text: 'hi' });
+  });
+
+  it('ignores boolean flags and value flags it does not care about', () => {
+    const parsed = unwrap(
+      `curl -sSL --compressed -o out.json --max-time 30 https://api.example.com/x`
+    );
+    expect(parsed.url).toBe('https://api.example.com/x');
+  });
+
+  it('preserves the query string on the URL', () => {
+    const parsed = unwrap('curl "https://api.example.com/search?q=hello&limit=5"');
+    expect(parsed.url).toBe('https://api.example.com/search?q=hello&limit=5');
+  });
+
+  it('normalizes a bare host to https', () => {
+    const parsed = unwrap('curl api.example.com/x');
+    expect(parsed.url).toBe('https://api.example.com/x');
+  });
+
+  it('errors on empty input', () => {
+    const result = parseCurl('   ');
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors when no URL is present', () => {
+    const result = parseCurl('curl -X GET -H "Accept: application/json"');
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors on an unsupported method', () => {
+    const result = parseCurl('curl -X OPTIONS https://api.example.com/x');
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/curl/parse_curl.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/curl/parse_curl.ts
@@ -1,0 +1,310 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { GENERIC_REQUEST_METHODS, type GenericRequestMethod } from '@kbn/connector-specs';
+
+/**
+ * A cURL command parsed into the parts a workflow `request` step cares about.
+ * Auth is intentionally represented separately from `headers` so callers can
+ * strip it (the connector injects its own credentials) while still telling the
+ * user what was dropped.
+ */
+export interface ParsedCurl {
+  method: GenericRequestMethod;
+  /** The absolute URL exactly as it appeared in the command (query string included). */
+  url: string;
+  /** Non-auth headers, keyed by their original (case-preserved) name. */
+  headers: Record<string, string>;
+  /** Parsed request body, when a data flag was present. */
+  body?: unknown;
+  /** Whether the parsed body was valid JSON (vs. a raw string). */
+  isJsonBody: boolean;
+  /**
+   * Auth-bearing inputs that were removed from {@link headers}. Surfaced so the
+   * UI can note that the connector supplies authentication instead.
+   */
+  strippedAuth: {
+    /** Names of `Authorization`/`x-api-key`/cookie-style headers that were removed. */
+    headerNames: string[];
+    /** True when a `-u`/`--user` basic-auth flag was present (and dropped). */
+    hadUserFlag: boolean;
+  };
+}
+
+export interface ParseCurlOk {
+  ok: true;
+  value: ParsedCurl;
+}
+
+export interface ParseCurlError {
+  ok: false;
+  error: string;
+}
+
+export type ParseCurlResult = ParseCurlOk | ParseCurlError;
+
+const METHOD_SET = new Set<string>(GENERIC_REQUEST_METHODS);
+
+// Header names whose value is credential material. Matched case-insensitively.
+const AUTH_HEADER_NAMES = new Set(['authorization', 'x-api-key', 'api-key', 'cookie']);
+
+const isAuthHeaderName = (name: string): boolean => AUTH_HEADER_NAMES.has(name.toLowerCase());
+
+/**
+ * Tokenizes a shell-ish command line, honoring single/double quotes and
+ * backslash line continuations. This is intentionally minimal — enough for the
+ * cURL commands people copy from API docs — and does not attempt full POSIX
+ * shell semantics.
+ */
+const tokenize = (input: string): string[] => {
+  const tokens: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  let hasToken = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (inSingle) {
+      if (char === "'") {
+        inSingle = false;
+      } else {
+        current += char;
+      }
+    } else if (inDouble) {
+      if (char === '\\' && i + 1 < input.length) {
+        const next = input[i + 1];
+        // In double quotes, backslash only escapes a handful of characters.
+        if (next === '"' || next === '\\' || next === '$' || next === '`') {
+          current += next;
+          i++;
+        } else {
+          current += char;
+        }
+      } else if (char === '"') {
+        inDouble = false;
+      } else {
+        current += char;
+      }
+    } else if (char === "'") {
+      inSingle = true;
+      hasToken = true;
+    } else if (char === '"') {
+      inDouble = true;
+      hasToken = true;
+    } else if (char === '\\') {
+      // Line continuation (`\` at end of line) or escaped character.
+      const next = input[i + 1];
+      if (next === '\n' || next === '\r') {
+        i++;
+        if (next === '\r' && input[i + 1] === '\n') {
+          i++;
+        }
+      } else if (next !== undefined) {
+        current += next;
+        hasToken = true;
+        i++;
+      }
+    } else if (char === ' ' || char === '\t' || char === '\n' || char === '\r') {
+      if (hasToken) {
+        tokens.push(current);
+        current = '';
+        hasToken = false;
+      }
+    } else {
+      current += char;
+      hasToken = true;
+    }
+  }
+
+  if (hasToken) {
+    tokens.push(current);
+  }
+
+  return tokens;
+};
+
+const stripInlineComment = (input: string): string => input.replace(/`.*?`/gs, ' ');
+
+const parseHeaderToken = (raw: string): { name: string; value: string } | null => {
+  const separatorIndex = raw.indexOf(':');
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  const name = raw.slice(0, separatorIndex).trim();
+  const value = raw.slice(separatorIndex + 1).trim();
+  if (!name) {
+    return null;
+  }
+  return { name, value };
+};
+
+const tryParseJson = (raw: string): { value: unknown; isJson: boolean } => {
+  try {
+    return { value: JSON.parse(raw), isJson: true };
+  } catch {
+    return { value: raw, isJson: false };
+  }
+};
+
+// Flags that take a value we don't care about (auth, output, TLS, etc.). We
+// skip the flag AND its argument so it doesn't get misread as the URL.
+const VALUE_FLAGS_TO_SKIP = new Set([
+  '--url', // handled specially below (it IS the url)
+  '-o',
+  '--output',
+  '-A',
+  '--user-agent',
+  '-e',
+  '--referer',
+  '--connect-timeout',
+  '--max-time',
+  '-m',
+  '--cacert',
+  '--cert',
+  '-E',
+  '--key',
+  '--cookie',
+  '-b',
+  '--cookie-jar',
+  '-c',
+]);
+
+const DATA_FLAGS = new Set(['-d', '--data', '--data-raw', '--data-binary', '--data-ascii']);
+
+/**
+ * Parses a raw cURL command string into a {@link ParsedCurl}. Auth headers and
+ * `-u/--user` are recognized and reported via `strippedAuth` but excluded from
+ * `headers`, because a workflow `request` step reuses the connector's
+ * configured authentication.
+ */
+export const parseCurl = (rawInput: string): ParseCurlResult => {
+  const input = stripInlineComment(rawInput).trim();
+  if (!input) {
+    return { ok: false, error: 'Paste a cURL command to continue.' };
+  }
+
+  const tokens = tokenize(input);
+  if (tokens.length === 0) {
+    return { ok: false, error: 'Could not read the cURL command.' };
+  }
+
+  let cursor = 0;
+  if (tokens[cursor]?.toLowerCase() === 'curl') {
+    cursor++;
+  }
+
+  let explicitMethod: GenericRequestMethod | undefined;
+  let url: string | undefined;
+  const headers: Record<string, string> = {};
+  const strippedHeaderNames: string[] = [];
+  let hadUserFlag = false;
+  let body: unknown;
+  let isJsonBody = false;
+  let hasBody = false;
+
+  const consumeValue = (flag: string): string | null => {
+    // Support `--flag=value` as well as `--flag value`.
+    const eqIndex = flag.indexOf('=');
+    if (eqIndex !== -1) {
+      return flag.slice(eqIndex + 1);
+    }
+    cursor++;
+    return cursor < tokens.length ? tokens[cursor] : null;
+  };
+
+  // Processes a single token, mutating the accumulators above. Returns an error
+  // result to abort parsing, or `undefined` to move on to the next token.
+  const handleToken = (token: string): ParseCurlError | undefined => {
+    const flagName = token.includes('=') ? token.slice(0, token.indexOf('=')) : token;
+
+    if (flagName === '-X' || flagName === '--request') {
+      const value = consumeValue(token);
+      if (value && METHOD_SET.has(value.toLowerCase())) {
+        explicitMethod = value.toLowerCase() as GenericRequestMethod;
+      } else if (value) {
+        return { ok: false, error: `Unsupported HTTP method "${value}".` };
+      }
+    } else if (flagName === '-H' || flagName === '--header') {
+      const value = consumeValue(token);
+      const parsed = value ? parseHeaderToken(value) : null;
+      if (parsed) {
+        if (isAuthHeaderName(parsed.name)) {
+          strippedHeaderNames.push(parsed.name);
+        } else {
+          headers[parsed.name] = parsed.value;
+        }
+      }
+    } else if (flagName === '-u' || flagName === '--user') {
+      consumeValue(token);
+      hadUserFlag = true;
+    } else if (DATA_FLAGS.has(flagName)) {
+      const value = consumeValue(token);
+      if (value !== null) {
+        const parsed = tryParseJson(value);
+        body = parsed.value;
+        isJsonBody = parsed.isJson;
+        hasBody = true;
+      }
+    } else if (flagName === '--url') {
+      const value = consumeValue(token);
+      if (value) {
+        url = value;
+      }
+    } else if (VALUE_FLAGS_TO_SKIP.has(flagName)) {
+      consumeValue(token);
+    } else if (!token.startsWith('-') && url === undefined) {
+      // First bare token is the URL. (Boolean flags such as -s/-k/-L/-v and
+      // --compressed/--location are ignored by falling through.)
+      url = token;
+    }
+
+    return undefined;
+  };
+
+  for (; cursor < tokens.length; cursor++) {
+    const error = handleToken(tokens[cursor]);
+    if (error) {
+      return error;
+    }
+  }
+
+  if (!url) {
+    return { ok: false, error: 'No URL found in the cURL command.' };
+  }
+
+  // Normalize a bare host into an absolute URL (cURL defaults to http).
+  const normalizedUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(url) ? url : `https://${url}`;
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(normalizedUrl);
+  } catch {
+    return { ok: false, error: `Could not parse the URL "${url}".` };
+  }
+
+  // cURL defaults to GET, or POST when a body is present without an explicit method.
+  const method: GenericRequestMethod = explicitMethod ?? (hasBody ? 'post' : 'get');
+
+  return {
+    ok: true,
+    value: {
+      method,
+      url: parsedUrl.toString(),
+      headers,
+      ...(hasBody ? { body } : {}),
+      isJsonBody,
+      strippedAuth: {
+        headerNames: strippedHeaderNames,
+        hadUserFlag,
+      },
+    },
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/spec_connector_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/spec_connector_handler.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ConnectorSpec } from '@kbn/connector-specs';
+import {
+  connectorsSpecs,
+  DEFAULT_GENERIC_REQUEST_DESCRIPTION,
+  GENERIC_REQUEST_SUB_ACTION,
+} from '@kbn/connector-specs';
+import type { monaco } from '@kbn/monaco';
+import { BaseMonacoConnectorHandler } from './base_monaco_connector_handler';
+import { resolveStaticBaseUrl } from '../connector_specs/resolve_static_base_url';
+import type { ConnectorExamples, HoverContext } from '../monaco_providers/provider_interfaces';
+
+/**
+ * Builds a lookup of v2 connector-spec connectors keyed by their workflow
+ * connector-type name (the spec `metadata.id` without the leading dot, e.g.
+ * `.slack` -> `slack`).
+ */
+const buildSpecsByTypeName = (): Map<string, ConnectorSpec> => {
+  const map = new Map<string, ConnectorSpec>();
+  for (const spec of Object.values(connectorsSpecs) as ConnectorSpec[]) {
+    const id = spec?.metadata?.id;
+    if (typeof id === 'string' && id.length > 0) {
+      map.set(id.replace(/^\./, ''), spec);
+    }
+  }
+  return map;
+};
+
+/**
+ * Monaco hover handler for v2 connector-spec connectors. Surfaces the real
+ * per-action description from the connector spec (including the synthesized
+ * generic `request` action) instead of the keyword-based generic fallback.
+ */
+export class SpecConnectorMonacoHandler extends BaseMonacoConnectorHandler {
+  private readonly specsByTypeName: Map<string, ConnectorSpec>;
+
+  constructor() {
+    // Above the generic fallback (priority 1), below the dedicated
+    // elasticsearch/kibana handlers.
+    super('SpecConnectorMonacoHandler', 50, []);
+    this.specsByTypeName = buildSpecsByTypeName();
+  }
+
+  /**
+   * Split a workflow connector type (`{typeName}.{action}`) into its spec and
+   * action parts, if it maps to a known connector spec.
+   */
+  private resolve(
+    connectorType: string
+  ): { spec: ConnectorSpec; typeName: string; actionName: string } | null {
+    const separatorIndex = connectorType.indexOf('.');
+    if (separatorIndex <= 0) {
+      return null;
+    }
+    const typeName = connectorType.slice(0, separatorIndex);
+    const actionName = connectorType.slice(separatorIndex + 1);
+    const spec = this.specsByTypeName.get(typeName);
+    if (!spec || !actionName) {
+      return null;
+    }
+    return { spec, typeName, actionName };
+  }
+
+  canHandle(connectorType: string): boolean {
+    return this.resolve(connectorType) !== null;
+  }
+
+  async generateHoverContent(context: HoverContext): Promise<monaco.IMarkdownString | null> {
+    try {
+      const { connectorType, stepContext } = context;
+      if (!stepContext) {
+        return null;
+      }
+
+      const resolved = this.resolve(connectorType);
+      if (!resolved) {
+        return null;
+      }
+      const { spec, actionName } = resolved;
+
+      const description = this.getActionDescription(spec, actionName);
+      if (!description) {
+        return null;
+      }
+
+      const bodyLines = [
+        `**Connector**: \`${spec.metadata.displayName}\``,
+        '',
+        `**Action**: \`${actionName}\``,
+        '',
+        description,
+      ];
+
+      // For the generic request action, surface the base URL that a relative
+      // `path` resolves against so authors know what to prefix.
+      if (actionName === GENERIC_REQUEST_SUB_ACTION && !spec.disableGenericRequest) {
+        bodyLines.push('', this.getBaseUrlHint(spec));
+      }
+
+      bodyLines.push(
+        '',
+        '_💡 Tip: Use Ctrl+Space for parameter autocomplete in the `with` block._'
+      );
+
+      return this.createMarkdownContent(
+        this.prependStabilityBadgeToContent(
+          this.getConnectorStabilityFromCache(connectorType),
+          bodyLines
+        )
+      );
+    } catch (error) {
+      return null;
+    }
+  }
+
+  getExamples(): ConnectorExamples | null {
+    return null;
+  }
+
+  /**
+   * Resolves the human-readable description for an action, falling back to the
+   * generic request description for the framework-synthesized `request` action.
+   */
+  private getActionDescription(spec: ConnectorSpec, actionName: string): string | null {
+    const definedDescription = spec.actions?.[actionName]?.description;
+    if (definedDescription) {
+      return definedDescription;
+    }
+    if (actionName === GENERIC_REQUEST_SUB_ACTION && !spec.disableGenericRequest) {
+      return spec.genericRequestDescription ?? DEFAULT_GENERIC_REQUEST_DESCRIPTION;
+    }
+    return null;
+  }
+
+  /**
+   * Builds the base-URL hint line for the request action. Constant-host specs
+   * resolve to a literal (their `getBaseUrl` ignores the context); config- or
+   * secret-derived specs cannot be resolved at authoring time, so we show a note
+   * instead. Specs without `getBaseUrl` (multi-host) only accept an absolute
+   * `url`.
+   */
+  private getBaseUrlHint(spec: ConnectorSpec): string {
+    if (!spec.getBaseUrl) {
+      return '**Base URL**: _not available — provide an absolute `url` (this connector targets multiple hosts)._';
+    }
+    const staticBaseUrl = resolveStaticBaseUrl(spec);
+    if (staticBaseUrl) {
+      return `**Base URL** (\`path\` is appended to this): \`${staticBaseUrl}\``;
+    }
+    return '**Base URL**: resolved from the connector configuration at run time; `path` is appended to it.';
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/snippets/insert_step_snippet.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/snippets/insert_step_snippet.ts
@@ -448,12 +448,24 @@ function getInsertPointFromCursor(
   return at(cursorLine + 1, false);
 }
 
+export interface InsertStepSnippetOptions {
+  /**
+   * Pre-built snippet text for a single step-sequence item (the `- name: …`
+   * block, without a `steps:` header). When provided, it is inserted verbatim
+   * (re-indented to the insert location) instead of generating one from
+   * `stepType`. Used by flows that build a fully-formed step ahead of time,
+   * e.g. mapping a pasted cURL command to a `request` step.
+   */
+  snippetOverride?: string;
+}
+
 export function insertStepSnippet(
   model: monaco.editor.ITextModel,
   yamlDocument: Document | null,
   stepType: string,
   cursorPosition?: monaco.Position | null,
-  editor?: monaco.editor.IStandaloneCodeEditor
+  editor?: monaco.editor.IStandaloneCodeEditor,
+  { snippetOverride }: InsertStepSnippetOptions = {}
 ) {
   let document: Document;
   try {
@@ -467,7 +479,9 @@ export function insertStepSnippet(
 
   if (!stepsPair) {
     const lineCount = model.getLineCount();
-    const insertText = isBuiltInStepType(stepType)
+    const insertText = snippetOverride
+      ? `steps:\n${prependIndentToLines(snippetOverride, 2)}`
+      : isBuiltInStepType(stepType)
       ? generateBuiltInStepSnippet(stepType, { full: true, withStepsSection: true })
       : generateConnectorSnippet(stepType, { full: true, withStepsSection: true });
 
@@ -551,9 +565,11 @@ export function insertStepSnippet(
     }
   }
 
-  const snippetText = isBuiltInStepType(stepType)
-    ? generateBuiltInStepSnippet(stepType, { full: true, withStepsSection: false })
-    : generateConnectorSnippet(stepType, { full: true, withStepsSection: false });
+  const snippetText =
+    snippetOverride ??
+    (isBuiltInStepType(stepType)
+      ? generateBuiltInStepSnippet(stepType, { full: true, withStepsSection: false })
+      : generateConnectorSnippet(stepType, { full: true, withStepsSection: false }));
 
   if (editor) editor.pushUndoStop();
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/build_request_from_curl_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/build_request_from_curl_modal.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiCodeBlock,
+  EuiFormRow,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiTextArea,
+} from '@elastic/eui';
+import React, { useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { curlToRequestStep } from '../lib/curl/curl_to_request_step';
+
+export interface BuildRequestFromCurlModalProps {
+  connectorType: string;
+  onClose: () => void;
+  /** Called with the generated single-step YAML snippet when the user inserts it. */
+  onInsert: (snippet: string) => void;
+}
+
+/**
+ * A lightweight modal that turns a pasted cURL command into a `request` step for
+ * the given connector. Auth is stripped (the connector injects its own), and a
+ * relative `path` is used when the URL matches the connector's base URL.
+ */
+export const BuildRequestFromCurlModal = ({
+  connectorType,
+  onClose,
+  onInsert,
+}: BuildRequestFromCurlModalProps) => {
+  const [curl, setCurl] = useState('');
+  const modalTitleId = useMemo(
+    () => `buildRequestFromCurl-${Math.random().toString(36).slice(2)}`,
+    []
+  );
+
+  const result = useMemo(() => {
+    if (!curl.trim()) {
+      return null;
+    }
+    return curlToRequestStep(connectorType, curl);
+  }, [connectorType, curl]);
+
+  const canInsert = result?.ok === true;
+
+  const handleInsert = () => {
+    if (result?.ok) {
+      onInsert(result.snippet);
+      onClose();
+    }
+  };
+
+  return (
+    <EuiModal onClose={onClose} aria-labelledby={modalTitleId} maxWidth={640}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={modalTitleId}>
+          <FormattedMessage
+            id="workflows.buildRequestFromCurl.title"
+            defaultMessage="Build a request from cURL"
+          />
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiFormRow
+          label={i18n.translate('workflows.buildRequestFromCurl.inputLabel', {
+            defaultMessage: 'Paste a cURL command',
+          })}
+          helpText={i18n.translate('workflows.buildRequestFromCurl.inputHelp', {
+            defaultMessage:
+              'Authentication is handled by the connector, so any auth headers you paste are ignored.',
+          })}
+          fullWidth
+        >
+          <EuiTextArea
+            fullWidth
+            rows={6}
+            value={curl}
+            onChange={(e) => setCurl(e.target.value)}
+            placeholder={`curl -X POST https://api.example.com/v2/resource -d '{"key":"value"}'`}
+            data-test-subj="buildRequestFromCurlInput"
+            autoFocus
+          />
+        </EuiFormRow>
+
+        {result && !result.ok && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              announceOnMount
+              color="danger"
+              size="s"
+              title={i18n.translate('workflows.buildRequestFromCurl.parseError', {
+                defaultMessage: "Couldn't parse that cURL command",
+              })}
+            >
+              {result.error}
+            </EuiCallOut>
+          </>
+        )}
+
+        {result?.ok && (
+          <>
+            {result.notes.length > 0 && (
+              <>
+                <EuiSpacer size="m" />
+                <EuiCallOut announceOnMount={false} color="primary" size="s" iconType="info">
+                  <ul style={{ margin: 0, paddingInlineStart: 16 }}>
+                    {result.notes.map((note) => (
+                      <li key={note}>{note}</li>
+                    ))}
+                  </ul>
+                </EuiCallOut>
+              </>
+            )}
+            <EuiSpacer size="m" />
+            <EuiFormRow
+              label={i18n.translate('workflows.buildRequestFromCurl.previewLabel', {
+                defaultMessage: 'Preview',
+              })}
+              fullWidth
+            >
+              <EuiCodeBlock language="yaml" fontSize="s" paddingSize="s" isCopyable>
+                {result.snippet}
+              </EuiCodeBlock>
+            </EuiFormRow>
+          </>
+        )}
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={onClose}>
+          <FormattedMessage id="workflows.buildRequestFromCurl.cancel" defaultMessage="Cancel" />
+        </EuiButtonEmpty>
+        <EuiButton
+          fill
+          onClick={handleInsert}
+          disabled={!canInsert}
+          data-test-subj="buildRequestFromCurlInsert"
+        >
+          <FormattedMessage
+            id="workflows.buildRequestFromCurl.insert"
+            defaultMessage="Insert step"
+          />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -16,12 +16,14 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux-v7';
 import type YAML from 'yaml';
 import { monaco, YAML_LANG_ID } from '@kbn/code-editor';
+import { GENERIC_REQUEST_SUB_ACTION } from '@kbn/connector-specs';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { isTriggerType, WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/workflows';
 import { useWorkflowsMonacoTheme, WORKFLOW_MONACO_LAYOUT_OPTIONS } from '@kbn/workflows-ui';
 import type { z } from '@kbn/zod/v4';
 import { ActionsMenuButton } from './actions_menu_button';
+import { BuildRequestFromCurlModal } from './build_request_from_curl_modal';
 import {
   useAlertTriggerDecorations,
   useConnectorTypeDecorations,
@@ -72,6 +74,7 @@ import {
 import { ActionsMenuPopover } from '../../../features/actions_menu_popover';
 import type {
   ActionOptionData,
+  BuildRequestMode,
   EditorCommand,
   JumpToStepEntry,
 } from '../../../features/actions_menu_popover/types';
@@ -666,6 +669,40 @@ export const WorkflowYAMLEditor = ({
     [closeActionsPopover, isReadOnlyYaml]
   );
 
+  // Connector type (e.g. `.slack`) whose "Build from cURL" modal is open, if any.
+  const [buildRequestConnectorType, setBuildRequestConnectorType] = useState<string | null>(null);
+
+  const insertRequestStep = useCallback(
+    (connectorType: string, snippetOverride?: string) => {
+      if (isReadOnlyYaml) {
+        return;
+      }
+      const model = editorRef.current?.getModel();
+      const editor = editorRef.current;
+      if (!model || !editor) {
+        return;
+      }
+      const stepType = `${connectorType.replace(/^\./, '')}.${GENERIC_REQUEST_SUB_ACTION}`;
+      insertStepSnippet(model, yamlDocumentRef.current, stepType, editor.getPosition(), editor, {
+        snippetOverride,
+      });
+      editor.focus();
+    },
+    [isReadOnlyYaml]
+  );
+
+  const onBuildRequestSelected = useCallback(
+    (connectorType: string, mode: BuildRequestMode) => {
+      closeActionsPopover();
+      if (mode === 'scratch') {
+        insertRequestStep(connectorType);
+        return;
+      }
+      setBuildRequestConnectorType(connectorType);
+    },
+    [closeActionsPopover, insertRequestStep]
+  );
+
   const editorCommands: EditorCommand[] = useMemo(() => {
     const cmds: EditorCommand[] = [
       {
@@ -863,7 +900,15 @@ export const WorkflowYAMLEditor = ({
         jumpToStepEntries={jumpToStepEntries}
         onCommandSelected={handleCommandSelected}
         onJumpToStep={handleJumpToStep}
+        onBuildRequestSelected={onBuildRequestSelected}
       />
+      {buildRequestConnectorType && (
+        <BuildRequestFromCurlModal
+          connectorType={buildRequestConnectorType}
+          onClose={() => setBuildRequestConnectorType(null)}
+          onInsert={(snippet) => insertRequestStep(buildRequestConnectorType, snippet)}
+        />
+      )}
       <UnsavedChangesPrompt hasUnsavedChanges={hasChanges} shouldPromptOnNavigation={true} />
       {/* Floating Elasticsearch step actions — anchored to the focused
           step's line in the Monaco editor, so they're meaningless (and


### PR DESCRIPTION
## Summary

Adds a contextual **"couldn't find your action? build one"** affordance inside a connector's submenu in the workflow YAML editor's actions palette, with two modes:

- **From scratch** – inserts a generic `request` step skeleton.
- **From cURL** – opens a lightweight modal that parses a pasted cURL command and inserts a mapped `request` step, with a live YAML preview.

https://github.com/user-attachments/assets/6fc06fdf-1b98-4e05-99a0-e19c72a4f5d6

The hand-rolled cURL parser (no new deps) extracts method, url, headers, and body, and strips authentication headers / `-u` (the connector injects its own auth). Mapping prefers a relative `path` when the URL matches the connector's statically resolvable base URL, otherwise falls back to an absolute `url`.



## ⚠️ Stacked on top of #280920

This is stacked on the generic `request` action work in **#280920** (branch `generic_request_connectors`) and depends on the `request` / `getBaseUrl` / `disableGenericRequest` infra introduced there.

Because this branch is cut from `main` rather than stacked in git, **it will not build/typecheck standalone until #280920 merges** — the new code imports symbols (`GENERIC_REQUEST_SUB_ACTION`, `getBaseUrl`, `disableGenericRequest`, `genericRequestDescription`, etc.) that only exist on that branch. Please review after / together with #280920.