### PR TITLE
[Cloud Connect] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.ts
@@ -18,7 +18,7 @@ import { createStorageService } from '../lib/create_storage_service';
 import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 const bodySchema = schema.object({
-  apiKey: schema.string({ minLength: 1 }),
+  apiKey: schema.string({ minLength: 1, maxLength: 1000 }),
 });
 
 interface CloudConnectedStartDeps {

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.ts
@@ -208,7 +208,7 @@ export const registerClustersRoute = ({
       validate: {
         body: schema.object({
           services: schema.recordOf(
-            schema.string(),
+            schema.string({ maxLength: 256 }),
             schema.object({
               enabled: schema.boolean(),
             })


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `cloud_connect` route request validation schemas — clears 2 alerts. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`apiKey`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.
- **bounded record keys** in `recordOf`/`z.record` schemas — key strings are attacker-controlled input too (same pattern as #279726).

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/shared/cloud_connect/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#6611](https://github.com/elastic/kibana/security/code-scanning/6611) | `server/routes/authenticate.ts:21` | `apiKey: schema.string({ minLength: 1 }),` | `maxLength: 1000` |
| [#6612](https://github.com/elastic/kibana/security/code-scanning/6612) | `server/routes/clusters.ts:211` | `services: schema.recordOf(schema.string(), ...)` | `maxLength: 256` |
