### PR TITLE
[Security Solution][Alerting] Add success-path audit logging to bulkEditRules

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules.test.ts
@@ -611,7 +611,11 @@ describe('bulkEditRules', () => {
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
       saved_objects: [
         existingRule,
-        { ...existingRule, id: '2', attributes: { ...existingRule.attributes, name: 'my other rule' } },
+        {
+          ...existingRule,
+          id: '2',
+          attributes: { ...existingRule.attributes, name: 'my other rule' },
+        },
       ],
     });
 
@@ -627,24 +631,30 @@ describe('bulkEditRules', () => {
     });
 
     expect(auditLogger.log).toHaveBeenCalledTimes(2);
-    expect(auditLogger.log).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      event: expect.objectContaining({
-        action: 'rule_bulk_edit',
-        outcome: 'success',
-      }),
-      kibana: expect.objectContaining({
-        saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '1', name: 'my rule name' },
-      }),
-    }));
-    expect(auditLogger.log).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      event: expect.objectContaining({
-        action: 'rule_bulk_edit',
-        outcome: 'success',
-      }),
-      kibana: expect.objectContaining({
-        saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '2', name: 'my other rule' },
-      }),
-    }));
+    expect(auditLogger.log).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        event: expect.objectContaining({
+          action: 'rule_bulk_edit',
+          outcome: 'success',
+        }),
+        kibana: expect.objectContaining({
+          saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '1', name: 'my rule name' },
+        }),
+      })
+    );
+    expect(auditLogger.log).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        event: expect.objectContaining({
+          action: 'rule_bulk_edit',
+          outcome: 'success',
+        }),
+        kibana: expect.objectContaining({
+          saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '2', name: 'my other rule' },
+        }),
+      })
+    );
   });
 
   test('should log audit event with BULK_EDIT_PARAMS action for read-auth operations', async () => {
@@ -659,15 +669,17 @@ describe('bulkEditRules', () => {
     });
 
     expect(auditLogger.log).toHaveBeenCalledTimes(1);
-    expect(auditLogger.log).toHaveBeenCalledWith(expect.objectContaining({
-      event: expect.objectContaining({
-        action: 'rule_bulk_edit_params',
-        outcome: 'success',
-      }),
-      kibana: expect.objectContaining({
-        saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '1', name: 'my rule name' },
-      }),
-    }));
+    expect(auditLogger.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          action: 'rule_bulk_edit_params',
+          outcome: 'success',
+        }),
+        kibana: expect.objectContaining({
+          saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '1', name: 'my rule name' },
+        }),
+      })
+    );
   });
 
   test('should not log audit event for skipped rules', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules.test.ts
@@ -590,6 +590,104 @@ describe('bulkEditRules', () => {
     });
   });
 
