### PR TITLE
[9.4] [Security Solution] Enforce rule params authorization on generic Alerting API writes to close the response actions RBAC bypass (#280430)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/backfill/methods/delete/delete_backfill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/backfill/methods/delete/delete_backfill.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../..';
@@ -50,6 +51,7 @@ const backfillClient = backfillClientMock.create();
 const logger = loggingSystemMock.create().get();
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/backfill/methods/find/find_backfill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/backfill/methods/find/find_backfill.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock, actionsClientMock } from '@kbn/actions-plugin/server/mocks';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../..';
@@ -204,6 +205,7 @@ describe('findBackfill()', () => {
     mockActionsClient.isSystemAction.mockImplementation(isSystemAction);
 
     rulesClient = new RulesClient({
+      request: httpServerMock.createKibanaRequest(),
       taskManager,
       ruleTypeRegistry,
       unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/backfill/methods/get/get_backfill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/backfill/methods/get/get_backfill.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock, actionsClientMock } from '@kbn/actions-plugin/server/mocks';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../..';
@@ -103,6 +104,7 @@ describe('getBackfill()', () => {
     mockActionsClient.isSystemAction.mockImplementation(isSystemAction);
 
     rulesClient = new RulesClient({
+      request: httpServerMock.createKibanaRequest(),
       taskManager,
       ruleTypeRegistry,
       unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/backfill/methods/schedule/schedule_backfill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/backfill/methods/schedule/schedule_backfill.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../..';
@@ -52,6 +53,7 @@ const filter = fromKueryExpression(
 );
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/create/create_gap_auto_fill_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/create/create_gap_auto_fill_scheduler.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import { coreFeatureFlagsMock } from '@kbn/core-feature-flags-server-mocks';
@@ -41,6 +42,7 @@ const auditLogger = auditLoggerMock.create();
 const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/delete/delete_gap_auto_fill_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/delete/delete_gap_auto_fill_scheduler.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
@@ -49,6 +50,7 @@ describe('deleteGapAutoFillScheduler()', () => {
   const eventLogClient = eventLogClientMock.create();
 
   const rulesClientParamsBase: jest.Mocked<ConstructorOptions> = {
+    request: httpServerMock.createKibanaRequest(),
     taskManager,
     ruleTypeRegistry,
     unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/find_logs/find_gap_auto_fill_scheduler_logs.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/find_logs/find_gap_auto_fill_scheduler_logs.test.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import type { IValidatedEventInternalDocInfo } from '@kbn/event-log-plugin/server';
@@ -100,6 +101,7 @@ describe('findGapAutoFillSchedulerLogs()', () => {
     jest.resetAllMocks();
 
     rulesClient = new RulesClient({
+      request: httpServerMock.createKibanaRequest(),
       taskManager,
       ruleTypeRegistry,
       unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/get/get_gap_auto_fill_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/get/get_gap_auto_fill_scheduler.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import Boom from '@hapi/boom';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
@@ -46,6 +47,7 @@ describe('getGapFillAutoScheduler()', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     rulesClient = new RulesClient({
+      request: httpServerMock.createKibanaRequest(),
       taskManager,
       ruleTypeRegistry,
       unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/update/update_gap_auto_fill_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/auto_fill_scheduler/methods/update/update_gap_auto_fill_scheduler.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
@@ -47,6 +48,7 @@ const eventLogClient = eventLogClientMock.create();
 const backfillClient = backfillClientMock.create();
 
 const rulesClientParamsBase: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/fill_gap_by_id/fill_gap_by_id.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/fill_gap_by_id/fill_gap_by_id.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
@@ -83,6 +84,7 @@ describe('fillGapById', () => {
     mockedGetRule.mockResolvedValue(mockRule);
 
     const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+      request: httpServerMock.createKibanaRequest(),
       taskManager: taskManagerMock.createStart(),
       ruleTypeRegistry: ruleTypeRegistryMock.create(),
       unsecuredSavedObjectsClient: savedObjectsClientMock.create(),

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/find_gaps/find_gaps.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/find_gaps/find_gaps.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import type { AlertingAuthorization } from '../../../../authorization';
@@ -91,6 +92,7 @@ describe('findGaps', () => {
     eventLogClient = eventLogClientMock.create();
 
     rulesClientParams = {
+      request: httpServerMock.createKibanaRequest(),
       taskManager,
       ruleTypeRegistry,
       unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/get_gaps_summary_by_rule_ids/get_gaps_summary_by_rule_ids.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/get_gaps_summary_by_rule_ids/get_gaps_summary_by_rule_ids.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import type { AlertingAuthorization } from '../../../../authorization';
@@ -43,6 +44,7 @@ const eventLogClient = eventLogClientMock.create();
 const eventLogger = eventLoggerMock.create();
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/get_rule_ids_with_gaps/get_rule_ids_with_gaps.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/get_rule_ids_with_gaps/get_rule_ids_with_gaps.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import type { AlertingAuthorization } from '../../../../authorization';
@@ -68,6 +69,7 @@ describe('getRuleIdsWithGaps', () => {
     eventLogClient = eventLogClientMock.create();
 
     rulesClientParams = {
+      request: httpServerMock.createKibanaRequest(),
       taskManager,
       ruleTypeRegistry,
       unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/aggregate/aggregate_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/aggregate/aggregate_rules.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client';
 import { RulesClient } from '../../../../rules_client';
 import {
@@ -45,6 +46,7 @@ const auditLogger = auditLoggerMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_delete/bulk_delete_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_delete/bulk_delete_rules.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -72,6 +73,7 @@ const eventLogger = eventLoggerMock.create();
 const kibanaVersion = 'v8.2.0';
 const createAPIKeyMock = jest.fn();
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_disable/bulk_disable_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_disable/bulk_disable_rules.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -72,6 +73,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 const kibanaVersion = 'v8.2.0';
 const createAPIKeyMock = jest.fn();
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit/bulk_edit_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit/bulk_edit_rules.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { schema } from '@kbn/config-schema';
 import { omit } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
@@ -76,6 +77,7 @@ const isAuthenticationTypeApiKeyMock = jest.fn();
 const getAuthenticationApiKeyMock = jest.fn();
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit_params/bulk_edit_rule_params.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit_params/bulk_edit_rule_params.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { schema } from '@kbn/config-schema';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
@@ -56,6 +57,7 @@ const isAuthenticationTypeApiKeyMock = jest.fn();
 const getAuthenticationApiKeyMock = jest.fn();
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -71,6 +72,7 @@ const alertsService = alertsServiceMock.create();
 const kibanaVersion = 'v8.2.0';
 const createAPIKeyMock = jest.fn();
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_untrack/bulk_untrack_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_untrack/bulk_untrack_alerts.test.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -43,6 +44,7 @@ const alertsService = alertsServiceMock.create();
 const kibanaVersion = 'v8.2.0';
 const createAPIKeyMock = jest.fn();
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/clone/clone_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/clone/clone_rule.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import {
   savedObjectsClientMock,
   loggingSystemMock,
@@ -46,6 +47,7 @@ describe('clone', () => {
   const getAuthenticationApiKeyMock = jest.fn();
 
   const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+    request: httpServerMock.createKibanaRequest(),
     taskManager,
     ruleTypeRegistry,
     unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/create/create_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/create/create_rule.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { schema } from '@kbn/config-schema';
 import type { CreateRuleParams } from './create_rule';
 import type { ConstructorOptions } from '../../../../rules_client';
@@ -73,6 +74,7 @@ const connectorAdapterRegistry = new ConnectorAdapterRegistry();
 
 const kibanaVersion = 'v8.0.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,
@@ -2763,6 +2765,72 @@ describe('create()', () => {
     });
     await expect(rulesClient.create({ data })).rejects.toThrowErrorMatchingInlineSnapshot(
       `"params invalid: [param1]: expected value of type [string] but got [undefined]"`
+    );
+  });
+
+  test('authorizes validated params via the rule type params authorizer with the request', async () => {
+    // No actions, so this test does not consume the shared generated-action uuid counter.
+    const data = getMockData({ actions: [] });
+    // Reject so we can assert the call arguments without exercising the full
+    // create pipeline (which needs additional per-test mocking).
+    const authorize = jest.fn().mockRejectedValue(new Error('stop'));
+    ruleTypeRegistry.get.mockReturnValue({
+      id: '123',
+      name: 'Test',
+      actionGroups: [{ id: 'default', name: 'Default' }],
+      category: 'test',
+      validLegacyConsumers: [],
+      defaultActionGroupId: 'default',
+      recoveryActionGroup: RecoveredActionGroup,
+      validate: {
+        params: schema.object({ bar: schema.boolean() }, { unknowns: 'allow' }),
+      },
+      authorize: { params: { authorize } },
+      minimumLicenseRequired: 'basic',
+      isExportable: true,
+      async executor() {
+        return { state: {} };
+      },
+      producer: 'alerts',
+      solution: 'stack',
+    });
+
+    await expect(rulesClient.create({ data })).rejects.toThrow('stop');
+
+    expect(authorize).toHaveBeenCalledTimes(1);
+    expect(authorize).toHaveBeenCalledWith(
+      { bar: true },
+      expect.objectContaining({ request: rulesClientParams.request })
+    );
+  });
+
+  test('propagates an error thrown by the rule type params authorizer', async () => {
+    const data = getMockData({ actions: [] });
+    ruleTypeRegistry.get.mockReturnValue({
+      id: '123',
+      name: 'Test',
+      actionGroups: [{ id: 'default', name: 'Default' }],
+      category: 'test',
+      validLegacyConsumers: [],
+      defaultActionGroupId: 'default',
+      recoveryActionGroup: RecoveredActionGroup,
+      validate: {
+        params: schema.object({}, { unknowns: 'allow' }),
+      },
+      authorize: {
+        params: { authorize: jest.fn().mockRejectedValue(new Error('not authorized')) },
+      },
+      minimumLicenseRequired: 'basic',
+      isExportable: true,
+      async executor() {
+        return { state: {} };
+      },
+      producer: 'alerts',
+      solution: 'stack',
+    });
+
+    await expect(rulesClient.create({ data })).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"not authorized"`
     );
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/create/create_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/create/create_rule.ts
@@ -15,6 +15,7 @@ import { parseDuration, getRuleCircuitBreakerErrorMessage } from '../../../../..
 import { WriteOperations, AlertingAuthorizationEntity } from '../../../../authorization';
 import {
   validateRuleTypeParams,
+  authorizeRuleTypeParams,
   getRuleNotifyWhenType,
   getDefaultMonitoringRuleDomainProperties,
 } from '../../../../lib';
@@ -136,6 +137,9 @@ export async function createRule<Params extends RuleParams = never>(
   const ruleType = context.ruleTypeRegistry.get(data.alertTypeId);
 
   const validatedRuleTypeParams = validateRuleTypeParams(data.params, ruleType.validate.params);
+  await authorizeRuleTypeParams(validatedRuleTypeParams, ruleType.authorize?.params, {
+    request: context.request,
+  });
   const username = await context.getUserName();
 
   let createdAPIKey = null;

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/delete/delete_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/delete/delete_rule.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -53,6 +54,7 @@ const eventLogger = eventLoggerMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/disable/disable_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/disable/disable_rule.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -49,6 +50,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/enable_rule/enable_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/enable_rule/enable_rule.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -59,6 +60,7 @@ const alertsService = alertsServiceMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/find/find_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/find/find_rules.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -55,6 +56,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get/get_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get/get_rule.test.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { AlertConsumers } from '@kbn/rule-data-utils';
 
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
@@ -47,6 +48,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get_rule_types_by_query/get_rule_types_by_query.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get_rule_types_by_query/get_rule_types_by_query.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import type { AlertingAuthorization } from '../../../../authorization';
@@ -65,6 +66,7 @@ describe('getRuleTypesByQuery', () => {
     ruleTypeRegistry.getAllTypes.mockReturnValue(['rule-type-1', 'rule-type-2']);
 
     rulesClientParams = {
+      request: httpServerMock.createKibanaRequest(),
       taskManager,
       ruleTypeRegistry,
       unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get_schedule_frequency/get_schedule_frequency.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get_schedule_frequency/get_schedule_frequency.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { validateScheduleLimit } from './get_schedule_frequency';
 import type { ConstructorOptions } from '../../../../rules_client';
 import { RulesClient } from '../../../../rules_client';
@@ -38,6 +39,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 const kibanaVersion = 'v8.0.0';
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/resolve/resolve.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/resolve/resolve.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -44,6 +45,7 @@ describe('resolve', () => {
   const getAuthenticationApiKeyMock = jest.fn();
 
   const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+    request: httpServerMock.createKibanaRequest(),
     taskManager,
     ruleTypeRegistry,
     unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/run_soon/run_soon.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/run_soon/run_soon.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client';
 import { RulesClient } from '../../../../rules_client';
 import {
@@ -41,6 +42,7 @@ const logger = loggingSystemMock.create().get();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/tags/get_rule_tags.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/tags/get_rule_tags.test.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { v4 } from 'uuid';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
@@ -42,6 +43,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unmute_alert/unmute_instance.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unmute_alert/unmute_instance.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -43,6 +44,7 @@ const alertsService = {
   unmuteAlertInstance: jest.fn(),
 };
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { v4 as uuidv4 } from 'uuid';
 import { schema } from '@kbn/config-schema';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
@@ -71,6 +72,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.ts
@@ -9,7 +9,11 @@ import Boom from '@hapi/boom';
 import { isEqual, omit } from 'lodash';
 import type { SavedObject } from '@kbn/core/server';
 import type { SanitizedRule, RawRule } from '../../../../types';
-import { validateRuleTypeParams, getRuleNotifyWhenType } from '../../../../lib';
+import {
+  validateRuleTypeParams,
+  authorizeRuleTypeParams,
+  getRuleNotifyWhenType,
+} from '../../../../lib';
 import { validateAndAuthorizeSystemActions } from '../../../../lib/validate_authorize_system_actions';
 import { WriteOperations, AlertingAuthorizationEntity } from '../../../../authorization';
 import { parseDuration, getRuleCircuitBreakerErrorMessage } from '../../../../../common';
@@ -183,6 +187,10 @@ async function updateWithOCC<Params extends RuleParams = never>(
   const actionsClient = await context.getActionsClient();
 
   const validatedRuleTypeParams = validateRuleTypeParams(data.params, ruleType.validate.params);
+  await authorizeRuleTypeParams(validatedRuleTypeParams, ruleType.authorize?.params, {
+    request: context.request,
+    previousParams: originalRuleSavedObject.attributes.params,
+  });
   await validateActions(context, ruleType, data, allowMissingConnectorSecrets);
   await validateAndAuthorizeSystemActions({
     actionsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update_api_key/update_rule_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update_api_key/update_rule_api_key.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
 import {
@@ -46,6 +47,7 @@ const kibanaVersion = 'v7.10.0';
 const ruleName = 'fakeRuleName';
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule_template/methods/get/get_rule_template.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule_template/methods/get/get_rule_template.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import Boom from '@hapi/boom';
 import type { ConstructorOptions } from '../../../../rules_client/rules_client';
 import { RulesClient } from '../../../../rules_client/rules_client';
@@ -45,6 +46,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/index.ts
@@ -14,6 +14,8 @@ export type RulesClient = PublicMethodsOf<RulesClientClass>;
 
 export type {
   RuleType,
+  RuleTypeParamsAuthorizer,
+  RuleTypeParamsAuthorizerContext,
   ActionGroup,
   ActionGroupIdsOf,
   AlertingPlugin,

--- a/x-pack/platform/plugins/shared/alerting/server/lib/authorize_rule_type_params.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/authorize_rule_type_params.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { authorizeRuleTypeParams } from './authorize_rule_type_params';
+import type { RuleTypeParams, RuleTypeParamsAuthorizer } from '../types';
+
+const request = httpServerMock.createKibanaRequest();
+
+test('resolves without calling anything when no authorizer is provided', async () => {
+  await expect(
+    authorizeRuleTypeParams({ foo: true }, undefined, { request })
+  ).resolves.toBeUndefined();
+});
+
+test('calls the authorizer with params and context', async () => {
+  const authorize = jest.fn().mockResolvedValue(undefined);
+  const authorizer: RuleTypeParamsAuthorizer<RuleTypeParams> = { authorize };
+  const params = { foo: true };
+  const previousParams = { foo: false };
+
+  await authorizeRuleTypeParams(params, authorizer, { request, previousParams });
+
+  expect(authorize).toHaveBeenCalledTimes(1);
+  expect(authorize).toHaveBeenCalledWith(params, { request, previousParams });
+});
+
+test('propagates the error thrown by the authorizer without wrapping it', async () => {
+  const error = new Error('not authorized');
+  const authorizer: RuleTypeParamsAuthorizer<RuleTypeParams> = {
+    authorize: jest.fn().mockRejectedValue(error),
+  };
+
+  await expect(authorizeRuleTypeParams({ foo: true }, authorizer, { request })).rejects.toBe(error);
+});

--- a/x-pack/platform/plugins/shared/alerting/server/lib/authorize_rule_type_params.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/authorize_rule_type_params.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { RuleTypeParams, RuleTypeParamsAuthorizer } from '../types';
+
+/**
+ * Runs a rule type's optional params authorizer on a rule write path
+ * (create/update/bulk), after the params have been validated.
+ *
+ * Thrown errors are not wrapped: the authorizer is responsible for throwing an
+ * HTTP-appropriate error (for example a `Boom.forbidden` for a privilege failure
+ * or `Boom.badRequest` for an invalid privileged payload), so that the status
+ * code is preserved when the write is driven through the generic Alerting APIs.
+ */
+export async function authorizeRuleTypeParams<Params extends RuleTypeParams>(
+  params: Params,
+  authorizer: RuleTypeParamsAuthorizer<Params> | undefined,
+  context: { request: KibanaRequest; previousParams?: Params }
+): Promise<void> {
+  if (!authorizer) {
+    return;
+  }
+
+  await authorizer.authorize(params, context);
+}

--- a/x-pack/platform/plugins/shared/alerting/server/lib/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/index.ts
@@ -10,6 +10,7 @@ export type { ILicenseState } from './license_state';
 export { LicenseState } from './license_state';
 export { validateRuleTypeParams } from './validate_rule_type_params';
 export { validateMutatedRuleTypeParams } from './validate_mutated_rule_type_params';
+export { authorizeRuleTypeParams } from './authorize_rule_type_params';
 export { getRuleNotifyWhenType } from './get_rule_notify_when_type';
 export { verifyApiAccess } from './license_api_access';
 export { ErrorWithReason, getReasonFromError, isErrorWithReason } from './error_with_reason';

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
 import {
   coreFeatureFlagsMock,
@@ -56,6 +57,7 @@ const taskManager = taskManagerMock.createStart();
 const unsecuredSavedObjectsClient = savedObjectsClientMock.create();
 
 const rulesClientContext: RulesClientContext = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/update_rule_in_memory.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/update_rule_in_memory.ts
@@ -8,6 +8,7 @@
 import { omit } from 'lodash';
 import type { SavedObjectsBulkUpdateObject, SavedObjectsFindResult } from '@kbn/core/server';
 import {
+  authorizeRuleTypeParams,
   getRuleNotifyWhenType,
   validateMutatedRuleTypeParams,
   validateRuleTypeParams,
@@ -153,6 +154,10 @@ export async function updateRuleInMemory<Params extends RuleParams>(
     rule.attributes.params,
     ruleType.validate.params
   );
+  await authorizeRuleTypeParams(validatedMutatedAlertTypeParams, ruleType.authorize?.params, {
+    request: context.request,
+    previousParams: rule.attributes.params,
+  });
 
   const {
     references,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/add_generated_action_values.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/add_generated_action_values.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { addGeneratedActionValues } from './add_generated_action_values';
 import type { RuleAction, RuleSystemAction } from '../../../common';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
@@ -45,6 +46,7 @@ describe('addGeneratedActionValues()', () => {
   uiSettings.asScopedToClient.mockReturnValue(uiSettingsClient);
 
   const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+    request: httpServerMock.createKibanaRequest(),
     taskManager,
     ruleTypeRegistry,
     unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/check_authorization_and_get_total.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/check_authorization_and_get_total.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
 import { ruleTypeRegistryMock } from '../../rule_type_registry.mock';
@@ -24,6 +25,7 @@ const ruleTypeRegistry = ruleTypeRegistryMock.create();
 const auditLogger = auditLoggerMock.create();
 
 const context: RulesClientContext = {
+  request: httpServerMock.createKibanaRequest(),
   logger,
   unsecuredSavedObjectsClient,
   authorization: authorization as unknown as AlertingAuthorization,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/create_new_api_key_set.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/create_new_api_key_set.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import {
   savedObjectsClientMock,
   loggingSystemMock,
@@ -36,6 +37,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v8.0.0';
 const rulesClientParams: jest.Mocked<RulesClientContext> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.mock.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ActionsAuthorization } from '@kbn/actions-plugin/server';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
@@ -38,6 +39,7 @@ const create = () => {
   const backfillClient = backfillClientMock.create();
 
   const rulesClientParams: jest.Mocked<RulesClientContext> = {
+    request: httpServerMock.createKibanaRequest(),
     taskManager,
     ruleTypeRegistry,
     unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_action_error_log.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_action_error_log.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../rules_client';
 import { RulesClient } from '../rules_client';
 import type { GetActionErrorLogByIdParams } from '../methods/get_action_error_log';
@@ -45,6 +46,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_alert_state.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_alert_state.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../rules_client';
 import { RulesClient } from '../rules_client';
 import {
@@ -39,6 +40,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_alert_summary.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_alert_summary.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { omit, mean } from 'lodash';
 import type { ConstructorOptions } from '../rules_client';
 import { RulesClient } from '../rules_client';
@@ -44,6 +45,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_execution_log.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_execution_log.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { ConstructorOptions } from '../rules_client';
 import { RulesClient } from '../rules_client';
@@ -46,6 +47,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/list_rule_types.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/list_rule_types.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../rules_client';
 import { RulesClient } from '../rules_client';
 import {
@@ -38,6 +39,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/mute_all.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/mute_all.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../rules_client';
 import { RulesClient } from '../rules_client';
 import {
@@ -38,6 +39,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/mute_instance.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/mute_instance.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../rules_client';
 import { RulesClient } from '../rules_client';
 import {
@@ -52,6 +53,7 @@ const alertsService = {
 } as unknown as jest.Mocked<AlertsService>;
 
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/resolve.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/resolve.test.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { AlertConsumers } from '@kbn/rule-data-utils';
 
 import type { ConstructorOptions } from '../rules_client';
@@ -47,6 +48,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/unmute_all.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/unmute_all.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import type { ConstructorOptions } from '../rules_client';
 import { RulesClient } from '../rules_client';
 import {
@@ -38,6 +39,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 
 const kibanaVersion = 'v7.10.0';
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/types.ts
@@ -8,6 +8,7 @@
 import type { KueryNode } from '@kbn/es-query';
 import type {
   Logger,
+  KibanaRequest,
   SavedObjectsClientContract,
   PluginInitializerContext,
   ISavedObjectsRepository,
@@ -60,6 +61,14 @@ export type { GetActionErrorLogByIdParams } from './methods/get_action_error_log
 
 export interface RulesClientContext {
   readonly logger: Logger;
+  /**
+   * The request that this rules client is scoped to. On rule write paths it is
+   * passed to rule-type-defined params authorizers so that authorization can be
+   * resolved against the acting user's privileges. In background/task contexts
+   * this is a fake request built from the rule's stored API key, which carries
+   * a snapshot of the rule owner's privileges.
+   */
+  readonly request: KibanaRequest;
   readonly getUserName: () => Promise<string | null>;
   readonly spaceId: string;
   readonly namespace?: string;

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client_conflict_retries.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client_conflict_retries.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { cloneDeep } from 'lodash';
 
 import type { ConstructorOptions } from './rules_client';
@@ -53,6 +54,7 @@ const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
 const kibanaVersion = 'v7.10.0';
 const logger = loggingSystemMock.create().get();
 const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  request: httpServerMock.createKibanaRequest(),
   taskManager,
   ruleTypeRegistry,
   unsecuredSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client_factory.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client_factory.ts
@@ -264,6 +264,7 @@ export class RulesClientFactory {
       .asScopedToNamespace(spaceId);
 
     return new RulesClient({
+      request,
       spaceId,
       kibanaVersion: this.kibanaVersion,
       logger: this.logger,

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -205,6 +205,28 @@ export interface RuleTypeParamsValidator<Params extends RuleTypeParams> {
   validateMutatedParams?: (mutatedOject: Params, origObject?: Params) => Params;
 }
 
+/**
+ * Context passed to a rule type's params authorizer. Provides the request that
+ * initiated the write (so authorization can be resolved against the acting
+ * user's privileges) and, on updates, the rule's previous params (so the
+ * authorizer can restrict its checks to params that actually changed).
+ */
+export interface RuleTypeParamsAuthorizerContext<Params extends RuleTypeParams> {
+  request: KibanaRequest;
+  previousParams?: Params;
+}
+
+/**
+ * Optional, rule-type-defined authorization gate for privileged params.
+ *
+ * An async guard that authorizes the params against the acting user's privileges
+ * and throws when the user is not allowed to set them. It is invoked on rule write paths
+ * (create/update/bulk) after params have been validated.
+ */
+export interface RuleTypeParamsAuthorizer<Params extends RuleTypeParams> {
+  authorize: (params: Params, context: RuleTypeParamsAuthorizerContext<Params>) => Promise<void>;
+}
+
 export type AlertHit = Alert & {
   _id: string;
   _index: string;
@@ -327,6 +349,15 @@ export interface RuleType<
   name: string;
   validate: {
     params: RuleTypeParamsValidator<Params>;
+  };
+  /**
+   * Optional, rule-type-defined authorization for privileged params. When
+   * provided, `authorize.params` is invoked on rule write paths after the
+   * params validator runs, and may throw to reject the write. Rule types with
+   * no privileged params simply omit this.
+   */
+  authorize?: {
+    params?: RuleTypeParamsAuthorizer<Params>;
   };
   schemas?: {
     params?:

--- a/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
 import { v4 as uuidv4 } from 'uuid';
 import type { Logger } from '@kbn/logging';
 import type { CoreSetup, ElasticsearchClient } from '@kbn/core/server';
@@ -483,6 +484,7 @@ function getAuthorizationRuleType(core: CoreSetup<FixtureStartDeps>) {
 function getValidationRuleType() {
   const paramsSchema = schema.object({
     param1: schema.string(),
+    param2: schema.maybe(schema.boolean()),
   });
   type ParamsType = TypeOf<typeof paramsSchema>;
   const result: RuleType<ParamsType, never, {}, {}, {}, 'default'> = {
@@ -502,6 +504,17 @@ function getValidationRuleType() {
     defaultActionGroupId: 'default',
     validate: {
       params: paramsSchema,
+    },
+    authorize: {
+      params: {
+        // Exercises the framework's params authorization hook: schema validation
+        // passes, but setting `param2` makes authorization throw.
+        authorize: async (params) => {
+          if (params.param2) {
+            throw Boom.forbidden('Not authorized to set param2');
+          }
+        },
+      },
     },
     async executor() {
       return { state: {} };

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/update.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/update.ts
@@ -1538,5 +1538,57 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
         expect(res.statusCode).to.eql(200);
       });
     });
+
+    describe('rule type params authorization', () => {
+      const { user, space } = SuperuserAtSpace1;
+
+      async function createValidationRule() {
+        const { body: createdAlert } = await supertest
+          .post(`${getUrlPrefix(space.id)}/api/alerting/rule`)
+          .set('kbn-xsrf', 'foo')
+          .send(getTestRuleData({ rule_type_id: 'test.validation', params: { param1: 'test' } }))
+          .expect(200);
+        objectRemover.add(space.id, createdAlert.id, 'rule', 'alerting');
+        return createdAlert.id;
+      }
+
+      const updateBody = (params: Record<string, unknown>) => ({
+        name: 'updated',
+        tags: [],
+        schedule: { interval: '1m' },
+        throttle: null,
+        notify_when: 'onActiveAlert',
+        actions: [],
+        params,
+      });
+
+      it('updates the rule when the rule type params authorization passes', async () => {
+        const id = await createValidationRule();
+
+        await supertestWithoutAuth
+          .put(`${getUrlPrefix(space.id)}/api/alerting/rule/${id}`)
+          .set('kbn-xsrf', 'foo')
+          .auth(user.username, user.password)
+          .send(updateBody({ param1: 'updated' }))
+          .expect(200);
+      });
+
+      it('rejects the update when the rule type params authorization throws', async () => {
+        const id = await createValidationRule();
+
+        const response = await supertestWithoutAuth
+          .put(`${getUrlPrefix(space.id)}/api/alerting/rule/${id}`)
+          .set('kbn-xsrf', 'foo')
+          .auth(user.username, user.password)
+          .send(updateBody({ param1: 'updated', param2: true }));
+
+        expect(response.statusCode).to.eql(403);
+        expect(response.body).to.eql({
+          error: 'Forbidden',
+          message: 'Not authorized to set param2',
+          statusCode: 403,
+        });
+      });
+    });
   });
 }

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group5/tests/alerting/create.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group5/tests/alerting/create.ts
@@ -735,5 +735,40 @@ export default function createAlertTests({ getService }: FtrProviderContext) {
         expect(response.statusCode).to.eql(400);
       });
     });
+
+    describe('rule type params authorization', () => {
+      const { user, space } = SuperuserAtSpace1;
+
+      it('creates the rule when the rule type params authorization passes', async () => {
+        const response = await supertestWithoutAuth
+          .post(`${getUrlPrefix(space.id)}/api/alerting/rule`)
+          .set('kbn-xsrf', 'foo')
+          .auth(user.username, user.password)
+          .send(getTestRuleData({ rule_type_id: 'test.validation', params: { param1: 'test' } }));
+
+        expect(response.statusCode).to.eql(200);
+        objectRemover.add(space.id, response.body.id, 'rule', 'alerting');
+      });
+
+      it('rejects the rule when the rule type params authorization throws', async () => {
+        const response = await supertestWithoutAuth
+          .post(`${getUrlPrefix(space.id)}/api/alerting/rule`)
+          .set('kbn-xsrf', 'foo')
+          .auth(user.username, user.password)
+          .send(
+            getTestRuleData({
+              rule_type_id: 'test.validation',
+              params: { param1: 'test', param2: true },
+            })
+          );
+
+        expect(response.statusCode).to.eql(403);
+        expect(response.body).to.eql({
+          error: 'Forbidden',
+          message: 'Not authorized to set param2',
+          statusCode: 403,
+        });
+      });
+    });
   });
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -44,6 +44,7 @@ import { buildTimestampRuntimeMapping } from './utils/build_timestamp_runtime_ma
 import { alertsFieldMap, rulesFieldMap } from '../../../../common/field_maps';
 import { sendAlertSuppressionTelemetryEvent } from './utils/telemetry/send_alert_suppression_telemetry_event';
 import { sendGapDetectedTelemetryEvent } from './utils/telemetry/send_gap_detected_telemetry_event';
+import { createResponseActionsParamsAuthorizer } from './utils/authorize_rule_response_actions';
 import type { RuleParams } from '../rule_schema';
 import {
   SECURITY_FROM,
@@ -111,6 +112,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
     scheduleNotificationResponseActionsService,
     endpointAppContextService,
     getEntityStore,
+    getOsqueryResponseActionsAuthzChecker,
   }) =>
   (type) => {
     const { alertIgnoreFields: ignoreFields, alertMergeStrategy: mergeStrategy } = config;
@@ -124,6 +126,15 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
 
     return persistenceRuleType({
       ...type,
+      // Authorize privileged `responseActions` params on every rule write path,
+      // including writes made through the generic Alerting APIs (which bypass the
+      // Detection Engine's own routes).
+      authorize: {
+        params: createResponseActionsParamsAuthorizer({
+          endpointAppContextService,
+          getOsqueryResponseActionsAuthzChecker,
+        }),
+      },
       cancelAlertsOnRuleTimeout: false,
       useSavedObjectReferences: {
         extractReferences: (params) => extractReferences({ logger, params }),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
@@ -31,9 +31,10 @@ import type { TypeOfFieldMap } from '@kbn/rule-registry-plugin/common/field_map'
 import type { Filter } from '@kbn/es-query';
 
 import type { LicensingPluginSetup } from '@kbn/licensing-plugin/server';
-import type { DocLinksServiceSetup } from '@kbn/core/server';
+import type { DocLinksServiceSetup, KibanaRequest } from '@kbn/core/server';
 import type { EntityStoreStartContract, EntityStoreCRUDClient } from '@kbn/entity-store/server';
 import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
+import type { CheckOsqueryResponseActionAuthz } from '../../../endpoint/services/actions/utils/rule_response_actions_validators';
 import type { RulePreviewLoggedRequest } from '../../../../common/api/detection_engine/rule_preview/rule_preview.gen';
 import type { RuleResponseAction } from '../../../../common/api/detection_engine/model/rule_response_actions';
 import type { ConfigType } from '../../../config';
@@ -165,6 +166,14 @@ export interface CreateSecurityRuleTypeWrapperProps {
   scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
   endpointAppContextService: EndpointAppContextService;
   getEntityStore: () => Promise<EntityStoreStartContract>;
+  /**
+   * Returns a request-scoped osquery response action authorization checker, used
+   * when authorizing rule `responseActions` on write paths. Optional because
+   * osquery may be unavailable.
+   */
+  getOsqueryResponseActionsAuthzChecker?: (
+    request: KibanaRequest
+  ) => CheckOsqueryResponseActionAuthz;
 }
 
 export type CreateSecurityRuleTypeWrapper = (

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/authorize_rule_response_actions.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/authorize_rule_response_actions.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { createMockEndpointAppContextService } from '../../../../endpoint/mocks';
+import { getEndpointAuthzInitialStateMock } from '../../../../../common/endpoint/service/authz/mocks';
+import type { RuleResponseAction } from '../../../../../common/api/detection_engine';
+import { getQueryRuleParams } from '../../rule_schema/model/rule_schemas.mock';
+import type { RuleParams } from '../../rule_schema';
+import { createResponseActionsParamsAuthorizer } from './authorize_rule_response_actions';
+
+const isolateResponseAction = (): RuleResponseAction =>
+  ({
+    actionTypeId: '.endpoint',
+    params: { command: 'isolate', comment: 'test' },
+  } as RuleResponseAction);
+
+const paramsWithResponseActions = (responseActions?: RuleResponseAction[]): RuleParams =>
+  ({ ...getQueryRuleParams(), responseActions } as RuleParams);
+
+describe('createResponseActionsParamsAuthorizer', () => {
+  let endpointAppContextService: ReturnType<typeof createMockEndpointAppContextService>;
+  const request = httpServerMock.createKibanaRequest();
+
+  beforeEach(() => {
+    endpointAppContextService = createMockEndpointAppContextService();
+  });
+
+  it('resolves when neither new nor previous params have response actions', async () => {
+    const authorizer = createResponseActionsParamsAuthorizer({ endpointAppContextService });
+
+    await expect(
+      authorizer.authorize(paramsWithResponseActions(), { request })
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves when the user is authorized for the added response action', async () => {
+    endpointAppContextService.getEndpointAuthz.mockResolvedValue(
+      getEndpointAuthzInitialStateMock({ canIsolateHost: true })
+    );
+    const authorizer = createResponseActionsParamsAuthorizer({ endpointAppContextService });
+
+    await expect(
+      authorizer.authorize(paramsWithResponseActions([isolateResponseAction()]), { request })
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws a 403 Boom error when the user lacks privileges for the added response action', async () => {
+    endpointAppContextService.getEndpointAuthz.mockResolvedValue(
+      getEndpointAuthzInitialStateMock({ canIsolateHost: false })
+    );
+    const authorizer = createResponseActionsParamsAuthorizer({ endpointAppContextService });
+
+    const error = await authorizer
+      .authorize(paramsWithResponseActions([isolateResponseAction()]), { request })
+      .catch((e) => e);
+
+    expect(Boom.isBoom(error)).toBe(true);
+    expect(error.output.statusCode).toBe(403);
+  });
+
+  it('does not re-authorize a response action that is unchanged from the previous params', async () => {
+    // User is NOT authorized, but since the response action is unchanged the
+    // authorizer must not block the write (mirrors the DE routes' behavior of
+    // only validating changed response actions). This also proves the internal
+    // camelCase params are correctly reconciled with the previous params.
+    endpointAppContextService.getEndpointAuthz.mockResolvedValue(
+      getEndpointAuthzInitialStateMock({ canIsolateHost: false })
+    );
+    const authorizer = createResponseActionsParamsAuthorizer({ endpointAppContextService });
+    const responseActions = [isolateResponseAction()];
+
+    await expect(
+      authorizer.authorize(paramsWithResponseActions(responseActions), {
+        request,
+        previousParams: paramsWithResponseActions(responseActions),
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('uses the request-scoped osquery authz checker for osquery response actions', async () => {
+    const osqueryCheck = jest.fn().mockResolvedValue(undefined);
+    const getOsqueryResponseActionsAuthzChecker = jest.fn().mockReturnValue(osqueryCheck);
+    const authorizer = createResponseActionsParamsAuthorizer({
+      endpointAppContextService,
+      getOsqueryResponseActionsAuthzChecker,
+    });
+
+    const osqueryAction = {
+      actionTypeId: '.osquery',
+      params: { savedQueryId: 'saved-query-1' },
+    } as RuleResponseAction;
+
+    await authorizer.authorize(paramsWithResponseActions([osqueryAction]), { request });
+
+    expect(getOsqueryResponseActionsAuthzChecker).toHaveBeenCalledWith(request);
+    expect(osqueryCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ saved_query_id: 'saved-query-1' })
+    );
+  });
+
+  const osqueryAction = () =>
+    ({ actionTypeId: '.osquery', params: { savedQueryId: 'q' } } as RuleResponseAction);
+
+  it('preserves the status code of a validator error thrown from a different class', async () => {
+    // Simulates osquery's own CustomHttpRequestError: a non-Boom error carrying a
+    // numeric `statusCode` that is NOT an instanceof the security_solution class.
+    const osqueryError = Object.assign(new Error('not authorized for osquery'), {
+      statusCode: 403,
+    });
+    const authorizer = createResponseActionsParamsAuthorizer({
+      endpointAppContextService,
+      getOsqueryResponseActionsAuthzChecker: () => jest.fn().mockRejectedValue(osqueryError),
+    });
+
+    const error = await authorizer
+      .authorize(paramsWithResponseActions([osqueryAction()]), { request })
+      .catch((e) => e);
+
+    expect(Boom.isBoom(error)).toBe(true);
+    expect(error.output.statusCode).toBe(403);
+    expect(error.message).toBe('not authorized for osquery');
+  });
+
+  it('defaults to a 400 status code for a thrown error without a status code', async () => {
+    const authorizer = createResponseActionsParamsAuthorizer({
+      endpointAppContextService,
+      getOsqueryResponseActionsAuthzChecker: () => jest.fn().mockRejectedValue(new Error('boom')),
+    });
+
+    const error = await authorizer
+      .authorize(paramsWithResponseActions([osqueryAction()]), { request })
+      .catch((e) => e);
+
+    expect(Boom.isBoom(error)).toBe(true);
+    expect(error.output.statusCode).toBe(400);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/authorize_rule_response_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/authorize_rule_response_actions.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import type { KibanaRequest } from '@kbn/core/server';
+import type { RuleTypeParamsAuthorizer } from '@kbn/alerting-plugin/server';
+import { transformAlertToRuleResponseAction } from '../../../../../common/detection_engine/transform_actions';
+import type { EndpointAppContextService } from '../../../../endpoint/endpoint_app_context_services';
+import type { CheckOsqueryResponseActionAuthz } from '../../../../endpoint/services/actions/utils/rule_response_actions_validators';
+import { validateRuleResponseActions } from '../../../../endpoint/services';
+import type { RuleAlertType, RuleParams } from '../../rule_schema';
+
+interface CreateResponseActionsParamsAuthorizerDeps {
+  endpointAppContextService: EndpointAppContextService;
+  /**
+   * Returns a request-scoped osquery response action authorization checker.
+   * Optional because osquery is not guaranteed to be available; when omitted,
+   * osquery response actions are not authorized here (matching the behavior of
+   * {@link validateRuleResponseActions} when no checker is provided).
+   */
+  getOsqueryResponseActionsAuthzChecker?: (
+    request: KibanaRequest
+  ) => CheckOsqueryResponseActionAuthz;
+}
+
+/**
+ * Builds the alerting {@link RuleTypeParamsAuthorizer} for security rule types.
+ *
+ * The Detection Engine's own rule CRUD routes authorize Elastic Defend / osquery
+ * response actions via {@link validateRuleResponseActions}. Writes performed
+ * through the generic Alerting APIs bypass those routes, so this authorizer runs
+ * the same validation from within the Alerting framework's rule write paths,
+ * against the acting user's privileges.
+ */
+export const createResponseActionsParamsAuthorizer = <TParams extends RuleParams>({
+  endpointAppContextService,
+  getOsqueryResponseActionsAuthzChecker,
+}: CreateResponseActionsParamsAuthorizerDeps): RuleTypeParamsAuthorizer<TParams> => ({
+  authorize: async (params, { request, previousParams }) => {
+    const responseActions = params.responseActions?.map(transformAlertToRuleResponseAction);
+
+    try {
+      await validateRuleResponseActions({
+        endpointService: endpointAppContextService,
+        endpointAuthz: await endpointAppContextService.getEndpointAuthz(request),
+        spaceId: endpointAppContextService.getActiveSpaceId(request),
+        rulePayload: { response_actions: responseActions },
+        // `validateRuleResponseActions` only reads `existingRule.params.responseActions`,
+        // so a minimal object is sufficient here.
+        existingRule: previousParams
+          ? ({ params: previousParams } as unknown as RuleAlertType)
+          : null,
+        checkOsqueryResponseActionAuthz: getOsqueryResponseActionsAuthzChecker?.(request),
+      });
+    } catch (err) {
+      // Preserve the HTTP status code (403 for authz failures, 400 for invalid
+      // payloads) as a Boom error so the generic Alerting APIs surface it
+      // correctly. Route-driven paths already translate both error shapes.
+      if (Boom.isBoom(err)) {
+        throw err;
+      }
+      // Both the Endpoint and osquery validators throw `CustomHttpRequestError`,
+      // but from different plugin-local classes, so duck-type on `statusCode`
+      // rather than `instanceof` to preserve 403 (authz) vs 400 (invalid payload).
+      const statusCode = typeof err.statusCode === 'number' ? err.statusCode : 400;
+      throw new Boom.Boom(err.message, { statusCode });
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -567,6 +567,13 @@ export class Plugin implements ISecuritySolutionPlugin {
       secondaryAlias: undefined,
     });
 
+    const osquery = plugins.osquery;
+    const getOsqueryResponseActionsAuthzChecker: CreateSecurityRuleTypeWrapperProps['getOsqueryResponseActionsAuthzChecker'] =
+      osquery
+        ? (request) => (actionParams) =>
+            osquery?.checkResponseActionAuthz(request, actionParams) ?? Promise.resolve()
+        : undefined;
+
     const securityRuleTypeOptions = {
       lists: plugins.lists,
       docLinks: core.docLinks,
@@ -593,6 +600,7 @@ export class Plugin implements ISecuritySolutionPlugin {
         const [, startPlugins] = await core.getStartServices();
         return startPlugins.entityStore;
       },
+      getOsqueryResponseActionsAuthzChecker,
     };
 
     const securityRuleTypeWrapper = createSecurityRuleTypeWrapper(securityRuleTypeOptions);

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -170,6 +170,7 @@ import { securityAlertsProfileInitializer } from './lib/anonymization';
 import { registerWatchlistMaintainer } from './lib/entity_analytics/watchlists/maintainer/register_watchlist_maintainer';
 import { registerEndpointExceptionsRoutes } from './endpoint/routes/endpoint_exceptions_per_policy_opt_in';
 import { initializeEndpointExceptionsPerPolicyOptInStatus } from './endpoint/lib/reference_data';
+import { CreateSecurityRuleTypeWrapperProps } from './lib/detection_engine/rule_types/types';
 
 export type { SetupPlugins, StartPlugins, PluginSetup, PluginStart } from './plugin_contract';
 

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -170,7 +170,7 @@ import { securityAlertsProfileInitializer } from './lib/anonymization';
 import { registerWatchlistMaintainer } from './lib/entity_analytics/watchlists/maintainer/register_watchlist_maintainer';
 import { registerEndpointExceptionsRoutes } from './endpoint/routes/endpoint_exceptions_per_policy_opt_in';
 import { initializeEndpointExceptionsPerPolicyOptInStatus } from './endpoint/lib/reference_data';
-import { CreateSecurityRuleTypeWrapperProps } from './lib/detection_engine/rule_types/types';
+import type { CreateSecurityRuleTypeWrapperProps } from './lib/detection_engine/rule_types/types';
 
 export type { SetupPlugins, StartPlugins, PluginSetup, PluginStart } from './plugin_contract';
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules.ts
@@ -704,13 +704,64 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('with endpoint response actions', () => {
       let superTestResponseActionsNoAuthz: TestAgent;
+      let superTestResponseActionsAuthz: TestAgent;
       let apiCreatePayload: ReturnType<typeof getCustomQueryRuleParams>;
+
+      // Internal (camelCase) query-rule params, in the shape the generic Alerting API expects.
+      const alertingQueryRuleParams = {
+        author: [],
+        description: 'response action authz test',
+        exceptionsList: [],
+        falsePositives: [],
+        filters: [],
+        from: 'now-3600s',
+        immutable: false,
+        index: ['logs-*'],
+        language: 'kuery',
+        license: '',
+        maxSignals: 100,
+        outputIndex: '',
+        query: '*:*',
+        references: [],
+        relatedIntegrations: [],
+        riskScore: 21,
+        riskScoreMapping: [],
+        setup: '',
+        severity: 'low',
+        severityMapping: [],
+        threat: [],
+        to: 'now',
+        type: 'query',
+        version: 1,
+        responseActions: [
+          {
+            actionTypeId: '.endpoint',
+            params: { command: 'kill-process', config: { field: '', overwrite: true } },
+          },
+        ],
+      };
+
+      const buildAlertingCreateBody = (params: Record<string, unknown>) => ({
+        rule_type_id: 'siem.queryRule',
+        consumer: 'siem',
+        name: `alerting-api-${uuidV4()}`,
+        enabled: false,
+        schedule: { interval: '5m' },
+        actions: [],
+        params: { ...params, ruleId: uuidV4() },
+      });
 
       before(async () => {
         superTestResponseActionsNoAuthz = await utils.createSuperTestWithCustomRole({
           name: ROLE.endpoint_response_actions_no_access,
           privileges: rolesUsersProvider.loader.getPreDefinedRole(
             ROLE.endpoint_response_actions_no_access
+          ),
+        });
+        superTestResponseActionsAuthz = await utils.createSuperTestWithCustomRole({
+          name: ROLE.endpoint_response_actions_access,
+          privileges: rolesUsersProvider.loader.getPreDefinedRole(
+            ROLE.endpoint_response_actions_access
           ),
         });
       });
@@ -744,6 +795,27 @@ export default ({ getService }: FtrProviderContext) => {
           .set('elastic-api-version', '2023-10-31')
           .on('error', createSupertestErrorLogger(log).ignoreCodes([403]))
           .send(apiCreatePayload)
+          .expect(403);
+
+        expect(body.message).toEqual(
+          'User is not authorized to create/update kill-process response action'
+        );
+      });
+
+      it('should create rule with response actions via the Alerting API when user has authz', async () => {
+        await superTestResponseActionsAuthz
+          .post('/api/alerting/rule')
+          .set('kbn-xsrf', 'true')
+          .send(buildAlertingCreateBody(alertingQueryRuleParams))
+          .expect(200);
+      });
+
+      it('should error creating rule with response actions via the Alerting API when user DOES NOT have authz', async () => {
+        const { body } = await superTestResponseActionsNoAuthz
+          .post('/api/alerting/rule')
+          .set('kbn-xsrf', 'true')
+          .on('error', createSupertestErrorLogger(log).ignoreCodes([403]))
+          .send(buildAlertingCreateBody(alertingQueryRuleParams))
           .expect(403);
 
         expect(body.message).toEqual(

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules.ts
@@ -827,14 +827,42 @@ export default ({ getService }: FtrProviderContext) => {
 
       describe('with endpoint response actions', () => {
         let superTestResponseActionsNoAuthz: TestAgent;
+        let superTestResponseActionsAuthz: TestAgent;
         let ruleToUpdate: RuleResponse;
         let updatePayload: RuleUpdateProps;
+
+        const getRuleAlertingUpdateBody = async (id: string, responseActions: unknown[]) => {
+          const { body: current } = await supertest
+            .get(`/api/alerting/rule/${id}`)
+            .set('kbn-xsrf', 'true')
+            .expect(200);
+
+          return {
+            name: current.name,
+            tags: current.tags,
+            schedule: current.schedule,
+            throttle: current.throttle ?? null,
+            notify_when: current.notify_when ?? null,
+            actions: current.actions,
+            params: { ...current.params, responseActions },
+          };
+        };
+
+        const isolateResponseAction = [
+          { actionTypeId: '.endpoint', params: { command: 'isolate', comment: 'test isolation' } },
+        ];
 
         before(async () => {
           superTestResponseActionsNoAuthz = await utils.createSuperTestWithCustomRole({
             name: ROLE.endpoint_response_actions_no_access,
             privileges: rolesUsersProvider.loader.getPreDefinedRole(
               ROLE.endpoint_response_actions_no_access
+            ),
+          });
+          superTestResponseActionsAuthz = await utils.createSuperTestWithCustomRole({
+            name: ROLE.endpoint_response_actions_access,
+            privileges: rolesUsersProvider.loader.getPreDefinedRole(
+              ROLE.endpoint_response_actions_access
             ),
           });
         });
@@ -916,6 +944,27 @@ export default ({ getService }: FtrProviderContext) => {
 
           expect(body.name).to.eql('updated rule name');
           expect(body.response_actions).to.eql(ruleToUpdate.response_actions);
+        });
+
+        it('should update rule response actions via the Alerting API when user has authz', async () => {
+          await superTestResponseActionsAuthz
+            .put(`/api/alerting/rule/${ruleToUpdate.id}`)
+            .set('kbn-xsrf', 'true')
+            .send(await getRuleAlertingUpdateBody(ruleToUpdate.id, isolateResponseAction))
+            .expect(200);
+        });
+
+        it('should error updating response actions via the Alerting API when user DOES NOT have authz', async () => {
+          const { body } = await superTestResponseActionsNoAuthz
+            .put(`/api/alerting/rule/${ruleToUpdate.id}`)
+            .set('kbn-xsrf', 'true')
+            .on('error', createSupertestErrorLogger(log).ignoreCodes([403]))
+            .send(await getRuleAlertingUpdateBody(ruleToUpdate.id, isolateResponseAction))
+            .expect(403);
+
+          expect(body.message).to.eql(
+            'User is not authorized to create/update isolate response action'
+          );
         });
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution] Enforce rule params authorization on generic Alerting API writes to close the response actions RBAC bypass (#280430)](https://github.com/elastic/kibana/pull/280430)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Edgar Santos","email":"edgar.santos@elastic.co"},"sourceCommit":{"committedDate":"2026-07-27T10:07:20Z","message":"[Security Solution] Enforce rule params authorization on generic Alerting API writes to close the response actions RBAC bypass (#280430)\n\n## Summary\n\nA user with only **Rules and Exceptions: All** (which grants\n`alerting.rule.all`) can attach Elastic Defend / osquery **response\nactions** (`params.responseActions`) to security rules through the\ngeneric Alerting API (`POST|PUT /api/alerting/rule/{id}`), bypassing the\nEndpoint and osquery privilege checks. This lets an unauthorized user\ncontrol Elastic Defend across every host a rule matches.\n\nResponse-action authorization is asynchronous and privilege-based, so it\nis not part of the normal (synchronous) rule param validation. The\nDetection Engine enforces it in its own CRUD routes via\n[`validateRuleResponseActions`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.ts),\nbut the generic Alerting APIs write rule params directly through the\nalerting `rulesClient` and never run that check.\n\n- Security incident: https://github.com/elastic/security/issues/12060\n- Tracking issue: https://github.com/elastic/kibana-team/issues/3776\n\n## Solution\n\nMove response-action authorization into the Alerting framework so every\nrule write path is covered, regardless of which API is used.\n\n- **New rule-type-defined authorization hook.** Rule types can now\ndeclare an `authorize: { params }` gate (`RuleTypeParamsAuthorizer`),\nmirroring the existing `validate: { params }`. It is an async guard that\nauthorizes params against the acting user's privileges and throws when\nthey are not allowed.\n- **Framework enforcement on write paths only.** A new\n`authorizeRuleTypeParams` runs immediately after\n`validateRuleTypeParams` on the four write paths (`create`, `update`,\n`bulk_create`, `bulk_edit`). The execution/task-runner paths are\nintentionally untouched, so no code needs to become async that was not\nalready.\n- **Request context.** `RulesClientContext` now carries the scoped\n`request`, which the write methods pass to the authorizer (along with\nthe previous params on updates, so only *changed* response actions are\nvalidated). This is not a public breaking change: a rules client can\nnever be constructed without a request. On background writes the request\nis the fake request built from the rule's stored API key, which carries\na snapshot of the owner's privileges, so authorization stays correct.\n- **Detection Engine wiring.** Security rule types define\n`authorize.params` to delegate to the existing\n`validateRuleResponseActions`, resolving Endpoint authz, space id, and\nthe osquery checker from the request. This is the same enforcement the\nDE routes already perform, now applied on every write path.\n\nThe existing DE-route validation is intentionally left in place (it\ncovers the bulk-action dry-run path, which never reaches a write\nmethod).\n\n### Tests\n\n- Unit tests for the framework hook and the Detection Engine authorizer\n(including HTTP status-code preservation across the Endpoint and osquery\nvalidators).\n- FTR API integration tests extended in `rule_creation` and\n`rule_update` to cover the generic Alerting API path for users with and\nwithout response-action privileges.\n\n## How to test\n\nThe checks below run entirely at rule **write** time, so no enrolled\nendpoints or live osquery agents are required.\n\n**Prerequisites**\n- Local Elasticsearch + Kibana running from this branch (`yarn start`),\nsecurity enabled.\n- Node 18+ (uses global `fetch`).\n\n**1. Roles / users — `roles.js`**\n\n<details><summary>roles.js</summary>\n\n```js\nconst KIBANA = process.env.KIBANA_URL || 'http://localhost:5601/kbn';\nconst ES = process.env.ES_URL || 'http://localhost:9200';\nconst ADMIN = {\n  username: process.env.ES_USER || 'elastic',\n  password: process.env.ES_PASS || 'changeme',\n};\nconst PASSWORD = 'changeme';\n\nconst BASE = [\n  'feature_siemV5.all',\n  'feature_securitySolutionRulesV4.all',\n  'feature_securitySolutionAlertsV1.all',\n  'feature_indexPatterns.all',\n  'feature_savedObjectsManagement.all',\n];\nconst ENDPOINT_RA = [\n  'feature_siemV5.host_isolation_all',\n  'feature_siemV5.process_operations_all',\n  'feature_siemV5.file_operations_all',\n  'feature_siemV5.execute_operations_all',\n  'feature_siemV5.scan_operations_all',\n];\nconst OSQUERY = ['feature_osquery.all'];\n\nconst INDICES = [\n  {\n    names: [\n      '.alerts-security.alerts-default',\n      '.internal.alerts-security.alerts-default-*',\n      '.lists-default',\n      '.items-default',\n      '.siem-signals-default',\n      'logs-*',\n    ],\n    privileges: ['read', 'write', 'manage', 'view_index_metadata'],\n    allow_restricted_indices: false,\n  },\n];\n\nconst roleBody = (features) => ({\n  cluster: [],\n  indices: INDICES,\n  applications: [{ application: 'kibana-.kibana', privileges: features, resources: ['space:default'] }],\n  run_as: [],\n});\n\nconst USERS = [\n  { tier: 'none', username: 'ra_authz_none', role: 'ra_authz_none', password: PASSWORD, roleBody: roleBody(BASE) },\n  {\n    tier: 'partial',\n    username: 'ra_authz_partial',\n    role: 'ra_authz_partial',\n    password: PASSWORD,\n    roleBody: roleBody([...BASE, ...ENDPOINT_RA]),\n  },\n  {\n    tier: 'full',\n    username: 'ra_authz_full',\n    role: 'ra_authz_full',\n    password: PASSWORD,\n    roleBody: roleBody([...BASE, ...ENDPOINT_RA, ...OSQUERY]),\n  },\n];\n\nmodule.exports = { KIBANA, ES, ADMIN, USERS };\n```\n\n</details>\n\n**2. Test runner — `test.js`**\n\n<details><summary>test.js</summary>\n\n```js\nconst { KIBANA, ES, ADMIN, USERS } = require('./roles');\n\nconst basic = (u, p) => 'Basic ' + Buffer.from(`${u}:${p}`).toString('base64');\nconst ADMIN_AUTH = basic(ADMIN.username, ADMIN.password);\n\nasync function req(base, path, { method = 'GET', auth = ADMIN_AUTH, body } = {}) {\n  const res = await fetch(base + path, {\n    method,\n    headers: { 'content-type': 'application/json', 'kbn-xsrf': 'true', authorization: auth },\n    body: body === undefined ? undefined : JSON.stringify(body),\n  });\n  const text = await res.text();\n  let data;\n  try {\n    data = text ? JSON.parse(text) : undefined;\n  } catch {\n    data = text;\n  }\n  return { status: res.status, body: data };\n}\nconst kb = (path, opts) => req(KIBANA, path, opts);\nconst es = (path, opts) => req(ES, path, opts);\n\nconst uid = (p) => `${p}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;\nconst cls = (s) => (s >= 200 && s < 300 ? 'ok' : s === 403 ? 'forbidden' : `http-${s}`);\nconst TAG = 'ra-authz-test';\n\nconst ENDPOINT_SNAKE = [{ action_type_id: '.endpoint', params: { command: 'isolate', comment: 'authz-test' } }];\nconst OSQUERY_SNAKE = [{ action_type_id: '.osquery', params: { query: 'SELECT * FROM processes;' } }];\nconst ENDPOINT_CAMEL = [{ actionTypeId: '.endpoint', params: { command: 'isolate', comment: 'authz-test' } }];\nconst OSQUERY_CAMEL = [{ actionTypeId: '.osquery', params: { query: 'SELECT * FROM processes;' } }];\n\nconst deRule = (name, extra = {}) => ({\n  name,\n  description: 'authz test',\n  risk_score: 21,\n  severity: 'low',\n  type: 'query',\n  query: '*:*',\n  language: 'kuery',\n  index: ['logs-*'],\n  from: 'now-3600s',\n  interval: '5m',\n  enabled: false,\n  tags: [TAG],\n  ...extra,\n});\n\nconst created = [];\nconst track = (r) => {\n  if (r.status >= 200 && r.status < 300 && r.body && r.body.id) created.push(r.body.id);\n  return r;\n};\n\nasync function deleteUserAndRole(u) {\n  await es(`/_security/user/${u.username}`, { method: 'DELETE' });\n  await es(`/_security/role/${u.role}`, { method: 'DELETE' });\n}\nasync function createRole(u) {\n  const r = await es(`/_security/role/${u.role}`, { method: 'PUT', body: u.roleBody });\n  if (r.status >= 300) throw new Error(`role ${u.role}: ${r.status} ${JSON.stringify(r.body)}`);\n}\nasync function createUser(u) {\n  const r = await es(`/_security/user/${u.username}`, {\n    method: 'PUT',\n    body: { password: u.password, roles: [u.role], full_name: u.tier },\n  });\n  if (r.status >= 300) throw new Error(`user ${u.username}: ${r.status} ${JSON.stringify(r.body)}`);\n}\n\nasync function createRule(name, extra) {\n  const r = track(await kb('/api/detection_engine/rules', { method: 'POST', body: deRule(name, extra) }));\n  if (r.status >= 300) throw new Error(`create rule: ${r.status} ${JSON.stringify(r.body)}`);\n  return r.body.id;\n}\n\nasync function createTestRules() {\n  const dePatchEpId = await createRule(uid('ra-de-ep-patch'));\n  const dePatchOsqId = await createRule(uid('ra-de-osq-patch'));\n  const alUpdateEpId = await createRule(uid('ra-al-ep-upd'));\n  const alUpdateOsqId = await createRule(uid('ra-al-osq-upd'));\n  const seededId = await createRule(uid('ra-seeded'), { response_actions: ENDPOINT_SNAKE });\n  const template = (await kb(`/api/alerting/rule/${dePatchEpId}`)).body.params;\n  return { dePatchEpId, dePatchOsqId, alUpdateEpId, alUpdateOsqId, seededId, template };\n}\n\nasync function alertingUpdate(id, auth, responseActions, name) {\n  const cur = (await kb(`/api/alerting/rule/${id}`)).body;\n  return kb(`/api/alerting/rule/${id}`, {\n    method: 'PUT',\n    auth,\n    body: {\n      name: name || cur.name,\n      tags: cur.tags || [],\n      schedule: cur.schedule,\n      throttle: cur.throttle || null,\n      notify_when: cur.notify_when || null,\n      actions: cur.actions || [],\n      params: responseActions ? { ...cur.params, responseActions } : cur.params,\n    },\n  });\n}\n\nasync function alertingCreate(template, auth, responseActions, tier) {\n  const ruleId = uid(`ra-al-create-${tier}`);\n  return track(\n    await kb('/api/alerting/rule', {\n      method: 'POST',\n      auth,\n      body: {\n        rule_type_id: 'siem.queryRule',\n        consumer: 'siem',\n        name: ruleId,\n        enabled: false,\n        tags: [TAG],\n        schedule: { interval: '5m' },\n        actions: [],\n        params: { ...template, ruleId, immutable: false, responseActions },\n      },\n    })\n  );\n}\n\nconst CASES = [\n  {\n    name: 'DE create rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: async (u) =>\n      track(\n        await kb('/api/detection_engine/rules', {\n          method: 'POST',\n          auth: u.auth,\n          body: deRule(uid(`ra-de-ep-create-${u.tier}`), { response_actions: ENDPOINT_SNAKE }),\n        })\n      ),\n  },\n  {\n    name: 'DE patch rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) =>\n      kb('/api/detection_engine/rules', {\n        method: 'PATCH',\n        auth: u.auth,\n        body: { id: r.dePatchEpId, response_actions: ENDPOINT_SNAKE },\n      }),\n  },\n  {\n    name: 'DE patch rule w/ osquery RA',\n    expected: { none: 'forbidden', partial: 'forbidden', full: 'ok' },\n    run: (u, r) =>\n      kb('/api/detection_engine/rules', {\n        method: 'PATCH',\n        auth: u.auth,\n        body: { id: r.dePatchOsqId, response_actions: OSQUERY_SNAKE },\n      }),\n  },\n  {\n    name: 'Alerting create rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingCreate(r.template, u.auth, ENDPOINT_CAMEL, u.tier),\n  },\n  {\n    name: 'Alerting update rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.alUpdateEpId, u.auth, ENDPOINT_CAMEL),\n  },\n  {\n    name: 'Alerting update rule w/ osquery RA',\n    expected: { none: 'forbidden', partial: 'forbidden', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.alUpdateOsqId, u.auth, OSQUERY_CAMEL),\n  },\n  {\n    name: 'Alerting update unchanged RA (rename only)',\n    expected: { none: 'ok', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.seededId, u.auth, undefined, uid(`ra-rename-${u.tier}`)),\n  },\n];\n\nasync function run() {\n  const results = [];\n  for (const u of USERS) {\n    await deleteUserAndRole(u);\n    await createRole(u);\n    await createUser(u);\n    u.auth = basic(u.username, u.password);\n    const rules = await createTestRules();\n    for (const c of CASES) {\n      const res = await c.run(u, rules);\n      const actual = cls(res.status);\n      const expected = c.expected[u.tier];\n      results.push({ user: u.tier, case: c.name, expected, actual, status: res.status, pass: actual === expected });\n    }\n  }\n  return results;\n}\n\nasync function cleanup() {\n  for (const id of created) await kb(`/api/alerting/rule/${id}`, { method: 'DELETE' });\n  for (const u of USERS) await deleteUserAndRole(u);\n}\n\n(async () => {\n  let results = [];\n  try {\n    results = await run();\n  } finally {\n    await cleanup();\n  }\n  console.table(\n    results.map((r) => ({\n      user: r.user,\n      case: r.case,\n      expected: r.expected,\n      actual: r.actual,\n      status: r.status,\n      result: r.pass ? 'PASS' : 'FAIL',\n    }))\n  );\n  const failed = results.filter((r) => !r.pass);\n  console.log(`\\n${results.length - failed.length}/${results.length} passed`);\n  process.exit(failed.length ? 1 : 0);\n})();\n\n```\n\n</details>\n\n\n**Run**\n\n```bash\nnode test.js\n```\n\n**What it covers**\n\nFor each of three privilege tiers, the script deletes any prior\nuser/role, recreates the role and user, creates fresh test rules, and\nasserts every case:\n\n- **none** — rule management only, no response-action or Endpoint\nprivileges (the reported attacker).\n- **partial** — adds Endpoint response-action privileges (host\nisolation, process operations, …) but no osquery.\n- **full** — adds osquery privileges as well.\n\nCases exercised per tier, across both the Detection Engine routes and\nthe generic Alerting API (create and update), for `.endpoint` and\n`.osquery` response actions:\n\n- Setting a response action a tier is **not** privileged for is rejected\nwith `403`.\n- Setting a response action a tier **is** privileged for succeeds.\n- Editing an unrelated field on a rule whose response actions are\nunchanged succeeds even without response-action privileges (only changed\nactions are validated).\n\nExpected result: **all cases pass** on this branch. Running the same\nscript against `main` shows the Alerting API cases for `none`/`partial`\nincorrectly returning `200`, demonstrating the bypass this PR closes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f35840c41ad3e25a057cc93b96eab0f0cf0ce34","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","Team:Detection Engineering","v9.6.0","v9.3.8","v9.4.5"],"title":"[Security Solution] Enforce rule params authorization on generic Alerting API writes to close the response actions RBAC bypass","number":280430,"url":"https://github.com/elastic/kibana/pull/280430","mergeCommit":{"message":"[Security Solution] Enforce rule params authorization on generic Alerting API writes to close the response actions RBAC bypass (#280430)\n\n## Summary\n\nA user with only **Rules and Exceptions: All** (which grants\n`alerting.rule.all`) can attach Elastic Defend / osquery **response\nactions** (`params.responseActions`) to security rules through the\ngeneric Alerting API (`POST|PUT /api/alerting/rule/{id}`), bypassing the\nEndpoint and osquery privilege checks. This lets an unauthorized user\ncontrol Elastic Defend across every host a rule matches.\n\nResponse-action authorization is asynchronous and privilege-based, so it\nis not part of the normal (synchronous) rule param validation. The\nDetection Engine enforces it in its own CRUD routes via\n[`validateRuleResponseActions`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.ts),\nbut the generic Alerting APIs write rule params directly through the\nalerting `rulesClient` and never run that check.\n\n- Security incident: https://github.com/elastic/security/issues/12060\n- Tracking issue: https://github.com/elastic/kibana-team/issues/3776\n\n## Solution\n\nMove response-action authorization into the Alerting framework so every\nrule write path is covered, regardless of which API is used.\n\n- **New rule-type-defined authorization hook.** Rule types can now\ndeclare an `authorize: { params }` gate (`RuleTypeParamsAuthorizer`),\nmirroring the existing `validate: { params }`. It is an async guard that\nauthorizes params against the acting user's privileges and throws when\nthey are not allowed.\n- **Framework enforcement on write paths only.** A new\n`authorizeRuleTypeParams` runs immediately after\n`validateRuleTypeParams` on the four write paths (`create`, `update`,\n`bulk_create`, `bulk_edit`). The execution/task-runner paths are\nintentionally untouched, so no code needs to become async that was not\nalready.\n- **Request context.** `RulesClientContext` now carries the scoped\n`request`, which the write methods pass to the authorizer (along with\nthe previous params on updates, so only *changed* response actions are\nvalidated). This is not a public breaking change: a rules client can\nnever be constructed without a request. On background writes the request\nis the fake request built from the rule's stored API key, which carries\na snapshot of the owner's privileges, so authorization stays correct.\n- **Detection Engine wiring.** Security rule types define\n`authorize.params` to delegate to the existing\n`validateRuleResponseActions`, resolving Endpoint authz, space id, and\nthe osquery checker from the request. This is the same enforcement the\nDE routes already perform, now applied on every write path.\n\nThe existing DE-route validation is intentionally left in place (it\ncovers the bulk-action dry-run path, which never reaches a write\nmethod).\n\n### Tests\n\n- Unit tests for the framework hook and the Detection Engine authorizer\n(including HTTP status-code preservation across the Endpoint and osquery\nvalidators).\n- FTR API integration tests extended in `rule_creation` and\n`rule_update` to cover the generic Alerting API path for users with and\nwithout response-action privileges.\n\n## How to test\n\nThe checks below run entirely at rule **write** time, so no enrolled\nendpoints or live osquery agents are required.\n\n**Prerequisites**\n- Local Elasticsearch + Kibana running from this branch (`yarn start`),\nsecurity enabled.\n- Node 18+ (uses global `fetch`).\n\n**1. Roles / users — `roles.js`**\n\n<details><summary>roles.js</summary>\n\n```js\nconst KIBANA = process.env.KIBANA_URL || 'http://localhost:5601/kbn';\nconst ES = process.env.ES_URL || 'http://localhost:9200';\nconst ADMIN = {\n  username: process.env.ES_USER || 'elastic',\n  password: process.env.ES_PASS || 'changeme',\n};\nconst PASSWORD = 'changeme';\n\nconst BASE = [\n  'feature_siemV5.all',\n  'feature_securitySolutionRulesV4.all',\n  'feature_securitySolutionAlertsV1.all',\n  'feature_indexPatterns.all',\n  'feature_savedObjectsManagement.all',\n];\nconst ENDPOINT_RA = [\n  'feature_siemV5.host_isolation_all',\n  'feature_siemV5.process_operations_all',\n  'feature_siemV5.file_operations_all',\n  'feature_siemV5.execute_operations_all',\n  'feature_siemV5.scan_operations_all',\n];\nconst OSQUERY = ['feature_osquery.all'];\n\nconst INDICES = [\n  {\n    names: [\n      '.alerts-security.alerts-default',\n      '.internal.alerts-security.alerts-default-*',\n      '.lists-default',\n      '.items-default',\n      '.siem-signals-default',\n      'logs-*',\n    ],\n    privileges: ['read', 'write', 'manage', 'view_index_metadata'],\n    allow_restricted_indices: false,\n  },\n];\n\nconst roleBody = (features) => ({\n  cluster: [],\n  indices: INDICES,\n  applications: [{ application: 'kibana-.kibana', privileges: features, resources: ['space:default'] }],\n  run_as: [],\n});\n\nconst USERS = [\n  { tier: 'none', username: 'ra_authz_none', role: 'ra_authz_none', password: PASSWORD, roleBody: roleBody(BASE) },\n  {\n    tier: 'partial',\n    username: 'ra_authz_partial',\n    role: 'ra_authz_partial',\n    password: PASSWORD,\n    roleBody: roleBody([...BASE, ...ENDPOINT_RA]),\n  },\n  {\n    tier: 'full',\n    username: 'ra_authz_full',\n    role: 'ra_authz_full',\n    password: PASSWORD,\n    roleBody: roleBody([...BASE, ...ENDPOINT_RA, ...OSQUERY]),\n  },\n];\n\nmodule.exports = { KIBANA, ES, ADMIN, USERS };\n```\n\n</details>\n\n**2. Test runner — `test.js`**\n\n<details><summary>test.js</summary>\n\n```js\nconst { KIBANA, ES, ADMIN, USERS } = require('./roles');\n\nconst basic = (u, p) => 'Basic ' + Buffer.from(`${u}:${p}`).toString('base64');\nconst ADMIN_AUTH = basic(ADMIN.username, ADMIN.password);\n\nasync function req(base, path, { method = 'GET', auth = ADMIN_AUTH, body } = {}) {\n  const res = await fetch(base + path, {\n    method,\n    headers: { 'content-type': 'application/json', 'kbn-xsrf': 'true', authorization: auth },\n    body: body === undefined ? undefined : JSON.stringify(body),\n  });\n  const text = await res.text();\n  let data;\n  try {\n    data = text ? JSON.parse(text) : undefined;\n  } catch {\n    data = text;\n  }\n  return { status: res.status, body: data };\n}\nconst kb = (path, opts) => req(KIBANA, path, opts);\nconst es = (path, opts) => req(ES, path, opts);\n\nconst uid = (p) => `${p}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;\nconst cls = (s) => (s >= 200 && s < 300 ? 'ok' : s === 403 ? 'forbidden' : `http-${s}`);\nconst TAG = 'ra-authz-test';\n\nconst ENDPOINT_SNAKE = [{ action_type_id: '.endpoint', params: { command: 'isolate', comment: 'authz-test' } }];\nconst OSQUERY_SNAKE = [{ action_type_id: '.osquery', params: { query: 'SELECT * FROM processes;' } }];\nconst ENDPOINT_CAMEL = [{ actionTypeId: '.endpoint', params: { command: 'isolate', comment: 'authz-test' } }];\nconst OSQUERY_CAMEL = [{ actionTypeId: '.osquery', params: { query: 'SELECT * FROM processes;' } }];\n\nconst deRule = (name, extra = {}) => ({\n  name,\n  description: 'authz test',\n  risk_score: 21,\n  severity: 'low',\n  type: 'query',\n  query: '*:*',\n  language: 'kuery',\n  index: ['logs-*'],\n  from: 'now-3600s',\n  interval: '5m',\n  enabled: false,\n  tags: [TAG],\n  ...extra,\n});\n\nconst created = [];\nconst track = (r) => {\n  if (r.status >= 200 && r.status < 300 && r.body && r.body.id) created.push(r.body.id);\n  return r;\n};\n\nasync function deleteUserAndRole(u) {\n  await es(`/_security/user/${u.username}`, { method: 'DELETE' });\n  await es(`/_security/role/${u.role}`, { method: 'DELETE' });\n}\nasync function createRole(u) {\n  const r = await es(`/_security/role/${u.role}`, { method: 'PUT', body: u.roleBody });\n  if (r.status >= 300) throw new Error(`role ${u.role}: ${r.status} ${JSON.stringify(r.body)}`);\n}\nasync function createUser(u) {\n  const r = await es(`/_security/user/${u.username}`, {\n    method: 'PUT',\n    body: { password: u.password, roles: [u.role], full_name: u.tier },\n  });\n  if (r.status >= 300) throw new Error(`user ${u.username}: ${r.status} ${JSON.stringify(r.body)}`);\n}\n\nasync function createRule(name, extra) {\n  const r = track(await kb('/api/detection_engine/rules', { method: 'POST', body: deRule(name, extra) }));\n  if (r.status >= 300) throw new Error(`create rule: ${r.status} ${JSON.stringify(r.body)}`);\n  return r.body.id;\n}\n\nasync function createTestRules() {\n  const dePatchEpId = await createRule(uid('ra-de-ep-patch'));\n  const dePatchOsqId = await createRule(uid('ra-de-osq-patch'));\n  const alUpdateEpId = await createRule(uid('ra-al-ep-upd'));\n  const alUpdateOsqId = await createRule(uid('ra-al-osq-upd'));\n  const seededId = await createRule(uid('ra-seeded'), { response_actions: ENDPOINT_SNAKE });\n  const template = (await kb(`/api/alerting/rule/${dePatchEpId}`)).body.params;\n  return { dePatchEpId, dePatchOsqId, alUpdateEpId, alUpdateOsqId, seededId, template };\n}\n\nasync function alertingUpdate(id, auth, responseActions, name) {\n  const cur = (await kb(`/api/alerting/rule/${id}`)).body;\n  return kb(`/api/alerting/rule/${id}`, {\n    method: 'PUT',\n    auth,\n    body: {\n      name: name || cur.name,\n      tags: cur.tags || [],\n      schedule: cur.schedule,\n      throttle: cur.throttle || null,\n      notify_when: cur.notify_when || null,\n      actions: cur.actions || [],\n      params: responseActions ? { ...cur.params, responseActions } : cur.params,\n    },\n  });\n}\n\nasync function alertingCreate(template, auth, responseActions, tier) {\n  const ruleId = uid(`ra-al-create-${tier}`);\n  return track(\n    await kb('/api/alerting/rule', {\n      method: 'POST',\n      auth,\n      body: {\n        rule_type_id: 'siem.queryRule',\n        consumer: 'siem',\n        name: ruleId,\n        enabled: false,\n        tags: [TAG],\n        schedule: { interval: '5m' },\n        actions: [],\n        params: { ...template, ruleId, immutable: false, responseActions },\n      },\n    })\n  );\n}\n\nconst CASES = [\n  {\n    name: 'DE create rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: async (u) =>\n      track(\n        await kb('/api/detection_engine/rules', {\n          method: 'POST',\n          auth: u.auth,\n          body: deRule(uid(`ra-de-ep-create-${u.tier}`), { response_actions: ENDPOINT_SNAKE }),\n        })\n      ),\n  },\n  {\n    name: 'DE patch rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) =>\n      kb('/api/detection_engine/rules', {\n        method: 'PATCH',\n        auth: u.auth,\n        body: { id: r.dePatchEpId, response_actions: ENDPOINT_SNAKE },\n      }),\n  },\n  {\n    name: 'DE patch rule w/ osquery RA',\n    expected: { none: 'forbidden', partial: 'forbidden', full: 'ok' },\n    run: (u, r) =>\n      kb('/api/detection_engine/rules', {\n        method: 'PATCH',\n        auth: u.auth,\n        body: { id: r.dePatchOsqId, response_actions: OSQUERY_SNAKE },\n      }),\n  },\n  {\n    name: 'Alerting create rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingCreate(r.template, u.auth, ENDPOINT_CAMEL, u.tier),\n  },\n  {\n    name: 'Alerting update rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.alUpdateEpId, u.auth, ENDPOINT_CAMEL),\n  },\n  {\n    name: 'Alerting update rule w/ osquery RA',\n    expected: { none: 'forbidden', partial: 'forbidden', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.alUpdateOsqId, u.auth, OSQUERY_CAMEL),\n  },\n  {\n    name: 'Alerting update unchanged RA (rename only)',\n    expected: { none: 'ok', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.seededId, u.auth, undefined, uid(`ra-rename-${u.tier}`)),\n  },\n];\n\nasync function run() {\n  const results = [];\n  for (const u of USERS) {\n    await deleteUserAndRole(u);\n    await createRole(u);\n    await createUser(u);\n    u.auth = basic(u.username, u.password);\n    const rules = await createTestRules();\n    for (const c of CASES) {\n      const res = await c.run(u, rules);\n      const actual = cls(res.status);\n      const expected = c.expected[u.tier];\n      results.push({ user: u.tier, case: c.name, expected, actual, status: res.status, pass: actual === expected });\n    }\n  }\n  return results;\n}\n\nasync function cleanup() {\n  for (const id of created) await kb(`/api/alerting/rule/${id}`, { method: 'DELETE' });\n  for (const u of USERS) await deleteUserAndRole(u);\n}\n\n(async () => {\n  let results = [];\n  try {\n    results = await run();\n  } finally {\n    await cleanup();\n  }\n  console.table(\n    results.map((r) => ({\n      user: r.user,\n      case: r.case,\n      expected: r.expected,\n      actual: r.actual,\n      status: r.status,\n      result: r.pass ? 'PASS' : 'FAIL',\n    }))\n  );\n  const failed = results.filter((r) => !r.pass);\n  console.log(`\\n${results.length - failed.length}/${results.length} passed`);\n  process.exit(failed.length ? 1 : 0);\n})();\n\n```\n\n</details>\n\n\n**Run**\n\n```bash\nnode test.js\n```\n\n**What it covers**\n\nFor each of three privilege tiers, the script deletes any prior\nuser/role, recreates the role and user, creates fresh test rules, and\nasserts every case:\n\n- **none** — rule management only, no response-action or Endpoint\nprivileges (the reported attacker).\n- **partial** — adds Endpoint response-action privileges (host\nisolation, process operations, …) but no osquery.\n- **full** — adds osquery privileges as well.\n\nCases exercised per tier, across both the Detection Engine routes and\nthe generic Alerting API (create and update), for `.endpoint` and\n`.osquery` response actions:\n\n- Setting a response action a tier is **not** privileged for is rejected\nwith `403`.\n- Setting a response action a tier **is** privileged for succeeds.\n- Editing an unrelated field on a rule whose response actions are\nunchanged succeeds even without response-action privileges (only changed\nactions are validated).\n\nExpected result: **all cases pass** on this branch. Running the same\nscript against `main` shows the Alerting API cases for `none`/`partial`\nincorrectly returning `200`, demonstrating the bypass this PR closes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f35840c41ad3e25a057cc93b96eab0f0cf0ce34"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280430","number":280430,"mergeCommit":{"message":"[Security Solution] Enforce rule params authorization on generic Alerting API writes to close the response actions RBAC bypass (#280430)\n\n## Summary\n\nA user with only **Rules and Exceptions: All** (which grants\n`alerting.rule.all`) can attach Elastic Defend / osquery **response\nactions** (`params.responseActions`) to security rules through the\ngeneric Alerting API (`POST|PUT /api/alerting/rule/{id}`), bypassing the\nEndpoint and osquery privilege checks. This lets an unauthorized user\ncontrol Elastic Defend across every host a rule matches.\n\nResponse-action authorization is asynchronous and privilege-based, so it\nis not part of the normal (synchronous) rule param validation. The\nDetection Engine enforces it in its own CRUD routes via\n[`validateRuleResponseActions`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.ts),\nbut the generic Alerting APIs write rule params directly through the\nalerting `rulesClient` and never run that check.\n\n- Security incident: https://github.com/elastic/security/issues/12060\n- Tracking issue: https://github.com/elastic/kibana-team/issues/3776\n\n## Solution\n\nMove response-action authorization into the Alerting framework so every\nrule write path is covered, regardless of which API is used.\n\n- **New rule-type-defined authorization hook.** Rule types can now\ndeclare an `authorize: { params }` gate (`RuleTypeParamsAuthorizer`),\nmirroring the existing `validate: { params }`. It is an async guard that\nauthorizes params against the acting user's privileges and throws when\nthey are not allowed.\n- **Framework enforcement on write paths only.** A new\n`authorizeRuleTypeParams` runs immediately after\n`validateRuleTypeParams` on the four write paths (`create`, `update`,\n`bulk_create`, `bulk_edit`). The execution/task-runner paths are\nintentionally untouched, so no code needs to become async that was not\nalready.\n- **Request context.** `RulesClientContext` now carries the scoped\n`request`, which the write methods pass to the authorizer (along with\nthe previous params on updates, so only *changed* response actions are\nvalidated). This is not a public breaking change: a rules client can\nnever be constructed without a request. On background writes the request\nis the fake request built from the rule's stored API key, which carries\na snapshot of the owner's privileges, so authorization stays correct.\n- **Detection Engine wiring.** Security rule types define\n`authorize.params` to delegate to the existing\n`validateRuleResponseActions`, resolving Endpoint authz, space id, and\nthe osquery checker from the request. This is the same enforcement the\nDE routes already perform, now applied on every write path.\n\nThe existing DE-route validation is intentionally left in place (it\ncovers the bulk-action dry-run path, which never reaches a write\nmethod).\n\n### Tests\n\n- Unit tests for the framework hook and the Detection Engine authorizer\n(including HTTP status-code preservation across the Endpoint and osquery\nvalidators).\n- FTR API integration tests extended in `rule_creation` and\n`rule_update` to cover the generic Alerting API path for users with and\nwithout response-action privileges.\n\n## How to test\n\nThe checks below run entirely at rule **write** time, so no enrolled\nendpoints or live osquery agents are required.\n\n**Prerequisites**\n- Local Elasticsearch + Kibana running from this branch (`yarn start`),\nsecurity enabled.\n- Node 18+ (uses global `fetch`).\n\n**1. Roles / users — `roles.js`**\n\n<details><summary>roles.js</summary>\n\n```js\nconst KIBANA = process.env.KIBANA_URL || 'http://localhost:5601/kbn';\nconst ES = process.env.ES_URL || 'http://localhost:9200';\nconst ADMIN = {\n  username: process.env.ES_USER || 'elastic',\n  password: process.env.ES_PASS || 'changeme',\n};\nconst PASSWORD = 'changeme';\n\nconst BASE = [\n  'feature_siemV5.all',\n  'feature_securitySolutionRulesV4.all',\n  'feature_securitySolutionAlertsV1.all',\n  'feature_indexPatterns.all',\n  'feature_savedObjectsManagement.all',\n];\nconst ENDPOINT_RA = [\n  'feature_siemV5.host_isolation_all',\n  'feature_siemV5.process_operations_all',\n  'feature_siemV5.file_operations_all',\n  'feature_siemV5.execute_operations_all',\n  'feature_siemV5.scan_operations_all',\n];\nconst OSQUERY = ['feature_osquery.all'];\n\nconst INDICES = [\n  {\n    names: [\n      '.alerts-security.alerts-default',\n      '.internal.alerts-security.alerts-default-*',\n      '.lists-default',\n      '.items-default',\n      '.siem-signals-default',\n      'logs-*',\n    ],\n    privileges: ['read', 'write', 'manage', 'view_index_metadata'],\n    allow_restricted_indices: false,\n  },\n];\n\nconst roleBody = (features) => ({\n  cluster: [],\n  indices: INDICES,\n  applications: [{ application: 'kibana-.kibana', privileges: features, resources: ['space:default'] }],\n  run_as: [],\n});\n\nconst USERS = [\n  { tier: 'none', username: 'ra_authz_none', role: 'ra_authz_none', password: PASSWORD, roleBody: roleBody(BASE) },\n  {\n    tier: 'partial',\n    username: 'ra_authz_partial',\n    role: 'ra_authz_partial',\n    password: PASSWORD,\n    roleBody: roleBody([...BASE, ...ENDPOINT_RA]),\n  },\n  {\n    tier: 'full',\n    username: 'ra_authz_full',\n    role: 'ra_authz_full',\n    password: PASSWORD,\n    roleBody: roleBody([...BASE, ...ENDPOINT_RA, ...OSQUERY]),\n  },\n];\n\nmodule.exports = { KIBANA, ES, ADMIN, USERS };\n```\n\n</details>\n\n**2. Test runner — `test.js`**\n\n<details><summary>test.js</summary>\n\n```js\nconst { KIBANA, ES, ADMIN, USERS } = require('./roles');\n\nconst basic = (u, p) => 'Basic ' + Buffer.from(`${u}:${p}`).toString('base64');\nconst ADMIN_AUTH = basic(ADMIN.username, ADMIN.password);\n\nasync function req(base, path, { method = 'GET', auth = ADMIN_AUTH, body } = {}) {\n  const res = await fetch(base + path, {\n    method,\n    headers: { 'content-type': 'application/json', 'kbn-xsrf': 'true', authorization: auth },\n    body: body === undefined ? undefined : JSON.stringify(body),\n  });\n  const text = await res.text();\n  let data;\n  try {\n    data = text ? JSON.parse(text) : undefined;\n  } catch {\n    data = text;\n  }\n  return { status: res.status, body: data };\n}\nconst kb = (path, opts) => req(KIBANA, path, opts);\nconst es = (path, opts) => req(ES, path, opts);\n\nconst uid = (p) => `${p}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;\nconst cls = (s) => (s >= 200 && s < 300 ? 'ok' : s === 403 ? 'forbidden' : `http-${s}`);\nconst TAG = 'ra-authz-test';\n\nconst ENDPOINT_SNAKE = [{ action_type_id: '.endpoint', params: { command: 'isolate', comment: 'authz-test' } }];\nconst OSQUERY_SNAKE = [{ action_type_id: '.osquery', params: { query: 'SELECT * FROM processes;' } }];\nconst ENDPOINT_CAMEL = [{ actionTypeId: '.endpoint', params: { command: 'isolate', comment: 'authz-test' } }];\nconst OSQUERY_CAMEL = [{ actionTypeId: '.osquery', params: { query: 'SELECT * FROM processes;' } }];\n\nconst deRule = (name, extra = {}) => ({\n  name,\n  description: 'authz test',\n  risk_score: 21,\n  severity: 'low',\n  type: 'query',\n  query: '*:*',\n  language: 'kuery',\n  index: ['logs-*'],\n  from: 'now-3600s',\n  interval: '5m',\n  enabled: false,\n  tags: [TAG],\n  ...extra,\n});\n\nconst created = [];\nconst track = (r) => {\n  if (r.status >= 200 && r.status < 300 && r.body && r.body.id) created.push(r.body.id);\n  return r;\n};\n\nasync function deleteUserAndRole(u) {\n  await es(`/_security/user/${u.username}`, { method: 'DELETE' });\n  await es(`/_security/role/${u.role}`, { method: 'DELETE' });\n}\nasync function createRole(u) {\n  const r = await es(`/_security/role/${u.role}`, { method: 'PUT', body: u.roleBody });\n  if (r.status >= 300) throw new Error(`role ${u.role}: ${r.status} ${JSON.stringify(r.body)}`);\n}\nasync function createUser(u) {\n  const r = await es(`/_security/user/${u.username}`, {\n    method: 'PUT',\n    body: { password: u.password, roles: [u.role], full_name: u.tier },\n  });\n  if (r.status >= 300) throw new Error(`user ${u.username}: ${r.status} ${JSON.stringify(r.body)}`);\n}\n\nasync function createRule(name, extra) {\n  const r = track(await kb('/api/detection_engine/rules', { method: 'POST', body: deRule(name, extra) }));\n  if (r.status >= 300) throw new Error(`create rule: ${r.status} ${JSON.stringify(r.body)}`);\n  return r.body.id;\n}\n\nasync function createTestRules() {\n  const dePatchEpId = await createRule(uid('ra-de-ep-patch'));\n  const dePatchOsqId = await createRule(uid('ra-de-osq-patch'));\n  const alUpdateEpId = await createRule(uid('ra-al-ep-upd'));\n  const alUpdateOsqId = await createRule(uid('ra-al-osq-upd'));\n  const seededId = await createRule(uid('ra-seeded'), { response_actions: ENDPOINT_SNAKE });\n  const template = (await kb(`/api/alerting/rule/${dePatchEpId}`)).body.params;\n  return { dePatchEpId, dePatchOsqId, alUpdateEpId, alUpdateOsqId, seededId, template };\n}\n\nasync function alertingUpdate(id, auth, responseActions, name) {\n  const cur = (await kb(`/api/alerting/rule/${id}`)).body;\n  return kb(`/api/alerting/rule/${id}`, {\n    method: 'PUT',\n    auth,\n    body: {\n      name: name || cur.name,\n      tags: cur.tags || [],\n      schedule: cur.schedule,\n      throttle: cur.throttle || null,\n      notify_when: cur.notify_when || null,\n      actions: cur.actions || [],\n      params: responseActions ? { ...cur.params, responseActions } : cur.params,\n    },\n  });\n}\n\nasync function alertingCreate(template, auth, responseActions, tier) {\n  const ruleId = uid(`ra-al-create-${tier}`);\n  return track(\n    await kb('/api/alerting/rule', {\n      method: 'POST',\n      auth,\n      body: {\n        rule_type_id: 'siem.queryRule',\n        consumer: 'siem',\n        name: ruleId,\n        enabled: false,\n        tags: [TAG],\n        schedule: { interval: '5m' },\n        actions: [],\n        params: { ...template, ruleId, immutable: false, responseActions },\n      },\n    })\n  );\n}\n\nconst CASES = [\n  {\n    name: 'DE create rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: async (u) =>\n      track(\n        await kb('/api/detection_engine/rules', {\n          method: 'POST',\n          auth: u.auth,\n          body: deRule(uid(`ra-de-ep-create-${u.tier}`), { response_actions: ENDPOINT_SNAKE }),\n        })\n      ),\n  },\n  {\n    name: 'DE patch rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) =>\n      kb('/api/detection_engine/rules', {\n        method: 'PATCH',\n        auth: u.auth,\n        body: { id: r.dePatchEpId, response_actions: ENDPOINT_SNAKE },\n      }),\n  },\n  {\n    name: 'DE patch rule w/ osquery RA',\n    expected: { none: 'forbidden', partial: 'forbidden', full: 'ok' },\n    run: (u, r) =>\n      kb('/api/detection_engine/rules', {\n        method: 'PATCH',\n        auth: u.auth,\n        body: { id: r.dePatchOsqId, response_actions: OSQUERY_SNAKE },\n      }),\n  },\n  {\n    name: 'Alerting create rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingCreate(r.template, u.auth, ENDPOINT_CAMEL, u.tier),\n  },\n  {\n    name: 'Alerting update rule w/ endpoint RA',\n    expected: { none: 'forbidden', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.alUpdateEpId, u.auth, ENDPOINT_CAMEL),\n  },\n  {\n    name: 'Alerting update rule w/ osquery RA',\n    expected: { none: 'forbidden', partial: 'forbidden', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.alUpdateOsqId, u.auth, OSQUERY_CAMEL),\n  },\n  {\n    name: 'Alerting update unchanged RA (rename only)',\n    expected: { none: 'ok', partial: 'ok', full: 'ok' },\n    run: (u, r) => alertingUpdate(r.seededId, u.auth, undefined, uid(`ra-rename-${u.tier}`)),\n  },\n];\n\nasync function run() {\n  const results = [];\n  for (const u of USERS) {\n    await deleteUserAndRole(u);\n    await createRole(u);\n    await createUser(u);\n    u.auth = basic(u.username, u.password);\n    const rules = await createTestRules();\n    for (const c of CASES) {\n      const res = await c.run(u, rules);\n      const actual = cls(res.status);\n      const expected = c.expected[u.tier];\n      results.push({ user: u.tier, case: c.name, expected, actual, status: res.status, pass: actual === expected });\n    }\n  }\n  return results;\n}\n\nasync function cleanup() {\n  for (const id of created) await kb(`/api/alerting/rule/${id}`, { method: 'DELETE' });\n  for (const u of USERS) await deleteUserAndRole(u);\n}\n\n(async () => {\n  let results = [];\n  try {\n    results = await run();\n  } finally {\n    await cleanup();\n  }\n  console.table(\n    results.map((r) => ({\n      user: r.user,\n      case: r.case,\n      expected: r.expected,\n      actual: r.actual,\n      status: r.status,\n      result: r.pass ? 'PASS' : 'FAIL',\n    }))\n  );\n  const failed = results.filter((r) => !r.pass);\n  console.log(`\\n${results.length - failed.length}/${results.length} passed`);\n  process.exit(failed.length ? 1 : 0);\n})();\n\n```\n\n</details>\n\n\n**Run**\n\n```bash\nnode test.js\n```\n\n**What it covers**\n\nFor each of three privilege tiers, the script deletes any prior\nuser/role, recreates the role and user, creates fresh test rules, and\nasserts every case:\n\n- **none** — rule management only, no response-action or Endpoint\nprivileges (the reported attacker).\n- **partial** — adds Endpoint response-action privileges (host\nisolation, process operations, …) but no osquery.\n- **full** — adds osquery privileges as well.\n\nCases exercised per tier, across both the Detection Engine routes and\nthe generic Alerting API (create and update), for `.endpoint` and\n`.osquery` response actions:\n\n- Setting a response action a tier is **not** privileged for is rejected\nwith `403`.\n- Setting a response action a tier **is** privileged for succeeds.\n- Editing an unrelated field on a rule whose response actions are\nunchanged succeeds even without response-action privileges (only changed\nactions are validated).\n\nExpected result: **all cases pass** on this branch. Running the same\nscript against `main` shows the Alerting API cases for `none`/`partial`\nincorrectly returning `200`, demonstrating the bypass this PR closes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f35840c41ad3e25a057cc93b96eab0f0cf0ce34"}},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->