### PR TITLE
Increasing the APM serverless api integration test setup timeout

### DIFF
--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/serverless.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/serverless.config.base.ts
@@ -23,6 +23,7 @@ interface CreateTestConfigOptions<T> {
   suiteTags?: { include?: string[]; exclude?: string[] };
   tier?: 'oblt_logs_essentials';
   indexRefreshInterval?: string | false;
+  mochaOpts?: { timeout?: number; hookTimeout?: number };
 }
 
 // These args replicate the MKI setup from the elasticsearch controller:
@@ -143,6 +144,10 @@ export function createServerlessTestConfig<T extends DeploymentAgnosticCommonSer
         exclude: [...(options.suiteTags?.exclude || []), 'skipServerless'],
       },
       indexRefreshInterval: options.indexRefreshInterval,
+      mochaOpts: {
+        ...svlSharedConfig.get('mochaOpts'),
+        ...options.mochaOpts,
+      },
     };
   };
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
@@ -15,4 +15,9 @@ export default createServerlessTestConfig<typeof services>({
   junit: {
     reportName: 'Serverless Observability - Deployment-agnostic APM API Integration Tests',
   },
+  mochaOpts: {
+    // synthtrace before hooks bulk-index >100k events, which takes longer than
+    // the default 2 min hookTimeout when running against real MKI projects
+    hookTimeout: 360_000,
+  },
 });


### PR DESCRIPTION
## Summary

Fixes the oblt.apm.serverless.config.ts failures on the appex-qa-serverless-kibana-ftr-tests pipeline, where nearly every scheduled run since 2026-07-24 has failed with Timeout of 120000ms exceeded in a before hook — most often in transactions_groups_alerts.spec.ts.

## Changes:

- createServerlessTestConfig now accepts an optional mochaOpts override, merged over the shared serverless base config.
- oblt.apm.serverless.config.ts bumps hookTimeout to 360s (matching the test timeout), the same per-config bump #278491 applied to other slow configs.

