### PR TITLE
[Dashboards][Visualizations] Promote public REST APIs to GA in 9.5

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/get_route_config.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/get_route_config.ts
@@ -38,13 +38,11 @@ export function getRouteConfig(isDashboardAppRequest: boolean) {
         basePath: DASHBOARD_API_PATH,
         routeConfig: {
           access: 'public',
-          description:
-            'This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
           options: {
             tags: ['oas-tag:Dashboards'],
             availability: {
-              stability: 'experimental',
-              since: '9.4.0',
+              stability: 'stable',
+              since: '9.5.0',
             },
           },
           security: {

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/create.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/create.ts
@@ -43,8 +43,8 @@ export const registerLensVisualizationsCreateAPIRoute: RegisterAPIRouteFn = (
     options: {
       tags: [LENS_API_TAG],
       availability: {
-        stability: 'experimental',
-        since: '9.4.0',
+        stability: 'stable',
+        since: '9.5.0',
       },
     },
     security: {

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/delete.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/delete.ts
@@ -32,8 +32,8 @@ export const registerLensVisualizationsDeleteAPIRoute: RegisterAPIRouteFn = (
     options: {
       tags: [LENS_API_TAG],
       availability: {
-        stability: 'experimental',
-        since: '9.4.0',
+        stability: 'stable',
+        since: '9.5.0',
       },
     },
     security: {

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/get.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/get.ts
@@ -38,8 +38,8 @@ export const registerLensVisualizationsGetAPIRoute: RegisterAPIRouteFn = (
     options: {
       tags: [LENS_API_TAG],
       availability: {
-        stability: 'experimental',
-        since: '9.4.0',
+        stability: 'stable',
+        since: '9.5.0',
       },
     },
     security: {

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/search.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/search.ts
@@ -38,8 +38,8 @@ export const registerLensVisualizationsSearchAPIRoute: RegisterAPIRouteFn = (
     options: {
       tags: [LENS_API_TAG],
       availability: {
-        stability: 'experimental',
-        since: '9.4.0',
+        stability: 'stable',
+        since: '9.5.0',
       },
     },
     security: {

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/update.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/update.ts
@@ -53,8 +53,8 @@ export const registerLensVisualizationsUpdateAPIRoute: RegisterAPIRouteFn = (
     options: {
       tags: [LENS_API_TAG],
       availability: {
-        stability: 'experimental',
-        since: '9.4.0',
+        stability: 'stable',
+        since: '9.5.0',
       },
     },
     security: {


### PR DESCRIPTION
## Summary

The Dashboards (`/api/dashboards`) and Visualizations (`/api/visualizations`) public REST APIs shipped as technical preview in 9.4 and are generally available in 9.5. Their route definitions still declared `availability.stability: 'experimental'`.

This sets `stability: 'stable'` and `since: '9.5.0'` on all ten public routes:

- **Dashboards** — one shared config in `get_route_config.ts`, spread into the create, read, update, delete, and search routes. Only the public branch changes; the internal dashboard-app routes are untouched.
- **Visualizations** — the five route files under `lens/server/api/routes/visualizations/`, which each declare `availability` inline. The parallel `routes/internal/` tree is untouched.

It also removes the technical-preview boilerplate `description` from the shared dashboards route config. That string never reached the generated OAS: four of the five dashboards routes set their own `description` *after* spreading `routeConfig`, and the fifth (`PUT`) is overridden by `updateDashboardOASOperationObject` via `mergeOperation`. Worth confirming that reading, since it means no user-visible description changes here.

### Note for reviewers: this produces no diff in the committed OAS bundles while these OAS docs are hosted separately

`/api/dashboards` and `/api/visualizations` are stripped to redirect-only stubs by `oas_docs/overlays/kibana.overlays.bump_slim.yaml` while the full reference is hosted externally (see #266195). Those stubs carry no `x-state` either way, and `oas_docs/bundle.json` is gitignored, so the change is invisible in `oas_docs/output/*.yaml`. The effect is visible only in the externally hosted spec, regenerated via `make api-docs-overlay-external`.

This also interacts with #280633, which extends the API contract check to the whole public surface. That check reads `oas_docs/output/kibana.yaml` and defaults a missing `x-state` to `stable`. Post-GA that inferred tier happens to be correct for these two APIs, but only by coincidence — the underlying gap is independent of this PR.

## Checklist

- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee.
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Identify risks

- **Tightened breaking-change policy.** Marking these routes `stable` brings them under the stable-tier breaking-change rules. This is the intended effect of GA, but it means future schema changes need breaking-change review.
- **No behavioral change.** `availability` is metadata only (`@remark intended to be used for informational purposes only`), so no runtime behavior, validation, or authorization is affected.

## Release note

The Dashboards and Visualizations REST APIs are now generally available.

## Test plan

- [x] `node scripts/check --scope branch` (lint, tsc on both projects, 11,291 Jest tests)
- [x] `node scripts/jest_integration --config src/platform/plugins/shared/dashboard/jest.integration.config.js server/api`
- [ ] Confirm the regenerated external spec renders `Generally available; added in 9.5.0` for all ten operations

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->