### PR TITLE
[Flaky] Fix timelines_table favorites toggle covered by timeline overlay (fixes #246751)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -327,13 +327,12 @@ export const navigateToCaseFromSuccessToaster = () => {
   cy.get(VIEW_CASE_TOASTER_LINK).click();
 };
 
-export const closeTimeline = () => {
-  // Retry closing the timeline until the overlay mask gets the --hidden class.
-  // Each iteration first checks whether the overlay is already hidden to avoid
-  // clicking a button that is no longer in the visible portal. When the overlay is
-  // still open, .should('be.visible') retries until the close button is actionable,
-  // letting any concurrent React re-renders (e.g. from markAsFavorite's Redux
-  // dispatches) settle before the click is issued.
+/**
+ * Retry until the timeline overlay mask is hidden. When the overlay is still open,
+ * click the close button so concurrent React re-renders (e.g. from markAsFavorite's
+ * timelines refresh) can settle before the next attempt.
+ */
+export const ensureTimelineOverlayHidden = () => {
   recurse(
     () => {
       return cy.get(TIMELINE_WRAPPER).then(($wrapper) => {
@@ -345,6 +344,10 @@ export const closeTimeline = () => {
     },
     ($timelineWrapper) => $timelineWrapper.hasClass('timeline-portal-overlay-mask--hidden')
   );
+};
+
+export const closeTimeline = () => {
+  ensureTimelineOverlayHidden();
 };
 
 export const createNewTimeline = () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timelines.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timelines.ts
@@ -18,6 +18,7 @@ import {
   TIMELINES_OVERVIEW_ONLY_FAVORITES,
 } from '../screens/timelines';
 import { SELECT_ALL_CHECKBOX } from '../screens/shared';
+import { ensureTimelineOverlayHidden } from './timeline';
 
 export const openTimeline = (id?: string) => {
   cy.get(id ? TIMELINE(id) : TIMELINE_NAME).click();
@@ -49,7 +50,10 @@ export const exportSelectedTimelines = () => {
  * Toggle on/off to filter for favorite timelines
  */
 export const toggleFavoriteFilter = () => {
-  cy.get(TIMELINES_OVERVIEW_ONLY_FAVORITES).click();
+  // Favorite refresh can reopen the timeline overlay after closeTimeline() in setup.
+  ensureTimelineOverlayHidden();
+  cy.get(TIMELINES_OVERVIEW_ONLY_FAVORITES).scrollIntoView();
+  cy.get(TIMELINES_OVERVIEW_ONLY_FAVORITES).should('be.visible').click();
 };
 
 /**


### PR DESCRIPTION
## Summary

- Extract `ensureTimelineOverlayHidden` and reuse it from `closeTimeline`.
- Wait for the timeline portal to hide before clicking `only-favorites-toggle`.

## Root cause

`markAsFavorite` triggers a timelines list refresh that can reopen the timeline overlay after `closeTimeline()` completes in `beforeEach`. The overlay's data grid then covers `only-favorites-toggle` when `toggleFavoriteFilter` clicks.

## Validation

- Reviewed Buildkite failure logs from kibana-on-merge build 102846; failure matches overlay still blocking the favorites toggle.
- Scoped eslint not run (worktree not bootstrapped); Cypress run pending in CI.

Closes #246751

Made with [Cursor](https://cursor.com)