### PR TITLE
[9.4] [ResponseOps] Don't lower alerts-as-data total_fields.limit below the already-set value (#277402)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_concrete_write_index.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_concrete_write_index.test.ts
@@ -374,6 +374,129 @@ describe('createConcreteWriteIndex', () => {
         expect(clusterClient.indices.putMapping).toHaveBeenCalledTimes(1);
       });
 
+      it(`should not lower an existing total_fields.limit that is higher than the configured value`, async () => {
+        clusterClient.indices.getAlias.mockImplementation(async () => GetAliasResponse);
+        clusterClient.indices.getDataStream.mockImplementation(async () => GetDataStreamResponse);
+        clusterClient.indices.simulateIndexTemplate.mockImplementation(
+          async () => SimulateTemplateResponse
+        );
+        clusterClient.indices.getSettings.mockResolvedValue({
+          '.internal.alerts-test.alerts-default-000001': {
+            settings: {
+              'index.mapping.total_fields.limit': '5000',
+              'index.mapping.total_fields.ignore_dynamic_beyond_limit': 'true',
+            },
+          },
+        });
+
+        await createConcreteWriteIndex({
+          logger,
+          esClient: clusterClient,
+          indexPatterns: IndexPatterns,
+          totalFieldsLimit: 2500,
+          dataStreamAdapter,
+        });
+
+        expect(clusterClient.indices.putSettings).not.toHaveBeenCalled();
+        expect(clusterClient.indices.putMapping).toHaveBeenCalledTimes(1);
+      });
+
+      it(`should skip the settings update when the existing limit equals the configured value`, async () => {
+        clusterClient.indices.getAlias.mockImplementation(async () => GetAliasResponse);
+        clusterClient.indices.getDataStream.mockImplementation(async () => GetDataStreamResponse);
+        clusterClient.indices.simulateIndexTemplate.mockImplementation(
+          async () => SimulateTemplateResponse
+        );
+        clusterClient.indices.getSettings.mockResolvedValue({
+          '.internal.alerts-test.alerts-default-000001': {
+            settings: {
+              'index.mapping.total_fields.limit': '2500',
+              'index.mapping.total_fields.ignore_dynamic_beyond_limit': 'true',
+            },
+          },
+        });
+
+        await createConcreteWriteIndex({
+          logger,
+          esClient: clusterClient,
+          indexPatterns: IndexPatterns,
+          totalFieldsLimit: 2500,
+          dataStreamAdapter,
+        });
+
+        expect(clusterClient.indices.putSettings).not.toHaveBeenCalled();
+        expect(clusterClient.indices.putMapping).toHaveBeenCalledTimes(1);
+      });
+
+      it(`should raise an existing lower total_fields.limit to the configured value`, async () => {
+        clusterClient.indices.getAlias.mockImplementation(async () => GetAliasResponse);
+        clusterClient.indices.getDataStream.mockImplementation(async () => GetDataStreamResponse);
+        clusterClient.indices.simulateIndexTemplate.mockImplementation(
+          async () => SimulateTemplateResponse
+        );
+        clusterClient.indices.getSettings.mockResolvedValue({
+          '.internal.alerts-test.alerts-default-000001': {
+            settings: {
+              'index.mapping.total_fields.limit': '2000',
+              'index.mapping.total_fields.ignore_dynamic_beyond_limit': 'true',
+            },
+          },
+        });
+
+        await createConcreteWriteIndex({
+          logger,
+          esClient: clusterClient,
+          indexPatterns: IndexPatterns,
+          totalFieldsLimit: 2500,
+          dataStreamAdapter,
+        });
+
+        expect(clusterClient.indices.putSettings).toHaveBeenCalledTimes(1);
+        expect(clusterClient.indices.putSettings).toHaveBeenCalledWith({
+          index: useDataStream
+            ? '.alerts-test.alerts-default'
+            : '.internal.alerts-test.alerts-default-000001',
+          settings: {
+            'index.mapping.total_fields.limit': 2500,
+            'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+          },
+        });
+      });
+
+      it(`should preserve a higher existing limit when the ignore_dynamic_beyond_limit flag is missing`, async () => {
+        clusterClient.indices.getAlias.mockImplementation(async () => GetAliasResponse);
+        clusterClient.indices.getDataStream.mockImplementation(async () => GetDataStreamResponse);
+        clusterClient.indices.simulateIndexTemplate.mockImplementation(
+          async () => SimulateTemplateResponse
+        );
+        clusterClient.indices.getSettings.mockResolvedValue({
+          '.internal.alerts-test.alerts-default-000001': {
+            settings: {
+              'index.mapping.total_fields.limit': '5000',
+            },
+          },
+        });
+
+        await createConcreteWriteIndex({
+          logger,
+          esClient: clusterClient,
+          indexPatterns: IndexPatterns,
+          totalFieldsLimit: 2500,
+          dataStreamAdapter,
+        });
+
+        expect(clusterClient.indices.putSettings).toHaveBeenCalledTimes(1);
+        expect(clusterClient.indices.putSettings).toHaveBeenCalledWith({
+          index: useDataStream
+            ? '.alerts-test.alerts-default'
+            : '.internal.alerts-test.alerts-default-000001',
+          settings: {
+            'index.mapping.total_fields.limit': 5000,
+            'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+          },
+        });
+      });
+
       it(`should skip updating underlying settings and mappings of existing concrete indices if they follow an unexpected naming convention`, async () => {
         clusterClient.indices.getAlias.mockImplementation(async () => ({
           bad_index_name: {

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_concrete_write_index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_concrete_write_index.ts
@@ -15,6 +15,10 @@ import type { IIndexPatternString } from '../resource_installer_utils';
 import { retryTransientEsErrors } from '../../lib/retry_transient_es_errors';
 import type { DataStreamAdapter } from './data_stream_adapter';
 import { updateIndexTemplateFieldsLimit } from './update_index_template_fields_limit';
+import {
+  evaluateTotalFieldsLimit,
+  getTotalFieldsLimitSettings,
+} from './total_fields_limit_settings';
 
 export interface ConcreteIndexInfo {
   index: string;
@@ -57,14 +61,28 @@ const updateTotalFieldLimitSetting = async ({
 }: UpdateTotalFieldLimitSettingOpts) => {
   const { index, alias } = concreteIndexInfo;
   try {
+    // `index` may be a data stream name, which resolves to its backing indices.
+    const currentSettings = await retryTransientEsErrors(
+      () => esClient.indices.getSettings({ index, flat_settings: true }),
+      { logger }
+    );
+    const { isSatisfied, effectiveLimit } = evaluateTotalFieldsLimit(
+      Object.values(currentSettings ?? {}).map((indexState) => indexState.settings),
+      totalFieldsLimit
+    );
+
+    if (isSatisfied) {
+      logger.debug(
+        `Skipping update of index.mapping.total_fields.limit for ${alias}: the current limit already satisfies ${totalFieldsLimit}`
+      );
+      return;
+    }
+
     await retryTransientEsErrors(
       () =>
         esClient.indices.putSettings({
           index,
-          settings: {
-            'index.mapping.total_fields.limit': totalFieldsLimit,
-            'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-          },
+          settings: getTotalFieldsLimitSettings(effectiveLimit),
         }),
       { logger }
     );

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_index_template.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_index_template.test.ts
@@ -148,6 +148,93 @@ describe('createOrUpdateIndexTemplate', () => {
     expect(clusterClient.indices.putIndexTemplate).toHaveBeenCalledWith(IndexTemplate());
   });
 
+  it(`should preserve a higher total_fields.limit from the existing template`, async () => {
+    clusterClient.indices.getIndexTemplate.mockResolvedValue({
+      index_templates: [
+        {
+          name: '.alerts-test.alerts-default-index-template',
+          index_template: {
+            index_patterns: ['.internal.alerts-test.alerts-default-*'],
+            composed_of: ['mappings1', 'framework-mappings'],
+            template: { settings: { 'index.mapping.total_fields.limit': 5000 } },
+          },
+        },
+      ],
+    });
+    clusterClient.indices.simulateTemplate.mockImplementation(async () => SimulateTemplateResponse);
+
+    await createOrUpdateIndexTemplate({
+      logger,
+      esClient: clusterClient,
+      template: IndexTemplate(),
+    });
+
+    const expectedTemplate = expect.objectContaining({
+      template: expect.objectContaining({
+        settings: expect.objectContaining({ 'index.mapping.total_fields.limit': 5000 }),
+      }),
+    });
+    expect(clusterClient.indices.simulateTemplate).toHaveBeenCalledWith(expectedTemplate);
+    expect(clusterClient.indices.putIndexTemplate).toHaveBeenCalledWith(expectedTemplate);
+  });
+
+  it(`should keep the configured total_fields.limit when the existing template limit is lower`, async () => {
+    clusterClient.indices.getIndexTemplate.mockResolvedValue({
+      index_templates: [
+        {
+          name: '.alerts-test.alerts-default-index-template',
+          index_template: {
+            index_patterns: ['.internal.alerts-test.alerts-default-*'],
+            composed_of: ['mappings1', 'framework-mappings'],
+            template: { settings: { 'index.mapping.total_fields.limit': 1000 } },
+          },
+        },
+      ],
+    });
+    clusterClient.indices.simulateTemplate.mockImplementation(async () => SimulateTemplateResponse);
+
+    await createOrUpdateIndexTemplate({
+      logger,
+      esClient: clusterClient,
+      template: IndexTemplate(),
+    });
+
+    expect(clusterClient.indices.putIndexTemplate).toHaveBeenCalledWith(IndexTemplate());
+  });
+
+  it(`should install the configured total_fields.limit when the template does not exist`, async () => {
+    clusterClient.indices.getIndexTemplate.mockRejectedValue(
+      Object.assign(new Error('not found'), { statusCode: 404 })
+    );
+    clusterClient.indices.simulateTemplate.mockImplementation(async () => SimulateTemplateResponse);
+
+    await createOrUpdateIndexTemplate({
+      logger,
+      esClient: clusterClient,
+      template: IndexTemplate(),
+    });
+
+    expect(clusterClient.indices.putIndexTemplate).toHaveBeenCalledWith(IndexTemplate());
+  });
+
+  it(`should log and throw when fetching the existing template fails`, async () => {
+    clusterClient.indices.getIndexTemplate.mockRejectedValue(new Error('fetch error'));
+
+    await expect(() =>
+      createOrUpdateIndexTemplate({
+        logger,
+        esClient: clusterClient,
+        template: IndexTemplate(),
+      })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"fetch error"`);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      `Error fetching existing index template .alerts-test.alerts-default-index-template - fetch error`,
+      expect.any(Error)
+    );
+    expect(clusterClient.indices.putIndexTemplate).not.toHaveBeenCalled();
+  });
+
   it(`should retry on transient ES errors`, async () => {
     clusterClient.indices.simulateTemplate.mockImplementation(async () => SimulateTemplateResponse);
     clusterClient.indices.putIndexTemplate

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_index_template.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_index_template.ts
@@ -15,6 +15,11 @@ import { isEmpty } from 'lodash';
 import type { IIndexPatternString } from '../resource_installer_utils';
 import { retryTransientEsErrors } from '../../lib/retry_transient_es_errors';
 import type { DataStreamAdapter } from './data_stream_adapter';
+import {
+  getTotalFieldsLimitFromSettings,
+  getTotalFieldsLimitSettings,
+  TOTAL_FIELDS_LIMIT_SETTING,
+} from './total_fields_limit_settings';
 
 interface GetIndexTemplateOpts {
   componentTemplateRefs: string[];
@@ -70,8 +75,7 @@ export const getIndexTemplate = ({
               'index.lifecycle': indexLifecycle,
             }),
         'index.mapping.ignore_malformed': true,
-        'index.mapping.total_fields.limit': totalFieldsLimit,
-        'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+        ...getTotalFieldsLimitSettings(totalFieldsLimit),
       },
       mappings: {
         dynamic: false,
@@ -107,6 +111,28 @@ interface CreateOrUpdateIndexTemplateOpts {
  * conflicts. Simulate should return an empty mapping if a template
  * conflicts with an already installed template.
  */
+const getExistingTemplateFieldsLimit = async (
+  esClient: ElasticsearchClient,
+  name: string,
+  logger: Logger
+): Promise<number | undefined> => {
+  try {
+    const response = await retryTransientEsErrors(
+      () => esClient.indices.getIndexTemplate({ name }),
+      { logger }
+    );
+    const existingTemplate = (response?.index_templates ?? []).find(
+      (indexTemplate) => indexTemplate.name === name
+    );
+    return getTotalFieldsLimitFromSettings(existingTemplate?.index_template?.template?.settings);
+  } catch (err) {
+    if (err?.statusCode === 404) {
+      return undefined;
+    }
+    throw err;
+  }
+};
+
 export const createOrUpdateIndexTemplate = async ({
   logger,
   esClient,
@@ -114,11 +140,41 @@ export const createOrUpdateIndexTemplate = async ({
 }: CreateOrUpdateIndexTemplateOpts) => {
   logger.debug(`Installing index template ${template.name}`);
 
+  let templateToInstall = template;
+  try {
+    // Never lower a total_fields.limit that is already higher than the configured value;
+    // a higher limit may have been set manually or by a previous, higher configuration.
+    const existingLimit = await getExistingTemplateFieldsLimit(esClient, template.name, logger);
+    const templateLimit = getTotalFieldsLimitFromSettings(template.template?.settings);
+    if (
+      existingLimit !== undefined &&
+      templateLimit !== undefined &&
+      existingLimit > templateLimit
+    ) {
+      logger.debug(
+        `Preserving existing total_fields.limit of ${existingLimit} for index template ${template.name} instead of lowering it to ${templateLimit}`
+      );
+      templateToInstall = {
+        ...template,
+        template: {
+          ...template.template,
+          settings: {
+            ...template.template?.settings,
+            [TOTAL_FIELDS_LIMIT_SETTING]: existingLimit,
+          },
+        },
+      };
+    }
+  } catch (err) {
+    logger.error(`Error fetching existing index template ${template.name} - ${err.message}`, err);
+    throw err;
+  }
+
   let mappings: MappingTypeMapping = {};
   try {
     // Simulate the index template to proactively identify any issues with the mapping
     const simulateResponse = await retryTransientEsErrors(
-      () => esClient.indices.simulateTemplate(template),
+      () => esClient.indices.simulateTemplate(templateToInstall),
       { logger }
     );
     mappings = simulateResponse.template.mappings;
@@ -137,7 +193,7 @@ export const createOrUpdateIndexTemplate = async ({
   }
 
   try {
-    await retryTransientEsErrors(() => esClient.indices.putIndexTemplate(template), {
+    await retryTransientEsErrors(() => esClient.indices.putIndexTemplate(templateToInstall), {
       logger,
     });
   } catch (err) {

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/total_fields_limit_settings.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/total_fields_limit_settings.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  evaluateTotalFieldsLimit,
+  getIgnoreDynamicBeyondLimitFromSettings,
+  getTotalFieldsLimitFromSettings,
+  getTotalFieldsLimitSettings,
+} from './total_fields_limit_settings';
+
+describe('getTotalFieldsLimitFromSettings', () => {
+  it('reads the limit from flat settings', () => {
+    expect(getTotalFieldsLimitFromSettings({ 'index.mapping.total_fields.limit': '5000' })).toBe(
+      5000
+    );
+  });
+
+  it('reads the limit from nested settings', () => {
+    expect(
+      getTotalFieldsLimitFromSettings({ index: { mapping: { total_fields: { limit: '5000' } } } })
+    ).toBe(5000);
+  });
+
+  it('reads the limit from settings without the index prefix', () => {
+    expect(getTotalFieldsLimitFromSettings({ mapping: { total_fields: { limit: 5000 } } })).toBe(
+      5000
+    );
+  });
+
+  it('reads a numeric limit', () => {
+    expect(getTotalFieldsLimitFromSettings({ 'index.mapping.total_fields.limit': 2500 })).toBe(
+      2500
+    );
+  });
+
+  it('returns undefined when the limit is not set', () => {
+    expect(getTotalFieldsLimitFromSettings({ hidden: true })).toBeUndefined();
+    expect(getTotalFieldsLimitFromSettings(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when the limit is not a number', () => {
+    expect(
+      getTotalFieldsLimitFromSettings({ 'index.mapping.total_fields.limit': 'not-a-number' })
+    ).toBeUndefined();
+  });
+});
+
+describe('getIgnoreDynamicBeyondLimitFromSettings', () => {
+  it('reads the flag from flat settings', () => {
+    expect(
+      getIgnoreDynamicBeyondLimitFromSettings({
+        'index.mapping.total_fields.ignore_dynamic_beyond_limit': 'true',
+      })
+    ).toBe(true);
+  });
+
+  it('reads a boolean flag from nested settings', () => {
+    expect(
+      getIgnoreDynamicBeyondLimitFromSettings({
+        index: { mapping: { total_fields: { ignore_dynamic_beyond_limit: true } } },
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for a false flag', () => {
+    expect(
+      getIgnoreDynamicBeyondLimitFromSettings({
+        'index.mapping.total_fields.ignore_dynamic_beyond_limit': 'false',
+      })
+    ).toBe(false);
+  });
+
+  it('returns undefined when the flag is not set', () => {
+    expect(getIgnoreDynamicBeyondLimitFromSettings({ hidden: true })).toBeUndefined();
+    expect(getIgnoreDynamicBeyondLimitFromSettings(undefined)).toBeUndefined();
+  });
+});
+
+describe('getTotalFieldsLimitSettings', () => {
+  it('builds the settings pair', () => {
+    expect(getTotalFieldsLimitSettings(2800)).toEqual({
+      'index.mapping.total_fields.limit': 2800,
+      'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+    });
+  });
+});
+
+describe('evaluateTotalFieldsLimit', () => {
+  const settingsWith = (limit: number | string, flag?: boolean | string) => ({
+    'index.mapping.total_fields.limit': limit,
+    ...(flag !== undefined
+      ? { 'index.mapping.total_fields.ignore_dynamic_beyond_limit': flag }
+      : {}),
+  });
+
+  it('is satisfied when all settings have a limit >= requested and the flag set', () => {
+    expect(
+      evaluateTotalFieldsLimit([settingsWith('5000', 'true'), settingsWith(2800, true)], 2800)
+    ).toEqual({ isSatisfied: true, effectiveLimit: 5000 });
+  });
+
+  it('is not satisfied when any limit is below the requested value', () => {
+    expect(
+      evaluateTotalFieldsLimit([settingsWith('5000', 'true'), settingsWith(2000, true)], 2800)
+    ).toEqual({ isSatisfied: false, effectiveLimit: 5000 });
+  });
+
+  it('is not satisfied when the flag is missing, but preserves a higher limit', () => {
+    expect(evaluateTotalFieldsLimit([settingsWith('5000')], 2800)).toEqual({
+      isSatisfied: false,
+      effectiveLimit: 5000,
+    });
+  });
+
+  it('is not satisfied when a settings object has no limit', () => {
+    expect(evaluateTotalFieldsLimit([{ hidden: true }], 2800)).toEqual({
+      isSatisfied: false,
+      effectiveLimit: 2800,
+    });
+    expect(evaluateTotalFieldsLimit([undefined], 2800)).toEqual({
+      isSatisfied: false,
+      effectiveLimit: 2800,
+    });
+  });
+
+  it('is not satisfied for an empty settings list', () => {
+    expect(evaluateTotalFieldsLimit([], 2800)).toEqual({
+      isSatisfied: false,
+      effectiveLimit: 2800,
+    });
+  });
+
+  it('never returns an effective limit below the requested value', () => {
+    expect(evaluateTotalFieldsLimit([settingsWith(1000, true)], 2800).effectiveLimit).toBe(2800);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/total_fields_limit_settings.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/total_fields_limit_settings.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { get } from 'lodash';
+import type { IndicesIndexSettings } from '@elastic/elasticsearch/lib/api/types';
+
+export const TOTAL_FIELDS_LIMIT_SETTING = 'index.mapping.total_fields.limit';
+export const TOTAL_FIELDS_IGNORE_DYNAMIC_BEYOND_LIMIT_SETTING =
+  'index.mapping.total_fields.ignore_dynamic_beyond_limit';
+
+// Settings may come back from ES in nested form (index.mapping.total_fields.limit as
+// nested objects), in flat form (when requested with flat_settings), or without the
+// `index.` prefix (as allowed in template bodies), so check all shapes.
+const readSetting = (settings: IndicesIndexSettings | undefined, setting: string): unknown => {
+  if (!settings) {
+    return undefined;
+  }
+  return (
+    get(settings, `index.${setting}`.split('.')) ??
+    get(settings, setting.split('.')) ??
+    get(settings, [`index.${setting}`]) ??
+    get(settings, [setting])
+  );
+};
+
+export const getTotalFieldsLimitFromSettings = (
+  settings: IndicesIndexSettings | undefined
+): number | undefined => {
+  const raw = readSetting(settings, 'mapping.total_fields.limit');
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const parsed = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const getIgnoreDynamicBeyondLimitFromSettings = (
+  settings: IndicesIndexSettings | undefined
+): boolean | undefined => {
+  const raw = readSetting(settings, 'mapping.total_fields.ignore_dynamic_beyond_limit');
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  return raw === true || raw === 'true';
+};
+
+export const getTotalFieldsLimitSettings = (limit: number): IndicesIndexSettings => ({
+  [TOTAL_FIELDS_LIMIT_SETTING]: limit,
+  [TOTAL_FIELDS_IGNORE_DYNAMIC_BEYOND_LIMIT_SETTING]: true,
+});
+
+export interface TotalFieldsLimitEvaluation {
+  // True when every settings object already has a limit >= the requested value and the
+  // ignore_dynamic_beyond_limit flag set, i.e. a settings update would be a no-op.
+  isSatisfied: boolean;
+  // Never lower a limit that is already higher than the requested value; a higher limit
+  // may have been set manually or by a previous, higher configuration and lowering it
+  // can immediately put the mapping over the limit.
+  effectiveLimit: number;
+}
+
+export const evaluateTotalFieldsLimit = (
+  allSettings: Array<IndicesIndexSettings | undefined>,
+  requestedLimit: number
+): TotalFieldsLimitEvaluation => {
+  const currentLimits = allSettings
+    .map(getTotalFieldsLimitFromSettings)
+    .filter((limit): limit is number => limit !== undefined);
+
+  const isSatisfied =
+    allSettings.length > 0 &&
+    currentLimits.length === allSettings.length &&
+    Math.min(...currentLimits) >= requestedLimit &&
+    allSettings.every((settings) => getIgnoreDynamicBeyondLimitFromSettings(settings) === true);
+
+  return {
+    isSatisfied,
+    effectiveLimit: Math.max(requestedLimit, ...currentLimits),
+  };
+};

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/update_index_template_fields_limit.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/update_index_template_fields_limit.test.ts
@@ -139,6 +139,86 @@ describe('updateIndexTemplateFieldsLimit', () => {
     expect(call.ignore_missing_component_templates).toBeUndefined();
   });
 
+  it('does not lower an existing limit that is higher than the requested value', async () => {
+    const template = createTemplate({
+      template: {
+        settings: {
+          hidden: true,
+          'index.mapping.total_fields.limit': 5000,
+          'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+        },
+        mappings: { dynamic: false },
+      },
+    });
+
+    await updateIndexTemplateFieldsLimit({ esClient, template, limit: 2800 });
+
+    expect(esClient.indices.putIndexTemplate).not.toHaveBeenCalled();
+  });
+
+  it('skips the update when the existing limit equals the requested value', async () => {
+    const template = createTemplate({
+      template: {
+        settings: {
+          hidden: true,
+          'index.mapping.total_fields.limit': 2800,
+          'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+        },
+        mappings: { dynamic: false },
+      },
+    });
+
+    await updateIndexTemplateFieldsLimit({ esClient, template, limit: 2800 });
+
+    expect(esClient.indices.putIndexTemplate).not.toHaveBeenCalled();
+  });
+
+  it('preserves a higher existing limit when the ignore_dynamic_beyond_limit flag is missing', async () => {
+    const template = createTemplate({
+      template: {
+        settings: {
+          hidden: true,
+          'index.mapping.total_fields.limit': 5000,
+        },
+        mappings: { dynamic: false },
+      },
+    });
+
+    await updateIndexTemplateFieldsLimit({ esClient, template, limit: 2800 });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(1);
+    const call = esClient.indices.putIndexTemplate.mock.calls[0][0];
+    expect(call.template?.settings).toEqual(
+      expect.objectContaining({
+        'index.mapping.total_fields.limit': 5000,
+        'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+      })
+    );
+  });
+
+  it('does not lower a higher existing limit expressed in nested settings form', async () => {
+    const template = createTemplate({
+      template: {
+        settings: {
+          hidden: true,
+          index: { mapping: { total_fields: { limit: '5000' } } },
+        },
+        mappings: { dynamic: false },
+      },
+    });
+
+    await updateIndexTemplateFieldsLimit({ esClient, template, limit: 2800 });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(1);
+    const call = esClient.indices.putIndexTemplate.mock.calls[0][0];
+    expect(call.template?.settings).toEqual(
+      expect.objectContaining({
+        'index.mapping.total_fields.limit': 5000,
+        'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+      })
+    );
+  });
+
   it('handles a template with no existing settings', async () => {
     const template = createTemplate({ template: { mappings: { dynamic: false } } });
 

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/update_index_template_fields_limit.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/update_index_template_fields_limit.ts
@@ -6,8 +6,12 @@
  */
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { IndicesGetIndexTemplateIndexTemplateItem } from '@elastic/elasticsearch/lib/api/types';
+import {
+  evaluateTotalFieldsLimit,
+  getTotalFieldsLimitSettings,
+} from './total_fields_limit_settings';
 
-export const updateIndexTemplateFieldsLimit = ({
+export const updateIndexTemplateFieldsLimit = async ({
   esClient,
   template,
   limit,
@@ -27,6 +31,14 @@ export const updateIndexTemplateFieldsLimit = ({
     ...rest
   } = template.index_template;
 
+  const { isSatisfied, effectiveLimit } = evaluateTotalFieldsLimit(
+    [existingTemplate?.settings],
+    limit
+  );
+  if (isSatisfied) {
+    return;
+  }
+
   return esClient.indices.putIndexTemplate({
     name: template.name,
     ...rest,
@@ -34,8 +46,7 @@ export const updateIndexTemplateFieldsLimit = ({
       ...existingTemplate,
       settings: {
         ...existingTemplate?.settings,
-        'index.mapping.total_fields.limit': limit,
-        'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+        ...getTotalFieldsLimitSettings(effectiveLimit),
       },
     },
     // GET brings string | string[] | undefined but this PUT expects string[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps] Don't lower alerts-as-data total_fields.limit below the already-set value (#277402)](https://github.com/elastic/kibana/pull/277402)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-14T08:32:33Z","message":"[ResponseOps] Don't lower alerts-as-data total_fields.limit below the already-set value (#277402)\n\n## Summary\n\nThe alerts-as-data (`.alerts-*`) resource installer set\n`index.mapping.total_fields.limit` by unconditionally writing the\nconfigured/hardcoded value onto existing indices, data streams, and\nindex templates. When a limit had previously been raised — manually\nduring an incident, or by a prior higher configuration — this\n**lowered** it, which can immediately put the mapping over the limit and\nre-trigger the reset-then-increase churn behind incident 3238.\n\nThe installer now applies **`max(currentLimit, configuredLimit)`** and\n**skips the write entirely** when the current value already satisfies\nthe configured one (and the `ignore_dynamic_beyond_limit` flag is\npresent). Brand-new indices/templates still get the configured value\ndirectly.\n\nFollow-up to #274024, which made the limit configurable\n(`xpack.alerting.alertsService.totalFieldsLimit`) and explicitly\ndeferred this \"never reduce an already-set limit\" improvement.\n\n## What changed\n\n* New `total_fields_limit_settings.ts` centralizes the concern:\n* reading the limit / `ignore_dynamic_beyond_limit` flag from any ES\nsettings shape (flat, nested, un-prefixed);\n   * building the settings pair (`getTotalFieldsLimitSettings`);\n* the skip / `max` decision (`evaluateTotalFieldsLimit` → `{\nisSatisfied, effectiveLimit }`).\n* `create_concrete_write_index.ts` — `updateTotalFieldLimitSetting`\nreads current settings first (works for a concrete index or a data\nstream name, which resolves to its backing indices), skips the PUT when\nalready satisfied, otherwise PUTs `max(configured, current)`.\n* `create_or_update_index_template.ts` — fetches the existing template\nand preserves a higher existing limit in the body before simulating and\nPUTting.\n* `update_index_template_fields_limit.ts` — applies `max(existing,\nrequested)` and skips when nothing would change. This also covers the\ncomponent-template failure handler, which pushes limits onto every index\ntemplate referencing the component template.\n* Because the `rule_registry` `ResourceInstaller` imports these\nfunctions from the alerting plugin, both installers are fixed by the\nsame change.\n\n### Note on the skip condition\n\nThe skip requires the `ignore_dynamic_beyond_limit` flag to already be\npresent. An index/template with a high enough limit but no flag still\ngets one PUT (keeping its higher limit, adding the flag), so pre-8.13 /\nmanually-edited resources converge on the flag rather than being skipped\nforever.\n\n## Acceptance criteria\n\n* Existing `.alerts-*` indices/templates with a `total_fields.limit`\nhigher than the configured value are **not** lowered on install/update.\n* Indices/templates below the configured value are still raised to it.\n* No-op PUTs are avoided when the current limit already satisfies the\nconfigured value.\n* Unit tests cover existing-higher (preserved), existing-lower (raised),\nand equal (no PUT) cases, plus the flag-missing and\nnested-settings-shape variants.\n\n## How to test manually\n\nThe core assertion: **once a limit is raised (by auto-increase, by\nconfig, or by hand), a later install with a lower configured value must\nnot lower it.**\n\nThe default limit is **2800**\n(`xpack.alerting.alertsService.totalFieldsLimit`, min 2500 / max 5000),\nand the base (non-dummy) field count of the threshold alerts mapping is\n~**2129**.\n\n### Setup — add the dynamic grouping object and run the rule first\n\nReuse the fixture from #216719 (which added the auto-increase logic this\nchange sits next to). Start with **only** the dynamic mapping — do *not*\nadd the dummy fields yet:\n\n* In the custom threshold rule type's `alerts.mappings`, add the dynamic\n`kibana.alerting.grouping` object, and add the grouping payload to its\nexecutor (exact snippets in the #216719 description). Leave the dummy\nfields out for now.\n* Run ES with `path.data=../your-local-data-path` so data survives\nrestarts.\n* Start Kibana, create a custom threshold rule with ≥2 groups, and let\nit run.\n* Because the mapping is well below the limit at this point, the dynamic\n`kibana.alert.grouping.*` fields are **indexed** (not dropped). This\nseeds the extra dynamic fields the increase needs.\n\n### Trigger the auto-increase — add dummy fields, then restart\n\nNow grow the *static* mapping so that, combined with the dynamic fields\nalready indexed above, it crosses the 2800 default. Because the base is\n~2129, ~**671** dummy fields lands the static mapping right at 2800;\ntogether with the dynamic grouping fields it goes over.\n\n* Stop Kibana.\n* Add the dummy keyword fields to the rule type's `alerts.mappings`,\ne.g.:\n  ```\n  ...Array(671)\n    .fill(0)\n    .reduce((acc, val, i) => {\nacc[`${i + 1}`] = { type: 'keyword', array: false, required: false };\n      return acc;\n    }, {}),\n  ```\n* Start Kibana again.\n* On startup the static mapping + the already-indexed dynamic fields\nexceed 2800, so `putMapping` trips the limit and the installer\nauto-increases it.\n* Confirm: `Stack Management → Index Management →\n.internal.alerts-observability.threshold.alerts-default-000001 →\nSettings` shows `index.mapping.total_fields.limit` **> 2800** (e.g.\n`2806`). Check the index template too: `GET\n_index_template/.alerts-observability.threshold.alerts-default-index-template`.\nThis raised value is what the following tests must protect.\n\n### Test A — auto-raised limit is preserved on restart (the regression\nthis fixes)\n\n* Stop Kibana. Leave config at the default `totalFieldsLimit` (2800) and\nleave the mapping unchanged.\n* Restart Kibana.\n* The index's Settings → `total_fields.limit` is **still the raised\nvalue** (e.g. 2806), not reset down to 2800.\n* The index template is not lowered either: `GET\n_index_template/.alerts-observability.threshold.alerts-default-index-template`.\n* On `main` (before this PR) the value drops back down here — that\ncontrast is the proof.\n\n### Test B — manual raise is preserved (the incident-3238 scenario)\n\n```\nPUT .internal.alerts-observability.threshold.alerts-default-000001/_settings\n{ \"index.mapping.total_fields.limit\": 5000 }\n```\n\n* Restart Kibana (config default 2800).\n* The index still reads `5000` afterward — Kibana no longer fights the\nmanual workaround.\n\n### Test C — a lower configured value still raises a below-limit index\n(no regression the other way)\n\n* Set an index to 2600 (`PUT .../_settings`), start Kibana with config\n`totalFieldsLimit: 2800`.\n* The index is **raised to 2800** — the change only blocks *lowering*,\nit still raises when below.\n\n### Test D — data streams (serverless path)\n\n* Run with serverless config (`useDataStreamForAlerts` true) and repeat\nTest A. Confirms the `getSettings` over a data stream name (resolving to\nbacking indices) and the skip/`max` logic behave the same for `.ds-*`\nbacking indices.\n\n> Quick config-only variant (less setup, skips the auto-increase\ninteraction): set `xpack.alerting.alertsService.totalFieldsLimit` high\n(e.g. 3000), start Kibana, then restart with it low (e.g. 2800) and\nconfirm indices/templates stay at 3000.\n\n## Testing\n\n* `node scripts/jest\nx-pack/platform/plugins/shared/alerting/server/alerts_service` — lib\nsuites + `alerts_service.test.ts` pass\n* `node scripts/jest\nx-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service`\n— pass\n* scoped type check and eslint clean\n\nCloses #275666\nContributes to #246016 (introduces the \"don't do redundant work\"\nprinciple for the fields-limit dimension; broader skip-unchanged\ninstallation is tracked there)\n\n🤖 Generated with Claude Code\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"b468e68c1b5cde62b253833749fa9cee70a04c14","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Alerting","backport:skip","Team:ResponseOps","v9.6.0"],"title":"[ResponseOps] Don't lower alerts-as-data total_fields.limit below the already-set value","number":277402,"url":"https://github.com/elastic/kibana/pull/277402","mergeCommit":{"message":"[ResponseOps] Don't lower alerts-as-data total_fields.limit below the already-set value (#277402)\n\n## Summary\n\nThe alerts-as-data (`.alerts-*`) resource installer set\n`index.mapping.total_fields.limit` by unconditionally writing the\nconfigured/hardcoded value onto existing indices, data streams, and\nindex templates. When a limit had previously been raised — manually\nduring an incident, or by a prior higher configuration — this\n**lowered** it, which can immediately put the mapping over the limit and\nre-trigger the reset-then-increase churn behind incident 3238.\n\nThe installer now applies **`max(currentLimit, configuredLimit)`** and\n**skips the write entirely** when the current value already satisfies\nthe configured one (and the `ignore_dynamic_beyond_limit` flag is\npresent). Brand-new indices/templates still get the configured value\ndirectly.\n\nFollow-up to #274024, which made the limit configurable\n(`xpack.alerting.alertsService.totalFieldsLimit`) and explicitly\ndeferred this \"never reduce an already-set limit\" improvement.\n\n## What changed\n\n* New `total_fields_limit_settings.ts` centralizes the concern:\n* reading the limit / `ignore_dynamic_beyond_limit` flag from any ES\nsettings shape (flat, nested, un-prefixed);\n   * building the settings pair (`getTotalFieldsLimitSettings`);\n* the skip / `max` decision (`evaluateTotalFieldsLimit` → `{\nisSatisfied, effectiveLimit }`).\n* `create_concrete_write_index.ts` — `updateTotalFieldLimitSetting`\nreads current settings first (works for a concrete index or a data\nstream name, which resolves to its backing indices), skips the PUT when\nalready satisfied, otherwise PUTs `max(configured, current)`.\n* `create_or_update_index_template.ts` — fetches the existing template\nand preserves a higher existing limit in the body before simulating and\nPUTting.\n* `update_index_template_fields_limit.ts` — applies `max(existing,\nrequested)` and skips when nothing would change. This also covers the\ncomponent-template failure handler, which pushes limits onto every index\ntemplate referencing the component template.\n* Because the `rule_registry` `ResourceInstaller` imports these\nfunctions from the alerting plugin, both installers are fixed by the\nsame change.\n\n### Note on the skip condition\n\nThe skip requires the `ignore_dynamic_beyond_limit` flag to already be\npresent. An index/template with a high enough limit but no flag still\ngets one PUT (keeping its higher limit, adding the flag), so pre-8.13 /\nmanually-edited resources converge on the flag rather than being skipped\nforever.\n\n## Acceptance criteria\n\n* Existing `.alerts-*` indices/templates with a `total_fields.limit`\nhigher than the configured value are **not** lowered on install/update.\n* Indices/templates below the configured value are still raised to it.\n* No-op PUTs are avoided when the current limit already satisfies the\nconfigured value.\n* Unit tests cover existing-higher (preserved), existing-lower (raised),\nand equal (no PUT) cases, plus the flag-missing and\nnested-settings-shape variants.\n\n## How to test manually\n\nThe core assertion: **once a limit is raised (by auto-increase, by\nconfig, or by hand), a later install with a lower configured value must\nnot lower it.**\n\nThe default limit is **2800**\n(`xpack.alerting.alertsService.totalFieldsLimit`, min 2500 / max 5000),\nand the base (non-dummy) field count of the threshold alerts mapping is\n~**2129**.\n\n### Setup — add the dynamic grouping object and run the rule first\n\nReuse the fixture from #216719 (which added the auto-increase logic this\nchange sits next to). Start with **only** the dynamic mapping — do *not*\nadd the dummy fields yet:\n\n* In the custom threshold rule type's `alerts.mappings`, add the dynamic\n`kibana.alerting.grouping` object, and add the grouping payload to its\nexecutor (exact snippets in the #216719 description). Leave the dummy\nfields out for now.\n* Run ES with `path.data=../your-local-data-path` so data survives\nrestarts.\n* Start Kibana, create a custom threshold rule with ≥2 groups, and let\nit run.\n* Because the mapping is well below the limit at this point, the dynamic\n`kibana.alert.grouping.*` fields are **indexed** (not dropped). This\nseeds the extra dynamic fields the increase needs.\n\n### Trigger the auto-increase — add dummy fields, then restart\n\nNow grow the *static* mapping so that, combined with the dynamic fields\nalready indexed above, it crosses the 2800 default. Because the base is\n~2129, ~**671** dummy fields lands the static mapping right at 2800;\ntogether with the dynamic grouping fields it goes over.\n\n* Stop Kibana.\n* Add the dummy keyword fields to the rule type's `alerts.mappings`,\ne.g.:\n  ```\n  ...Array(671)\n    .fill(0)\n    .reduce((acc, val, i) => {\nacc[`${i + 1}`] = { type: 'keyword', array: false, required: false };\n      return acc;\n    }, {}),\n  ```\n* Start Kibana again.\n* On startup the static mapping + the already-indexed dynamic fields\nexceed 2800, so `putMapping` trips the limit and the installer\nauto-increases it.\n* Confirm: `Stack Management → Index Management →\n.internal.alerts-observability.threshold.alerts-default-000001 →\nSettings` shows `index.mapping.total_fields.limit` **> 2800** (e.g.\n`2806`). Check the index template too: `GET\n_index_template/.alerts-observability.threshold.alerts-default-index-template`.\nThis raised value is what the following tests must protect.\n\n### Test A — auto-raised limit is preserved on restart (the regression\nthis fixes)\n\n* Stop Kibana. Leave config at the default `totalFieldsLimit` (2800) and\nleave the mapping unchanged.\n* Restart Kibana.\n* The index's Settings → `total_fields.limit` is **still the raised\nvalue** (e.g. 2806), not reset down to 2800.\n* The index template is not lowered either: `GET\n_index_template/.alerts-observability.threshold.alerts-default-index-template`.\n* On `main` (before this PR) the value drops back down here — that\ncontrast is the proof.\n\n### Test B — manual raise is preserved (the incident-3238 scenario)\n\n```\nPUT .internal.alerts-observability.threshold.alerts-default-000001/_settings\n{ \"index.mapping.total_fields.limit\": 5000 }\n```\n\n* Restart Kibana (config default 2800).\n* The index still reads `5000` afterward — Kibana no longer fights the\nmanual workaround.\n\n### Test C — a lower configured value still raises a below-limit index\n(no regression the other way)\n\n* Set an index to 2600 (`PUT .../_settings`), start Kibana with config\n`totalFieldsLimit: 2800`.\n* The index is **raised to 2800** — the change only blocks *lowering*,\nit still raises when below.\n\n### Test D — data streams (serverless path)\n\n* Run with serverless config (`useDataStreamForAlerts` true) and repeat\nTest A. Confirms the `getSettings` over a data stream name (resolving to\nbacking indices) and the skip/`max` logic behave the same for `.ds-*`\nbacking indices.\n\n> Quick config-only variant (less setup, skips the auto-increase\ninteraction): set `xpack.alerting.alertsService.totalFieldsLimit` high\n(e.g. 3000), start Kibana, then restart with it low (e.g. 2800) and\nconfirm indices/templates stay at 3000.\n\n## Testing\n\n* `node scripts/jest\nx-pack/platform/plugins/shared/alerting/server/alerts_service` — lib\nsuites + `alerts_service.test.ts` pass\n* `node scripts/jest\nx-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service`\n— pass\n* scoped type check and eslint clean\n\nCloses #275666\nContributes to #246016 (introduces the \"don't do redundant work\"\nprinciple for the fields-limit dimension; broader skip-unchanged\ninstallation is tracked there)\n\n🤖 Generated with Claude Code\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"b468e68c1b5cde62b253833749fa9cee70a04c14"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277402","number":277402,"mergeCommit":{"message":"[ResponseOps] Don't lower alerts-as-data total_fields.limit below the already-set value (#277402)\n\n## Summary\n\nThe alerts-as-data (`.alerts-*`) resource installer set\n`index.mapping.total_fields.limit` by unconditionally writing the\nconfigured/hardcoded value onto existing indices, data streams, and\nindex templates. When a limit had previously been raised — manually\nduring an incident, or by a prior higher configuration — this\n**lowered** it, which can immediately put the mapping over the limit and\nre-trigger the reset-then-increase churn behind incident 3238.\n\nThe installer now applies **`max(currentLimit, configuredLimit)`** and\n**skips the write entirely** when the current value already satisfies\nthe configured one (and the `ignore_dynamic_beyond_limit` flag is\npresent). Brand-new indices/templates still get the configured value\ndirectly.\n\nFollow-up to #274024, which made the limit configurable\n(`xpack.alerting.alertsService.totalFieldsLimit`) and explicitly\ndeferred this \"never reduce an already-set limit\" improvement.\n\n## What changed\n\n* New `total_fields_limit_settings.ts` centralizes the concern:\n* reading the limit / `ignore_dynamic_beyond_limit` flag from any ES\nsettings shape (flat, nested, un-prefixed);\n   * building the settings pair (`getTotalFieldsLimitSettings`);\n* the skip / `max` decision (`evaluateTotalFieldsLimit` → `{\nisSatisfied, effectiveLimit }`).\n* `create_concrete_write_index.ts` — `updateTotalFieldLimitSetting`\nreads current settings first (works for a concrete index or a data\nstream name, which resolves to its backing indices), skips the PUT when\nalready satisfied, otherwise PUTs `max(configured, current)`.\n* `create_or_update_index_template.ts` — fetches the existing template\nand preserves a higher existing limit in the body before simulating and\nPUTting.\n* `update_index_template_fields_limit.ts` — applies `max(existing,\nrequested)` and skips when nothing would change. This also covers the\ncomponent-template failure handler, which pushes limits onto every index\ntemplate referencing the component template.\n* Because the `rule_registry` `ResourceInstaller` imports these\nfunctions from the alerting plugin, both installers are fixed by the\nsame change.\n\n### Note on the skip condition\n\nThe skip requires the `ignore_dynamic_beyond_limit` flag to already be\npresent. An index/template with a high enough limit but no flag still\ngets one PUT (keeping its higher limit, adding the flag), so pre-8.13 /\nmanually-edited resources converge on the flag rather than being skipped\nforever.\n\n## Acceptance criteria\n\n* Existing `.alerts-*` indices/templates with a `total_fields.limit`\nhigher than the configured value are **not** lowered on install/update.\n* Indices/templates below the configured value are still raised to it.\n* No-op PUTs are avoided when the current limit already satisfies the\nconfigured value.\n* Unit tests cover existing-higher (preserved), existing-lower (raised),\nand equal (no PUT) cases, plus the flag-missing and\nnested-settings-shape variants.\n\n## How to test manually\n\nThe core assertion: **once a limit is raised (by auto-increase, by\nconfig, or by hand), a later install with a lower configured value must\nnot lower it.**\n\nThe default limit is **2800**\n(`xpack.alerting.alertsService.totalFieldsLimit`, min 2500 / max 5000),\nand the base (non-dummy) field count of the threshold alerts mapping is\n~**2129**.\n\n### Setup — add the dynamic grouping object and run the rule first\n\nReuse the fixture from #216719 (which added the auto-increase logic this\nchange sits next to). Start with **only** the dynamic mapping — do *not*\nadd the dummy fields yet:\n\n* In the custom threshold rule type's `alerts.mappings`, add the dynamic\n`kibana.alerting.grouping` object, and add the grouping payload to its\nexecutor (exact snippets in the #216719 description). Leave the dummy\nfields out for now.\n* Run ES with `path.data=../your-local-data-path` so data survives\nrestarts.\n* Start Kibana, create a custom threshold rule with ≥2 groups, and let\nit run.\n* Because the mapping is well below the limit at this point, the dynamic\n`kibana.alert.grouping.*` fields are **indexed** (not dropped). This\nseeds the extra dynamic fields the increase needs.\n\n### Trigger the auto-increase — add dummy fields, then restart\n\nNow grow the *static* mapping so that, combined with the dynamic fields\nalready indexed above, it crosses the 2800 default. Because the base is\n~2129, ~**671** dummy fields lands the static mapping right at 2800;\ntogether with the dynamic grouping fields it goes over.\n\n* Stop Kibana.\n* Add the dummy keyword fields to the rule type's `alerts.mappings`,\ne.g.:\n  ```\n  ...Array(671)\n    .fill(0)\n    .reduce((acc, val, i) => {\nacc[`${i + 1}`] = { type: 'keyword', array: false, required: false };\n      return acc;\n    }, {}),\n  ```\n* Start Kibana again.\n* On startup the static mapping + the already-indexed dynamic fields\nexceed 2800, so `putMapping` trips the limit and the installer\nauto-increases it.\n* Confirm: `Stack Management → Index Management →\n.internal.alerts-observability.threshold.alerts-default-000001 →\nSettings` shows `index.mapping.total_fields.limit` **> 2800** (e.g.\n`2806`). Check the index template too: `GET\n_index_template/.alerts-observability.threshold.alerts-default-index-template`.\nThis raised value is what the following tests must protect.\n\n### Test A — auto-raised limit is preserved on restart (the regression\nthis fixes)\n\n* Stop Kibana. Leave config at the default `totalFieldsLimit` (2800) and\nleave the mapping unchanged.\n* Restart Kibana.\n* The index's Settings → `total_fields.limit` is **still the raised\nvalue** (e.g. 2806), not reset down to 2800.\n* The index template is not lowered either: `GET\n_index_template/.alerts-observability.threshold.alerts-default-index-template`.\n* On `main` (before this PR) the value drops back down here — that\ncontrast is the proof.\n\n### Test B — manual raise is preserved (the incident-3238 scenario)\n\n```\nPUT .internal.alerts-observability.threshold.alerts-default-000001/_settings\n{ \"index.mapping.total_fields.limit\": 5000 }\n```\n\n* Restart Kibana (config default 2800).\n* The index still reads `5000` afterward — Kibana no longer fights the\nmanual workaround.\n\n### Test C — a lower configured value still raises a below-limit index\n(no regression the other way)\n\n* Set an index to 2600 (`PUT .../_settings`), start Kibana with config\n`totalFieldsLimit: 2800`.\n* The index is **raised to 2800** — the change only blocks *lowering*,\nit still raises when below.\n\n### Test D — data streams (serverless path)\n\n* Run with serverless config (`useDataStreamForAlerts` true) and repeat\nTest A. Confirms the `getSettings` over a data stream name (resolving to\nbacking indices) and the skip/`max` logic behave the same for `.ds-*`\nbacking indices.\n\n> Quick config-only variant (less setup, skips the auto-increase\ninteraction): set `xpack.alerting.alertsService.totalFieldsLimit` high\n(e.g. 3000), start Kibana, then restart with it low (e.g. 2800) and\nconfirm indices/templates stay at 3000.\n\n## Testing\n\n* `node scripts/jest\nx-pack/platform/plugins/shared/alerting/server/alerts_service` — lib\nsuites + `alerts_service.test.ts` pass\n* `node scripts/jest\nx-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service`\n— pass\n* scoped type check and eslint clean\n\nCloses #275666\nContributes to #246016 (introduces the \"don't do redundant work\"\nprinciple for the fields-limit dimension; broader skip-unchanged\ninstallation is tracked there)\n\n🤖 Generated with Claude Code\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"b468e68c1b5cde62b253833749fa9cee70a04c14"}}]}] BACKPORT-->