### PR TITLE
[Fleet] Enable disableAgentlessLegacyAPI feature flag

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -21,7 +21,7 @@ const _allowedExperimentalValues = {
   installIntegrationsKnowledge: true,
   enableFleetPolicyRevisionsCleanupTask: true,
   enableAgentRollback: true, // When enabled, agent upgrade rollback will be available in the API and UI.
-  disableAgentlessLegacyAPI: false, // When enabled, the legacy agent/package policy APIs reject agentless create, update, upgrade, and copy. Forces enableAgentlessPoliciesUI on (see below).
+  disableAgentlessLegacyAPI: true, // When enabled, the legacy agent/package policy APIs reject agentless create, update, upgrade, and copy. Forces enableAgentlessPoliciesUI on (see below).
   enableAgentlessPoliciesUI: true, // When enabled, the UI reads/writes agentless integration policies through the managed integrations API. Disable as a kill switch to fall back to the legacy APIs — but disableAgentlessLegacyAPI overrides it (the fallback would 400).
   enableEsqlViewInstall: false,
   enableSloTemplates: true,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -658,7 +658,17 @@ describe('usePackagePolicy - agentless', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Pin the legacy-block flag off so this describe exercises the default (flag-off) agentless
+    // behavior — the flag-on counterpart lives in the describe below.
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      disableAgentlessLegacyAPI: false,
+    });
     jest.mocked(sendGetAgentlessPolicy).mockResolvedValue({ item: agentlessPolicy } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('reads through the agentless API and skips the upgrade dry-run', async () => {
@@ -972,6 +982,8 @@ describe('usePackagePolicy - agentless policies UI kill switch off', () => {
     jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
       ...allowedExperimentalValues,
       enableAgentlessPoliciesUI: false,
+      // disableAgentlessLegacyAPI forces the UI on, so it must be off to exercise the kill switch.
+      disableAgentlessLegacyAPI: false,
     });
     jest.mocked(sendUpdatePackagePolicy).mockResolvedValue({
       data: { item: { id: 'nginx-1' } },

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -938,11 +938,10 @@ describe('usePackagePolicy - agentless with disableAgentlessLegacyAPI enabled', 
   beforeEach(() => {
     jest.clearAllMocks();
     // The legacy-block flag makes the package-policy upgrade dry-run 400 for agentless policies
-    // server-side. `enableAgentlessPoliciesUI` stays on (its default) so the save still routes
-    // through the agentless API.
+    // server-side. It (and `enableAgentlessPoliciesUI`) are on by default via
+    // allowedExperimentalValues, so the save still routes through the agentless API.
     jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
       ...allowedExperimentalValues,
-      disableAgentlessLegacyAPI: true,
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
@@ -212,6 +212,8 @@ describe('AgentlessPackagePoliciesTable', () => {
     jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
       ...allowedExperimentalValues,
       enableAgentlessPoliciesUI: false,
+      // disableAgentlessLegacyAPI forces the UI on, so it must be off to exercise the disabled path.
+      disableAgentlessLegacyAPI: false,
     });
     const renderer = createIntegrationsTestRendererMock();
     const result = renderer.render(<AgentlessPackagePoliciesTable {...defaultProps} />);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_upgrade_cell.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_upgrade_cell.test.tsx
@@ -75,9 +75,9 @@ describe('PackagePolicyUpgradeCell', () => {
 
   describe('with disableAgentlessLegacyAPI enabled', () => {
     beforeEach(() => {
+      // disableAgentlessLegacyAPI is on by default via allowedExperimentalValues.
       jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
         ...allowedExperimentalValues,
-        disableAgentlessLegacyAPI: true,
       });
     });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_upgrade_cell.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_upgrade_cell.test.tsx
@@ -63,6 +63,10 @@ describe('PackagePolicyUpgradeCell', () => {
   });
 
   it('links to the legacy upgrade route for an agentless policy while disableAgentlessLegacyAPI is off', async () => {
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      disableAgentlessLegacyAPI: false,
+    });
     const utils = renderCell({ packagePolicy: createPackagePolicy({ supports_agentless: true }) });
     const button = await utils.findByTestId('integrationPolicyUpgradeBtn');
     // Flag off (default): the legacy edit-page upgrade still works, so the link is untouched.

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.test.tsx
@@ -165,6 +165,8 @@ describe('PackagePoliciesPage agentless table source', () => {
     jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
       ...allowedExperimentalValues,
       enableAgentlessPoliciesUI: false,
+      // disableAgentlessLegacyAPI forces the UI on, so it must be off to exercise the disabled path.
+      disableAgentlessLegacyAPI: false,
     });
 
     renderPage();

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
@@ -210,9 +210,9 @@ describe('PackagePolicyActionsMenu', () => {
   describe('agentless upgrade (disableAgentlessLegacyAPI enabled)', () => {
     beforeEach(() => {
       jest.mocked(sendBulkUpgradeAgentlessPolicies).mockReset();
+      // disableAgentlessLegacyAPI is on by default via allowedExperimentalValues.
       jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
         ...allowedExperimentalValues,
-        disableAgentlessLegacyAPI: true,
       });
     });
 

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
@@ -262,13 +262,18 @@ describe('PackagePolicyActionsMenu', () => {
   });
 
   it('keeps the legacy upgrade link for an agentless policy while disableAgentlessLegacyAPI is off', async () => {
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      disableAgentlessLegacyAPI: false,
+    });
     const agentPolicies = createMockAgentPolicies({ supports_agentless: true });
     const packagePolicy = createMockPackagePolicy({ hasUpgrade: true, supports_agentless: true });
     const { utils } = renderMenu({ agentPolicies, packagePolicy });
 
     const upgradeButton = await utils.findByTestId('PackagePolicyActionsUpgradeItem');
-    // Flag off (default): the legacy edit-page upgrade still works, so the link is untouched.
+    // Flag off: the legacy edit-page upgrade still works, so the link is untouched.
     expect(upgradeButton).toHaveAttribute('href', '/test/upgrade-link');
+    jest.mocked(ExperimentalFeaturesService.get).mockRestore();
   });
 
   it('Should not be able to delete integration from a managed policy', async () => {
@@ -370,6 +375,8 @@ describe('PackagePolicyActionsMenu', () => {
     jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
       ...allowedExperimentalValues,
       enableAgentlessPoliciesUI: false,
+      // disableAgentlessLegacyAPI forces the UI on, so it must be off to exercise the disabled path.
+      disableAgentlessLegacyAPI: false,
     });
     const agentPolicies = createMockAgentPolicies({});
     const packagePolicy = createMockPackagePolicy({

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_is_agentless_query_param.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_is_agentless_query_param.test.tsx
@@ -49,6 +49,8 @@ describe('useIsAgentlessQueryParam', () => {
     jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
       ...allowedExperimentalValues,
       enableAgentlessPoliciesUI: false,
+      // disableAgentlessLegacyAPI forces the UI on, so it must be off to exercise the disabled path.
+      disableAgentlessLegacyAPI: false,
     });
     const { result } = renderWithSearch('?isAgentless=true');
     expect(result.current).toBe(false);

--- a/x-pack/platform/plugins/shared/fleet/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.test.ts
@@ -260,6 +260,8 @@ describe('Config schema', () => {
       const res = applyConfigDeprecations({
         experimentalFeatures: {
           enableAgentlessPoliciesUI: false,
+          // disableAgentlessLegacyAPI defaults on, so pin it off to isolate "only the UI disabled".
+          disableAgentlessLegacyAPI: false,
         },
       });
 

--- a/x-pack/platform/test/fleet_api_integration/config.base.ts
+++ b/x-pack/platform/test/fleet_api_integration/config.base.ts
@@ -98,6 +98,9 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
           enableVersionSpecificPolicies: true,
           enableOpAMP: true,
           enableCloudOnboardingDeployments: true,
+          // Keep the legacy agentless APIs enabled here so the base suite exercises legacy behavior;
+          // config.agentless_legacy_disabled.ts overrides this to true for the rejection tests.
+          disableAgentlessLegacyAPI: false,
         })}`,
         `--xpack.fleet.agentless.enabled=true`,
         `--xpack.fleet.agentless.api.url=http://localhost:8089/agentless-api`,


### PR DESCRIPTION
## Summary
This PR enables `disableAgentlessLegacyAPI` feature flagf for 9.5.


## Release Note
Clients that create, update, upgrade, or copy managed integrations through the package policy and agent policy APIs will receive a 400 error.




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->