### PR TITLE
[Security Solution][Cypress] Unskip inspect Hosts page test (#178367)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect/inspect_button.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect/inspect_button.cy.ts
@@ -24,9 +24,14 @@ import { mockRiskEngineEnabled } from '../../../tasks/entity_analytics';
 
 const DATA_VIEW = 'auditbeat-*';
 
-// FLAKY: https://github.com/elastic/kibana/issues/199563
-// FLAKY: https://github.com/elastic/kibana/issues/178367
-describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => {
+// The Network and Users pages in this suite are still individually flaky/skipped for reasons
+// tracked by their own issues below. Their root cause has not been verified as fixed, so they
+// stay skipped here. Do not remove these without separately verifying and closing those issues.
+// FLAKY (Network page): https://github.com/elastic/kibana/issues/199563
+// FLAKY (Users page): https://github.com/elastic/kibana/issues/199583
+const SKIPPED_PAGES = ['Network', 'Users'];
+
+describe('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     // illegal_argument_exception: unknown setting [index.lifecycle.name]
     cy.task('esArchiverLoad', { archiveName: 'risk_scores_new' });
@@ -44,7 +49,7 @@ describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => 
     /**
      * Group all tests of a page into one "it" call to improve speed
      */
-    it(`inspect ${pageName} page`, () => {
+    const testBody = () => {
       visitWithTimeRange(url, {
         visitOptions: {
           onLoad: () => {
@@ -79,6 +84,16 @@ describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => 
 
         closesModal();
       });
-    });
+    };
+
+    // NOTE: the CI spec load-balancer statically parses this file for literal `it`/`it.skip`
+    // calls, so this must stay an if/else rather than a `const itFn = cond ? it.skip : it`
+    // (a dynamic reference isn't recognized and would cause the whole file to be treated as
+    // fully skipped and excluded from CI runs).
+    if (SKIPPED_PAGES.includes(pageName)) {
+      it.skip(`inspect ${pageName} page`, testBody);
+    } else {
+      it(`inspect ${pageName} page`, testBody);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Re-enable the Hosts inspect Explore page Cypress test after the sourcerer UI setup failure was removed.
- Keep Network and Users cases skipped under their own tracked flaky issues (#199563, #199583).

## Root cause

The original timeout waited for a sourcerer superselect option during page onLoad via the deleted `tasks/sourcerer.ts` helper. Setup now uses `postDataView` via API, so that failure mode no longer exists; the suite remained skipped only because of historical flakiness.

## Validation

- Confirmed upstream/main already uses API data view setup and no longer calls `selectDataView` in onLoad.
- Scoped re-enable to the Hosts page case named in #178367; Network/Users stay `it.skip` for separate issues.
- Local Cypress not run in this worktree (not bootstrapped); CI pending on this draft PR.

Closes #178367

Made with [Cursor](https://cursor.com)