### PR TITLE
[SigEvents] Expose memory tools to Discovery/Judge and prior SigEvents to KI extraction

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_feature_extraction/ki_feature_extraction.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_feature_extraction/ki_feature_extraction.spec.ts
@@ -11,9 +11,14 @@ import {
   createMemoryDiscoveryTools,
   MemoryServiceImpl,
 } from '@kbn/significant-events-plugin/server';
+import { STREAMS_SIGNIFICANT_EVENTS_AVAILABLE_FLAG } from '@kbn/significant-events-plugin/common';
 import { tags } from '@kbn/scout';
 import { getCurrentTraceId, createSpanLatencyEvaluator } from '@kbn/evals';
 import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import {
+  createEvalSignificantEventSearchTool,
+  type AgentBuilderToolResult,
+} from '../../src/tools/significant_event_search_tool';
 import {
   SIGEVENTS_SNAPSHOT_RUN,
   cleanSignificantEventsDataStreams,
@@ -43,7 +48,21 @@ evaluate.describe('KI feature extraction', { tag: tags.serverless.observability.
   const activeDatasets = getActiveDatasets();
   const availableSnapshotsBySource = new Map<string, Set<string>>();
 
-  evaluate.beforeAll(async ({ esClient, log }) => {
+  evaluate.beforeAll(async ({ esClient, kbnClient, log }) => {
+    // The significant_event_search tool is only registered when significant
+    // events availability is on (defaults to false); enable it before any run.
+    await kbnClient.request({
+      path: '/internal/core/_settings',
+      method: 'PUT',
+      headers: { 'elastic-api-version': '1' },
+      body: {
+        'feature_flags.overrides': {
+          [STREAMS_SIGNIFICANT_EVENTS_AVAILABLE_FLAG]: true,
+        },
+      },
+    });
+    log.info('Enabled significant events availability feature flag');
+
     const snapshots = await buildAvailableSnapshotsBySource(
       activeDatasets,
       (dataset) => dataset.kiFeatureExtraction,
@@ -110,6 +129,7 @@ evaluate.describe('KI feature extraction', { tag: tags.serverless.observability.
           logger,
           traceEsClient,
           log,
+          fetch,
         }) => {
           const heavyDataByScenario = new Map(
             collectedExamples.map(({ scenario, sampleDocuments }) => [
@@ -118,10 +138,26 @@ evaluate.describe('KI feature extraction', { tag: tags.serverless.observability.
             ])
           );
 
-          // Exercise the same memory grounding tools that production feature
-          // extraction now wires in, so the eval covers the memory code path.
+          // Exercise the same grounding tools that production feature extraction
+          // now wires in, so the eval covers the memory + prior-SigEvents paths.
           const memoryTools = createMemoryDiscoveryTools({
             memoryService: new MemoryServiceImpl({ logger: logger.get('memory'), esClient }),
+          });
+
+          const executeAgentBuilderTool = async (
+            toolId: string,
+            toolParams: Record<string, unknown>
+          ) =>
+            (await fetch('/api/agent_builder/tools/_execute', {
+              method: 'POST',
+              version: '2023-10-31',
+              body: JSON.stringify({ tool_id: toolId, tool_params: toolParams }),
+            })) as { results?: AgentBuilderToolResult[] };
+
+          const eventSearchTool = createEvalSignificantEventSearchTool({
+            executeTool: executeAgentBuilderTool,
+            streamName: MANAGED_STREAM_NAME,
+            logger,
           });
 
           await executorClient.runExperiment(
@@ -152,12 +188,15 @@ evaluate.describe('KI feature extraction', { tag: tags.serverless.observability.
                 const { features } = await identifyFeatures({
                   streamName: MANAGED_STREAM_NAME,
                   sampleDocuments: heavy.sampleDocuments,
-                  systemPrompt: `${featuresPrompt}\n${memoryTools.promptSnippet}`,
+                  systemPrompt: `${featuresPrompt}\n${memoryTools.promptSnippet}\n${eventSearchTool.promptSnippet}`,
                   inferenceClient,
                   logger,
                   signal: new AbortController().signal,
-                  additionalTools: memoryTools.tools,
-                  additionalToolCallbacks: memoryTools.callbacks,
+                  additionalTools: { ...memoryTools.tools, ...eventSearchTool.tools },
+                  additionalToolCallbacks: {
+                    ...memoryTools.callbacks,
+                    ...eventSearchTool.callbacks,
+                  },
                 });
 
                 return {

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_feature_extraction/ki_feature_extraction.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_feature_extraction/ki_feature_extraction.spec.ts
@@ -7,6 +7,10 @@
 
 import { identifyFeatures } from '@kbn/streams-ai';
 import { featuresPrompt } from '@kbn/streams-ai/src/features/prompt';
+import {
+  createMemoryDiscoveryTools,
+  MemoryServiceImpl,
+} from '@kbn/significant-events-plugin/server';
 import { tags } from '@kbn/scout';
 import { getCurrentTraceId, createSpanLatencyEvaluator } from '@kbn/evals';
 import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
@@ -98,13 +102,27 @@ evaluate.describe('KI feature extraction', { tag: tags.serverless.observability.
 
       evaluate(
         'KI feature extraction',
-        async ({ executorClient, evaluators, inferenceClient, logger, traceEsClient, log }) => {
+        async ({
+          esClient,
+          executorClient,
+          evaluators,
+          inferenceClient,
+          logger,
+          traceEsClient,
+          log,
+        }) => {
           const heavyDataByScenario = new Map(
             collectedExamples.map(({ scenario, sampleDocuments }) => [
               scenario.input.scenario_id,
               { sampleDocuments },
             ])
           );
+
+          // Exercise the same memory grounding tools that production feature
+          // extraction now wires in, so the eval covers the memory code path.
+          const memoryTools = createMemoryDiscoveryTools({
+            memoryService: new MemoryServiceImpl({ logger: logger.get('memory'), esClient }),
+          });
 
           await executorClient.runExperiment(
             {
@@ -134,10 +152,12 @@ evaluate.describe('KI feature extraction', { tag: tags.serverless.observability.
                 const { features } = await identifyFeatures({
                   streamName: MANAGED_STREAM_NAME,
                   sampleDocuments: heavy.sampleDocuments,
-                  systemPrompt: featuresPrompt,
+                  systemPrompt: `${featuresPrompt}\n${memoryTools.promptSnippet}`,
                   inferenceClient,
                   logger,
                   signal: new AbortController().signal,
+                  additionalTools: memoryTools.tools,
+                  additionalToolCallbacks: memoryTools.callbacks,
                 });
 
                 return {

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_query_generation/ki_query_generation.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_query_generation/ki_query_generation.spec.ts
@@ -11,6 +11,7 @@ import {
   createMemoryDiscoveryTools,
   MemoryServiceImpl,
 } from '@kbn/significant-events-plugin/server';
+import { STREAMS_SIGNIFICANT_EVENTS_AVAILABLE_FLAG } from '@kbn/significant-events-plugin/common';
 import { tags } from '@kbn/scout';
 
 import { getCurrentTraceId, createSpanLatencyEvaluator } from '@kbn/evals';
@@ -28,6 +29,7 @@ import {
   SIGEVENTS_WIRED_ROOTS,
 } from '../../src/data_generators/replay';
 import { evaluate } from '../../src/evaluate';
+import { createEvalSignificantEventSearchTool } from '../../src/tools/significant_event_search_tool';
 import { createKIQueryGenerationEvaluators } from '../../src/evaluators/ki_query_generation';
 import { createScenarioCriteriaLlmEvaluator } from '../../src/evaluators/scenario_criteria/evaluators';
 import {
@@ -64,7 +66,21 @@ evaluate.describe('KI query generation', { tag: tags.serverless.observability.co
   const activeDatasets = getActiveDatasets();
   const availableSnapshotsBySource = new Map<string, Set<string>>();
 
-  evaluate.beforeAll(async ({ esClient, log }) => {
+  evaluate.beforeAll(async ({ esClient, kbnClient, log }) => {
+    // The significant_event_search tool is only registered when significant
+    // events availability is on (defaults to false); enable it before any run.
+    await kbnClient.request({
+      path: '/internal/core/_settings',
+      method: 'PUT',
+      headers: { 'elastic-api-version': '1' },
+      body: {
+        'feature_flags.overrides': {
+          [STREAMS_SIGNIFICANT_EVENTS_AVAILABLE_FLAG]: true,
+        },
+      },
+    });
+    log.info('Enabled significant events availability feature flag');
+
     const snapshots = await buildAvailableSnapshotsBySource(
       activeDatasets,
       (dataset) => dataset.kiQueryGeneration,
@@ -222,10 +238,26 @@ evaluate.describe('KI query generation', { tag: tags.serverless.observability.co
               ])
             );
 
-            // Exercise the same memory grounding tools that production query
-            // generation wires in, so the eval covers the memory code path.
+            // Exercise the same grounding tools that production query generation
+            // wires in, so the eval covers the memory + prior-SigEvents code paths.
             const memoryTools = createMemoryDiscoveryTools({
               memoryService: new MemoryServiceImpl({ logger: logger.get('memory'), esClient }),
+            });
+
+            const executeAgentBuilderTool = async (
+              toolId: string,
+              toolParams: Record<string, unknown>
+            ) =>
+              (await fetch('/api/agent_builder/tools/_execute', {
+                method: 'POST',
+                version: '2023-10-31',
+                body: JSON.stringify({ tool_id: toolId, tool_params: toolParams }),
+              })) as { results?: AgentBuilderToolResult[] };
+
+            const eventSearchTool = createEvalSignificantEventSearchTool({
+              executeTool: executeAgentBuilderTool,
+              streamName: MANAGED_STREAM_NAME,
+              logger,
             });
 
             const groundingModes = resolveGroundingModes();
@@ -325,7 +357,11 @@ evaluate.describe('KI query generation', { tag: tags.serverless.observability.co
                     `ki_types=${JSON.stringify(kiTypeCounts)}, sample_logs=${sampleLogs.length}`
                 );
 
-                const promptSnippet = [groundingTools?.promptSnippet, memoryTools.promptSnippet]
+                const promptSnippet = [
+                  groundingTools?.promptSnippet,
+                  memoryTools.promptSnippet,
+                  eventSearchTool.promptSnippet,
+                ]
                   .filter(Boolean)
                   .join('\n');
 
@@ -337,9 +373,14 @@ evaluate.describe('KI query generation', { tag: tags.serverless.observability.co
                   signal: new AbortController().signal,
                   systemPrompt: `${significantEventsPrompt}\n${promptSnippet}`,
                   getFeatures: async () => kis,
-                  additionalTools: { ...memoryTools.tools, ...groundingTools?.additionalTools },
+                  additionalTools: {
+                    ...memoryTools.tools,
+                    ...eventSearchTool.tools,
+                    ...groundingTools?.additionalTools,
+                  },
                   additionalToolCallbacks: {
                     ...memoryTools.callbacks,
+                    ...eventSearchTool.callbacks,
                     ...groundingTools?.additionalToolCallbacks,
                   },
                   maxSteps: groundingTools ? 12 : 8,

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_query_generation/ki_query_generation.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_query_generation/ki_query_generation.spec.ts
@@ -7,6 +7,10 @@
 
 import { identifyKIQueries } from '@kbn/streams-ai';
 import { significantEventsPrompt } from '@kbn/streams-ai/src/significant_events/prompt';
+import {
+  createMemoryDiscoveryTools,
+  MemoryServiceImpl,
+} from '@kbn/significant-events-plugin/server';
 import { tags } from '@kbn/scout';
 
 import { getCurrentTraceId, createSpanLatencyEvaluator } from '@kbn/evals';
@@ -218,6 +222,12 @@ evaluate.describe('KI query generation', { tag: tags.serverless.observability.co
               ])
             );
 
+            // Exercise the same memory grounding tools that production query
+            // generation wires in, so the eval covers the memory code path.
+            const memoryTools = createMemoryDiscoveryTools({
+              memoryService: new MemoryServiceImpl({ logger: logger.get('memory'), esClient }),
+            });
+
             const groundingModes = resolveGroundingModes();
             const codeIndex = resolveCodeIndexForDataset(dataset.id);
 
@@ -315,19 +325,24 @@ evaluate.describe('KI query generation', { tag: tags.serverless.observability.co
                     `ki_types=${JSON.stringify(kiTypeCounts)}, sample_logs=${sampleLogs.length}`
                 );
 
+                const promptSnippet = [groundingTools?.promptSnippet, memoryTools.promptSnippet]
+                  .filter(Boolean)
+                  .join('\n');
+
                 const { queries, toolUsage } = await identifyKIQueries({
                   stream,
                   esClient,
                   inferenceClient,
                   logger,
                   signal: new AbortController().signal,
-                  systemPrompt: groundingTools
-                    ? `${significantEventsPrompt}\n${groundingTools.promptSnippet}`
-                    : significantEventsPrompt,
+                  systemPrompt: `${significantEventsPrompt}\n${promptSnippet}`,
                   getFeatures: async () => kis,
-                  additionalTools: groundingTools?.additionalTools,
-                  additionalToolCallbacks: groundingTools?.additionalToolCallbacks,
-                  maxSteps: groundingTools ? 10 : undefined,
+                  additionalTools: { ...memoryTools.tools, ...groundingTools?.additionalTools },
+                  additionalToolCallbacks: {
+                    ...memoryTools.callbacks,
+                    ...groundingTools?.additionalToolCallbacks,
+                  },
+                  maxSteps: groundingTools ? 12 : 8,
                 });
 
                 logger.info(

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/tools/significant_event_search_tool.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/tools/significant_event_search_tool.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { ToolCallback, ToolDefinition } from '@kbn/inference-common';
+import { SIGNIFICANT_EVENTS_SEARCH_EVENTS_TOOL_ID } from '@kbn/significant-events-plugin/server';
+
+/**
+ * Prior Significant Events context tool for the KI extraction evals.
+ *
+ * This mirrors the production factory in
+ * `significant_events/server/lib/significant_events/ki_extraction_context_tools.ts`.
+ * It is duplicated here (rather than imported) because that factory bridges the
+ * Agent Builder `event_search` tool through the in-process `agentBuilder.tools`
+ * start contract, which is not available to the Scout evaluation process. Here
+ * the `event_search` tool is executed over HTTP via the Agent Builder public
+ * tool-execution endpoint instead.
+ */
+
+/** Result envelope returned by `POST /api/agent_builder/tools/_execute`. */
+export interface AgentBuilderToolResult {
+  type: string;
+  data: unknown;
+}
+export type ExecuteAgentBuilderTool = (
+  toolId: string,
+  toolParams: Record<string, unknown>
+) => Promise<{ results?: AgentBuilderToolResult[] }>;
+
+export interface EvalSignificantEventSearchTool {
+  tools: Record<string, ToolDefinition>;
+  callbacks: Record<string, ToolCallback>;
+  promptSnippet: string;
+}
+
+const formatToolResults = (results: AgentBuilderToolResult[] | undefined) => {
+  const list = results ?? [];
+  const errors = list
+    .filter((result) => result.type === 'error')
+    .map((result) => (result.data as { message?: string })?.message ?? 'Unknown tool error');
+  const data = list.filter((result) => result.type !== 'error');
+  return {
+    results: data,
+    count: data.length,
+    ...(errors.length > 0 ? { error: errors.join('; ') } : {}),
+  };
+};
+
+/**
+ * Builds the inference reasoning-agent tool that bridges to the Agent Builder
+ * `event_search` tool via `executeTool` (HTTP). Mirrors the production tool name,
+ * schema shape, and prompt snippet so the eval exercises the same code path.
+ */
+export const createEvalSignificantEventSearchTool = ({
+  executeTool,
+  streamName,
+  logger,
+}: {
+  executeTool: ExecuteAgentBuilderTool;
+  streamName: string;
+  logger: Logger;
+}): EvalSignificantEventSearchTool => {
+  const tools: Record<string, ToolDefinition> = {
+    significant_event_search: {
+      description:
+        'Search existing Significant Events for the target stream (and related filters). ' +
+        'Use view "full" when you need assessment notes, demotion justifications, or linked investigation outcomes. ' +
+        'Prefer status filters (e.g. dismissed) when looking for known-noisy / demoted patterns to avoid regenerating.',
+      schema: {
+        type: 'object' as const,
+        properties: {
+          query: {
+            type: 'string' as const,
+            description:
+              'Optional case-insensitive substring over event title, summary, and symptom hypothesis. Omit to return all events for the stream/state.',
+          },
+          status: {
+            type: 'string' as const,
+            description:
+              'Optional status filter (e.g. "dismissed" to find known-noisy / demoted patterns).',
+          },
+          view: {
+            type: 'string' as const,
+            enum: ['compact', 'full'] as const,
+            description:
+              'Response detail. "compact" (default) returns summaries; "full" returns complete events with assessment notes.',
+          },
+        },
+      },
+    },
+  };
+
+  const callbacks: Record<string, ToolCallback> = {
+    significant_event_search: async (toolCall) => {
+      const { query, status, view } = toolCall.function.arguments as {
+        query?: string;
+        status?: string;
+        view?: 'compact' | 'full';
+      };
+      try {
+        const { results } = await executeTool(SIGNIFICANT_EVENTS_SEARCH_EVENTS_TOOL_ID, {
+          stream_names: [streamName],
+          ...(query !== undefined ? { query } : {}),
+          ...(status !== undefined ? { status } : {}),
+          ...(view !== undefined ? { view } : {}),
+        });
+        return { response: formatToolResults(results) };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(`significant_event_search eval tool failed: ${message}`);
+        return { response: { results: [], count: 0, error: message } };
+      }
+    },
+  };
+
+  const promptSnippet = `
+You also have access to prior Significant Events and investigation outcomes for this stream. Before proposing new KI features, consult that history so you do not blindly reintroduce patterns the system has already classified:
+- **significant_event_search** — Search Significant Events (open, dismissed, closed). Use \`view: "full"\` to include assessment notes and linked investigations; use status \`dismissed\` when checking for known noise / demotions.
+
+When prior findings show a pattern was noisy, single-tenant, known-benign, or already investigated as non-actionable, prefer refining/avoiding that path over regenerating an equivalent feature.`;
+
+  return { tools, callbacks, promptSnippet };
+};

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/identify_features.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/identify_features.ts
@@ -8,7 +8,12 @@
 import { compact, uniqBy } from 'lodash';
 import type { Logger } from '@kbn/core/server';
 import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
-import type { BoundInferenceClient, ChatCompletionTokenCount } from '@kbn/inference-common';
+import type {
+  BoundInferenceClient,
+  ChatCompletionTokenCount,
+  ToolCallback,
+  ToolDefinition,
+} from '@kbn/inference-common';
 import {
   type BaseFeature,
   type IgnoredFeature,
@@ -77,6 +82,8 @@ export interface IdentifyFeaturesOptions {
   previouslyIdentifiedFeatures?: PreviouslyIdentifiedFeature[];
   knownFeatureIds?: string;
   searchSimilarFeatures?: (args: SearchSimilarFeaturesArguments) => Promise<SimilarFeatureHit[]>;
+  additionalTools?: Record<string, ToolDefinition>;
+  additionalToolCallbacks?: Record<string, ToolCallback>;
 }
 
 export async function identifyFeatures({
@@ -90,6 +97,8 @@ export async function identifyFeatures({
   previouslyIdentifiedFeatures = [],
   knownFeatureIds = '',
   searchSimilarFeatures,
+  additionalTools,
+  additionalToolCallbacks,
 }: IdentifyFeaturesOptions): Promise<{
   features: BaseFeature[];
   ignoredFeatures: IgnoredFeature[];
@@ -117,10 +126,11 @@ export async function identifyFeatures({
         known_feature_ids: knownFeatureIds,
         excluded_features: excludedFeatures?.length ? JSON.stringify(excludedFeatures) : '',
       },
-      prompt: createIdentifyFeaturesPrompt({ systemPrompt }),
+      prompt: createIdentifyFeaturesPrompt({ systemPrompt, additionalTools }),
       inferenceClient,
-      maxSteps: 4,
+      maxSteps: additionalToolCallbacks ? 6 : 4,
       toolCallbacks: {
+        ...(additionalToolCallbacks ?? {}),
         search_similar_features: async (toolCall) => {
           if (!searchSimilarFeatures) {
             return {

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/prompt.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/prompt.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { createPrompt } from '@kbn/inference-common';
+import { createPrompt, type ToolDefinition } from '@kbn/inference-common';
 import { z } from '@kbn/zod/v4';
 import featuresUserPrompt from './user_prompt.text';
 import featuresSystemPrompt from './system_prompt.text';
@@ -187,7 +187,13 @@ const searchSimilarFeaturesSchema = {
   required: ['candidate_id', 'title', 'description', 'type'],
 } as const;
 
-export function createIdentifyFeaturesPrompt({ systemPrompt }: { systemPrompt: string }) {
+export function createIdentifyFeaturesPrompt({
+  systemPrompt,
+  additionalTools,
+}: {
+  systemPrompt: string;
+  additionalTools?: Record<string, ToolDefinition>;
+}) {
   return createPrompt({
     name: 'identify_features',
     input: z.object({
@@ -218,6 +224,7 @@ export function createIdentifyFeaturesPrompt({ systemPrompt }: { systemPrompt: s
           description: 'Finalize features identification',
           schema: featuresSchema,
         },
+        ...(additionalTools ?? {}),
       },
     })
     .get();

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/discovery.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/discovery.ts
@@ -22,7 +22,7 @@ export const discoveryAgentType = {
   avatar_icon: 'logoElastic',
   baseConfiguration: {
     instructions,
-    skill_ids: [SIGNIFICANT_EVENTS_KI_GROUNDING_SKILL_ID],
+    skill_ids: [SIGNIFICANT_EVENTS_KI_GROUNDING_SKILL_ID, 'significant-events-memory'],
     // The tool set below is fully explicit — the generic platform_core_* tools are irrelevant
     // to discovery and only add noise to tool selection, so elastic capabilities stay disabled.
     enable_elastic_capabilities: false,

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/index.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/index.test.ts
@@ -27,7 +27,7 @@ describe('discovery agent types', () => {
       baseConfiguration: {
         enable_elastic_capabilities: false,
         connector_ids: [],
-        skill_ids: ['significant-events-ki-grounding'],
+        skill_ids: ['significant-events-ki-grounding', 'significant-events-memory'],
       },
     });
     expect(judgeAgentType).toMatchObject({
@@ -35,7 +35,7 @@ describe('discovery agent types', () => {
       baseConfiguration: {
         enable_elastic_capabilities: false,
         connector_ids: [],
-        skill_ids: ['significant-events-ki-grounding'],
+        skill_ids: ['significant-events-ki-grounding', 'significant-events-memory'],
       },
     });
   });

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/discovery.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/discovery.md.text
@@ -47,7 +47,7 @@ Use each detection's `change_point_type` as an investigation hint. The type dict
 
 <tools>
 
-- `significant-events-memory` (via `load_skill`) — prior learnings about services, known-benign patterns, past false positives, and known ongoing/background issues SREs already track. Load it early and consult it before promoting a discovery so already-known ongoing/background issues and known noise are recognized as such.
+- `significant-events-memory` (via `load_skill`) — prior learnings about services, known-benign patterns, past false positives, and known ongoing/background issues SREs already track. **You MUST load this skill and search memory before promoting any discovery** — treat consulting memory as a required grounding step, never optional. Writing a discovery without first checking memory is an error. An empty memory result is acceptable and expected; skipping the check is not. Use what memory returns so already-known ongoing/background issues and known noise are recognized as such.
 - `platform_sig_events_event_search` — retrieves existing significant events
 - `platform_sig_events_discovery_write` — final output step; submit every discovery in one `items` array.
 
@@ -189,6 +189,7 @@ Split when no conditions are affirmatively and fully met — the default — or 
 1. `load_skill` with `significant-events-ki-grounding` — `platform_sig_events_ki_search` and `platform_core_execute_esql` are not available until that skill is loaded.
 2. Complete the `significant-events-ki-grounding` protocol for the batch. The skill owns KI search, exact rule-to-query mapping, ES|QL execution, objective verification results, and per-detection topology candidates.
 3. Apply `<verification_lens>` to each KI grounding result. Retain the lens outcome for signal construction after routing.
+4. **Mandatory memory check.** `load_skill` with `significant-events-memory` (in its own tool-call batch, per `<tool_discipline>`), then run at least one `platform_sig_events_memory_search` scoped to the batch's services, symptoms, and candidate mechanisms **before routing or promoting any discovery**. This step is required for every run — an empty result is acceptable and expected, but omitting the search is an error. Feed what memory returns into severity/known-issue handling per `<field_rules>`.
 
 ### Step 2: Form Symptom Hypotheses
 

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/discovery.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/discovery.md.text
@@ -45,6 +45,7 @@ Use each detection's `change_point_type` as an investigation hint. The type dict
 
 <tools>
 
+- `significant-events-memory` (via `load_skill`) — prior learnings about services, known-benign patterns, and past false positives. Load it early; consult memory with `memory_search` / `memory_read` before promoting a new discovery when the signal looks familiar or noisy.
 - `platform_sig_events_event_search` — retrieves existing significant events
 - `platform_sig_events_discovery_write` — final output step; submit every discovery in one `items` array.
 
@@ -57,6 +58,12 @@ Example: load_skill (must be called alone — do not batch with any other tool)
 { "skill": "significant-events-ki-grounding" }
 ```
 Response: `{ "skill": { "id": "...", "name": "..." }, "loaded_tools": ["platform_sig_events_ki_search", "platform_core_execute_esql"] }`
+
+Example: load_skill for memory (must be called alone)
+```json
+{ "skill": "significant-events-memory" }
+```
+Response: `{ "skill": { "id": "significant-events-memory", "name": "..." }, "loaded_tools": ["memory_search", "memory_read", "memory_list", ...] }`
 
 Example: platform_sig_events_event_search. Populate `stream_names` and `rule_uuids` with all distinct non-empty values from the detection batch.
 ```json

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/discovery.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/discovery.md.text
@@ -2,6 +2,8 @@ You are the **Operations Lead** triaging a batch of anomaly detection signals. Y
 
 Your primary questions for each signal, in order: **Is this real? What is failing, and why? Who cannot do what?** The answers become the discovery — the incident brief that enables the escalation decision.
 
+The high-level goal is to surface **new** problems that human SREs do not already know about. When memory shows a problem is already known and ongoing, it is fine to record the discovery, but cap its severity at `40-medium` — SREs already track it, so it should not compete with genuinely new findings for attention.
+
 You read the detection change points, search your service knowledge base, confirm or refute hypotheses with targeted queries, and document. You are not making the final paging decision — you are producing the evidence, preliminary impact assessment, and working theory that make that decision possible. Every claim must trace back to a detection doc, a tool result, or a KI — if you cannot cite a source, you do not make the claim.
 
 You receive a batch of active change-point detections — each representing one alerting rule whose firing pattern changed significantly. Evaluate each signal individually before deciding grouping into discoveries. One discovery per distinct failure; one grouped discovery when multiple signals share the same evidence-backed symptom hypothesis.
@@ -45,7 +47,7 @@ Use each detection's `change_point_type` as an investigation hint. The type dict
 
 <tools>
 
-- `significant-events-memory` (via `load_skill`) — prior learnings about services, known-benign patterns, and past false positives. Load it early; consult memory with `memory_search` / `memory_read` before promoting a new discovery when the signal looks familiar or noisy.
+- `significant-events-memory` (via `load_skill`) — prior learnings about services, known-benign patterns, past false positives, and known ongoing/background issues SREs already track. Load it early and consult it before promoting a discovery: when memory shows the signal is an already-known ongoing or background issue, still record it but cap its severity at `40-medium`.
 - `platform_sig_events_event_search` — retrieves existing significant events
 - `platform_sig_events_discovery_write` — final output step; submit every discovery in one `items` array.
 
@@ -58,12 +60,6 @@ Example: load_skill (must be called alone — do not batch with any other tool)
 { "skill": "significant-events-ki-grounding" }
 ```
 Response: `{ "skill": { "id": "...", "name": "..." }, "loaded_tools": ["platform_sig_events_ki_search", "platform_core_execute_esql"] }`
-
-Example: load_skill for memory (must be called alone)
-```json
-{ "skill": "significant-events-memory" }
-```
-Response: `{ "skill": { "id": "significant-events-memory", "name": "..." }, "loaded_tools": ["memory_search", "memory_read", "memory_list", ...] }`
 
 Example: platform_sig_events_event_search. Populate `stream_names` and `rule_uuids` with all distinct non-empty values from the detection batch.
 ```json
@@ -276,7 +272,7 @@ Field content rules, use only when calling `platform_sig_events_discovery_write`
   - Sources in priority order: (1) confirming `platform_core_execute_esql` found-rows; (2) aligned entity KI content when the row confirms the same operation/path; (3) tech KI content for an evidence-supported `causal_features` entity; (4) change semantics plus dependency topology when no confirming row exists; (5) onset order alone.
   - KI metadata may refine an evidenced hypothesis but cannot establish a live failure by itself. When rows contain no error signature, state the observed volume driver and that no mechanism was confirmed. Scope the hypothesis to this discovery's rules only.
 - `summary`: Lead with the problem: affected operation, observed condition, and whether user impact is confirmed, possible, or not established. **Topology** `blast_radius` dependency entries name the explicit dependency path; **KI context** may qualify the conclusion. Never narrate detections, queries, or analysis steps.
-- `severity`: make a preliminary user-impact classification per the `severity`. Use `"20-low"` for possible recovery, minor impact, noise, false-alarm candidates, non-issues, or any positive/health alert symptom; use confidence to distinguish a corroborated low-impact finding from evidence too thin to trust.
+- `severity`: make a preliminary user-impact classification per the `severity`. Use `"20-low"` for possible recovery, minor impact, noise, false-alarm candidates, non-issues, or any positive/health alert symptom; use confidence to distinguish a corroborated low-impact finding from evidence too thin to trust. Cap severity at `40-medium` when memory identifies the signal as an already-known ongoing or background issue, regardless of raw impact.
 - `signals`: for each assigned detection, construct one signal from its grounding result and Step 2 hypothesis; copy metadata and preserve the exact query/result. Set `confirmed` using `<verification_lens>`, never from `evidence.result`.
   - For continuations, submit current signals only.
 - `blast_radius`, `causal_features`: combine the candidates belonging to this discovery's assigned detections, keeping only entries relevant to its failure signature. Apply the formats from the loaded skill and never place one feature in both arrays. For continuations, submit current candidates only; `platform_sig_events_discovery_write` carries prior episode topology forward.

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/discovery.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/discovery.md.text
@@ -2,7 +2,7 @@ You are the **Operations Lead** triaging a batch of anomaly detection signals. Y
 
 Your primary questions for each signal, in order: **Is this real? What is failing, and why? Who cannot do what?** The answers become the discovery — the incident brief that enables the escalation decision.
 
-The high-level goal is to surface **new** problems that human SREs do not already know about. When memory shows a problem is already known and ongoing, it is fine to record the discovery, but cap its severity at `40-medium` — SREs already track it, so it should not compete with genuinely new findings for attention.
+The high-level goal is to surface **new** problems that human SREs do not already know about. Problems that memory shows are already known and ongoing still count, but should not compete with genuinely new findings for attention (see `severity` in `<field_rules>`).
 
 You read the detection change points, search your service knowledge base, confirm or refute hypotheses with targeted queries, and document. You are not making the final paging decision — you are producing the evidence, preliminary impact assessment, and working theory that make that decision possible. Every claim must trace back to a detection doc, a tool result, or a KI — if you cannot cite a source, you do not make the claim.
 
@@ -47,7 +47,7 @@ Use each detection's `change_point_type` as an investigation hint. The type dict
 
 <tools>
 
-- `significant-events-memory` (via `load_skill`) — prior learnings about services, known-benign patterns, past false positives, and known ongoing/background issues SREs already track. Load it early and consult it before promoting a discovery: when memory shows the signal is an already-known ongoing or background issue, still record it but cap its severity at `40-medium`.
+- `significant-events-memory` (via `load_skill`) — prior learnings about services, known-benign patterns, past false positives, and known ongoing/background issues SREs already track. Load it early and consult it before promoting a discovery so already-known ongoing/background issues and known noise are recognized as such.
 - `platform_sig_events_event_search` — retrieves existing significant events
 - `platform_sig_events_discovery_write` — final output step; submit every discovery in one `items` array.
 

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
@@ -47,6 +47,7 @@ Use tools only for **fresh** detection signals (see `<inputs>` for the fresh/car
 
 Your queries answer: **is the failure still happening now?** They are current-state checks, not root-cause investigations.
 
+- `significant-events-memory` (via `load_skill`) — optional prior context (known-benign patterns, past dismissals). Load once early if a discovery looks familiar; do not let memory override a failed current-state check.
 - `platform_sig_events_ki_search` — apply one hard gate before dispatching any verification. Call at most once for the whole run when `signals` is absent or empty **OR** any fresh entry in `signals[]` has missing/null `evidence` or an empty `evidence.esql_query`.
     If every fresh signal carries a non-empty `esql_query`, this tool is **FORBIDDEN for the entire run** — do not call it for enrichment, confidence, severity, or corroboration.
     When required, pass only `kind: ["feature", "query"]` and `stream_names` (the deduplicated union of discovery `stream_names[]`); never pass `search_text`. Do not issue a follow-up search when 0 query KIs are returned — the one-call limit is absolute. Query selection is constrained to KIs whose `rule.id` matches a `rule_uuid` in `signals[]` — feature KI results are topology context only, never proof of current failure. This judge-specific gate and one-call limit override the loaded skill's unconditional-call and follow-up rules.
@@ -64,6 +65,12 @@ Example: load_skill (must be called alone — do not batch with any other tool)
 { "skill": "significant-events-ki-grounding" }
 ```
 Response: `{ "skill": { "id": "...", "name": "..." }, "loaded_tools": ["platform_sig_events_ki_search", "platform_core_execute_esql"] }`
+
+Example: load_skill for memory (must be called alone)
+```json
+{ "skill": "significant-events-memory" }
+```
+Response: `{ "skill": { "id": "significant-events-memory", "name": "..." }, "loaded_tools": ["memory_search", "memory_read", "memory_list", ...] }`
 
 Example: platform_core_execute_esql (current-state check, DESC LIMIT 1)
 ```json

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
@@ -47,7 +47,7 @@ Use tools only for **fresh** detection signals (see `<inputs>` for the fresh/car
 
 Your queries answer: **is the failure still happening now?** They are current-state checks, not root-cause investigations.
 
-- `significant-events-memory` (via `load_skill`) — optional prior context (known-benign patterns, past dismissals). Load once early if a discovery looks familiar; do not let memory override a failed current-state check.
+- `significant-events-memory` (via `load_skill`) — optional prior context (known-benign patterns, past dismissals, known ongoing/background issues SREs already track). Load once early if a discovery looks familiar. The goal is to surface **new** problems SREs do not yet know about: when memory shows the discovery is an already-known ongoing or background issue, it may stay `open` but cap its severity at `40-medium`, noting the memory reference in `assessment_note`. Do not let memory override a failed current-state check that reveals a genuinely new failure.
 - `platform_sig_events_ki_search` — apply one hard gate before dispatching any verification. Call at most once for the whole run when `signals` is absent or empty **OR** any fresh entry in `signals[]` has missing/null `evidence` or an empty `evidence.esql_query`.
     If every fresh signal carries a non-empty `esql_query`, this tool is **FORBIDDEN for the entire run** — do not call it for enrichment, confidence, severity, or corroboration.
     When required, pass only `kind: ["feature", "query"]` and `stream_names` (the deduplicated union of discovery `stream_names[]`); never pass `search_text`. Do not issue a follow-up search when 0 query KIs are returned — the one-call limit is absolute. Query selection is constrained to KIs whose `rule.id` matches a `rule_uuid` in `signals[]` — feature KI results are topology context only, never proof of current failure. This judge-specific gate and one-call limit override the loaded skill's unconditional-call and follow-up rules.
@@ -65,12 +65,6 @@ Example: load_skill (must be called alone — do not batch with any other tool)
 { "skill": "significant-events-ki-grounding" }
 ```
 Response: `{ "skill": { "id": "...", "name": "..." }, "loaded_tools": ["platform_sig_events_ki_search", "platform_core_execute_esql"] }`
-
-Example: load_skill for memory (must be called alone)
-```json
-{ "skill": "significant-events-memory" }
-```
-Response: `{ "skill": { "id": "significant-events-memory", "name": "..." }, "loaded_tools": ["memory_search", "memory_read", "memory_list", ...] }`
 
 Example: platform_core_execute_esql (current-state check, DESC LIMIT 1)
 ```json
@@ -130,6 +124,7 @@ Response: `{ "results": [{ "index": 0, "event_uuid": "...", "event_id": "...", "
    - `status: "open"` with `severity: "40-medium"`: evidence supports the medium tier. Do not pick medium merely to hedge on signal quality — express that in `confidence` instead.
    - `status: "open"` with `severity: "20-low"`: confirmed minor impact with at least one event-aligned signal.
    - `status: "dismissed"`: every completed check is non-confirming, unrelated, or verifies only benign/positive activity, and no plausible failure, material degradation, or sensitive-data exposure remains unverified. Also the disposition for a same-batch duplicate of a more comprehensive discovery (see `<inputs>`).
+   - **Known ongoing/background issue cap**: a still-active failure that memory identifies as an already-known ongoing or background issue SREs already track may stay `open`, but cap its severity at `40-medium` regardless of raw impact — the goal is to surface new problems, not re-page on known ones. Note the memory reference in `assessment_note`.
    - `status: "closed"`: a failure condition closes only when every fresh signal's current-state check finds no active failure rows (`result: "empty"` or healthy rows only) AND a broad `COUNT(*)` confirms the stream is live. Carried signals are trusted as recorded and need no re-verification. An error, telemetry gap, or missing check stays `open` only when a failure, degradation, or exposure remains plausible. The change-point shape alone is never sufficient. A healthy or positive predicate is dismissed, not closed.
 
 </critical_rules>
@@ -210,7 +205,7 @@ Emit only fields defined in this schema. Output discipline applies to all narrat
 - `status`: apply the status gate in Critical Rule 5.
 - `symptom_hypothesis`: exactly one sentence derived from confirmed event-aligned signals. When dismissed with none, preserve the tested input hypothesis without broadening it. Record unrelated targets or operations in `assessment_note`, not this field. Apply the sensitive-value rule from the field description.
 - `severity`: required for all events.
-  - `open`: assess per the tool field description and severity-calibration guards; `"20-low"` requires a confirmed event-aligned signal with minor impact.
+  - `open`: assess per the tool field description and severity-calibration guards; `"20-low"` requires a confirmed event-aligned signal with minor impact. Cap at `40-medium` when memory flags the condition as an already-known ongoing or background issue (see Critical Rule 5).
   - `closed` / `dismissed`: always `"20-low"` — these statuses are low severity by definition, not an impact assessment.
 - `causal_features`, `blast_radius`: read-only — echo verbatim. Never add, remove, or modify.
 - `confidence`: start from the discovery's `confidence` value (prior):

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
@@ -47,7 +47,7 @@ Use tools only for **fresh** detection signals (see `<inputs>` for the fresh/car
 
 Your queries answer: **is the failure still happening now?** They are current-state checks, not root-cause investigations.
 
-- `significant-events-memory` (via `load_skill`) — optional prior context (known-benign patterns, past dismissals, known ongoing/background issues SREs already track). Load once early if a discovery looks familiar. The goal is to surface **new** problems SREs do not yet know about: when memory shows the discovery is an already-known ongoing or background issue, it may stay `open` but cap its severity at `40-medium`, noting the memory reference in `assessment_note`. Do not let memory override a failed current-state check that reveals a genuinely new failure.
+- `significant-events-memory` (via `load_skill`) — optional prior context (known-benign patterns, past dismissals, known ongoing/background issues SREs already track). Load once early if a discovery looks familiar; the goal is to surface **new** problems SREs do not yet know about (memory-known ongoing issues are bounded by Critical Rule 5). Do not let memory override a failed current-state check that reveals a genuinely new failure.
 - `platform_sig_events_ki_search` — apply one hard gate before dispatching any verification. Call at most once for the whole run when `signals` is absent or empty **OR** any fresh entry in `signals[]` has missing/null `evidence` or an empty `evidence.esql_query`.
     If every fresh signal carries a non-empty `esql_query`, this tool is **FORBIDDEN for the entire run** — do not call it for enrichment, confidence, severity, or corroboration.
     When required, pass only `kind: ["feature", "query"]` and `stream_names` (the deduplicated union of discovery `stream_names[]`); never pass `search_text`. Do not issue a follow-up search when 0 query KIs are returned — the one-call limit is absolute. Query selection is constrained to KIs whose `rule.id` matches a `rule_uuid` in `signals[]` — feature KI results are topology context only, never proof of current failure. This judge-specific gate and one-call limit override the loaded skill's unconditional-call and follow-up rules.
@@ -205,7 +205,7 @@ Emit only fields defined in this schema. Output discipline applies to all narrat
 - `status`: apply the status gate in Critical Rule 5.
 - `symptom_hypothesis`: exactly one sentence derived from confirmed event-aligned signals. When dismissed with none, preserve the tested input hypothesis without broadening it. Record unrelated targets or operations in `assessment_note`, not this field. Apply the sensitive-value rule from the field description.
 - `severity`: required for all events.
-  - `open`: assess per the tool field description and severity-calibration guards; `"20-low"` requires a confirmed event-aligned signal with minor impact. Cap at `40-medium` when memory flags the condition as an already-known ongoing or background issue (see Critical Rule 5).
+  - `open`: assess per the tool field description and severity-calibration guards; `"20-low"` requires a confirmed event-aligned signal with minor impact.
   - `closed` / `dismissed`: always `"20-low"` — these statuses are low severity by definition, not an impact assessment.
 - `causal_features`, `blast_radius`: read-only — echo verbatim. Never add, remove, or modify.
 - `confidence`: start from the discovery's `confidence` value (prior):

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/judge.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/judge.ts
@@ -22,7 +22,7 @@ export const judgeAgentType = {
   avatar_icon: 'logoElastic',
   baseConfiguration: {
     instructions,
-    skill_ids: [SIGNIFICANT_EVENTS_KI_GROUNDING_SKILL_ID],
+    skill_ids: [SIGNIFICANT_EVENTS_KI_GROUNDING_SKILL_ID, 'significant-events-memory'],
     // The tool set below is fully explicit — the generic platform_core_* tools are irrelevant
     // to discovery and only add noise to tool selection, so elastic capabilities stay disabled.
     enable_elastic_capabilities: false,

--- a/x-pack/platform/plugins/shared/significant_events/server/index.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/index.ts
@@ -29,4 +29,8 @@ export {
   SIGNIFICANT_EVENTS_EVENT_INVESTIGATION_ATTACH_TOOL_ID,
 } from './agent_builder/tools/tool_ids';
 
+export { createMemoryDiscoveryTools } from './lib/significant_events/memory_discovery_tools';
+export type { MemoryDiscoveryTools } from './lib/significant_events/memory_discovery_tools';
+export { MemoryServiceImpl } from './memory_and_investigation/lib/memory';
+
 export type { SignificantEventsRouteRepository } from './routes';

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/features/identify_inferred_features.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/features/identify_inferred_features.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient } from '@kbn/core/server';
+import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { ToolsStart } from '@kbn/agent-builder-server';
 import type { Logger } from '@kbn/logging';
 import type { BoundInferenceClient, ChatCompletionTokenCount } from '@kbn/inference-common';
 import type { StreamType } from '@kbn/streams-schema';
@@ -36,7 +37,11 @@ import { PromptsConfigService } from '@kbn/streams-plugin/server';
 import type { ToolCallback, ToolDefinition } from '@kbn/inference-common';
 import type { KnowledgeIndicatorClient } from '../../knowledge_indicators';
 import { MemoryServiceImpl } from '../../../memory_and_investigation/lib/memory';
-import { createMemoryDiscoveryTools } from '../memory_discovery_tools';
+import { createMemoryDiscoveryTools, type MemoryDiscoveryTools } from '../memory_discovery_tools';
+import {
+  createKiExtractionContextTools,
+  type KiExtractionContextTools,
+} from '../ki_extraction_context_tools';
 import { fetchSampleDocuments } from './fetch_sample_documents';
 
 import {
@@ -669,6 +674,8 @@ export interface IdentifyInferredFeaturesOptions {
   tuning?: IterationTuningParams;
   diverseOffset?: number;
   trackFeaturesIdentified?: (data: FeaturesIdentifiedTelemetry) => void;
+  agentBuilderTools?: ToolsStart;
+  request?: KibanaRequest;
 }
 
 export interface IdentifyInferredFeaturesResult {
@@ -698,6 +705,8 @@ export async function identifyInferredFeatures({
   tuning = {},
   diverseOffset = 0,
   trackFeaturesIdentified,
+  agentBuilderTools,
+  request,
 }: IdentifyInferredFeaturesOptions): Promise<IdentifyInferredFeaturesResult> {
   const [
     { hits: allFeatures },
@@ -711,13 +720,40 @@ export async function identifyInferredFeatures({
 
   const discoveredFeatures = allFeatures.filter((f) => !isComputedFeature(f) && f.run_id === runId);
 
-  // Expose the shared memory (prior learnings about services, known-benign
-  // patterns, past false positives) to feature extraction so it can ground new
-  // KI features in durable prior knowledge. Read-only tools only.
+  // Expose read-only grounding tools to feature extraction so it can anchor new
+  // KI features in durable prior knowledge:
+  // - memory: prior learnings, known-benign patterns, past false positives.
+  // - significant_event_search: prior Significant Events (already-tracked /
+  //   demoted patterns). Only available when Agent Builder tools are wired.
   const memoryTools = createMemoryDiscoveryTools({
     memoryService: new MemoryServiceImpl({ logger: logger.get('memory'), esClient }),
   });
-  const combinedSystemPrompt = `${systemPrompt}\n${memoryTools.promptSnippet}`;
+
+  const kiExtractionContextTools =
+    agentBuilderTools && request
+      ? await createKiExtractionContextTools({
+          agentBuilderTools,
+          request,
+          logger: logger.get('ki_extraction_context'),
+        })
+      : undefined;
+
+  const groundingToolsets = [memoryTools, kiExtractionContextTools].filter(
+    (toolset): toolset is MemoryDiscoveryTools | KiExtractionContextTools => toolset !== undefined
+  );
+
+  const additionalTools: Record<string, ToolDefinition> = Object.assign(
+    {},
+    ...groundingToolsets.map((toolset) => toolset.tools)
+  );
+  const additionalToolCallbacks: Record<string, ToolCallback> = Object.assign(
+    {},
+    ...groundingToolsets.map((toolset) => toolset.callbacks)
+  );
+  const combinedSystemPrompt = groundingToolsets.reduce(
+    (prompt, toolset) => `${prompt}\n${toolset.promptSnippet}`,
+    systemPrompt
+  );
 
   const startedAt = Date.now();
 
@@ -738,8 +774,8 @@ export async function identifyInferredFeatures({
     signal,
     tuning,
     diverseOffset,
-    additionalTools: memoryTools.tools,
-    additionalToolCallbacks: memoryTools.callbacks,
+    additionalTools,
+    additionalToolCallbacks,
   });
 
   if (!iterationResult.hasDocuments) {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/features/identify_inferred_features.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/features/identify_inferred_features.ts
@@ -33,7 +33,10 @@ import {
   type SignificantEventsTuningConfig,
 } from '@kbn/significant-events-schema';
 import { PromptsConfigService } from '@kbn/streams-plugin/server';
+import type { ToolCallback, ToolDefinition } from '@kbn/inference-common';
 import type { KnowledgeIndicatorClient } from '../../knowledge_indicators';
+import { MemoryServiceImpl } from '../../../memory_and_investigation/lib/memory';
+import { createMemoryDiscoveryTools } from '../memory_discovery_tools';
 import { fetchSampleDocuments } from './fetch_sample_documents';
 
 import {
@@ -453,6 +456,8 @@ interface RunInferredIterationOptions {
   signal: AbortSignal;
   tuning: IterationTuningParams;
   diverseOffset: number;
+  additionalTools?: Record<string, ToolDefinition>;
+  additionalToolCallbacks?: Record<string, ToolCallback>;
 }
 
 type InferredIterationResult =
@@ -497,6 +502,8 @@ async function runInferredIteration({
   signal,
   tuning,
   diverseOffset,
+  additionalTools,
+  additionalToolCallbacks,
 }: RunInferredIterationOptions): Promise<InferredIterationResult> {
   const {
     sample_size: sampleSize = DEFAULT_SIGNIFICANT_EVENTS_TUNING_CONFIG.sample_size,
@@ -584,6 +591,8 @@ async function runInferredIteration({
       searchRecordsByCandidate.set(recordKey, searchRecord);
       return hits;
     },
+    additionalTools,
+    additionalToolCallbacks,
   });
 
   if (!inferResult.success) {
@@ -702,6 +711,14 @@ export async function identifyInferredFeatures({
 
   const discoveredFeatures = allFeatures.filter((f) => !isComputedFeature(f) && f.run_id === runId);
 
+  // Expose the shared memory (prior learnings about services, known-benign
+  // patterns, past false positives) to feature extraction so it can ground new
+  // KI features in durable prior knowledge. Read-only tools only.
+  const memoryTools = createMemoryDiscoveryTools({
+    memoryService: new MemoryServiceImpl({ logger: logger.get('memory'), esClient }),
+  });
+  const combinedSystemPrompt = `${systemPrompt}\n${memoryTools.promptSnippet}`;
+
   const startedAt = Date.now();
 
   const iterationResult = await runInferredIteration({
@@ -716,11 +733,13 @@ export async function identifyInferredFeatures({
     discoveredFeatures,
     excludedFeatures,
     inferenceClient,
-    systemPrompt,
+    systemPrompt: combinedSystemPrompt,
     logger,
     signal,
     tuning,
     diverseOffset,
+    additionalTools: memoryTools.tools,
+    additionalToolCallbacks: memoryTools.callbacks,
   });
 
   if (!iterationResult.hasDocuments) {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/identify_ki_queries.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/identify_ki_queries.test.ts
@@ -128,4 +128,26 @@ describe('generateSignificantEventDefinitions (semantic code search wiring)', ()
     expect(args.systemPrompt).toContain('MEMORY_SNIPPET');
     expect(args.systemPrompt).toContain('SCS_GROUNDING_SNIPPET');
   });
+
+  it('forwards Significant Event context tools and appends the prompt snippet', async () => {
+    const kiExtractionContextTools = {
+      tools: {
+        significant_event_search: {
+          description: 'search events',
+          schema: { type: 'object' as const, properties: {} },
+        },
+      },
+      callbacks: { significant_event_search: jest.fn() },
+      promptSnippet: 'SIGEVENT_CONTEXT_SNIPPET',
+    };
+
+    await identifyKIQueries(
+      { definition, connectorId: 'c1', systemPrompt: 'SYSTEM' },
+      buildDeps({ kiExtractionContextTools })
+    );
+
+    const args = generateSignificantEventsMock.mock.calls[0][0];
+    expect(Object.keys(args.additionalTools ?? {})).toEqual(['significant_event_search']);
+    expect(args.systemPrompt).toContain('SIGEVENT_CONTEXT_SNIPPET');
+  });
 });

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/identify_ki_queries.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/identify_ki_queries.ts
@@ -31,10 +31,7 @@ import type { SemanticCodeSearchTools } from '../semantic_code_search_grounding/
  */
 const MAX_STEPS_WITH_SEMANTIC_CODE_SEARCH_TOOLS = 10;
 
-type KiDiscoveryToolset =
-  | MemoryDiscoveryTools
-  | KiExtractionContextTools
-  | SemanticCodeSearchTools;
+type KiDiscoveryToolset = MemoryDiscoveryTools | KiExtractionContextTools | SemanticCodeSearchTools;
 
 interface Params {
   definition: Streams.all.Definition;

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/identify_ki_queries.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/identify_ki_queries.ts
@@ -20,6 +20,7 @@ import type { SignificantEventsToolUsage } from '@kbn/streams-ai';
 import type { ToolCallback, ToolDefinition } from '@kbn/inference-common';
 import type { KnowledgeIndicatorClient } from '../knowledge_indicators';
 import type { MemoryDiscoveryTools } from './memory_discovery_tools';
+import type { KiExtractionContextTools } from './ki_extraction_context_tools';
 import type { SemanticCodeSearchTools } from '../semantic_code_search_grounding/semantic_code_search_tools';
 
 /**
@@ -29,6 +30,11 @@ import type { SemanticCodeSearchTools } from '../semantic_code_search_grounding/
  * repository is linked, its git history — adds tool round-trips.
  */
 const MAX_STEPS_WITH_SEMANTIC_CODE_SEARCH_TOOLS = 10;
+
+type KiDiscoveryToolset =
+  | MemoryDiscoveryTools
+  | KiExtractionContextTools
+  | SemanticCodeSearchTools;
 
 interface Params {
   definition: Streams.all.Definition;
@@ -45,6 +51,7 @@ interface Dependencies {
   signal: AbortSignal;
   esClient: ElasticsearchClient;
   memoryTools?: MemoryDiscoveryTools;
+  kiExtractionContextTools?: KiExtractionContextTools;
   semanticCodeSearchTools?: SemanticCodeSearchTools;
 }
 
@@ -70,11 +77,12 @@ export async function identifyKIQueries(
     signal,
     esClient,
     memoryTools,
+    kiExtractionContextTools,
     semanticCodeSearchTools,
   } = dependencies;
 
-  const discoveryTools = [memoryTools, semanticCodeSearchTools].filter(
-    (toolset): toolset is MemoryDiscoveryTools | SemanticCodeSearchTools => toolset !== undefined
+  const discoveryTools = [memoryTools, kiExtractionContextTools, semanticCodeSearchTools].filter(
+    (toolset): toolset is KiDiscoveryToolset => toolset !== undefined
   );
 
   const additionalTools: Record<string, ToolDefinition> = Object.assign(

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/ki_extraction_context_tools.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/ki_extraction_context_tools.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import { loggerMock } from '@kbn/logging-mocks';
+import type { ToolsStart } from '@kbn/agent-builder-server';
+import { platformSignificantEventsTools } from '@kbn/agent-builder-common/tools';
+import { createInferenceToolsFromAgentBuilder } from '../agent_builder/inference_tool_bridge';
+import { createKiExtractionContextTools } from './ki_extraction_context_tools';
+
+jest.mock('../agent_builder/inference_tool_bridge', () => ({
+  createInferenceToolsFromAgentBuilder: jest.fn(),
+}));
+
+const createInferenceToolsFromAgentBuilderMock =
+  createInferenceToolsFromAgentBuilder as jest.MockedFunction<
+    typeof createInferenceToolsFromAgentBuilder
+  >;
+
+describe('createKiExtractionContextTools', () => {
+  let logger: jest.Mocked<Logger>;
+  const request = {} as KibanaRequest;
+  const agentBuilderTools = {} as ToolsStart;
+
+  beforeEach(() => {
+    logger = loggerMock.create();
+    createInferenceToolsFromAgentBuilderMock.mockReset();
+  });
+
+  it('returns undefined when the bridge resolves no tools', async () => {
+    createInferenceToolsFromAgentBuilderMock.mockResolvedValue({ tools: {}, callbacks: {} });
+
+    await expect(
+      createKiExtractionContextTools({ agentBuilderTools, request, logger })
+    ).resolves.toBeUndefined();
+  });
+
+  it('bridges event_search as significant_event_search with a prompt snippet', async () => {
+    createInferenceToolsFromAgentBuilderMock.mockResolvedValue({
+      tools: {
+        significant_event_search: {
+          description: 'search',
+          schema: { type: 'object', properties: {} },
+        },
+      },
+      callbacks: { significant_event_search: jest.fn() },
+    });
+
+    const result = await createKiExtractionContextTools({
+      agentBuilderTools,
+      request,
+      logger,
+    });
+
+    expect(createInferenceToolsFromAgentBuilderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: agentBuilderTools,
+        request,
+        specs: [
+          expect.objectContaining({
+            sourceToolId: platformSignificantEventsTools.searchEvent,
+            name: 'significant_event_search',
+          }),
+        ],
+      })
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        tools: expect.objectContaining({ significant_event_search: expect.any(Object) }),
+        promptSnippet: expect.stringContaining('significant_event_search'),
+      })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/ki_extraction_context_tools.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/ki_extraction_context_tools.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { ToolsStart } from '@kbn/agent-builder-server';
+import type { ToolCallback, ToolDefinition } from '@kbn/inference-common';
+import { platformSignificantEventsTools } from '@kbn/agent-builder-common/tools';
+import {
+  createInferenceToolsFromAgentBuilder,
+  type BridgedToolSpec,
+} from '../agent_builder/inference_tool_bridge';
+
+/**
+ * Prior Significant Events / investigation context tools for KI query generation
+ * (`executeAsReasoningAgent`). Bridged from the Agent Builder `event_search` tool
+ * so schemas stay in sync with the managed tool registration.
+ *
+ * Read-only: these tools only search existing events; they never write them.
+ */
+export interface KiExtractionContextTools {
+  tools: Record<string, ToolDefinition>;
+  callbacks: Record<string, ToolCallback>;
+  promptSnippet: string;
+}
+
+const EVENT_SEARCH_SPEC: BridgedToolSpec = {
+  sourceToolId: platformSignificantEventsTools.searchEvent,
+  name: 'significant_event_search',
+  description:
+    'Search existing Significant Events for the target stream (and related filters). ' +
+    'Use view "full" when you need assessment notes, demotion justifications, or linked investigation outcomes. ' +
+    'Prefer status filters (e.g. dismissed) when looking for known-noisy / demoted patterns to avoid regenerating.',
+};
+
+const PROMPT_SNIPPET = `
+You also have access to prior Significant Events and investigation outcomes for this stream. Before proposing new or refreshed KI queries, consult that history so you do not blindly reintroduce patterns the system has already classified:
+- **significant_event_search** — Search Significant Events (open, dismissed, closed). Use \`view: "full"\` to include assessment notes and linked investigations. Filter by \`stream_names\` for the current stream; use status \`dismissed\` when checking for known noise / demotions.
+
+When prior findings show a query path was noisy, single-tenant, known-benign, or already investigated as non-actionable, prefer refining/avoiding that path over regenerating an equivalent rule. Prefer and annotate high-value patterns that previously produced useful detections.`;
+
+/**
+ * Builds inference tools that expose Significant Event (and attached investigation)
+ * history to KI extraction. Returns `undefined` when Agent Builder tools are
+ * unavailable or `event_search` cannot be resolved, so extraction degrades gracefully.
+ */
+export const createKiExtractionContextTools = async ({
+  agentBuilderTools,
+  request,
+  logger,
+}: {
+  agentBuilderTools: ToolsStart;
+  request: KibanaRequest;
+  logger: Logger;
+}): Promise<KiExtractionContextTools | undefined> => {
+  const { tools, callbacks } = await createInferenceToolsFromAgentBuilder({
+    tools: agentBuilderTools,
+    request,
+    specs: [EVENT_SEARCH_SPEC],
+    logger,
+  });
+
+  if (Object.keys(tools).length === 0) {
+    return undefined;
+  }
+
+  return { tools, callbacks, promptSnippet: PROMPT_SNIPPET };
+};

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/ki_queries_generation_service.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/ki_queries_generation_service.ts
@@ -34,6 +34,7 @@ import { formatInferenceProviderError } from '../../routes/utils/create_connecto
 import { identifyKIQueries } from './identify_ki_queries';
 import { MemoryServiceImpl } from '../../memory_and_investigation/lib/memory';
 import { createMemoryDiscoveryTools } from './memory_discovery_tools';
+import { createKiExtractionContextTools } from './ki_extraction_context_tools';
 
 export interface GenerateKIQueriesParams {
   streamName: string;
@@ -139,6 +140,15 @@ export async function generateKIQueries(
     );
   }
 
+  const kiExtractionContextTools =
+    significantEventsAvailable && agentBuilderTools
+      ? await createKiExtractionContextTools({
+          agentBuilderTools,
+          request,
+          logger: logger.get('ki_extraction_context'),
+        })
+      : undefined;
+
   const startedAt = Date.now();
   const result = await identifyKIQueries(
     {
@@ -155,6 +165,7 @@ export async function generateKIQueries(
       logger: logger.get('significant_events_generation'),
       signal,
       memoryTools,
+      kiExtractionContextTools,
       semanticCodeSearchTools,
     }
   ).catch(async (error) => {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/memory_discovery_tools.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/memory_discovery_tools.ts
@@ -155,12 +155,15 @@ export const createMemoryDiscoveryTools = ({
   };
 
   const promptSnippet = `
-You have access to a knowledge base ("memory") that stores what the system has learned about monitored services, infrastructure, operational patterns, known-benign noise, and prior false positives. Pages are organized by categories (like Wikipedia). Before inventing or promoting new KI queries — especially anything that looks familiar or historically noisy — consult memory:
+You have access to a knowledge base ("memory") that stores what the system has learned about monitored services, infrastructure, operational patterns, known-benign noise, and prior false positives. Pages are organized by categories (like Wikipedia).
+
+**Required grounding step:** before you finalize your output, you MUST call \`memory_search\` at least once — scoped to the services, symptoms, and patterns you are considering — to ground your work in prior learnings. Treat this as mandatory, never optional: finalizing without first consulting memory is an error. An empty memory result is acceptable and expected; skipping the search is not.
+
 - **memory_search** — Search by keyword to find relevant pages (supports category filter)
 - **memory_read** — Read the full content of a specific page by name or ID
 - **memory_list** — List all pages to discover what knowledge exists
 
-Use memory to avoid regenerating known-bad / demoted patterns and to prefer queries aligned with durable prior learnings. Still ground every proposed query in the current stream data; memory is prior context, not a substitute for evidence.`;
+Use memory to avoid regenerating known-bad / demoted patterns and to prefer outputs aligned with durable prior learnings. Still ground everything you propose in the current stream data; memory is prior context, not a substitute for evidence.`;
 
   return { tools, callbacks, promptSnippet };
 };

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/memory_discovery_tools.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/memory_discovery_tools.ts
@@ -155,12 +155,12 @@ export const createMemoryDiscoveryTools = ({
   };
 
   const promptSnippet = `
-You have access to a knowledge base ("memory") that stores what the system has learned about monitored services, infrastructure, and operational patterns. Pages are organized by categories (like Wikipedia). After analyzing the current data independently, you may use memory tools to enrich your findings with additional context:
+You have access to a knowledge base ("memory") that stores what the system has learned about monitored services, infrastructure, operational patterns, known-benign noise, and prior false positives. Pages are organized by categories (like Wikipedia). Before inventing or promoting new KI queries — especially anything that looks familiar or historically noisy — consult memory:
 - **memory_search** — Search by keyword to find relevant pages (supports category filter)
 - **memory_read** — Read the full content of a specific page by name or ID
 - **memory_list** — List all pages to discover what knowledge exists
 
-Analyze the data on its own merits first. Use the knowledge base to add context or cross-reference, not as a starting point.`;
+Use memory to avoid regenerating known-bad / demoted patterns and to prefer queries aligned with durable prior learnings. Still ground every proposed query in the current stream data; memory is prior context, not a substitute for evidence.`;
 
   return { tools, callbacks, promptSnippet };
 };

--- a/x-pack/platform/plugins/shared/significant_events/server/routes/internal/knowledge_indicators/features/identify_route.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/routes/internal/knowledge_indicators/features/identify_route.ts
@@ -148,6 +148,11 @@ const identifyInferredFeaturesRoute = createServerRoute({
         },
         diverseOffset,
         trackFeaturesIdentified: (data) => telemetry.trackFeaturesIdentified(data),
+        // Expose prior Significant Events (read-only search) to feature
+        // extraction when Agent Builder tools are available.
+        ...(server.agentBuilder?.tools
+          ? { agentBuilderTools: server.agentBuilder.tools, request }
+          : {}),
       });
       return { ...result, connectorId };
     } catch (error) {


### PR DESCRIPTION
## Summary

Closes the Discovery/Judge + KI-extraction side of the Significant Events **learning loop** by giving those agents read-only access to what the system already knows — the shared **memory** knowledge base and **prior Significant Events** — and by making sure issues we already know about don't re-page as new criticals. (Investigation already had the memory skill; this closes the rest of the loop.)

### Memory in Discovery & Judge
- Add `significant-events-memory` (via `load_skill`) to the Discovery and Judge managed agent types.
- Discovery **must** load the skill and `memory_search` before promoting any discovery (required grounding step; an empty result is fine, skipping it is an error). Judge consults it to recognize familiar / known-noisy signals. ([nightshift#732](https://github.com/elastic/nightshift-program/issues/732))

### Known ongoing/background issues → capped at medium severity
- When memory identifies a still-active signal as an issue SREs **already track** (a known ongoing/background problem), Discovery and Judge keep it `open` but **cap its severity at `40-medium`** regardless of raw impact. The goal is to surface *new* problems, not re-page on ones we already know about; the memory reference is recorded in `assessment_note`.

### Prior Significant Events + memory in KI extraction
- Bridge the Agent Builder `event_search` tool into KI extraction as the read-only `significant_event_search` tool, so extraction can consult prior SigEvents, demotions, and linked investigation outcomes before proposing new features/queries. ([nightshift#735](https://github.com/elastic/nightshift-program/issues/735))
- Wire both the **memory tools** and **`significant_event_search`** into KI **feature extraction** *and* **query generation** (previously feature extraction had neither), and strengthen the memory prompt to require a consult before finalizing.

### Evals
- The KI feature-extraction and query-generation eval suites now exercise both memory and `significant_event_search` (the latter via an HTTP bridge to the Agent Builder tool), with the significant-events availability feature flag enabled so the tools are registered.
- Verified locally via traces that both tools are invoked **and** executed end-to-end in both KI paths (see PR comments for the trace evidence).

Addresses https://github.com/elastic/nightshift-program/issues/732
Addresses https://github.com/elastic/nightshift-program/issues/735

## Test plan

- [ ] Unit: `node scripts/jest` on discovery agent type, `identify_ki_queries`, and `ki_extraction_context_tools` tests (passed locally)
- [ ] Discovery/Judge: in a space with SigEvents + memory enabled, confirm agents can `load_skill` `significant-events-memory` and call `memory_search` / `memory_read`
- [ ] Severity cap: with a memory page describing a known ongoing/background issue, confirm a matching still-active discovery stays `open` but is capped at `40-medium` and cites the memory reference in `assessment_note`
- [ ] KI extraction: with Agent Builder available, confirm `significant_event_search` and the memory tools are in the reasoning-agent toolset for both feature extraction and query generation; with prior dismissed events, extraction avoids regenerating the same noisy path (qualitative)
- [ ] Evals: run the KI feature-extraction and query-generation suites and confirm `memory_search` + `significant_event_search` (+ underlying `platform.sig_events.event_search`) spans appear in traces
- [ ] Confirm Investigation agent unchanged (still has memory skill)


Made with [Cursor](https://cursor.com)