### PR TITLE
[8.19] Bound unbounded strings in files route schemas (#280772)

### DIFF
--- a/src/platform/plugins/shared/files/server/routes/bulk_delete.ts
+++ b/src/platform/plugins/shared/files/server/routes/bulk_delete.ts
@@ -12,12 +12,13 @@ import { FILES_MANAGE_PRIVILEGE } from '../../common/constants';
 import { FilesClient } from '../../common/files_client';
 import type { CreateHandler, FilesRouter } from './types';
 import { FILES_API_ROUTES, CreateRouteDefinition } from './api_routes';
+import { fileId } from './common_schemas';
 
 const method = 'delete' as const;
 
 const rt = {
   body: schema.object({
-    ids: schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1, maxSize: 100 }),
+    ids: schema.arrayOf(fileId, { minSize: 1, maxSize: 100 }),
   }),
 };
 

--- a/src/platform/plugins/shared/files/server/routes/common_schemas.ts
+++ b/src/platform/plugins/shared/files/server/routes/common_schemas.ts
@@ -44,6 +44,27 @@ export const fileAlt = schema.maybe(
   })
 );
 
+/** Saved-object style file / share IDs (request params & body). */
+export const fileId = schema.string({
+  minLength: 1,
+  maxLength: 256,
+});
+
+/** MIME type strings (e.g. application/pdf). */
+export const fileMimeType = schema.string({
+  minLength: 1,
+  maxLength: 256,
+});
+
+/**
+ * Public file-share tokens. Generated tokens are 40 chars; 1024 is a generous
+ * DoS ceiling for the request query param.
+ */
+export const fileShareToken = schema.string({
+  minLength: 1,
+  maxLength: 1024,
+});
+
 export const page = schema.number({ min: 1, defaultValue: 1 });
 export const pageSize = schema.number({ min: 1, defaultValue: 100 });
 

--- a/src/platform/plugins/shared/files/server/routes/file_kind/create.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/create.ts
@@ -23,7 +23,7 @@ export const rt = {
     name: commonSchemas.fileName,
     alt: commonSchemas.fileAlt,
     meta: commonSchemas.fileMeta,
-    mimeType: schema.maybe(schema.string()),
+    mimeType: schema.maybe(commonSchemas.fileMimeType),
   }),
 };
 

--- a/src/platform/plugins/shared/files/server/routes/file_kind/delete.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/delete.ts
@@ -12,6 +12,7 @@ import type { FileKind } from '../../../common/types';
 import { FilesClient } from '../../../common/files_client';
 import { fileErrors } from '../../file';
 import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
+import { fileId } from '../common_schemas';
 import type { CreateHandler, FileKindRouter } from './types';
 
 import { getById } from './helpers';
@@ -20,7 +21,7 @@ export const method = 'delete' as const;
 
 const rt = {
   params: schema.object({
-    id: schema.string(),
+    id: fileId,
   }),
 };
 

--- a/src/platform/plugins/shared/files/server/routes/file_kind/download.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/download.ts
@@ -11,7 +11,7 @@ import { schema } from '@kbn/config-schema';
 import { Readable } from 'stream';
 import type { FilesClient } from '../../../common/files_client';
 import type { FileKind } from '../../../common/types';
-import { fileNameWithExt } from '../common_schemas';
+import { fileId, fileNameWithExt } from '../common_schemas';
 import { fileErrors } from '../../file';
 import { getFileHttpResponseOptions, getDownloadedFileName } from '../common';
 import { getById, validateFileNameExtension } from './helpers';
@@ -22,7 +22,7 @@ export const method = 'get' as const;
 
 const rt = {
   params: schema.object({
-    id: schema.string(),
+    id: fileId,
     fileName: schema.maybe(fileNameWithExt),
   }),
 };

--- a/src/platform/plugins/shared/files/server/routes/file_kind/get_by_id.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/get_by_id.ts
@@ -11,6 +11,7 @@ import { schema } from '@kbn/config-schema';
 import type { FileJSON, FileKind } from '../../../common/types';
 import type { FilesClient } from '../../../common/files_client';
 import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
+import { fileId } from '../common_schemas';
 import { getById } from './helpers';
 import type { CreateHandler, FileKindRouter } from './types';
 
@@ -18,7 +19,7 @@ export const method = 'get' as const;
 
 const rt = {
   params: schema.object({
-    id: schema.string(),
+    id: fileId,
   }),
 };
 

--- a/src/platform/plugins/shared/files/server/routes/file_kind/share/get.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/share/get.ts
@@ -13,6 +13,7 @@ import type { FilesClient } from '../../../../common/files_client';
 import { FileShareNotFoundError } from '../../../file_share_service/errors';
 import { CreateRouteDefinition, FILES_API_ROUTES } from '../../api_routes';
 import type { FileKind, FileShareJSON } from '../../../../common/types';
