### PR TITLE
[Painless Lab] Add maxLength constraint to execute route validation (CodeQL)

### DIFF
--- a/x-pack/platform/plugins/private/painless_lab/server/routes/api/execute.ts
+++ b/x-pack/platform/plugins/private/painless_lab/server/routes/api/execute.ts
@@ -11,7 +11,7 @@ import { API_BASE_PATH } from '../../../common/constants';
 import type { RouteDependencies } from '../../types';
 import { handleEsError } from '../../shared_imports';
 
-const bodySchema = schema.string();
+const bodySchema = schema.string({ maxLength: 100000 });
 
 export function registerExecuteRoute({ router, license }: RouteDependencies) {
   router.post(


### PR DESCRIPTION
## Summary

Adds `maxLength` to every `schema.string()` flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in the `painless_lab` route request validation schemas — clears 1 alert. Without a length bound, an attacker can send arbitrarily large strings that the server buffers, validates, and forwards to Elasticsearch (CWE-400 / CWE-770).

Only a maximum length is added (no `minLength`/regex changes), so existing legitimate values keep validating.

### Reasoning

- **`maxLength: 100000`** for the Painless script source executed by the lab.

### Fixed alerts

| Alert | Location (`x-pack/platform/plugins/private/painless_lab/…`) | Flagged schema | Fix |
| --- | --- | --- | --- |
| [#11990](https://github.com/elastic/kibana/security/code-scanning/11990) | `server/routes/api/execute.ts:14` | `const bodySchema = schema.string();` | `maxLength: 100000` |
