### PR TITLE
[One Workflow][docs] Sublime Security connector applies_to 9.6 → 9.5

### DIFF
--- a/docs/reference/connectors-kibana/sublime-security-action-type.md
+++ b/docs/reference/connectors-kibana/sublime-security-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "Sublime Security"
 type: reference
 description: "Use the Sublime Security connector to search flagged email, get verdicts, and quarantine, trash, or restore message groups."
 applies_to:
-  stack: preview 9.6
+  stack: preview 9.5
   serverless: preview
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/elastic/kibana/pull/279707. The Sublime Security connector was backported to 9.5 (https://github.com/elastic/kibana/pull/280984), so the docs `applies_to` badge should reflect availability from 9.5, not 9.6 — as requested by @nastasha-solomon in [Slack](https://elastic.slack.com/archives/C08TKN4P51V/p1785167895993479?thread_ts=1784674982.509069&cid=C08TKN4P51V).

Docs-only, one line.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->