### PR TITLE
[Dashboards in Chat] Slim down the dashboard skill guidance

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common/dashboard_schema_types.ts
+++ b/x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common/dashboard_schema_types.ts
@@ -17,10 +17,18 @@ import { z } from '@kbn/zod/v4';
  * Dashboard grid is 48 columns wide; height is in same units.
  */
 export const panelGridSchema = z.object({
-  x: z.number(),
-  y: z.number(),
-  w: z.number().int().min(1).max(48),
-  h: z.number().int().min(1),
+  x: z
+    .number()
+    .describe(
+      'Leftmost column, 0-based, in a 48-column grid. `x + w` must not exceed 48. Inside a section, coordinates are section-relative.'
+    ),
+  y: z
+    .number()
+    .describe(
+      'Top row, 0-based, growing downwards from the top-left origin. Inside a section, each section starts again at 0.'
+    ),
+  w: z.number().int().min(1).max(48).describe('Width in columns, out of 48.'),
+  h: z.number().int().min(1).describe('Height in rows. Roughly 20-24 rows fit on a 16:9 screen.'),
 });
 
 // ============================================================================
@@ -45,7 +53,13 @@ export type AttachmentPanel = z.infer<typeof attachmentPanelSchema>;
 // ============================================================================
 
 export const sectionGridSchema = z.object({
-  y: z.number().int().min(0).describe('Section position in outer dashboard grid coordinates.'),
+  y: z
+    .number()
+    .int()
+    .min(0)
+    .describe(
+      'Section position in outer dashboard grid coordinates. A section occupies exactly one outer row regardless of how tall its panels are, so the next widget below it goes at `y + 1`.'
+    ),
 });
 
 const dashboardSectionSchema = z.object({

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/design/composition.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/design/composition.ts
@@ -14,10 +14,8 @@ A well-composed dashboard tells a coherent story about the data:
 2. **Lead with high-level metrics** (Metric or Gauge panels): total counts, averages, key performance indicators that give an at-a-glance summary.
 3. **Follow with time-series trends** (XY line/area panels): how the key metrics change over time.
 4. **Add breakdowns and distributions** (XY bar, Heatmap, Tagcloud panels): top-N rankings, categorical splits, and density views.
-5. **Include as many panels as are valuable for the underlying data and user intent.** Let the richness and diversity of the available fields drive the panel count instead of a fixed numeric target.
-6. **Every panel should serve a clear purpose.** Do not add panels just to fill space, but do not artificially limit the dashboard when more panels would provide genuine insight.
 
-When the user's request is vague (e.g., "create a dashboard for my logs"), explore the discovered index mapping thoroughly and compose a rich dashboard that covers the breadth of the available data — overview metrics, time-series trends, breakdowns, and distributions. Let the fields drive the panel count rather than defaulting to a minimal set.
+Let the data decide how many panels that comes to. A rich set of fields deserves a rich dashboard, and a vague request such as "create a dashboard for my logs" is a reason to explore the index mapping and cover the breadth of what is there rather than to ship a minimal set. A panel that tells the reader nothing is still noise, however, so every one should earn its space.
 
 ### When to use sections
 

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/design/grid_layout.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/design/grid_layout.ts
@@ -7,9 +7,7 @@
 
 export const gridLayoutPrompt = `## Panel Layout
 
-The dashboard uses a **48-column grid**. On a 16:9 screen, roughly **20–24 rows** are visible without scrolling. Aim for **8–12 panels above the fold**.
-
-Every \`add_panels.panels[]\` item and every \`add_section.panels[]\` item requires \`grid: { x, y, w, h }\`. The origin \`(0, 0)\` is the top-left corner.
+Panels are placed on the 48-column grid described by each panel's \`grid\` field. On a 16:9 screen roughly 20–24 rows are visible, so the first 8–12 panels are what a reader sees before scrolling — put the panels that answer the question there.
 
 ### Grid sizes by chart type
 
@@ -30,6 +28,8 @@ Use these sizes — **do not make metric or gauge panels full-width**:
 
 Prefer \`w\` values that divide 48 evenly: **6, 8, 12, 24, 48**.
 
+These sizes bind on \`update_panel_layouts\` too: moving a panel changes \`x\` and \`y\`, never \`w\` and \`h\`, unless the user asked for a resize.
+
 **Grid Packing Rules:**
 
 - **Eliminate Dead Space:** Always calculate the bottom edge (\`y + h\`) of every panel. When starting a new row or
@@ -40,38 +40,18 @@ Prefer \`w\` values that divide 48 evenly: **6, 8, 12, 24, 48**.
 
 ### Positioning rules
 
-Always set \`x\` and \`y\` so panels tile with **no gaps**:
+Panels should tile with no gaps:
 
 1. **Fill rows left to right.** Start at \`x: 0\`. The next panel's \`x\` = previous panel's \`x + w\`. When a panel would exceed column 48, start a new row.
 2. **New row \`y\`** = previous row's \`y + max(h)\` of all panels in that row.
 3. **Same \`h\` per row** when possible, so rows align cleanly.
-4. Panels' \`x + w\` must never exceed 48.
-5. **When updating a dashboard**, inspect the existing panels' \`grid\` from the previous tool result. If there is empty space (a gap where a panel was removed, or unused columns beside a tall panel), place the new panel in that gap instead of appending below. Choose \`w\` and \`h\` to fit the available space.
-6. **Markdown panels** use agent-specified \`grid\` like any other panel. Size based on content length (\`w: 24–48, h: 4–9\`). Account for their height when positioning subsequent panels.
+4. **When updating a dashboard**, inspect the existing panels' \`grid\` from the previous tool result. If there is empty space — a gap where a panel was removed, or unused columns beside a tall panel — place the new panel there instead of appending below, at whichever size from the list above fits.
 
-### Reflow after removals
+### After removing a panel
 
-- If removing a panel leaves a gap in a row, shift the affected neighboring panels left by re-adding them with updated \`x\` values.
-- If removing a panel leaves later rows with unnecessary empty space above them, re-add the affected panels with updated \`y\` values.
+Vertical gaps close by themselves, horizontal ones do not. So when \`remove_panels\` takes out a panel that had row-mates, include an \`update_panel_layouts\` in the same call that slides the rest of that row left, without being asked. Keep every panel at the size its chart type calls for: a row ending before column 48 is fine — better than stretching a panel to fill it.
 
-### Section grid rules
+### Sections and the outer grid
 
-- When using \`add_section\`, each section has its own coordinate space.
-- Panels nested under \`add_section.panels\` use that same section-relative coordinate space.
-- Panel coordinates inside a section are section-relative: each section starts at \`y: 0\`. The same 48-column grid and sizing guidance apply within each section.
-- A section occupies exactly one row (\`h: 1\`) in the outer dashboard grid. When placing widgets after a section, compute the next outer \`y\` as \`section.grid.y + 1\` (not by summing internal panel heights).
-- Internal section panel heights affect layout inside the section only; they do not increase the section's outer-grid height.
-- When mixing top-level panels and sections, compute outer \`y\` sequentially: top-level panels advance by \`y + h\`, sections advance by \`y + 1\`.
-- **Inserting above existing sections:** Top-level panels and sections share the same outer grid coordinates. If a section occupies \`y: 0\`, a new top-level panel at \`y: 0\` will collide and be pushed **below** the section. To place a panel above an existing section, first \`remove_section\` (with \`panelAction: "promote"\` or \`"delete"\`) and re-add it via \`add_section\` at a higher \`y\` to make room, then add the panel at the freed \`y\`.
-
-### Example: 4 KPI metrics + 2 time-series charts + 1 breakdown bar chart
-
-\`\`\`
-metric  (x:0,  y:0,  w:12, h:5)
-metric  (x:12, y:0,  w:12, h:5)
-metric  (x:24, y:0,  w:12, h:5)
-metric  (x:36, y:0,  w:12, h:5)
-xy-line (x:0,  y:5,  w:24, h:10)
-xy-line (x:24, y:5,  w:24, h:10)
-xy-bar  (x:0,  y:15, w:48, h:10)
-\`\`\``;
+- When mixing top-level panels and sections, walk the outer grid in order: a top-level panel advances the next \`y\` by its own \`h\`, a section advances it by 1.
+- **Inserting above an existing section:** top-level panels and sections share the outer grid coordinates, so a new panel at a \`y\` that a section already occupies collides with it and gets pushed below. To make room, \`remove_section\` (with \`panelAction: "promote"\` to keep its panels, or \`"delete"\` to discard them), re-add it with \`add_section\` at a higher \`y\`, then add the new panel at the freed \`y\`.`;

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/generation_guidance.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/generation_guidance.ts
@@ -9,79 +9,46 @@ import { getChartTypeSelectionPromptContent } from '@kbn/agent-builder-visualiza
 import { dashboardTools } from '../../../common';
 import type { DashboardGuidanceModule } from '../guidance_module';
 import { dashboardDesignGuidancePrompt } from './design';
+import {
+  panelEditingReference,
+  PANEL_EDITING_REFERENCE_NAME,
+  PANEL_EDITING_REFERENCE_PATH,
+} from './panel_editing_reference';
 
 const chartTypeSelectionGuidance = getChartTypeSelectionPromptContent();
 
 const guidance = `## Building a Dashboard
 
-The ${dashboardTools.generateDashboard} tool builds the resulting dashboard from the current dashboard (if any) plus an ordered \`operations\` array. This section describes the \`operations\` vocabulary; see the environment workflow below for how the current dashboard is referenced and how the result is surfaced.
+The ${dashboardTools.generateDashboard} tool builds the resulting dashboard from the current dashboard (if any) plus an ordered \`operations\` array. The operation schemas describe the mechanics; this section is about what makes a dashboard worth looking at.
 
-Every dashboard MUST have a non-empty \`title\`. If the current dashboard's title is empty, missing, or \`"User Dashboard"\`, your first operation MUST be \`set_metadata\` with a title you invent from its contents.
+For a new dashboard, start with \`set_metadata\`, then create the panels. \`add_panels\` can create all of them in one operation, and \`add_section\` can create a section together with its initial panels — reach for a follow-up \`add_panels\` with \`sectionId\` only when targeting a section that already exists.
 
-Operations run in order, so earlier operations should set up state needed by later ones. Batch all operations into a single ${dashboardTools.generateDashboard} call whenever possible.
+For an existing dashboard, prefer \`edit_panels\` to change panel content in place and \`update_panel_layouts\` to resize or move panels, rather than removing and re-adding them.
 
-When a dashboard needs sections, prefer a single batched call:
-1. Use \`add_section\` with its optional \`panels\` array when you already know the panels that belong in the new section.
-2. Use a follow-up \`add_panels\` with per-item \`sectionId\` only when you need to target an existing section returned by an earlier tool result.
-
-For a new dashboard:
-- Start with \`set_metadata\` and provide both \`title\` and \`description\`. Only include \`time_range\` when the user explicitly named a specific time window (e.g. "last 7 days", "May 20–24"). Do not set it otherwise — a data-aware default is applied automatically.
-- Use \`add_panels\` to add panels in one batched operation. A single \`add_panels\` call may mix panel kinds and target different \`sectionId\` values, so batch related panels together.
-- Use \`add_section\` when panels naturally group into distinct topics or the dashboard is large enough that sections improve scanability. Include \`panels\` on the section when you can create that section's initial panels immediately.
-
-For an existing dashboard:
-- Prefer \`edit_panels\` to change existing panel content in place rather than removing and re-adding a panel.
-- If a requested change targets a DSL, form-based, or other non-ES|QL Lens visualization panel, explicitly tell the user direct editing is not supported and ask for confirmation before replacing that panel with a newly created ES|QL-based Lens panel.
-- Use \`update_panel_layouts\` to resize, reposition, or move existing panels between top-level and sections without changing panel content.
+**Read [${PANEL_EDITING_REFERENCE_NAME}.md](${PANEL_EDITING_REFERENCE_PATH}/${PANEL_EDITING_REFERENCE_NAME}.md) before any \`edit_panels\` call.** Not every panel can be edited in place, and the ones that cannot need the user's confirmation first.
 
 ## Panel Inputs
 
-- Use \`source: "request"\` to create or edit a Lens or Vega panel from a natural-language / ES|QL query — this is the only correct way to make a **new** visualization. Never hand-build a visualization \`config\` for a new visualization.
-- Use \`source: "config"\` only for content you have already resolved (an existing visualization's config, or markdown). The generation tool never reads an attachment or saved-object store, so the config must be supplied directly.
+Every new panel comes from one of two sources, and picking the wrong one is the most common way to produce a broken panel:
+
+- \`source: "request"\` resolves a Lens or Vega visualization from a natural-language query. This is how new visualizations are made — the tool generates and validates the ES|QL for you.
+- \`source: "config"\` takes content you have already resolved: an existing visualization's config read from an attachment, or markdown you are authoring. The tool never reads an attachment or saved-object store itself, so the config has to be passed by value.
 
 ## Chart Type Guidance
 
-For every new Lens panel, choose and pass \`chartType\`; it is required. For a new Vega panel, \`chartType\` is an optional authoring hint — omit it when no Lens chart type represents the requested visualization. On edits, \`chartType\` is optional because the existing panel configuration provides the current visual form. When editing a Lens panel, omit \`chartType\` to preserve its current chart family; provide a new \`chartType\` when the request changes the chart family, such as from \`xy\` to \`pie\`.
-
 ${chartTypeSelectionGuidance}
+
+For every new Lens panel, choose and pass \`chartType\`. For a new Vega panel it is an optional authoring hint — omit it when no Lens chart type represents the requested visualization. When editing a Lens panel, omit \`chartType\` to preserve its current chart family, and provide a new \`chartType\` when the request changes the chart family, such as from \`xy\` to \`pie\`.
 
 ${dashboardDesignGuidancePrompt}
 
-## ES|QL
-
-Omit the \`esql\` field on visualization panels unless you received a validated query from a prior tool result or the user pasted one explicitly. Do not write or derive ES|QL yourself — the tool generates it from the natural language \`query\`.
-
 ## Controls
 
-Controls are interactive filters pinned above the dashboard that let users explore data without editing queries. Add them with \`add_controls\` and remove them by id with \`remove_controls\`.
+Controls are interactive filters pinned above the dashboard that let users explore without editing queries. Add them with \`add_controls\` and remove them with \`remove_controls\`.
 
-**When building a new dashboard from scratch**, proactively add 3–5 \`options_list_control\` dropdowns for the most useful categorical fields. Pick fields that appear in panel \`BY\` / \`WHERE\` clauses, prefer low-cardinality keyword fields (e.g. \`service.name\`, \`host.name\`, \`env\`, \`region\`, \`kubernetes.namespace\`, \`http.response.status_code\`). Avoid high-cardinality identifiers (trace IDs, request IDs, UUIDs).
+A new dashboard usually deserves a few \`options_list_control\` dropdowns for the categorical fields a reader would actually filter by — typically the low-cardinality keyword fields that already appear in panel \`BY\` and \`WHERE\` clauses, such as \`service.name\`, \`host.name\`, or \`region\`. High-cardinality identifiers like trace or request IDs make useless dropdowns. A dashboard already scoped to a single entity, such as one host or one service, does not need controls at all.
 
-Do not add controls to dashboards already scoped to a single entity (one host, one service, etc.).
-
-**Control types:**
-- \`options_list_control\` — dropdown for categorical / keyword fields. The most common type (95% of cases).
-- \`range_slider_control\` — numeric range slider. Add sparingly, only when filtering by a numeric threshold is useful across multiple panels (e.g. \`latency\`, \`bytes\`, \`duration\`).
-- \`time_slider_control\` — global time sub-range picker. Add at most one per dashboard, only when time-range narrowing within the global window is useful.
-
-**Required fields per control:**
-- \`type\`: one of the three above.
-- \`field_name\` (not for \`time_slider_control\`): exact field name as it appears in the panel queries (e.g. \`"service.name"\`).
-- \`index\` (not for \`time_slider_control\`): same index as the dashboard panels (e.g. \`"logs-*"\`).
-- \`title\` (optional, \`options_list_control\` and \`range_slider_control\` only): human-readable label shown above the control (e.g. \`"Service"\`).
-
-**Defaults applied by the server:** \`width: "medium"\`, \`grow: true\` (fills available horizontal space). Override only if the user asks.
-
-**Removing controls:** use \`remove_controls\` with the \`id\` values from the \`controls[]\` list in the tool result.
-
-## Generation Edge Cases
-
-- Never invent a \`source: "config"\` payload for content you have not actually resolved. If you cannot obtain a panel's configuration, report it clearly instead of fabricating one.
-- Use \`update_panel_layouts\` when the user wants to resize, reposition, or move panels without changing panel content.
-- If a user wants to change a dashboard panel's content, prefer \`edit_panels\` over removing and re-adding the panel. \`edit_panels\` works for ES|QL-backed Lens visualization panels (\`source: "request"\`) and markdown panels (\`source: "config"\`, \`type: "markdown"\`).
-- A dashboard can include DSL-based, form-based, or other non-ES|QL Lens panels. Do not attempt to edit those panels directly.
-- If the user asks to modify a DSL visualization or any other non-ES|QL panel, explicitly explain that direct editing is not supported, propose recreating and replacing it as a new ES|QL-based Lens chart, and ask for confirmation before you remove or replace the existing panel.
-- Never silently follow a remove-and-recreate flow for a non-ES|QL panel. Wait for explicit user confirmation before regenerating the dashboard with replacement operations.`;
+The other two types are situational: \`range_slider_control\` for a numeric threshold worth filtering across several panels, and \`time_slider_control\` for narrowing time within the dashboard's global range.`;
 
 /**
  * Environment-agnostic dashboard *generation* guidance.
@@ -92,7 +59,11 @@ Do not add controls to dashboards already scoped to a single entity (one host, o
  * environment-specific and avoided here so the block can be reused across environments. Pair it with
  * an environment-specific rendering guidance block (e.g. the Kibana one) that explains how the
  * generated dashboard is surfaced.
+ *
+ * Panel editing details live in `referencedContent`. The body tells the agent to read that file
+ * before any `edit_panels` call, so it is loaded on edit requests only.
  */
 export const dashboardGeneration: DashboardGuidanceModule = {
   guidance,
+  referencedContent: [panelEditingReference],
 };

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/panel_editing_reference.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/panel_editing_reference.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReferencedContent } from '@kbn/agent-builder-server/skills/type_definition';
+
+export const PANEL_EDITING_REFERENCE_NAME = 'panel-editing';
+export const PANEL_EDITING_REFERENCE_PATH = './references';
+
+/**
+ * Read before every `edit_panels` call — the skill body says so unconditionally, so this covers
+ * the ordinary edit as well as the panels that cannot be edited at all.
+ */
+export const panelEditingReference: ReferencedContent = {
+  name: PANEL_EDITING_REFERENCE_NAME,
+  relativePath: PANEL_EDITING_REFERENCE_PATH,
+  content: `# Editing Existing Panels
+
+Work out what backs the target panel before calling \`edit_panels\`. What you find decides which of the two cases below you are in, and if you cannot determine it, you are in the second one.
+
+## Panels that can be edited in place
+
+- ES|QL-backed Lens and Vega panels, via \`source: "request"\` with a natural-language query. The panel keeps its existing renderer, so describe the new content rather than restating the chart it already is.
+- Markdown panels, via \`source: "config"\` with \`type: "markdown"\`. The new config fully replaces the old one, so include everything the panel should still say — anything left out is gone.
+
+That is the whole list.
+
+## Panels that cannot
+
+Anything else — a DSL-based panel, a form-based panel, another legacy Lens config — cannot be edited, and nothing converts one in place. The only route is to build a replacement as a new ES|QL-based Lens panel and swap it in, which throws away whatever the original config expressed. That makes it the user's call, not yours:
+
+1. Say plainly that this panel can't be edited directly.
+2. Offer to recreate it as a new ES|QL-based Lens chart, and say what that costs — a fresh chart built from a query, not a copy of the original.
+3. Wait for confirmation before removing or replacing anything.
+
+Never run a remove-and-recreate sequence without that confirmation, even when the replacement looks obviously equivalent. An edit that happens to succeed does not mean the check was unnecessary — the panels where it silently loses the original are the ones you cannot spot without looking.
+
+When you cannot tell what backs a panel, ask instead of guessing: say what you were able to determine and let the user decide whether to recreate it.
+`,
+};

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/register_skills.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/register_skills.test.ts
@@ -43,4 +43,31 @@ describe('registerSkills', () => {
       'provide a new `chartType` when the request changes the chart family'
     );
   });
