### PR TITLE
[Reindex Service] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/reindex_service/server/src/routes/reindex_indices.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/src/routes/reindex_indices.ts
@@ -13,8 +13,8 @@ import type { RouteDependencies } from '../../types';
 import { mapAnyErrorToKibanaHttpResponse } from './map_any_error_to_kibana_http_response';
 
 export const reindexSchema = schema.object({
-  indexName: schema.string(),
-  newIndexName: schema.string(),
+  indexName: schema.string({ maxLength: 1000 }),
+  newIndexName: schema.string({ maxLength: 1000 }),
   reindexOptions: schema.maybe(
     schema.object({
       enqueue: schema.maybe(schema.boolean()),
@@ -94,7 +94,7 @@ export function registerReindexIndicesRoutes({ router, getReindexService }: Rout
       },
       validate: {
         params: schema.object({
-          indexName: schema.string(),
+          indexName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -135,7 +135,7 @@ export function registerReindexIndicesRoutes({ router, getReindexService }: Rout
       },
       validate: {
         params: schema.object({
-          indexName: schema.string(),
+          indexName: schema.string({ maxLength: 1000 }),
         }),
       },
     },


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `reindex_service` route request validation schemas — clears 4 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`indexName`, `newIndexName`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/reindex_service/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11991](https://github.com/elastic/kibana/security/code-scanning/11991) | `server/src/routes/reindex_indices.ts:16` | `indexName: schema.string(),` | `maxLength: 1000` |
| [#11992](https://github.com/elastic/kibana/security/code-scanning/11992) | `server/src/routes/reindex_indices.ts:17` | `newIndexName: schema.string(),` | `maxLength: 1000` |
| [#11993](https://github.com/elastic/kibana/security/code-scanning/11993) | `server/src/routes/reindex_indices.ts:97` | `indexName: schema.string(),` | `maxLength: 1000` |
| [#11994](https://github.com/elastic/kibana/security/code-scanning/11994) | `server/src/routes/reindex_indices.ts:138` | `indexName: schema.string(),` | `maxLength: 1000` |
