### PR TITLE
[docs] Scope docs-build workflow to main branch only

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,6 +1,7 @@
 name: docs-build
 on:
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened]
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

The `docs-build` workflow's `pull_request` trigger had no branch filter, so the docs build ran on PRs targeting **any** base branch — including release branches like `9.5`. This adds a `branches: [main]` filter so it only runs for PRs whose base is `main`.

For the `pull_request` event, GitHub's `branches` filter matches the PR's **base** (target) branch, which is exactly the intended scope. The `push` trigger was already scoped to `main`.

```yaml
on:
  pull_request:
    branches: [main]
    types: [opened, synchronize, reopened]
  push:
    branches: [main]
```

## Release note

`release_note:skip`