### PR TITLE
[Snapshot & Restore] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/default_repository.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/default_repository.ts
@@ -18,7 +18,7 @@ interface DefaultRepositorySettings {
 }
 
 const defaultRepositorySchema = schema.object({
-  name: schema.string({ minLength: 1 }),
+  name: schema.string({ minLength: 1, maxLength: 1000 }),
 });
 
 const DEFAULT_REPOSITORY_PATH = 'persistent.repositories.default_repository';

--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/policy.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/policy.ts
@@ -344,7 +344,9 @@ export function registerPolicyRoutes({
   );
 
   // Update retention settings
-  const retentionSettingsSchema = schema.object({ retentionSchedule: schema.string() });
+  const retentionSettingsSchema = schema.object({
+    retentionSchedule: schema.string({ maxLength: 256 }),
+  });
 
   router.put(
     {

--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/snapshots.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/snapshots.ts
@@ -216,8 +216,8 @@ export function registerSnapshotsRoutes({
   );
 
   const getOneParamsSchema = schema.object({
-    repository: schema.string(),
-    snapshot: schema.string(),
+    repository: schema.string({ maxLength: 1000 }),
+    snapshot: schema.string({ maxLength: 1000 }),
   });
 
   // GET one snapshot
@@ -280,8 +280,8 @@ export function registerSnapshotsRoutes({
 
   const deleteSchema = schema.arrayOf(
     schema.object({
-      repository: schema.string(),
-      snapshot: schema.string(),
+      repository: schema.string({ maxLength: 1000 }),
+      snapshot: schema.string({ maxLength: 1000 }),
     }),
     { maxSize: 1000 }
   );

--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/validate_schemas.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/validate_schemas.ts
@@ -57,7 +57,7 @@ export const snapshotListSchema = schema.object({
       schema.literal('state'),
     ])
   ),
-  searchValue: schema.maybe(schema.string()),
+  searchValue: schema.maybe(schema.string({ maxLength: 1024 })),
   searchMatch: schema.maybe(schema.oneOf([schema.literal('must'), schema.literal('must_not')])),
   searchOperator: schema.maybe(schema.oneOf([schema.literal('eq'), schema.literal('exact')])),
 });


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `snapshot_restore` route request validation schemas — clears 7 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`name`, `repository`, `snapshot`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 256`** for the SLM/cron schedule string (``).
- **`maxLength: 1024`** for user-typed search values (`searchValue`).

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/snapshot_restore/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#12020](https://github.com/elastic/kibana/security/code-scanning/12020) | `server/routes/api/default_repository.ts:21` | `name: schema.string({ minLength: 1 }),` | `maxLength: 1000` |
| [#12026](https://github.com/elastic/kibana/security/code-scanning/12026) | `server/routes/api/policy.ts:347` | `const retentionSettingsSchema = schema.object({ retentionSchedule: schema.string() });` | `maxLength: 256` |
| [#12022](https://github.com/elastic/kibana/security/code-scanning/12022) | `server/routes/api/snapshots.ts:219` | `repository: schema.string(),` | `maxLength: 1000` |
| [#12023](https://github.com/elastic/kibana/security/code-scanning/12023) | `server/routes/api/snapshots.ts:220` | `snapshot: schema.string(),` | `maxLength: 1000` |
| [#12024](https://github.com/elastic/kibana/security/code-scanning/12024) | `server/routes/api/snapshots.ts:283` | `repository: schema.string(),` | `maxLength: 1000` |
| [#12025](https://github.com/elastic/kibana/security/code-scanning/12025) | `server/routes/api/snapshots.ts:284` | `snapshot: schema.string(),` | `maxLength: 1000` |
| [#12021](https://github.com/elastic/kibana/security/code-scanning/12021) | `server/routes/api/validate_schemas.ts:60` | `searchValue: schema.maybe(schema.string()),` | `maxLength: 1024` |
