### PR TITLE
[9.4][Cases][AiOps] Fix AIOps charts in cases

### DIFF
--- a/x-pack/platform/plugins/shared/aiops/public/hooks/use_cases_modal.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/hooks/use_cases_modal.ts
@@ -9,6 +9,18 @@ import { useCallback, useMemo } from 'react';
 import { stringHash } from '@kbn/ml-string-hash';
 import { AttachmentType } from '@kbn/cases-plugin/common';
 import { i18n } from '@kbn/i18n';
+import {
+  CASES_ATTACHMENT_CHANGE_POINT_CHART,
+  EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
+} from '@kbn/aiops-change-point-detection/constants';
+import {
+  CASES_ATTACHMENT_LOG_PATTERN,
+  EMBEDDABLE_PATTERN_ANALYSIS_TYPE,
+} from '@kbn/aiops-log-pattern-analysis/constants';
+import {
+  CASES_ATTACHMENT_LOG_RATE_ANALYSIS,
+  EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE,
+} from '@kbn/aiops-log-rate-analysis/constants';
 import type { ChangePointEmbeddableState } from '../../common/embeddables/change_point_chart/types';
 import type { EmbeddableChangePointChartType } from '../embeddables/change_point_chart/embeddable_change_point_chart_factory';
 import { useAiopsAppContext } from './use_aiops_app_context';
@@ -30,6 +42,12 @@ type EmbeddableRuntimeState<T extends SupportedEmbeddableTypes> =
     : T extends EmbeddableLogRateAnalysisType
     ? LogRateAnalysisEmbeddableState
     : never;
+
+const attachmentTypeByEmbeddableType: Record<SupportedEmbeddableTypes, string> = {
+  [EMBEDDABLE_CHANGE_POINT_CHART_TYPE]: CASES_ATTACHMENT_CHANGE_POINT_CHART,
+  [EMBEDDABLE_PATTERN_ANALYSIS_TYPE]: CASES_ATTACHMENT_LOG_PATTERN,
+  [EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE]: CASES_ATTACHMENT_LOG_RATE_ANALYSIS,
+};
 
 /**
  * Returns a callback for opening the cases modal with provided attachment state.
@@ -69,7 +87,7 @@ export const useCasesModal = <EmbeddableType extends SupportedEmbeddableTypes>(
         getAttachments: () => [
           {
             type: AttachmentType.persistableState,
-            persistableStateAttachmentTypeId: embeddableType,
+            persistableStateAttachmentTypeId: attachmentTypeByEmbeddableType[embeddableType],
             persistableStateAttachmentState: JSON.parse(
               JSON.stringify(persistableStateAttachmentState)
             ),


### PR DESCRIPTION
## Summary

This PR fixed a bug when attaching AIOps charts to a case, it throws an error `Attachment type aiops_xxx is not registered`.

Root cause: https://github.com/elastic/kibana/pull/254079 renamed the three AIOps embeddable panel-type constants to snake_case. The PR changed only the `EMBEDDABLE_*_TYPE` values and left the `CASES_ATTACHMENT_*` registration ids untouched, desyncing them and causing the server validator to reject the attachment as "not registered".

`aiopsChangePointChart ` -> `aiops_change_point_chart`
`aiopsPatternAnalysisEmbeddable` -> `aiops_pattern_analysis`
`aiopsLogRateAnalysisEmbeddable` -> `aiops_log_rate_analysis`

Note:
1. ML was untouched by this rename, which is why ML attachments never broke.
2. The mapping was fixed in 9.5 when migrating AIOps to the unified attachment framework, hence this PR is targeting 9.4 only

Before
<img width="1515" height="832" alt="image" src="https://github.com/user-attachments/assets/c9977a7f-8255-47f7-bf55-26e0554b5287" />

After

<img width="1517" height="794" alt="image" src="https://github.com/user-attachments/assets/702b2d04-c8b1-4d2d-9968-15e4491fe66c" />

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.