### PR TITLE
[License Management] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/shared/license_management/server/routes/api/license/register_license_route.ts
+++ b/x-pack/platform/plugins/shared/license_management/server/routes/api/license/register_license_route.ts
@@ -26,7 +26,7 @@ export function registerLicenseRoute({
         },
       },
       validate: {
-        query: schema.object({ acknowledge: schema.string() }),
+        query: schema.object({ acknowledge: schema.string({ maxLength: 64 }) }),
         body: schema.object({
           license: schema.object({}, { unknowns: 'allow' }),
         }),

--- a/x-pack/platform/plugins/shared/license_management/server/routes/api/license/register_start_basic_route.ts
+++ b/x-pack/platform/plugins/shared/license_management/server/routes/api/license/register_start_basic_route.ts
@@ -24,7 +24,7 @@ export function registerStartBasicRoute({
           reason: 'Relies on es client for authorization',
         },
       },
-      validate: { query: schema.object({ acknowledge: schema.string() }) },
+      validate: { query: schema.object({ acknowledge: schema.string({ maxLength: 64 }) }) },
     },
     async (ctx, req, res) => {
       const { client } = (await ctx.core).elasticsearch;


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `license_management` route request validation schemas — clears 2 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 64`** for short fixed-format values (`query`, `validate`): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/shared/license_management/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#7908](https://github.com/elastic/kibana/security/code-scanning/7908) | `server/routes/api/license/register_license_route.ts:29` | `query: schema.object({ acknowledge: schema.string() }),` | `maxLength: 64` |
| [#7909](https://github.com/elastic/kibana/security/code-scanning/7909) | `server/routes/api/license/register_start_basic_route.ts:27` | `validate: { query: schema.object({ acknowledge: schema.string() }) },` | `maxLength: 64` |
