### PR TITLE
[Workflows] Fix workflows callKibanaApi to space-prefix request paths so custom steps target the workflow's space

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/kibana_request_builder.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/kibana_request_builder.ts
@@ -193,7 +193,7 @@ function selectBestPattern(patterns: string[], params: Record<string, unknown>):
  * Applies the space prefix to the path for non-default spaces
  * Following Kibana's standard space-aware API pattern: /s/{spaceId}/api/...
  */
-function applySpacePrefix(path: string, spaceId?: string): string {
+export function applySpacePrefix(path: string, spaceId?: string): string {
   // Only prepend space prefix for non-default spaces
   // Default space can use /api/... directly without the /s/default prefix
   if (spaceId && spaceId !== 'default') {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/call_kibana_api.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/call_kibana_api.test.ts
@@ -117,6 +117,42 @@ describe('callKibanaApi', () => {
     expect((init as RequestInit).body).toBeUndefined();
   });
 
+  it('prefixes the path with /s/{spaceId} for a non-default space', async () => {
+    mockedFetch.mockResolvedValue(createMockResponse({ body: { ok: true } }));
+
+    await callKibanaApi(
+      { fakeRequest: createFakeRequest(), coreStart: createCoreStart(), spaceId: 'my-space' },
+      { method: 'GET', path: '/api/cases/_find', query: { perPage: 20 } }
+    );
+
+    const [url] = mockedFetch.mock.calls[0];
+    expect(url).toBe('https://kibana.example.com/s/my-space/api/cases/_find?perPage=20');
+  });
+
+  it('does not prefix the path for the default space', async () => {
+    mockedFetch.mockResolvedValue(createMockResponse({ body: { ok: true } }));
+
+    await callKibanaApi(
+      { fakeRequest: createFakeRequest(), coreStart: createCoreStart(), spaceId: 'default' },
+      { method: 'GET', path: '/api/cases/_find' }
+    );
+
+    const [url] = mockedFetch.mock.calls[0];
+    expect(url).toBe('https://kibana.example.com/api/cases/_find');
+  });
+
+  it('does not prefix the path when no space is provided', async () => {
+    mockedFetch.mockResolvedValue(createMockResponse({ body: { ok: true } }));
+
+    await callKibanaApi(
+      { fakeRequest: createFakeRequest(), coreStart: createCoreStart() },
+      { method: 'GET', path: '/api/status' }
+    );
+
+    const [url] = mockedFetch.mock.calls[0];
+    expect(url).toBe('https://kibana.example.com/api/status');
+  });
+
   it('serializes the body as JSON for POST', async () => {
     mockedFetch.mockResolvedValue(createMockResponse({ body: { id: 'abc' } }));
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/call_kibana_api.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/call_kibana_api.ts
@@ -9,6 +9,7 @@
 
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { CoreStart, KibanaRequest } from '@kbn/core/server';
+import { applySpacePrefix } from '@kbn/workflows';
 import {
   getOutboundEventChainHeaders,
   KibanaApiCallError,
@@ -54,7 +55,11 @@ export class CallKibanaApiResponseTooLargeError extends Error {
  */
 export interface CallKibanaApiParams {
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
-  /** Route path starting with `/`, e.g. `/api/cases`. Space prefix is added automatically. */
+  /**
+   * Space-relative route path starting with `/`, e.g. `/api/cases`. When `deps.spaceId`
+   * is a non-default space, it is prefixed with `/s/{spaceId}` automatically; pass the
+   * path without a space segment.
+   */
   path: string;
   body?: unknown;
   query?: Record<string, string | number | boolean | undefined>;
@@ -81,6 +86,11 @@ export interface CallKibanaApiDeps {
   workflowRunId?: string;
   coreStart: CoreStart;
   cloudSetup?: CloudSetup;
+  /**
+   * Space the workflow is running in. When set to a non-default space, the request path is
+   * prefixed with `/s/{spaceId}`. When omitted or `'default'`, the path is used as-is.
+   */
+  spaceId?: string;
   /**
    * Cap on the size of the response body in bytes. `0` disables the limit. When omitted,
    * `DEFAULT_MAX_RESPONSE_BYTES` is used.
@@ -228,11 +238,12 @@ export async function callKibanaApi<T = unknown>(
   deps: CallKibanaApiDeps,
   params: CallKibanaApiParams
 ): Promise<CallKibanaApiResult<T>> {
-  const { fakeRequest, workflowRunId, coreStart, cloudSetup, baseUrlOverride } = deps;
+  const { fakeRequest, workflowRunId, coreStart, cloudSetup, baseUrlOverride, spaceId } = deps;
   const maxResponseBytes = deps.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
 
   const baseUrl = baseUrlOverride ?? getKibanaUrl(coreStart, cloudSetup);
-  const url = `${baseUrl}${params.path}${buildQueryString(params.query)}`;
+  const path = applySpacePrefix(params.path, spaceId);
+  const url = `${baseUrl}${path}${buildQueryString(params.query)}`;
 
   const callerHeaders = stripReservedHeaders(params.headers);
   const outboundHeaders: Record<string, string> = {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -316,6 +316,7 @@ export class WorkflowContextManager {
         coreStart: this.coreStart,
         cloudSetup: this.dependencies.cloudSetup,
         workflowRunId: this.workflowExecutionState.getWorkflowExecution().id,
+        spaceId: this.getWorkflowSpaceId(),
       },
       params
     );


### PR DESCRIPTION
# Summary

Custom workflow steps called Kibana APIs in the wrong space. The `contextManager.callKibanaApi` helper built request URLs from the Kibana base URL and the step's path only. It never added the `/s/{spaceId}` segment. As a result, a step that ran in a non-default space sent its request to the **default** space. The step then acted on the wrong data, or failed with a confusing "not found" error. This affected every custom step, including the recently added `security.enableRule` and `security.disableRule`. The `path` field was [documented](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/workflows_execution_engine/server/lib/call_kibana_api.ts#L57) as "Space prefix is added automatically", but the code did not do this.

This change makes the helper add the space prefix. `WorkflowContextManager.callKibanaApi` now reads the workflow's space with `getWorkflowSpaceId()` and passes it to the helper. The helper applies the shared `applySpacePrefix` function to the path. It adds `/s/{spaceId}` for a non-default space. It leaves the path unchanged for the default space. The `applySpacePrefix` function is now exported from `@kbn/workflows`. The `kibana.request` step already used it, so both HTTP paths now follow the same rule. New unit tests cover the non-default space, the default space, and the no-space cases.

# How to test

Use the `security.enableRule` step. Run each request in a **non-default** space, for example `test-space`.

**1. Create a detection rule in the space.**

Send this request. Replace `test-space` with your space id.

```bash
curl -u elastic:changeme -X POST \
  "http://localhost:5601/s/test-space/api/detection_engine/rules" \
  -H "kbn-xsrf: true" \
  -H "Content-Type: application/json" \
  -d '{
    "rule_id": "space-bug-repro-rule",
    "name": "Space bug repro rule",
    "description": "Rule used to reproduce the workflow space bug",
    "type": "query",
    "query": "*:*",
    "language": "kuery",
    "index": ["logs-*"],
    "risk_score": 21,
    "severity": "low",
    "enabled": false
  }'

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->