### PR TITLE
[Cases] Add EBT telemetry for redesigned list and attachments

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -384,6 +384,19 @@ export const CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE = 'cases_list_view_mode_cha
 
 export const CASES_LIST_PAGE_VIEW_EVENT_TYPE = 'cases_list_page_view' as const;
 
+export const CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE =
+  'case_view_attachment_accordion_opened' as const;
+
+/**
+ * Cases list view toggle. Defined in `common` (rather than the redesign UI package) so that
+ * non-UI consumers, such as the analytics/EBT layer, can depend on it without reaching into a
+ * specific UI feature's implementation.
+ */
+export const VIEW_TOGGLE_LIST_ID = 'list' as const;
+export const VIEW_TOGGLE_TABLE_ID = 'table' as const;
+
+export type ViewToggleId = typeof VIEW_TOGGLE_LIST_ID | typeof VIEW_TOGGLE_TABLE_ID;
+
 /**
  * Exporting this to make it easier to track the usage across the codebase
  * via lsp references.

--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -380,6 +380,10 @@ export const CASE_VIEW_ATTACHMENTS_TAB_CLICKED_EVENT_TYPE =
 export const CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE =
   'case_view_attachments_sub_tab_clicked' as const;
 
+export const CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE = 'cases_list_view_mode_changed' as const;
+
+export const CASES_LIST_PAGE_VIEW_EVENT_TYPE = 'cases_list_page_view' as const;
+
 /**
  * Exporting this to make it easier to track the usage across the codebase
  * via lsp references.

--- a/x-pack/platform/plugins/shared/cases/public/analytics/get_active_filter_dimensions.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/get_active_filter_dimensions.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FilterOptions } from '../../common/ui/types';
+import { CaseSeverity, CaseStatuses, CustomFieldTypes } from '../../common/types/domain';
+import { DEFAULT_FILTER_OPTIONS } from '../containers/constants';
+import { getActiveFilterDimensions } from './get_active_filter_dimensions';
+
+describe('getActiveFilterDimensions', () => {
+  it('returns an empty array when the filters match the defaults', () => {
+    expect(getActiveFilterDimensions(DEFAULT_FILTER_OPTIONS, DEFAULT_FILTER_OPTIONS)).toEqual([]);
+  });
+
+  it('detects each changed dimension independently', () => {
+    const filterOptions: FilterOptions = {
+      ...DEFAULT_FILTER_OPTIONS,
+      search: 'foo',
+      severity: [CaseSeverity.HIGH],
+      status: [CaseStatuses.open],
+      tags: ['tag-1'],
+      assignees: ['user-1'],
+      category: ['category-1'],
+      customFields: { 'cf-1': { type: CustomFieldTypes.TEXT, options: [] } },
+      extendedFieldFilters: [{ label: 'label', value: 'value' }],
+      from: 'now-7d',
+    };
+
+    expect(getActiveFilterDimensions(filterOptions, DEFAULT_FILTER_OPTIONS)).toEqual([
+      'search',
+      'severity',
+      'status',
+      'tags',
+      'assignees',
+      'category',
+      'customFields',
+      'extendedFieldFilters',
+      'dateRange',
+    ]);
+  });
+
+  it('does not report unbounded custom field values, only the bucketed dimension name', () => {
+    const filterOptions: FilterOptions = {
+      ...DEFAULT_FILTER_OPTIONS,
+      customFields: {
+        'some-uuid-custom-field-key': { type: CustomFieldTypes.TEXT, options: ['a', 'b'] },
+      },
+    };
+
+    expect(getActiveFilterDimensions(filterOptions, DEFAULT_FILTER_OPTIONS)).toEqual([
+      'customFields',
+    ]);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/analytics/get_active_filter_dimensions.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/get_active_filter_dimensions.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import deepEqual from 'react-fast-compare';
+import type { FilterOptions } from '../../common/ui/types';
+
+/**
+ * Bounded set of cases list filter dimensions that can be reported for telemetry. This is a
+ * fixed enum of dimension *names* (not filter values) so the EBT field stays low-cardinality,
+ * e.g. custom field filters are all bucketed under the single "customFields" dimension rather
+ * than reporting the underlying custom field keys.
+ */
+export type FilterDimension =
+  | 'search'
+  | 'severity'
+  | 'status'
+  | 'tags'
+  | 'assignees'
+  | 'reporters'
+  | 'category'
+  | 'customFields'
+  | 'extendedFieldFilters'
+  | 'dateRange';
+
+/**
+ * Compares `filterOptions` against `defaultFilterOptions` and returns the bounded list of
+ * dimensions that have been changed from their defaults, i.e. the filters actively applied to
+ * the cases list.
+ */
+export const getActiveFilterDimensions = (
+  filterOptions: FilterOptions,
+  defaultFilterOptions: FilterOptions
+): FilterDimension[] => {
+  const dimensions: FilterDimension[] = [];
+
+  const isActive = <T>(value: T, defaultValue: T) => !deepEqual(value, defaultValue);
+
+  if (isActive(filterOptions.search, defaultFilterOptions.search)) {
+    dimensions.push('search');
+  }
+  if (isActive(filterOptions.severity, defaultFilterOptions.severity)) {
+    dimensions.push('severity');
+  }
+  if (isActive(filterOptions.status, defaultFilterOptions.status)) {
+    dimensions.push('status');
+  }
+  if (isActive(filterOptions.tags, defaultFilterOptions.tags)) {
+    dimensions.push('tags');
+  }
+  if (isActive(filterOptions.assignees, defaultFilterOptions.assignees)) {
+    dimensions.push('assignees');
+  }
+  if (isActive(filterOptions.reporters, defaultFilterOptions.reporters)) {
+    dimensions.push('reporters');
+  }
+  if (isActive(filterOptions.category, defaultFilterOptions.category)) {
+    dimensions.push('category');
+  }
+  if (isActive(filterOptions.customFields, defaultFilterOptions.customFields)) {
+    dimensions.push('customFields');
+  }
+  if (isActive(filterOptions.extendedFieldFilters, defaultFilterOptions.extendedFieldFilters)) {
+    dimensions.push('extendedFieldFilters');
+  }
+  if (
+    filterOptions.from !== defaultFilterOptions.from ||
+    filterOptions.to !== defaultFilterOptions.to
+  ) {
+    dimensions.push('dateRange');
+  }
+
+  return dimensions;
+};

