### PR TITLE
[Transform] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/audit_messages.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/audit_messages.ts
@@ -16,7 +16,7 @@ export interface GetTransformsAuditMessagesResponseSchema {
 }
 
 export const getTransformAuditMessagesQuerySchema = schema.object({
-  sortField: schema.string(),
+  sortField: schema.string({ maxLength: 1000 }),
   sortDirection: schema.oneOf([schema.literal('asc'), schema.literal('desc')]),
 });
 

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/common.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/common.ts
@@ -33,7 +33,7 @@ export const transformStateSchema = schema.oneOf([
 
 export const dataViewTitleSchema = schema.object({
   /** Title of the data view for which to return stats. */
-  dataViewTitle: schema.string(),
+  dataViewTitle: schema.string({ maxLength: 1000 }),
 });
 
 export type DataViewTitleSchema = TypeOf<typeof dataViewTitleSchema>;

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/delete_transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/delete_transforms.ts
@@ -18,7 +18,7 @@ export const deleteTransformsRequestSchema = schema.object({
    */
   transformsInfo: schema.arrayOf(
     schema.object({
-      id: schema.string(),
+      id: schema.string({ maxLength: 1000 }),
       state: transformStateSchema,
     }),
     { maxSize: 1000 }

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/reset_transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/reset_transforms.ts
@@ -17,7 +17,7 @@ export const resetTransformsRequestSchema = schema.object({
    */
   transformsInfo: schema.arrayOf(
     schema.object({
-      id: schema.string(),
+      id: schema.string({ maxLength: 1000 }),
       state: transformStateSchema,
     }),
     { maxSize: 1000 }

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/stop_transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/stop_transforms.ts
@@ -13,7 +13,7 @@ import { transformStateSchema } from './common';
 
 export const stopTransformsRequestSchema = schema.arrayOf(
   schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
     state: transformStateSchema,
   }),
   { maxSize: 1000 }

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/transforms.ts
@@ -155,7 +155,7 @@ export type PutTransformsLatestRequestSchema = Omit<PutTransformsRequestSchema, 
 
 export const putTransformQuerySchema = schema.object({
   createDataView: schema.boolean({ defaultValue: false }),
-  timeFieldName: schema.maybe(schema.string()),
+  timeFieldName: schema.maybe(schema.string({ maxLength: 1000 })),
   deferValidation: schema.boolean({ defaultValue: false }),
 });
 

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/update_transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/update_transforms.ts
@@ -14,15 +14,15 @@ import { retentionPolicySchema, settingsSchema, sourceSchema, syncSchema } from 
 
 // POST _transform/{transform_id}/_update
 export const postTransformsUpdateRequestSchema = schema.object({
-  description: schema.maybe(schema.string()),
+  description: schema.maybe(schema.string({ maxLength: 1000 })),
   // we cannot reuse `destSchema` because `index` is optional for the update request
   dest: schema.maybe(
     schema.object({
-      index: schema.string(),
-      pipeline: schema.maybe(schema.string()),
+      index: schema.string({ maxLength: 1000 }),
+      pipeline: schema.maybe(schema.string({ maxLength: 1000 })),
     })
   ),
-  frequency: schema.maybe(schema.string()),
+  frequency: schema.maybe(schema.string({ maxLength: 64 })),
   // maybe: If not set, any existing `retention_policy` config will not be updated.
   // nullable: If set to `null`, any existing `retention_policy` will be removed.
   retention_policy: schema.maybe(schema.nullable(retentionPolicySchema)),


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `transform` route request validation schemas — clears 10 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`sortField`, `dataViewTitle`, `id`, `timeFieldName`, `index`, `pipeline`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 64`** for short fixed-format values (`frequency`): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.
- **`maxLength: 1000`** for the transform description free-text field.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/transform/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#12027](https://github.com/elastic/kibana/security/code-scanning/12027) | `server/routes/api_schemas/audit_messages.ts:19` | `sortField: schema.string(),` | `maxLength: 1000` |
| [#12031](https://github.com/elastic/kibana/security/code-scanning/12031) | `server/routes/api_schemas/common.ts:36` | `dataViewTitle: schema.string(),` | `maxLength: 1000` |
| [#12028](https://github.com/elastic/kibana/security/code-scanning/12028) | `server/routes/api_schemas/delete_transforms.ts:21` | `id: schema.string(),` | `maxLength: 1000` |
| [#12029](https://github.com/elastic/kibana/security/code-scanning/12029) | `server/routes/api_schemas/reset_transforms.ts:20` | `id: schema.string(),` | `maxLength: 1000` |
| [#12030](https://github.com/elastic/kibana/security/code-scanning/12030) | `server/routes/api_schemas/stop_transforms.ts:16` | `id: schema.string(),` | `maxLength: 1000` |
| [#12036](https://github.com/elastic/kibana/security/code-scanning/12036) | `server/routes/api_schemas/transforms.ts:158` | `timeFieldName: schema.maybe(schema.string()),` | `maxLength: 1000` |
| [#12032](https://github.com/elastic/kibana/security/code-scanning/12032) | `server/routes/api_schemas/update_transforms.ts:17` | `description: schema.maybe(schema.string()),` | `maxLength: 1000` |
| [#12033](https://github.com/elastic/kibana/security/code-scanning/12033) | `server/routes/api_schemas/update_transforms.ts:21` | `index: schema.string(),` | `maxLength: 1000` |
| [#12034](https://github.com/elastic/kibana/security/code-scanning/12034) | `server/routes/api_schemas/update_transforms.ts:22` | `pipeline: schema.maybe(schema.string()),` | `maxLength: 1000` |
| [#12035](https://github.com/elastic/kibana/security/code-scanning/12035) | `server/routes/api_schemas/update_transforms.ts:25` | `frequency: schema.maybe(schema.string()),` | `maxLength: 64` |
