### PR TITLE
[KBN_UI][EUI] Add `@kbn/kbn-ui/prefer_kbn_ui_callout` ESLint rule

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -459,6 +459,7 @@ module.exports = {
      * kbn-ui rules
      */
     '@kbn/kbn-ui/prefer_toast_action_props': 'warn',
+    '@kbn/kbn-ui/prefer_kbn_ui_callout': 'warn',
 
     /**
      * EUI Team rules

--- a/packages/kbn-eslint-plugin-kbn-ui/README.mdx
+++ b/packages/kbn-eslint-plugin-kbn-ui/README.mdx
@@ -8,6 +8,46 @@ tags: ['kibana', 'dev', 'contributor', 'operations', 'eslint', 'kbn-ui']
 
 `@kbn/eslint-plugin-kbn-ui` is a collection of custom ESLint rules for `@kbn/ui-` components.
 
+## `@kbn/kbn-ui/prefer_kbn_ui_callout`
+
+Flags direct usage of `<EuiCallOut>` in favour of the semantic wrapper components from `@kbn/ui-callout`.
+
+Choose the wrapper that matches the intent:
+
+| `EuiCallOut` color  | Wrapper             |
+| ------------------- | ------------------- |
+| `primary` (default) | `KbnInfoCallout`    |
+| `success`           | `KbnSuccessCallout` |
+| `warning`           | `KbnWarningCallout` |
+| `danger`            | `KbnDangerCallout`  |
+
+**Known limitation:** the rule only detects `<EuiCallOut>` in JSX. Usage as a value (e.g. `const C = condition ? EuiCallOut : Other`) is not flagged.
+
+### Examples
+
+✅ valid
+
+```tsx
+import { KbnWarningCallout } from '@kbn/ui-callout';
+
+<KbnWarningCallout title="Something went wrong" />;
+```
+
+❌ invalid
+
+```tsx
+import { EuiCallOut } from '@elastic/eui';
+
+// No color — EuiCallOut defaults to primary (info)
+<EuiCallOut title="Note" />
+
+// Known color
+<EuiCallOut color="warning" title="Something went wrong" />
+
+// Spread props
+<EuiCallOut {...props} title="Note" />
+```
+
 ## `@kbn/kbn-ui/prefer_toast_action_props`
 
 Flags legacy usage of passing actions as content to toasts that are added via the `ToastsApi`'s methods (`add()`, `addInfo()`, `addSuccess()`, `addWarning()`, `addDanger()`) as actions should instead be passed via the `actionProps` prop.

--- a/packages/kbn-eslint-plugin-kbn-ui/index.ts
+++ b/packages/kbn-eslint-plugin-kbn-ui/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { PreferToastActionProps } from './rules/prefer_toast_action_props';
+import { PreferKbnUiCallout } from './rules/prefer_kbn_ui_callout';
 
 /**
  * Custom ESLint rules for kbn-ui packages.
@@ -16,4 +17,5 @@ import { PreferToastActionProps } from './rules/prefer_toast_action_props';
  */
 export const rules = {
   prefer_toast_action_props: PreferToastActionProps,
+  prefer_kbn_ui_callout: PreferKbnUiCallout,
 };

--- a/packages/kbn-eslint-plugin-kbn-ui/rules/prefer_kbn_ui_callout.test.ts
+++ b/packages/kbn-eslint-plugin-kbn-ui/rules/prefer_kbn_ui_callout.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { RuleTester } from 'eslint';
+import { PreferKbnUiCallout } from './prefer_kbn_ui_callout';
+
+const tester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+tester.run('prefer_kbn_ui_callout', PreferKbnUiCallout, {
+  valid: [
+    {
+      name: 'using a semantic KbnInfoCallout wrapper component is allowed',
+      code: `
+        <KbnInfoCallout title="Note" />;
+      `,
+    },
+    {
+      name: 'using a semantic KbnSuccessCallout wrapper component is allowed',
+      code: `
+        <KbnSuccessCallout title="Success" />;
+      `,
+    },
+    {
+      name: 'using a semantic KbnWarningCallout wrapper component is allowed',
+      code: `
+        <KbnWarningCallout title="Warning" />;
+      `,
+    },
+    {
+      name: 'using a semantic KbnDangerCallout wrapper component is allowed',
+      code: `
+        <KbnDangerCallout title="Error" />;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'using <EuiCallOut> without a color prop suggests KbnInfoCallout (EuiCallOut defaults to primary)',
+      code: `
+        <EuiCallOut title="Note" />;
+      `,
+      errors: [{ messageId: 'noDirectEuiCallOutJsx' }],
+    },
+    {
+      name: 'using <EuiCallOut color="primary"> suggests KbnInfoCallout',
+      code: `
+        <EuiCallOut color="primary" title="Note" />;
+      `,
+      errors: [
+        {
+          messageId: 'noDirectEuiCallOutJsxWithColor',
+          data: { wrapper: 'KbnInfoCallout', color: 'primary' },
+        },
+      ],
+    },
+    {
+      name: 'using <EuiCallOut color="success"> suggests KbnSuccessCallout',
+      code: `
+        <EuiCallOut color="success" title="Success" />;
+      `,
+      errors: [
+        {
+          messageId: 'noDirectEuiCallOutJsxWithColor',
+          data: { wrapper: 'KbnSuccessCallout', color: 'success' },
+        },
+      ],
+    },
+    {
+      name: 'using <EuiCallOut color="warning"> suggests KbnWarningCallout',
+      code: `
+        <EuiCallOut color="warning" title="Warning" />;
+      `,
+      errors: [
+        {
+          messageId: 'noDirectEuiCallOutJsxWithColor',
+          data: { wrapper: 'KbnWarningCallout', color: 'warning' },
+        },
+      ],
+    },
+    {
+      name: 'using <EuiCallOut color="danger"> suggests KbnDangerCallout',
+      code: `
+        <EuiCallOut color="danger" title="Error" />;
+      `,
+      errors: [
+        {
+          messageId: 'noDirectEuiCallOutJsxWithColor',
+          data: { wrapper: 'KbnDangerCallout', color: 'danger' },
+        },
+      ],
+    },
+    {
+      name: 'using <EuiCallOut> with a dynamic color expression reports the generic message',
+      code: `
+        const color = 'primary';
+        <EuiCallOut color={color} title="Note" />;
+      `,
+      errors: [{ messageId: 'noDirectEuiCallOutJsx' }],
+    },
+    {
+      name: 'using <EuiCallOut> with spread props',
+      code: `
+        const props = { color: 'warning' };
+        <EuiCallOut {...props} title="Note" />;
+      `,
+      errors: [{ messageId: 'noDirectEuiCallOutJsxSpread' }],
+    },
+    {
+      name: 'using <EuiCallOut> with spread props and an explicit color use',
+      code: `
+        <EuiCallOut {...rest} color="danger" title="Error" />;
+      `,
+      errors: [
+        {
+          messageId: 'noDirectEuiCallOutJsxWithColor',
+          data: { wrapper: 'KbnDangerCallout', color: 'danger' },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/kbn-eslint-plugin-kbn-ui/rules/prefer_kbn_ui_callout.ts
+++ b/packages/kbn-eslint-plugin-kbn-ui/rules/prefer_kbn_ui_callout.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TSESTree } from '@typescript-eslint/typescript-estree';
+import type { Rule } from 'eslint';
+
+const SEMANTIC_PACKAGE = '@kbn/ui-callout';
+
+const COLOR_TO_WRAPPER: Record<string, string> = {
+  primary: 'KbnInfoCallout',
+  success: 'KbnSuccessCallout',
+  warning: 'KbnWarningCallout',
+  danger: 'KbnDangerCallout',
+};
+
+/**
+ * Returns the string value of a JSX attribute's value node, or undefined if
+ * the value is not a simple string literal.
+ */
+const getStringValue = (valueNode: TSESTree.JSXAttribute['value']): string | undefined => {
+  if (!valueNode) return undefined;
+  if (valueNode.type === 'Literal' && typeof valueNode.value === 'string') {
+    return valueNode.value;
+  }
+  return undefined;
+};
+
+export const PreferKbnUiCallout: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: `Disallow direct usage of EuiCallOut in favour of semantic wrapper components from ${SEMANTIC_PACKAGE}`,
+      category: 'Migration',
+      recommended: true,
+    },
+    messages: {
+      noDirectEuiCallOutJsx: `Use <KbnInfoCallout> from '${SEMANTIC_PACKAGE}' instead of <EuiCallOut> (defaults to color="primary").`,
+      noDirectEuiCallOutJsxWithColor: `Use <{{wrapper}}> from '${SEMANTIC_PACKAGE}' instead of <EuiCallOut color="{{color}}">.`,
+      noDirectEuiCallOutJsxSpread: `Use a semantic wrapper from '${SEMANTIC_PACKAGE}' instead of <EuiCallOut>. Color may be set via spread props — choose KbnInfoCallout, KbnSuccessCallout, KbnWarningCallout, or KbnDangerCallout based on the resolved color value.`,
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node: Rule.Node) {
+        const jsxNode = node as unknown as TSESTree.JSXOpeningElement;
+        if (jsxNode.name.type !== 'JSXIdentifier' || jsxNode.name.name !== 'EuiCallOut') {
+          return;
+        }
+
+        const hasSpread = jsxNode.attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
+
+        const colorAttr = jsxNode.attributes.find(
+          (attr): attr is TSESTree.JSXAttribute =>
+            attr.type === 'JSXAttribute' &&
+            attr.name.type === 'JSXIdentifier' &&
+            attr.name.name === 'color'
+        );
+
+        const color = colorAttr ? getStringValue(colorAttr.value) : undefined;
+        const wrapper = color ? COLOR_TO_WRAPPER[color] : undefined;
+
+        if (wrapper && color) {
+          context.report({
+            node,
+            messageId: 'noDirectEuiCallOutJsxWithColor',
+            data: { wrapper, color },
+          });
+        } else if (hasSpread && !color) {
+          context.report({
+            node,
+            messageId: 'noDirectEuiCallOutJsxSpread',
+          });
+        } else {
+          context.report({
+            node,
+            messageId: 'noDirectEuiCallOutJsx',
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

**What**: This PR adds a new ESLint rule to the `@kbn/eslint-plugin-kbn-ui` package: `@kbn/kbn-ui/prefer_kbn_ui_callout`.

**Why**: After introducing Kibana level callout wrappers in `@kbn/ui-callout` ([PR](https://github.com/elastic/kibana/pull/277978)), this rule is meant to help with driving the adoption of the kbn-ui callout wrapper components (`KbnInfoCallout`, `KbnSuccessCallout`, `KbnWarningCallout`, and `KbnDangerCallout`) over the base `EuiCallOut`.

✅ valid

```jsx
import {
  KbnInfoCallout,
  KbnSuccessCallout,
  KbnWarningCallout,
  KbnDangerCallout
} from '@kbn/ui-callout';

<KbnInfoCallout title="The process was started." />
<KbnSuccessCallout title="Saved successfully." />
<KbnWarningCallout title="Something went wrong." />
<KbnDangerCallout title="An error occurred." />
```

❌ invalid

```jsx
import { EuiCallOut } from '@elastic/eui';

// No color — EuiCallOut defaults to primary (info)
<EuiCallOut title="Note" />

// Known color
<EuiCallOut color="warning" title="Something went wrong" />

// Spread props
<EuiCallOut {...props} title="Note" />
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



