### PR TITLE
[Rollup] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/rollup/server/routes/api/indices/register_validate_index_pattern_route.ts
+++ b/x-pack/platform/plugins/private/rollup/server/routes/api/indices/register_validate_index_pattern_route.ts
@@ -68,7 +68,7 @@ export const registerValidateIndexPatternRoute = ({
       },
       validate: {
         params: schema.object({
-          indexPattern: schema.string(),
+          indexPattern: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_delete_route.ts
@@ -25,7 +25,7 @@ export const registerDeleteRoute = ({
       },
       validate: {
         body: schema.object({
-          jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          jobIds: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_start_route.ts
+++ b/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_start_route.ts
@@ -25,11 +25,11 @@ export const registerStartRoute = ({
       },
       validate: {
         body: schema.object({
-          jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          jobIds: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
         query: schema.maybe(
           schema.object({
-            waitForCompletion: schema.maybe(schema.string()),
+            waitForCompletion: schema.maybe(schema.string({ maxLength: 64 })),
           })
         ),
       },

--- a/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_stop_route.ts
+++ b/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_stop_route.ts
@@ -25,10 +25,10 @@ export const registerStopRoute = ({
       },
       validate: {
         body: schema.object({
-          jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          jobIds: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
         query: schema.object({
-          waitForCompletion: schema.maybe(schema.string()),
+          waitForCompletion: schema.maybe(schema.string({ maxLength: 64 })),
         }),
       },
     },


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `rollup` route request validation schemas — clears 6 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`indexPattern`, `jobIds`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 64`** for short fixed-format values (`waitForCompletion`): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/rollup/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#12017](https://github.com/elastic/kibana/security/code-scanning/12017) | `server/routes/api/indices/register_validate_index_pattern_route.ts:71` | `indexPattern: schema.string(),` | `maxLength: 1000` |
| [#12014](https://github.com/elastic/kibana/security/code-scanning/12014) | `server/routes/api/jobs/register_delete_route.ts:28` | `jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),` | `maxLength: 1000` |
| [#12015](https://github.com/elastic/kibana/security/code-scanning/12015) | `server/routes/api/jobs/register_start_route.ts:28` | `jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),` | `maxLength: 1000` |
| [#12016](https://github.com/elastic/kibana/security/code-scanning/12016) | `server/routes/api/jobs/register_start_route.ts:32` | `waitForCompletion: schema.maybe(schema.string()),` | `maxLength: 64` |
| [#12018](https://github.com/elastic/kibana/security/code-scanning/12018) | `server/routes/api/jobs/register_stop_route.ts:28` | `jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),` | `maxLength: 1000` |
| [#12019](https://github.com/elastic/kibana/security/code-scanning/12019) | `server/routes/api/jobs/register_stop_route.ts:31` | `waitForCompletion: schema.maybe(schema.string()),` | `maxLength: 64` |
