### PR TITLE
[Console] Add maxLength constraints to proxy route validation strings (CodeQL)

### DIFF
--- a/src/platform/plugins/shared/console/server/routes/api/console/proxy/validation_config.ts
+++ b/src/platform/plugins/shared/console/server/routes/api/console/proxy/validation_config.ts
@@ -14,6 +14,7 @@ export type Query = TypeOf<typeof routeValidationConfig.query>;
 export type Body = TypeOf<typeof routeValidationConfig.body>;
 
 export const acceptedHttpVerb = schema.string({
+  maxLength: 64,
   validate: (method) => {
     return ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'PATCH'].some(
       (verb) => verb.toLowerCase() === method.toLowerCase()
@@ -24,6 +25,7 @@ export const acceptedHttpVerb = schema.string({
 });
 
 export const nonEmptyString = schema.string({
+  maxLength: 4096,
   validate: (s) => (s === '' ? 'Expected non-empty string' : undefined),
 });
 


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `console` route request validation schemas — clears 2 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 64`** for short fixed-format values (``): time/byte-size values, dates, version strings, and boolean-like flags are all a handful of characters at most.
- **`maxLength: 4096`** for the Elasticsearch URL path proxied by Console (well above any legitimate ES API path).

### Fixed alerts

| Alert | Location (`src/platform/plugins/shared/console/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11270](https://github.com/elastic/kibana/security/code-scanning/11270) | `server/routes/api/console/proxy/validation_config.ts:16` | `export const acceptedHttpVerb = schema.string({ validate: ... })` | `maxLength: 64` |
| [#11271](https://github.com/elastic/kibana/security/code-scanning/11271) | `server/routes/api/console/proxy/validation_config.ts:26` | `export const nonEmptyString = schema.string({ validate: ... })` | `maxLength: 4096` |
