### PR TITLE
[9.5] [One Workflow] Refactor liquidjs code to make full usage of its api (#278127)

### DIFF
--- a/src/platform/packages/shared/kbn-workflows-yaml/common/liquid/liquid_parse_cache.ts
+++ b/src/platform/packages/shared/kbn-workflows-yaml/common/liquid/liquid_parse_cache.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Liquid, Template } from 'liquidjs';
-import { createWorkflowLiquidEngine, pickObjectFields } from '@kbn/workflows';
+import { createWorkflowLiquidEngine } from '@kbn/workflows';
 
 let liquidInstance: Liquid | null = null;
 
@@ -28,26 +28,6 @@ export function getLiquidInstance(): Liquid {
     liquidInstance = createWorkflowLiquidEngine({
       strictFilters: true,
       strictVariables: false,
-    });
-    liquidInstance.registerFilter('json_parse', (value: unknown): unknown => {
-      if (typeof value !== 'string') {
-        return value;
-      }
-      try {
-        return JSON.parse(value);
-      } catch {
-        return value;
-      }
-    });
-    liquidInstance.registerFilter('entries', (value: unknown): unknown => {
-      return value;
-    });
-    liquidInstance.registerFilter('pick', (value: unknown, ...args: unknown[]): unknown => {
-      const paths = args.length === 1 && Array.isArray(args[0]) ? args[0] : args;
-      return pickObjectFields(
-        value,
-        paths.filter((path): path is string => typeof path === 'string')
-      );
     });
   }
   return liquidInstance;

--- a/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/create_workflow_liquid_engine.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/create_workflow_liquid_engine.ts
@@ -9,6 +9,7 @@
 
 import type { FS, LiquidOptions } from 'liquidjs';
 import { Liquid } from 'liquidjs';
+import { pickObjectFields } from '../pick_object_fields/pick_object_fields';
 
 /**
  * LiquidJS tags supported in workflow templates.
@@ -96,5 +97,47 @@ export const createWorkflowLiquidEngine = (options?: LiquidOptions): Liquid => {
     memoryLimit,
   });
   removeDisallowedLiquidTags(engine);
+  registerWorkflowLiquidFilters(engine);
   return engine;
+};
+
+/**
+ * Registers the custom filters required by workflow templates onto the given engine.
+ * Called automatically by {@link createWorkflowLiquidEngine}; exposed for testing.
+ *
+ * Registering centrally here ensures every engine instance (server-side execution,
+ * YAML validation, editor evaluation) uses identical filter implementations and
+ * eliminates the risk of divergence (e.g. a no-op stub instead of the real function).
+ */
+export const registerWorkflowLiquidFilters = (engine: Liquid): void => {
+  // Converts a JSON string to a parsed object; passes non-strings through unchanged.
+  engine.registerFilter('json_parse', (value: unknown): unknown => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  });
+
+  // Converts a plain object to an array of { key, value } pairs.
+  engine.registerFilter('entries', (value: unknown): unknown => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return value;
+    }
+    return Object.entries(value).map(([k, v]) => ({ key: k, value: v }));
+  });
+
+  // Keeps only the given dotted-path fields of an object, preserving nested structure.
+  // Accepts a single array of paths (| pick: consts.fields) or several string args
+  // (| pick: "a", "b").
+  engine.registerFilter('pick', (value: unknown, ...args: unknown[]): unknown => {
+    const paths = args.length === 1 && Array.isArray(args[0]) ? args[0] : args;
+    return pickObjectFields(
+      value,
+      paths.filter((path): path is string => typeof path === 'string')
+    );
+  });
 };

