### PR TITLE
[9.5] [Lens] Fix missing small percentage tick values on Y axis (#279489)

### DIFF
--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -96,7 +96,7 @@ import {
   getLinesCausedPaddings,
   validateExtent,
   getOriginalAxisPosition,
-  getDecimalsFromFormat,
+  getMaximumFractionDigits,
 } from '../helpers';
 import { getXDomain, XyEndzones } from './x_domain';
 import { getLegendAction } from './legend_action';
@@ -386,7 +386,7 @@ export function XYChart({
     xAxisColumn?.id ? fieldFormats[dataLayers[0].layerId].xAccessors[xAxisColumn?.id] : undefined
   );
 
-  const xTickDecimals = getDecimalsFromFormat(xAxisFormatter);
+  const xTickMfd = getMaximumFractionDigits(xAxisFormatter);
 
   // This is a safe formatter for the xAccessor that abstracts the knowledge of already formatted layers
   const safeXAccessorLabelRenderer = (value: unknown): string =>
@@ -973,7 +973,7 @@ export function XYChart({
               gridLine={gridLineStyle}
               hide={xAxisConfig?.hide || dataLayers[0]?.simpleView || !dataLayers[0]?.xAccessor}
               tickFormat={(d) => safeXAccessorLabelRenderer(d) || ''}
-              maximumFractionDigits={xTickDecimals}
+              maximumFractionDigits={xTickMfd}
               style={xAxisStyle}
               showOverlappingLabels={xAxisConfig?.showOverlappingLabels}
               showDuplicatedTicks={xAxisConfig?.showDuplicates}
@@ -994,10 +994,7 @@ export function XYChart({
               />
             )}
             {yAxesConfiguration.map((axis) => {
-              const tickDecimals = axis.formatter
-                ? getDecimalsFromFormat(axis.formatter)
-                : undefined;
-
+              const mfd = axis.formatter ? getMaximumFractionDigits(axis.formatter) : undefined;
               return (
                 <Axis
                   key={axis.groupId}
@@ -1010,7 +1007,7 @@ export function XYChart({
                   }}
                   hide={axis.hide || dataLayers[0]?.simpleView}
                   tickFormat={(d) => axis.formatter?.convertToText(d) || ''}
-                  maximumFractionDigits={tickDecimals}
+                  maximumFractionDigits={mfd}
                   style={getYAxesStyle(axis)}
                   domain={getYAxisDomain(axis)}
                   showOverlappingLabels={axis.showOverlappingLabels}

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/format.test.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/format.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FieldFormatParams } from '@kbn/field-formats-plugin/common';
+import { BytesFormat, NumberFormat, PercentFormat } from '@kbn/field-formats-plugin/common';
+import { getMaximumFractionDigits } from './format';
+
+describe('getMaximumFractionDigits', () => {
+  const getConfig = <T = unknown>() => undefined as unknown as T;
+
+  it('maps decimals directly for unscaled number formats', () => {
+    const format = new NumberFormat({ decimals: 2 }, getConfig);
+    expect(getMaximumFractionDigits(format)).toBe(2);
+  });
+
+  it('adds 2 for percent formats since the value is multiplied by 100', () => {
+    const format = new PercentFormat({ decimals: 0 }, getConfig);
+    expect(getMaximumFractionDigits(format)).toBe(2);
+  });
+
+  it('adds 2 for percent formats with non-zero decimals', () => {
+    const format = new PercentFormat({ decimals: 2 }, getConfig);
+    expect(getMaximumFractionDigits(format)).toBe(4);
+  });
+
+  it('returns undefined for bytes/bits formats', () => {
+    const format = new BytesFormat({ decimals: 0 }, getConfig);
+    expect(getMaximumFractionDigits(format)).toBeUndefined();
+  });
+
+  it('returns undefined when no decimals param is set', () => {
+    const format = new NumberFormat({}, getConfig);
+    expect(getMaximumFractionDigits(format)).toBeUndefined();
+  });
+
+  it('returns undefined when decimals is not a number', () => {
+    const format = new NumberFormat({ decimals: 'foo' } as FieldFormatParams, getConfig);
+    expect(getMaximumFractionDigits(format)).toBeUndefined();
+  });
+});

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/format.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/format.ts
@@ -10,6 +10,7 @@
 import type { ExpressionValueVisDimension } from '@kbn/chart-expressions-common';
 import { getColumnByAccessor, getFormatByAccessor } from '@kbn/chart-expressions-common';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
+import { FIELD_FORMAT_IDS } from '@kbn/field-formats-plugin/common';
 import type { FieldFormat, FieldFormatParams } from '@kbn/field-formats-plugin/common';
 import { isNumber, isUndefined } from 'lodash';
 
@@ -53,7 +54,22 @@ export const getFormatParam = (format: FieldFormat, param: string, maxDepth = 3)
   return getNested(format.params(), 0);
 };
 
-export const getDecimalsFromFormat = (format: FieldFormat) => {
-  const value = getFormatParam(format, 'decimals');
-  return isNumber(value) ? value : undefined;
+export const getMaximumFractionDigits = (format: FieldFormat): number | undefined => {
+  const decimals = getFormatParam(format, 'decimals');
+
+  if (!isNumber(decimals)) {
+    return undefined;
+  }
+
+  switch (format.type?.id) {
+    case FIELD_FORMAT_IDS.NUMBER:
+    case FIELD_FORMAT_IDS.CURRENCY:
+      return decimals;
+    case FIELD_FORMAT_IDS.PERCENT:
+      return decimals + 2; // formatter multiplies by 100 before rendering, so we add 2
+    default:
+      // to be safe, when we don't know if applicable (e.g., in bytes/bits, duration, etc,
+      // formatter scales value by unit), we fall back to undefined
+      return undefined;
+  }
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Lens] Fix missing small percentage tick values on Y axis (#279489)](https://github.com/elastic/kibana/pull/279489)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Beatriz Malveiro","email":"beatriz.malveiro@elastic.co"},"sourceCommit":{"committedDate":"2026-07-24T11:57:34Z","message":"[Lens] Fix missing small percentage tick values on Y axis (#279489)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/275622\n\nFixes issue when configuring a percentage Y axis with less than 2\ndecimals made some relevant tick values missing.\n\n\n| Before | After |\n| ------------- | ------------- |\n| <img width=\"997\" height=\"523\" alt=\"Screenshot 2026-07-20 at 16 01 28\"\nsrc=\"https://github.com/user-attachments/assets/57a8faf3-c9bc-4f72-92a3-0ba77dd49f44\"\n/> | <img width=\"997\" height=\"523\" alt=\"Screenshot 2026-07-20 at 16 01\n51\"\nsrc=\"https://github.com/user-attachments/assets/5a1345ce-22b5-426a-97a8-25bcf5a113ef\"\n/> |\n\n\n### Description\n\nThis was a regression from\nhttps://github.com/elastic/kibana/pull/265529. Lens was passing the\nnumeric axis's display decimals directly to prop `maximumFractionDigits`\nthat filters ticks based on the raw domain value. So for formats where\nthe domain value is scaled by the formatter (e.g. percent renders 0.01\nas 1%), this meant that valid ticks were dropped.\n\nSo, replaced `getDecimalsFromFormat` with `getMaximumFractionDigits`.\nNow, in addition to getting the `decimals` value from the formatter, we\nscale it for percentages, and only return a value if applicable for the\nselected formatter. For example, if bytes/bits/duration, we return\n`undefined` because no exact scale mapping exists, and therefore skip\nthe base 10 domain values filtering that `maximumFractionDigits` does,\nand let the formatter own display precision.\n\n(also considered if it made sense to have elastic-charts apply\n`maximumFractionDigits` filtering on the formatted label instead (closer\nto the intent we have this parameter). However, that meant parsing\ndigits back out of the display string (locale separators, %, currency,\nunits), so kind of reverse-engineering the formatter, which could be a\ncan of worms. So, it seemed cleaner to let the consumer (Lens), which\nalready knows the formatter, work out the right `maximumFractionDigits`\nvalue to pass, if any)\n\n\n### Testing\n\nHere's a demo dashboard, \n\n[mfd.ndjson.zip](https://github.com/user-attachments/files/30186341/mfd.ndjson.zip)\n\nIn the dashboard there are three charts, check that:\n- (Percentage). For the first chart, single digit percentage values are\ndisplayed when `Decimals` input parameter is smaller than 2.\n- (Bytes) For the second chart, check that displayed tick label values\nare the same regardless of `Decimals` input, only formatter changes (on\nVertical axis / Formula, divide value by 1000 and 10000), change\n`Decimals` value to 0,1,2.\n- (Number) On third chart, change `Decimals` from 2 to 1 and check that\nno repeated values are shown (`maximumFractionDigits` is applied)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e7b2169f8657b738e5c03f787ff9f830a1e1d63e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Visualizations","backport:skip","v9.6.0"],"title":"[Lens] Fix missing small percentage tick values on Y axis ","number":279489,"url":"https://github.com/elastic/kibana/pull/279489","mergeCommit":{"message":"[Lens] Fix missing small percentage tick values on Y axis (#279489)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/275622\n\nFixes issue when configuring a percentage Y axis with less than 2\ndecimals made some relevant tick values missing.\n\n\n| Before | After |\n| ------------- | ------------- |\n| <img width=\"997\" height=\"523\" alt=\"Screenshot 2026-07-20 at 16 01 28\"\nsrc=\"https://github.com/user-attachments/assets/57a8faf3-c9bc-4f72-92a3-0ba77dd49f44\"\n/> | <img width=\"997\" height=\"523\" alt=\"Screenshot 2026-07-20 at 16 01\n51\"\nsrc=\"https://github.com/user-attachments/assets/5a1345ce-22b5-426a-97a8-25bcf5a113ef\"\n/> |\n\n\n### Description\n\nThis was a regression from\nhttps://github.com/elastic/kibana/pull/265529. Lens was passing the\nnumeric axis's display decimals directly to prop `maximumFractionDigits`\nthat filters ticks based on the raw domain value. So for formats where\nthe domain value is scaled by the formatter (e.g. percent renders 0.01\nas 1%), this meant that valid ticks were dropped.\n\nSo, replaced `getDecimalsFromFormat` with `getMaximumFractionDigits`.\nNow, in addition to getting the `decimals` value from the formatter, we\nscale it for percentages, and only return a value if applicable for the\nselected formatter. For example, if bytes/bits/duration, we return\n`undefined` because no exact scale mapping exists, and therefore skip\nthe base 10 domain values filtering that `maximumFractionDigits` does,\nand let the formatter own display precision.\n\n(also considered if it made sense to have elastic-charts apply\n`maximumFractionDigits` filtering on the formatted label instead (closer\nto the intent we have this parameter). However, that meant parsing\ndigits back out of the display string (locale separators, %, currency,\nunits), so kind of reverse-engineering the formatter, which could be a\ncan of worms. So, it seemed cleaner to let the consumer (Lens), which\nalready knows the formatter, work out the right `maximumFractionDigits`\nvalue to pass, if any)\n\n\n### Testing\n\nHere's a demo dashboard, \n\n[mfd.ndjson.zip](https://github.com/user-attachments/files/30186341/mfd.ndjson.zip)\n\nIn the dashboard there are three charts, check that:\n- (Percentage). For the first chart, single digit percentage values are\ndisplayed when `Decimals` input parameter is smaller than 2.\n- (Bytes) For the second chart, check that displayed tick label values\nare the same regardless of `Decimals` input, only formatter changes (on\nVertical axis / Formula, divide value by 1000 and 10000), change\n`Decimals` value to 0,1,2.\n- (Number) On third chart, change `Decimals` from 2 to 1 and check that\nno repeated values are shown (`maximumFractionDigits` is applied)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e7b2169f8657b738e5c03f787ff9f830a1e1d63e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279489","number":279489,"mergeCommit":{"message":"[Lens] Fix missing small percentage tick values on Y axis (#279489)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/275622\n\nFixes issue when configuring a percentage Y axis with less than 2\ndecimals made some relevant tick values missing.\n\n\n| Before | After |\n| ------------- | ------------- |\n| <img width=\"997\" height=\"523\" alt=\"Screenshot 2026-07-20 at 16 01 28\"\nsrc=\"https://github.com/user-attachments/assets/57a8faf3-c9bc-4f72-92a3-0ba77dd49f44\"\n/> | <img width=\"997\" height=\"523\" alt=\"Screenshot 2026-07-20 at 16 01\n51\"\nsrc=\"https://github.com/user-attachments/assets/5a1345ce-22b5-426a-97a8-25bcf5a113ef\"\n/> |\n\n\n### Description\n\nThis was a regression from\nhttps://github.com/elastic/kibana/pull/265529. Lens was passing the\nnumeric axis's display decimals directly to prop `maximumFractionDigits`\nthat filters ticks based on the raw domain value. So for formats where\nthe domain value is scaled by the formatter (e.g. percent renders 0.01\nas 1%), this meant that valid ticks were dropped.\n\nSo, replaced `getDecimalsFromFormat` with `getMaximumFractionDigits`.\nNow, in addition to getting the `decimals` value from the formatter, we\nscale it for percentages, and only return a value if applicable for the\nselected formatter. For example, if bytes/bits/duration, we return\n`undefined` because no exact scale mapping exists, and therefore skip\nthe base 10 domain values filtering that `maximumFractionDigits` does,\nand let the formatter own display precision.\n\n(also considered if it made sense to have elastic-charts apply\n`maximumFractionDigits` filtering on the formatted label instead (closer\nto the intent we have this parameter). However, that meant parsing\ndigits back out of the display string (locale separators, %, currency,\nunits), so kind of reverse-engineering the formatter, which could be a\ncan of worms. So, it seemed cleaner to let the consumer (Lens), which\nalready knows the formatter, work out the right `maximumFractionDigits`\nvalue to pass, if any)\n\n\n### Testing\n\nHere's a demo dashboard, \n\n[mfd.ndjson.zip](https://github.com/user-attachments/files/30186341/mfd.ndjson.zip)\n\nIn the dashboard there are three charts, check that:\n- (Percentage). For the first chart, single digit percentage values are\ndisplayed when `Decimals` input parameter is smaller than 2.\n- (Bytes) For the second chart, check that displayed tick label values\nare the same regardless of `Decimals` input, only formatter changes (on\nVertical axis / Formula, divide value by 1000 and 10000), change\n`Decimals` value to 0,1,2.\n- (Number) On third chart, change `Decimals` from 2 to 1 and check that\nno repeated values are shown (`maximumFractionDigits` is applied)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e7b2169f8657b738e5c03f787ff9f830a1e1d63e"}}]}] BACKPORT-->