+
+  it('inlines the layout guidance for reworking an existing dashboard', () => {
+    expect(dashboardManagementSkill.content).toContain('Vertical gaps close by themselves');
+    expect(dashboardManagementSkill.content).toContain(
+      'Keep every panel at the size its chart type'
+    );
+    expect(dashboardManagementSkill.content).toContain('never `w` and `h`');
+    expect(dashboardManagementSkill.content).toContain('Inserting above an existing section');
+  });
+
+  describe('panel editing reference', () => {
+    const reference = (dashboardManagementSkill.referencedContent ?? []).find(
+      ({ name }) => name === 'panel-editing'
+    );
+
+    it('defers the panel editing details to a referenced file', () => {
+      expect(reference?.content).toContain('Panels that can be edited in place');
+      expect(reference?.content).toContain('Wait for confirmation before removing or replacing');
+    });
+
+    it('tells the skill body to read the file before every edit', () => {
+      expect(dashboardManagementSkill.content).toContain(
+        `${reference?.relativePath}/${reference?.name}.md`
+      );
+      expect(dashboardManagementSkill.content).toContain('before any `edit_panels` call');
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/register_skills.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/register_skills.test.ts
@@ -44,24 +44,10 @@ describe('registerSkills', () => {
     );
   });
 
-  it('inlines the layout guidance for reworking an existing dashboard', () => {
-    expect(dashboardManagementSkill.content).toContain('Vertical gaps close by themselves');
-    expect(dashboardManagementSkill.content).toContain(
-      'Keep every panel at the size its chart type'
-    );
-    expect(dashboardManagementSkill.content).toContain('never `w` and `h`');
-    expect(dashboardManagementSkill.content).toContain('Inserting above an existing section');
-  });
-
   describe('panel editing reference', () => {
     const reference = (dashboardManagementSkill.referencedContent ?? []).find(
       ({ name }) => name === 'panel-editing'
     );
-
-    it('defers the panel editing details to a referenced file', () => {
-      expect(reference?.content).toContain('Panels that can be edited in place');
-      expect(reference?.content).toContain('Wait for confirmation before removing or replacing');
-    });
 
     it('tells the skill body to read the file before every edit', () => {
       expect(dashboardManagementSkill.content).toContain(

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/rendering_guidance/kibana_rendering_guidance.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/rendering_guidance/kibana_rendering_guidance.ts
@@ -19,7 +19,7 @@ In Kibana, a dashboard request follows three stages: resolve inputs, generate (w
    - To put an existing visualization onto a dashboard, read that visualization attachment's content with \`${attachmentTools.read}\` and pass its configuration as a \`source: "config"\` panel input (with panel \`type: "vis"\` and \`config\`). The generation core never reads attachments itself, so the visualization config must be passed by value here.
 2. **Generate** (persists automatically):
    - Call ${dashboardTools.generateDashboard} with \`dashboardAttachmentId\` set to the dashboard you are editing (omit it for a new dashboard) and your batched \`operations\`. The tool reads the current payload from that reference, applies the operations, and persists the result as a \`${DASHBOARD_ATTACHMENT_TYPE}\` attachment for you.
-   - It returns \`data.attachment_id\`, \`data.version\`, a compact \`data.dashboard\` summary whose panels carry a one-sentence \`authoring_note\` for the charts authored in this call, and optional \`data.failures\`. Do **not** pass the dashboard payload back into any tool — reference \`data.attachment_id\` instead.
+   - It returns \`data.attachment_id\`, \`data.version\`, a compact \`data.dashboard\` summary whose panels carry a one-sentence \`authoring_note\` for the charts authored in this call, and optional \`data.failures\`.
 3. **Render**:
    - Render the persisted attachment inline with a render-attachment tag using the returned \`attachment_id\` and \`version\`:
      \`<render_attachment id="{attachment_id}" version="{version}" />\`
@@ -34,9 +34,7 @@ In Kibana, a dashboard request follows three stages: resolve inputs, generate (w
 ## After Rendering
 
 - Render only the final dashboard attachment inline, as the last part of your response, after any text. Never render individual visualization attachments during dashboard composition.
-- Remember the dashboard's \`attachment_id\`. On later updates, pass the same \`attachment_id\` back as \`dashboardAttachmentId\` so generation edits the existing dashboard in place.
-- Use returned panel \`id\` values for future panel removals, and section \`id\` values for future section-targeted changes.
-- Never invent an \`attachment_id\`, panel \`id\`, or \`sectionId\`. Reuse values returned by prior tool results.
+- Every id you pass back — \`attachment_id\`, panel \`id\`, \`sectionId\` — must come from a prior tool result, never invented. Keep the dashboard's \`attachment_id\` for later updates: passing it as \`dashboardAttachmentId\` is what makes generation edit that dashboard instead of creating another one.
 - If the generation result includes \`data.failures\`, explain which panel creations failed and report each returned \`type\`, \`identifier\`, and \`error\`.
 
 ## Rendering Edge Cases

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/generate/core/operations/add_panels.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/generate/core/operations/add_panels.ts
@@ -15,7 +15,12 @@ import { createPanelInputMaterializer } from './panel_creation';
 export const addPanelsOperation = defineOperation({
   schema: z.object({
     operation: z.literal('add_panels'),
-    panels: z.array(addPanelsItemSchema).min(1),
+    panels: z
+      .array(addPanelsItemSchema)
+      .min(1)
+      .describe(
+        'Panels to append. One operation may mix panel kinds and target different sectionId values, so batch related panels here instead of repeating the operation.'
+      ),
   }),
   handler: ({ dashboardData, operation, operationIndex, context }) => {
     const materializePanelInput = createPanelInputMaterializer({

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/generate/core/operations/set_metadata.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/generate/core/operations/set_metadata.ts
@@ -18,9 +18,13 @@ export const setMetadataOperation = defineOperation({
       .max(256)
       .optional()
       .describe(
-        "Non-empty dashboard title. If the current title is empty, missing, or a placeholder, invent one from the dashboard's contents."
+        "Non-empty dashboard title. Required for a new dashboard. Invent one from the dashboard's contents when the current title is empty, missing, or the `User Dashboard` placeholder."
       ),
-    description: z.string().max(2048).optional(),
+    description: z
+      .string()
+      .max(2048)
+      .optional()
+      .describe('What the dashboard shows, for someone browsing a list of saved dashboards.'),
     time_range: timeRangeSchema
       .optional()
       .describe(

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/generate/generate_dashboard_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/generate/generate_dashboard_tool.ts
@@ -39,7 +39,12 @@ const generateDashboardSchema = z.object({
     .describe(
       '(optional) The id of the dashboard attachment to update. Omit to create a new dashboard. The tool reads the current dashboard payload from this reference, so you never have to pass the full payload back in.'
     ),
-  operations: z.array(dashboardOperationSchema).min(1),
+  operations: z
+    .array(dashboardOperationSchema)
+    .min(1)
+    .describe(
+      'Ordered operations applied to the dashboard. Each one sees the state left by the previous one, so ordering matters (create a section before targeting it by id). Batch every change for one request into a single call. A panel that fails to resolve does not fail the call — it is reported in the result `failures` while the rest are applied.'
+    ),
 });
 
 /**
@@ -105,18 +110,9 @@ export const generateDashboardTool = (): BuiltinSkillBoundedTool<
   return {
     id: dashboardTools.generateDashboard,
     type: ToolType.builtin,
-    description: `Generate or update a dashboard from ordered operations.
+    description: `Generate or update a dashboard from ordered operations: metadata, panels, layouts, sections, and controls.
 
-Persists the resulting dashboard as an attachment and returns its id plus a compact summary (not the full payload). Reference the returned attachment id to render the dashboard; do not copy the payload into follow-up tool calls.
-
-Use operations[] to:
-1. set metadata
-2. add panels (resolved panel configs, or Lens/Vega visualizations from a natural-language query — pick the engine with the panel "renderer" field; defaults to Lens)
-3. edit existing Lens, Vega, or markdown panel content
-4. update panel layouts without changing content
-5. add / remove sections, including inline section panels during add_section
-6. remove panels
-7. add / remove controls (interactive filters pinned above the dashboard: dropdown, range slider, or time slider)`,
+Persists the resulting dashboard as an attachment and returns its id plus a compact summary (not the full payload). Reference the returned attachment id to render the dashboard; do not copy the payload into follow-up tool calls.`,
     schema: generateDashboardSchema,
     handler: async (
       { dashboardAttachmentId: previousAttachmentId, operations },


### PR DESCRIPTION
## Summary

Bits of the dashboard skill had started repeating themselves. The 48-column grid was explained in prose while the schemas said nothing about it, a few rules showed up in two or three places with slightly different wording, and the tool description restated the operation list that the schema already spells out.

So the mechanical facts moved into the schemas that carry them — `panelGridSchema` now explains what `x`, `y`, `w` and `h` mean and that a section's coordinates are section-relative, and `operations` covers ordering, batching and partial failures. The prose keeps what is actually judgement: what makes a dashboard worth looking at, which chart goes where, how big panels should be.

Two things I kept running into while testing are clearer now:

- **Removing a panel.** The grid closes vertical gaps on its own but not horizontal ones, so taking a panel out of the middle of a row left a hole behind. The guidance now says to slide the rest of that row left in the same call, keeping every panel at the size its chart type calls for instead of stretching them over the gap.
- **Editing a panel that is not ES|QL-backed.** Those cannot be edited or converted in place, only replaced by a new chart, which throws the original config away. The agent now reads `panel-editing.md` before any `edit_panels` call, and that file is explicit that replacing one needs the user's confirmation first — it had been quietly recreating such panels on its own initiative.

Net effect is a skill body about a quarter smaller, with the panel editing details loaded only on the requests that edit something.

Stacked on #280670, so its commits show up in the diff until that one merges.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios