### PR TITLE
Update Nightshift code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1768,6 +1768,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/observability/public/pages/alerts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/pages/annotations @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/pages/cases @elastic/actionable-obs-team
+/x-pack/solutions/observability/plugins/observability/public/pages/nightshift @elastic/nightshift-context-and-research-team @elastic/nightshift-sre-agent-team
 /x-pack/solutions/observability/plugins/observability/public/pages/rule_details @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/pages/rules @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/rules @elastic/actionable-obs-team

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.test.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.test.ts
@@ -57,6 +57,7 @@ const LEGACY_CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
   observability: [
     'elastic/actionable-obs-team',
     'elastic/nightshift-context-and-research-team',
+    'elastic/nightshift-sre-agent-team',
     'elastic/obs-cloudnative-monitoring',
     'elastic/obs-docs',
     'elastic/obs-exploration-team',

--- a/src/platform/packages/private/kbn-code-owners/teams.jsonc
+++ b/src/platform/packages/private/kbn-code-owners/teams.jsonc
@@ -513,6 +513,13 @@
     ]
   },
   {
+    "id": "nightshift-sre-agent",
+    "name": "Nightshift SRE Agent Team",
+    "github": {
+      "team": "elastic/nightshift-sre-agent-team"
+    }
+  },
+  {
     "id": "obs-cloudnative-monitoring",
     "name": "Obs Cloudnative Monitoring",
     "areas": [

--- a/src/platform/packages/private/kbn-code-owners/teams.jsonc
+++ b/src/platform/packages/private/kbn-code-owners/teams.jsonc
@@ -515,6 +515,7 @@
   {
     "id": "nightshift-sre-agent",
     "name": "Nightshift SRE Agent Team",
+    "areas": ["observability"],
     "github": {
       "team": "elastic/nightshift-sre-agent-team"
     }

--- a/src/platform/packages/private/kbn-code-owners/teams.jsonc
+++ b/src/platform/packages/private/kbn-code-owners/teams.jsonc
@@ -436,7 +436,6 @@
     "github": {
       "team": "elastic/kibana-telemetry",
       "label": "Team:Core"
-
     }
   },
   {

--- a/src/platform/packages/private/kbn-code-owners/teams.jsonc
+++ b/src/platform/packages/private/kbn-code-owners/teams.jsonc
@@ -436,7 +436,7 @@
     "github": {
       "team": "elastic/kibana-telemetry",
       "label": "Team:Core"
-      
+
     }
   },
   {


### PR DESCRIPTION
## Summary

- Assign the Observability Nightshift page to the Context and Research and SRE Agent teams.