### PR TITLE
[CCR] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_delete_route.ts
@@ -19,7 +19,7 @@ export const registerDeleteRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.delete(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_get_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_get_route.ts
@@ -20,7 +20,7 @@ export const registerGetRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.get(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_pause_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_pause_route.ts
@@ -18,7 +18,7 @@ export const registerPauseRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.post(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_resume_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_resume_route.ts
@@ -18,7 +18,7 @@ export const registerResumeRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.post(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_update_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_update_route.ts
@@ -25,9 +25,9 @@ export const registerUpdateRoute = ({
 
   const bodySchema = schema.object({
     active: schema.boolean(),
-    remoteCluster: schema.string(),
-    leaderIndexPatterns: schema.arrayOf(schema.string(), { maxSize: 1000 }),
-    followIndexPattern: schema.string(),
+    remoteCluster: schema.string({ maxLength: 1000 }),
+    leaderIndexPatterns: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
+    followIndexPattern: schema.string({ maxLength: 1000 }),
   });
 
   router.put(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_get_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_get_route.ts
@@ -19,7 +19,7 @@ export const registerGetRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.get(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_pause_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_pause_route.ts
@@ -17,7 +17,7 @@ export const registerPauseRoute = ({
   license,
   lib: { handleEsError },
 }: RouteDependencies) => {
-  const paramsSchema = schema.object({ id: schema.string() });
+  const paramsSchema = schema.object({ id: schema.string({ maxLength: 1000 }) });
 
   router.put(
     {

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_resume_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_resume_route.ts
@@ -17,7 +17,7 @@ export const registerResumeRoute = ({
   license,
   lib: { handleEsError },
 }: RouteDependencies) => {
-  const paramsSchema = schema.object({ id: schema.string() });
+  const paramsSchema = schema.object({ id: schema.string({ maxLength: 1000 }) });
 
   router.put(
     {

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_unfollow_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_unfollow_route.ts
@@ -17,7 +17,7 @@ export const registerUnfollowRoute = ({
   license,
   lib: { handleEsError },
 }: RouteDependencies) => {
-  const paramsSchema = schema.object({ id: schema.string() });
+  const paramsSchema = schema.object({ id: schema.string({ maxLength: 1000 }) });
 
   router.put(
     {

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_update_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_update_route.ts
@@ -20,19 +20,19 @@ export const registerUpdateRoute = ({
   license,
   lib: { handleEsError },
 }: RouteDependencies) => {
-  const paramsSchema = schema.object({ id: schema.string() });
+  const paramsSchema = schema.object({ id: schema.string({ maxLength: 1000 }) });
 
   const bodySchema = schema.object({
     maxReadRequestOperationCount: schema.maybe(schema.number()),
     maxOutstandingReadRequests: schema.maybe(schema.number()),
-    maxReadRequestSize: schema.maybe(schema.string()), // byte value
+    maxReadRequestSize: schema.maybe(schema.string({ maxLength: 64 })), // byte value
     maxWriteRequestOperationCount: schema.maybe(schema.number()),
-    maxWriteRequestSize: schema.maybe(schema.string()), // byte value
+    maxWriteRequestSize: schema.maybe(schema.string({ maxLength: 64 })), // byte value
     maxOutstandingWriteRequests: schema.maybe(schema.number()),
     maxWriteBufferCount: schema.maybe(schema.number()),
-    maxWriteBufferSize: schema.maybe(schema.string()), // byte value
-    maxRetryDelay: schema.maybe(schema.string()), // time value
-    readPollTimeout: schema.maybe(schema.string()), // time value
+    maxWriteBufferSize: schema.maybe(schema.string({ maxLength: 64 })), // byte value
+    maxRetryDelay: schema.maybe(schema.string({ maxLength: 64 })), // time value
+    readPollTimeout: schema.maybe(schema.string({ maxLength: 64 })), // time value
   });
 
   router.put(


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `cross_cluster_replication` route request validation schemas — clears 17 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`id`, `remoteCluster`, `leaderIndexPatterns`, `followIndexPattern`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 64`** for short fixed-format values (`maxReadRequestSize`, `maxWriteRequestSize`, `maxWriteBufferSize`, `maxRetryDelay`, `readPollTimeout`): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/cross_cluster_replication/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11903](https://github.com/elastic/kibana/security/code-scanning/11903) | `server/routes/api/auto_follow_pattern/register_delete_route.ts:22` | `id: schema.string(),` | `maxLength: 1000` |
| [#11910](https://github.com/elastic/kibana/security/code-scanning/11910) | `server/routes/api/auto_follow_pattern/register_get_route.ts:23` | `id: schema.string(),` | `maxLength: 1000` |
| [#11904](https://github.com/elastic/kibana/security/code-scanning/11904) | `server/routes/api/auto_follow_pattern/register_pause_route.ts:21` | `id: schema.string(),` | `maxLength: 1000` |
| [#11905](https://github.com/elastic/kibana/security/code-scanning/11905) | `server/routes/api/auto_follow_pattern/register_resume_route.ts:21` | `id: schema.string(),` | `maxLength: 1000` |
| [#11906](https://github.com/elastic/kibana/security/code-scanning/11906) | `server/routes/api/auto_follow_pattern/register_update_route.ts:28` | `remoteCluster: schema.string(),` | `maxLength: 1000` |
| [#11907](https://github.com/elastic/kibana/security/code-scanning/11907) | `server/routes/api/auto_follow_pattern/register_update_route.ts:29` | `leaderIndexPatterns: schema.arrayOf(schema.string(), { maxSize: 1000 }),` | `maxLength: 1000` |
| [#11908](https://github.com/elastic/kibana/security/code-scanning/11908) | `server/routes/api/auto_follow_pattern/register_update_route.ts:30` | `followIndexPattern: schema.string(),` | `maxLength: 1000` |
| [#11911](https://github.com/elastic/kibana/security/code-scanning/11911) | `server/routes/api/follower_index/register_get_route.ts:22` | `id: schema.string(),` | `maxLength: 1000` |
| [#11909](https://github.com/elastic/kibana/security/code-scanning/11909) | `server/routes/api/follower_index/register_pause_route.ts:20` | `const paramsSchema = schema.object({ id: schema.string() });` | `maxLength: 1000` |
| [#11912](https://github.com/elastic/kibana/security/code-scanning/11912) | `server/routes/api/follower_index/register_resume_route.ts:20` | `const paramsSchema = schema.object({ id: schema.string() });` | `maxLength: 1000` |
| [#11913](https://github.com/elastic/kibana/security/code-scanning/11913) | `server/routes/api/follower_index/register_unfollow_route.ts:20` | `const paramsSchema = schema.object({ id: schema.string() });` | `maxLength: 1000` |
| [#11914](https://github.com/elastic/kibana/security/code-scanning/11914) | `server/routes/api/follower_index/register_update_route.ts:23` | `const paramsSchema = schema.object({ id: schema.string() });` | `maxLength: 1000` |
| [#11915](https://github.com/elastic/kibana/security/code-scanning/11915) | `server/routes/api/follower_index/register_update_route.ts:28` | `maxReadRequestSize: schema.maybe(schema.string()), // byte value` | `maxLength: 64` |
| [#11916](https://github.com/elastic/kibana/security/code-scanning/11916) | `server/routes/api/follower_index/register_update_route.ts:30` | `maxWriteRequestSize: schema.maybe(schema.string()), // byte value` | `maxLength: 64` |
| [#11917](https://github.com/elastic/kibana/security/code-scanning/11917) | `server/routes/api/follower_index/register_update_route.ts:33` | `maxWriteBufferSize: schema.maybe(schema.string()), // byte value` | `maxLength: 64` |
| [#11918](https://github.com/elastic/kibana/security/code-scanning/11918) | `server/routes/api/follower_index/register_update_route.ts:34` | `maxRetryDelay: schema.maybe(schema.string()), // time value` | `maxLength: 64` |
| [#11919](https://github.com/elastic/kibana/security/code-scanning/11919) | `server/routes/api/follower_index/register_update_route.ts:35` | `readPollTimeout: schema.maybe(schema.string()), // time value` | `maxLength: 64` |
