### PR TITLE
[ResponseOps] Harden Task Manager poll cycle against cancelExpiredTasks failures

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.test.ts
@@ -518,6 +518,111 @@ describe('TaskPool', () => {
       taskHasExpired.resolve();
     });
 
+    test('a task whose expiration check throws is evicted without aborting cancellation of the rest of the pool', async () => {
+      const pool = new TaskPool({
+        capacity$: of(3),
+        definitions,
+        logger,
+        strategy: CLAIM_STRATEGY_UPDATE_BY_QUERY,
+      });
+
+      const halt = resolvable();
+      const brokenCancel = sinon.spy(() => Promise.resolve());
+      const expiredCancel = sinon.spy(() => Promise.resolve());
+      const healthyCancel = sinon.spy(() => Promise.resolve());
+      const now = new Date();
+
+      await pool.run([
+        // a runner in a corrupt state: computing its expiration throws, mirroring the
+        // production null-`startedAt` crash
+        {
+          ...mockTask({ id: 'broken' }),
+          async run() {
+            await halt;
+            return asOk({ state: {} });
+          },
+          get isExpired(): boolean {
+            throw new Error("Cannot read properties of null (reading 'valueOf')");
+          },
+          cancel: brokenCancel,
+        },
+        // a genuinely expired runner ordered AFTER the broken one: it must still be cancelled
+        {
+          ...mockTask({ id: 'expired' }),
+          async run() {
+            await halt;
+            return asOk({ state: {} });
+          },
+          isExpired: true,
+          get expiration() {
+            return now;
+          },
+          get startedAt() {
+            return now;
+          },
+          cancel: expiredCancel,
+        },
+        // a healthy running runner that must be left alone
+        {
+          ...mockTask({ id: 'healthy' }),
+          async run() {
+            await halt;
+            return asOk({ state: {} });
+          },
+          isExpired: false,
+          cancel: healthyCancel,
+        },
+      ]);
+
+      // pool.run() re-checks availableCapacity() with all three runners in the pool, so
+      // the broken runner must have been best-effort cancelled and dropped without the
+      // throw aborting the claim path
+      sinon.assert.calledOnce(brokenCancel);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Failed to cancel expired task TaskType "shooooo"; removing it from the pool`
+        )
+      );
+      // the genuinely expired runner ordered after it is still cancelled, healthy untouched
+      sinon.assert.calledOnce(expiredCancel);
+      sinon.assert.notCalled(healthyCancel);
+      expect(pool.usedCapacity).toEqual(1);
+
+      // a subsequent capacity check still succeeds and reflects the freed capacity
+      let capacity: number | undefined;
+      expect(() => {
+        capacity = pool.availableCapacity();
+      }).not.toThrow();
+      expect(capacity).toEqual(2);
+
+      halt.resolve();
+    });
+
+    test('availableCapacity still returns if cancelExpiredTasks throws', () => {
+      const pool = new TaskPool({
+        capacity$: of(5),
+        definitions,
+        logger,
+        strategy: CLAIM_STRATEGY_UPDATE_BY_QUERY,
+      });
+
+      jest
+        .spyOn(pool as unknown as { cancelExpiredTasks: () => void }, 'cancelExpiredTasks')
+        .mockImplementation(() => {
+          throw new Error('boom');
+        });
+
+      let capacity: number | undefined;
+      expect(() => {
+        capacity = pool.availableCapacity();
+      }).not.toThrow();
+
+      expect(capacity).toEqual(5);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to cancel expired tasks')
+      );
+    });
+
     test('logs if cancellation errors', async () => {
       const pool = new TaskPool({
         capacity$: of(10),

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.test.ts
@@ -518,7 +518,7 @@ describe('TaskPool', () => {
       taskHasExpired.resolve();
     });
 
-    test('a task whose expiration check throws is evicted without aborting cancellation of the rest of the pool', async () => {
+    test('a task whose expiration check throws is skipped without aborting cancellation of the rest of the pool', async () => {
       const pool = new TaskPool({
         capacity$: of(3),
         definitions,
@@ -574,26 +574,29 @@ describe('TaskPool', () => {
         },
       ]);
 
-      // pool.run() re-checks availableCapacity() with all three runners in the pool, so
-      // the broken runner must have been best-effort cancelled and dropped without the
-      // throw aborting the claim path
-      sinon.assert.calledOnce(brokenCancel);
-      expect(logger.error).toHaveBeenCalledWith(
+      // pool.run() re-checks availableCapacity() with all three runners in the pool. The
+      // broken runner is left in place (not cancelled) so its throw can't abort the claim
+      // path; it is simply skipped and logged.
+      sinon.assert.notCalled(brokenCancel);
+      expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Failed to cancel expired task TaskType "shooooo"; removing it from the pool`
+          `Failed to determine whether task TaskType "shooooo" is expired; skipping it`
         )
       );
       // the genuinely expired runner ordered after it is still cancelled, healthy untouched
       sinon.assert.calledOnce(expiredCancel);
       sinon.assert.notCalled(healthyCancel);
-      expect(pool.usedCapacity).toEqual(1);
 
-      // a subsequent capacity check still succeeds and reflects the freed capacity
+      // only the expired runner's slot is cleared; the broken runner keeps its slot instead
+      // of wedging the whole node
+      expect(pool.usedCapacity).toEqual(2);
+
+      // a subsequent capacity check still succeeds instead of throwing
       let capacity: number | undefined;
       expect(() => {
         capacity = pool.availableCapacity();
       }).not.toThrow();
-      expect(capacity).toEqual(2);
+      expect(capacity).toEqual(1);
 
       halt.resolve();
     });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.ts