+import { fileId } from '../../common_schemas';
 
 import { CreateHandler, FileKindRouter } from '../types';
 
@@ -20,7 +21,7 @@ export const method = 'get' as const;
 
 const rt = {
   params: schema.object({
-    id: schema.string(),
+    id: fileId,
   }),
 };
 

--- a/src/platform/plugins/shared/files/server/routes/file_kind/share/list.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/share/list.ts
@@ -21,7 +21,7 @@ const rt = {
   query: schema.object({
     page: schema.maybe(cs.page),
     perPage: schema.maybe(cs.pageSize),
-    forFileId: schema.maybe(schema.string()),
+    forFileId: schema.maybe(cs.fileId),
   }),
 };
 

--- a/src/platform/plugins/shared/files/server/routes/file_kind/share/share.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/share/share.ts
@@ -14,6 +14,7 @@ import { CreateHandler, FileKindRouter } from '../types';
 
 import { CreateRouteDefinition, FILES_API_ROUTES } from '../../api_routes';
 import type { FileKind, FileShareJSONWithToken } from '../../../../common/types';
+import { fileId as fileIdSchema } from '../../common_schemas';
 import { getById } from '../helpers';
 
 export const method = 'post' as const;
@@ -22,7 +23,7 @@ const nameRegex = /^[a-z0-9-_]+$/i;
 
 const rt = {
   params: schema.object({
-    fileId: schema.string(),
+    fileId: fileIdSchema,
   }),
   body: schema.object({
     validUntil: schema.maybe(schema.number()),

--- a/src/platform/plugins/shared/files/server/routes/file_kind/share/unshare.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/share/unshare.ts
@@ -13,13 +13,14 @@ import type { FilesClient } from '../../../../common/files_client';
 import { CreateRouteDefinition, FILES_API_ROUTES } from '../../api_routes';
 import type { FileKind } from '../../../../common/types';
 import { CreateHandler, FileKindRouter } from '../types';
+import { fileId } from '../../common_schemas';
 import { FileShareNotFoundError } from '../../../file_share_service/errors';
 
 export const method = 'delete' as const;
 
 const rt = {
   params: schema.object({
-    id: schema.string(),
+    id: fileId,
   }),
 };
 

--- a/src/platform/plugins/shared/files/server/routes/file_kind/update.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/update.ts
@@ -25,7 +25,7 @@ const rt = {
     meta: schema.maybe(commonSchemas.fileMeta),
   }),
   params: schema.object({
-    id: schema.string(),
+    id: commonSchemas.fileId,
   }),
 };
 

--- a/src/platform/plugins/shared/files/server/routes/file_kind/upload.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/upload.ts
@@ -15,6 +15,7 @@ import type { FileKind } from '../../../common/types';
 import type { CreateRouteDefinition } from '../../../common/api_routes';
 import { MaxByteSizeExceededError } from '../../file_client/stream_transforms/max_byte_size_transform/errors';
 import { FILES_API_ROUTES } from '../api_routes';
+import { fileId } from '../common_schemas';
 import { fileErrors } from '../../file';
 import { getById } from './helpers';
 import type { FileKindRouter } from './types';
@@ -24,7 +25,7 @@ export const method = 'put' as const;
 
 const rt = {
   params: schema.object({
-    id: schema.string(),
+    id: fileId,
   }),
   body: schema.stream() as Type<unknown>,
   query: schema.object({

--- a/src/platform/plugins/shared/files/server/routes/public_facing/download.ts
+++ b/src/platform/plugins/shared/files/server/routes/public_facing/download.ts
@@ -20,7 +20,7 @@ import type { FilesRouter } from '../types';
 import type { CreateRouteDefinition } from '../api_routes';
 import { FILES_API_ROUTES } from '../api_routes';
 import { getFileHttpResponseOptions, getDownloadedFileName } from '../common';
-import { fileNameWithExt } from '../common_schemas';
+import { fileNameWithExt, fileShareToken } from '../common_schemas';
 import type { CreateHandler } from '../types';
 import { validateFileNameExtension } from '../file_kind/helpers';
 
@@ -28,7 +28,7 @@ const method = 'get' as const;
 
 const rt = {
   query: schema.object({
-    token: schema.string(),
+    token: fileShareToken,
   }),
   params: schema.object({
     fileName: schema.maybe(fileNameWithExt),


### PR DESCRIPTION
Backport of #280772 to `8.19`.

Adds `maxLength` bounds to unbounded `schema.string()` fields in `files` plugin route request schemas (CodeQL `js/kibana/unbounded-string-in-schema`). Part of elastic/kibana-team#3691.

Cherry-pick had import-ordering conflicts only (8.19 vs main import-style drift); resolved by keeping 8.19's import style and adding the new `fileId` import. No behavioral difference from the original.