--- a/x-pack/platform/plugins/shared/cases/public/analytics/get_ebt_owner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/get_ebt_owner.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
+import { getEbtOwner } from './get_ebt_owner';
+
+describe('getEbtOwner', () => {
+  it('returns the first owner when it is registered', () => {
+    expect(getEbtOwner([SECURITY_SOLUTION_OWNER])).toBe(SECURITY_SOLUTION_OWNER);
+  });
+
+  it('returns "unknown" when the owner is not a registered solution', () => {
+    expect(getEbtOwner(['not-a-real-owner'])).toBe('unknown');
+  });
+
+  it('returns "unknown" when the owner array is empty', () => {
+    expect(getEbtOwner([])).toBe('unknown');
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/analytics/get_ebt_owner.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/get_ebt_owner.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isRegisteredOwner } from '../files';
+
+/**
+ * Resolves the case context's owner into the value reported on EBT events, falling back to
+ * `'unknown'` when the owner is missing or is not a registered solution.
+ */
+export const getEbtOwner = (owner: string[]): string =>
+  owner[0] && isRegisteredOwner(owner[0]) ? owner[0] : 'unknown';

--- a/x-pack/platform/plugins/shared/cases/public/analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/index.ts
@@ -9,6 +9,7 @@ import type { AnalyticsServiceSetup } from '@kbn/core/public';
 import {
   CASE_ATTACH_EVENTS_EVENT_TYPE,
   CASE_PAGE_VIEW_EVENT_TYPE,
+  CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE,
   CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE,
   CASE_VIEW_ATTACHMENTS_TAB_CLICKED_EVENT_TYPE,
   CASES_LIST_PAGE_VIEW_EVENT_TYPE,
@@ -87,6 +88,27 @@ export const registerAnalytics = ({
   });
 
   analyticsService.registerEventType({
+    eventType: CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE,
+    schema: {
+      owner: {
+        type: 'keyword',
+        _meta: {
+          description:
+            'The solution ID (owner) in which the redesigned attachments accordion was opened',
+          optional: false,
+        },
+      },
+      attachment_type: {
+        type: 'keyword',
+        _meta: {
+          description: 'Which attachments type the opened accordion renders',
+          optional: false,
+        },
+      },
+    },
+  });
+
+  analyticsService.registerEventType({
     eventType: CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
     schema: {
       owner: {
@@ -128,7 +150,11 @@ export const registerAnalytics = ({
         items: {
           type: 'keyword',
           _meta: {
-            description: 'A column/field currently selected for display in the cases list',
+            description:
+              'A column/field currently selected for display in the cases list. Built-in ' +
+              'fields use stable names (e.g. "status", "severity"). Custom field columns are ' +
+              'included as their per-space UUID key (max 36 chars); at most ' +
+              'MAX_CUSTOM_FIELDS_PER_CASE (10) distinct custom field keys can appear per space',
           },
         },
         _meta: {
@@ -141,6 +167,37 @@ export const registerAnalytics = ({
         type: 'integer',
         _meta: {
           description: 'The number of rows selected per page in the cases list',
+          optional: false,
+        },
+      },
+      sort_field: {
+        type: 'keyword',
+        _meta: {
+          description:
+            'The case field the list is sorted by at load time, e.g. "createdAt" or "severity"',
+          optional: false,
+        },
+      },
+      sort_order: {
+        type: 'keyword',
+        _meta: {
+          description: 'The sort direction at load time, either "asc" or "desc"',
+          optional: false,
+        },
+      },
+      active_filter_dimensions: {
+        type: 'array',
+        items: {
+          type: 'keyword',
+          _meta: {
+            description:
+              'A bounded filter dimension name (e.g. "status", "severity", "customFields") ' +
+              'that is actively applied to the cases list at load time. Underlying filter ' +
+              'values are never reported, only the dimension name',
+          },
+        },
+        _meta: {
+          description: 'The bounded set of filter dimensions actively applied at load time',
           optional: false,
         },
       },

--- a/x-pack/platform/plugins/shared/cases/public/analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/index.ts
@@ -11,6 +11,8 @@ import {
   CASE_PAGE_VIEW_EVENT_TYPE,
   CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE,
   CASE_VIEW_ATTACHMENTS_TAB_CLICKED_EVENT_TYPE,
+  CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+  CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
 } from '../../common/constants';
 
 export const registerAnalytics = ({
@@ -78,6 +80,67 @@ export const registerAnalytics = ({
         type: 'keyword',
         _meta: {
           description: 'Which attachments type is rendered in the sub tab',
+          optional: false,
+        },
+      },
+    },
+  });
+
+  analyticsService.registerEventType({
+    eventType: CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
+    schema: {
+      owner: {
+        type: 'keyword',
+        _meta: {
+          description: 'The solution ID (owner) in which the cases list view mode was changed',
+          optional: false,
+        },
+      },
+      view_mode: {
+        type: 'keyword',
+        _meta: {
+          description: 'The cases list view mode the user switched to, either "list" or "table"',
+          optional: false,
+        },
+      },
+    },
+  });
+
+  analyticsService.registerEventType({
+    eventType: CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+    schema: {
+      owner: {
+        type: 'keyword',
+        _meta: {
+          description: 'The solution ID (owner) that rendered the cases list page',
+          optional: false,
+        },
+      },
+      view_mode: {
+        type: 'keyword',
+        _meta: {
+          description: 'The cases list view mode active on load, either "list" or "table"',
+          optional: false,
+        },
+      },
+      selected_columns: {
+        type: 'array',
+        items: {
+          type: 'keyword',
+          _meta: {
+            description: 'A column/field currently selected for display in the cases list',
+          },
+        },
+        _meta: {
+          description:
+            'The columns (table view) or fields (list view) currently selected for display',
+          optional: false,
+        },
+      },
+      per_page: {
+        type: 'integer',
+        _meta: {
+          description: 'The number of rows selected per page in the cases list',
           optional: false,
         },
       },

--- a/x-pack/platform/plugins/shared/cases/public/analytics/use_attachments_tab_ebt.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/use_attachments_tab_ebt.ts
@@ -7,12 +7,13 @@
 import { useCallback } from 'react';
 
 import {
+  CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE,
   CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE,
   CASE_VIEW_ATTACHMENTS_TAB_CLICKED_EVENT_TYPE,
 } from '../../common/constants';
 import { useKibana } from '../common/lib/kibana';
 import { useCasesContext } from '../components/cases_context/use_cases_context';
-import { isRegisteredOwner } from '../files';
+import { getEbtOwner } from './get_ebt_owner';
 
 /**
  * Events Based Tracking for Case View attachments tab
@@ -23,7 +24,7 @@ export const useAttachmentsTabClickedEBT = () => {
 
   return useCallback(() => {
     analytics.reportEvent(CASE_VIEW_ATTACHMENTS_TAB_CLICKED_EVENT_TYPE, {
-      owner: owner[0] && isRegisteredOwner(owner[0]) ? owner[0] : 'unknown',
+      owner: getEbtOwner(owner),
     });
   }, [analytics, owner]);
 };
@@ -38,7 +39,26 @@ export const useAttachmentsSubTabClickedEBT = () => {
   return useCallback(
     (attachmentType: string) => {
       analytics.reportEvent(CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE, {
-        owner: owner[0] && isRegisteredOwner(owner[0]) ? owner[0] : 'unknown',
+        owner: getEbtOwner(owner),
+        attachment_type: attachmentType,
+      });
+    },
+    [analytics, owner]
+  );
+};
+
+/**
+ * Events Based Tracking for opening an attachment accordion in the redesigned Case View.
+ * Distinct from `useAttachmentsSubTabClickedEBT`, which tracks the legacy horizontal tabs UI.
+ */
+export const useAttachmentAccordionOpenedEBT = () => {
+  const { analytics } = useKibana().services;
+  const { owner } = useCasesContext();
+
+  return useCallback(
+    (attachmentType: string) => {
+      analytics.reportEvent(CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE, {
+        owner: getEbtOwner(owner),
         attachment_type: attachmentType,
       });
     },

--- a/x-pack/platform/plugins/shared/cases/public/analytics/use_cases_list_ebt.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/use_cases_list_ebt.test.tsx
@@ -10,13 +10,13 @@ import {
   CASES_LIST_PAGE_VIEW_EVENT_TYPE,
   CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
   SECURITY_SOLUTION_OWNER,
-} from '../../common/constants';
-import { useKibana } from '../common/lib/kibana';
-import { useCasesContext } from '../components/cases_context/use_cases_context';
-import {
   VIEW_TOGGLE_LIST_ID,
   VIEW_TOGGLE_TABLE_ID,
-} from '../components/cases_redesign/all_cases/constants';
+} from '../../common/constants';
+import { SortFieldCase } from '../../common/ui/types';
+import { useKibana } from '../common/lib/kibana';
+import { useCasesContext } from '../components/cases_context/use_cases_context';
+import type { FilterDimension } from './get_active_filter_dimensions';
 import { useCasesListPageViewEBT, useCasesListViewModeChangedEBT } from './use_cases_list_ebt';
 
 jest.mock('../common/lib/kibana', () => ({
@@ -34,6 +34,8 @@ const getMockServices = (reportEvent: jest.Mock) => ({
     },
   },
 });
+
+const noActiveFilterDimensions: FilterDimension[] = [];
 
 describe('cases list EBT hooks', () => {
   const reportEvent = jest.fn();
@@ -66,6 +68,9 @@ describe('cases list EBT hooks', () => {
           viewMode: VIEW_TOGGLE_TABLE_ID,
           selectedColumns: ['title', 'status'],
           perPage: 25,
+          sortField: SortFieldCase.createdAt,
+          sortOrder: 'desc',
+          activeFilterDimensions: noActiveFilterDimensions,
         })
       );
 
@@ -74,7 +79,32 @@ describe('cases list EBT hooks', () => {
         view_mode: VIEW_TOGGLE_TABLE_ID,
         selected_columns: ['title', 'status'],
         per_page: 25,
+        sort_field: SortFieldCase.createdAt,
+        sort_order: 'desc',
+        active_filter_dimensions: [],
       });
+    });
+
+    it('reports the active filter dimensions and sorting', () => {
+      renderHook(() =>
+        useCasesListPageViewEBT({
+          viewMode: VIEW_TOGGLE_TABLE_ID,
+          selectedColumns: ['title'],
+          perPage: 25,
+          sortField: SortFieldCase.severity,
+          sortOrder: 'asc',
+          activeFilterDimensions: ['status', 'customFields'],
+        })
+      );
+
+      expect(reportEvent).toHaveBeenCalledWith(
+        CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+        expect.objectContaining({
+          sort_field: SortFieldCase.severity,
+          sort_order: 'asc',
+          active_filter_dimensions: ['status', 'customFields'],
+        })
+      );
     });
 
     it('does not report when disabled', () => {
@@ -83,6 +113,9 @@ describe('cases list EBT hooks', () => {
           viewMode: VIEW_TOGGLE_TABLE_ID,
           selectedColumns: ['title'],
           perPage: 10,
+          sortField: SortFieldCase.createdAt,
+          sortOrder: 'desc',
+          activeFilterDimensions: noActiveFilterDimensions,
           enabled: false,
         })
       );
@@ -97,6 +130,9 @@ describe('cases list EBT hooks', () => {
             viewMode: VIEW_TOGGLE_TABLE_ID,
             selectedColumns,
             perPage: 10,
+            sortField: SortFieldCase.createdAt,
+            sortOrder: 'desc',
+            activeFilterDimensions: noActiveFilterDimensions,
             isReady,
           }),
         {
@@ -119,6 +155,9 @@ describe('cases list EBT hooks', () => {
         view_mode: VIEW_TOGGLE_TABLE_ID,
         selected_columns: ['title', 'custom-field'],
         per_page: 10,
+        sort_field: SortFieldCase.createdAt,
+        sort_order: 'desc',
+        active_filter_dimensions: [],
       });
 
       rerender({

--- a/x-pack/platform/plugins/shared/cases/public/analytics/use_cases_list_ebt.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/use_cases_list_ebt.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import {
+  CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+  CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
+  SECURITY_SOLUTION_OWNER,
+} from '../../common/constants';
+import { useKibana } from '../common/lib/kibana';
+import { useCasesContext } from '../components/cases_context/use_cases_context';
+import {
+  VIEW_TOGGLE_LIST_ID,
+  VIEW_TOGGLE_TABLE_ID,
+} from '../components/cases_redesign/all_cases/constants';
+import { useCasesListPageViewEBT, useCasesListViewModeChangedEBT } from './use_cases_list_ebt';
+
+jest.mock('../common/lib/kibana', () => ({
+  useKibana: jest.fn(),
+}));
+
+jest.mock('../components/cases_context/use_cases_context', () => ({
+  useCasesContext: jest.fn(),
+}));
+
+const getMockServices = (reportEvent: jest.Mock) => ({
+  services: {
+    analytics: {
+      reportEvent,
+    },
+  },
+});
+
+describe('cases list EBT hooks', () => {
+  const reportEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue(getMockServices(reportEvent));
+    (useCasesContext as jest.Mock).mockReturnValue({ owner: [SECURITY_SOLUTION_OWNER] });
+  });
+
+  describe('useCasesListViewModeChangedEBT', () => {
+    it('reports the selected view mode with the owner', () => {
+      const { result } = renderHook(() => useCasesListViewModeChangedEBT());
+
+      result.current(VIEW_TOGGLE_LIST_ID);
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE, {
+        owner: SECURITY_SOLUTION_OWNER,
+        view_mode: VIEW_TOGGLE_LIST_ID,
+      });
+    });
+  });
+
+  describe('useCasesListPageViewEBT', () => {
+    it('reports the page view payload with an unknown owner fallback', () => {
+      (useCasesContext as jest.Mock).mockReturnValue({ owner: ['invalid'] });
+
+      renderHook(() =>
+        useCasesListPageViewEBT({
+          viewMode: VIEW_TOGGLE_TABLE_ID,
+          selectedColumns: ['title', 'status'],
+          perPage: 25,
+        })
+      );
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_LIST_PAGE_VIEW_EVENT_TYPE, {
+        owner: 'unknown',
+        view_mode: VIEW_TOGGLE_TABLE_ID,
+        selected_columns: ['title', 'status'],
+        per_page: 25,
+      });
+    });
+
+    it('does not report when disabled', () => {
+      renderHook(() =>
+        useCasesListPageViewEBT({
+          viewMode: VIEW_TOGGLE_TABLE_ID,
+          selectedColumns: ['title'],
+          perPage: 10,
+          enabled: false,
+        })
+      );
+
+      expect(reportEvent).not.toHaveBeenCalled();
+    });
+
+    it('waits for configuration and reports the latest payload only once', () => {
+      const { rerender } = renderHook(
+        ({ isReady, selectedColumns }: { isReady: boolean; selectedColumns: string[] }) =>
+          useCasesListPageViewEBT({
+            viewMode: VIEW_TOGGLE_TABLE_ID,
+            selectedColumns,
+            perPage: 10,
+            isReady,
+          }),
+        {
+          initialProps: {
+            isReady: false,
+            selectedColumns: ['title'],
+          },
+        }
+      );
+
+      expect(reportEvent).not.toHaveBeenCalled();
+
+      rerender({
+        isReady: true,
+        selectedColumns: ['title', 'custom-field'],
+      });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_LIST_PAGE_VIEW_EVENT_TYPE, {
+        owner: SECURITY_SOLUTION_OWNER,
+        view_mode: VIEW_TOGGLE_TABLE_ID,
+        selected_columns: ['title', 'custom-field'],
+        per_page: 10,
+      });
+
+      rerender({
+        isReady: true,
+        selectedColumns: ['title', 'status', 'custom-field'],
+      });
+
+      expect(reportEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/analytics/use_cases_list_ebt.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/use_cases_list_ebt.ts
@@ -11,13 +11,12 @@ import {
   CASES_LIST_PAGE_VIEW_EVENT_TYPE,
   CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
 } from '../../common/constants';
-import type { ViewToggleId } from '../components/cases_redesign/all_cases/constants';
+import type { ViewToggleId } from '../../common/constants';
+import type { SortFieldCase, SortOrder } from '../../common/ui/types';
 import { useKibana } from '../common/lib/kibana';
 import { useCasesContext } from '../components/cases_context/use_cases_context';
-import { isRegisteredOwner } from '../files';
-
-const getEbtOwner = (owner: string[]): string =>
-  owner[0] && isRegisteredOwner(owner[0]) ? owner[0] : 'unknown';
+import { getEbtOwner } from './get_ebt_owner';
+import type { FilterDimension } from './get_active_filter_dimensions';
 
 /**
  * Events Based Tracking for switching between the cases list "list" and "table" view modes
@@ -44,6 +43,12 @@ export interface UseCasesListPageViewEBTArgs {
   selectedColumns: string[];
   /** The number of rows selected per page */
   perPage: number;
+  /** The case field the list is sorted by at load time */
+  sortField: SortFieldCase;
+  /** The sort direction at load time */
+  sortOrder: SortOrder;
+  /** The bounded set of filter dimensions that are actively applied at load time */
+  activeFilterDimensions: FilterDimension[];
   /** Whether asynchronously loaded list configuration is ready to report */
   isReady?: boolean;
   /**
@@ -55,12 +60,16 @@ export interface UseCasesListPageViewEBTArgs {
 
 /**
  * Events Based Tracking for the cases list page load. Reports the view mode, selected
- * columns/fields, and page size that were active at load time.
+ * columns/fields, sorting, active filter dimensions, and page size that were active at load
+ * time.
  */
 export const useCasesListPageViewEBT = ({
   viewMode,
   selectedColumns,
   perPage,
+  sortField,
+  sortOrder,
+  activeFilterDimensions,
   isReady = true,
   enabled = true,
 }: UseCasesListPageViewEBTArgs) => {
@@ -79,6 +88,20 @@ export const useCasesListPageViewEBT = ({
       view_mode: viewMode,
       selected_columns: selectedColumns,
       per_page: perPage,
+      sort_field: sortField,
+      sort_order: sortOrder,
+      active_filter_dimensions: activeFilterDimensions,
     });
-  }, [analytics, enabled, isReady, owner, perPage, selectedColumns, viewMode]);
+  }, [
+    analytics,
+    enabled,
+    isReady,
+    owner,
+    perPage,
+    selectedColumns,
+    viewMode,
+    sortField,
+    sortOrder,
+    activeFilterDimensions,
+  ]);
 };

--- a/x-pack/platform/plugins/shared/cases/public/analytics/use_cases_list_ebt.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/use_cases_list_ebt.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+
+import {
+  CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+  CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
+} from '../../common/constants';
+import type { ViewToggleId } from '../components/cases_redesign/all_cases/constants';
+import { useKibana } from '../common/lib/kibana';
+import { useCasesContext } from '../components/cases_context/use_cases_context';
+import { isRegisteredOwner } from '../files';
+
+const getEbtOwner = (owner: string[]): string =>
+  owner[0] && isRegisteredOwner(owner[0]) ? owner[0] : 'unknown';
+
+/**
+ * Events Based Tracking for switching between the cases list "list" and "table" view modes
+ */
+export const useCasesListViewModeChangedEBT = () => {
+  const { analytics } = useKibana().services;
+  const { owner } = useCasesContext();
+
+  return useCallback(
+    (viewMode: ViewToggleId) => {
+      analytics.reportEvent(CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE, {
+        owner: getEbtOwner(owner),
+        view_mode: viewMode,
+      });
+    },
+    [analytics, owner]
+  );
+};
+
+export interface UseCasesListPageViewEBTArgs {
+  /** The active view mode ("list" or "table") at the time the page loaded */
+  viewMode: ViewToggleId;
+  /** The columns (table view) or fields (list view) currently selected for display */
+  selectedColumns: string[];
+  /** The number of rows selected per page */
+  perPage: number;
+  /** Whether asynchronously loaded list configuration is ready to report */
+  isReady?: boolean;
+  /**
+   * Set to `false` to skip reporting, e.g. when the list is rendered inside the
+   * "add to existing case" selector modal rather than as the main cases list page.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Events Based Tracking for the cases list page load. Reports the view mode, selected
+ * columns/fields, and page size that were active at load time.
+ */
+export const useCasesListPageViewEBT = ({
+  viewMode,
+  selectedColumns,
+  perPage,
+  isReady = true,
+  enabled = true,
+}: UseCasesListPageViewEBTArgs) => {
+  const { analytics } = useKibana().services;
+  const { owner } = useCasesContext();
+  const hasReportedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || !isReady || hasReportedRef.current) {
+      return;
+    }
+
+    hasReportedRef.current = true;
+    analytics.reportEvent(CASES_LIST_PAGE_VIEW_EVENT_TYPE, {
+      owner: getEbtOwner(owner),
+      view_mode: viewMode,
+      selected_columns: selectedColumns,
+      per_page: perPage,
+    });
+  }, [analytics, enabled, isReady, owner, perPage, selectedColumns, viewMode]);
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_accordion.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_accordion.test.tsx
@@ -12,7 +12,7 @@ import type { CoreStart } from '@kbn/core/public';
 
 import { AttachmentAccordion } from './attachment_accordion';
 import { mockedTestProvidersOwner, renderWithTestingProviders } from '../../../common/mock';
-import { CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE } from '../../../../common/constants';
+import { CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE } from '../../../../common/constants';
 
 describe('AttachmentAccordion', () => {
   it('renders the title, count badge, and children', () => {
@@ -52,7 +52,24 @@ describe('AttachmentAccordion', () => {
     );
   });
 
-  it('reports a case_view_attachments_sub_tab_clicked EBT event when the accordion is opened', () => {
+  it('reports a case_view_attachment_accordion_opened EBT event on initial mount, since accordions default to open', () => {
+    const coreStart = coreMock.createStart() as unknown as CoreStart;
+
+    renderWithTestingProviders(
+      <AttachmentAccordion id="alerts" title="Alerts" count={5}>
+        <div />
+      </AttachmentAccordion>,
+      { wrapperProps: { coreStart } }
+    );
+
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+      CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE,
+      { owner: mockedTestProvidersOwner[0], attachment_type: 'alerts' }
+    );
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports another case_view_attachment_accordion_opened EBT event each time the accordion is re-opened', () => {
     const coreStart = coreMock.createStart() as unknown as CoreStart;
 
     renderWithTestingProviders(
@@ -64,16 +81,18 @@ describe('AttachmentAccordion', () => {
 
     const toggleButton = screen.getByTestId('case-view-attachment-accordion-toggle-alerts');
 
-    // Collapse it first (already open by default) so the next click reports the "opened" event.
-    fireEvent.click(toggleButton);
-    expect(coreStart.analytics.reportEvent).not.toHaveBeenCalledWith(
-      CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE,
-      expect.anything()
-    );
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
 
+    // Collapsing must not report another "opened" event.
     fireEvent.click(toggleButton);
-    expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
-      CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE,
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+
+    // Re-opening reports a second "opened" event.
+    fireEvent.click(toggleButton);
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(2);
+    expect(coreStart.analytics.reportEvent).toHaveBeenNthCalledWith(
+      2,
+      CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE,
       { owner: mockedTestProvidersOwner[0], attachment_type: 'alerts' }
     );
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_accordion.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_accordion.test.tsx
@@ -6,10 +6,13 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
+import { coreMock } from '@kbn/core/public/mocks';
+import type { CoreStart } from '@kbn/core/public';
 
 import { AttachmentAccordion } from './attachment_accordion';
-import { renderWithTestingProviders } from '../../../common/mock';
+import { mockedTestProvidersOwner, renderWithTestingProviders } from '../../../common/mock';
+import { CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE } from '../../../../common/constants';
 
 describe('AttachmentAccordion', () => {
   it('renders the title, count badge, and children', () => {
@@ -46,6 +49,32 @@ describe('AttachmentAccordion', () => {
     expect(screen.getByTestId('case-view-attachment-accordion-toggle-observables')).toHaveAttribute(
       'aria-expanded',
       'true'
+    );
+  });
+
+  it('reports a case_view_attachments_sub_tab_clicked EBT event when the accordion is opened', () => {
+    const coreStart = coreMock.createStart() as unknown as CoreStart;
+
+    renderWithTestingProviders(
+      <AttachmentAccordion id="alerts" title="Alerts" count={5}>
+        <div />
+      </AttachmentAccordion>,
+      { wrapperProps: { coreStart } }
+    );
+
+    const toggleButton = screen.getByTestId('case-view-attachment-accordion-toggle-alerts');
+
+    // Collapse it first (already open by default) so the next click reports the "opened" event.
+    fireEvent.click(toggleButton);
+    expect(coreStart.analytics.reportEvent).not.toHaveBeenCalledWith(
+      CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE,
+      expect.anything()
+    );
+
+    fireEvent.click(toggleButton);
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+      CASE_VIEW_ATTACHMENTS_SUB_TAB_CLICKED_EVENT_TYPE,
+      { owner: mockedTestProvidersOwner[0], attachment_type: 'alerts' }
     );
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_accordion.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_accordion.tsx
@@ -15,8 +15,8 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useCallback, useState } from 'react';
-import { useAttachmentsSubTabClickedEBT } from '../../../analytics/use_attachments_tab_ebt';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useAttachmentAccordionOpenedEBT } from '../../../analytics/use_attachments_tab_ebt';
 
 interface AttachmentAccordionProps {
   id: string;
@@ -30,16 +30,19 @@ export const AttachmentAccordion = ({ id, title, count, children }: AttachmentAc
   const accordionId = useGeneratedHtmlId({ prefix: `case-view-attachment-${id}` });
   // Controlled isOpen so we can fully unmount children when collapsed
   const [isOpen, setIsOpen] = useState(true);
-  const trackAttachmentsSubTabClick = useAttachmentsSubTabClickedEBT();
-  const onToggle = useCallback(
-    (nextIsOpen: boolean) => {
-      setIsOpen(nextIsOpen);
-      if (nextIsOpen) {
-        trackAttachmentsSubTabClick(id);
-      }
-    },
-    [id, trackAttachmentsSubTabClick]
-  );
+  const trackAttachmentAccordionOpened = useAttachmentAccordionOpenedEBT();
+
+  // Reports every time the accordion becomes visible, including the initial mount (accordions
+  // default to open), not just on user-driven re-opens.
+  useEffect(() => {
+    if (isOpen) {
+      trackAttachmentAccordionOpened(id);
+    }
+  }, [isOpen, id, trackAttachmentAccordionOpened]);
+
+  const onToggle = useCallback((nextIsOpen: boolean) => {
+    setIsOpen(nextIsOpen);
+  }, []);
   return (
     <EuiFlexItem grow={false}>
       <EuiPanel hasBorder>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_accordion.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_accordion.tsx
@@ -16,6 +16,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useCallback, useState } from 'react';
+import { useAttachmentsSubTabClickedEBT } from '../../../analytics/use_attachments_tab_ebt';
 
 interface AttachmentAccordionProps {
   id: string;
@@ -29,7 +30,16 @@ export const AttachmentAccordion = ({ id, title, count, children }: AttachmentAc
   const accordionId = useGeneratedHtmlId({ prefix: `case-view-attachment-${id}` });
   // Controlled isOpen so we can fully unmount children when collapsed
   const [isOpen, setIsOpen] = useState(true);
-  const onToggle = useCallback((nextIsOpen: boolean) => setIsOpen(nextIsOpen), []);
+  const trackAttachmentsSubTabClick = useAttachmentsSubTabClickedEBT();
+  const onToggle = useCallback(
+    (nextIsOpen: boolean) => {
+      setIsOpen(nextIsOpen);
+      if (nextIsOpen) {
+        trackAttachmentsSubTabClick(id);
+      }
+    },
+    [id, trackAttachmentsSubTabClick]
+  );
   return (
     <EuiFlexItem grow={false}>
       <EuiPanel hasBorder>

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.test.tsx
@@ -1298,6 +1298,31 @@ describe('AllCasesListGeneric', () => {
           view_mode: VIEW_TOGGLE_TABLE_ID,
           selected_columns: expect.arrayContaining(['title', 'status', 'severity']),
           per_page: DEFAULT_QUERY_PARAMS.perPage,
+          sort_field: DEFAULT_QUERY_PARAMS.sortField,
+          sort_order: DEFAULT_QUERY_PARAMS.sortOrder,
+          active_filter_dimensions: [],
+        })
+      );
+    });
+
+    it('reports a cases_list_page_view EBT event on load in list view mode with the selected fields', async () => {
+      useViewModeMock.mockReturnValue({
+        viewMode: VIEW_TOGGLE_LIST_ID,
+        setViewMode: jest.fn(),
+      });
+
+      renderWithTestingProviders(<AllCasesList />);
+
+      await screen.findByTestId('cases-list-view');
+
+      expect(useKibanaMock().services.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+        expect.objectContaining({
+          owner: SECURITY_SOLUTION_OWNER,
+          view_mode: VIEW_TOGGLE_LIST_ID,
+          // No optional fields are checked in the list view by default.
+          selected_columns: [],
+          per_page: DEFAULT_QUERY_PARAMS.perPage,
         })
       );
     });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.test.tsx
@@ -22,7 +22,11 @@ import { useGetCasesMockState, connectorsMock } from '../../../containers/mock';
 
 import { SortFieldCase } from '../../../../common/ui/types';
 import { CaseSeverity, CaseStatuses } from '../../../../common/types/domain';
-import { SECURITY_SOLUTION_OWNER } from '../../../../common/constants';
+import {
+  CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+  CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
+  SECURITY_SOLUTION_OWNER,
+} from '../../../../common/constants';
 import { useKibana } from '../../../common/lib/kibana';
 import { AllCasesList } from './all_cases_list';
 import { VIEW_TOGGLE_LIST_ID, VIEW_TOGGLE_TABLE_ID, type ViewToggleId } from './constants';
@@ -1278,6 +1282,53 @@ describe('AllCasesListGeneric', () => {
           });
         });
       });
+    });
+  });
+
+  describe('Telemetry', () => {
+    it('reports a cases_list_page_view EBT event on load with the view mode, columns, and page size', async () => {
+      renderWithTestingProviders(<AllCasesList />);
+
+      await screen.findByTestId('cases-table');
+
+      expect(useKibanaMock().services.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+        expect.objectContaining({
+          owner: SECURITY_SOLUTION_OWNER,
+          view_mode: VIEW_TOGGLE_TABLE_ID,
+          selected_columns: expect.arrayContaining(['title', 'status', 'severity']),
+          per_page: DEFAULT_QUERY_PARAMS.perPage,
+        })
+      );
+    });
+
+    it('does not report a cases_list_page_view EBT event in the selector view', async () => {
+      renderWithTestingProviders(<AllCasesList isSelectorView={true} />);
+
+      await screen.findByTestId('cases-table');
+
+      expect(useKibanaMock().services.analytics.reportEvent).not.toHaveBeenCalledWith(
+        CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+        expect.anything()
+      );
+    });
+
+    it('reports a cases_list_view_mode_changed EBT event when the view toggle is clicked', async () => {
+      const setViewMode = jest.fn();
+      useViewModeMock.mockReturnValue({
+        viewMode: VIEW_TOGGLE_TABLE_ID,
+        setViewMode,
+      });
+
+      renderWithTestingProviders(<AllCasesList />);
+
+      await userEvent.click(await screen.findByRole('button', { name: /list view/i }));
+
+      expect(setViewMode).toHaveBeenCalledWith(VIEW_TOGGLE_LIST_ID);
+      expect(useKibanaMock().services.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
+        expect.objectContaining({ view_mode: VIEW_TOGGLE_LIST_ID })
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
@@ -37,6 +37,7 @@ import { useCasesColumnsSelection } from '../../all_cases/use_cases_columns_sele
 import { useListFieldsSelection } from './hooks/use_list_fields_selection';
 import { useViewMode } from './hooks/use_view_mode';
 import { DEFAULT_CASES_TABLE_STATE } from '../../../containers/constants';
+import { getActiveFilterDimensions } from '../../../analytics/get_active_filter_dimensions';
 import { CasesTableUtilityBar } from './components/utility_bar';
 import { useCheckDocumentAttachments } from '../../../containers/use_check_alert_attachments';
 import { type GetAttachments } from '../../all_cases/selector_modal/use_cases_add_to_existing_case_modal';
@@ -208,10 +209,18 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       disabledCases,
     });
 
+    const activeFilterDimensions = useMemo(
+      () => getActiveFilterDimensions(filterOptions, DEFAULT_CASES_TABLE_STATE.filterOptions),
+      [filterOptions]
+    );
+
     useCasesListPageViewEBT({
       viewMode,
       selectedColumns: selectedColumnFields,
       perPage: queryParams.perPage,
+      sortField: queryParams.sortField,
+      sortOrder: queryParams.sortOrder,
+      activeFilterDimensions,
       isReady: !isLoadingColumns,
       enabled: !isSelectorView,
     });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
@@ -40,6 +40,10 @@ import { DEFAULT_CASES_TABLE_STATE } from '../../../containers/constants';
 import { CasesTableUtilityBar } from './components/utility_bar';
 import { useCheckDocumentAttachments } from '../../../containers/use_check_alert_attachments';
 import { type GetAttachments } from '../../all_cases/selector_modal/use_cases_add_to_existing_case_modal';
+import {
+  useCasesListPageViewEBT,
+  useCasesListViewModeChangedEBT,
+} from '../../../analytics/use_cases_list_ebt';
 
 const getSortField = (field: string): SortFieldCase =>
   // @ts-ignore
@@ -167,11 +171,22 @@ export const AllCasesList = React.memo<AllCasesListProps>(
     const { viewMode: storedViewMode, setViewMode } = useViewMode();
     const viewMode = isSelectorView ? VIEW_TOGGLE_TABLE_ID : storedViewMode;
 
+    const trackViewModeChanged = useCasesListViewModeChangedEBT();
     const onViewModeChange = useCallback(
       (mode: ViewToggleId) => {
         setViewMode(mode);
+        trackViewModeChanged(mode);
       },
-      [setViewMode]
+      [setViewMode, trackViewModeChanged]
+    );
+
+    const selectedColumnFields = useMemo(
+      () =>
+        (viewMode === VIEW_TOGGLE_TABLE_ID ? selectedColumns : selectedFields).reduce<string[]>(
+          (fields, { field, isChecked }) => (isChecked ? [...fields, field] : fields),
+          []
+        ),
+      [viewMode, selectedColumns, selectedFields]
     );
 
     const onSortOrderChange = useCallback(
@@ -191,6 +206,14 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       disableActions: selectedCases.length > 0,
       selectedColumns,
       disabledCases,
+    });
+
+    useCasesListPageViewEBT({
+      viewMode,
+      selectedColumns: selectedColumnFields,
+      perPage: queryParams.perPage,
+      isReady: !isLoadingColumns,
+      enabled: !isSelectorView,
     });
 
     const pagination = useMemo(

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/constants.ts
@@ -5,6 +5,12 @@
  * 2.0.
  */
 
+export {
+  VIEW_TOGGLE_LIST_ID,
+  VIEW_TOGGLE_TABLE_ID,
+  type ViewToggleId,
+} from '../../../../common/constants';
+
 export const CUSTOM_FIELD_KEY_PREFIX = 'cf_';
 export const ALL_CASES_STATE_URL_KEY = 'cases';
 
@@ -16,11 +22,6 @@ export const LEGACY_SUPPORTED_STATE_KEYS = [
   'sortField',
   'sortOrder',
 ] as const;
-
-export const VIEW_TOGGLE_LIST_ID = 'list' as const;
-export const VIEW_TOGGLE_TABLE_ID = 'table' as const;
-
-export type ViewToggleId = typeof VIEW_TOGGLE_LIST_ID | typeof VIEW_TOGGLE_TABLE_ID;
 
 /**
  * Fields rendered directly in every list item (title row + meta row).

--- a/x-pack/platform/plugins/shared/cases/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/plugin.test.ts
@@ -24,6 +24,7 @@ import { ALLOWED_MIME_TYPES } from '../common/constants/mime_types';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 import {
   CASE_PAGE_VIEW_EVENT_TYPE,
+  CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE,
   CASES_LIST_PAGE_VIEW_EVENT_TYPE,
   CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
 } from '../common/constants';
@@ -154,6 +155,23 @@ describe('Cases Ui Plugin', () => {
             view_mode: expect.objectContaining({ type: 'keyword' }),
             selected_columns: expect.objectContaining({ type: 'array' }),
             per_page: expect.objectContaining({ type: 'integer' }),
+            sort_field: expect.objectContaining({ type: 'keyword' }),
+            sort_order: expect.objectContaining({ type: 'keyword' }),
+            active_filter_dimensions: expect.objectContaining({ type: 'array' }),
+          }),
+        })
+      );
+    });
+
+    it('registers the attachment accordion opened event type', async () => {
+      plugin.setup(coreSetup, pluginsSetup);
+
+      expect(coreSetup.analytics.registerEventType).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: CASE_VIEW_ATTACHMENT_ACCORDION_OPENED_EVENT_TYPE,
+          schema: expect.objectContaining({
+            owner: expect.objectContaining({ type: 'keyword' }),
+            attachment_type: expect.objectContaining({ type: 'keyword' }),
           }),
         })
       );

--- a/x-pack/platform/plugins/shared/cases/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/plugin.test.ts
@@ -22,7 +22,11 @@ import type { CasesPublicStartDependencies, CasesPublicSetupDependencies } from 
 import { CasesUiPlugin } from './plugin';
 import { ALLOWED_MIME_TYPES } from '../common/constants/mime_types';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
-import { CASE_PAGE_VIEW_EVENT_TYPE } from '../common/constants';
+import {
+  CASE_PAGE_VIEW_EVENT_TYPE,
+  CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+  CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
+} from '../common/constants';
 import { toastsServiceMock } from '@kbn/core-notifications-browser-mocks/src/toasts_service.mock';
 
 function getConfig(overrides = {}) {
@@ -126,6 +130,31 @@ describe('Cases Ui Plugin', () => {
         expect.objectContaining({
           eventType: CASE_PAGE_VIEW_EVENT_TYPE,
           schema: expect.objectContaining({ owner: expect.objectContaining({ type: 'keyword' }) }),
+        })
+      );
+    });
+
+    it('registers cases list event types', async () => {
+      plugin.setup(coreSetup, pluginsSetup);
+
+      expect(coreSetup.analytics.registerEventType).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
+          schema: expect.objectContaining({
+            owner: expect.objectContaining({ type: 'keyword' }),
+            view_mode: expect.objectContaining({ type: 'keyword' }),
+          }),
+        })
+      );
+      expect(coreSetup.analytics.registerEventType).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: CASES_LIST_PAGE_VIEW_EVENT_TYPE,
+          schema: expect.objectContaining({
+            owner: expect.objectContaining({ type: 'keyword' }),
+            view_mode: expect.objectContaining({ type: 'keyword' }),
+            selected_columns: expect.objectContaining({ type: 'array' }),
+            per_page: expect.objectContaining({ type: 'integer' }),
+          }),
         })
       );
     });


### PR DESCRIPTION
## What & Why

Adds EBT coverage for redesigned Cases list page views, view-mode changes, and attachment accordion opens. This closes telemetry gaps while preserving selector behavior and waiting for list configuration before reporting columns.

## How to Test

1. Run the updated Cases Jest suites.
2. Start Kibana with the analytics FTR helper plugin.
3. Confirm list page-view and view-toggle events contain the expected owner and display settings.
4. Confirm opening an attachment accordion reports an event, while closing it does not.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->