### PR TITLE
[Upgrade Assistant] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/cloud_stack_versions.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/cloud_stack_versions.ts
@@ -359,7 +359,7 @@ export function registerCloudStackVersionsRoute(deps: RouteDependencies) {
       },
       validate: {
         params: schema.object({
-          currentVersion: schema.string(),
+          currentVersion: schema.string({ maxLength: 64 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/cluster_settings.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/cluster_settings.ts
@@ -26,7 +26,7 @@ export function registerClusterSettingsRoute({
       },
       validate: {
         body: schema.object({
-          settings: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          settings: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/deprecation_logging.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/deprecation_logging.ts
@@ -91,7 +91,7 @@ export function registerDeprecationLoggingRoutes({
       },
       validate: {
         query: schema.object({
-          from: schema.string(),
+          from: schema.string({ maxLength: 64 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/migrate_data_streams/data_stream_routes.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/migrate_data_streams/data_stream_routes.ts
@@ -38,7 +38,7 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -89,7 +89,7 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -138,7 +138,7 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -181,7 +181,7 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -236,10 +236,10 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         body: schema.object({
-          indices: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          indices: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/ml_snapshots.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/ml_snapshots.ts
@@ -155,8 +155,8 @@ export function registerMlSnapshotRoutes({
       },
       validate: {
         body: schema.object({
-          snapshotId: schema.string(),
-          jobId: schema.string(),
+          snapshotId: schema.string({ maxLength: 1000 }),
+          jobId: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -211,8 +211,8 @@ export function registerMlSnapshotRoutes({
       },
       validate: {
         params: schema.object({
-          snapshotId: schema.string(),
-          jobId: schema.string(),
+          snapshotId: schema.string({ maxLength: 1000 }),
+          jobId: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -403,8 +403,8 @@ export function registerMlSnapshotRoutes({
       },
       validate: {
         params: schema.object({
-          snapshotId: schema.string(),
-          jobId: schema.string(),
+          snapshotId: schema.string({ maxLength: 1000 }),
+          jobId: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.ts
@@ -41,7 +41,7 @@ export function registerUpgradeStatusRoute({
       },
       validate: {
         query: schema.object({
-          targetVersion: schema.maybe(schema.string()),
+          targetVersion: schema.maybe(schema.string({ maxLength: 64 })),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/update_index_settings.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/update_index_settings.ts
@@ -22,7 +22,7 @@ export function registerUpdateSettingsRoute({ router, current }: RouteDependenci
       },
       validate: {
         params: schema.object({
-          indexName: schema.string(),
+          indexName: schema.string({ maxLength: 1000 }),
         }),
         body: schema.object({
           settings: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `upgrade_assistant` route request validation schemas — clears 17 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`settings`, `dataStreamName`, `indices`, `snapshotId`, `jobId`, `indexName`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 64`** for short fixed-format values (`currentVersion`, `from`, `targetVersion`): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/upgrade_assistant/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#12047](https://github.com/elastic/kibana/security/code-scanning/12047) | `server/routes/cloud_stack_versions.ts:362` | `currentVersion: schema.string(),` | `maxLength: 64` |
| [#12037](https://github.com/elastic/kibana/security/code-scanning/12037) | `server/routes/cluster_settings.ts:29` | `settings: schema.arrayOf(schema.string(), { maxSize: 1000 }),` | `maxLength: 1000` |
| [#12038](https://github.com/elastic/kibana/security/code-scanning/12038) | `server/routes/deprecation_logging.ts:94` | `from: schema.string(),` | `maxLength: 64` |
| [#12039](https://github.com/elastic/kibana/security/code-scanning/12039) | `server/routes/migrate_data_streams/data_stream_routes.ts:41` | `dataStreamName: schema.string(),` | `maxLength: 1000` |
| [#12040](https://github.com/elastic/kibana/security/code-scanning/12040) | `server/routes/migrate_data_streams/data_stream_routes.ts:92` | `dataStreamName: schema.string(),` | `maxLength: 1000` |
| [#12041](https://github.com/elastic/kibana/security/code-scanning/12041) | `server/routes/migrate_data_streams/data_stream_routes.ts:141` | `dataStreamName: schema.string(),` | `maxLength: 1000` |
| [#12043](https://github.com/elastic/kibana/security/code-scanning/12043) | `server/routes/migrate_data_streams/data_stream_routes.ts:184` | `dataStreamName: schema.string(),` | `maxLength: 1000` |
| [#12044](https://github.com/elastic/kibana/security/code-scanning/12044) | `server/routes/migrate_data_streams/data_stream_routes.ts:239` | `indices: schema.arrayOf(schema.string(), { maxSize: 1000 }),` | `maxLength: 1000` |
| [#12045](https://github.com/elastic/kibana/security/code-scanning/12045) | `server/routes/migrate_data_streams/data_stream_routes.ts:242` | `dataStreamName: schema.string(),` | `maxLength: 1000` |
| [#12048](https://github.com/elastic/kibana/security/code-scanning/12048) | `server/routes/ml_snapshots.ts:158` | `snapshotId: schema.string(),` | `maxLength: 1000` |
| [#12049](https://github.com/elastic/kibana/security/code-scanning/12049) | `server/routes/ml_snapshots.ts:159` | `jobId: schema.string(),` | `maxLength: 1000` |
| [#12050](https://github.com/elastic/kibana/security/code-scanning/12050) | `server/routes/ml_snapshots.ts:214` | `snapshotId: schema.string(),` | `maxLength: 1000` |
| [#12051](https://github.com/elastic/kibana/security/code-scanning/12051) | `server/routes/ml_snapshots.ts:215` | `jobId: schema.string(),` | `maxLength: 1000` |
| [#12052](https://github.com/elastic/kibana/security/code-scanning/12052) | `server/routes/ml_snapshots.ts:406` | `snapshotId: schema.string(),` | `maxLength: 1000` |
| [#12053](https://github.com/elastic/kibana/security/code-scanning/12053) | `server/routes/ml_snapshots.ts:407` | `jobId: schema.string(),` | `maxLength: 1000` |
| [#12046](https://github.com/elastic/kibana/security/code-scanning/12046) | `server/routes/status.ts:44` | `targetVersion: schema.maybe(schema.string()),` | `maxLength: 64` |
| [#12042](https://github.com/elastic/kibana/security/code-scanning/12042) | `server/routes/update_index_settings.ts:25` | `indexName: schema.string(),` | `maxLength: 1000` |
