### PR TITLE
[Fleet] Fix hasFleetServersForPolicies to match versioned policy_id variants

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
@@ -208,6 +208,52 @@ describe('checkFleetServerVersionsForSecretsStorage', () => {
     const kuery = mockedGetAgentsByKuery.mock.calls[0][2].kuery as string;
     expect(kuery).toContain('fleet-server-policy#*');
   });
+
+  it('should return true if a versioned-policy agent is offline but its base policy is managed', async () => {
+    // Regression: managedAgentPolicies contains base IDs (e.g. 'fleet-server-policy'),
+    // but an agent on a versioned policy has policy_id 'fleet-server-policy#9.4'.
+    // The comparison must strip the version suffix before matching.
+    const version = '10.0.0';
+
+    jest
+      .spyOn(mockedPackagePolicyService, 'list')
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: '1',
+            policy_id: 'fleet-server-policy',
+            policy_ids: ['fleet-server-policy'],
+            package: { name: 'fleet_server', version: '10.0.0' },
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ items: [] } as any);
+
+    mockedAgentPolicyService.getAllManagedAgentPolicies.mockResolvedValueOnce([
+      { id: 'fleet-server-policy', is_managed: true } as any,
+    ]);
+
+    mockedGetAgentsByKuery.mockResolvedValueOnce({
+      agents: [
+        {
+          id: 'agent-versioned',
+          policy_id: 'fleet-server-policy#9.4',
+          active: true,
+          local_metadata: { elastic: { agent: { version: '9.4.0' } } },
+        },
+      ],
+    } as any);
+
+    mockedGetAgentStatusById.mockResolvedValue('offline');
+
+    const result = await checkFleetServerVersionsForSecretsStorage(
+      esClientMock,
+      soClientMock,
+      version
+    );
+    // Offline managed versioned agent must not block secrets storage
+    expect(result).toBe(true);
+  });
 });
 
 describe('getFleetServerPolicies', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
@@ -122,7 +122,8 @@ describe('checkFleetServerVersionsForSecretsStorage', () => {
       esClientMock,
       soClientMock,
       expect.objectContaining({
-        kuery: 'policy_id:("1" or "2")',
+        // kuery must cover both base and versioned variants (e.g. policy_id:1#*)
+        kuery: expect.stringContaining('policy_id:1#*'),
       })
     );
   });
@@ -163,6 +164,49 @@ describe('checkFleetServerVersionsForSecretsStorage', () => {
       version
     );
     expect(result).toBe(true);
+  });
+
+  it('should query versioned policy_id variants when Fleet Server agent is reassigned', async () => {
+    const version = '1.0.0';
+
+    jest
+      .spyOn(mockedPackagePolicyService, 'list')
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: '1',
+            policy_id: 'fleet-server-policy',
+            policy_ids: ['fleet-server-policy'],
+            package: { name: 'fleet_server', version: '10.0.0' },
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ items: [] } as any);
+
+    mockedAgentPolicyService.getAllManagedAgentPolicies.mockResolvedValueOnce([]);
+
+    // Simulate an agent whose policy_id is the versioned variant (fleet-server-policy#9.4)
+    mockedGetAgentsByKuery.mockResolvedValueOnce({
+      agents: [
+        {
+          id: 'agent-1',
+          local_metadata: { elastic: { agent: { version: '10.0.0' } } },
+        },
+      ],
+    } as any);
+
+    mockedGetAgentStatusById.mockResolvedValue('online');
+
+    const result = await checkFleetServerVersionsForSecretsStorage(
+      esClientMock,
+      soClientMock,
+      version
+    );
+
+    expect(result).toBe(true);
+    // Kuery must include the wildcard variant so versioned agents are found
+    const kuery = mockedGetAgentsByKuery.mock.calls[0][2].kuery as string;
+    expect(kuery).toContain('fleet-server-policy#*');
   });
 });
 
