### PR TITLE
[Watcher] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/watcher/server/routes/api/indices/register_get_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/indices/register_get_route.ts
@@ -11,7 +11,10 @@ import type { IScopedClusterClient } from '@kbn/core/server';
 import { reduce, size } from 'lodash';
 import type { RouteDependencies } from '../../../types';
 
-const bodySchema = schema.object({ pattern: schema.string() }, { unknowns: 'allow' });
+const bodySchema = schema.object(
+  { pattern: schema.string({ maxLength: 1000 }) },
+  { unknowns: 'allow' }
+);
 
 function getIndexNamesFromAliasesResponse(json: Record<string, any>) {
   return reduce(

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/register_load_history_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/register_load_history_route.ts
@@ -14,7 +14,7 @@ import type { RouteDependencies } from '../../types';
 import { WatchHistoryItem } from '../../models/watch_history_item';
 
 const paramsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: 1000 }),
 });
 
 function fetchHistoryItem(dataClient: IScopedClusterClient, watchHistoryItemId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/action/register_acknowledge_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/action/register_acknowledge_route.ts
@@ -16,8 +16,8 @@ import {
 import type { RouteDependencies } from '../../../../types';
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
-  actionId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
+  actionId: schema.string({ maxLength: 1000 }),
 });
 
 function acknowledgeAction(dataClient: IScopedClusterClient, watchId: string, actionId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_activate_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_activate_route.ts
@@ -22,7 +22,7 @@ function activateWatch(dataClient: IScopedClusterClient, watchId: string) {
 }
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
 });
 
 export function registerActivateRoute({

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_deactivate_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_deactivate_route.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../models/watch_status_model';
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
 });
 
 function deactivateWatch(dataClient: IScopedClusterClient, watchId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_delete_route.ts
@@ -10,7 +10,7 @@ import type { IScopedClusterClient } from '@kbn/core/server';
 import type { RouteDependencies } from '../../../types';
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
 });
 
 function deleteWatch(dataClient: IScopedClusterClient, watchId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_history_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_history_route.ts
@@ -15,11 +15,11 @@ import type { RouteDependencies } from '../../../types';
 import { WatchHistoryItem } from '../../../models/watch_history_item';
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
 });
 
 const querySchema = schema.object({
-  startTime: schema.string(),
+  startTime: schema.string({ maxLength: 64 }),
 });
 
 function fetchHistoryItems(dataClient: IScopedClusterClient, watchId: any, startTime: any) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_load_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_load_route.ts
@@ -13,7 +13,7 @@ import { Watch } from '../../../models/watch';
 import type { RouteDependencies } from '../../../types';
 
 const paramsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: 1000 }),
 });
 
 function fetchWatch(dataClient: IScopedClusterClient, watchId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watches/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watches/register_delete_route.ts
@@ -11,7 +11,7 @@ import type { IScopedClusterClient } from '@kbn/core/server';
 import type { RouteDependencies } from '../../../types';
 
 const bodySchema = schema.object({
-  watchIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+  watchIds: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
 });
 
 type DeleteWatchPromiseArray = Promise<{


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `watcher` route request validation schemas — clears 11 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`id`, `watchId`, `actionId`, `watchIds`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 64`** for short fixed-format values (`startTime`): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/watcher/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#12054](https://github.com/elastic/kibana/security/code-scanning/12054) | `server/routes/api/indices/register_get_route.ts:14` | `const bodySchema = schema.object({ pattern: schema.string() }, ...);` | `maxLength: 1000` |
| [#12055](https://github.com/elastic/kibana/security/code-scanning/12055) | `server/routes/api/register_load_history_route.ts:17` | `id: schema.string(),` | `maxLength: 1000` |
| [#12056](https://github.com/elastic/kibana/security/code-scanning/12056) | `server/routes/api/watch/action/register_acknowledge_route.ts:19` | `watchId: schema.string(),` | `maxLength: 1000` |
| [#12057](https://github.com/elastic/kibana/security/code-scanning/12057) | `server/routes/api/watch/action/register_acknowledge_route.ts:20` | `actionId: schema.string(),` | `maxLength: 1000` |
| [#12059](https://github.com/elastic/kibana/security/code-scanning/12059) | `server/routes/api/watch/register_activate_route.ts:25` | `watchId: schema.string(),` | `maxLength: 1000` |
| [#12058](https://github.com/elastic/kibana/security/code-scanning/12058) | `server/routes/api/watch/register_deactivate_route.ts:18` | `watchId: schema.string(),` | `maxLength: 1000` |
| [#12060](https://github.com/elastic/kibana/security/code-scanning/12060) | `server/routes/api/watch/register_delete_route.ts:13` | `watchId: schema.string(),` | `maxLength: 1000` |
| [#12062](https://github.com/elastic/kibana/security/code-scanning/12062) | `server/routes/api/watch/register_history_route.ts:18` | `watchId: schema.string(),` | `maxLength: 1000` |
| [#12063](https://github.com/elastic/kibana/security/code-scanning/12063) | `server/routes/api/watch/register_history_route.ts:22` | `startTime: schema.string(),` | `maxLength: 64` |
| [#12061](https://github.com/elastic/kibana/security/code-scanning/12061) | `server/routes/api/watch/register_load_route.ts:16` | `id: schema.string(),` | `maxLength: 1000` |
| [#12064](https://github.com/elastic/kibana/security/code-scanning/12064) | `server/routes/api/watches/register_delete_route.ts:14` | `watchIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),` | `maxLength: 1000` |
