### PR TITLE
[Data Usage] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/data_usage/server/routes/internal/usage_metrics.ts
+++ b/x-pack/platform/plugins/private/data_usage/server/routes/internal/usage_metrics.ts
@@ -45,6 +45,7 @@ export const registerUsageMetricsRoute = (
 };
 
 const DateSchema = schema.string({
+  maxLength: 64,
   minLength: 1,
   validate: (v) => (v.trim().length ? undefined : 'Date ISO string must not be empty'),
 });
@@ -52,7 +53,7 @@ const DateSchema = schema.string({
 export const UsageMetricsRequestSchema = schema.object({
   from: DateSchema,
   to: DateSchema,
-  metricTypes: schema.arrayOf(schema.string(), {
+  metricTypes: schema.arrayOf(schema.string({ maxLength: 1000 }), {
     minSize: 1,
     maxSize: 1000,
     validate: (values) => {
@@ -64,7 +65,7 @@ export const UsageMetricsRequestSchema = schema.object({
       }
     },
   }),
-  dataStreams: schema.arrayOf(schema.string(), {
+  dataStreams: schema.arrayOf(schema.string({ maxLength: 1000 }), {
     maxSize: 1000,
     validate: (values) => {
       if (values.map((v) => v.trim()).some((v) => !v.length)) {


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `data_usage` route request validation schemas — clears 3 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`metricTypes`, `dataStreams`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **`maxLength: 64`** for short fixed-format values (``): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/data_usage/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11920](https://github.com/elastic/kibana/security/code-scanning/11920) | `server/routes/internal/usage_metrics.ts:47` | `const DateSchema = schema.string({ ... })` | `maxLength: 64` |
| [#11921](https://github.com/elastic/kibana/security/code-scanning/11921) | `server/routes/internal/usage_metrics.ts:55` | `metricTypes: schema.arrayOf(schema.string(), { ... })` | `maxLength: 1000` |
| [#11922](https://github.com/elastic/kibana/security/code-scanning/11922) | `server/routes/internal/usage_metrics.ts:67` | `dataStreams: schema.arrayOf(schema.string(), { ... })` | `maxLength: 1000` |
