### PR TITLE
Fix flaky SIEM rule migration delete API tests (#229031)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/delete.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/delete.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from 'expect';
+import pRetry from 'p-retry';
 import {
   createLookupsForMigrationId,
   createMacrosForMigrationId,
@@ -25,13 +26,16 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const ruleMigrationRoutes = ruleMigrationRouteHelpersFactory(supertest);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/228826
-  describe.skip('@ess @serverless @serverlessQA Delete API', () => {
+  describe('@ess @serverless @serverlessQA Delete API', () => {
     let migrationId: string;
     beforeEach(async () => {
       await deleteAllRuleMigrations(es);
       const response = await ruleMigrationRoutes.create({});
       migrationId = response.body.migration_id;
+    });
+
+    afterEach(async () => {
+      await ruleMigrationRoutes.stop({ migrationId });
     });
 
     describe('Happy path', () => {
@@ -112,10 +116,10 @@ export default ({ getService }: FtrProviderContext) => {
 
       describe('Error handling', () => {
         it('should return 409 if migration is already running', async () => {
-          // start a migration
           await ruleMigrationRoutes.addRulesToMigration({
             migrationId,
-            payload: [splunkRuleWithResources],
+            /** enough rules to keep the migration running while delete is attempted */
+            payload: Array.from({ length: 40 }, () => splunkRuleWithResources),
           });
 
           const response = await ruleMigrationRoutes.start({
@@ -128,6 +132,16 @@ export default ({ getService }: FtrProviderContext) => {
           });
 
           expect(response.body).toMatchObject({ started: true });
+
+          await pRetry(
+            async () => {
+              const statsResponse = await ruleMigrationRoutes.stats({ migrationId });
+              if (statsResponse.body.status !== 'running') {
+                throw new Error('Retry until migration is running');
+              }
+            },
+            { retries: 5 }
+          );
 
           const deleteResponse = await ruleMigrationRoutes.delete({
             migrationId,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/utils/mocks.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/utils/mocks.ts
@@ -150,27 +150,15 @@ export const createMigrationRules = async (
 
 export const deleteAllRuleMigrations = async (es: Client): Promise<void> => {
   await es.deleteByQuery({
-    index: [SIEM_MIGRATIONS_INDEX_PATTERN],
+    index: [
+      SIEM_MIGRATIONS_INDEX_PATTERN,
+      SIEM_MIGRATIONS_RULES_INDEX_PATTERN,
+      SIEM_MIGRATIONS_RESOURCES_INDEX_PATTERN,
+    ],
     query: {
       match_all: {},
     },
-    ignore_unavailable: true,
-    refresh: true,
-  });
-
-  await es.deleteByQuery({
-    index: [SIEM_MIGRATIONS_RULES_INDEX_PATTERN],
-    query: {
-      match_all: {},
-    },
-    ignore_unavailable: true,
-    refresh: true,
-  });
-  await es.deleteByQuery({
-    index: [SIEM_MIGRATIONS_RESOURCES_INDEX_PATTERN],
-    query: {
-      match_all: {},
-    },
+    conflicts: 'proceed',
     ignore_unavailable: true,
     refresh: true,
   });


### PR DESCRIPTION
## Summary

- Re-enable the skipped SIEM rule migration Delete API suite.
- Stop running migrations after each test and wait for running status before asserting delete returns 409.
- Make shared migration cleanup tolerate Elasticsearch version conflicts.

## Root cause

The 409 test could delete after a single-rule migration finished, and the 409 test left a running migration that caused version conflicts in the next test's beforeEach cleanup.

## Validation

- Changes follow existing patterns in stop.ts and deleteAllDashboardMigrations.
- Local FTR not run; worktree lacks bootstrap. CI pending on the SIEM Migrations ESS/serverless configs.

Closes #229031

Made with [Cursor](https://cursor.com)