### PR TITLE
[Ingest Pipelines] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/database/delete.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/database/delete.ts
@@ -10,7 +10,7 @@ import type { RouteDependencies } from '../../../types';
 import { API_BASE_PATH } from '../../../../common/constants';
 
 const paramsSchema = schema.object({
-  database_id: schema.string(),
+  database_id: schema.string({ maxLength: 1000 }),
 });
 
 export const registerDeleteDatabaseRoute = ({

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/delete.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/delete.ts
@@ -11,7 +11,7 @@ import { API_BASE_PATH } from '../../../common/constants';
 import type { RouteDependencies } from '../../types';
 
 const paramsSchema = schema.object({
-  names: schema.string(),
+  names: schema.string({ maxLength: 10000 }),
 });
 
 export const registerDeleteRoute = ({ router }: RouteDependencies): void => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/documents.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/documents.ts
@@ -11,8 +11,8 @@ import { API_BASE_PATH } from '../../../common/constants';
 import type { RouteDependencies } from '../../types';
 
 const paramsSchema = schema.object({
-  index: schema.string(),
-  id: schema.string(),
+  index: schema.string({ maxLength: 1000 }),
+  id: schema.string({ maxLength: 1000 }),
 });
 
 export const registerDocumentsRoute = ({

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/get.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/get.ts
@@ -13,7 +13,7 @@ import { API_BASE_PATH } from '../../../common/constants';
 import type { RouteDependencies } from '../../types';
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export const registerGetRoutes = ({ router, lib: { handleEsError } }: RouteDependencies): void => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/parse_csv.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/parse_csv.ts
@@ -14,8 +14,8 @@ import { csvToIngestPipeline } from '../../lib';
 import type { RouteDependencies } from '../../types';
 
 const bodySchema = schema.object({
-  file: schema.string(),
-  copyAction: schema.string() as Type<FieldCopyAction>,
+  file: schema.string({ maxLength: 1000000 }),
+  copyAction: schema.string({ maxLength: 64 }) as Type<FieldCopyAction>,
 });
 
 type ReqBody = TypeOf<typeof bodySchema>;

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/simulate.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/simulate.ts
@@ -13,7 +13,9 @@ import { pipelineSchema } from './shared';
 
 const bodySchema = schema.object({
   pipeline: schema.object(pipelineSchema),
-  documents: schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 1000 }),
+  documents: schema.arrayOf(schema.recordOf(schema.string({ maxLength: 1000 }), schema.any()), {
+    maxSize: 1000,
+  }),
   verbose: schema.maybe(schema.boolean()),
 });
 

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/update.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/update.ts
@@ -14,7 +14,7 @@ import { pipelineSchema } from './shared';
 const bodySchema = schema.object(pipelineSchema);
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export const registerUpdateRoute = ({


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `ingest_pipelines` route request validation schemas — clears 9 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`database_id`, `index`, `id`, `name`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 64`** for short fixed-format values (`copyAction`): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.
- **`maxLength: 10000`** for comma-separated multi-name params (`names`), split on `,` in the handler, so bulk operations on many resources keep working.
- **bounded record keys** in `recordOf`/`z.record` schemas — key strings are attacker-controlled input too (same pattern as #279726).
- **`maxLength: 1000000`** for the uploaded CSV file content (matches the 1 MB default server payload cap).

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/shared/ingest_pipelines/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#7879](https://github.com/elastic/kibana/security/code-scanning/7879) | `server/routes/api/database/delete.ts:13` | `database_id: schema.string(),` | `maxLength: 1000` |
| [#7880](https://github.com/elastic/kibana/security/code-scanning/7880) | `server/routes/api/delete.ts:14` | `names: schema.string(),` | `maxLength: 10000` |
| [#7881](https://github.com/elastic/kibana/security/code-scanning/7881) | `server/routes/api/documents.ts:14` | `index: schema.string(),` | `maxLength: 1000` |
| [#7882](https://github.com/elastic/kibana/security/code-scanning/7882) | `server/routes/api/documents.ts:15` | `id: schema.string(),` | `maxLength: 1000` |
| [#7888](https://github.com/elastic/kibana/security/code-scanning/7888) | `server/routes/api/get.ts:16` | `name: schema.string(),` | `maxLength: 1000` |
| [#7885](https://github.com/elastic/kibana/security/code-scanning/7885) | `server/routes/api/parse_csv.ts:17` | `file: schema.string(),` | `maxLength: 1000000` |
| [#7886](https://github.com/elastic/kibana/security/code-scanning/7886) | `server/routes/api/parse_csv.ts:18` | `copyAction: schema.string() as Type<FieldCopyAction>,` | `maxLength: 64` |
| [#7889](https://github.com/elastic/kibana/security/code-scanning/7889) | `server/routes/api/simulate.ts:16` | `documents: schema.arrayOf(schema.recordOf(schema.string(), schema.any()), ...)` | `maxLength: 1000` |
| [#7887](https://github.com/elastic/kibana/security/code-scanning/7887) | `server/routes/api/update.ts:17` | `name: schema.string(),` | `maxLength: 1000` |
