### PR TITLE
[APM] Fix `transactions_groups_alerts.spec.ts` timing out due to reduced Mocha timeout limit

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/transactions/transactions_groups_alerts.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/transactions/transactions_groups_alerts.spec.ts
@@ -116,7 +116,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
         await apmSynthtraceEsClient.index([
           timerange(start, end)
-            .interval('1m')
+            .interval('5m')
             .rate(1)
             .generator((timestamp) => {
               return transactions.map(({ name, duration, type }) => {
@@ -128,7 +128,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
               });
             }),
           timerange(start, end)
-            .interval('1m')
+            .interval('5m')
             .rate(1)
             .generator((timestamp) => {
               return transactions.map(({ name, duration, type }) => {


### PR DESCRIPTION
## Summary

#278491 lowered the mocha `hookTimeout` to 120s. The `before` hook in this spec indexes a large synthtrace fixture that regularly takes longer than that on MKI, so the hook times out and aborts the config. It was the top FTR failure in the appex-qa serverless suite from Jul 24-27.

This PR change the synthtrace interval from `1m` to `5m`, which cuts the indexed volume enough to finish comfortably under the timeout. The reduced volume does not affect any assertion. 

Test suite run against MKI cluster shows reduction in total time from ~120s to ~58s.