### PR TITLE
[CI] Enable FTR auto retry for RSPack e2e

### DIFF
--- a/.buildkite/pipelines/rspack_e2e_test.yml
+++ b/.buildkite/pipelines/rspack_e2e_test.yml
@@ -1,5 +1,6 @@
 env:
   GITHUB_COMMIT_STATUS_ENABLED: 'false'
+  FTR_AUTO_RETRY_COUNT: '1'
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build


### PR DESCRIPTION
## Summary

Set `FTR_AUTO_RETRY_COUNT` to `1` for the RSPack end-to-end test pipeline so failing FTR test files can be retried once with the recreated config flow.

## Testing

- `node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.buildkite/pipelines/rspack_e2e_test.yml','utf8')); console.log('YAML OK')"`
- `git diff --check -- .buildkite/pipelines/rspack_e2e_test.yml`