### PR TITLE
[Security Solution][Cypress] Unskip inspect Users page test (#199583)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect/inspect_button.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect/inspect_button.cy.ts
@@ -24,9 +24,14 @@ import { mockRiskEngineEnabled } from '../../../tasks/entity_analytics';
 
 const DATA_VIEW = 'auditbeat-*';
 
-// FLAKY: https://github.com/elastic/kibana/issues/199563
-// FLAKY: https://github.com/elastic/kibana/issues/178367
-describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => {
+// The Hosts and Network pages in this suite are still individually flaky/skipped for reasons
+// tracked by their own issues below. Do not remove them without separately verifying and
+// closing those issues.
+// FLAKY (Hosts page): https://github.com/elastic/kibana/issues/178367
+// FLAKY (Network page): https://github.com/elastic/kibana/issues/199563
+const SKIPPED_PAGES = ['Hosts', 'Network'];
+
+describe('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     // illegal_argument_exception: unknown setting [index.lifecycle.name]
     cy.task('esArchiverLoad', { archiveName: 'risk_scores_new' });
@@ -44,7 +49,7 @@ describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => 
     /**
      * Group all tests of a page into one "it" call to improve speed
      */
-    it(`inspect ${pageName} page`, () => {
+    const testBody = () => {
       visitWithTimeRange(url, {
         visitOptions: {
           onLoad: () => {
@@ -79,6 +84,16 @@ describe.skip('Inspect Explore pages', { tags: ['@ess', '@serverless'] }, () => 
 
         closesModal();
       });
-    });
+    };
+
+    // NOTE: the CI spec load-balancer statically parses this file for literal `it`/`it.skip`
+    // calls, so this must stay an if/else rather than a `const itFn = cond ? it.skip : it`
+    // (a dynamic reference isn't recognized and would cause the whole file to be treated as
+    // fully skipped and excluded from CI runs).
+    if (SKIPPED_PAGES.includes(pageName)) {
+      it.skip(`inspect ${pageName} page`, testBody);
+    } else {
+      it(`inspect ${pageName} page`, testBody);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replaces suite-level `describe.skip` with per-page `it.skip` so the Users inspect test runs again.
- Hosts (#178367) and Network (#199563) cases remain skipped until their issues are resolved.

## Root cause

The recorded failure timed out waiting for the removed `sourcerer-trigger` control during `selectDataView` in `onLoad`. Commit c30b6a6f4e9b (#234101) removed that UI interaction; `postDataView` now creates the data view via API, so the original timeout cannot recur.

## Validation

- Local Cypress run blocked by Docker Desktop org sign-in on this machine.
- Pending kibana-serverless-security-solution-quality-gate-explore CI on the inspect Users page case.

Closes #199583

Made with [Cursor](https://cursor.com)