### PR TITLE
[ILM] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/index/register_add_policy_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/index/register_add_policy_route.ts
@@ -28,9 +28,9 @@ async function addLifecyclePolicy(
 }
 
 const bodySchema = schema.object({
-  indexName: schema.string(),
-  policyName: schema.string(),
-  alias: schema.maybe(schema.string()),
+  indexName: schema.string({ maxLength: 1000 }),
+  policyName: schema.string({ maxLength: 1000 }),
+  alias: schema.maybe(schema.string({ maxLength: 1000 })),
 });
 
 export function registerAddPolicyRoute({

--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/nodes/register_details_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/nodes/register_details_route.ts
@@ -27,7 +27,7 @@ function findMatchingNodes(stats: any, nodeAttrs: string): any {
 }
 
 const paramsSchema = schema.object({
-  nodeAttrs: schema.string(),
+  nodeAttrs: schema.string({ maxLength: 1000 }),
 });
 
 export function registerDetailsRoute({

--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/policies/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/policies/register_delete_route.ts
@@ -21,7 +21,7 @@ async function deletePolicies(client: ElasticsearchClient, policyName: string): 
 }
 
 const paramsSchema = schema.object({
-  policyNames: schema.string(),
+  policyNames: schema.string({ maxLength: 10000 }),
 });
 
 export function registerDeleteRoute({

--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/templates/register_add_policy_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/templates/register_add_policy_route.ts
@@ -91,9 +91,9 @@ async function updateIndexTemplate(
 }
 
 const bodySchema = schema.object({
-  templateName: schema.string(),
-  policyName: schema.string(),
-  aliasName: schema.maybe(schema.string()),
+  templateName: schema.string({ maxLength: 1000 }),
+  policyName: schema.string({ maxLength: 1000 }),
+  aliasName: schema.maybe(schema.string({ maxLength: 1000 })),
 });
 
 const querySchema = schema.object({


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `index_lifecycle_management` route request validation schemas — clears 8 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`indexName`, `policyName`, `alias`, `nodeAttrs`, `templateName`, `aliasName`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 10000`** for comma-separated multi-name params (`policyNames`), split on `,` in the handler, so bulk operations on many resources keep working.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/index_lifecycle_management/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11970](https://github.com/elastic/kibana/security/code-scanning/11970) | `server/routes/api/index/register_add_policy_route.ts:31` | `indexName: schema.string(),` | `maxLength: 1000` |
| [#11971](https://github.com/elastic/kibana/security/code-scanning/11971) | `server/routes/api/index/register_add_policy_route.ts:32` | `policyName: schema.string(),` | `maxLength: 1000` |
| [#11972](https://github.com/elastic/kibana/security/code-scanning/11972) | `server/routes/api/index/register_add_policy_route.ts:33` | `alias: schema.maybe(schema.string()),` | `maxLength: 1000` |
| [#11973](https://github.com/elastic/kibana/security/code-scanning/11973) | `server/routes/api/nodes/register_details_route.ts:30` | `nodeAttrs: schema.string(),` | `maxLength: 1000` |
| [#11974](https://github.com/elastic/kibana/security/code-scanning/11974) | `server/routes/api/policies/register_delete_route.ts:24` | `policyNames: schema.string(),` | `maxLength: 10000` |
| [#11975](https://github.com/elastic/kibana/security/code-scanning/11975) | `server/routes/api/templates/register_add_policy_route.ts:94` | `templateName: schema.string(),` | `maxLength: 1000` |
| [#11976](https://github.com/elastic/kibana/security/code-scanning/11976) | `server/routes/api/templates/register_add_policy_route.ts:95` | `policyName: schema.string(),` | `maxLength: 1000` |
| [#11977](https://github.com/elastic/kibana/security/code-scanning/11977) | `server/routes/api/templates/register_add_policy_route.ts:96` | `aliasName: schema.maybe(schema.string()),` | `maxLength: 1000` |
