### PR TITLE
[VectorDB] Add Scout UI and API tests for serverless_vectordb

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -70,6 +70,7 @@ plugins:
     - security
     - security_solution
     - serverless_observability
+    - serverless_vectordb
     - share
     - significant_events
     - slo

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/README.md
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/README.md
@@ -1,0 +1,34 @@
+# Scout tests for serverless_vectordb
+
+The Vector DB plugin only runs in serverless Vector DB projects, so all suites are
+tagged with `tags.serverless.vectordb` and run against `--arch serverless --domain vectordb`.
+
+## How to run tests
+
+Run everything with managed servers:
+
+```bash
+# UI (parallel)
+node scripts/scout.js run-tests --arch serverless --domain vectordb --config x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel.playwright.config.ts
+
+# API
+node scripts/scout.js run-tests --arch serverless --domain vectordb --config x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/playwright.config.ts
+```
+
+For faster iteration, start the servers once:
+
+```bash
+node scripts/scout.js start-server --arch serverless --domain vectordb
+```
+
+Then run Playwright directly in another terminal:
+
+```bash
+# UI (parallel)
+node scripts/playwright test --project local --config x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel.playwright.config.ts
+
+# API
+node scripts/playwright test --project local --config x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/playwright.config.ts
+```
+
+Test results are available in `x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/{ui,api}/output`.

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/constants.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const DEPLOYMENT_STATS_API_PATH = 'internal/serverless_vectordb/deployment_stats';
+export const API_KEY_API_PATH = 'internal/serverless_vectordb/api_key';
+
+/** Name prefix used by the api_key route (server/routes/api_key.ts). */
+export const ONBOARDING_KEY_NAME_PREFIX = 'vectordb-onboarding-';
+
+// Both routes are unversioned internal routes, so no elastic-api-version header
+export const COMMON_HEADERS = {
+  'kbn-xsrf': 'some-xsrf-token',
+  'x-elastic-internal-origin': 'kibana',
+  'Content-Type': 'application/json;charset=UTF-8',
+} as const;

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/fixtures/index.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/fixtures/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { apiTest } from '@kbn/scout';

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/playwright.config.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/tests/api_key.spec.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/tests/api_key.spec.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+import { apiTest } from '../fixtures';
+import { API_KEY_API_PATH, COMMON_HEADERS, ONBOARDING_KEY_NAME_PREFIX } from '../constants';
+
+const invalidateOnboardingKeys = async (esClient: Client) => {
+  const { api_keys: apiKeys } = await esClient.security.getApiKey({
+    name: `${ONBOARDING_KEY_NAME_PREFIX}*`,
+  });
+  const ids = apiKeys.filter((key) => !key.invalidated).map((key) => key.id);
+  if (ids.length > 0) {
+    await esClient.security.invalidateApiKey({ ids });
+  }
+};
+
+apiTest.describe('Vector DB onboarding API key API', { tag: [...tags.serverless.vectordb] }, () => {
+  let cookieHeader: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    ({ cookieHeader } = await samlAuth.asInteractiveUser('admin'));
+  });
+
+  // The route treats any active `vectordb-onboarding-*` key as "already onboarded",
+  // so each test needs a clean slate; also clean up after the suite.
+  apiTest.beforeEach(async ({ esClient }) => {
+    await invalidateOnboardingKeys(esClient);
+  });
+
+  apiTest.afterAll(async ({ esClient }) => {
+    await invalidateOnboardingKeys(esClient);
+  });
+
+  apiTest('POST creates an onboarding API key when none is active', async ({ apiClient }) => {
+    const response = await apiClient.post(API_KEY_API_PATH, {
+      headers: { ...COMMON_HEADERS, ...cookieHeader },
+      body: JSON.stringify({}),
+    });
+
+    expect(response).toHaveStatusCode(200);
+    expect(typeof response.body.id).toBe('string');
+    expect(response.body.name).toMatch(new RegExp(`^${ONBOARDING_KEY_NAME_PREFIX}`));
+    expect(typeof response.body.encoded).toBe('string');
+  });
+
+  apiTest(
+    'POST returns nulls when an active onboarding key already exists',
+    async ({ apiClient }) => {
+      const first = await apiClient.post(API_KEY_API_PATH, {
+        headers: { ...COMMON_HEADERS, ...cookieHeader },
+        body: JSON.stringify({}),
+      });
+      expect(first).toHaveStatusCode(200);
+      expect(typeof first.body.id).toBe('string');
+
+      const second = await apiClient.post(API_KEY_API_PATH, {
+        headers: { ...COMMON_HEADERS, ...cookieHeader },
+        body: JSON.stringify({}),
+      });
+      expect(second).toHaveStatusCode(200);
+      expect(second.body).toStrictEqual({ id: null, name: null, encoded: null });
+    }
+  );
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/tests/deployment_stats.spec.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/tests/deployment_stats.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+import { apiTest } from '../fixtures';
+import { COMMON_HEADERS, DEPLOYMENT_STATS_API_PATH } from '../constants';
+
+apiTest.describe('Vector DB deployment stats API', { tag: [...tags.serverless.vectordb] }, () => {
+  let cookieHeader: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    ({ cookieHeader } = await samlAuth.asInteractiveUser('admin'));
+  });
+
+  apiTest('GET returns deployment stats with the expected shape', async ({ apiClient }) => {
+    const response = await apiClient.get(DEPLOYMENT_STATS_API_PATH, {
+      headers: { ...COMMON_HEADERS, ...cookieHeader },
+    });
+
+    expect(response).toHaveStatusCode(200);
+
+    const { body } = response;
+    expect(Object.keys(body).sort()).toStrictEqual([
+      'dashboardsCount',
+      'indicesCount',
+      'storeSizeBytes',
+      'vectorDocsCount',
+    ]);
+    // Counts are numbers, or null when the underlying fetch could not resolve them
+    for (const key of Object.keys(body)) {
+      const value = body[key];
+      expect(value === null || typeof value === 'number').toBe(true);
+    }
+  });
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * localStorage key checked by `hasSeenOnboarding()` in `@kbn/vectordb-onboarding`
+ * (`src/storage_keys.ts`, not exported from the package entry point). When unset,
+ * `/app/vectordb` redirects to the onboarding landing page and chrome is hidden.
+ */
+export const ONBOARDING_SEEN_STORAGE_KEY = 'serverless.onboarding.completed';
+
+/**
+ * Budget for chrome nav and app shells on serverless — primary nav and lazily
+ * mounted app roots can lag behind Playwright defaults (see gh-267186).
+ */
+export const VECTORDB_SPA_SHELL_TIMEOUT_MS = 45_000;

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/index.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/index.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  PageObjects,
+  ScoutTestFixtures,
+  ScoutWorkerFixtures,
+  ScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures,
+} from '@kbn/scout';
+import { test as baseTest, spaceTest as spaceBase, createLazyPageObject } from '@kbn/scout';
+import {
+  VectordbOnboardingPage,
+  VectordbHomePage,
+  VectordbTutorialsPage,
+  VectordbNavigation,
+} from './page_objects';
+
+export interface ExtScoutTestFixtures extends ScoutTestFixtures {
+  pageObjects: PageObjects & {
+    vectordbOnboarding: VectordbOnboardingPage;
+    vectordbHome: VectordbHomePage;
+    vectordbTutorials: VectordbTutorialsPage;
+    vectordbNavigation: VectordbNavigation;
+  };
+}
+
+export interface ExtScoutParallelTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: ScoutParallelTestFixtures['pageObjects'] & {
+    vectordbOnboarding: VectordbOnboardingPage;
+    vectordbHome: VectordbHomePage;
+    vectordbTutorials: VectordbTutorialsPage;
+    vectordbNavigation: VectordbNavigation;
+  };
+}
+
+export const test = baseTest.extend<ExtScoutTestFixtures, ScoutWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: ExtScoutTestFixtures['pageObjects'];
+      page: ExtScoutTestFixtures['page'];
+    },
+    use: (pageObjects: ExtScoutTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    const extendedPageObjects = {
+      ...pageObjects,
+      vectordbOnboarding: createLazyPageObject(VectordbOnboardingPage, page),
+      vectordbHome: createLazyPageObject(VectordbHomePage, page),
+      vectordbTutorials: createLazyPageObject(VectordbTutorialsPage, page),
+      vectordbNavigation: createLazyPageObject(VectordbNavigation, page),
+    };
+
+    await use(extendedPageObjects);
+  },
+});
+
+export const spaceTest = spaceBase.extend<
+  ExtScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures
+>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: ExtScoutParallelTestFixtures['pageObjects'];
+      page: ExtScoutParallelTestFixtures['page'];
+    },
+    use: (pageObjects: ExtScoutParallelTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    const extendedPageObjects = {
+      ...pageObjects,
+      vectordbOnboarding: createLazyPageObject(VectordbOnboardingPage, page),
+      vectordbHome: createLazyPageObject(VectordbHomePage, page),
+      vectordbTutorials: createLazyPageObject(VectordbTutorialsPage, page),
+      vectordbNavigation: createLazyPageObject(VectordbNavigation, page),
+    };
+
+    await use(extendedPageObjects);
+  },
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/mocks.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/mocks.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+
+const DEPLOYMENT_STATS_ROUTE = '**/internal/serverless_vectordb/deployment_stats';
+
+export interface MockDeploymentStats {
+  indicesCount: number | null;
+  storeSizeBytes: number | null;
+  vectorDocsCount: number | null;
+  dashboardsCount: number | null;
+}
+
+export const EMPTY_DEPLOYMENT_STATS: MockDeploymentStats = {
+  indicesCount: 0,
+  storeSizeBytes: 0,
+  vectorDocsCount: 0,
+  dashboardsCount: 0,
+};
+
+export const POPULATED_DEPLOYMENT_STATS: MockDeploymentStats = {
+  indicesCount: 3,
+  storeSizeBytes: 123456789,
+  vectorDocsCount: 42000,
+  dashboardsCount: 2,
+};
+
+/**
+ * Mocks `GET /internal/serverless_vectordb/deployment_stats` so home page tests can
+ * deterministically exercise both banner states: `hasData` is derived from
+ * `vectorDocsCount`/`indicesCount` in `HomePage` (`public/home/home_page.tsx`).
+ */
+export async function mockDeploymentStats(page: ScoutPage, stats: MockDeploymentStats) {
+  await page.route(DEPLOYMENT_STATS_ROUTE, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(stats),
+    });
+  });
+}
+
+export async function unmockDeploymentStats(page: ScoutPage) {
+  await page.unroute(DEPLOYMENT_STATS_ROUTE);
+}

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/home_page.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/home_page.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+
+/** Vector DB home page: stats overview, banner CTA, and documentation quick links. */
+export class VectordbHomePage {
+  readonly banner: Locator;
+  readonly getStartedButton: Locator;
+  readonly viewSupportedModelsButton: Locator;
+  readonly viewDocumentationLink: Locator;
+  readonly quickLinkPanels: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.banner = page.testSubj.locator('homePageBanner');
+    this.getStartedButton = page.testSubj.locator('homePageBannerGetStartedBtn');
+    this.viewSupportedModelsButton = page.testSubj.locator('homePageBannerViewSupportedModelsBtn');
+    this.viewDocumentationLink = page.testSubj.locator('viewDocumentationLink');
+    this.quickLinkPanels = page.locator('[data-test-subj^="quickLinkPanel-"]');
+  }
+
+  async goto() {
+    await this.page.gotoApp('vectordb');
+  }
+
+  quickLinkPanel(id: string): Locator {
+    return this.page.testSubj.locator(`quickLinkPanel-${id}`);
+  }
+}

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { VectordbOnboardingPage } from './onboarding_page';
+export { VectordbHomePage } from './home_page';
+export { VectordbTutorialsPage } from './tutorials_page';
+export { VectordbNavigation } from './navigation';

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/navigation.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/navigation.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+import { VECTORDB_SPA_SHELL_TIMEOUT_MS } from '../constants';
+
+/**
+ * Chrome side nav for the Vector DB project — locators and actions only; specs own `expect`.
+ * Modeled on `ObservabilityNavigation` in `@kbn/scout-oblt`.
+ */
+export class VectordbNavigation {
+  readonly sidenav: Locator;
+  readonly primaryNav: Locator;
+  readonly footerNav: Locator;
+  readonly breadcrumbs: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.sidenav = page.testSubj.locator('kbnChromeLayoutNavigation');
+    this.primaryNav = page.testSubj.locator('kbnChromeNav-primaryNavigation');
+    this.footerNav = page.testSubj.locator('kbnChromeNav-footer');
+    this.breadcrumbs = page.testSubj.locator('breadcrumbs');
+  }
+
+  async goto() {
+    await this.page.gotoApp('vectordb');
+  }
+
+  /** Waits on `primaryNav` (outer layout can be 0-width until CSS vars apply). */
+  async waitForLoad(options?: { timeout?: number }) {
+    await this.primaryNav.waitFor({
+      state: 'visible',
+      timeout: options?.timeout ?? VECTORDB_SPA_SHELL_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * App root or one of the shared no-data shells: Discover/Dashboards delegate to
+   * `KibanaNoDataPage`, which renders `kbnNoDataPage` or `noDataViewsPrompt` depending
+   * on cluster state. The shells are mutually exclusive, so an `.or()` chain is enough.
+   */
+  pageOrNoData(testSubj: string): Locator {
+    return this.page.testSubj
+      .locator(testSubj)
+      .or(this.page.testSubj.locator('kbnNoDataPage'))
+      .or(this.page.testSubj.locator('noDataViewsPrompt'));
+  }
+
+  navItemInPrimaryByDeepLinkId(deepLinkId: string): Locator {
+    return this.primaryNav.locator(`[data-test-subj~="nav-item-deepLinkId-${deepLinkId}"]`);
+  }
+
+  navItemInPrimaryById(id: string): Locator {
+    return this.primaryNav.locator(`[data-test-subj~="nav-item-id-${id}"]`);
+  }
+
+  navItemInFooterByDeepLinkId(deepLinkId: string): Locator {
+    return this.footerNav.locator(`[data-test-subj~="nav-item-deepLinkId-${deepLinkId}"]`);
+  }
+
+  navItemInFooterById(id: string): Locator {
+    return this.footerNav.locator(`[data-test-subj~="nav-item-id-${id}"]`);
+  }
+
+  /** Item with `nav-item-isActive` in test-subj (current route). */
+  activeNavItemByDeepLinkId(deepLinkId: string): Locator {
+    return this.sidenav.locator(
+      `[data-test-subj~="nav-item-deepLinkId-${deepLinkId}"][data-test-subj~="nav-item-isActive"]`
+    );
+  }
+
+  sidePanel(id: string): Locator {
+    return this.page.testSubj.locator(`~kbnChromeNav-sidePanel_${id}`);
+  }
+}

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/onboarding_page.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/onboarding_page.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+
+/** Onboarding landing page (path selection) and the ingest/search wizard steps. */
+export class VectordbOnboardingPage {
+  // Path selection landing page
+  readonly generatePathCard: Locator;
+  readonly storePathCard: Locator;
+  readonly skipButton: Locator;
+  readonly documentationLink: Locator;
+
+  // Wizard steps (ingest/search)
+  readonly snippet: Locator;
+  readonly languagePicker: Locator;
+  readonly copyCodeButton: Locator;
+  readonly runInConsoleButton: Locator;
+  readonly stepsRail: Locator;
+  readonly continueToSearchButton: Locator;
+  readonly completeSetupButton: Locator;
+  readonly backButton: Locator;
+  readonly connectionDetailsButton: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.generatePathCard = page.testSubj.locator('vectordbPathSelectionGenerate');
+    this.storePathCard = page.testSubj.locator('vectordbPathSelectionStore');
+    this.skipButton = page.testSubj.locator('vectordbPathSelectionSkip');
+    this.documentationLink = page.testSubj.locator('vectordbPathSelectionDocumentation');
+
+    this.snippet = page.testSubj.locator('vectordbWizardSnippet');
+    this.languagePicker = page.testSubj.locator('vectordbWizardLanguagePicker');
+    this.copyCodeButton = page.testSubj.locator('vectordbWizardCopyCode');
+    this.runInConsoleButton = page.testSubj.locator('vectordbWizardRunInConsole');
+    this.stepsRail = page.testSubj.locator('vectordbWizardSteps');
+    this.continueToSearchButton = page.testSubj.locator('vectordbWizardContinueToSearch');
+    this.completeSetupButton = page.testSubj.locator('vectordbWizardCompleteSetup');
+    this.backButton = page.testSubj.locator('stepLayoutBackToOnboarding');
+    this.connectionDetailsButton = page.testSubj.locator('openConnectionDetails');
+  }
+
+  async goto() {
+    await this.page.gotoApp('vectordb');
+  }
+
+  languageOption(languageId: string): Locator {
+    return this.page.testSubj.locator(`vectordbWizardLanguageOption-${languageId}`);
+  }
+
+  async selectLanguage(languageId: string) {
+    await this.languagePicker.click();
+    await this.languageOption(languageId).click();
+  }
+}

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/tutorials_page.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/fixtures/page_objects/tutorials_page.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+
+/** Tutorials ("Getting started") page: topic filter and tutorial cards. */
+export class VectordbTutorialsPage {
+  readonly topicFilter: Locator;
+  readonly tutorialCards: Locator;
+  readonly generatePathCard: Locator;
+  readonly storePathCard: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.topicFilter = page.testSubj.locator('tutorialsTopicFilter');
+    this.tutorialCards = page.locator('[data-test-subj^="tutorialCard-"]');
+    this.generatePathCard = page.testSubj.locator('vectordbPathSelectionGenerate');
+    this.storePathCard = page.testSubj.locator('vectordbPathSelectionStore');
+  }
+
+  async goto() {
+    await this.page.gotoApp('vectordb/tutorials');
+  }
+
+  tutorialCard(id: string): Locator {
+    return this.page.testSubj.locator(`tutorialCard-${id}`);
+  }
+
+  /** EuiButtonGroup option; options carry labels but no per-button test subject. */
+  topicFilterButton(label: string): Locator {
+    return this.topicFilter.getByRole('button', { name: label });
+  }
+}

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel.playwright.config.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel.playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './parallel_tests',
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/global.setup.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { globalSetupHook } from '@kbn/scout';
+
+globalSetupHook('Setup environment for Vector DB tests', async ({}) => {});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/home.spec.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/home.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../fixtures';
+import { ONBOARDING_SEEN_STORAGE_KEY } from '../fixtures/constants';
+import {
+  EMPTY_DEPLOYMENT_STATS,
+  POPULATED_DEPLOYMENT_STATS,
+  mockDeploymentStats,
+} from '../fixtures/mocks';
+
+test.describe('Vector DB home page', { tag: [...tags.serverless.vectordb] }, () => {
+  test.beforeEach(async ({ browserAuth, page }) => {
+    await browserAuth.loginAsAdmin();
+    // Skip the first-load onboarding redirect (see routes.tsx / hasSeenOnboarding)
+    await page.addInitScript((key) => {
+      window.localStorage.setItem(key, 'true');
+    }, ONBOARDING_SEEN_STORAGE_KEY);
+  });
+
+  test('renders the overview with banner and documentation quick links', async ({
+    pageObjects,
+  }) => {
+    const home = pageObjects.vectordbHome;
+    await home.goto();
+
+    await expect(home.banner).toBeVisible();
+    await expect(home.viewDocumentationLink).toBeVisible();
+    await expect(home.quickLinkPanels).toHaveCount(3);
+  });
+
+  test('empty deployment shows the Get started CTA and navigates to tutorials', async ({
+    pageObjects,
+    page,
+  }) => {
+    await mockDeploymentStats(page, EMPTY_DEPLOYMENT_STATS);
+    const home = pageObjects.vectordbHome;
+    await home.goto();
+
+    await expect(home.getStartedButton).toBeVisible();
+    await home.getStartedButton.click();
+
+    await expect(pageObjects.vectordbTutorials.topicFilter).toBeVisible();
+    await expect(page).toHaveURL(/\/app\/vectordb\/tutorials/);
+  });
+
+  test('populated deployment shows the View supported models CTA', async ({
+    pageObjects,
+    page,
+  }) => {
+    await mockDeploymentStats(page, POPULATED_DEPLOYMENT_STATS);
+    const home = pageObjects.vectordbHome;
+    await home.goto();
+
+    await expect(home.viewSupportedModelsButton).toBeVisible();
+    await expect(home.getStartedButton).toBeHidden();
+  });
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/navigation.spec.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/navigation.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../fixtures';
+import { ONBOARDING_SEEN_STORAGE_KEY, VECTORDB_SPA_SHELL_TIMEOUT_MS } from '../fixtures/constants';
+
+test.describe('Vector DB navigation', { tag: [...tags.serverless.vectordb] }, () => {
+  test.beforeEach(async ({ browserAuth, page, pageObjects }) => {
+    await browserAuth.loginAsAdmin();
+    // Side nav is hidden until onboarding has been seen (public/plugin.ts)
+    await page.addInitScript((key) => {
+      window.localStorage.setItem(key, 'true');
+    }, ONBOARDING_SEEN_STORAGE_KEY);
+    await pageObjects.vectordbNavigation.goto();
+    await pageObjects.vectordbNavigation.waitForLoad();
+  });
+
+  test('renders expected body and footer nav items with working links', async ({ pageObjects }) => {
+    const nav = pageObjects.vectordbNavigation;
+
+    await test.step('primary body items are visible and linked', async () => {
+      const primaryDeepLinks = ['discover', 'dashboards', 'agent_builder'];
+      for (const deepLinkId of primaryDeepLinks) {
+        const item = nav.navItemInPrimaryByDeepLinkId(deepLinkId);
+        await expect(item).toBeVisible();
+        await expect(item).toHaveAttribute('href', /.+/);
+      }
+    });
+
+    await test.step('Data management panel opener is visible', async () => {
+      await expect(nav.navItemInPrimaryById('data_management')).toBeVisible();
+    });
+
+    await test.step('footer items are visible', async () => {
+      await expect(nav.navItemInFooterById('vectordb_getting_started')).toBeVisible();
+      await expect(nav.navItemInFooterById('dev_tools')).toBeVisible();
+      await expect(nav.navItemInFooterById('admin_and_settings')).toBeVisible();
+    });
+  });
+
+  test('Getting started footer link opens the tutorials page', async ({ pageObjects, page }) => {
+    const nav = pageObjects.vectordbNavigation;
+
+    await nav.navItemInFooterById('vectordb_getting_started').click();
+
+    await expect(pageObjects.vectordbTutorials.topicFilter).toBeVisible({
+      timeout: VECTORDB_SPA_SHELL_TIMEOUT_MS,
+    });
+    await expect(page).toHaveURL(/\/app\/vectordb\/tutorials/);
+  });
+
+  test('Discover nav item navigates and becomes active', async ({ pageObjects }) => {
+    const nav = pageObjects.vectordbNavigation;
+
+    await nav.navItemInPrimaryByDeepLinkId('discover').click();
+
+    await expect(nav.pageOrNoData('dscPage')).toBeVisible({
+      timeout: VECTORDB_SPA_SHELL_TIMEOUT_MS,
+    });
+    await expect(nav.activeNavItemByDeepLinkId('discover')).toBeVisible({
+      timeout: VECTORDB_SPA_SHELL_TIMEOUT_MS,
+    });
+  });
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/onboarding.spec.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/onboarding.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../fixtures';
+
+const ONBOARDING_KEY_NAME_PREFIX = 'vectordb-onboarding-';
+
+test.describe('Vector DB onboarding', { tag: [...tags.serverless.vectordb] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  // Visiting the landing page auto-creates an onboarding API key (useOnboardingCredentials)
+  test.afterAll(async ({ esClient }) => {
+    const { api_keys: apiKeys } = await esClient.security.getApiKey({
+      name: `${ONBOARDING_KEY_NAME_PREFIX}*`,
+    });
+    const ids = apiKeys.filter((key) => !key.invalidated).map((key) => key.id);
+    if (ids.length > 0) {
+      await esClient.security.invalidateApiKey({ ids });
+    }
+  });
+
+  test('redirects a new user to the path selection landing page', async ({ pageObjects, page }) => {
+    const onboarding = pageObjects.vectordbOnboarding;
+    await onboarding.goto();
+
+    await test.step('lands on the onboarding route with path cards', async () => {
+      await expect(onboarding.generatePathCard).toBeVisible();
+      await expect(onboarding.storePathCard).toBeVisible();
+      await expect(onboarding.skipButton).toBeVisible();
+      await expect(onboarding.documentationLink).toBeVisible();
+      await expect(page).toHaveURL(/\/app\/vectordb\/onboarding/);
+    });
+
+    await test.step('chrome navigation is hidden during first-load onboarding', async () => {
+      await expect(pageObjects.vectordbNavigation.sidenav).toBeHidden();
+    });
+  });
+
+  test('skip goes straight to the home page', async ({ pageObjects, page }) => {
+    const onboarding = pageObjects.vectordbOnboarding;
+    await onboarding.goto();
+    await expect(onboarding.skipButton).toBeVisible();
+
+    await onboarding.skipButton.click();
+
+    await expect(pageObjects.vectordbHome.banner).toBeVisible();
+    await expect(page).not.toHaveURL(/\/onboarding/);
+  });
+
+  test('walks the ingest and search wizard for the generate-embeddings path', async ({
+    pageObjects,
+  }) => {
+    const onboarding = pageObjects.vectordbOnboarding;
+    await onboarding.goto();
+
+    await test.step('choose the generate-embeddings path', async () => {
+      await expect(onboarding.generatePathCard).toBeVisible();
+      await onboarding.generatePathCard.click();
+    });
+
+    await test.step('ingest step shows snippet tooling', async () => {
+      await expect(onboarding.snippet).toBeVisible();
+      await expect(onboarding.stepsRail).toBeVisible();
+      await expect(onboarding.copyCodeButton).toBeVisible();
+      await expect(onboarding.runInConsoleButton).toBeVisible();
+      await expect(onboarding.backButton).toBeVisible();
+      await expect(onboarding.connectionDetailsButton).toBeVisible();
+    });
+
+    await test.step('switch snippet language to JavaScript', async () => {
+      await onboarding.selectLanguage('javascript');
+      await expect(onboarding.languagePicker).toContainText('JavaScript');
+    });
+
+    await test.step('continue to the search step', async () => {
+      await onboarding.continueToSearchButton.click();
+      await expect(onboarding.completeSetupButton).toBeVisible();
+      await expect(onboarding.snippet).toBeVisible();
+    });
+
+    await test.step('complete setup lands on the home page', async () => {
+      await onboarding.completeSetupButton.click();
+      await expect(pageObjects.vectordbHome.banner).toBeVisible();
+    });
+  });
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/tutorials.spec.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel_tests/tutorials.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../fixtures';
+import { ONBOARDING_SEEN_STORAGE_KEY } from '../fixtures/constants';
+
+test.describe('Vector DB tutorials page', { tag: [...tags.serverless.vectordb] }, () => {
+  test.beforeEach(async ({ browserAuth, page, pageObjects }) => {
+    await browserAuth.loginAsAdmin();
+    await page.addInitScript((key) => {
+      window.localStorage.setItem(key, 'true');
+    }, ONBOARDING_SEEN_STORAGE_KEY);
+    await pageObjects.vectordbTutorials.goto();
+  });
+
+  test('renders tutorial cards and onboarding path panels', async ({ pageObjects }) => {
+    const tutorials = pageObjects.vectordbTutorials;
+
+    await expect(tutorials.topicFilter).toBeVisible();
+    await expect(tutorials.tutorialCard('vector-search-documentation')).toBeVisible();
+    await expect(tutorials.generatePathCard).toBeVisible();
+    await expect(tutorials.storePathCard).toBeVisible();
+  });
+
+  test('topic filter narrows the visible cards', async ({ pageObjects }) => {
+    const tutorials = pageObjects.vectordbTutorials;
+
+    await expect(tutorials.tutorialCard('vector-search-documentation')).toBeVisible();
+    const allCount = await tutorials.tutorialCards.count();
+    expect(allCount).toBeGreaterThan(0);
+
+    await test.step('filter to Articles only', async () => {
+      await tutorials.topicFilterButton('Articles').click();
+      await expect(tutorials.tutorialCard('preconditioning-vectors-bbq-article')).toBeVisible();
+      await expect(tutorials.tutorialCard('vector-search-documentation')).toBeHidden();
+      await expect.poll(() => tutorials.tutorialCards.count()).toBeLessThan(allCount);
+    });
+
+    await test.step('reset back to All', async () => {
+      await tutorials.topicFilterButton('All').click();
+      await expect.poll(() => tutorials.tutorialCards.count()).toBe(allCount);
+    });
+  });
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/tsconfig.json
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/tsconfig.json
@@ -9,6 +9,7 @@
     "public/**/*.ts",
     "public/**/*.tsx",
     "server/**/*.ts",
+    "test/scout/**/*",
     "../../../../../typings/**/*",
   ],
   "exclude": [
@@ -39,5 +40,6 @@
     "@kbn/alerting-v2-utils",
     "@kbn/deeplinks-workflows",
     "@kbn/data-views-plugin",
+    "@kbn/scout",
   ]
 }


### PR DESCRIPTION
## Summary

Adds Scout test coverage for the serverless Vector DB plugin under `x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/`, modeled on the `search_homepage` / `search_getting_started` layout and the `search_inference_endpoints/test/scout_inference_test` patterns (readonly-`Locator` page objects, `fixtures/mocks.ts` route mocks, `apiTest` suites).

- **UI (parallel)**: onboarding flow (new-user redirect to path selection with chrome hidden, skip-to-home, full generate-embeddings wizard walk), home page (banner + quick links, both banner CTA states via a mocked `deployment_stats` response), tutorials page (cards, topic filter), and side navigation (body/footer entries, Getting started link, Discover navigation).
- **API**: `GET /internal/serverless_vectordb/deployment_stats` (response shape) and `POST /internal/serverless_vectordb/api_key` (creates a `vectordb-onboarding-*` key when none is active, returns nulls when one exists), with ES-side API key cleanup.
- Wires the specs into the plugin `tsconfig.json` (Pattern A, `@kbn/scout` reference) and registers `serverless_vectordb` in `.buildkite/scout_ci_config.yml`.

The plugin only exists in serverless Vector DB projects, so all suites are tagged `tags.serverless.vectordb` only. Note that the `['serverless', 'vectordb']` target is still commented out in `getServerRunFlagsFromTags` (`kbn-scout/src/tests_discovery/tag_utils.ts`), so Scout CI will discover but not yet fan out these suites until that target is enabled.

## How to test

```
node scripts/scout.js run-tests --arch serverless --domain vectordb --config x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/ui/parallel.playwright.config.ts
node scripts/scout.js run-tests --arch serverless --domain vectordb --config x-pack/solutions/vectordb/plugins/serverless_vectordb/test/scout/api/playwright.config.ts
```

Both suites pass locally: 11 UI tests, 3 API tests.

Made with [Cursor](https://cursor.com)