--- a/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/create_workflow_liquid_engine_filters.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/create_workflow_liquid_engine_filters.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * B5 refactor: custom filters (json_parse, entries, pick) are now registered
+ * once inside createWorkflowLiquidEngine, not separately in each consumer.
+ *
+ * These tests verify:
+ * 1. Every engine returned by the factory includes all three filters.
+ * 2. The `entries` filter is the *real* object-to-array implementation — not the
+ *    no-op identity stub that previously existed in liquid_parse_cache.ts.
+ * 3. The `json_parse` and `pick` filter behaviours are correct.
+ * 4. Filters work correctly regardless of whether strictFilters is set.
+ */
+
+import { createWorkflowLiquidEngine } from './create_workflow_liquid_engine';
+
+describe('createWorkflowLiquidEngine — built-in custom filters (B5)', () => {
+  // -----------------------------------------------------------------------
+  // json_parse
+  // -----------------------------------------------------------------------
+  describe('json_parse filter', () => {
+    it('parses a valid JSON string to an object (rendered via | json)', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      const result = engine.parseAndRenderSync('{{ val | json_parse | json }}', {
+        val: '{"a":1}',
+      });
+      expect(JSON.parse(result)).toEqual({ a: 1 });
+    });
+
+    it('returns the input unchanged for non-string values', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      const result = engine.parseAndRenderSync('{{ val | json_parse }}', { val: 42 });
+      expect(result).toBe('42');
+    });
+
+    it('returns the original string when JSON is invalid', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      const result = engine.parseAndRenderSync('{{ val | json_parse }}', { val: 'not-json' });
+      expect(result).toBe('not-json');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // entries — key fix: the former no-op stub in liquid_parse_cache.ts is gone
+  // -----------------------------------------------------------------------
+  describe('entries filter', () => {
+    it('converts a plain object to an array of { key, value } pairs', () => {
+      // Previously, the engine returned by getLiquidInstance() (liquid_parse_cache.ts)
+      // had a no-op entries filter that simply returned the input unchanged.
+      // After B5, every engine shares the same real implementation.
+      const engine = createWorkflowLiquidEngine({ strictFilters: true, strictVariables: false });
+      const result = engine.parseAndRenderSync(
+        '{% assign pairs = obj | entries %}{% for p in pairs %}{{ p.key }}={{ p.value }} {% endfor %}',
+        { obj: { x: 1, y: 2 } }
+      );
+      // Order is insertion order (Object.entries guarantee)
+      expect(result.trim()).toBe('x=1 y=2');
+    });
+
+    it('returns a non-object value unchanged (array passthrough)', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      const result = engine.parseAndRenderSync('{{ val | entries | json }}', {
+        val: [1, 2, 3],
+      });
+      expect(JSON.parse(result)).toEqual([1, 2, 3]);
+    });
+
+    it('returns null unchanged', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      const result = engine.parseAndRenderSync('{{ val | entries }}', { val: null });
+      expect(result).toBe('');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // pick
+  // -----------------------------------------------------------------------
+  describe('pick filter', () => {
+    it('keeps only the requested dotted-path fields', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      const result = engine.parseAndRenderSync('{{ obj | pick: "a", "b.c" | json }}', {
+        obj: { a: 1, b: { c: 2, d: 99 }, z: 42 },
+      });
+      expect(JSON.parse(result)).toEqual({ a: 1, b: { c: 2 } });
+    });
+
+    it('accepts a single array of paths passed as argument', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true, strictVariables: false });
+      const result = engine.parseAndRenderSync(
+        '{% assign paths = "a,b" | split: "," %}{{ obj | pick: paths | json }}',
+        { obj: { a: 1, b: 2, c: 3 } }
+      );
+      expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Availability under strictFilters (regression: filters must be registered
+  // before the engine is used, regardless of the strictFilters option)
+  // -----------------------------------------------------------------------
+  describe('filter availability with strictFilters: true', () => {
+    it('json_parse does not throw with strictFilters: true', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      expect(() =>
+        engine.parseAndRenderSync('{{ v | json_parse }}', { v: '"hello"' })
+      ).not.toThrow();
+    });
+
+    it('entries does not throw with strictFilters: true', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      expect(() =>
+        engine.parseAndRenderSync('{{ v | entries | json }}', { v: { k: 1 } })
+      ).not.toThrow();
+    });
+
+    it('pick does not throw with strictFilters: true', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      expect(() =>
+        engine.parseAndRenderSync('{{ v | pick: "k" | json }}', { v: { k: 1 } })
+      ).not.toThrow();
+    });
+
+    it('still rejects genuinely unknown filters with strictFilters: true', () => {
+      const engine = createWorkflowLiquidEngine({ strictFilters: true });
+      expect(() => engine.parseAndRenderSync('{{ v | no_such_filter }}', { v: 1 })).toThrow();
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.ts
@@ -10,7 +10,7 @@
 import type { Template } from 'liquidjs';
 import { i18n } from '@kbn/i18n';
 import type { LiquidSettings } from '@kbn/workflows';
-import { createWorkflowLiquidEngine, pickObjectFields } from '@kbn/workflows';
+import { createWorkflowLiquidEngine } from '@kbn/workflows';
 
 type TemplateVariableSegment = string | number;
 type TemplateVariableSegments = TemplateVariableSegment[];
@@ -54,37 +54,6 @@ export class WorkflowTemplatingEngine {
       parseLimit: liquidSettings?.parseLimit,
       renderLimit: liquidSettings?.renderLimit,
       memoryLimit: liquidSettings?.memoryLimit,
-    });
-
-    // register json_parse filter that converts JSON string to object
-    this.engine.registerFilter('json_parse', (value: unknown): unknown => {
-      if (typeof value !== 'string') {
-        return value;
-      }
-      try {
-        return JSON.parse(value);
-      } catch (error) {
-        return value;
-      }
-    });
-
-    // register entries filter that converts an object into an array of {key, value} pairs
-    this.engine.registerFilter('entries', (value: unknown): unknown => {
-      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-        return value;
-      }
-      return Object.entries(value).map(([k, v]) => ({ key: k, value: v }));
-    });
-
-    // register pick filter that keeps only the given dotted-path fields of an object,
-    // preserving nested structure and value types. Accepts a single array of paths
-    // (e.g. `| pick: consts.fields`) or several string args (e.g. `| pick: "a", "b"`).
-    this.engine.registerFilter('pick', (value: unknown, ...args: unknown[]): unknown => {
-      const paths = args.length === 1 && Array.isArray(args[0]) ? args[0] : args;
-      return pickObjectFields(
-        value,
-        paths.filter((path): path is string => typeof path === 'string')
-      );
     });
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/evaluate_expression.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/evaluate_expression.ts
@@ -8,41 +8,15 @@
  */
 
 import type { JsonArray, JsonObject, JsonValue } from '@kbn/utility-types';
-import { createWorkflowLiquidEngine, pickObjectFields } from '@kbn/workflows';
+import { createWorkflowLiquidEngine } from '@kbn/workflows';
 import { resolvePathValue } from './resolve_path_value';
 import type { ExecutionContext } from '../execution_context/build_execution_context';
 
-// Create a liquid engine instance with the same configuration as the server
+// Create a liquid engine instance with the same configuration as the server.
+// Custom filters (json_parse, entries, pick) are registered inside createWorkflowLiquidEngine.
 const liquidEngine = createWorkflowLiquidEngine({
   strictFilters: true, // Match server-side behavior - error on unknown filters
   strictVariables: false,
-});
-
-// Register custom filters that match server-side exactly
-liquidEngine.registerFilter('json_parse', (value: unknown): unknown => {
-  if (typeof value !== 'string') {
-    return value;
-  }
-  try {
-    return JSON.parse(value);
-  } catch (error) {
-    return value;
-  }
-});
-
-liquidEngine.registerFilter('entries', (value: unknown): unknown => {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return value;
-  }
-  return Object.entries(value).map(([k, v]) => ({ key: k, value: v }));
-});
-
-liquidEngine.registerFilter('pick', (value: unknown, ...args: unknown[]): unknown => {
-  const paths = args.length === 1 && Array.isArray(args[0]) ? args[0] : args;
-  return pickObjectFields(
-    value,
-    paths.filter((path): path is string => typeof path === 'string')
-  );
 });
 
 export interface EvaluateExpressionOptions {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/parse_template_at_position.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/parse_template_at_position.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { Output } from 'liquidjs';
 import { monaco } from '@kbn/monaco';
 import { createWorkflowLiquidEngine } from '@kbn/workflows';
 
@@ -51,19 +52,15 @@ export function parseTemplateAtPosition(
     const tokens = liquidEngine.parse(lineContent);
     // Find output tokens ({{ }}) that contain the cursor position
     for (const token of tokens) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tokenAny = token as any;
       // Check if this is an Output token ({{ }})
-      // The constructor name is "Output" not "OutputToken"
-      if (tokenAny.constructor.name === 'Output') {
+      if (token instanceof Output) {
         // Check if cursor is within this token's range
-        // The begin/end positions are in tokenAny.token (the OutputToken)
-        const tokenStart = tokenAny.token.begin;
-        const tokenEnd = tokenAny.token.end;
+        const tokenStart = token.token.begin;
+        const tokenEnd = token.token.end;
         if (cursorOffset >= tokenStart && cursorOffset <= tokenEnd) {
           // Extract the expression content using contentRange for the actual content (without {{ }})
           // contentRange gives us the range of just the expression inside the braces
-          const contentRange = tokenAny.token.contentRange;
+          const contentRange = token.token.contentRange;
           const expression = contentRange
             ? lineContent.substring(contentRange[0], contentRange[1])
             : lineContent.substring(tokenStart + 2, tokenEnd - 2).trim();
@@ -71,10 +68,7 @@ export function parseTemplateAtPosition(
           const pipeIndex = expression.indexOf('|');
           const variablePath =
             pipeIndex >= 0 ? expression.substring(0, pipeIndex).trim() : expression.trim();
-          const filtersString = pipeIndex >= 0 ? expression.substring(pipeIndex + 1).trim() : '';
-          const filters = filtersString
-            ? filtersString.split('|').map((f) => f.trim().split(':')[0].trim())
-            : [];
+          const filters = token.value.filters.map((f) => f.name);
           if (!variablePath) {
             return null;
           }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/parse_template_at_position_typed_api.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/parse_template_at_position_typed_api.test.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Regression / correctness tests for the B2 + B4 refactor:
+ *  B2 — replaced `token as any` + constructor-name sniff with `instanceof Output`
+ *  B4 — replaced `expression.split('|')` filter extraction with `token.value.filters.map(f => f.name)`
+ *
+ * The existing tests in parse_template_at_position.test.ts confirm that all previously
+ * tested behaviours are preserved after the refactor (they pass unchanged).
+ *
+ * This file adds:
+ * 1. Cases that were *already correct* under both old and new code — explicitly marking them
+ *    as regressions to guard the refactor.
+ * 2. A case that was *wrong* under the old string-split but is *correct* under the AST-based
+ *    extraction (filter with a literal `|` in its string argument), to prove the refactor
+ *    strictly improves correctness.
+ */
+
+import { monaco } from '@kbn/monaco';
+import { parseTemplateAtPosition } from './parse_template_at_position';
+
+// Shared mock helpers (mirrors parse_template_at_position.test.ts helpers,
+// but defined here independently to avoid importing from the test file)
+function createMockModel(content: string): monaco.editor.ITextModel {
+  return {
+    getLineContent: (lineNumber: number) => {
+      const lines = content.split('\n');
+      return lines[lineNumber - 1] || '';
+    },
+  } as monaco.editor.ITextModel;
+}
+
+function createPosition(lineNumber: number, column: number): monaco.Position {
+  return new monaco.Position(lineNumber, column);
+}
+
+describe('parseTemplateAtPosition — typed Output + AST filter extraction (B2/B4)', () => {
+  // -----------------------------------------------------------------------
+  // B2 regression: instanceof Output correctly identifies Output tokens
+  // -----------------------------------------------------------------------
+  describe('B2 — typed token recognition via instanceof Output', () => {
+    it('correctly identifies an output token and returns isInsideTemplate=true', () => {
+      // Verifies that the instanceof Output check matches the same tokens the old
+      // constructor.name === "Output" check matched.
+      const model = createMockModel('{{ steps.a.output }}');
+      const result = parseTemplateAtPosition(model, createPosition(1, 5));
+      expect(result?.isInsideTemplate).toBe(true);
+      expect(result?.variablePath).toBe('steps.a.output');
+    });
+
+    it('returns null for plain text (no output token at cursor position)', () => {
+      const model = createMockModel('just plain text');
+      const result = parseTemplateAtPosition(model, createPosition(1, 5));
+      expect(result).toBeNull();
+    });
+
+    it('returns null when cursor is outside the {{ }} delimiters', () => {
+      const model = createMockModel('prefix {{ steps.a }} suffix');
+      // cursor before {{ (column 1)
+      expect(parseTemplateAtPosition(model, createPosition(1, 1))).toBeNull();
+      // cursor after }} (column 25+)
+      expect(parseTemplateAtPosition(model, createPosition(1, 25))).toBeNull();
+    });
+
+    it('correctly reads begin/end from the OutputToken (token.token.begin/end)', () => {
+      // The tokenStart/tokenEnd bounds are used to decide if cursor is inside.
+      // Cursor right at the opening {{ is inside; the char before it is not.
+      const line = 'pre {{ steps.x }} post';
+      //                 ^4 ^5 (0-indexed)  =>  column 5 (1-indexed) is on '{'
+      const model = createMockModel(line);
+      // column 5 = first '{' of '{{', 0-indexed offset 4 → inside token
+      expect(parseTemplateAtPosition(model, createPosition(1, 5))?.isInsideTemplate).toBe(true);
+      // column 4 = 'e' of 'pre', offset 3 → outside token
+      expect(parseTemplateAtPosition(model, createPosition(1, 4))).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // B4 regression: filter names from AST (token.value.filters)
+  // -----------------------------------------------------------------------
+  describe('B4 — filter extraction via token.value.filters', () => {
+    it('regression: extracts a single filter name correctly', () => {
+      // 'upcase' — same result under both old and new code.
+      const model = createMockModel('{{ x | upcase }}');
+      const result = parseTemplateAtPosition(model, createPosition(1, 4));
+      expect(result?.filters).toEqual(['upcase']);
+    });
+
+    it('regression: extracts multiple filter names in order', () => {
+      // 'json | upcase' — same result under both old and new code.
+      const model = createMockModel('{{ data | json | upcase }}');
+      const result = parseTemplateAtPosition(model, createPosition(1, 4));
+      expect(result?.filters).toEqual(['json', 'upcase']);
+    });
+
+    it('regression: strips argument from filter name (truncate: 5 → "truncate")', () => {
+      // old: ".split(':')[0].trim()" • new: "f.name" (already just the name)
+      const model = createMockModel('{{ x | truncate: 5 }}');
+      const result = parseTemplateAtPosition(model, createPosition(1, 4));
+      expect(result?.filters).toEqual(['truncate']);
+    });
+
+    it('regression: handles filter with multiple arguments correctly', () => {
+      const model = createMockModel("{{ x | truncate: 10, '...' }}");
+      const result = parseTemplateAtPosition(model, createPosition(1, 4));
+      expect(result?.filters).toEqual(['truncate']);
+    });
+
+    it('regression: returns empty filters when no pipe is present', () => {
+      const model = createMockModel('{{ steps.a.value }}');
+      const result = parseTemplateAtPosition(model, createPosition(1, 4));
+      expect(result?.filters).toEqual([]);
+    });
+
+    /**
+     * NEW CORRECTNESS CASE (B4 improvement over string-split):
+     *
+     * When a filter argument contains a literal pipe character inside a quoted string,
+     * the old `expression.split('|')` approach would split on the pipe inside the
+     * string and produce garbage filter names (e.g. ["replace: 'a", "b', 'c'"]).
+     *
+     * The AST-based approach (`token.value.filters.map(f => f.name)`) reads the filter
+     * name directly from the parsed token, so it correctly returns ["replace"].
+     */
+    it('correctly extracts filter name when a string argument contains a literal pipe', () => {
+      // "replace: 'a|b', 'c'" — the '|' is inside a quoted string, not a filter separator.
+      // Old string-split code would yield: ["replace: 'a", "b', 'c'"] (wrong).
+      // New AST code yields: ["replace"] (correct).
+      const model = createMockModel("{{ x | replace: 'a|b', 'c' }}");
+      const result = parseTemplateAtPosition(model, createPosition(1, 4));
+      expect(result?.filters).toEqual(['replace']);
+    });
+
+    it('correctly extracts filter name when a double-quoted argument contains a pipe', () => {
+      const model = createMockModel('{{ x | replace: "a|b", "c" }}');
+      const result = parseTemplateAtPosition(model, createPosition(1, 4));
+      expect(result?.filters).toEqual(['replace']);
+    });
+
+    it('regression: variablePath is correctly split from expression when filters are present', () => {
+      // variable path extraction still uses the pipe index from the expression string —
+      // this regression verifies the path is not broken by the filter change.
+      const model = createMockModel('{{ steps.s.output | upcase | downcase }}');
+      const result = parseTemplateAtPosition(model, createPosition(1, 10));
+      expect(result?.variablePath).toBe('steps.s.output');
+      expect(result?.filters).toEqual(['upcase', 'downcase']);
+      expect(result?.isOnFilter).toBe(false);
+    });
+
+    it('regression: isOnFilter=true when cursor is on the filter part', () => {
+      const model = createMockModel('{{ x | upcase }}');
+      // column 10 is on 'upcase' (0-indexed: offset 9, after the '| ')
+      const result = parseTemplateAtPosition(model, createPosition(1, 10));
+      expect(result?.isOnFilter).toBe(true);
+      expect(result?.filters).toEqual(['upcase']);
+    });
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[One Workflow] Refactor liquidjs code to make full usage of its api (#278127)](https://github.com/elastic/kibana/pull/278127)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Liberati","email":"dej611@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-14T15:27:40Z","message":"[One Workflow] Refactor liquidjs code to make full usage of its api (#278127)\n\n## Summary\n\nThis PR does a first refactor pass for:\n* centralize duplicate liquidjs code\n* make full usage of existing liquidjs api\n\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"377526db51e00000714dfb80d829948ac4b6e297","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","Team:One Workflow","v9.5.0","v9.6.0"],"title":"[One Workflow] Refactor liquidjs code to make full usage of its api","number":278127,"url":"https://github.com/elastic/kibana/pull/278127","mergeCommit":{"message":"[One Workflow] Refactor liquidjs code to make full usage of its api (#278127)\n\n## Summary\n\nThis PR does a first refactor pass for:\n* centralize duplicate liquidjs code\n* make full usage of existing liquidjs api\n\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"377526db51e00000714dfb80d829948ac4b6e297"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278127","number":278127,"mergeCommit":{"message":"[One Workflow] Refactor liquidjs code to make full usage of its api (#278127)\n\n## Summary\n\nThis PR does a first refactor pass for:\n* centralize duplicate liquidjs code\n* make full usage of existing liquidjs api\n\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"377526db51e00000714dfb80d829948ac4b6e297"}}]}] BACKPORT-->