### PR TITLE
[Security Solution][Endpoint] Remove stale policy_response step from periodic defend workflows pipeline

### DIFF
--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
@@ -142,26 +142,6 @@ steps:
         soft_fail:
           - exit_status: 101
 
-      - label: "API MKI - edr_workflows:policy_response:qa:serverless"
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy_response:qa:serverless
-        key: edr_workflows:policy_response:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
-        agents:
-          image: family/kibana-ubuntu-2404
-          imageProject: elastic-images-prod
-          provider: gcp
-          enableNestedVirtualization: true
-          machineType: n2-standard-4
-          diskSizeGb: 130
-        timeout_in_minutes: 120
-        retry:
-          automatic:
-            - exit_status: "1"
-              limit: 2
-        soft_fail:
-          - exit_status: 101
-
       - label: "API MKI - edr_workflows:resolver:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:resolver:qa:serverless
         key: edr_workflows:resolver:qa:serverless


### PR DESCRIPTION
## Summary

The `policy_response` FTR test suite was deleted in #280168 due to instability. That PR cleaned up the FTR manifests (`ftr_security_serverless_configs.yml`, `ftr_security_stateful_configs.yml`) and the quality-gate pipelines, but **missed the periodic pipeline** (`mki_periodic_defend_workflows.yml`).

As a result, the [periodic defend workflows run](https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-defend-workflows) has been failing since Thursday Jul 23 with:

```
ERROR Unable to find config file [.../edr_workflows/policy_response/trial_license_complete_tier/configs/serverless.config.ts]
```

because the step still runs `edr_workflows:policy_response:qa:serverless`, which resolves to the now-deleted config. The monitoring / quality-gate runs pass because their pipelines were already cleaned up in #280168.

This PR removes the stale `policy_response` step from the periodic pipeline.

### Checklist

- [x] No remaining references to `policy_response` in the periodic pipeline

### Release note

N/A — CI-only change.
