### PR TITLE
fix(fleet): fix hasChanged() in fleet_proxies.ts always returning truthy

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FleetProxy } from '../../../common/types';
+
+import { hasChanged } from './fleet_proxies';
+
+const baseProxy: FleetProxy = {
+  id: 'proxy-1',
+  name: 'My Proxy',
+  url: 'http://proxy.example.com:3128',
+  is_preconfigured: true,
+  proxy_headers: null,
+  certificate_authorities: null,
+  certificate: null,
+  certificate_key: null,
+};
+
+describe('hasChanged()', () => {
+  it('returns false when existing proxy is identical to preconfigured one', () => {
+    expect(hasChanged(baseProxy, { ...baseProxy })).toBe(false);
+  });
+
+  it('returns true when existing proxy is not preconfigured', () => {
+    expect(hasChanged({ ...baseProxy, is_preconfigured: false }, baseProxy)).toBe(true);
+  });
+
+  it('returns true when name differs', () => {
+    expect(hasChanged(baseProxy, { ...baseProxy, name: 'Other Proxy' })).toBe(true);
+  });
+
+  it('returns true when url differs', () => {
+    expect(hasChanged(baseProxy, { ...baseProxy, url: 'http://other.example.com:3128' })).toBe(
+      true
+    );
+  });
+
+  describe('proxy_headers', () => {
+    it('returns false when both proxy_headers are null', () => {
+      expect(
+        hasChanged({ ...baseProxy, proxy_headers: null }, { ...baseProxy, proxy_headers: null })
+      ).toBe(false);
+    });
+
+    it('returns false when proxy_headers are deeply equal', () => {
+      const headers = { Authorization: 'Bearer token', 'X-Custom': 1 };
+      expect(
+        hasChanged(
+          { ...baseProxy, proxy_headers: headers },
+          { ...baseProxy, proxy_headers: { ...headers } }
+        )
+      ).toBe(false);
+    });
+
+    it('returns true when proxy_headers differ', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, proxy_headers: { Authorization: 'Bearer old' } },
+          { ...baseProxy, proxy_headers: { Authorization: 'Bearer new' } }
+        )
+      ).toBe(true);
+    });
+
+    it('returns true when one proxy_headers is null and other is not', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, proxy_headers: null },
+          { ...baseProxy, proxy_headers: { 'X-Header': 'value' } }
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('certificate_authorities', () => {
+    it('returns true when certificate_authorities differs', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate_authorities: 'old-ca' },
+          { ...baseProxy, certificate_authorities: 'new-ca' }
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when undefined and null (normalized equal)', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate_authorities: undefined },
+          { ...baseProxy, certificate_authorities: null }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('certificate', () => {
+    it('returns true when certificate differs', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate: 'old-cert' },
+          { ...baseProxy, certificate: 'new-cert' }
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when undefined and null (normalized equal)', () => {
+      expect(
+        hasChanged({ ...baseProxy, certificate: undefined }, { ...baseProxy, certificate: null })
+      ).toBe(false);
+    });
+  });
+
+  describe('certificate_key', () => {
+    it('returns true when certificate_key differs', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate_key: 'old-key' },
+          { ...baseProxy, certificate_key: 'new-key' }
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when undefined and null (normalized equal)', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate_key: undefined },
+          { ...baseProxy, certificate_key: null }
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.ts
@@ -33,32 +33,19 @@ export function getPreconfiguredFleetProxiesFromConfig(config?: FleetConfigType)
   }));
 }
 
-// Widens an operand to include `null` so TS6's stricter `??` reachability
-// check (TS2869) stays satisfied across the whole chain, without `any`.
-const nullable = <T>(value: T): T | null => value;
-
-function hasChanged(existingProxy: FleetProxy, preconfiguredFleetProxy: FleetProxy) {
-  // Pre-existing buggy logic carried verbatim from the TS 5.9.3 era (typo
-  // `existingProxy.name !== existingProxy.name`, `??` where `||` was likely
-  // intended). Kept byte-for-byte here to stay behavior-neutral for the TS6
-  // migration. Actual fix tracked in https://github.com/elastic/kibana/issues/275879.
+export function hasChanged(
+  existingProxy: FleetProxy,
+  preconfiguredFleetProxy: FleetProxy
+): boolean {
   return (
-    nullable(
-      !existingProxy.is_preconfigured ||
-        existingProxy.name !== existingProxy.name ||
-        existingProxy.url !== preconfiguredFleetProxy.name ||
-        !isEqual(
-          existingProxy.proxy_headers ?? null,
-          preconfiguredFleetProxy.proxy_headers ?? null
-        ) ||
-        existingProxy.certificate_authorities
-    ) ??
-    nullable(null !== preconfiguredFleetProxy.certificate_authorities) ??
-    nullable(existingProxy.certificate) ??
-    nullable(null !== preconfiguredFleetProxy.certificate) ??
-    nullable(existingProxy.certificate_key) ??
-    nullable(null !== preconfiguredFleetProxy.certificate_key) ??
-    null
+    !existingProxy.is_preconfigured ||
+    existingProxy.name !== preconfiguredFleetProxy.name ||
+    existingProxy.url !== preconfiguredFleetProxy.url ||
+    !isEqual(existingProxy.proxy_headers ?? null, preconfiguredFleetProxy.proxy_headers ?? null) ||
+    (existingProxy.certificate_authorities ?? null) !==
+      (preconfiguredFleetProxy.certificate_authorities ?? null) ||
+    (existingProxy.certificate ?? null) !== (preconfiguredFleetProxy.certificate ?? null) ||
+    (existingProxy.certificate_key ?? null) !== (preconfiguredFleetProxy.certificate_key ?? null)
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #275879. Three pre-existing bugs in `hasChanged()` ([fleet_proxies.ts](x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.ts)) caused it to always return truthy — so every preconfigured Fleet proxy was re-written on every setup run, unnecessarily bumping all dependent agent policies.

### Bugs fixed

| Line | Bug | Fix |
|------|-----|-----|
| `existingProxy.name !== existingProxy.name` | Self-comparison, always `false` | Compare to `preconfiguredFleetProxy.name` |
| `existingProxy.url !== preconfiguredFleetProxy.name` | Compares `url` to `name`, truthy in nearly every real case → short-circuits whole `\|\|` chain to `true` | Compare `.url` to `.url` |
| Certificate fields chained with `??` instead of `\|\|` | Never contribute to the result | Use `\|\|` |

The TS6 migration (#271514) carried these byte-for-byte to stay behavior-neutral; this PR applies the intended fix.

### Changes

- Rewrite `hasChanged()` with the correct logic
- Remove the now-unused `nullable` TS6-migration helper
- Export `hasChanged` for direct unit testing
- Add 14 unit tests (none existed before), including a regression case that the old code always returned `true` for identical proxies

### Behavioral impact

Proxies will stop being re-written on every setup when nothing has changed, reducing unnecessary agent policy bumps.

## Testing

```bash
node scripts/jest --config x-pack/platform/plugins/shared/fleet/server/jest.config.js \
  x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.test.ts
```

All 14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->