### PR TITLE
[Remote Clusters] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/remote_clusters/server/routes/api/delete_route.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/server/routes/api/delete_route.ts
@@ -18,7 +18,7 @@ import { doesClusterExist } from '../../lib/does_cluster_exist';
 import { licensePreRoutingFactory } from '../../lib/license_pre_routing_factory';
 
 const paramsValidation = schema.object({
-  nameOrNames: schema.string(),
+  nameOrNames: schema.string({ maxLength: 10000 }),
 });
 
 type RouteParams = TypeOf<typeof paramsValidation>;

--- a/x-pack/platform/plugins/private/remote_clusters/server/routes/api/update_route.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/server/routes/api/update_route.ts
@@ -20,16 +20,16 @@ import { licensePreRoutingFactory } from '../../lib/license_pre_routing_factory'
 const bodyValidation = schema.object({
   skipUnavailable: schema.boolean(),
   mode: schema.oneOf([schema.literal(PROXY_MODE), schema.literal(SNIFF_MODE)]),
-  seeds: schema.nullable(schema.arrayOf(schema.string(), { maxSize: 1000 })),
+  seeds: schema.nullable(schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 })),
   nodeConnections: schema.nullable(schema.number()),
-  proxyAddress: schema.nullable(schema.string()),
+  proxyAddress: schema.nullable(schema.string({ maxLength: 1000 })),
   proxySocketConnections: schema.nullable(schema.number()),
-  serverName: schema.nullable(schema.string()),
+  serverName: schema.nullable(schema.string({ maxLength: 1000 })),
   hasDeprecatedProxySetting: schema.maybe(schema.boolean()),
 });
 
 const paramsValidation = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 type RouteParams = TypeOf<typeof paramsValidation>;


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `remote_clusters` route request validation schemas — clears 5 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`seeds`, `proxyAddress`, `serverName`, `name`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 10000`** for comma-separated multi-name params (`nameOrNames`), split on `,` in the handler, so bulk operations on many resources keep working.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/remote_clusters/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11995](https://github.com/elastic/kibana/security/code-scanning/11995) | `server/routes/api/delete_route.ts:21` | `nameOrNames: schema.string(),` | `maxLength: 10000` |
| [#11996](https://github.com/elastic/kibana/security/code-scanning/11996) | `server/routes/api/update_route.ts:23` | `seeds: schema.nullable(schema.arrayOf(schema.string(), { maxSize: 1000 })),` | `maxLength: 1000` |
| [#11997](https://github.com/elastic/kibana/security/code-scanning/11997) | `server/routes/api/update_route.ts:25` | `proxyAddress: schema.nullable(schema.string()),` | `maxLength: 1000` |
| [#11998](https://github.com/elastic/kibana/security/code-scanning/11998) | `server/routes/api/update_route.ts:27` | `serverName: schema.nullable(schema.string()),` | `maxLength: 1000` |
| [#11999](https://github.com/elastic/kibana/security/code-scanning/11999) | `server/routes/api/update_route.ts:32` | `name: schema.string(),` | `maxLength: 1000` |
