### PR TITLE
[Fleet] Fix ML transform Cypress test

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/cypress/e2e/assets_integration_with_ml_and_transforms.cy.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/e2e/assets_integration_with_ml_and_transforms.cy.ts
@@ -90,9 +90,30 @@ describe('Assets - Real API for integration with ML and transforms', () => {
 
     cleanupAgentPolicies();
     deleteIntegrations();
+
+    // lmd 3.3.0+ changed the transform source from `logs-*` to
+    // `logs-endpoint.events.process-*`. Without a matching index, Fleet silently
+    // skips starting the transform and the destination index is never created.
+    // Create a minimal index here so the transform can start during installation.
+    request({
+      method: 'POST',
+      url: `/api/console/proxy?method=PUT&path=${encodeURIComponent(
+        '/logs-endpoint.events.process-default'
+      )}`,
+      body: {},
+      failOnStatusCode: false,
+    });
   });
 
-  after(() => {});
+  after(() => {
+    request({
+      method: 'POST',
+      url: `/api/console/proxy?method=DELETE&path=${encodeURIComponent(
+        '/logs-endpoint.events.process-default'
+      )}`,
+      failOnStatusCode: false,
+    });
+  });
 
   const expandAssetPanelIfNeeded = (asset: Asset) => {
     cy.get(`[aria-controls="${asset.type}"]`)


### PR DESCRIPTION
## Summary

Fixes this test that has been failing CI on `main`:
```
Fleet Cypress Tests #4 / Assets - Real API for integration with ML and transforms should install integration with ML module & transforms
```

Example affected PR: https://github.com/elastic/kibana/pull/277223/

### Cause

This test failed recently when integration `lmd` 3.0.0 was published. https://github.com/elastic/kibana/pull/264584 fixed it.

`lmd` 3.3.0 was [recently pusblished](https://github.com/elastic/integrations/pull/19998) which changed the transform source index from `logs-*` to `logs-endpoint.events.process-*`. It seems likely that that source data stream doesn't exist in CI, so the transform health would be non-green, causing the test's final assertion `expect(response.body.transforms[0].health.status).to.equal('green')` to fail.

### Fix

Add a `before` step to create an empty `logs-endpoint.events.process-default` index and delete it after the test.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

N/A: fixes a failing Cypress test.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->