### PR TITLE
Fix flaky SIEM rule migration delete API test cleanup (#228826)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/delete.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/delete.ts
@@ -25,8 +25,7 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const ruleMigrationRoutes = ruleMigrationRouteHelpersFactory(supertest);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/228826
-  describe.skip('@ess @serverless @serverlessQA Delete API', () => {
+  describe('@ess @serverless @serverlessQA Delete API', () => {
     let migrationId: string;
     beforeEach(async () => {
       await deleteAllRuleMigrations(es);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/utils/mocks.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/utils/mocks.ts
@@ -150,27 +150,15 @@ export const createMigrationRules = async (
 
 export const deleteAllRuleMigrations = async (es: Client): Promise<void> => {
   await es.deleteByQuery({
-    index: [SIEM_MIGRATIONS_INDEX_PATTERN],
+    index: [
+      SIEM_MIGRATIONS_INDEX_PATTERN,
+      SIEM_MIGRATIONS_RULES_INDEX_PATTERN,
+      SIEM_MIGRATIONS_RESOURCES_INDEX_PATTERN,
+    ],
     query: {
       match_all: {},
     },
-    ignore_unavailable: true,
-    refresh: true,
-  });
-
-  await es.deleteByQuery({
-    index: [SIEM_MIGRATIONS_RULES_INDEX_PATTERN],
-    query: {
-      match_all: {},
-    },
-    ignore_unavailable: true,
-    refresh: true,
-  });
-  await es.deleteByQuery({
-    index: [SIEM_MIGRATIONS_RESOURCES_INDEX_PATTERN],
-    query: {
-      match_all: {},
-    },
+    conflicts: 'proceed',
     ignore_unavailable: true,
     refresh: true,
   });


### PR DESCRIPTION
## Summary

- Add `conflicts: 'proceed'` to `deleteAllRuleMigrations` so beforeEach cleanup tolerates concurrent document updates.
- Re-enable the skipped Delete API integration suite.

## Root cause

`deleteAllRuleMigrations` used `deleteByQuery` without `conflicts: 'proceed'`. Background migration tasks can update documents while cleanup runs, causing `version_conflict_engine_exception` in the beforeEach hook.

## Validation

- Matches the existing `deleteAllDashboardMigrations` helper pattern added in #234435.
- Local FTR run pending — ES/Kibana not available in this environment.
- CI verification pending on kibana-on-merge ESS and serverless lanes.

Closes #228826

Made with [Cursor](https://cursor.com)