### PR TITLE
[Security Solution][OneDiscover] Prevent duplicate risk inputs flyout telemetry

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
@@ -15,6 +15,8 @@ import {
 import { HostDetailsPanelKey } from '../../host_details_left';
 import { createTelemetryServiceMock } from '../../../../common/lib/telemetry/telemetry_service.mock';
 import { HostPanelKey } from '../../shared/constants';
+import { EntityEventTypes } from '../../../../common/lib/telemetry';
+import { EntityType } from '../../../../../common/search_strategy';
 
 jest.mock('@kbn/expandable-flyout');
 
@@ -66,8 +68,14 @@ describe('useNavigateToHostDetails', () => {
   it('returns callback that opens details panel when not in preview mode', () => {
     const { result } = renderHook(() => useNavigateToHostDetails(mockProps));
 
+    expect(mockedTelemetry.reportEvent).not.toHaveBeenCalled();
+
     result.current({ tab, subTab });
 
+    expect(mockedTelemetry.reportEvent).toHaveBeenCalledWith(
+      EntityEventTypes.RiskInputsExpandedFlyoutOpened,
+      { entity: EntityType.host }
+    );
     expect(mockOpenLeftPanel).toHaveBeenCalledWith({
       id: HostDetailsPanelKey,
       params: {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.ts
@@ -42,12 +42,12 @@ export const useNavigateToHostDetails = ({
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
 
-  telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
-    entity: EntityType.host,
-  });
-
   return useCallback(
     (path?: EntityDetailsPath) => {
+      telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
+        entity: EntityType.host,
+      });
+
       const left = {
         id: HostDetailsPanelKey,
         params: {
@@ -92,6 +92,7 @@ export const useNavigateToHostDetails = ({
       hasNonClosedAlerts,
       contextID,
       entityStoreEntityId,
+      telemetry,
     ]
   );
 };


### PR DESCRIPTION
## Summary

EntityEventTypes.RiskInputsExpandedFlyoutOpened was being spammed (especially in within discover) and sending erroneous logs when the v2 flyout is opened. It should only be sent in v1. 

- Reports `RiskInputsExpandedFlyoutOpened` only when the v1 host details flyout navigation callback runs.
- Prevents v2 flyout renders from repeatedly emitting the v1 event.
- Adds unit coverage confirming render does not report the event and navigation does.

### Testing
1. Look at the telemetry network calls when opening a v2 flyout (either from discover or security solution). 
2. Check that `EntityEventTypes.RiskInputsExpandedFlyoutOpened` event_type is no longer sent

Before:

https://github.com/user-attachments/assets/bdf07c99-bd5f-4464-85a8-7acb06250c2f


After:

https://github.com/user-attachments/assets/d6973a60-3554-4451-988e-cd2362070e9b




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->