### PR TITLE
[8.19] Bound unbounded strings in saved_objects_tagging route schemas (#280764)

### DIFF
--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/assignments/find_assignable_objects.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/assignments/find_assignable_objects.ts
@@ -22,9 +22,14 @@ export const registerFindAssignableObjectsRoute = (router: TagsPluginRouter) => 
       },
       validate: {
         query: schema.object({
-          search: schema.maybe(schema.string()),
+          search: schema.maybe(schema.string({ maxLength: 2048 })),
           max_results: schema.number({ min: 0, defaultValue: 1000 }),
-          types: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+          types: schema.maybe(
+            schema.oneOf([
+              schema.string({ minLength: 1, maxLength: 256 }),
+              schema.arrayOf(schema.string({ minLength: 1, maxLength: 256 }), { maxSize: 100 }),
+            ])
+          ),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/assignments/update_tags_assignments.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/assignments/update_tags_assignments.ts
@@ -11,8 +11,8 @@ import { AssignmentError } from '../../services';
 
 export const registerUpdateTagsAssignmentsRoute = (router: TagsPluginRouter) => {
   const objectReferenceSchema = schema.object({
-    type: schema.string(),
-    id: schema.string(),
+    type: schema.string({ minLength: 1, maxLength: 256 }),
+    id: schema.string({ minLength: 1, maxLength: 256 }),
   });
 
   router.post(
@@ -28,9 +28,12 @@ export const registerUpdateTagsAssignmentsRoute = (router: TagsPluginRouter) => 
       validate: {
         body: schema.object(
           {
-            tags: schema.arrayOf(schema.string(), { minSize: 1 }),
-            assign: schema.arrayOf(objectReferenceSchema, { defaultValue: [] }),
-            unassign: schema.arrayOf(objectReferenceSchema, { defaultValue: [] }),
+            tags: schema.arrayOf(schema.string({ minLength: 1, maxLength: 256 }), {
+              minSize: 1,
+              maxSize: 100,
+            }),
+            assign: schema.arrayOf(objectReferenceSchema, { defaultValue: [], maxSize: 1000 }),
+            unassign: schema.arrayOf(objectReferenceSchema, { defaultValue: [], maxSize: 1000 }),
           },
           {
             validate: ({ assign, unassign }) => {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/internal/bulk_delete.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/internal/bulk_delete.ts
@@ -21,7 +21,7 @@ export const registerInternalBulkDeleteRoute = (router: TagsPluginRouter) => {
       },
       validate: {
         body: schema.object({
-          ids: schema.arrayOf(schema.string()),
+          ids: schema.arrayOf(schema.string({ minLength: 1, maxLength: 256 }), { maxSize: 100 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/internal/find_tags.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/internal/find_tags.ts
@@ -27,7 +27,7 @@ export const registerInternalFindTagsRoute = (router: TagsPluginRouter) => {
         query: schema.object({
           perPage: schema.number({ min: 0, defaultValue: 20 }),
           page: schema.number({ min: 0, defaultValue: 1 }),
-          search: schema.maybe(schema.string()),
+          search: schema.maybe(schema.string({ maxLength: 2048 })),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/create_tag.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/create_tag.ts
@@ -22,9 +22,9 @@ export const registerCreateTagRoute = (router: TagsPluginRouter) => {
       },
       validate: {
         body: schema.object({
-          name: schema.string(),
-          description: schema.string(),
-          color: schema.string(),
+          name: schema.string({ minLength: 1, maxLength: 256 }),
+          description: schema.string({ maxLength: 2048 }),
+          color: schema.string({ minLength: 1, maxLength: 256 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/delete_tag.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/delete_tag.ts
@@ -21,7 +21,7 @@ export const registerDeleteTagRoute = (router: TagsPluginRouter) => {
       },
       validate: {
         params: schema.object({
-          id: schema.string(),
+          id: schema.string({ minLength: 1, maxLength: 256 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/get_tag.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/get_tag.ts
@@ -21,7 +21,7 @@ export const registerGetTagRoute = (router: TagsPluginRouter) => {
       },
       validate: {
         params: schema.object({
-          id: schema.string(),
+          id: schema.string({ minLength: 1, maxLength: 256 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/update_tag.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/update_tag.ts
@@ -22,12 +22,12 @@ export const registerUpdateTagRoute = (router: TagsPluginRouter) => {
       },
       validate: {
         params: schema.object({
-          id: schema.string(),
+          id: schema.string({ minLength: 1, maxLength: 256 }),
         }),
         body: schema.object({
-          name: schema.string(),
-          description: schema.string(),
-          color: schema.string(),
+          name: schema.string({ minLength: 1, maxLength: 256 }),
+          description: schema.string({ maxLength: 2048 }),
+          color: schema.string({ minLength: 1, maxLength: 256 }),
         }),
       },
     },


### PR DESCRIPTION
Backport of #280764 to `8.19`.

Adds `maxLength` bounds to unbounded `schema.string()` fields in `saved_objects_tagging` route request schemas (CodeQL `js/kibana/unbounded-string-in-schema`). Part of elastic/kibana-team#3691.

Adaptations for 8.19 (the original touched code that doesn't exist on this branch):
- `server/routes/api/schemas.ts` (the "as code" shared schemas) doesn't exist in 8.19 and isn't imported anywhere, so it's dropped. The equivalent request bounds are applied directly to the inline route schemas that 8.19 uses.
- The generated OAS output (`oas_docs/output/kibana*.yaml`) is left unchanged: these tag routes aren't part of 8.19's public OAS, so the bounds don't affect it.