### PR TITLE
[Streams] Add max length constraints to lifecycle route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/lifecycle/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/lifecycle/route.ts
@@ -406,8 +406,8 @@ const lifecycleIlmPoliciesRoute = createServerRoute({
 });
 
 const ilmPhaseSchema = z.looseObject({
-  min_age: z.string().optional(),
-  actions: z.record(z.string(), z.any()).optional(),
+  min_age: z.string().max(64).optional(),
+  actions: z.record(z.string().max(1000), z.any()).optional(),
 });
 
 const lifecycleIlmPoliciesUpdateRoute = createServerRoute({
@@ -422,7 +422,7 @@ const lifecycleIlmPoliciesUpdateRoute = createServerRoute({
   },
   params: z.object({
     body: z.object({
-      name: z.string(),
+      name: z.string().max(1000),
       phases: z.object({
         hot: ilmPhaseSchema.optional(),
         warm: ilmPhaseSchema.optional(),
@@ -430,9 +430,9 @@ const lifecycleIlmPoliciesUpdateRoute = createServerRoute({
         frozen: ilmPhaseSchema.optional(),
         delete: ilmPhaseSchema.optional(),
       }),
-      meta: z.record(z.string(), z.any()).optional(),
+      meta: z.record(z.string().max(1000), z.any()).optional(),
       deprecated: z.boolean().optional(),
-      source_policy_name: z.string().optional(),
+      source_policy_name: z.string().max(1000).optional(),
     }),
     query: z.object({
       allow_overwrite: BooleanFromString.optional().default(false),


### PR DESCRIPTION
## Summary

Adds `.max()` to every `z.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `streams` route request validation schemas — clears 5 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`.max(1000)`** for identifier-like fields (`name`, `source_policy_name`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`.max(64)`** for short fixed-format values (`min_age`): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.
- **bounded record keys** in `recordOf`/`z.record` schemas — key strings are attacker-controlled input too (same pattern as #279726).

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/shared/streams/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11036](https://github.com/elastic/kibana/security/code-scanning/11036) | `server/routes/internal/streams/lifecycle/route.ts:409` | `min_age: z.string().optional(),` | `.max(64)` |
| [#11037](https://github.com/elastic/kibana/security/code-scanning/11037) | `server/routes/internal/streams/lifecycle/route.ts:410` | `actions: z.record(z.string(), z.any()).optional(),` | `.max(1000)` |
| [#11038](https://github.com/elastic/kibana/security/code-scanning/11038) | `server/routes/internal/streams/lifecycle/route.ts:425` | `name: z.string(),` | `.max(1000)` |
| [#11039](https://github.com/elastic/kibana/security/code-scanning/11039) | `server/routes/internal/streams/lifecycle/route.ts:433` | `meta: z.record(z.string(), z.any()).optional(),` | `.max(1000)` |
| [#11040](https://github.com/elastic/kibana/security/code-scanning/11040) | `server/routes/internal/streams/lifecycle/route.ts:435` | `source_policy_name: z.string().optional(),` | `.max(1000)` |