+  test('should log audit event for each successfully updated rule', async () => {
+    const decryptedRule1 = {
+      ...existingDecryptedRule,
+      attributes: { ...existingDecryptedRule.attributes, enabled: true },
+    };
+    const decryptedRule2 = {
+      ...existingDecryptedRule,
+      id: '2',
+      attributes: {
+        ...existingDecryptedRule.attributes,
+        name: 'my other rule',
+        apiKey: MOCK_API_KEY_2,
+        enabled: true,
+      },
+    };
+    mockCreatePointInTimeFinderAsInternalUser({
+      saved_objects: [decryptedRule1, decryptedRule2],
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+      saved_objects: [
+        existingRule,
+        { ...existingRule, id: '2', attributes: { ...existingRule.attributes, name: 'my other rule' } },
+      ],
+    });
+
+    await bulkEditRules(rulesClientContext, {
+      name: `rulesClient.bulkEdit`,
+      updateFn: jest.fn().mockImplementation(({ rules }) => {
+        rules.push(decryptedRule1);
+        rules.push(decryptedRule2);
+      }),
+      shouldInvalidateApiKeys: false,
+      requiredAuthOperation: WriteOperations.BulkEdit,
+      auditAction: RuleAuditAction.BULK_EDIT,
+    });
+
+    expect(auditLogger.log).toHaveBeenCalledTimes(2);
+    expect(auditLogger.log).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      event: expect.objectContaining({
+        action: 'rule_bulk_edit',
+        outcome: 'success',
+      }),
+      kibana: expect.objectContaining({
+        saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '1', name: 'my rule name' },
+      }),
+    }));
+    expect(auditLogger.log).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      event: expect.objectContaining({
+        action: 'rule_bulk_edit',
+        outcome: 'success',
+      }),
+      kibana: expect.objectContaining({
+        saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '2', name: 'my other rule' },
+      }),
+    }));
+  });
+
+  test('should log audit event with BULK_EDIT_PARAMS action for read-auth operations', async () => {
+    await bulkEditRules(rulesClientContext, {
+      name: `rulesClient.bulkEditRuleParams`,
+      updateFn: jest.fn().mockImplementation(({ rules }) => {
+        rules.push(existingDecryptedRule);
+      }),
+      shouldInvalidateApiKeys: false,
+      requiredAuthOperation: ReadOperations.BulkEditParams,
+      auditAction: RuleAuditAction.BULK_EDIT_PARAMS,
+    });
+
+    expect(auditLogger.log).toHaveBeenCalledTimes(1);
+    expect(auditLogger.log).toHaveBeenCalledWith(expect.objectContaining({
+      event: expect.objectContaining({
+        action: 'rule_bulk_edit_params',
+        outcome: 'success',
+      }),
+      kibana: expect.objectContaining({
+        saved_object: { type: RULE_SAVED_OBJECT_TYPE, id: '1', name: 'my rule name' },
+      }),
+    }));
+  });
+
+  test('should not log audit event for skipped rules', async () => {
+    await bulkEditRules(rulesClientContext, {
+      name: `rulesClient.bulkEdit`,
+      updateFn: jest.fn().mockImplementation(({ skipped }) => {
+        skipped.push({
+          id: 'skip-1',
+          name: 'skip-1',
+          skip_reason: 'RULE_NOT_MODIFIED' as BulkEditSkipReason,
+        });
+      }),
+      shouldInvalidateApiKeys: false,
+      requiredAuthOperation: WriteOperations.BulkEdit,
+      auditAction: RuleAuditAction.BULK_EDIT,
+    });
+
+    expect(auditLogger.log).not.toHaveBeenCalled();
+  });
+
   describe('internally managed rule types', () => {
     beforeEach(() => {
       ruleTypeRegistry.list.mockReturnValue(

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules.ts
@@ -10,9 +10,10 @@ import { nodeBuilder, type KueryNode } from '@kbn/es-query';
 import type { RuleChangeTracking } from '@kbn/alerting-types';
 import type { RuleParams } from '../../../application/rule/types';
 import type { RulesClientContext } from '../../types';
-import { type RuleAuditAction } from '../audit_events';
+import { ruleAuditEvent, type RuleAuditAction } from '../audit_events';
 import { ReadOperations, type WriteOperations } from '../../../authorization';
 import type { RawRule, SanitizedRule } from '../../../types';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../saved_objects';
 import { buildKueryNodeFilter } from '../build_kuery_node_filter';
 import { checkAuthorizationAndGetTotal } from '../../lib/check_authorization_and_get_total';
 import { getAuthorizationFilter } from '../../lib/get_authorization_filter';
@@ -118,6 +119,15 @@ export async function bulkEditRules<Params extends RuleParams>(
       }),
     finalFilter
   );
+
+  for (const { id, attributes } of results) {
+    context.auditLogger?.log(
+      ruleAuditEvent({
+        action: options.auditAction,
+        savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: attributes.name },
+      })
+    );
+  }
 
   if (apiKeysToInvalidate.length > 0) {
     await bulkMarkApiKeysForInvalidation(


### PR DESCRIPTION
## Summary

Adds success-path audit event logging to the shared `bulkEditRules` function in the alerting plugin's rules client.

Previously, `bulkEditRules` (`rules_client/common/bulk_edit/bulk_edit_rules.ts`) only emitted audit events on the **error path**. The success path — which writes rules via `bulkCreateRulesSo` using the unsecured SO client — produced no per-rule audit event.

This affected two code paths that share `bulkEditRules`:

1. **Exception list attach/detach** (#278133, #280321) — The "Manage rules" screen on a shared exception list calls `PATCH /api/detection_engine/rules` per rule (note: #278133 describes this as `_bulk_action`, but the UI actually sends individual PATCH requests). This routes through `bulkEditRuleParamsWithReadAuth` → `bulkEditRules` — no success audit event was emitted.

2. **`_bulk_action` edit operations** — Bulk edits to tags, index patterns, schedule, actions, etc. via `POST /api/detection_engine/rules/_bulk_action` route through `rulesClient.bulkEdit` → `bulkEditRules` — same gap.

The fix emits one `ruleAuditEvent` per successfully updated rule after the SO write completes, using the caller-supplied audit action. The action name reflects the **authorization model**, not the endpoint:
- `rule_bulk_edit_params` — for read-auth operations (exception lists via PATCH, investigation fields via `_bulk_action`)
- `rule_bulk_edit` — for write-auth operations (tags, index patterns, schedule, actions via `_bulk_action`)

This is consistent with how `rulesClient.update()` emits `rule_update` audit events for single-rule updates.

Closes #278133
Closes #280321

### How to test

#### Setup

1. Enable audit logging in `kibana.dev.yml`:
   ```yaml
   xpack.security.audit.enabled: true
   xpack.security.audit.appender:
     type: file
     fileName: /tmp/kibana-audit.log
     layout:
       type: json
   ```
2. Start Kibana and Elasticsearch
3. Open a watcher terminal:
   ```bash
   tail -f /tmp/kibana-audit.log | jq 'select(.event.action | test("rule_"))'
   ```

#### Scenario 1 — Bulk edit via `_bulk_action` endpoint

Bulk rule edits via `_bulk_action` previously produced only a generic `http_request` audit event with `kibana.saved_object.type: null`.

**Via UI:**
1. Go to **Security > Rules > Detection Rules**
2. Select 2+ rules → **Bulk actions > Add tags** → add a tag → Save

**Via API:**
```bash
curl -u elastic:changeme \
  -X POST "http://localhost:5601/api/detection_engine/rules/_bulk_action" \
  -H 'kbn-xsrf: true' \
  -H 'Content-Type: application/json' \
  -H 'elastic-api-version: 2023-10-31' \
  -d '{
    "action": "edit",
    "ids": ["<rule-id-1>", "<rule-id-2>"],
    "edit": [{"type": "add_tags", "value": ["audit-test"]}]
  }'
```

**Expected in audit log** — 1 event per rule:
```json
{
  "event": {
    "action": "rule_bulk_edit",
    "category": ["database"],
    "type": ["change"],
    "outcome": "success"
  },
  "kibana": {
    "saved_object": {
      "type": "alert",
      "id": "<rule-id>",
      "name": "<rule-name>"
    }
  },
  "message": "User has updated rule [id=<rule-id>] [name=<rule-name>]"
}
```

**Before (unfixed):** Only a generic `http_request` event:
```json
{
  "event": { "action": "http_request", "outcome": "unknown" },
  "kibana": { "saved_object": null },
  "message": "User is requesting [/api/detection_engine/rules/_bulk_action] endpoint"
}
```

#### Scenario 2 — Attach shared exception list to rules (#278133 / #280321 repro)

1. Go to **Security > Rules > Shared Exception Lists** — create a list
2. Click the list → **Manage rules** → link 2 rules → Save
3. **Expected** — 2 events with `event.action: "rule_bulk_edit_params"` (one per rule, same shape as Scenario 1 but with action `rule_bulk_edit_params`)

#### Scenario 3 — Detach shared exception list

1. Open the list → **Manage rules** → unlink both rules → Save
2. **Expected** — 2 more `rule_bulk_edit_params` events

#### Scenario 4 — No-op (no selection change)

1. Open an exception list's **Manage rules** screen, make no changes, and Save
2. **Expected** — 0 `rule_bulk_edit_params` events (the UI diffs the selection client-side and sends no PATCH requests when nothing changed)

To test the **server-side** skip path (`RULE_NOT_MODIFIED`), use `_bulk_action` to add a tag that the rules already have — 0 `rule_bulk_edit` events should appear.

#### Quick verification commands

```bash
# Count all rule audit events
jq -r '.event.action' /tmp/kibana-audit.log | grep "rule_" | sort | uniq -c | sort -rn

# Show only bulk edit audit events
jq 'select(.event.action | test("rule_bulk_edit"))' /tmp/kibana-audit.log

# On an unfixed instance, confirm the gap — only http_request for _bulk_action
jq 'select(.url.path // "" | test("_bulk_action")) | {action: .event.action, so_type: .kibana.saved_object.type}' /tmp/kibana-audit.log
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

**Risk: Low** — The change adds audit logging (a side-effect-free observation) to an existing code path. It does not alter the bulk edit logic, authorization, or SO write behavior.

- The audit logger call uses optional chaining (`context.auditLogger?.log`), so environments without audit logging enabled are unaffected.
- The loop only iterates over `results` (successfully written rules), not `errors` or `skipped`.
- Unit tests verify: per-rule audit events for both `BULK_EDIT` and `BULK_EDIT_PARAMS` actions, and that skipped rules produce no audit events.

### Release Note

Fix missing audit events when bulk editing rules. Operations like attaching or detaching shared exception lists to detection rules via the Manage Rules screen now emit per-rule audit write events in the Kibana audit log.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->