@@ -368,7 +412,7 @@ describe('hasActiveFleetServersForPolicies', () => {
 
       await hasFleetServersForPolicies(mockEsClient, mockSoClient, [{ id: 'fleet-server-policy' }]);
 
-      const kuery = (getAgentStatusForAgentPolicy as jest.Mock).mock.calls[0][3] as string;
+      const kuery = (getAgentStatusForAgentPolicy as jest.Mock).mock.calls.at(-1)![3] as string;
       // Must match the base policy_id exactly
       expect(kuery).toContain('policy_id:"fleet-server-policy"');
       // Must also match versioned variants like fleet-server-policy#9.4

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
@@ -349,4 +349,59 @@ describe('hasActiveFleetServersForPolicies', () => {
       expect(hasFs).toBe(true);
     });
   });
+
+  describe('kuery includes versioned policy_id variants', () => {
+    it('passes a kuery matching both the base policy_id and versioned variants', async () => {
+      (getAgentStatusForAgentPolicy as jest.Mock).mockResolvedValueOnce({
+        other: 0,
+        events: 0,
+        total: 1,
+        all: 1,
+        active: 0,
+        updating: 0,
+        offline: 0,
+        inactive: 0,
+        unenrolled: 0,
+        online: 1,
+        error: 0,
+      });
+
+      await hasFleetServersForPolicies(mockEsClient, mockSoClient, [{ id: 'fleet-server-policy' }]);
+
+      const kuery = (getAgentStatusForAgentPolicy as jest.Mock).mock.calls[0][3] as string;
+      // Must match the base policy_id exactly
+      expect(kuery).toContain('policy_id:"fleet-server-policy"');
+      // Must also match versioned variants like fleet-server-policy#9.4
+      expect(kuery).toContain('policy_id:fleet-server-policy#*');
+    });
+
+    it('returns true when the Fleet Server agent is on a versioned policy_id', async () => {
+      // Simulate: agent has policy_id "fleet-server-policy#9.4" (no exact-match on base id).
+      // The old exact-match query returned all:0; the new kuery must return all:1.
+      (getAgentStatusForAgentPolicy as jest.Mock).mockImplementationOnce(
+        (_es, _so, _id, kuery: string) => {
+          // Simulate ES matching an agent whose policy_id is "fleet-server-policy#9.4"
+          const agentMatchesVersionedVariant = kuery.includes('fleet-server-policy#*');
+          return Promise.resolve({
+            other: 0,
+            events: 0,
+            total: agentMatchesVersionedVariant ? 1 : 0,
+            all: agentMatchesVersionedVariant ? 1 : 0,
+            active: 0,
+            updating: 0,
+            offline: 0,
+            inactive: 0,
+            unenrolled: 0,
+            online: agentMatchesVersionedVariant ? 1 : 0,
+            error: 0,
+          });
+        }
+      );
+
+      const hasFs = await hasFleetServersForPolicies(mockEsClient, mockSoClient, [
+        { id: 'fleet-server-policy' },
+      ]);
+      expect(hasFs).toBe(true);
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
@@ -20,6 +20,7 @@ import { SO_SEARCH_LIMIT } from '../../constants';
 import {
   buildPolicyIdOrVariantsKuery,
   buildPolicyIdsOrVariantsKuery,
+  removeVersionSuffixFromPolicyId,
 } from '../../../common/services/version_specific_policies_utils';
 import { getAgentsByKuery, getAgentStatusById } from '../agents';
 import { packagePolicyService } from '../package_policy';
@@ -182,8 +183,9 @@ export async function checkFleetServerVersionsForSecretsStorage(
         continue;
       }
 
+      const agentPolicyBaseId = removeVersionSuffixFromPolicyId(fleetServerAgent.policy_id ?? '');
       const isManagedAgentPolicy = managedAgentPolicies.some(
-        (managedPolicy) => managedPolicy.id === fleetServerAgent.policy_id
+        (managedPolicy) => managedPolicy.id === agentPolicyBaseId
       );
 
       // If this is an agent enrolled in a managed policy, and it is no longer active then we ignore it if it's

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
@@ -7,7 +7,6 @@
 
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
-import { escapeQuotes } from '@kbn/es-query';
 import semverGte from 'semver/functions/gte';
 import semverCoerce from 'semver/functions/coerce';
 import { uniqBy } from 'lodash';
@@ -18,6 +17,7 @@ import {
   FLEET_SERVER_PACKAGE,
 } from '../../../common/constants';
 import { SO_SEARCH_LIMIT } from '../../constants';
+import { buildPolicyIdOrVariantsKuery } from '../../../common/services/version_specific_policies_utils';
 import { getAgentsByKuery, getAgentStatusById } from '../agents';
 import { packagePolicyService } from '../package_policy';
 import { agentPolicyService } from '../agent_policy';
@@ -76,7 +76,7 @@ export const hasFleetServersForPolicies = async (
               ? `namespaces:"${spaceIds?.[0]}"`
               : `not namespaces:* or namespaces:"${DEFAULT_SPACE_ID}"`;
 
-          return `(policy_id:"${escapeQuotes(id)}" and (${space}))`;
+          return `(${buildPolicyIdOrVariantsKuery(id)} and (${space}))`;
         })
         .join(' or ')
     );

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
@@ -17,7 +17,10 @@ import {
   FLEET_SERVER_PACKAGE,
 } from '../../../common/constants';
 import { SO_SEARCH_LIMIT } from '../../constants';
-import { buildPolicyIdOrVariantsKuery } from '../../../common/services/version_specific_policies_utils';
+import {
+  buildPolicyIdOrVariantsKuery,
+  buildPolicyIdsOrVariantsKuery,
+} from '../../../common/services/version_specific_policies_utils';
 import { getAgentsByKuery, getAgentStatusById } from '../agents';
 import { packagePolicyService } from '../package_policy';
 import { agentPolicyService } from '../agent_policy';
@@ -140,9 +143,7 @@ export async function checkFleetServerVersionsForSecretsStorage(
     return false;
   }
 
-  const kuery = `policy_id:(${Array.from(policyIds)
-    .map((id) => `"${escapeQuotes(id)}"`)
-    .join(' or ')})`;
+  const kuery = buildPolicyIdsOrVariantsKuery(Array.from(policyIds));
 
   const managedAgentPolicies = await agentPolicyService.getAllManagedAgentPolicies(soClient);
   const fleetServerAgents = await getAgentsByKuery(esClient, soClient, {


### PR DESCRIPTION
## Summary

Relates #278548.

When the `fleet:version-specific-policy-assignment-task` reassigns a Fleet Server agent from its base policy ID (e.g. `fleet-server-policy`) to a versioned variant (e.g. `fleet-server-policy#9.4`), the exact-match KQL filter in `hasFleetServersForPolicies`:

```ts
`(policy_id:"${escapeQuotes(id)}" and (${space}))`
```

no longer matches the agent. `hasFleetServers()` returns `false`, `GET /api/fleet/agents/setup` returns `isReady: false, missing_requirements: ["fleet_server"]`, and the Fleet Agents page permanently shows the "Add a Fleet Server" onboarding screen even though the Fleet Server agent is online and healthy.

**Fix**: replace the exact match with `buildPolicyIdOrVariantsKuery(id)` which emits `(policy_id:"id" or policy_id:id#*)`, covering both the base policy and all versioned variants.

No schema changes or backfill needed — this is a pure query fix using the existing `policy_id` field.

## Test plan

- [ ] Enroll a Fleet Server agent on a policy that contains a version-gating integration (auditd)
- [ ] Wait for `fleet:version-specific-policy-assignment-task` to run (≤1 min)
- [ ] Confirm Fleet → Agents shows the agent list (not the "Add a Fleet Server" screen)
- [ ] Confirm `GET /api/fleet/agents/setup` returns `isReady: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1576" height="593" alt="image" src="https://github.com/user-attachments/assets/35f78d97-d0a8-47d0-bbf2-39a499a007ff" />
<img width="1586" height="543" alt="image" src="https://github.com/user-attachments/assets/d79a61f9-1bfd-4f30-8827-fd849c7eed44" />
<img width="820" height="434" alt="image" src="https://github.com/user-attachments/assets/e2ee0761-4281-47c8-80ae-be384e1b17ec" />
<img width="972" height="416" alt="image" src="https://github.com/user-attachments/assets/ed32db71-8717-4525-98d6-cad1702e267a" />


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->