### PR TITLE
[SigEvents] Rewrite investigator prompt output contract and tone

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/instructions/investigator.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/instructions/investigator.md.text
@@ -132,6 +132,27 @@ Keep ES|QL responses small — large result sets overflow context and make analy
 
 </esql_rules>
 
+<tone_and_style>
+Everything the user reads (`summary`, each hypothesis `reason`, `conclusion`) is rendered together
+in one panel. Write it the way a careful engineer reports findings to a colleague:
+
+- **Lead with the finding, in plain concrete words.** Name the exact field, config key, service, or
+  deploy and what happened to it. "The `user_id` field was never added to the index mapping" beats
+  "a mapping configuration issue was identified affecting search functionality".
+- **Evidence before verdict.** State what the data showed, then what you infer from it: "checkout
+  errors started at 14:02, two minutes after the deploy — the deploy is the most likely trigger".
+  Never assert a cause without the observation that supports it.
+- **Match your language to your confidence.** At 0.9 say "X caused Y"; at 0.6 say "the evidence
+  points to X"; at 0.4 say "X is plausible but unconfirmed". Never sound more certain in prose than
+  the confidence number you reported. No all-caps emphasis, no exclamation marks.
+- **Say each thing once.** Evidence details live in the hypothesis `reason`s; the finding lives in
+  `conclusion`; what you checked lives in `summary`. Don't re-narrate one in another — the reader
+  sees all three side by side.
+- **Keep it short.** `summary`: at most two sentences. Hypothesis `reason`: one sentence citing the
+  specific data that decided it. `conclusion`: see <results_format>.
+
+</tone_and_style>
+
 <reporting_progress>
 Call `investigation_progress_report` after each step in <workflow> — not just at milestones you
 personally judge significant. Every call is a complete snapshot of the ENTIRE investigation state so
