### PR TITLE
[9.5] [Workflows] Add pick Liquid filter and trim alert analysis model input (#277085)

### DIFF
--- a/src/platform/packages/shared/kbn-workflows-yaml/common/liquid/liquid_parse_cache.test.ts
+++ b/src/platform/packages/shared/kbn-workflows-yaml/common/liquid/liquid_parse_cache.test.ts
@@ -67,6 +67,25 @@ describe('getLiquidInstance', () => {
       expect(result).toBe('not json');
     });
   });
+
+  describe('pick filter behavior', () => {
+    it('registers pick so a template using it parses and renders (strictFilters)', () => {
+      const engine = getLiquidInstance();
+      const template = engine.parse('{{ val | pick: fields | json }}');
+      const result = engine.renderSync(template, { val: { a: 1, b: 2 }, fields: ['a'] });
+      expect(JSON.parse(result as string)).toEqual({ a: 1 });
+    });
+
+    it('keeps nested dotted-path fields', () => {
+      const engine = getLiquidInstance();
+      const template = engine.parse('{{ val | pick: fields | json }}');
+      const result = engine.renderSync(template, {
+        val: { host: { name: 'h1', ip: '10.0.0.1' } },
+        fields: ['host.name'],
+      });
+      expect(JSON.parse(result as string)).toEqual({ host: { name: 'h1' } });
+    });
+  });
 });
 
 describe('parseTemplateString', () => {

--- a/src/platform/packages/shared/kbn-workflows-yaml/common/liquid/liquid_parse_cache.ts
+++ b/src/platform/packages/shared/kbn-workflows-yaml/common/liquid/liquid_parse_cache.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Liquid, Template } from 'liquidjs';
-import { createWorkflowLiquidEngine } from '@kbn/workflows';
+import { createWorkflowLiquidEngine, pickObjectFields } from '@kbn/workflows';
 
 let liquidInstance: Liquid | null = null;
 
@@ -41,6 +41,13 @@ export function getLiquidInstance(): Liquid {
     });
     liquidInstance.registerFilter('entries', (value: unknown): unknown => {
       return value;
+    });
+    liquidInstance.registerFilter('pick', (value: unknown, ...args: unknown[]): unknown => {
+      const paths = args.length === 1 && Array.isArray(args[0]) ? args[0] : args;
+      return pickObjectFields(
+        value,
+        paths.filter((path): path is string => typeof path === 'string')
+      );
     });
   }
   return liquidInstance;

--- a/src/platform/packages/shared/kbn-workflows/common/utils/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/index.ts
@@ -30,6 +30,7 @@ export {
   LIQUID_ALLOWED_TAGS,
   createWorkflowLiquidEngine,
 } from './create_workflow_liquid_engine/create_workflow_liquid_engine';
