### PR TITLE
Fix skipped Timeline integration tests (#213990)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/tests/timeline.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/tests/timeline.ts
@@ -16,13 +16,19 @@ import {
   resolveTimeline,
 } from '../../utils/timelines';
 
+const EXACT_MATCH_TIMELINE_ID = '8dc70950-1012-11ec-9ad3-2d7c6600c0f7';
+const TIMELINE_WITH_NOTES_ID = '6484cc90-126e-11ec-83d2-db1096c73738';
+const NOTE_WITH_EVENT_ID = '989002c0-126e-11ec-83d2-db1096c73738';
+const NOTE_WITHOUT_EVENT_ID = 'f09b5980-1271-11ec-83d2-db1096c73738';
+const PINNED_EVENT_ID_1 = '7a9a5540-126e-11ec-83d2-db1096c73738';
+const PINNED_EVENT_ID_2 = '98d919b0-126e-11ec-83d2-db1096c73738';
+
 export default function ({ getService }: FtrProviderContextWithSpaces) {
   const utils = getService('securitySolutionUtils');
-  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
   let supertest: TestAgent;
 
-  // Failing: See https://github.com/elastic/kibana/issues/213990
-  describe.skip('Timeline', () => {
+  describe('Timeline', () => {
     before(async () => (supertest = await utils.createSuperTest()));
 
     describe('timelines', () => {
@@ -62,25 +68,93 @@ export default function ({ getService }: FtrProviderContextWithSpaces) {
         ).to.equal(0);
       });
     });
-    /**
-     * Migration of saved object not working to current serverless version
-     * https://github.com/elastic/kibana/issues/196483
-     * */
+
     describe('@skipInServerless resolve timeline', () => {
       before(async () => {
-        await esArchiver.load(
-          'x-pack/solutions/security/test/fixtures/es_archives/security_solution/timelines/7.15.0'
-        );
+        // Kibana 9.x refuses to migrate pre-8.18 `.kibana_1` archives via esArchiver
+        // (see timeline_migrations_8_0_id.test.ts). Seed the post-migration state directly
+        // instead, mirroring resolve_read_rules.ts.
+        const timelineReference = {
+          id: TIMELINE_WITH_NOTES_ID,
+          name: 'timelineId',
+          type: 'siem-ui-timeline',
+        };
+
+        await kibanaServer.savedObjects.create({
+          type: 'siem-ui-timeline',
+          id: EXACT_MATCH_TIMELINE_ID,
+          overwrite: true,
+          attributes: {
+            title: 'Awesome Timeline',
+          },
+        });
+
+        await kibanaServer.savedObjects.create({
+          type: 'siem-ui-timeline',
+          id: TIMELINE_WITH_NOTES_ID,
+          overwrite: true,
+          attributes: {
+            title: 'timeline with pinned events',
+          },
+        });
+
+        await kibanaServer.savedObjects.create({
+          type: 'siem-ui-timeline-note',
+          id: NOTE_WITH_EVENT_ID,
+          overwrite: true,
+          attributes: {
+            eventId: 'Edo00XsBEVtyvU-8LGNe',
+            note: 'A comment on an event',
+          },
+          references: [timelineReference],
+        });
+
+        await kibanaServer.savedObjects.create({
+          type: 'siem-ui-timeline-note',
+          id: NOTE_WITHOUT_EVENT_ID,
+          overwrite: true,
+          attributes: {
+            note: 'a non pin comment',
+          },
+          references: [timelineReference],
+        });
+
+        await kibanaServer.savedObjects.create({
+          type: 'siem-ui-timeline-pinned-event',
+          id: PINNED_EVENT_ID_1,
+          overwrite: true,
+          attributes: {
+            eventId: 'DNo00XsBEVtyvU-8LGNe',
+          },
+          references: [timelineReference],
+        });
+
+        await kibanaServer.savedObjects.create({
+          type: 'siem-ui-timeline-pinned-event',
+          id: PINNED_EVENT_ID_2,
+          overwrite: true,
+          attributes: {
+            eventId: 'Edo00XsBEVtyvU-8LGNe',
+          },
+          references: [timelineReference],
+        });
       });
 
       after(async () => {
-        await esArchiver.unload(
-          'x-pack/solutions/security/test/fixtures/es_archives/security_solution/timelines/7.15.0'
-        );
+        for (const { type, id } of [
+          { type: 'siem-ui-timeline-pinned-event', id: PINNED_EVENT_ID_1 },
+          { type: 'siem-ui-timeline-pinned-event', id: PINNED_EVENT_ID_2 },
+          { type: 'siem-ui-timeline-note', id: NOTE_WITH_EVENT_ID },
+          { type: 'siem-ui-timeline-note', id: NOTE_WITHOUT_EVENT_ID },
+          { type: 'siem-ui-timeline', id: TIMELINE_WITH_NOTES_ID },
+          { type: 'siem-ui-timeline', id: EXACT_MATCH_TIMELINE_ID },
+        ]) {
+          await kibanaServer.savedObjects.delete({ type, id }).catch(() => undefined);
+        }
       });
 
       it('should return outcome exactMatch when the id is unchanged', async () => {
-        const resp = await resolveTimeline(supertest, '8dc70950-1012-11ec-9ad3-2d7c6600c0f7');
+        const resp = await resolveTimeline(supertest, EXACT_MATCH_TIMELINE_ID);
         expect(resp.body.outcome).to.be('exactMatch');
         expect(resp.body.alias_target_id).to.be(undefined);
         expect(resp.body.timeline.title).to.be('Awesome Timeline');
@@ -88,25 +162,21 @@ export default function ({ getService }: FtrProviderContextWithSpaces) {
 
       describe('notes', () => {
         it('should return notes with eventId', async () => {
-          const resp = await resolveTimeline(supertest, '6484cc90-126e-11ec-83d2-db1096c73738');
+          const resp = await resolveTimeline(supertest, TIMELINE_WITH_NOTES_ID);
           expect(resp.body.timeline.notes![0].eventId).to.be('Edo00XsBEVtyvU-8LGNe');
         });
 
         it('should return notes with the timelineId matching request id', async () => {
-          const resp = await resolveTimeline(supertest, '6484cc90-126e-11ec-83d2-db1096c73738');
+          const resp = await resolveTimeline(supertest, TIMELINE_WITH_NOTES_ID);
 
-          expect(resp.body.timeline.notes![0].timelineId).to.be(
-            '6484cc90-126e-11ec-83d2-db1096c73738'
-          );
-          expect(resp.body.timeline.notes![1].timelineId).to.be(
-            '6484cc90-126e-11ec-83d2-db1096c73738'
-          );
+          expect(resp.body.timeline.notes![0].timelineId).to.be(TIMELINE_WITH_NOTES_ID);
+          expect(resp.body.timeline.notes![1].timelineId).to.be(TIMELINE_WITH_NOTES_ID);
         });
       });
 
       describe('pinned events', () => {
         it('should pinned events with eventId', async () => {
-          const resp = await resolveTimeline(supertest, '6484cc90-126e-11ec-83d2-db1096c73738');
+          const resp = await resolveTimeline(supertest, TIMELINE_WITH_NOTES_ID);
 
           expect(resp.body.timeline.pinnedEventsSaveObject![0].eventId).to.be(
             'DNo00XsBEVtyvU-8LGNe'
@@ -117,16 +187,16 @@ export default function ({ getService }: FtrProviderContextWithSpaces) {
         });
 
         it('should return pinned events with the timelineId matching request id', async () => {
-          const resp = await resolveTimeline(supertest, '6484cc90-126e-11ec-83d2-db1096c73738');
+          const resp = await resolveTimeline(supertest, TIMELINE_WITH_NOTES_ID);
 
           expect(resp.body.timeline.pinnedEventsSaveObject![0].timelineId).to.be(
-            '6484cc90-126e-11ec-83d2-db1096c73738'
+            TIMELINE_WITH_NOTES_ID
           );
           expect(resp.body.timeline.pinnedEventsSaveObject![1].timelineId).to.be(
-            '6484cc90-126e-11ec-83d2-db1096c73738'
+            TIMELINE_WITH_NOTES_ID
           );
         });
       });
     });
   });
-}
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/tests/timeline.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/tests/timeline.ts
@@ -199,4 +199,4 @@ export default function ({ getService }: FtrProviderContextWithSpaces) {
       });
     });
   });
-};
+}


### PR DESCRIPTION
## Summary

- Restores the Timeline API integration suite skipped since April 2025.
- Replaces the 7.15.0 esArchiver fixture with direct saved-object seeding.

## Root cause

Loading the legacy 7.15.0 kibana_1 archive triggers saved_objects/_migrate, which returns 500 on current Kibana because the migration framework no longer upgrades indices older than 8.18.0.

## Validation

- Refactored setup mirrors resolve_read_rules.ts and timeline_migrations_8_0_id.test.ts.
- Local FTR not run in this worker (worktree lacks bootstrapped deps); CI pending on Timeline Integration Tests - ESS Env - Trial License.

Closes #213990

Made with [Cursor](https://cursor.com)