### PR TITLE
[One workflow] Bump version and write history only when YAML changes

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/api/lib/bulk_occ_index.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/lib/bulk_occ_index.test.ts
@@ -156,7 +156,7 @@ describe('bulkIndexWithOccRetry', () => {
     expect(mutate).toHaveBeenCalledWith(makeOccHit('wf-1', 7, 2));
   });
 
-  it('bumps document version when bumpVersion is enabled', async () => {
+  it('preserves document version when bumpVersion is enabled but YAML is unchanged', async () => {
     const client = makeClient();
     client.bulk.mockResolvedValue(bulkResponse([bulkIndexItem('wf-1', 200)]));
 
@@ -164,6 +164,23 @@ describe('bulkIndexWithOccRetry', () => {
       client,
       hits: [makeOccHit('wf-1', 7, 2, { version: 4 })],
       mutate: (hit) => hit._source,
+      bumpVersion: true,
+      retryDelayMs: 0,
+    });
+
+    expectIndexOperation(client.bulk.mock.calls[0][0].operations[0], {
+      document: expect.objectContaining({ version: 4 }),
+    });
+  });
+
+  it('bumps document version when bumpVersion is enabled and YAML changed', async () => {
+    const client = makeClient();
+    client.bulk.mockResolvedValue(bulkResponse([bulkIndexItem('wf-1', 200)]));
+
+    await bulkIndexWithOccRetry({
+      client,
+      hits: [makeOccHit('wf-1', 7, 2, { version: 4 })],
+      mutate: (hit) => ({ ...hit._source, yaml: 'name: Changed\nenabled: true' }),
       bumpVersion: true,
       retryDelayMs: 0,
     });

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
@@ -1195,10 +1195,6 @@ steps:
       mockWorkflowsService.bulkCreateWorkflows.mockResolvedValue({
         created: [createWorkflowDto({ id: 'wf-b1' }), createWorkflowDto({ id: 'wf-b2' })],
         failed: [],
-        historyActionsById: {
-          'wf-b1': 'create',
-          'wf-b2': 'create',
-        },
       });
 
       await api.bulkCreateWorkflows(
@@ -1216,14 +1212,10 @@ steps:
       );
     });
 
-    it('uses per-item create/update actions in bulkCreateWorkflows when overwrite is true', async () => {
+    it('notifies SML with "create" for bulkCreateWorkflows when overwrite is true', async () => {
       mockWorkflowsService.bulkCreateWorkflows.mockResolvedValue({
         created: [createWorkflowDto({ id: 'wf-new' }), createWorkflowDto({ id: 'wf-existing' })],
         failed: [],
-        historyActionsById: {
-          'wf-new': 'create',
-          'wf-existing': 'update',
-        },
       });
 
       await api.bulkCreateWorkflows(
@@ -1239,7 +1231,7 @@ steps:
         expect.objectContaining({ originId: 'wf-new', action: 'create' })
       );
       expect(mockSmlIndex).toHaveBeenCalledWith(
-        expect.objectContaining({ originId: 'wf-existing', action: 'update' })
+        expect.objectContaining({ originId: 'wf-existing', action: 'create' })
       );
     });
 

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -81,7 +81,6 @@ import type {
 } from './workflows_management_service';
 import { connectorParamsSchemaResolver } from '../../common/lib/connector_params_schema_resolver';
 import { formatWorkflowDiagnostic } from '../../common/lib/format_workflow_diagnostic';
-import { WorkflowChangeHistoryAction } from '../../common/lib/workflow_change_history/constants';
 import type {
   RestoreWorkflowVersionResponseDto,
   WorkflowChangesHistoryResponse,
@@ -358,13 +357,7 @@ export class WorkflowsManagementApi {
       options
     );
     for (const created of result.created) {
-      const historyAction =
-        result.historyActionsById[created.id] ?? WorkflowChangeHistoryAction.workflowCreate;
-      this.notifySml(
-        created.id,
-        historyAction === WorkflowChangeHistoryAction.workflowUpdate ? 'update' : 'create',
-        request
-      );
+      this.notifySml(created.id, 'create', request);
     }
     return result;
   }

--- a/src/platform/plugins/shared/workflows_management/server/lib/workflow_version.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/lib/workflow_version.test.ts
@@ -49,17 +49,40 @@ describe('applyWorkflowVersion', () => {
     );
   });
 
-  it('bumps version from fresh existing on update', () => {
+  it('bumps version from fresh existing when YAML changed', () => {
     const existing = { ...baseDocument(), version: 6 };
-    expect(applyWorkflowVersion({ ...existing, tags: ['new'] }, existing)).toEqual(
-      expect.objectContaining({ tags: ['new'], version: 7 })
+    expect(
+      applyWorkflowVersion({ ...existing, tags: ['new'], yaml: 'name: Changed' }, existing)
+    ).toEqual(expect.objectContaining({ tags: ['new'], version: 7 }));
+  });
+
+  it('preserves version when YAML is unchanged (including whitespace-only diffs)', () => {
+    const existing = { ...baseDocument(), version: 6, yaml: '  name: Test\n' };
+    expect(
+      applyWorkflowVersion(
+        { ...existing, tags: ['new'], yaml: 'name: Test\n  ', lastUpdatedBy: 'other' },
+        existing
+      )
+    ).toEqual(expect.objectContaining({ tags: ['new'], version: 6 }));
+  });
+
+  it('heals legacy missing version to 1 when YAML is unchanged', () => {
+    const existing = { ...baseDocument(), version: undefined, yaml: 'name: Test' };
+    expect(applyWorkflowVersion({ ...existing, tags: ['new'] }, existing).version).toBe(
+      INITIAL_WORKFLOW_VERSION
     );
   });
 
-  it('uses fresh existing version after concurrent writer wins OCC', () => {
-    const staleExisting = { ...baseDocument(), version: 5 };
-    const freshExisting = { ...baseDocument(), version: 6 };
-    const document = { ...staleExisting, tags: ['patched'] };
+  it('treats nullish YAML as empty for change detection', () => {
+    const existing = { ...baseDocument(), version: 2, yaml: undefined as unknown as string };
+    expect(applyWorkflowVersion({ ...existing, yaml: '' }, existing).version).toBe(2);
+    expect(applyWorkflowVersion({ ...existing, yaml: 'name: A\n' }, existing).version).toBe(3);
+  });
+
+  it('uses fresh existing version after concurrent writer wins OCC when YAML changed', () => {
+    const staleExisting = { ...baseDocument(), version: 5, yaml: 'name: Old' };
+    const freshExisting = { ...baseDocument(), version: 6, yaml: 'name: Old' };
+    const document = { ...staleExisting, yaml: 'name: New', tags: ['patched'] };
 
     expect(applyWorkflowVersion(document, staleExisting).version).toBe(6);
     expect(applyWorkflowVersion(document, freshExisting).version).toBe(7);

--- a/src/platform/plugins/shared/workflows_management/server/lib/workflow_version.ts
+++ b/src/platform/plugins/shared/workflows_management/server/lib/workflow_version.ts
@@ -15,11 +15,30 @@ export const INITIAL_WORKFLOW_VERSION = 1;
 export const getNextWorkflowVersion = (existing?: Pick<WorkflowProperties, 'version'>): number =>
   (existing?.version ?? 0) + 1;
 
-/** Assign the next definition version from fresh primary-index state. */
+/** Same trim normalization as managed `definitionHash`. */
+const hasWorkflowYamlChanged = (
+  previousYaml: string | undefined | null,
+  nextYaml: string | undefined | null
+): boolean => (previousYaml ?? '').trim() !== (nextYaml ?? '').trim();
+
+/**
+ * Assign definition version from fresh primary-index state.
+ * Create (`existing` undefined) → 1. Update → bump only when YAML changed;
+ * otherwise preserve.
+ */
 export const applyWorkflowVersion = (
   document: WorkflowProperties,
   existing?: WorkflowProperties
-): WorkflowProperties => ({
-  ...document,
-  version: getNextWorkflowVersion(existing),
-});
+): WorkflowProperties => {
+  if (existing && !hasWorkflowYamlChanged(existing.yaml, document.yaml)) {
+    return {
+      ...document,
+      version: existing.version ?? INITIAL_WORKFLOW_VERSION,
+    };
+  }
+
+  return {
+    ...document,
+    version: getNextWorkflowVersion(existing),
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts
@@ -513,8 +513,11 @@ describe('ManagedWorkflowsService', () => {
       );
     });
 
-    it('bumps document.version from the existing document on managed update', async () => {
-      const definition = createDefinition({ version: 2 });
+    it('bumps document.version and logs history when managed update changes YAML', async () => {
+      const definition = createDefinition({
+        version: 2,
+        yaml: workflowYaml({ name: 'Managed Workflow - Updated' }),
+      });
       mockManagedWorkflowDefinitions = [definition];
       const { audit, crudService, service } = createService();
       mockPrepareReturnsInitialVersion(crudService);
@@ -524,6 +527,7 @@ describe('ManagedWorkflowsService', () => {
             version: 5,
             definitionHash: 'old-hash',
             managedVersion: 1,
+            yaml: workflowYaml({ name: 'Managed Workflow - Original' }),
           })
         )
       );
@@ -563,6 +567,36 @@ describe('ManagedWorkflowsService', () => {
         spaceId: SPACE_ID,
         reason: 'reinstall',
       });
+    });
+
+    it('preserves document.version and skips history when managed update YAML is unchanged', async () => {
+      const definition = createDefinition({ version: 2 });
+      mockManagedWorkflowDefinitions = [definition];
+      const { audit, crudService, service } = createService();
+      mockPrepareReturnsInitialVersion(crudService);
+      const existingYaml = workflowYaml();
+      crudService.getWorkflowDocumentWithVersion.mockResolvedValue(
+        createVersionedDocument(
+          createWorkflowSource({
+            version: 5,
+            definitionHash: 'old-hash',
+            managedVersion: 1,
+            yaml: existingYaml,
+          })
+        )
+      );
+
+      await service.installManagedWorkflow(WORKFLOW_ID, { spaceId: SPACE_ID }, definition.pluginId);
+
+      expect(crudService.writeWorkflowDocumentWithOcc).toHaveBeenCalledWith(
+        WORKFLOW_ID,
+        SPACE_ID,
+        expect.objectContaining({
+          document: expect.objectContaining({ version: 5, managedVersion: 2 }),
+        })
+      );
+      expect(crudService.logWorkflowChangesAfterWrite).not.toHaveBeenCalled();
+      expect(audit.logWorkflowUpdated).toHaveBeenCalled();
     });
 
     it('logs workflow install to change history after creating a managed workflow', async () => {

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
@@ -276,12 +276,14 @@ export class ManagedWorkflowsService {
         ifPrimaryTerm: existingDocument.primaryTerm,
       }
     );
-    await this.deps.crudService.logWorkflowChangesAfterWrite({
-      workflows: [{ id: workflowDocumentId, document: savedDocument }],
-      action: WorkflowChangeHistoryAction.workflowUpdate,
-      spaceId,
-      timestamp: now,
-    });
+    if (savedDocument.version !== existing.version) {
+      await this.deps.crudService.logWorkflowChangesAfterWrite({
+        workflows: [{ id: workflowDocumentId, document: savedDocument }],
+        action: WorkflowChangeHistoryAction.workflowUpdate,
+        spaceId,
+        timestamp: now,
+      });
+    }
     this.deps.audit?.logWorkflowUpdated(undefined, {
       id: workflowDocumentId,
       managed: true,

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.restore.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.restore.test.ts
@@ -95,14 +95,12 @@ const makeFinalWorkflowProperties = (
 interface ApplyWorkflowUpdateResult {
   response: UpdatedWorkflowResponseDto;
   finalData: WorkflowProperties;
-  timestamp: Date;
 }
 
 const makeApplyWorkflowUpdateResult = (
   overrides: {
     response?: Partial<UpdatedWorkflowResponseDto>;
     finalData?: WorkflowProperties;
-    timestamp?: Date;
   } = {}
 ): ApplyWorkflowUpdateResult => ({
   response: {
@@ -115,7 +113,6 @@ const makeApplyWorkflowUpdateResult = (
     ...overrides.response,
   },
   finalData: overrides.finalData ?? makeFinalWorkflowProperties(),
-  timestamp: overrides.timestamp ?? new Date('2026-01-02T00:00:00.000Z'),
 });
 
 interface WorkflowCrudServiceWithApplyUpdate {
@@ -123,7 +120,9 @@ interface WorkflowCrudServiceWithApplyUpdate {
     id: string,
     workflow: Partial<{ yaml: string }>,
     spaceId: string,
-    request: ReturnType<typeof httpServerMock.createKibanaRequest>
+    request: ReturnType<typeof httpServerMock.createKibanaRequest>,
+    historyAction: string,
+    restoreMetadata?: { eventId: string; sequence?: number }
   ) => Promise<ApplyWorkflowUpdateResult>;
 }
 
@@ -144,16 +143,12 @@ describe('WorkflowCrudService.restoreWorkflowVersion', () => {
     const applyWorkflowUpdate = jest
       .spyOn(service as unknown as WorkflowCrudServiceWithApplyUpdate, 'applyWorkflowUpdate')
       .mockResolvedValue(makeApplyWorkflowUpdateResult());
-    const logWorkflowChangesAfterWrite = jest
-      .spyOn(service, 'logWorkflowChangesAfterWrite')
-      .mockResolvedValue();
 
-    return { service, getHistory, applyWorkflowUpdate, logWorkflowChangesAfterWrite };
+    return { service, getHistory, applyWorkflowUpdate };
   };
 
-  it('restores snapshot yaml via applyWorkflowUpdate and logs restore change history', async () => {
-    const { service, getHistory, applyWorkflowUpdate, logWorkflowChangesAfterWrite } =
-      makeService();
+  it('restores snapshot yaml via applyWorkflowUpdate with restore history options', async () => {
+    const { service, getHistory, applyWorkflowUpdate } = makeService();
 
     const result = await service.restoreWorkflowVersion('wf-1', 'event-v3', 'default', request);
 
@@ -165,19 +160,13 @@ describe('WorkflowCrudService.restoreWorkflowVersion', () => {
       'wf-1',
       { yaml: 'name: Restored workflow' },
       'default',
-      request
-    );
-    expect(logWorkflowChangesAfterWrite).toHaveBeenCalledWith({
-      workflows: [{ id: 'wf-1', document: makeFinalWorkflowProperties() }],
-      action: WorkflowChangeHistoryAction.workflowRestore,
-      spaceId: 'default',
-      timestamp: new Date('2026-01-02T00:00:00.000Z'),
       request,
-      restoreMetadata: {
+      WorkflowChangeHistoryAction.workflowRestore,
+      {
         eventId: 'event-v3',
         sequence: 3,
-      },
-    });
+      }
+    );
     expect(result).toEqual(
       expect.objectContaining({
         id: 'wf-1',
@@ -415,6 +404,23 @@ describe('WorkflowCrudService.restoreWorkflowVersion integration', () => {
         document: expect.objectContaining({
           enabled: false,
           yaml: expect.stringContaining('enabled: false'),
+        }),
+      })
+    );
+  });
+
+  it('skips change history and version bump when restored YAML matches stored YAML', async () => {
+    const { service, client, scopedChangeHistory } = makeIntegrationService(workflowYamlV2);
+
+    const result = await service.restoreWorkflowVersion('wf-1', 'event-v3', 'default', request);
+
+    expect(result.version).toBe(7);
+    expect(scopedChangeHistory.logBulk).not.toHaveBeenCalled();
+    expect(client.index).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.objectContaining({
+          yaml: workflowYamlV2,
+          version: 7,
         }),
       })
     );

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.test.ts
@@ -820,7 +820,7 @@ describe('WorkflowCrudService', () => {
 
       const result = await service.bulkCreateWorkflows([], 'default', request);
 
-      expect(result).toEqual({ created: [], failed: [], historyActionsById: {} });
+      expect(result).toEqual({ created: [], failed: [] });
       expect(client.bulk).not.toHaveBeenCalled();
     });
 
@@ -1076,7 +1076,7 @@ describe('WorkflowCrudService', () => {
       client.index.mockResolvedValue({ result: 'updated', _seq_no: 2, _primary_term: 1 });
 
       const service = new WorkflowCrudService(deps);
-      const result = await service.bulkCreateWorkflows(
+      await service.bulkCreateWorkflows(
         [
           { id: 'wf-existing', yaml: validYaml('Existing') },
           { id: 'wf-new', yaml: validYaml('New') },
@@ -1085,11 +1085,6 @@ describe('WorkflowCrudService', () => {
         request,
         { overwrite: true }
       );
-
-      expect(result.historyActionsById).toEqual({
-        'wf-new': WorkflowChangeHistoryAction.workflowCreate,
-        'wf-existing': WorkflowChangeHistoryAction.workflowUpdate,
-      });
       expect(mockedLogWorkflowChanges).toHaveBeenCalledWith(
         expect.objectContaining({
           getAction: expect.any(Function),
@@ -1098,7 +1093,6 @@ describe('WorkflowCrudService', () => {
         })
       );
       const callArgs = mockedLogWorkflowChanges.mock.calls[0][0];
-      expect(callArgs.getAction).toBeDefined();
       expect(callArgs.getAction!('wf-new')).toBe(WorkflowChangeHistoryAction.workflowCreate);
       expect(callArgs.getAction!('wf-existing')).toBe(WorkflowChangeHistoryAction.workflowUpdate);
     });
@@ -1119,9 +1113,6 @@ describe('WorkflowCrudService', () => {
       );
 
       expect(result.created).toHaveLength(1);
-      expect(result.historyActionsById).toEqual({
-        'wf-new': WorkflowChangeHistoryAction.workflowCreate,
-      });
       expect(client.bulk).toHaveBeenCalledWith({
         operations: [
           {
@@ -1156,19 +1147,16 @@ describe('WorkflowCrudService', () => {
       client.index.mockResolvedValue({ result: 'updated', _seq_no: 4, _primary_term: 1 });
 
       const service = new WorkflowCrudService(deps);
-      const result = await service.bulkCreateWorkflows(
+      await service.bulkCreateWorkflows(
         [{ id: 'wf-existing', yaml: validYaml('Existing') }],
         'default',
         request,
         { overwrite: true }
       );
-
-      expect(result.historyActionsById).toEqual({
-        'wf-existing': WorkflowChangeHistoryAction.workflowUpdate,
-      });
       expect(mockedLogWorkflowChanges).toHaveBeenCalledWith(
         expect.objectContaining({
           getAction: expect.any(Function),
+          workflows: [expect.objectContaining({ id: 'wf-existing' })],
         })
       );
       const callArgs = mockedLogWorkflowChanges.mock.calls[0][0];
@@ -1184,23 +1172,60 @@ describe('WorkflowCrudService', () => {
       });
 
       const service = new WorkflowCrudService(deps);
-      const result = await service.bulkCreateWorkflows(
+      await service.bulkCreateWorkflows(
         [{ id: 'wf-new', yaml: validYaml('New') }],
         'default',
         request,
         { overwrite: true }
       );
-
-      expect(result.historyActionsById).toEqual({
-        'wf-new': WorkflowChangeHistoryAction.workflowCreate,
-      });
       expect(mockedLogWorkflowChanges).toHaveBeenCalledWith(
         expect.objectContaining({
           getAction: expect.any(Function),
+          workflows: [expect.objectContaining({ id: 'wf-new' })],
         })
       );
-      const callArgs = mockedLogWorkflowChanges.mock.calls[0][0];
-      expect(callArgs.getAction!('wf-new')).toBe(WorkflowChangeHistoryAction.workflowCreate);
+      const createCallArgs = mockedLogWorkflowChanges.mock.calls[0][0];
+      expect(createCallArgs.getAction!('wf-new')).toBe(WorkflowChangeHistoryAction.workflowCreate);
+    });
+
+    it('overwrite=true preserves version and skips history when YAML is unchanged', async () => {
+      mockedLogWorkflowChanges.mockClear();
+      const scopedChangeHistory = { logBulk: jest.fn() };
+      const changeHistoryService = {
+        isInitialized: () => true,
+        asScoped: jest.fn().mockReturnValue(scopedChangeHistory),
+      };
+      const { deps, client } = makeDeps();
+      deps.changeHistoryService = changeHistoryService as any;
+      const existingYaml = validYaml('Existing');
+      client.search
+        .mockResolvedValueOnce({
+          hits: {
+            hits: [occSearchHit('wf-existing', { version: 7, yaml: existingYaml }, 3, 1)],
+          },
+        })
+        .mockResolvedValueOnce({
+          hits: {
+            hits: [occSearchHit('wf-existing', { version: 7, yaml: existingYaml }, 3, 1)],
+          },
+        });
+      client.index.mockResolvedValue({ result: 'updated', _seq_no: 4, _primary_term: 1 });
+
+      const service = new WorkflowCrudService(deps);
+      const result = await service.bulkCreateWorkflows(
+        [{ id: 'wf-existing', yaml: existingYaml }],
+        'default',
+        request,
+        { overwrite: true }
+      );
+
+      expect(result.created).toHaveLength(1);
+      expect(client.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({ version: 7, yaml: existingYaml }),
+        })
+      );
+      expect(mockedLogWorkflowChanges).not.toHaveBeenCalled();
     });
 
     it('overwrite=true surfaces OCC conflicts as failures after retries are exhausted', async () => {
@@ -1743,6 +1768,76 @@ describe('WorkflowCrudService', () => {
               document: expect.objectContaining({ tags: ['t1', 't2'], version: 5 }),
             }),
           ],
+        })
+      );
+    });
+
+    it('preserves version and skips change history when YAML is unchanged', async () => {
+      mockedLogWorkflowChanges.mockClear();
+      const scopedChangeHistory = { logBulk: jest.fn() };
+      const changeHistoryService = {
+        isInitialized: () => true,
+        asScoped: jest.fn().mockReturnValue(scopedChangeHistory),
+      };
+      const { deps, client } = makeDeps();
+      deps.changeHistoryService = changeHistoryService as any;
+      client.search.mockResolvedValue({
+        hits: {
+          hits: [
+            {
+              _id: 'wf-1',
+              _source: makeSource({ version: 4 }),
+              _seq_no: 5,
+              _primary_term: 1,
+            },
+          ],
+        },
+      });
+
+      const service = new WorkflowCrudService(deps);
+      await service.updateWorkflow('wf-1', {} as any, 'default', request);
+
+      expect(client.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({ version: 4 }),
+        })
+      );
+      expect(mockedLogWorkflowChanges).not.toHaveBeenCalled();
+    });
+
+    it('heals legacy missing version and writes change history when YAML is unchanged', async () => {
+      mockedLogWorkflowChanges.mockClear();
+      const scopedChangeHistory = { logBulk: jest.fn() };
+      const changeHistoryService = {
+        isInitialized: () => true,
+        asScoped: jest.fn().mockReturnValue(scopedChangeHistory),
+      };
+      const { deps, client } = makeDeps();
+      deps.changeHistoryService = changeHistoryService as any;
+      client.search.mockResolvedValue({
+        hits: {
+          hits: [
+            {
+              _id: 'wf-1',
+              _source: makeSource({ version: undefined }),
+              _seq_no: 5,
+              _primary_term: 1,
+            },
+          ],
+        },
+      });
+
+      const service = new WorkflowCrudService(deps);
+      await service.updateWorkflow('wf-1', {} as any, 'default', request);
+
+      expect(client.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({ version: 1 }),
+        })
+      );
+      expect(mockedLogWorkflowChanges).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflows: [expect.objectContaining({ id: 'wf-1' })],
         })
       );
     });

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
@@ -107,35 +107,16 @@ export type {
 interface ApplyWorkflowUpdateResult {
   response: UpdatedWorkflowResponseDto;
   finalData: WorkflowProperties;
-  timestamp: Date;
 }
 
 export interface BulkCreateWorkflowsResult {
   created: WorkflowDetailDto[];
   failed: BulkFailureEntry[];
-  historyActionsById: Record<string, WorkflowChangeHistoryActionType>;
 }
 
 type SuccessfullyWrittenBulkEntry = BulkWorkflowEntry & {
   workflowData: WorkflowProperties;
-  existedBeforeWrite?: boolean;
 };
-
-const resolveBulkHistoryAction = (
-  entry: SuccessfullyWrittenBulkEntry,
-  overwrite: boolean
-): WorkflowChangeHistoryActionType =>
-  overwrite && entry.existedBeforeWrite
-    ? WorkflowChangeHistoryAction.workflowUpdate
-    : WorkflowChangeHistoryAction.workflowCreate;
-
-const toHistoryActionsById = (
-  entries: readonly SuccessfullyWrittenBulkEntry[],
-  overwrite: boolean
-): Record<string, WorkflowChangeHistoryActionType> =>
-  Object.fromEntries(
-    entries.map((entry) => [entry.id, resolveBulkHistoryAction(entry, overwrite)])
-  );
 
 export class WorkflowCrudService {
   private indexOccWriter?: OccWriter<WorkflowProperties>;
@@ -659,7 +640,10 @@ export class WorkflowCrudService {
     const successfullyWritten: SuccessfullyWrittenBulkEntry[] = [];
 
     if (overwrite) {
-      const overwriteResult = await this.executeBulkOverwrite(resolvedWorkflows, spaceId);
+      const overwriteResult = await this.executeBulkOverwrite(resolvedWorkflows, spaceId, {
+        request,
+        timestamp: now,
+      });
       created.push(...overwriteResult.created);
       failed.push(...overwriteResult.failed);
       successfullyWritten.push(...overwriteResult.successfullyWritten);
@@ -692,7 +676,7 @@ export class WorkflowCrudService {
 
           if (!operation?.error) {
             created.push(transformStorageDocumentToWorkflowDto(entry.id, entry.workflowData));
-            successfullyWritten.push({ ...entry, existedBeforeWrite: false });
+            successfullyWritten.push(entry);
           } else {
             const isVersionConflict = operation.status === OCC_CONFLICT_STATUS_CODE;
             const canRetry = isVersionConflict && entry.idSource === 'server-generated';
@@ -719,6 +703,20 @@ export class WorkflowCrudService {
           this.checkExistingIds(candidateIds)
         );
         pending = toRetryEntries.map((entry, i) => ({ ...entry, id: reResolved[i] }));
+      }
+
+      if (successfullyWritten.length > 0) {
+        await this.logWorkflowChangesAfterWrite({
+          workflows: successfullyWritten.map((entry) => ({
+            id: entry.id,
+            document: entry.workflowData,
+          })),
+          action: WorkflowChangeHistoryAction.workflowCreate,
+          spaceId,
+          timestamp: now,
+          request,
+          correlationId: randomBytes(16).toString('hex'),
+        });
       }
     }
 
@@ -758,32 +756,16 @@ export class WorkflowCrudService {
       );
     }
 
-    const historyActionsById = toHistoryActionsById(successfullyWritten, overwrite);
-
-    if (successfullyWritten.length > 0) {
-      await this.logWorkflowChangesAfterWrite({
-        workflows: successfullyWritten.map((entry) => ({
-          id: entry.id,
-          document: entry.workflowData,
-        })),
-        ...(overwrite
-          ? { getAction: (id) => historyActionsById[id] }
-          : { action: WorkflowChangeHistoryAction.workflowCreate }),
-        spaceId,
-        timestamp: now,
-        request,
-        correlationId: randomBytes(16).toString('hex'),
-      });
-    }
-
-    return { created, failed, historyActionsById };
+    return { created, failed };
   }
 
   private async applyWorkflowUpdate(
     id: string,
     workflow: Partial<EsWorkflow>,
     spaceId: string,
-    request: KibanaRequest
+    request: KibanaRequest,
+    historyAction: WorkflowChangeHistoryActionType,
+    restoreMetadata?: WorkflowRestoreMetadata
   ): Promise<ApplyWorkflowUpdateResult> {
     const authenticatedUser = getAuthenticatedUser(request, this.deps.getSecurity());
     const now = new Date();
@@ -809,6 +791,7 @@ export class WorkflowCrudService {
           }
         : undefined;
 
+    let previousVersion: number | undefined;
     const finalData = await this.readModifyWriteWorkflowDocument(id, spaceId, {
       getOptions: { includeDeleted: true, includeGlobal: true },
       mutate: (existingSource: WorkflowProperties) => {
@@ -855,6 +838,7 @@ export class WorkflowCrudService {
         if (merged.triggerTypes === undefined) {
           merged.triggerTypes = getTriggerTypesFromDefinition(merged.definition) ?? [];
         }
+        previousVersion = existingSource.version;
         return merged;
       },
     });
@@ -867,6 +851,17 @@ export class WorkflowCrudService {
       shouldUpdateScheduler,
     });
 
+    if (finalData.version !== previousVersion) {
+      await this.logWorkflowChangesAfterWrite({
+        workflows: [{ id, document: finalData }],
+        action: historyAction,
+        spaceId,
+        timestamp: now,
+        request,
+        restoreMetadata,
+      });
+    }
+
     return {
       response: {
         id,
@@ -877,7 +872,6 @@ export class WorkflowCrudService {
         valid: finalData.valid,
       },
       finalData,
-      timestamp: now,
     };
   }
 
@@ -888,20 +882,13 @@ export class WorkflowCrudService {
     request: KibanaRequest
   ): Promise<UpdatedWorkflowResponseDto> {
     try {
-      const { response, finalData, timestamp } = await this.applyWorkflowUpdate(
+      const { response } = await this.applyWorkflowUpdate(
         id,
         workflow,
         spaceId,
-        request
-      );
-
-      await this.logWorkflowChangesAfterWrite({
-        workflows: [{ id, document: finalData }],
-        action: WorkflowChangeHistoryAction.workflowUpdate,
-        spaceId,
-        timestamp,
         request,
-      });
+        WorkflowChangeHistoryAction.workflowUpdate
+      );
 
       return response;
     } catch (error) {
@@ -941,24 +928,17 @@ export class WorkflowCrudService {
 
     const sequence = historyEvent.object.sequence;
 
-    const { response, finalData, timestamp } = await this.applyWorkflowUpdate(
+    const { response, finalData } = await this.applyWorkflowUpdate(
       workflowId,
       { yaml },
       spaceId,
-      request
-    );
-
-    await this.logWorkflowChangesAfterWrite({
-      workflows: [{ id: workflowId, document: finalData }],
-      action: WorkflowChangeHistoryAction.workflowRestore,
-      spaceId,
-      timestamp,
       request,
-      restoreMetadata: {
+      WorkflowChangeHistoryAction.workflowRestore,
+      {
         eventId,
         ...(sequence != null ? { sequence } : {}),
-      },
-    });
+      }
+    );
 
     if (finalData.version == null) {
       throw new Error(`Workflow '${workflowId}' is missing version after restore.`);
@@ -1108,7 +1088,8 @@ export class WorkflowCrudService {
 
   private async executeBulkOverwrite(
     entries: BulkWorkflowEntry[],
-    spaceId: string
+    spaceId: string,
+    params: { request: KibanaRequest; timestamp: Date }
   ): Promise<{
     created: WorkflowDetailDto[];
     failed: BulkFailureEntry[];
@@ -1117,6 +1098,11 @@ export class WorkflowCrudService {
     const created: WorkflowDetailDto[] = [];
     const failed: BulkFailureEntry[] = [];
     const successfullyWritten: SuccessfullyWrittenBulkEntry[] = [];
+    const historyEntries: Array<{
+      id: string;
+      document: WorkflowProperties;
+      action: WorkflowChangeHistoryActionType;
+    }> = [];
 
     if (entries.length === 0) {
       return { created, failed, successfullyWritten };
@@ -1169,7 +1155,12 @@ export class WorkflowCrudService {
 
         if (!operation?.error) {
           created.push(transformStorageDocumentToWorkflowDto(entry.id, document));
-          successfullyWritten.push({ ...entry, workflowData: document, existedBeforeWrite: false });
+          successfullyWritten.push({ ...entry, workflowData: document });
+          historyEntries.push({
+            id: entry.id,
+            document,
+            action: WorkflowChangeHistoryAction.workflowCreate,
+          });
         } else {
           failed.push({
             index: entry.idx,
@@ -1184,12 +1175,23 @@ export class WorkflowCrudService {
       for (const entry of inSpaceUpdateEntries) {
         const prepared = entry.workflowData;
         try {
+          let previousVersion: number | undefined;
           const document = await this.readModifyWriteWorkflowDocument(entry.id, spaceId, {
             getOptions: bulkOverwriteGetOptions,
-            mutate: (existing) => this.buildBulkOverwriteDocument(prepared, existing),
+            mutate: (existing) => {
+              previousVersion = existing.version;
+              return this.buildBulkOverwriteDocument(prepared, existing);
+            },
           });
           created.push(transformStorageDocumentToWorkflowDto(entry.id, document));
-          successfullyWritten.push({ ...entry, workflowData: document, existedBeforeWrite: true });
+          successfullyWritten.push({ ...entry, workflowData: document });
+          if (document.version !== previousVersion) {
+            historyEntries.push({
+              id: entry.id,
+              document,
+              action: WorkflowChangeHistoryAction.workflowUpdate,
+            });
+          }
         } catch (error) {
           failed.push({
             index: entry.idx,
@@ -1209,7 +1211,14 @@ export class WorkflowCrudService {
             ifPrimaryTerm: occHit.primaryTerm,
           });
           created.push(transformStorageDocumentToWorkflowDto(entry.id, document));
-          successfullyWritten.push({ ...entry, workflowData: document, existedBeforeWrite: true });
+          successfullyWritten.push({ ...entry, workflowData: document });
+          if (document.version !== occHit._source.version) {
+            historyEntries.push({
+              id: entry.id,
+              document,
+              action: WorkflowChangeHistoryAction.workflowUpdate,
+            });
+          }
         } catch (error) {
           failed.push({
             index: entry.idx,
@@ -1218,6 +1227,18 @@ export class WorkflowCrudService {
           });
         }
       }
+    }
+
+    if (historyEntries.length > 0) {
+      const actionsById = new Map(historyEntries.map((entry) => [entry.id, entry.action] as const));
+      await this.logWorkflowChangesAfterWrite({
+        workflows: historyEntries.map(({ id, document }) => ({ id, document })),
+        getAction: (id) => actionsById.get(id) ?? WorkflowChangeHistoryAction.workflowUpdate,
+        spaceId,
+        timestamp: params.timestamp,
+        request: params.request,
+        correlationId: randomBytes(16).toString('hex'),
+      });
     }
 
     return { created, failed, successfullyWritten };


### PR DESCRIPTION
## Summary

Fixes workflow change-history noise and stuck / missing version sequences by aligning `document.version` and history writes with stored YAML (trim compare, same idea as managed `definitionHash`).

**Before**
- History rows with no visible YAML delta (enable/tags/name/description no-ops that still rewrote nothing meaningful, identical restores, identical bulk overwrite / managed reconcile).
- Multiple timeline rows labeled **v1** when `version` was missing or not bumped with history.

<img width="4608" height="2700" alt="image" src="https://github.com/user-attachments/assets/48972d91-61e2-4688-b472-d607b652ac5c" />

**After**

| Case | Version | History |
|------|---------|---------|
| YAML changed | bump | yes |
| YAML same, version present | preserve | no |
| YAML same, version missing (legacy) | heal → `1` | yes (bootstrap first sequenced row) |
| Restore / overwrite / managed reinstall with identical YAML | preserve | no |

Applies to CRUD update, restore, bulk create/overwrite, and managed install/reinstall.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->