### PR TITLE
[9.5] [Entity Analytics][Cases]Block adding same Entity to same case  (#276262)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.test.ts
@@ -16,6 +16,7 @@ import { AttachmentType } from './v1';
 import {
   SECURITY_ALERT_ATTACHMENT_TYPE,
   SECURITY_EVENT_ATTACHMENT_TYPE,
+  SECURITY_ENTITY_ATTACHMENT_TYPE,
 } from '../../../constants/attachments';
 
 describe('Unified Attachments', () => {
@@ -532,6 +533,23 @@ describe('Unified Attachments', () => {
       };
 
       expect(DocumentAttachmentAttributesRtV2.decode(unifiedAlert)._tag).toBe('Right');
+    });
+
+    it('accepts unified security.entity attributes so entities participate in dedup', () => {
+      const unifiedEntity = {
+        type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+        attachmentId: 'user:alice@host@default',
+        metadata: { index: '.entities.*' },
+        owner: 'securitySolution',
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: { full_name: 'elastic', email: 'testemail@elastic.co', username: 'elastic' },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+      };
+
+      expect(DocumentAttachmentAttributesRtV2.decode(unifiedEntity)._tag).toBe('Right');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.ts
@@ -12,6 +12,7 @@ import {
   SECURITY_ALERT_ATTACHMENT_TYPE,
   OBSERVABILITY_ALERT_ATTACHMENT_TYPE,
   STACK_ALERT_ATTACHMENT_TYPE,
+  SECURITY_ENTITY_ATTACHMENT_TYPE,
 } from '../../../constants/attachments';
 import {
   AlertAttachmentAttributesRt,
@@ -132,6 +133,7 @@ const UnifiedDocumentAttachmentAttributesRt = rt.intersection([
       rt.literal(SECURITY_ALERT_ATTACHMENT_TYPE),
       rt.literal(OBSERVABILITY_ALERT_ATTACHMENT_TYPE),
       rt.literal(STACK_ALERT_ATTACHMENT_TYPE),
+      rt.literal(SECURITY_ENTITY_ATTACHMENT_TYPE),
     ]),
     attachmentId: rt.union([rt.string, rt.array(rt.string)]),
     owner: rt.string,

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
@@ -121,6 +121,13 @@ export const ALREADY_ATTACHED = i18n.translate('xpack.cases.caseTable.alreadyAtt
     'In this context, "Added" is letting the user know that all of their selected alerts were previously added to the case in question, and the "Add to case" button is disabled',
 });
 
+export const ALREADY_ATTACHED_TOOLTIP = i18n.translate(
+  'xpack.cases.caseTable.alreadyAttachedTooltip',
+  {
+    defaultMessage: 'This item is already added to this case',
+  }
+);
+
 export const REQUIRES_UPDATE = i18n.translate('xpack.cases.caseTable.requiresUpdate', {
   defaultMessage: ' requires update',
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -14,7 +14,7 @@ import { useGetCasesMockState } from '../../containers/mock';
 import { connectors, useCaseConfigureResponse } from '../configure_cases/__mock__';
 
 import { readCasesPermissions, renderWithTestingProviders, TestProviders } from '../../common/mock';
-import { renderHook, screen } from '@testing-library/react';
+import { fireEvent, renderHook, screen } from '@testing-library/react';
 import { CaseStatuses, CustomFieldTypes } from '../../../common/types/domain';
 import { userProfilesMap } from '../../containers/user_profiles/api.mock';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
@@ -517,6 +517,66 @@ describe('useCasesColumns ', () => {
         "width": "8em",
       }
     `);
+  });
+
+  it('disables the select button and shows a tooltip when the case is already attached', async () => {
+    const theCase = useGetCasesMockState.data.cases[0];
+    const { result } = renderHook(
+      () =>
+        useCasesColumns({
+          ...useCasesColumnsProps,
+          isSelectorView: true,
+          disabledCases: new Set([theCase.id]),
+        }),
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    const assignActionColumn = result.current.columns[
+      result.current.columns.length - 1
+    ] as unknown as {
+      render: (theCase: (typeof useGetCasesMockState.data.cases)[number]) => JSX.Element;
+    };
+
+    renderWithTestingProviders(assignActionColumn.render(theCase));
+
+    const button = screen.getByTestId(`cases-table-row-select-${theCase.id}`);
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('Added');
+
+    // EuiToolTip renders its content lazily on hover; the disabled button is
+    // wrapped in a span so the tooltip anchor still receives the pointer event.
+    fireEvent.mouseOver(screen.getByTestId(`cases-table-row-select-tooltip-${theCase.id}`));
+    expect(await screen.findByText('This item is already added to this case')).toBeInTheDocument();
+  });
+
+  it('shows an enabled select button without a tooltip when the case is not attached', async () => {
+    const theCase = useGetCasesMockState.data.cases[0];
+    const { result } = renderHook(
+      () =>
+        useCasesColumns({
+          ...useCasesColumnsProps,
+          isSelectorView: true,
+          disabledCases: new Set<string>(),
+        }),
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    const assignActionColumn = result.current.columns[
+      result.current.columns.length - 1
+    ] as unknown as {
+      render: (theCase: (typeof useGetCasesMockState.data.cases)[number]) => JSX.Element;
+    };
+
+    renderWithTestingProviders(assignActionColumn.render(theCase));
+
+    const button = screen.getByTestId(`cases-table-row-select-${theCase.id}`);
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent('Select');
+    expect(screen.queryByText('This item is already added to this case')).not.toBeInTheDocument();
   });
 
   it('does not shows the actions if the user does not have the right permissions', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
@@ -299,7 +299,7 @@ export const useCasesColumns = ({
             const isAlreadyAttached = disabledCases?.has(theCase.id) ?? false;
             const isClosed = theCase.status === CaseStatuses.closed;
             const disabled = isAlreadyAttached || isClosed;
-            return (
+            const selectButton = (
               <EuiButton
                 data-test-subj={`cases-table-row-select-${theCase.id}`}
                 onClick={() => assignCaseAction(theCase)}
@@ -310,6 +310,20 @@ export const useCasesColumns = ({
                 {isAlreadyAttached ? i18n.ALREADY_ATTACHED : i18n.SELECT}
               </EuiButton>
             );
+
+            // Disabled buttons do not emit pointer events, so wrap in a span to
+            // ensure the explanatory tooltip still shows on hover.
+            if (isAlreadyAttached) {
+              return (
+                <EuiToolTip content={i18n.ALREADY_ATTACHED_TOOLTIP}>
+                  <span data-test-subj={`cases-table-row-select-tooltip-${theCase.id}`}>
+                    {selectButton}
+                  </span>
+                </EuiToolTip>
+              );
+            }
+
+            return selectButton;
           }
           return getEmptyCellValue();
         },

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_check_alert_attachments.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_check_alert_attachments.test.tsx
@@ -6,12 +6,39 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useCheckDocumentAttachments } from './use_check_alert_attachments';
+import { hasDocReferences, useCheckDocumentAttachments } from './use_check_alert_attachments';
 import { useFindCasesContainingAllSelectedDocuments } from './use_find_cases_containing_all_selected_alerts';
 
 jest.mock('./use_find_cases_containing_all_selected_alerts');
 
 const cases = [{ id: 'case-1' }, { id: 'case-2' }];
+
+describe('hasDocReferences', () => {
+  it('returns true for an alert attachment', () => {
+    expect(hasDocReferences({ alertId: 'alert-1' })).toBe(true);
+  });
+
+  it('returns true for an event attachment', () => {
+    expect(hasDocReferences({ eventId: 'event-1' })).toBe(true);
+  });
+
+  it('returns true for an external reference attachment', () => {
+    expect(hasDocReferences({ externalReferenceId: 'ext-1' })).toBe(true);
+  });
+
+  it('returns true for a unified attachment with attachmentId (e.g. entity)', () => {
+    expect(hasDocReferences({ attachmentId: 'user:alice@host@default' })).toBe(true);
+  });
+
+  it('returns false when no document reference field is present', () => {
+    expect(hasDocReferences({ type: 'lens', data: {} })).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(hasDocReferences(null)).toBe(false);
+    expect(hasDocReferences('attachmentId')).toBe(false);
+  });
+});
 
 describe('useCheckDocumentAttachments', () => {
   beforeEach(() => {
@@ -38,6 +65,24 @@ describe('useCheckDocumentAttachments', () => {
     expect(getAttachments).toHaveBeenCalledWith({ theCase: undefined });
     expect(useFindCasesContainingAllSelectedDocuments).toHaveBeenCalledWith(
       ['alert-1', 'event-1', 'alert-2', 'event-2', 'external-ref-1'],
+      ['case-1', 'case-2']
+    );
+  });
+
+  it('extracts the attachmentId from an entity attachment so entities participate in dedup', () => {
+    const entityId = 'user:alice@host@default';
+    const getAttachments = jest.fn().mockReturnValue([
+      {
+        type: 'security.entity',
+        attachmentId: entityId,
+        metadata: { entityName: 'alice', entityType: 'user' },
+      },
+    ]);
+
+    renderHook(() => useCheckDocumentAttachments({ cases, getAttachments }));
+
+    expect(useFindCasesContainingAllSelectedDocuments).toHaveBeenCalledWith(
+      [entityId],
       ['case-1', 'case-2']
     );
   });

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_check_alert_attachments.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_check_alert_attachments.ts
@@ -19,6 +19,7 @@ interface DocumentReference {
   alertId?: string[] | string;
   eventId?: string | string[];
   externalReferenceId?: string | string[];
+  attachmentId?: string | string[];
 }
 
 export const hasDocReferences = <T>(arg: T): arg is T & DocumentReference => {
@@ -27,7 +28,7 @@ export const hasDocReferences = <T>(arg: T): arg is T & DocumentReference => {
   }
 
   const candidate = arg as DocumentReference;
-  const idFields = ['alertId', 'eventId', 'externalReferenceId'] as const;
+  const idFields = ['alertId', 'eventId', 'externalReferenceId', 'attachmentId'] as const;
 
   for (const fieldName of idFields) {
     if (
@@ -47,8 +48,8 @@ export const useCheckDocumentAttachments = ({
 }: UseCheckAlertAttachmentsProps): { disabledCases: Set<string>; isLoading: boolean } => {
   const selectedDocumentIds = (getAttachments?.({ theCase: undefined }) ?? [])
     .filter(hasDocReferences)
-    .flatMap(({ alertId, eventId, externalReferenceId }) =>
-      [alertId, eventId, externalReferenceId].flat()
+    .flatMap(({ alertId, eventId, externalReferenceId, attachmentId }) =>
+      [alertId, eventId, externalReferenceId, attachmentId].flat()
     )
     .filter(
       (reference): reference is string => typeof reference === 'string' && reference.length > 0

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/get.ts
@@ -69,7 +69,7 @@ const normalizeDocumentResponse = (
  * Retrieves all documents attached to a specific case.
  */
 export const getAllDocumentsAttachedToCase = async (
-  { caseId, filter, attachmentTypes }: GetAllDocumentsAttachedToCase,
+  { caseId, filter, attachmentTypes, unifiedAttachmentTypes }: GetAllDocumentsAttachedToCase,
   clientArgs: CasesClientArgs,
   casesClient: CasesClient
 ): Promise<DocumentResponse> => {
@@ -94,6 +94,7 @@ export const getAllDocumentsAttachedToCase = async (
 
     const documents = await attachmentService.getter.getAllDocumentsAttachedToCase({
       attachmentTypes,
+      unifiedAttachmentTypes,
       caseId: theCase.id,
       filter: combineFilters(filterArray),
       owner: theCase.owner,

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/types.ts
@@ -136,6 +136,11 @@ export interface GetAllDocumentsAttachedToCase {
   caseId: string;
   filter?: KueryNode;
   attachmentTypes?: AttachmentType[];
+  /**
+   * Extra unified attachment `type` values (e.g. `security.entity`) to include alongside
+   * the alert/event types, so non-alert unified attachments participate in the query.
+   */
+  unifiedAttachmentTypes?: string[];
 }
 
 /**

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_cases_containing_all_documents.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_cases_containing_all_documents.test.ts
@@ -53,5 +53,25 @@ describe('findCasesContainingAllDocuments', () => {
       // type/owner restriction is handled by the attachment service, not the route
       expect(filter).not.toContain('cases-attachments.attributes.type');
     });
+
+    it('includes the security.entity unified type so entity attachments participate', async () => {
+      const casesClient = buildCasesClient({ documents: [{ id: 'alert-id' }] });
+
+      await processCase(casesClient, 'case-id', new Set(['alert-id']));
+
+      const {
+        calls: [params],
+      } = jest.mocked(casesClient.attachments.getAllDocumentsAttachedToCase).mock;
+
+      expect(params[0].unifiedAttachmentTypes).toEqual(['security.entity']);
+    });
+
+    it('returns case id when an entity attachment id is present', async () => {
+      const entityId = 'user:alice@host@default';
+      const casesClient = buildCasesClient({ documents: [{ id: entityId }] });
+
+      const result = await processCase(casesClient, 'case-id', new Set([entityId]));
+      expect(result).toBe('case-id');
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_cases_containing_all_documents.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_cases_containing_all_documents.ts
@@ -13,6 +13,7 @@ import {
   CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
   INTERNAL_CASE_GET_CASES_BY_ATTACHMENT_URL,
+  SECURITY_ENTITY_ATTACHMENT_TYPE,
 } from '../../../../common/constants';
 import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 import { type CasesClient } from '../../../client';
@@ -121,6 +122,9 @@ export const processCase = async (
   const documentsForCase = await casesClient.attachments.getAllDocumentsAttachedToCase({
     caseId,
     filter: combineFilters([legacyFilter, unifiedFilter], 'or' as const),
+    // Entity attachments aren't alerts/events, so include their unified type explicitly
+    // or the getter's default alert/event type filter would exclude them.
+    unifiedAttachmentTypes: [SECURITY_ENTITY_ATTACHMENT_TYPE],
   });
 
   // Combine document ids from cases-comments and cases-attachments for deduplication

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
@@ -266,6 +266,7 @@ export class AttachmentGetter {
     caseId,
     filter,
     attachmentTypes = [AttachmentType.alert, AttachmentType.event],
+    unifiedAttachmentTypes = [],
     owner,
   }: GetAllDocumentsAttachedToCaseArgs): Promise<
     Array<SavedObject<DocumentAttachmentAttributesV2>>
@@ -280,7 +281,10 @@ export class AttachmentGetter {
       });
 
       const unifiedDocumentsFilter = buildFilter({
-        filters: attachmentTypes.map((type) => toUnifiedAttachmentType(type, owner)),
+        filters: [
+          ...attachmentTypes.map((type) => toUnifiedAttachmentType(type, owner)),
+          ...unifiedAttachmentTypes,
+        ],
         field: 'type',
         operator: 'or',
         type: CASE_ATTACHMENT_SAVED_OBJECT,

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
@@ -72,6 +72,12 @@ export interface BulkOptionalAttributes<T>
 
 export type GetAllAlertsAttachToCaseArgs = AttachedToCaseArgs & {
   owner: string;
+  /**
+   * Extra unified attachment `type` values (e.g. `security.entity`) to include in the
+   * query alongside the alert/event types. Used by the "already attached" dedup check so
+   * non-alert unified attachments can participate.
+   */
+  unifiedAttachmentTypes?: string[];
 };
 
 export interface AlertIdsAggsResult {

--- a/x-pack/solutions/security/plugins/security_solution/common/cases/attachments/entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/cases/attachments/entity.ts
@@ -19,6 +19,13 @@ const EntityAttachmentMetadataSchema = z
     riskScore: z.number().min(0).max(100).optional(),
     /** Optional risk level (e.g. Low, Moderate, High, Critical) captured at attach time. */
     riskLevel: z.string().max(50).optional(),
+    /**
+     * The entity store index pattern the attached entity lives in. Read by the Cases
+     * platform (`getIndexFromMetadata`) so the "already attached" duplicate check can
+     * pair this attachment's id with an index — unified attachment matching requires a
+     * 1:1 id/index mapping, and without it the attachment is dropped from the check.
+     */
+    index: z.string().max(256).optional(),
   })
   .strict();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
@@ -19,6 +19,7 @@ import type { EntityType } from '../../../../common/entity_analytics/types';
 import { EntityIconByType } from '../../../entity_analytics/components/entity_store/entity_icon_by_type';
 import type { EntityAttachmentMetadata } from '../../../../common/cases/attachments/entity';
 import { EntityAttachmentPayloadSchema } from '../../../../common/cases/attachments/entity';
+import { ENTITY_STORE_INDEX_PATTERN } from '../../../../common/entity_analytics/entity_store/constants';
 
 export type { EntityAttachmentMetadata };
 export interface EntityToAttach {
@@ -93,6 +94,9 @@ export const generateEntityAttachmentsWithoutOwner = (
       metadata: {
         entityName: entity.name,
         entityType: entity.type,
+        // Lets the Cases platform pair this attachment's id with an index so the
+        // "already attached" duplicate check works (unified matching needs id+index).
+        index: ENTITY_STORE_INDEX_PATTERN,
         ...(entity.riskScore != null ? { riskScore: entity.riskScore } : {}),
         ...(entity.riskLevel != null ? { riskLevel: entity.riskLevel } : {}),
       } satisfies EntityAttachmentMetadata,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Entity Analytics][Cases]Block adding same Entity to same case  (#276262)](https://github.com/elastic/kibana/pull/276262)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Charlotte Alexandra Wilson","email":"CAWilson94@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-20T14:05:00Z","message":"[Entity Analytics][Cases]Block adding same Entity to same case  (#276262)\n\n###  Summary\n- This PR adds the functionality to block adding the same entity to the\nsame case multiple times.\n- Before, if you picked \"Add to existing case\" and chose a case the\nentity was already in, it just added a duplicate - which made the\nAttachments tab show the wrong entity count.\n- Now, in the case picker, any case that already has the entity shows a\ngreyed-out \"Added\" button instead of \"Select\", with a tooltip saying\n\"This item is already added to this case.\"\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/b2b0d2db-095b-4e91-87f1-10d033b74beb\n\n### Desk Test\nTurn on the entityAttachmentsEnabled flag and the entity store (with at\nleast one entity).\n\nGo to entity analytics management page - make sure entity store is on \n\nmanual add one host entity: \n\n```\nPOST entities-latest-default/_doc?refresh=wait_for\n{\n  \"@timestamp\": \"2026-07-17T12:00:00.000Z\",\n  \"entity\": {\n    \"id\": \"host:web01.acme.com\",\n    \"name\": \"web01.acme.com\",\n    \"type\": \"host\",\n    \"EngineMetadata\": { \"Type\": \"host\" }\n  },\n  \"host\": { \"name\": \"web01.acme.com\" }\n}\n```\n\n1. Open an entity's flyout → Take Action → Add to new case → create it.\n2. Open the same entity's flyout again → Add to existing case.\n3. That case's button is greyed out and says \"Added\", and hovering shows\nthe tooltip.\n4. A different case is still selectable, and a different entity can\nstill be added to the first case — only the exact same entity+case is\nblocked.\n5. Open the case → Attachments tab → the \"Entities\" count matches the\nrows in the table.\n\n\nHeads up for reviewers: this touches Cases-team files (the decoder, the\nattachment getter, and the internal dedup route).\n\n**Why it needed three changes**\n- The \"already attached\" check already existed for alerts, but it\nquietly ignored entity attachments in three spots, so I fixed each:\n\n- Entity attachments now save the entity store index alongside them —\nthe check needs that to match an attachment to a case.\n- The bit that reads attachments back was rejecting entity ones as an\nunknown type — added security.entity to the allowed list.\n- The search that finds which cases already contain the entity was\nhard-coded to alerts/events only — it now includes entities too.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bdeabf9eb3adbe986e1ce95e227ae3c3c8d47498","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Entity Analytics","backport:version","v9.5.0","v9.6.0"],"title":"[Entity Analytics][Cases]Block adding same Entity to same case ","number":276262,"url":"https://github.com/elastic/kibana/pull/276262","mergeCommit":{"message":"[Entity Analytics][Cases]Block adding same Entity to same case  (#276262)\n\n###  Summary\n- This PR adds the functionality to block adding the same entity to the\nsame case multiple times.\n- Before, if you picked \"Add to existing case\" and chose a case the\nentity was already in, it just added a duplicate - which made the\nAttachments tab show the wrong entity count.\n- Now, in the case picker, any case that already has the entity shows a\ngreyed-out \"Added\" button instead of \"Select\", with a tooltip saying\n\"This item is already added to this case.\"\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/b2b0d2db-095b-4e91-87f1-10d033b74beb\n\n### Desk Test\nTurn on the entityAttachmentsEnabled flag and the entity store (with at\nleast one entity).\n\nGo to entity analytics management page - make sure entity store is on \n\nmanual add one host entity: \n\n```\nPOST entities-latest-default/_doc?refresh=wait_for\n{\n  \"@timestamp\": \"2026-07-17T12:00:00.000Z\",\n  \"entity\": {\n    \"id\": \"host:web01.acme.com\",\n    \"name\": \"web01.acme.com\",\n    \"type\": \"host\",\n    \"EngineMetadata\": { \"Type\": \"host\" }\n  },\n  \"host\": { \"name\": \"web01.acme.com\" }\n}\n```\n\n1. Open an entity's flyout → Take Action → Add to new case → create it.\n2. Open the same entity's flyout again → Add to existing case.\n3. That case's button is greyed out and says \"Added\", and hovering shows\nthe tooltip.\n4. A different case is still selectable, and a different entity can\nstill be added to the first case — only the exact same entity+case is\nblocked.\n5. Open the case → Attachments tab → the \"Entities\" count matches the\nrows in the table.\n\n\nHeads up for reviewers: this touches Cases-team files (the decoder, the\nattachment getter, and the internal dedup route).\n\n**Why it needed three changes**\n- The \"already attached\" check already existed for alerts, but it\nquietly ignored entity attachments in three spots, so I fixed each:\n\n- Entity attachments now save the entity store index alongside them —\nthe check needs that to match an attachment to a case.\n- The bit that reads attachments back was rejecting entity ones as an\nunknown type — added security.entity to the allowed list.\n- The search that finds which cases already contain the entity was\nhard-coded to alerts/events only — it now includes entities too.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bdeabf9eb3adbe986e1ce95e227ae3c3c8d47498"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276262","number":276262,"mergeCommit":{"message":"[Entity Analytics][Cases]Block adding same Entity to same case  (#276262)\n\n###  Summary\n- This PR adds the functionality to block adding the same entity to the\nsame case multiple times.\n- Before, if you picked \"Add to existing case\" and chose a case the\nentity was already in, it just added a duplicate - which made the\nAttachments tab show the wrong entity count.\n- Now, in the case picker, any case that already has the entity shows a\ngreyed-out \"Added\" button instead of \"Select\", with a tooltip saying\n\"This item is already added to this case.\"\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/b2b0d2db-095b-4e91-87f1-10d033b74beb\n\n### Desk Test\nTurn on the entityAttachmentsEnabled flag and the entity store (with at\nleast one entity).\n\nGo to entity analytics management page - make sure entity store is on \n\nmanual add one host entity: \n\n```\nPOST entities-latest-default/_doc?refresh=wait_for\n{\n  \"@timestamp\": \"2026-07-17T12:00:00.000Z\",\n  \"entity\": {\n    \"id\": \"host:web01.acme.com\",\n    \"name\": \"web01.acme.com\",\n    \"type\": \"host\",\n    \"EngineMetadata\": { \"Type\": \"host\" }\n  },\n  \"host\": { \"name\": \"web01.acme.com\" }\n}\n```\n\n1. Open an entity's flyout → Take Action → Add to new case → create it.\n2. Open the same entity's flyout again → Add to existing case.\n3. That case's button is greyed out and says \"Added\", and hovering shows\nthe tooltip.\n4. A different case is still selectable, and a different entity can\nstill be added to the first case — only the exact same entity+case is\nblocked.\n5. Open the case → Attachments tab → the \"Entities\" count matches the\nrows in the table.\n\n\nHeads up for reviewers: this touches Cases-team files (the decoder, the\nattachment getter, and the internal dedup route).\n\n**Why it needed three changes**\n- The \"already attached\" check already existed for alerts, but it\nquietly ignored entity attachments in three spots, so I fixed each:\n\n- Entity attachments now save the entity store index alongside them —\nthe check needs that to match an attachment to a case.\n- The bit that reads attachments back was rejecting entity ones as an\nunknown type — added security.entity to the allowed list.\n- The search that finds which cases already contain the entity was\nhard-coded to alerts/events only — it now includes entities too.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bdeabf9eb3adbe986e1ce95e227ae3c3c8d47498"}}]}] BACKPORT-->