### PR TITLE
[Query Activity] Add maxLength constraints to route validation strings (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/shared/query_activity/server/routes/cancel.ts
+++ b/x-pack/platform/plugins/shared/query_activity/server/routes/cancel.ts
@@ -20,7 +20,7 @@ export const registerCancelRoute = ({ router, logger }: RouteOptions) => {
       },
       validate: {
         body: schema.object({
-          taskId: schema.string({ minLength: 1 }),
+          taskId: schema.string({ minLength: 1, maxLength: 1000 }),
         }),
       },
       options: {


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `query_activity` route request validation schemas — clears 1 alert. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 1000`** for identifier-like fields (`taskId`). Matches the convention used across kibana-management plugins (see #280344 and existing bounds in `index_management`) and is generous compared to Elasticsearch's own 255-byte limit on index and data stream names, so no legitimate value can be affected.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/shared/query_activity/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#10813](https://github.com/elastic/kibana/security/code-scanning/10813) | `server/routes/cancel.ts:23` | `taskId: schema.string({ minLength: 1 }),` | `maxLength: 1000` |
