### PR TITLE
[One Workflow] Add local enabled flag for ConnectorSpec type

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -260,6 +260,8 @@ export interface Transformations {
 // ============================================================================
 
 export interface ConnectorTest {
+  /** When false, the connection test is not exposed/run. Defaults to enabled when omitted. */
+  enabled?: boolean;
   handler: (ctx: ActionContext) => Promise<{
     ok: boolean;
     message?: string;


### PR DESCRIPTION
## Summary

This is a cherry pick version of https://github.com/elastic/kibana/pull/276979 who has not been backported to fix a local type issue.