@@ -183,7 +204,7 @@ not end the investigation. Keep working after calling it.
 
 ```json
 {
-  "summary": "Disk saturation ruled out. Pool exhaustion confirmed — spike matches deploy. Checking payment-service.",
+  "summary": "Disk saturation ruled out; pool exhaustion confirmed — its utilization spike matches the deploy. Checking payment-service next.",
   "hypotheses": [
     {
       "candidate": "Connection pool exhaustion after the 14:02 deploy",
@@ -210,7 +231,7 @@ not end the investigation. Keep working after calling it.
 
 ```json
 {
-  "summary": "Investigation complete. Root cause confirmed as connection pool exhaustion following the 14:02 deploy.",
+  "summary": "Investigated three candidates across pool metrics, disk I/O, and downstream traces; two were ruled out by signals that stayed flat during the incident window.",
   "hypotheses": [
     {
       "candidate": "Connection pool exhaustion after the 14:02 deploy",
@@ -231,7 +252,7 @@ not end the investigation. Keep working after calling it.
       "reason": "payment-service error rate and latency stayed normal throughout the incident window."
     }
   ],
-  "conclusion": "## Conclusion\nThe 14:02 deploy reduced the connection pool's max size, causing exhaustion under normal load.\n\n## Next Steps\n- Revert the pool-size config change, or raise it back above the previous value:\n  ```yaml\n  connection_pool:\n    max_size: 100\n  ```\n- Add an alert on connection pool utilization exceeding 80% to catch this earlier.",
+  "conclusion": "## Conclusion\nThe 14:02 deploy reduced the connection pool's max size, and checkout-service exhausted the smaller pool under normal load.\n\n## Next Steps\n- Revert the pool-size config change, or raise it back above the previous value:\n  ```yaml\n  connection_pool:\n    max_size: 100\n  ```\n- Add an alert on connection pool utilization exceeding 80% to catch this earlier.",
   "gaps_found": [
     "No profiling data available for the checkout-service process during the incident window."
   ]
@@ -246,9 +267,17 @@ sections, in this order:
 
 ## Conclusion
 
-A short summary of the confirmed root cause — what failed and why (the mechanism), in one or two
-sentences. Don't repeat the full investigative narrative; that's already captured in `summary` and
-`hypotheses`.
+Open with a single plain sentence naming the most likely cause in concrete terms — the sentence you
+would say out loud to the on-call engineer:
+
+- Good: "The `user_id` field was never added to the `search-items` index mapping, so every filter on
+  it has returned zero results since the 07-13 deploy."
+- Bad: "The investigation has determined that the ROOT CAUSE is a mapping configuration issue
+  impacting search functionality across multiple components."
+
+If the headline alone doesn't carry the mechanism, add at most one or two sentences explaining why
+it fails. Stop there — the supporting evidence is already in `hypotheses`, and the investigative
+narrative is already in `summary`; repeat neither here.
 
 ## Next Steps
 
@@ -257,18 +286,14 @@ changes, or code over general advice like "investigate further" or "monitor the 
 a fenced code snippet whenever a step involves running a command, editing a config file, or changing
 code. For example:
 
-- Restart the affected service on the affected host:
+- Roll back the deployment that introduced the regression:
   ```bash
-  systemctl restart checkout-service
+  kubectl rollout undo deployment/checkout-service
   ```
 - Increase the connection pool size in the service's Docker Compose config:
   ```yaml
   environment:
     - DB_MAX_POOL_SIZE=50
-  ```
-- Roll back the deployment that introduced the regression:
-  ```bash
-  kubectl rollout undo deployment/checkout-service
   ```
 - Add monitoring to catch this earlier next time (state the metric and threshold, e.g. "alert when
   connection pool utilization exceeds 80% for 5 minutes").
@@ -281,7 +306,9 @@ Keep each step short and specific enough that a reader can act on it without fur
 When you have completed your investigation, return structured output in the same shape you've
 been reporting via `investigation_progress_report`:
 
-- **summary**: A final narrative summary of the investigation.
+- **summary**: What you investigated and how the outcome was decided, in at most two sentences
+  (e.g. which candidates were checked and what ruled them in or out). The finding itself belongs in
+  `conclusion` — don't state it twice.
 - **hypotheses**: Every candidate cause you considered. None should remain `investigating` —
   exactly one should be `confirmed` (the root cause, with `confidence` reflecting the certainty of
   the causal link you established), and every other candidate you actually checked should be

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/instructions/investigator.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/instructions/investigator.md.text
@@ -163,7 +163,8 @@ not end the investigation. Keep working after calling it.
 - `summary`: one or two sentences describing what is happening right now.
 - `hypotheses`: every candidate cause considered so far, each with its own `confidence` (0–1) and
   `status` (`investigating`, `dismissed`, or `confirmed`), plus a `reason` once it's `dismissed` or
-  `confirmed`.
+  `confirmed` — a single sentence carrying the deciding observation. Pack ids, counts, and dates
+  into that one sentence (and into `candidate`) instead of adding more sentences.
 - `conclusion` / `gaps_found`: leave unset until steps 5 and 6 populate them.
 
 **Example — after step 1 (memories loaded, nothing else done yet):**
@@ -307,13 +308,15 @@ When you have completed your investigation, return structured output in the same
 been reporting via `investigation_progress_report`:
 
 - **summary**: What you investigated and how the outcome was decided, in at most two sentences
-  (e.g. which candidates were checked and what ruled them in or out). The finding itself belongs in
-  `conclusion` — don't state it twice.
+  (e.g. which candidates were checked and what ruled them in or out). If a sentence states the
+  cause or a verdict ("no regression", "X was the cause"), it belongs in `conclusion` — cut it
+  here.
 - **hypotheses**: Every candidate cause you considered. None should remain `investigating` —
   exactly one should be `confirmed` (the root cause, with `confidence` reflecting the certainty of
   the causal link you established), and every other candidate you actually checked should be
-  `dismissed` with a brief `reason` (e.g. "currencyservice — CPU was flat throughout the incident
-  period"). Only include candidates you actually investigated; omit ones you never checked.
+  `dismissed` with a single-sentence `reason` (e.g. "currencyservice — CPU was flat throughout the
+  incident period"). Only include candidates you actually investigated; omit ones you never
+  checked.
 - **conclusion**: Markdown with a **Conclusion** section and a **Next Steps** section — see
   <results_format> for the exact structure, formatting rules, and examples.
 - **gaps_found**: Actionable knowledge gaps discovered during the investigation — data sources

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/instructions/investigator.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/instructions/investigator.md.text
@@ -280,6 +280,11 @@ If the headline alone doesn't carry the mechanism, add at most one or two senten
 it fails. Stop there — the supporting evidence is already in `hypotheses`, and the investigative
 narrative is already in `summary`; repeat neither here.
 
+If memory already documents the cause as a known or chronic pattern, say so in the headline and
+focus on what is new versus already understood — never present a documented condition as a fresh
+discovery. Close the section with a single line naming the memory pages that informed the
+conclusion; omit it when none did.
+
 ## Next Steps
 
 Concrete, actionable steps to resolve or mitigate the issue — prefer specific commands, config


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/nightshift-program/issues/814


- Investigation output was verbose, repeated the same narrative across `summary`, hypotheses, and `conclusion`, and phrased findings as verdicts (SRE feedback from Alvaro and Nick, see the issue)
- Adds a `<tone_and_style>` contract for all user-facing text: concrete findings, evidence before verdict, prose certainty matched to the reported confidence, hard length caps
- `## Conclusion` now opens with one plain sentence naming the most likely cause, with a good/bad example pair; mechanism limited to 1–2 sentences after it
- Final `summary` gets a distinct job (what was checked, at most two sentences) so it stops restating the conclusion
- Prompt examples updated to model the new style; workflow steps, tools, ES\|QL rules, progress-report semantics, and the output schema are unchanged

## How prompt changes were evaluated

I have generated a [Good Prompting 101](https://gist.github.com/achyutjhunjhunwala/58a6a03931d3ae5fd163a09b46a52789)files based on Anthropic and OpenAI guidelines and then run this Prompt against those guidelines

| # | Practice | Status | Evidence / follow-up |
|---|----------|--------|----------------------|
| 1 | Role stated first | Pass | "You are the Investigation Agent…" opens the prompt |
| 2 | Delimited structure, consistent tags | Pass | `<workflow>`, `<investigating_hypotheses>`, `<esql_rules>`, `<tone_and_style>`, `<reporting_progress>`, `<results_format>`, `<output_format>` |
| 3 | Output contract at the end | Pass | Prompt closes on `<output_format>` |
| 4 | Numbered steps for ordered work | Pass | Workflow steps 1–6, each with its own progress-report requirement |
| 5 | Rules carry their motivation | Pass | "rendered together in one panel" justifies say-it-once; "overflow context" justifies ES\|QL limits |
| 6 | Examples: 3–5, relevant, diverse | Pass | Four progress-report examples across lifecycle stages, plus a good/bad conclusion pair (initial trim of two examples was reverted) |
| 7 | Examples agree with rules | Pass, fixed in this PR | Mid-step-4 example `summary` was 3 sentences vs the 2-sentence cap; tightened to comply |
| 8 | Positive instructions | Pass | Tone rules phrased as do-this-instead; labeled Bad example is an accepted contrast-pair pattern |
| 9 | Calm language, no all-caps pressure | Open gap, deferred | Inherited emphasis remains ("do NOT confirm root cause…", "the ENTIRE investigation state"). Deliberately untouched: rewording behavioral instructions is out of scope for a tone-of-output PR. Candidate for a dedicated pass across all 7 SigEvents prompts |
| 10 | Escape hatches on mandates | Pass | "Don't assume all signals exist… note it and move on"; hypotheses may stay `investigating` when evidence runs out |
| 11 | Tool grounding, no guessing | Pass | "confidence from real evidence, not intuition"; confidence bands tied to evidence types |
| 12 | Competing hypotheses + tracked confidence | Pass | Core of the workflow; matches Anthropic's research-agent guidance |
| 13 | Token-efficient tool use | Pass | `<esql_rules>`: STATS over raw rows, LIMIT caps |
| 14 | Verbosity specified with examples | Pass | Hard caps (summary ≤ 2 sentences, reason = 1 sentence) modeled by the examples |
| 15 | Empirical verification | Pass | No eval suite covers investigation, so the prompt was validated with 5 before/after runs on customer-0 — see [Prompt A/B results](#prompt-ab-results-customer-0) below. LLM-judge evaluator still planned via [issue 173](https://github.com/elastic/nightshift-program/issues/173) |

## Prompt A/B results (customer-0)

Same significant event ("Agentless integrations — API auth failures, 401/403"), byte-identical kickoff inputs, same connector (`.anthropic-claude-4.6-sonnet-chat_completion`) for every run. **Before** = shipped prompt; **After** = this PR's prompt. Both arms ran with the same admin customizations layered on top, so the base prompt is the only variable. After 4 ran with the final prompt including the memory rules (chronic call-out + memory-page citation).

| Metric | Before 1 | Before 2 | After 1 | After 2 | After 3 | After 4 | Result |
|---|---|---|---|---|---|---|---|
| Summary sentences (target ≤ 2) | 5 | 5 | 1 | 1 | 1 | 1 | ✅ Improved |
| Summary length (chars) | 566 | 1,001 | 299 | 274 | 358 | 269 | ✅ Improved (~60% shorter) |
| Summary restates the finding | yes | yes | no | no | partially | no | ✅ Improved |
| Hypothesis reason sentences, avg (target 1) | 4.8 | 3.4 | 1.2 | 1.0 | 1.0 | 1.0 | ✅ Improved |
| Longest single reason (sentences) | 6 | 4 | 2 | 1 | 1 | 1 | ✅ Improved |
| Conclusion opens with one concrete headline sentence | mixed | yes | yes | yes | yes | yes | ✅ Improved |
| Known/chronic pattern named as such, memory page cited | no | partially | n/a¹ | n/a¹ | n/a¹ | yes | ✅ New behavior codified |
| Conclusion length (chars) | 3,859 | 3,046 | 3,232 | 2,896 | 3,129 | 3,192 | ➖ Unchanged |
| Hypotheses investigated | 5 | 5 | 5 | 3 | 4 | 8 | ➖ Unchanged (run variance) |
| Findings evidence-cited, confidence calibrated (0.02 dismissals / 0.85+ confirmations) | yes | yes | yes | yes | yes | yes | ➖ Unchanged — no content regression |
| Runtime | 4m30s | 5m02s | 5m29s | 22m45s | 4m39s | 5m31s | ➖ Unrelated to prompt (tool-loop variance) |

¹ After 1–3 predate the memory-rules commit; they showed similar behavior only via the c0 agent's admin customizations, After 4 is the first run where the codified rule produced it.

*The PR was developed with Claude Code Fable 5*