+export { pickObjectFields } from './pick_object_fields/pick_object_fields';
 export {
   pickManagedWorkflowFields,
   toManagedWorkflowTelemetryFields,

--- a/src/platform/packages/shared/kbn-workflows/common/utils/pick_object_fields/pick_object_fields.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/pick_object_fields/pick_object_fields.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { pickObjectFields } from './pick_object_fields';
+
+describe('pickObjectFields', () => {
+  it('keeps only the requested top-level fields', () => {
+    expect(pickObjectFields({ a: 1, b: 2, c: 3 }, ['a', 'c'])).toEqual({ a: 1, c: 3 });
+  });
+
+  it('picks nested fields by dotted path and preserves structure', () => {
+    const source = { host: { name: 'h1', os: { name: 'linux', version: '5' } } };
+    expect(pickObjectFields(source, ['host.name', 'host.os.name'])).toEqual({
+      host: { name: 'h1', os: { name: 'linux' } },
+    });
+  });
+
+  it('preserves value types (numbers, booleans, arrays) rather than stringifying', () => {
+    const source = { risk_score: 73, enabled: true, args: ['-a', '-b'] };
+    expect(pickObjectFields(source, ['risk_score', 'enabled', 'args'])).toEqual({
+      risk_score: 73,
+      enabled: true,
+      args: ['-a', '-b'],
+    });
+  });
+
+  it('skips absent paths without creating empty keys', () => {
+    expect(pickObjectFields({ a: 1 }, ['a', 'b.c'])).toEqual({ a: 1 });
+  });
+
+  it('skips a path that traverses through a non-object', () => {
+    expect(pickObjectFields({ a: 1 }, ['a.b'])).toEqual({});
+  });
+
+  it('does not mutate the source object', () => {
+    const source = { a: { b: 1 } };
+    pickObjectFields(source, ['a']);
+    expect(source).toEqual({ a: { b: 1 } });
+  });
+
+  it('returns a deep clone so mutating the result leaves the source untouched', () => {
+    const source = { a: { b: 1 } };
+    const result = pickObjectFields(source, ['a']) as { a: { b: number } };
+    result.a.b = 999;
+    expect(source.a.b).toBe(1);
+  });
+
+  it('returns a non-object source unchanged', () => {
+    expect(pickObjectFields('not-an-object', ['a'])).toBe('not-an-object');
+  });
+
+  it('returns an empty object when no paths are provided', () => {
+    expect(pickObjectFields({ a: 1 }, [])).toEqual({});
+  });
+
+  it('picks a field from an array element by numeric index', () => {
+    const source = { users: [{ name: 'a', age: 1 }, { name: 'b' }] };
+    expect(pickObjectFields(source, ['users.0.name'])).toEqual({ users: [{ name: 'a' }] });
+  });
+
+  it('merges picks across array indices into one array', () => {
+    const source = {
+      users: [
+        { name: 'a', age: 1 },
+        { name: 'b', age: 2 },
+      ],
+    };
+    expect(pickObjectFields(source, ['users.0.name', 'users.1.age'])).toEqual({
+      users: [{ name: 'a' }, { age: 2 }],
+    });
+  });
+
+  it('preserves the original index when picking a later array element', () => {
+    const source = { users: [{ name: 'a' }, { name: 'b' }] };
+    // A sparse pick keeps element 1 at index 1; the hole serializes as null.
+    expect(JSON.stringify(pickObjectFields(source, ['users.1.name']))).toBe(
+      '{"users":[null,{"name":"b"}]}'
+    );
+  });
+
+  it('skips an out-of-bounds array index', () => {
+    expect(pickObjectFields({ users: [{ name: 'a' }] }, ['users.5.name'])).toEqual({});
+  });
+
+  it('skips paths containing prototype-pollution segments', () => {
+    // A source with own `__proto__`/`constructor` keys, as JSON.parse produces.
+    const source = JSON.parse('{"__proto__":{"polluted":true},"constructor":{"polluted":true}}');
+    expect(
+      pickObjectFields(source, ['__proto__.polluted', 'constructor.polluted', 'prototype.x'])
+    ).toEqual({});
+  });
+
+  it('does not pollute Object.prototype through a crafted path', () => {
+    const source = JSON.parse('{"__proto__":{"polluted":true}}');
+    pickObjectFields(source, ['__proto__.polluted']);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/kbn-workflows/common/utils/pick_object_fields/pick_object_fields.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/pick_object_fields/pick_object_fields.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+type PlainObject = Record<string, unknown>;
+// A container we build into during reconstruction: either a plain object keyed by
+// string, or an array indexed by a numeric segment.
+type Container = PlainObject | unknown[];
+
+const isPlainObject = (value: unknown): value is PlainObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+// A segment addresses an array element when it is a run of digits (e.g. `9`).
+const isArrayIndex = (segment: string): boolean => /^\d+$/.test(segment);
+
+// Keys that would let a crafted path walk into the prototype chain and pollute
+// Object.prototype during the write phase below. The shared Liquid engine enforces
+// `ownPropertyOnly` for template access; this keeps the raw JS traversal here in step.
+const UNSAFE_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
+
+const getChild = (container: Container, key: string): unknown =>
+  Array.isArray(container) ? container[Number(key)] : container[key];
+
+const setChild = (container: Container, key: string, value: unknown): void => {
+  if (Array.isArray(container)) {
+    container[Number(key)] = value;
+  } else {
+    container[key] = value;
+  }
+};
+
+// Deep clone limited to JSON-serializable values. Leaf values are cloned so the
+// returned object never shares references with `source`, which keeps callers from
+// mutating the original through overlapping paths.
+const cloneValue = (value: unknown): unknown => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+  const clone: PlainObject = {};
+  for (const [key, val] of Object.entries(value)) {
+    clone[key] = cloneValue(val);
+  }
+  return clone;
+};
+
+// Copies a single dotted `path` from `source` into `result`, in place. Absent paths,
+// paths that traverse a non-object, and prototype-polluting paths are ignored.
+const copyPath = (source: PlainObject, result: PlainObject, path: string): void => {
+  if (path.length === 0) {
+    return;
+  }
+
+  const segments = path.split('.');
+  if (segments.some((segment) => UNSAFE_SEGMENTS.has(segment))) {
+    return;
+  }
+
+  let cursor: unknown = source;
+  for (const segment of segments) {
+    if (isPlainObject(cursor) && Object.prototype.hasOwnProperty.call(cursor, segment)) {
+      cursor = cursor[segment];
+    } else if (
+      Array.isArray(cursor) &&
+      isArrayIndex(segment) &&
+      Object.prototype.hasOwnProperty.call(cursor, segment)
+    ) {
+      cursor = cursor[Number(segment)];
+    } else {
+      return;
+    }
+  }
+
+  if (cursor === undefined) {
+    return;
+  }
+
+  // Rebuild the path in `result`. Each intermediate container is an array when the
+  // next segment is a numeric index (so `users.9.surname` yields an array with the
+  // element at index 9, positions preserved) and a plain object otherwise.
+  let target: Container = result;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    const childShouldBeArray = isArrayIndex(segments[i + 1]);
+    const existing = getChild(target, segment);
+    const existingIsRightType = childShouldBeArray
+      ? Array.isArray(existing)
+      : isPlainObject(existing);
+    if (!existingIsRightType) {
+      setChild(target, segment, childShouldBeArray ? [] : {});
+    }
+    target = getChild(target, segment) as Container;
+  }
+  setChild(target, segments[segments.length - 1], cloneValue(cursor));
+};
+
+/**
+ * Returns a new object containing only the given dotted-path fields from `source`,
+ * preserving the original nested structure and value types (numbers, booleans, and
+ * arrays are kept as-is, not stringified).
+ *
+ * - Paths that are absent, or that traverse through a non-object/non-array, are skipped.
+ * - Numeric segments index into arrays (`users.9.surname`); the picked structure keeps
+ *   the array shape and the element's original index (intervening positions stay empty).
+ * - Paths containing `__proto__`, `prototype`, or `constructor` are skipped to
+ *   avoid prototype pollution.
+ * - The `source` is never mutated; leaf values are deep-cloned.
+ * - A non-object `source` is returned unchanged.
+ *
+ * @example
+ * pickObjectFields({ a: { b: 1, c: 2 }, d: 3 }, ['a.b', 'd']) // => { a: { b: 1 }, d: 3 }
+ * @example
+ * pickObjectFields({ users: [{ name: 'a', age: 1 }] }, ['users.0.name']) // => { users: [{ name: 'a' }] }
+ */
+export const pickObjectFields = (source: unknown, paths: readonly string[]): unknown => {
+  if (!isPlainObject(source)) {
+    return source;
+  }
+
+  const result: PlainObject = {};
+  for (const path of paths) {
+    if (typeof path === 'string') {
+      copyPath(source, result, path);
+    }
+  }
+
+  return result;
+};

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.test.ts
@@ -25,6 +25,23 @@ const findStepByName = (steps: unknown[], name: string): Record<string, unknown>
   return undefined;
 };
 
+// Look the agent step up by type rather than name so these assertions survive the
+// onechat_runAgent_step -> runAgent_step rename that lands in a separate PR.
+const findStepByType = (steps: unknown[], type: string): Record<string, unknown> | undefined => {
+  for (const step of steps) {
+    const s = step as Record<string, unknown>;
+    if (s.type === type) return s;
+    for (const key of ['steps', 'else']) {
+      const nested = s[key];
+      if (Array.isArray(nested)) {
+        const found = findStepByType(nested, type);
+        if (found) return found;
+      }
+    }
+  }
+  return undefined;
+};
+
 describe('SECURITY_ALERT_ANALYSIS_WORKFLOW yaml', () => {
   // The workflow is installed statically (no template rendering); it reads per-space config at run
   // time. These assertions run against the static yaml the definition ships.
@@ -112,6 +129,37 @@ describe('SECURITY_ALERT_ANALYSIS_WORKFLOW yaml', () => {
     expect(agentStep['connector-id']).toBe('{{ variables.connector_id }}');
     // `${{ }}` preserves the boolean; a plain `{{ }}` would render the string "false" (truthy).
     expect(agentStep['create-conversation']).toBe('${{ variables.create_conversation }}');
+  });
+
+  it('trims the alert with the pick filter over the configured allow-list before the agent step', () => {
+    const minimalAlertStep = findStepByName(workflow.steps, 'build_minimal_alert') as {
+      type: string;
+      with: { minimal_alert: string };
+    };
+
+    expect(minimalAlertStep).toBeDefined();
+    expect(minimalAlertStep.type).toBe('data.set');
+    // Delegates the field selection to the `pick` filter + the shared const list, rather than
+    // hand-reshaping ~60 nested fields inline.
+    expect(minimalAlertStep.with.minimal_alert).toBe(
+      '${{ foreach.item | pick: consts.model_alert_fields }}'
+    );
+  });
+
+  it('lists the high-signal allow-list fields in consts.model_alert_fields', () => {
+    const fields = workflow.consts.model_alert_fields as string[];
+
+    expect(fields).toEqual(
+      expect.arrayContaining(['_id', '_index', 'process.command_line', 'kibana.alert.rule.name'])
+    );
+  });
+
+  it('sends the trimmed alert (not the full foreach item) to the agent attachment', () => {
+    const agentStep = findStepByType(workflow.steps, 'ai.agent') as {
+      with: { attachments: Array<{ type: string; data: { alert: string } }> };
+    };
+
+    expect(agentStep.with.attachments[0].data.alert).toBe('{{ variables.minimal_alert | json:2 }}');
   });
 
   it('adds token usage metadata to the verdict note', () => {

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.yaml
@@ -62,6 +62,73 @@ consts:
   # Tag suffix appended when an alert is auto-closed by this workflow
   closed_tag_suffix: "closed"
 
+  # High-signal fields sent to the model in place of the full alert _source.
+  # Consumed by build_minimal_alert via the `pick` filter, which keeps only these dotted paths and
+  # preserves value types. Absent fields are skipped.
+  model_alert_fields:
+    - _id
+    - _index
+    - "@timestamp"
+    - event.category
+    - event.action
+    - event.type
+    - event.outcome
+    - event.code
+    - event.severity
+    - event.dataset
+    - event.module
+    - host.name
+    - host.architecture
+    - host.os.name
+    - host.os.version
+    - host.asset.criticality
+    - host.risk.calculated_level
+    - host.risk.calculated_score_norm
+    - user.name
+    - user.domain
+    - user.id
+    - user.asset.criticality
+    - user.risk.calculated_level
+    - user.risk.calculated_score_norm
+    - process.name
+    - process.executable
+    - process.command_line
+    - process.args
+    - process.pid
+    - process.working_directory
+    - process.hash.sha256
+    - process.code_signature.exists
+    - process.code_signature.trusted
+    - process.code_signature.status
+    - process.code_signature.subject_name
+    - process.parent.name
+    - process.parent.executable
+    - process.parent.command_line
+    - process.parent.args
+    - process.parent.code_signature.trusted
+    - process.parent.code_signature.subject_name
+    - file.name
+    - file.path
+    - file.hash.sha256
+    - source.ip
+    - destination.ip
+    - network.protocol
+    - url.full
+    - dns.question.name
+    - dns.question.type
+    - cloud.provider
+    - cloud.region
+    - cloud.account.id
+    - message
+    - kibana.alert.severity
+    - kibana.alert.risk_score
+    - kibana.alert.workflow_status
+    - kibana.alert.rule.name
+    - kibana.alert.rule.description
+    - kibana.alert.rule.references
+    - kibana.alert.rule.threat
+    - threat
+
 # NOTE: the tag prefix, connector, auto-close, create-conversation, and enabled settings are NOT
 # constants here. They are per-space and read at run time from the invoking space's uiSettings (see
 # the fetch_runtime_config step below), so a single global install serves every space with live
@@ -940,6 +1007,14 @@ steps:
                 {%- endif %}
                 {%- endif %}
 
+          # Trim the alert before sending it to the model. `pick` keeps only the dotted paths in
+          # consts.model_alert_fields (id/index plus the curated high-signal triage fields),
+          # preserving value types, and drops the rest of the noisy _source.
+          - name: build_minimal_alert
+            type: data.set
+            with:
+              minimal_alert: "${{ foreach.item | pick: consts.model_alert_fields }}"
+
           - name: runAgent_step
             type: ai.agent
             agent-id: "{{ variables.agent_id }}"
@@ -954,7 +1029,7 @@ steps:
               attachments:
                 - type: "security.alert"
                   data:
-                    alert: "{{ foreach.item | json:2 }}"
+                    alert: "{{ variables.minimal_alert | json:2 }}"
                     attachmentLabel: "{{ steps.get_seed_timeline_string.output.attachment_label }}"
 
               # Structured output schema the AI agent must conform to.

--- a/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.test.ts
@@ -327,6 +327,43 @@ describe('WorkflowTemplatingEngine', () => {
     });
   });
 
+  describe('custom pick filter', () => {
+    it('should keep only the requested dotted-path fields, preserving structure and types', () => {
+      const template = '${{ alert | pick: fields }}';
+      const context = {
+        alert: {
+          host: { name: 'h1', ip: '10.0.0.1' },
+          event: { action: 'login' },
+          risk_score: 73,
+        },
+        fields: ['host.name', 'risk_score'],
+      };
+      const result = templatingEngine.render({ out: template }, context);
+      expect(result.out).toEqual({ host: { name: 'h1' }, risk_score: 73 });
+    });
+
+    it('should accept several string args instead of an array', () => {
+      const template = '${{ alert | pick: "a", "b" }}';
+      const context = { alert: { a: 1, b: 2, c: 3 } };
+      const result = templatingEngine.render({ out: template }, context);
+      expect(result.out).toEqual({ a: 1, b: 2 });
+    });
+
+    it('should skip absent paths', () => {
+      const template = '${{ alert | pick: fields }}';
+      const context = { alert: { a: 1 }, fields: ['a', 'x.y'] };
+      const result = templatingEngine.render({ out: template }, context);
+      expect(result.out).toEqual({ a: 1 });
+    });
+
+    it('should return a non-object value as-is', () => {
+      const template = '{{ value | pick: fields }}';
+      const context = { value: 'hello', fields: ['a'] };
+      const result = templatingEngine.render(template, context);
+      expect(result).toBe('hello');
+    });
+  });
+
   describe('filter chaining', () => {
     it('should chain json and json_parse filters', () => {
       const template = '{{ data | json | json_parse | json }}';

--- a/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.ts
@@ -10,7 +10,7 @@
 import type { Template } from 'liquidjs';
 import { i18n } from '@kbn/i18n';
 import type { LiquidSettings } from '@kbn/workflows';
-import { createWorkflowLiquidEngine } from '@kbn/workflows';
+import { createWorkflowLiquidEngine, pickObjectFields } from '@kbn/workflows';
 
 type TemplateVariableSegment = string | number;
 type TemplateVariableSegments = TemplateVariableSegment[];
@@ -74,6 +74,17 @@ export class WorkflowTemplatingEngine {
         return value;
       }
       return Object.entries(value).map(([k, v]) => ({ key: k, value: v }));
+    });
+
+    // register pick filter that keeps only the given dotted-path fields of an object,
+    // preserving nested structure and value types. Accepts a single array of paths
+    // (e.g. `| pick: consts.fields`) or several string args (e.g. `| pick: "a", "b"`).
+    this.engine.registerFilter('pick', (value: unknown, ...args: unknown[]): unknown => {
+      const paths = args.length === 1 && Array.isArray(args[0]) ? args[0] : args;
+      return pickObjectFields(
+        value,
+        paths.filter((path): path is string => typeof path === 'string')
+      );
     });
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/liquid/liquid_completions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/liquid/liquid_completions.ts
@@ -262,6 +262,14 @@ export const LIQUID_FILTERS = [
     example: '{{ "hello world" | number_of_words }} => 2',
   },
   {
+    name: 'pick',
+    description:
+      'Keeps only the given dotted-path fields of an object, preserving nested structure and value types',
+    insertText: 'pick: ${1:paths}',
+    example:
+      '{{ alert | pick: ["host.name", "event.action"] }} => { host: { name: ... }, event: { action: ... } }',
+  },
+  {
     name: 'plus',
     description: 'Adds a number to another number',
     insertText: 'plus: ${1:number}',

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/evaluate_expression.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/evaluate_expression.ts
@@ -8,7 +8,7 @@
  */
 
 import type { JsonArray, JsonObject, JsonValue } from '@kbn/utility-types';
-import { createWorkflowLiquidEngine } from '@kbn/workflows';
+import { createWorkflowLiquidEngine, pickObjectFields } from '@kbn/workflows';
 import { resolvePathValue } from './resolve_path_value';
 import type { ExecutionContext } from '../execution_context/build_execution_context';
 
@@ -35,6 +35,14 @@ liquidEngine.registerFilter('entries', (value: unknown): unknown => {
     return value;
   }
   return Object.entries(value).map(([k, v]) => ({ key: k, value: v }));
+});
+
+liquidEngine.registerFilter('pick', (value: unknown, ...args: unknown[]): unknown => {
+  const paths = args.length === 1 && Array.isArray(args[0]) ? args[0] : args;
+  return pickObjectFields(
+    value,
+    paths.filter((path): path is string => typeof path === 'string')
+  );
 });
 
 export interface EvaluateExpressionOptions {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Workflows] Add pick Liquid filter and trim alert analysis model input (#277085)](https://github.com/elastic/kibana/pull/277085)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Steph Milovic","email":"stephanie.milovic@elastic.co"},"sourceCommit":{"committedDate":"2026-07-10T19:51:01Z","message":"[Workflows] Add pick Liquid filter and trim alert analysis model input (#277085)","sha":"545a63feb1118718773f380d4a0e27439e60032a","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team: SecuritySolution","Team:One Workflow","v9.5.0","v9.6.0"],"title":"[Workflows] Add pick Liquid filter and trim alert analysis model input","number":277085,"url":"https://github.com/elastic/kibana/pull/277085","mergeCommit":{"message":"[Workflows] Add pick Liquid filter and trim alert analysis model input (#277085)","sha":"545a63feb1118718773f380d4a0e27439e60032a"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277085","number":277085,"mergeCommit":{"message":"[Workflows] Add pick Liquid filter and trim alert analysis model input (#277085)","sha":"545a63feb1118718773f380d4a0e27439e60032a"}}]}] BACKPORT-->