### PR TITLE
[Security solution] Fix duped navigation item bug

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
@@ -213,7 +213,6 @@ export const createNavigationTree = (
                       link: 'cloud_connect' as const,
                     },
                   ]),
-              { link: 'monitoring' },
             ],
           },
           ...getAlertingV2ManagementNavPanel(services),


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/279836

## Summary

Fix a duped entry in the navigation, the `badgeType: new` was already defined for the `queryActivity` plugin.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->