### PR TITLE
[Search Profiler] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/shared/searchprofiler/server/routes/profile.ts
+++ b/x-pack/platform/plugins/shared/searchprofiler/server/routes/profile.ts
@@ -23,7 +23,7 @@ export const register = ({ router, getLicenseStatus, log }: RouteDependencies) =
       validate: {
         body: schema.object({
           query: schema.object({}, { unknowns: 'allow' }),
-          index: schema.string(),
+          index: schema.string({ maxLength: 1000 }),
         }),
       },
     },


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `searchprofiler` route request validation schemas — clears 1 alert. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`index`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/shared/searchprofiler/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#10840](https://github.com/elastic/kibana/security/code-scanning/10840) | `server/routes/profile.ts:26` | `index: schema.string(),` | `maxLength: 1000` |