@@ -135,7 +135,13 @@ export class TaskPool {
     // cancel expired task whenever a call is made to check for capacity
     // this ensures that we don't end up with a queue of hung tasks causing both
     // the poller and the pool from hanging due to lack of capacity
-    this.cancelExpiredTasks();
+    try {
+      this.cancelExpiredTasks();
+    } catch (err) {
+      // cancelling expired tasks is a best-effort side effect; it must never prevent
+      // capacity from being calculated and tasks from being claimed
+      this.logger.error(`Failed to cancel expired tasks: ${getErrorMessage(err)}`);
+    }
 
     return this.capacityCalculator.availableCapacity(
       this.tasksInPool,
@@ -249,19 +255,31 @@ export class TaskPool {
 
   private cancelExpiredTasks() {
     for (const taskRunner of this.tasksInPool.values()) {
-      if (taskRunner.isExpired) {
-        this.logger.warn(
-          `Cancelling task ${taskRunner.toString()} as it expired at ${taskRunner.expiration.toISOString()}${
-            taskRunner.startedAt
-              ? ` after running for ${durationAsString(
-                  moment.duration(moment(new Date()).utc().diff(taskRunner.startedAt))
-                )}`
-              : ``
-          }${
-            taskRunner.definition?.timeout
-              ? ` (with timeout set at ${taskRunner.definition.timeout})`
-              : ``
-          }.`
+      try {
+        if (taskRunner.isExpired) {
+          this.logger.warn(
+            `Cancelling task ${taskRunner.toString()} as it expired at ${taskRunner.expiration.toISOString()}${
+              taskRunner.startedAt
+                ? ` after running for ${durationAsString(
+                    moment.duration(moment(new Date()).utc().diff(taskRunner.startedAt))
+                  )}`
+                : ``
+            }${
+              taskRunner.definition?.timeout
+                ? ` (with timeout set at ${taskRunner.definition.timeout})`
+                : ``
+            }.`
+          );
+          this.cancelTask(taskRunner);
+        }
+      } catch (err) {
+        // A single broken runner (e.g. an invariant violation while computing its
+        // expiration) must not abort cancellation for the rest of the pool. Remove it
+        // so it can't wedge capacity or keep throwing on every poll.
+        this.logger.error(
+          `Failed to cancel expired task ${taskRunner.toString()}; removing it from the pool: ${getErrorMessage(
+            err
+          )}`
         );
         this.cancelTask(taskRunner);
       }

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.ts
@@ -273,15 +273,15 @@ export class TaskPool {
           this.cancelTask(taskRunner);
         }
       } catch (err) {
-        // A single broken runner (e.g. an invariant violation while computing its
-        // expiration) must not abort cancellation for the rest of the pool. Remove it
-        // so it can't wedge capacity or keep throwing on every poll.
-        this.logger.error(
-          `Failed to cancel expired task ${taskRunner.toString()}; removing it from the pool: ${getErrorMessage(
+        // We couldn't determine whether this runner is expired, so we can't safely cancel
+        // it. Skip it: leaving its slot occupied until its run() completes is a far better
+        // failure mode than letting one broken runner abort cancellation for the rest of
+        // the pool or, via availableCapacity, the node's entire claim cycle.
+        this.logger.warn(
+          `Failed to determine whether task ${taskRunner.toString()} is expired; skipping it: ${getErrorMessage(
             err
           )}`
         );
-        this.cancelTask(taskRunner);
       }
     }
   }


### PR DESCRIPTION
## Summary

`TaskPool.availableCapacity()` runs `cancelExpiredTasks()` on every poll, and every claim-path entrypoint (the poller's `getCapacity`, `getAvailableCapacity` for claiming, and `pool.run`) goes through it. `cancelExpiredTasks` had no per-task error handling, so a single runner whose expiration can't be evaluated — e.g. a `READY_TO_RUN` task with a null `startedAt` (see #281133) — would:

1. abort the loop (no other expired task gets cancelled),
2. propagate out of `availableCapacity()` and crash the whole poll cycle (`Failed to poll for work: Cannot read properties of null (reading 'valueOf')`), and
3. re-throw on every subsequent poll — the node claims **zero** tasks and stays wedged until restart.

Merely reading `taskRunner.isExpired` is enough to throw: it delegates to the `expiration` getter → `intervalFromDate` → `secondsFromDate`, which does `date.valueOf()` on a value typed `Date` that can be `null` at runtime.

### Fix — contain the failure, don't clean up aggressively

The only real problem is the throw escaping and killing the claim cycle, so the fix just contains it:

- **Per-task isolation (skip, don't cancel):** wrap each runner's expiry check in `cancelExpiredTasks` with a try/catch. If it throws we can't confirm the task is expired, so we **log and skip it** rather than cancelling it (which would cut short a possibly-healthy run). The rest of the pool is still processed normally.
- **Decouple the claimer:** wrap the `cancelExpiredTasks()` call in `availableCapacity()` so capacity calculation and task claiming always proceed even if cancellation throws for any (future) reason.

The skipped runner keeps its slot until its `run()` completes on its own, so the failure mode degrades from **"node can't claim any tasks"** to **"node can't clear one slot"** — and no task is ever cancelled without confirming it expired.

This is defense-in-depth for the root-cause fix in #281133 (which removes the null-`startedAt` producer).

## Test plan

- `node scripts/jest x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.test.ts`
- Two new tests in `task_pool.test.ts`:
  - a runner whose `isExpired` throws is skipped (not cancelled) and keeps its slot, while a genuinely expired runner ordered after it is still cancelled and the capacity check still returns
  - `availableCapacity()` still returns and logs when `cancelExpiredTasks` throws