### PR TITLE
[9.5] [Data Federation] Disable by deafult (#280968)

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -134,7 +134,6 @@ xpack.remote_clusters.enabled: false
 xpack.snapshot_restore.enabled: false
 xpack.license_management.enabled: false
 xpack.cloud_connect.enabled: false
-xpack.dataFederation.enabled: false
 xpack.reindex_service.rollupsEnabled: false
 
 # Management team UI configurations

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sublime_security/sublime_security.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sublime_security/sublime_security.test.ts
@@ -528,8 +528,7 @@ describe('SublimeSecurityConnector', () => {
       throw new Error('expected the Sublime Security spec to define a test handler');
     }
 
-    it('is enabled and lists one mailbox on success', async () => {
-      expect(testDef.enabled).toBe(true);
+    it('lists one mailbox on success', async () => {
       (mockClient.get as jest.Mock).mockResolvedValue({ data: { mailboxes: [], total: 0 } });
 
       const result = await testDef.handler(mockContext);

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sublime_security/sublime_security.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sublime_security/sublime_security.ts
@@ -557,7 +557,6 @@ Gotchas:
   },
 
   test: {
-    enabled: true,
     description: i18n.translate('core.kibanaConnectorSpecs.sublimeSecurity.test.description', {
       defaultMessage: 'Verifies the Sublime Security connection by listing one protected mailbox',
     }),

--- a/src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts
+++ b/src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts
@@ -64,7 +64,7 @@ test.describe('Stack Management — data section', { tag: tags.stateful.classic 
     });
   });
 
-  test('ccr_user sees cross_cluster_replication and the full cluster:manage data section', async ({
+  test('ccr_user sees cross_cluster_replication and the cluster:manage data section', async ({
     browserAuth,
     pageObjects,
   }) => {
@@ -87,7 +87,6 @@ test.describe('Stack Management — data section', { tag: tags.stateful.classic 
         sectionLinks: [
           'index_management',
           'index_lifecycle_management',
-          'data_federation',
           'snapshot_restore',
           'rollup_jobs',
           'transform',

--- a/src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts
+++ b/src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts
@@ -92,7 +92,6 @@ test.describe(
           sectionLinks: [
             'index_management',
             'index_lifecycle_management',
-            'data_federation',
             'snapshot_restore',
             'rollup_jobs',
             'transform',

--- a/x-pack/platform/plugins/private/data_federation/server/config.ts
+++ b/x-pack/platform/plugins/private/data_federation/server/config.ts
@@ -10,7 +10,7 @@ import type { PluginConfigDescriptor } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 
 const configSchema = schema.object({
-  enabled: schema.boolean({ defaultValue: true }),
+  enabled: schema.boolean({ defaultValue: false }),
   enableFederatedIdentityAuth: schema.boolean({ defaultValue: false }),
   enableGoogleCloudStorageDataSourceType: schema.boolean({ defaultValue: false }),
   enableAzureDataSourceType: schema.boolean({ defaultValue: false }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Data Federation] Disable by deafult (#280968)](https://github.com/elastic/kibana/pull/280968)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2026-07-27T14:47:29Z","message":"[Data Federation] Disable by deafult (#280968)","sha":"e3a87cd417dd158cb629cef4c5b7b548766f7014","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:version","v9.5.0","v9.6.0","Feature:Data Federation","v9.5.1"],"title":"[Data Federation] Disable by deafult","number":280968,"url":"https://github.com/elastic/kibana/pull/280968","mergeCommit":{"message":"[Data Federation] Disable by deafult (#280968)","sha":"e3a87cd417dd158cb629cef4c5b7b548766f7014"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280968","number":280968,"mergeCommit":{"message":"[Data Federation] Disable by deafult (#280968)","sha":"e3a87cd417dd158cb629cef4c5b7b548766f7014"}}]}] BACKPORT-->