### PR TITLE
[Grok Debugger] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/grokdebugger/server/routes/api/grokdebugger/register_grok_simulate_route.ts
+++ b/x-pack/platform/plugins/private/grokdebugger/server/routes/api/grokdebugger/register_grok_simulate_route.ts
@@ -16,10 +16,14 @@ import { handleEsError } from '../../../shared_imports';
 import type { KibanaFramework } from '../../../lib/kibana_framework';
 
 export const requestBodySchema = schema.object({
-  pattern: schema.string(),
-  rawEvent: schema.string(),
+  pattern: schema.string({ maxLength: 10000 }),
+  rawEvent: schema.string({ maxLength: 100000 }),
   // Dynamic pattern-name keys with string definitions, e.g. { POSTFIX_QUEUEID: '[0-9A-F]{10,11}' }
-  customPatterns: schema.recordOf(schema.string(), schema.string(), { defaultValue: {} }),
+  customPatterns: schema.recordOf(
+    schema.string({ maxLength: 1000 }),
+    schema.string({ maxLength: 10000 }),
+    { defaultValue: {} }
+  ),
 });
 
 export function registerGrokSimulateRoute(framework: KibanaFramework) {


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `grokdebugger` route request validation schemas — clears 4 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **bounded record keys** in `recordOf`/`z.record` schemas — key strings are attacker-controlled input too (same pattern as #279726).
- **`maxLength: 10000`** for the grok pattern to simulate — a tight bound matters here because long patterns amplify regex backtracking.
- **`maxLength: 100000`** for the sample event text to run the pattern against.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/grokdebugger/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11966](https://github.com/elastic/kibana/security/code-scanning/11966) | `server/routes/api/grokdebugger/register_grok_simulate_route.ts:19` | `pattern: schema.string(),` | `maxLength: 10000` |
| [#11967](https://github.com/elastic/kibana/security/code-scanning/11967) | `server/routes/api/grokdebugger/register_grok_simulate_route.ts:20` | `rawEvent: schema.string(),` | `maxLength: 100000` |
| [#11968](https://github.com/elastic/kibana/security/code-scanning/11968) | `server/routes/api/grokdebugger/register_grok_simulate_route.ts:22` | `customPatterns: schema.recordOf(schema.string(), schema.string(), ...) — key` | `maxLength: 1000` |
| [#11969](https://github.com/elastic/kibana/security/code-scanning/11969) | `server/routes/api/grokdebugger/register_grok_simulate_route.ts:22` | `customPatterns: schema.recordOf(schema.string(), schema.string(), ...) — value` | `maxLength: 10000` |
