### PR TITLE
[9.5] [Entity Analytics] Update success toast to work on fullscreen Entity Analytics Table  (#280206)

### DIFF
--- a/src/core/packages/notifications/browser-internal/src/notifications_service.test.ts
+++ b/src/core/packages/notifications/browser-internal/src/notifications_service.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { overlayServiceMock } from '@kbn/core-overlays-browser-mocks';
+import { uiSettingsServiceMock, settingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
+import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
+import { renderingServiceMock } from '@kbn/core-rendering-browser-mocks';
+import { NotificationsService } from './notifications_service';
+
+jest.mock('react-dom', () => ({
+  render: jest.fn(),
+  unmountComponentAtNode: jest.fn(),
+}));
+
+describe('NotificationsService', () => {
+  const setupAndStart = (targetDomElement: HTMLElement) => {
+    const service = new NotificationsService();
+    service.setup({
+      uiSettings: uiSettingsServiceMock.createSetupContract(),
+      analytics: analyticsServiceMock.createAnalyticsServiceSetup(),
+    });
+    service.start({
+      overlays: overlayServiceMock.createStartContract(),
+      rendering: renderingServiceMock.create(),
+      analytics: analyticsServiceMock.createAnalyticsServiceStart(),
+      settings: settingsServiceMock.createStartContract(),
+      targetDomElement,
+    });
+    return service;
+  };
+
+  it('marks the toasts container to preserve its z-index in full-screen data grids', () => {
+    const targetDomElement = document.createElement('div');
+    const service = setupAndStart(targetDomElement);
+
+    const toastsContainer = targetDomElement.firstElementChild;
+    expect(toastsContainer).not.toBeNull();
+    expect(toastsContainer!.getAttribute('data-kbn-preserve-zindex')).toBe('true');
+
+    service.stop();
+  });
+});

--- a/src/core/packages/notifications/browser-internal/src/notifications_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/notifications_service.ts
@@ -75,6 +75,11 @@ export class NotificationsService {
   }: StartDeps): NotificationsStart {
     this.targetDomElement = targetDomElement;
     const toastsContainer = document.createElement('div');
+    // Global toasts must remain visible above full-screen data grids. Full-screen
+    // `UnifiedDataTable` mode (see `useFullScreenWatcher`) resets `z-index` on all
+    // elements except those opted out via `data-kbn-preserve-zindex`, so mark the
+    // toasts container to preserve its stacking context and that of its toasts.
+    toastsContainer.setAttribute('data-kbn-preserve-zindex', 'true');
     targetDomElement.appendChild(toastsContainer);
 
     return {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Entity Analytics] Update success toast to work on fullscreen Entity Analytics Table  (#280206)](https://github.com/elastic/kibana/pull/280206)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Charlotte Alexandra Wilson","email":"CAWilson94@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-22T17:22:51Z","message":"[Entity Analytics] Update success toast to work on fullscreen Entity Analytics Table  (#280206)\n\n## Summary\nSuccess toast from 'add to case' and 'add to existing case' now\nsupported by fullscreen Entity Analytics table workflow options - both\nEntity Analytics homepage and cases attachments view entry points.\n\n\n\nhttps://github.com/user-attachments/assets/50ba4dce-1b3a-4dbb-b251-fc29f6cd04ad\n\n\n**Test Steps**\n1. Ingest some entities yarn start risk-score-v2 --entity-kinds host\n--hosts 20 --no-setup from document generator\n2. Open Entity Analytics home page table to fullscreen (top right button\non table, square)\n3. Add Entity to case / Add entity to existing case - note success toast\npops up\n4. Repeat step above from the cases attachments view with entity table","sha":"6d40e48e0e6467ba5a7f3dc0af58e10bc646c822","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.5.0","v9.6.0"],"title":"[Entity Analytics] Update success toast to work on fullscreen Entity Analytics Table ","number":280206,"url":"https://github.com/elastic/kibana/pull/280206","mergeCommit":{"message":"[Entity Analytics] Update success toast to work on fullscreen Entity Analytics Table  (#280206)\n\n## Summary\nSuccess toast from 'add to case' and 'add to existing case' now\nsupported by fullscreen Entity Analytics table workflow options - both\nEntity Analytics homepage and cases attachments view entry points.\n\n\n\nhttps://github.com/user-attachments/assets/50ba4dce-1b3a-4dbb-b251-fc29f6cd04ad\n\n\n**Test Steps**\n1. Ingest some entities yarn start risk-score-v2 --entity-kinds host\n--hosts 20 --no-setup from document generator\n2. Open Entity Analytics home page table to fullscreen (top right button\non table, square)\n3. Add Entity to case / Add entity to existing case - note success toast\npops up\n4. Repeat step above from the cases attachments view with entity table","sha":"6d40e48e0e6467ba5a7f3dc0af58e10bc646c822"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280206","number":280206,"mergeCommit":{"message":"[Entity Analytics] Update success toast to work on fullscreen Entity Analytics Table  (#280206)\n\n## Summary\nSuccess toast from 'add to case' and 'add to existing case' now\nsupported by fullscreen Entity Analytics table workflow options - both\nEntity Analytics homepage and cases attachments view entry points.\n\n\n\nhttps://github.com/user-attachments/assets/50ba4dce-1b3a-4dbb-b251-fc29f6cd04ad\n\n\n**Test Steps**\n1. Ingest some entities yarn start risk-score-v2 --entity-kinds host\n--hosts 20 --no-setup from document generator\n2. Open Entity Analytics home page table to fullscreen (top right button\non table, square)\n3. Add Entity to case / Add entity to existing case - note success toast\npops up\n4. Repeat step above from the cases attachments view with entity table","sha":"6d40e48e0e6467ba5a7f3dc0af58e10bc646c822"}}]}] BACKPORT-->