### PR TITLE
[Response Ops] Prototype cross-node event bus (ES-backed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -700,6 +700,7 @@
     "@kbn/event-annotation-components": "link:src/platform/packages/shared/kbn-event-annotation-components",
     "@kbn/event-annotation-listing-plugin": "link:src/platform/plugins/private/event_annotation_listing",
     "@kbn/event-annotation-plugin": "link:src/platform/plugins/private/event_annotation",
+    "@kbn/event-bus-plugin": "link:x-pack/platform/plugins/shared/event_bus",
     "@kbn/event-log-fixture-plugin": "link:x-pack/platform/test/plugin_api_integration/plugins/event_log",
     "@kbn/event-log-plugin": "link:x-pack/platform/plugins/shared/event_log",
     "@kbn/event-stacktrace": "link:x-pack/platform/packages/shared/kbn-event-stacktrace",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1343,6 +1343,8 @@
       "@kbn/event-annotation-listing-plugin/*": ["./src/platform/plugins/private/event_annotation_listing/*"],
       "@kbn/event-annotation-plugin": ["./src/platform/plugins/private/event_annotation"],
       "@kbn/event-annotation-plugin/*": ["./src/platform/plugins/private/event_annotation/*"],
+      "@kbn/event-bus-plugin": ["./x-pack/platform/plugins/shared/event_bus"],
+      "@kbn/event-bus-plugin/*": ["./x-pack/platform/plugins/shared/event_bus/*"],
       "@kbn/event-log-fixture-plugin": ["./x-pack/platform/test/plugin_api_integration/plugins/event_log"],
       "@kbn/event-log-fixture-plugin/*": ["./x-pack/platform/test/plugin_api_integration/plugins/event_log/*"],
       "@kbn/event-log-plugin": ["./x-pack/platform/plugins/shared/event_log"],

--- a/x-pack/platform/plugins/shared/event_bus/jest.config.js
+++ b/x-pack/platform/plugins/shared/event_bus/jest.config.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/platform/plugins/shared/event_bus'],
+  coverageDirectory:
+    '<rootDir>/target/kibana-coverage/jest/x-pack/platform/plugins/shared/event_bus',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: ['<rootDir>/x-pack/platform/plugins/shared/event_bus/server/**/*.{ts,tsx}'],
+};

--- a/x-pack/platform/plugins/shared/event_bus/jest.integration.config.js
+++ b/x-pack/platform/plugins/shared/event_bus/jest.integration.config.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_integration',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/platform/plugins/shared/event_bus'],
+};

--- a/x-pack/platform/plugins/shared/event_bus/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/event_bus/kibana.jsonc
@@ -1,0 +1,22 @@
+{
+  "type": "plugin",
+  "id": "@kbn/event-bus-plugin",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
+  "description": "Prototype cross-node, in-cluster event bus for Kibana using Elasticsearch as the transport (append-only datastream read by per-consumer offset).",
+  "plugin": {
+    "id": "eventBus",
+    "browser": false,
+    "server": true,
+    "configPath": [
+      "xpack",
+      "eventBus"
+    ],
+    "requiredPlugins": [
+      "taskManager"
+    ]
+  }
+}

--- a/x-pack/platform/plugins/shared/event_bus/server/config.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/config.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema, type TypeOf } from '@kbn/config-schema';
+
+export const configSchema = schema.object({
+  /**
+   * How often each node's ephemeral tail loop polls the datastream when it is
+   * caught up. This is the latency floor for broadcast/directed delivery.
+   */
+  pollInterval: schema.duration({ defaultValue: '1s' }),
+  /**
+   * Safety lag (Δ). The tail only consumes events with `@timestamp <= now - Δ`
+   * so that documents made searchable slightly out of order (refresh delay,
+   * indexing reorder, minor clock skew) are not skipped. Must comfortably
+   * exceed the index refresh interval plus expected cross-node clock skew.
+   */
+  safetyLag: schema.duration({ defaultValue: '2s' }),
+  /** Maximum number of events read per poll. */
+  batchSize: schema.number({ defaultValue: 1000, min: 1, max: 10000 }),
+  /** Datastream lifecycle (DSL) retention for the transport datastream. */
+  retention: schema.string({ defaultValue: '7d' }),
+  durable: schema.object({
+    /**
+     * Recurring interval for durable consumer Task Manager tasks. This is the
+     * latency floor for at-least-once (durable) consumers.
+     */
+    pollInterval: schema.duration({ defaultValue: '3s' }),
+  }),
+});
+
+export type EventBusConfig = TypeOf<typeof configSchema>;

--- a/x-pack/platform/plugins/shared/event_bus/server/durable/durable_consumer_task.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/durable/durable_consumer_task.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import { schema } from '@kbn/config-schema';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import {
+  TaskCost,
+  TaskPriority,
+  type RunContext,
+  type TaskManagerSetupContract,
+  type TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import { BROADCAST_TARGET } from '../types';
+import type { EsNames } from '../es/names';
+import type { SubscriptionRegistry } from '../subscription_registry';
+import { readBatch } from '../tail/tail_reader';
+import { cursorFromEvent, fromStored, toStored, type StoredCursor } from '../tail/cursor';
+
+export const DURABLE_CONSUMER_TASK_TYPE = 'event_bus:durable_consumer';
+
+export const durableConsumerTaskId = (consumer: string): string =>
+  `${DURABLE_CONSUMER_TASK_TYPE}:${consumer}`;
+
+const paramsSchema = schema.object({
+  consumer: schema.string(),
+  types: schema.arrayOf(schema.string(), { minSize: 1 }),
+  startTs: schema.number(),
+});
+
+const storedCursorSchema = schema.nullable(
+  schema.object({ ts: schema.number(), id: schema.string() })
+);
+
+const stateSchemaV1 = schema.object({
+  cursor: storedCursorSchema,
+});
+
+interface DurableConsumerParams {
+  consumer: string;
+  types: string[];
+  startTs: number;
+}
+
+interface DurableConsumerState {
+  cursor: StoredCursor | null;
+}
+
+export interface RegisterDurableConsumerTaskDeps {
+  taskManager: TaskManagerSetupContract;
+  getEsClient: () => Promise<ElasticsearchClient>;
+  registry: SubscriptionRegistry;
+  names: EsNames;
+  logger: Logger;
+  safetyLagMs: number;
+  batchSize: number;
+}
+
+/**
+ * Registers the durable consumer task type. Each run drains exactly one bounded
+ * batch and returns `{ state: { cursor } }` — it never runs an infinite loop,
+ * because Task Manager discards state when a run times out. A recurring task is
+ * a single-runner (claimed by one node at a time) which is the correct model
+ * for a logical, at-least-once consumer.
+ */
+export const registerDurableConsumerTask = (deps: RegisterDurableConsumerTaskDeps): void => {
+  const { taskManager, getEsClient, registry, names, logger, safetyLagMs, batchSize } = deps;
+
+  taskManager.registerTaskDefinitions({
+    [DURABLE_CONSUMER_TASK_TYPE]: {
+      title: 'Event bus durable consumer',
+      description:
+        'Tails the event bus datastream for one durable logical consumer, persisting its cursor in task state (at-least-once).',
+      timeout: '1m',
+      // We never throw on failure (we self-heal on the next recurring run), so
+      // retries are unnecessary.
+      maxAttempts: 1,
+      cost: TaskCost.Normal,
+      priority: TaskPriority.Normal,
+      paramsSchema,
+      stateSchemaByVersion: {
+        1: { schema: stateSchemaV1, up: (state) => state },
+      },
+      createTaskRunner: ({ taskInstance, signal }: RunContext) => ({
+        run: async () => {
+          const { consumer, types, startTs } = taskInstance.params as DurableConsumerParams;
+          const previousState = (taskInstance.state ?? {}) as Partial<DurableConsumerState>;
+          let cursor = fromStored(previousState.cursor);
+
+          const returnState = (): { state: Record<string, unknown> } => ({
+            state: { cursor: toStored(cursor) },
+          });
+
+          const subscription = registry.getDurable(consumer);
+          if (!subscription) {
+            // No handler registered on this node yet (e.g. dependent plugin not
+            // started). Skip without advancing; retry next interval.
+            logger.warn(
+              `event bus durable consumer "${consumer}" has no handler on this node; skipping run`
+            );
+            return returnState();
+          }
+
+          const esClient = await getEsClient();
+          const filter: estypes.QueryDslQueryContainer[] = [
+            { terms: { target: [BROADCAST_TARGET] } },
+            { terms: { 'event.type': types } },
+          ];
+
+          let batch;
+          try {
+            batch = await readBatch({
+              esClient,
+              index: names.dataStream,
+              filter,
+              cursor,
+              startTs,
+              safetyLagMs,
+              batchSize,
+              signal,
+            });
+          } catch (err) {
+            // Transient read failure: keep the cursor and retry next run. We do
+            // not throw, because a thrown (or timed-out) run discards state.
+            logger.error(`event bus durable consumer "${consumer}" read failed: ${err.message}`);
+            return returnState();
+          }
+
+          for (const event of batch.events) {
+            if (signal.aborted) {
+              break;
+            }
+            try {
+              await subscription.handler(event);
+            } catch (err) {
+              // Stop before advancing past the failed event so it is retried
+              // (at-least-once + idempotent handlers). Head-of-line blocking on
+              // a poison event is a known prototype limitation.
+              logger.error(
+                `event bus durable consumer "${consumer}" handler failed for event ${event.id}: ${err.message}`
+              );
+              return returnState();
+            }
+            cursor = cursorFromEvent(event.timestamp, event.id);
+          }
+
+          return returnState();
+        },
+      }),
+    },
+  });
+};
+
+export interface ScheduleDurableConsumerDeps {
+  taskManager: TaskManagerStartContract;
+  consumer: string;
+  types: string[];
+  startTs: number;
+  intervalMs: number;
+}
+
+const toInterval = (ms: number): string => `${Math.max(1, Math.round(ms / 1000))}s`;
+
+/**
+ * Idempotently schedules the recurring durable consumer task for a logical
+ * consumer. Uses `ensureScheduled` so a Kibana restart does not create
+ * duplicates; the persisted cursor survives in the task's state.
+ */
+export const scheduleDurableConsumer = ({
+  taskManager,
+  consumer,
+  types,
+  startTs,
+  intervalMs,
+}: ScheduleDurableConsumerDeps): Promise<unknown> =>
+  taskManager.ensureScheduled({
+    id: durableConsumerTaskId(consumer),
+    taskType: DURABLE_CONSUMER_TASK_TYPE,
+    schedule: { interval: toInterval(intervalMs) },
+    params: { consumer, types, startTs },
+    state: { cursor: null },
+  });

--- a/x-pack/platform/plugins/shared/event_bus/server/es/index_template.test.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/es/index_template.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getEsNames } from './names';
+import { getEventBusMappings, getIndexTemplate } from './index_template';
+
+describe('event bus index template', () => {
+  const names = getEsNames('.kibana');
+
+  describe('getEventBusMappings', () => {
+    const mappings = getEventBusMappings();
+
+    it('keeps payload unindexed to avoid mapping explosion', () => {
+      expect(mappings.properties.payload).toEqual({ type: 'object', enabled: false });
+    });
+
+    it('does not dynamically map unexpected fields', () => {
+      expect(mappings.dynamic).toBe(false);
+    });
+
+    it('indexes @timestamp, event.id, event.type, target as sortable/filterable keywords', () => {
+      expect(mappings.properties['@timestamp']).toEqual({ type: 'date' });
+      expect(mappings.properties.event.properties.id).toEqual({ type: 'keyword' });
+      expect(mappings.properties.event.properties.type).toEqual({ type: 'keyword' });
+      expect(mappings.properties.target).toEqual({ type: 'keyword' });
+    });
+  });
+
+  describe('getIndexTemplate', () => {
+    interface TemplateShape {
+      index_patterns: string[];
+      data_stream: { hidden: boolean };
+      template: {
+        settings: { number_of_shards: number; hidden: boolean; index?: { lifecycle?: unknown } };
+        lifecycle: { data_retention: string };
+      };
+    }
+
+    it('is a hidden, single-shard data stream template targeting the datastream', () => {
+      const template = getIndexTemplate(names, '7d') as unknown as TemplateShape;
+      expect(template.index_patterns).toEqual([names.dataStream]);
+      expect(template.data_stream).toEqual({ hidden: true });
+      expect(template.template.settings.number_of_shards).toBe(1);
+      expect(template.template.settings.hidden).toBe(true);
+    });
+
+    it('uses Data Stream Lifecycle (DSL) retention, not ILM', () => {
+      const template = getIndexTemplate(names, '30d') as unknown as TemplateShape;
+      expect(template.template.lifecycle).toEqual({ data_retention: '30d' });
+      expect(template.template.settings.index?.lifecycle).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/event_bus/server/es/index_template.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/es/index_template.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsNames } from './names';
+
+/**
+ * Datastream mapping. `payload` is unindexed (`enabled: false`) to avoid mapping
+ * explosion — subscribers filter on `event.type`/`target`, never on payload.
+ * `dynamic: false` so unexpected fields never mutate the mapping.
+ */
+export const getEventBusMappings = () => ({
+  dynamic: false,
+  properties: {
+    '@timestamp': { type: 'date' },
+    event: {
+      properties: {
+        id: { type: 'keyword' },
+        type: { type: 'keyword' },
+      },
+    },
+    target: { type: 'keyword' },
+    source: { type: 'keyword' },
+    space: { type: 'keyword' },
+    partition: { type: 'keyword' },
+    payload: { type: 'object', enabled: false },
+  },
+});
+
+/**
+ * Composable index template for the event bus datastream. Mirrors the event_log
+ * bootstrap: single shard (total order within a backing index), hidden, and
+ * time-based retention via Data Stream Lifecycle (DSL) — NOT ILM.
+ */
+export const getIndexTemplate = (names: EsNames, retention: string): Record<string, unknown> => ({
+  _meta: {
+    description: 'index template for the Kibana event bus',
+    managed: true,
+  },
+  index_patterns: [names.dataStream],
+  data_stream: {
+    hidden: true,
+  },
+  priority: 50,
+  template: {
+    settings: {
+      hidden: true,
+      number_of_shards: 1,
+      auto_expand_replicas: '0-1',
+    },
+    lifecycle: {
+      data_retention: retention,
+    },
+    mappings: getEventBusMappings(),
+  },
+});

--- a/x-pack/platform/plugins/shared/event_bus/server/es/names.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/es/names.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const EVENT_BUS_NAME_SUFFIX = '-event-bus';
+
+export interface EsNames {
+  /** Datastream we index into and tail. */
+  dataStream: string;
+  /** Wildcard pattern covering the datastream's backing indices. */
+  indexPattern: string;
+  /** Composable index template name. */
+  indexTemplate: string;
+}
+
+export const getEsNames = (baseName: string): EsNames => {
+  const root = `${baseName}${EVENT_BUS_NAME_SUFFIX}`;
+  return {
+    dataStream: `${root}-ds`,
+    indexPattern: `${root}-*`,
+    indexTemplate: `${root}-template`,
+  };
+};

--- a/x-pack/platform/plugins/shared/event_bus/server/es/resource_installer.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/es/resource_installer.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { FailedAttemptError } from 'p-retry';
+import pRetry from 'p-retry';
+import { getIndexTemplate } from './index_template';
+import type { EsNames } from './names';
+
+const MAX_RETRY_DELAY = 30000;
+
+export interface ResourceInstallerDeps {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  names: EsNames;
+  retention: string;
+}
+
+/**
+ * Bootstraps (and idempotently updates) the event bus datastream and its
+ * composable index template. Safe to run concurrently across multiple Kibana
+ * nodes — template creation re-checks existence on error and datastream
+ * creation swallows `resource_already_exists_exception`.
+ */
+export class ResourceInstaller {
+  private installed?: Promise<boolean>;
+
+  constructor(private readonly deps: ResourceInstallerDeps) {}
+
+  /** Runs the install once; subsequent calls return the same promise. */
+  public install(): Promise<boolean> {
+    if (!this.installed) {
+      this.installed = this.doInstall();
+    }
+    return this.installed;
+  }
+
+  public waitUntilReady(): Promise<boolean> {
+    return this.install();
+  }
+
+  private async doInstall(): Promise<boolean> {
+    try {
+      await this.retry('create-index-template', () => this.createOrUpdateIndexTemplate());
+      await this.retry('create-data-stream', () => this.createOrUpdateDataStream());
+      this.deps.logger.debug(`event bus resources initialized (${this.deps.names.dataStream})`);
+      return true;
+    } catch (err) {
+      this.deps.logger.error(`error initializing event bus resources: ${err.message}`);
+      return false;
+    }
+  }
+
+  private retry(operation: string, fn: () => Promise<void>): Promise<void> {
+    return pRetry(fn, {
+      minTimeout: 1000,
+      maxTimeout: MAX_RETRY_DELAY,
+      retries: 4,
+      factor: 2,
+      randomize: true,
+      onFailedAttempt: (err: FailedAttemptError) => {
+        this.deps.logger.warn(
+          `event bus initialization step "${operation}" failed, ${err.retriesLeft} retries left: ${err.message}`
+        );
+      },
+    });
+  }
+
+  private async createOrUpdateIndexTemplate(): Promise<void> {
+    const { esClient, names, retention } = this.deps;
+    const template = getIndexTemplate(names, retention);
+    const exists = await esClient.indices.existsIndexTemplate({ name: names.indexTemplate });
+
+    if (!exists) {
+      try {
+        await esClient.indices.putIndexTemplate({
+          name: names.indexTemplate,
+          body: template,
+          create: true,
+        });
+      } catch (err) {
+        // Concurrent bootstrap from another node may have created it between the
+        // existence check and the create; only rethrow if it still doesn't exist.
+        const existsNow = await esClient.indices.existsIndexTemplate({ name: names.indexTemplate });
+        if (!existsNow) {
+          throw new Error(`error creating event bus index template: ${err.message}`);
+        }
+      }
+      return;
+    }
+
+    await esClient.indices.putIndexTemplate({ name: names.indexTemplate, body: template });
+  }
+
+  private async createOrUpdateDataStream(): Promise<void> {
+    const { esClient, names } = this.deps;
+    const exists = await this.doesDataStreamExist();
+
+    if (!exists) {
+      try {
+        await esClient.indices.createDataStream({ name: names.dataStream });
+      } catch (err) {
+        if (err.body?.error?.type !== 'resource_already_exists_exception') {
+          throw new Error(`error creating event bus data stream: ${err.message}`);
+        }
+      }
+      return;
+    }
+
+    // Apply the latest mapping to existing backing indices.
+    const simulated = await esClient.indices.simulateIndexTemplate({ name: names.dataStream });
+    const mappings = simulated.template?.mappings;
+    if (mappings) {
+      await esClient.indices.putMapping({ index: names.dataStream, ...mappings });
+    }
+  }
+
+  private async doesDataStreamExist(): Promise<boolean> {
+    try {
+      const response = await this.deps.esClient.indices.getDataStream({
+        name: this.deps.names.dataStream,
+        expand_wildcards: 'all',
+      });
+      return response.data_streams.length > 0;
+    } catch (err) {
+      if (err.meta?.statusCode === 404) {
+        return false;
+      }
+      throw new Error(`error checking existence of event bus data stream: ${err.message}`);
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/event_bus/server/index.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginConfigDescriptor, PluginInitializerContext } from '@kbn/core/server';
+import { configSchema, type EventBusConfig } from './config';
+
+export { BROADCAST_TARGET } from './types';
+export type {
+  EventBusSetup,
+  EventBusStart,
+  BusEvent,
+  EventHandler,
+  EventTypeDefinition,
+  PublishEventParams,
+  SubscribeOptions,
+  Subscription,
+} from './types';
+
+export const config: PluginConfigDescriptor<EventBusConfig> = {
+  schema: configSchema,
+};
+
+export const plugin = async (initializerContext: PluginInitializerContext) => {
+  const { EventBusPlugin } = await import('./plugin');
+  return new EventBusPlugin(initializerContext);
+};

--- a/x-pack/platform/plugins/shared/event_bus/server/integration_tests/event_bus.test.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/integration_tests/event_bus.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { InternalCoreStart } from '@kbn/core-lifecycle-server-internal';
+import { createTestServers } from '@kbn/core-test-helpers-kbn-server';
+import type {
+  createRootWithCorePlugins,
+  TestElasticsearchUtils,
+} from '@kbn/core-test-helpers-kbn-server';
+import { getEsNames } from '../es/names';
+import { ResourceInstaller } from '../es/resource_installer';
+import { EventPublisher } from '../publisher';
+import { readBatch } from '../tail/tail_reader';
+import { fromStored, toStored } from '../tail/cursor';
+import { BROADCAST_TARGET, type PublishEventParams } from '../types';
+
+// Use a dedicated base name so this test's datastream is isolated from the
+// datastream the (background-loaded) eventBus plugin bootstraps in the harness.
+const names = getEsNames('.kibana-eb-it');
+
+const logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+} as unknown as Logger;
+
+describe('event bus integration', () => {
+  let manageES: TestElasticsearchUtils;
+  let kbnRoot: ReturnType<typeof createRootWithCorePlugins>;
+  let coreStart: InternalCoreStart;
+  let esClient: ElasticsearchClient;
+  let publisher: EventPublisher;
+
+  const publishAndRefresh = async (params: PublishEventParams): Promise<string> => {
+    const id = await publisher.publish(params);
+    await esClient.indices.refresh({ index: names.dataStream });
+    return id;
+  };
+
+  beforeAll(async () => {
+    const { startES, startKibana } = createTestServers({ adjustTimeout: jest.setTimeout });
+    const testServers = await Promise.all([startES(), startKibana()]);
+    manageES = testServers[0];
+    ({ root: kbnRoot, coreStart } = testServers[1]);
+
+    esClient = coreStart.elasticsearch.client.asInternalUser;
+
+    // M0: bootstrap our transport datastream + template.
+    const installer = new ResourceInstaller({ esClient, logger, names, retention: '7d' });
+    const ok = await installer.install();
+    expect(ok).toBe(true);
+
+    publisher = new EventPublisher({ esClient, names, nodeId: 'node-A' });
+  });
+
+  afterAll(async () => {
+    try {
+      await esClient.indices.deleteDataStream({ name: names.dataStream });
+    } catch (e) {
+      // ignore
+    }
+    try {
+      await esClient.indices.deleteIndexTemplate({ name: names.indexTemplate });
+    } catch (e) {
+      // ignore
+    }
+    await kbnRoot?.shutdown();
+    await manageES?.stop();
+  });
+
+  it('M0: creates a hidden data stream with an unindexed payload mapping', async () => {
+    const dataStreams = await esClient.indices.getDataStream({ name: names.dataStream });
+    expect(dataStreams.data_streams).toHaveLength(1);
+
+    const templateExists = await esClient.indices.existsIndexTemplate({
+      name: names.indexTemplate,
+    });
+    expect(templateExists).toBe(true);
+
+    const mappingResponse = await esClient.indices.getMapping({ index: names.dataStream });
+    const backingIndex = Object.keys(mappingResponse)[0];
+    const properties = mappingResponse[backingIndex].mappings.properties ?? {};
+    expect((properties.payload as { enabled?: boolean }).enabled).toBe(false);
+    expect(properties.target).toEqual({ type: 'keyword' });
+  });
+
+  it('M1: publish → tail round trip returns the event with all fields', async () => {
+    const payload = { hello: 'm1' };
+    const id = await publishAndRefresh({ type: 'it.m1', payload });
+
+    const { events, nextCursor, hasMore } = await readBatch({
+      esClient,
+      index: names.dataStream,
+      filter: [{ terms: { 'event.type': ['it.m1'] } }],
+      cursor: null,
+      startTs: 0,
+      safetyLagMs: 0,
+      batchSize: 10,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(id);
+    expect(events[0].type).toBe('it.m1');
+    expect(events[0].source).toBe('node-A');
+    expect(events[0].target).toBe(BROADCAST_TARGET);
+    expect(events[0].payload).toEqual(payload);
+    expect(hasMore).toBe(false);
+    expect(nextCursor).not.toBeNull();
+  });
+
+  it('M2: broadcast reaches every node; directed reaches only the target node', async () => {
+    await publishAndRefresh({ type: 'it.m2', target: BROADCAST_TARGET, payload: { t: 'all' } });
+    await publishAndRefresh({ type: 'it.m2', target: 'node-A', payload: { t: 'A' } });
+    await publishAndRefresh({ type: 'it.m2', target: 'node-B', payload: { t: 'B' } });
+
+    const tagsFor = async (nodeId: string): Promise<string[]> => {
+      const { events } = await readBatch({
+        esClient,
+        index: names.dataStream,
+        filter: [
+          { terms: { target: [BROADCAST_TARGET, nodeId] } },
+          { terms: { 'event.type': ['it.m2'] } },
+        ],
+        cursor: null,
+        startTs: 0,
+        safetyLagMs: 0,
+        batchSize: 10,
+      });
+      return events.map((event) => (event.payload as { t: string }).t).sort();
+    };
+
+    // node-A sees broadcast + its own directed event, never node-B's.
+    expect(await tagsFor('node-A')).toEqual(['A', 'all']);
+    // node-B sees broadcast + its own directed event, never node-A's.
+    expect(await tagsFor('node-B')).toEqual(['B', 'all']);
+  });
+
+  it('M3: a durable consumer resumes from its stored cursor with no gap and no duplicate', async () => {
+    const id1 = await publishAndRefresh({ type: 'it.m3', payload: { n: 1 } });
+    const id2 = await publishAndRefresh({ type: 'it.m3', payload: { n: 2 } });
+
+    const filter = [{ terms: { 'event.type': ['it.m3'] } }];
+    const first = await readBatch({
+      esClient,
+      index: names.dataStream,
+      filter,
+      cursor: null,
+      startTs: 0,
+      safetyLagMs: 0,
+      batchSize: 10,
+    });
+    expect(first.events.map((event) => event.id)).toEqual([id1, id2]);
+
+    // Simulate a restart: the cursor survives as Task Manager state (round-tripped
+    // through its serializable form) and the consumer resumes from it.
+    const resumedCursor = fromStored(toStored(first.nextCursor));
+
+    const id3 = await publishAndRefresh({ type: 'it.m3', payload: { n: 3 } });
+    const id4 = await publishAndRefresh({ type: 'it.m3', payload: { n: 4 } });
+
+    const second = await readBatch({
+      esClient,
+      index: names.dataStream,
+      filter,
+      cursor: resumedCursor,
+      startTs: 0,
+      safetyLagMs: 0,
+      batchSize: 10,
+    });
+
+    // Exclusive cursor: only the two new events, no re-delivery of id1/id2.
+    expect(second.events.map((event) => event.id)).toEqual([id3, id4]);
+  });
+});

--- a/x-pack/platform/plugins/shared/event_bus/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/plugin.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CoreSetup,
+  CoreStart,
+  ElasticsearchClient,
+  Logger,
+  Plugin,
+  PluginInitializerContext,
+} from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { EventBusConfig } from './config';
+import type { EventBusSetup, EventBusStart, EventHandler, EventTypeDefinition } from './types';
+import { getEsNames, type EsNames } from './es/names';
+import { ResourceInstaller } from './es/resource_installer';
+import { EventPublisher } from './publisher';
+import { SubscriptionRegistry } from './subscription_registry';
+import { NodeTailLoop } from './tail/node_tail_loop';
+import {
+  registerDurableConsumerTask,
+  scheduleDurableConsumer,
+} from './durable/durable_consumer_task';
+
+export interface EventBusSetupDeps {
+  taskManager: TaskManagerSetupContract;
+}
+
+export interface EventBusStartDeps {
+  taskManager: TaskManagerStartContract;
+}
+
+export class EventBusPlugin
+  implements Plugin<EventBusSetup, EventBusStart, EventBusSetupDeps, EventBusStartDeps>
+{
+  private readonly logger: Logger;
+  private readonly config: EventBusConfig;
+  private readonly nodeId: string;
+  private readonly registry = new SubscriptionRegistry();
+  private readonly eventTypes = new Map<string, EventTypeDefinition>();
+
+  private names?: EsNames;
+  private esClientPromise?: Promise<ElasticsearchClient>;
+  private installer?: ResourceInstaller;
+  private publisher?: EventPublisher;
+  private nodeTailLoop?: NodeTailLoop;
+
+  constructor(context: PluginInitializerContext) {
+    this.logger = context.logger.get();
+    this.config = context.config.get<EventBusConfig>();
+    this.nodeId = context.env.instanceUuid;
+  }
+
+  public setup(core: CoreSetup, plugins: EventBusSetupDeps): EventBusSetup {
+    const names = getEsNames(core.savedObjects.getDefaultIndex());
+    this.names = names;
+
+    // Resolve the internal ES client lazily; only available at start.
+    this.esClientPromise = core
+      .getStartServices()
+      .then(([{ elasticsearch }]) => elasticsearch.client.asInternalUser);
+
+    // M3: register the durable consumer task type (scheduling happens per
+    // consumer, when subscribe({ durable: true }) is called).
+    registerDurableConsumerTask({
+      taskManager: plugins.taskManager,
+      getEsClient: () => this.esClientPromise!,
+      registry: this.registry,
+      names,
+      logger: this.logger,
+      safetyLagMs: this.config.safetyLag.asMilliseconds(),
+      batchSize: this.config.batchSize,
+    });
+
+    return {
+      registerEventType: (definition: EventTypeDefinition) => {
+        if (this.eventTypes.has(definition.type)) {
+          throw new Error(`event bus type "${definition.type}" is already registered`);
+        }
+        this.eventTypes.set(definition.type, definition);
+      },
+    };
+  }
+
+  public start(core: CoreStart, plugins: EventBusStartDeps): EventBusStart {
+    const esClient = core.elasticsearch.client.asInternalUser;
+    const names = this.names!;
+
+    this.installer = new ResourceInstaller({
+      esClient,
+      logger: this.logger,
+      names,
+      retention: this.config.retention,
+    });
+    void this.installer.install().then((ok) => {
+      if (!ok) {
+        this.logger.error(
+          'event bus resources failed to initialize; publish/subscribe will not work'
+        );
+      }
+    });
+
+    this.publisher = new EventPublisher({ esClient, names, nodeId: this.nodeId });
+
+    this.nodeTailLoop = new NodeTailLoop({
+      esClient,
+      names,
+      nodeId: this.nodeId,
+      registry: this.registry,
+      logger: this.logger,
+      pollIntervalMs: this.config.pollInterval.asMilliseconds(),
+      safetyLagMs: this.config.safetyLag.asMilliseconds(),
+      batchSize: this.config.batchSize,
+    });
+
+    const durableIntervalMs = this.config.durable.pollInterval.asMilliseconds();
+
+    return {
+      publish: async (event) => {
+        const ready = await this.installer!.waitUntilReady();
+        if (!ready) {
+          throw new Error('event bus is not initialized');
+        }
+        this.validateEvent(event.type, event.payload);
+        await this.publisher!.publish(event);
+      },
+
+      subscribe: (options, handler) => {
+        const typedHandler = handler as unknown as EventHandler;
+
+        if (options.durable) {
+          if (!options.consumer) {
+            throw new Error('durable event bus subscriptions require a stable "consumer" id');
+          }
+          const consumer = options.consumer;
+          this.registry.registerDurable(consumer, options.types, typedHandler);
+          void scheduleDurableConsumer({
+            taskManager: plugins.taskManager,
+            consumer,
+            types: options.types,
+            startTs: Date.now(),
+            intervalMs: durableIntervalMs,
+          }).catch((err) => {
+            this.logger.error(
+              `failed to schedule durable event bus consumer "${consumer}": ${err.message}`
+            );
+          });
+          return { unsubscribe: () => this.registry.unregisterDurable(consumer) };
+        }
+
+        const id = this.registry.addEphemeral(options.types, typedHandler);
+        this.nodeTailLoop!.start();
+        return { unsubscribe: () => this.registry.removeEphemeral(id) };
+      },
+    };
+  }
+
+  public stop(): void {
+    this.nodeTailLoop?.stop();
+  }
+
+  private validateEvent(type: string, payload: unknown): void {
+    const definition = this.eventTypes.get(type);
+    if (!definition) {
+      throw new Error(`event bus type "${type}" is not registered`);
+    }
+    if (definition.schema) {
+      definition.schema.validate(payload);
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/event_bus/server/publisher.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/publisher.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { v7 as uuidv7 } from 'uuid';
+import type { EsNames } from './es/names';
+import { BROADCAST_TARGET, type PublishEventParams } from './types';
+
+export interface EventPublisherDeps {
+  esClient: ElasticsearchClient;
+  names: EsNames;
+  /** Publishing node id (server.uuid), stored as `source`. */
+  nodeId: string;
+}
+
+/**
+ * Indexes a single event document into the datastream and resolves once ES
+ * acks the write. Unbuffered (unlike event_log) — for a control-plane bus,
+ * per-event durability matters more than write throughput. The event is not
+ * searchable by tail loops until the next refresh (~1s).
+ */
+export class EventPublisher {
+  constructor(private readonly deps: EventPublisherDeps) {}
+
+  public async publish(params: PublishEventParams): Promise<string> {
+    const id = uuidv7();
+    const document = {
+      '@timestamp': new Date().toISOString(),
+      event: { id, type: params.type },
+      target: params.target ?? BROADCAST_TARGET,
+      source: this.deps.nodeId,
+      space: params.space,
+      partition: params.partition,
+      payload: params.payload,
+    };
+
+    await this.deps.esClient.index({
+      index: this.deps.names.dataStream,
+      document,
+      op_type: 'create',
+    });
+
+    return id;
+  }
+}

--- a/x-pack/platform/plugins/shared/event_bus/server/subscription_registry.test.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/subscription_registry.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { SubscriptionRegistry } from './subscription_registry';
+import type { BusEvent } from './types';
+
+const logger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+} as unknown as Logger;
+
+const event = (type: string): BusEvent => ({
+  id: `id-${type}`,
+  type,
+  target: 'all',
+  source: 'node-a',
+  payload: {},
+  timestamp: new Date().toISOString(),
+});
+
+describe('SubscriptionRegistry', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('ephemeral', () => {
+    it('reports the union of subscribed types for the shared tail filter', () => {
+      const registry = new SubscriptionRegistry();
+      registry.addEphemeral(['a', 'b'], jest.fn());
+      registry.addEphemeral(['b', 'c'], jest.fn());
+      expect(registry.hasEphemeral()).toBe(true);
+      expect(registry.ephemeralTypes().sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('dispatches only to handlers subscribed to the event type', async () => {
+      const registry = new SubscriptionRegistry();
+      const handlerA = jest.fn();
+      const handlerB = jest.fn();
+      registry.addEphemeral(['a'], handlerA);
+      registry.addEphemeral(['b'], handlerB);
+
+      await registry.dispatchEphemeral(event('a'), logger);
+
+      expect(handlerA).toHaveBeenCalledTimes(1);
+      expect(handlerB).not.toHaveBeenCalled();
+    });
+
+    it('isolates handler failures: a throwing handler is logged and siblings still run', async () => {
+      const registry = new SubscriptionRegistry();
+      const throwing = jest.fn().mockRejectedValue(new Error('boom'));
+      const healthy = jest.fn();
+      registry.addEphemeral(['a'], throwing);
+      registry.addEphemeral(['a'], healthy);
+
+      await expect(registry.dispatchEphemeral(event('a'), logger)).resolves.toBeUndefined();
+
+      expect(throwing).toHaveBeenCalledTimes(1);
+      expect(healthy).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops dispatching to a removed subscription', async () => {
+      const registry = new SubscriptionRegistry();
+      const handler = jest.fn();
+      const id = registry.addEphemeral(['a'], handler);
+      registry.removeEphemeral(id);
+
+      expect(registry.hasEphemeral()).toBe(false);
+      await registry.dispatchEphemeral(event('a'), logger);
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('durable', () => {
+    it('registers, resolves, and unregisters a durable consumer handler', () => {
+      const registry = new SubscriptionRegistry();
+      const handler = jest.fn();
+      registry.registerDurable('my-consumer', ['a'], handler);
+
+      const sub = registry.getDurable('my-consumer');
+      expect(sub).toMatchObject({ consumer: 'my-consumer', types: ['a'] });
+
+      registry.unregisterDurable('my-consumer');
+      expect(registry.getDurable('my-consumer')).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/event_bus/server/subscription_registry.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/subscription_registry.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { BusEvent, EventHandler } from './types';
+
+interface EphemeralSubscription {
+  id: string;
+  types: Set<string>;
+  handler: EventHandler;
+}
+
+interface DurableSubscription {
+  consumer: string;
+  types: string[];
+  handler: EventHandler;
+}
+
+/**
+ * In-process registry of this node's subscriptions. Ephemeral subscriptions are
+ * driven by the shared node tail loop; durable subscriptions are looked up by
+ * the durable consumer Task Manager task when it runs on this node.
+ */
+export class SubscriptionRegistry {
+  private readonly ephemeral = new Map<string, EphemeralSubscription>();
+  private readonly durable = new Map<string, DurableSubscription>();
+  private sequence = 0;
+
+  public addEphemeral(types: string[], handler: EventHandler): string {
+    const id = `ephemeral-${this.sequence++}`;
+    this.ephemeral.set(id, { id, types: new Set(types), handler });
+    return id;
+  }
+
+  public removeEphemeral(id: string): void {
+    this.ephemeral.delete(id);
+  }
+
+  public hasEphemeral(): boolean {
+    return this.ephemeral.size > 0;
+  }
+
+  /** Union of all ephemeral subscribers' types, for the shared tail filter. */
+  public ephemeralTypes(): string[] {
+    const types = new Set<string>();
+    for (const sub of this.ephemeral.values()) {
+      for (const type of sub.types) {
+        types.add(type);
+      }
+    }
+    return [...types];
+  }
+
+  /**
+   * Dispatches an event to every ephemeral subscriber interested in its type.
+   * Handlers are isolated: a throwing/rejecting handler is logged and does not
+   * prevent sibling handlers from running or the cursor from advancing.
+   */
+  public async dispatchEphemeral(event: BusEvent, logger: Logger): Promise<void> {
+    for (const sub of this.ephemeral.values()) {
+      if (!sub.types.has(event.type)) {
+        continue;
+      }
+      try {
+        await sub.handler(event);
+      } catch (err) {
+        logger.error(
+          `event bus subscriber for "${event.type}" threw for event ${event.id}: ${err.message}`
+        );
+      }
+    }
+  }
+
+  public registerDurable(consumer: string, types: string[], handler: EventHandler): void {
+    this.durable.set(consumer, { consumer, types, handler });
+  }
+
+  public unregisterDurable(consumer: string): void {
+    this.durable.delete(consumer);
+  }
+
+  public getDurable(consumer: string): DurableSubscription | undefined {
+    return this.durable.get(consumer);
+  }
+}

--- a/x-pack/platform/plugins/shared/event_bus/server/tail/cursor.test.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/tail/cursor.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cursorFromEvent, cursorFromNow, fromStored, toStored } from './cursor';
+
+describe('cursor', () => {
+  it('cursorFromNow starts at the current time with an empty tiebreaker', () => {
+    const before = Date.now();
+    const [ts, id] = cursorFromNow();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(id).toBe('');
+  });
+
+  it('round-trips through the stored (Task Manager state) form', () => {
+    expect(toStored([123, 'abc'])).toEqual({ ts: 123, id: 'abc' });
+    expect(fromStored({ ts: 123, id: 'abc' })).toEqual([123, 'abc']);
+  });
+
+  it('treats a null/undefined stored cursor as no position', () => {
+    expect(toStored(null)).toBeNull();
+    expect(fromStored(null)).toBeNull();
+    expect(fromStored(undefined)).toBeNull();
+  });
+
+  it('builds a cursor from an event timestamp and id', () => {
+    expect(cursorFromEvent('1970-01-01T00:00:01.000Z', 'evt-1')).toEqual([1000, 'evt-1']);
+  });
+});

--- a/x-pack/platform/plugins/shared/event_bus/server/tail/cursor.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/tail/cursor.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * A tail cursor is exactly the `sort` values of the last consumed document:
+ * `[@timestamp epoch millis, event.id]`. It is plain data, so it can live in
+ * memory (ephemeral) or be persisted in Task Manager state (durable), and
+ * resumed at any time. It is used as an exclusive `search_after`, so the next
+ * read resumes at the event *after* the cursor (no re-delivery).
+ */
+export type Cursor = [number, string];
+
+/** Serializable form of a cursor for Task Manager state. */
+export interface StoredCursor {
+  ts: number;
+  id: string;
+}
+
+/**
+ * Cursor positioned at "now": `search_after` of `[now, '']` returns only
+ * documents indexed at or after now (an empty-string id sorts before any real
+ * UUIDv7). This is the ephemeral default (at-most-once, start fresh on boot).
+ */
+export const cursorFromNow = (): Cursor => [Date.now(), ''];
+
+export const toStored = (cursor: Cursor | null): StoredCursor | null =>
+  cursor ? { ts: cursor[0], id: cursor[1] } : null;
+
+export const fromStored = (stored: StoredCursor | null | undefined): Cursor | null =>
+  stored ? [stored.ts, stored.id] : null;
+
+/** Build the cursor for an event from its delivered fields. */
+export const cursorFromEvent = (timestamp: string, id: string): Cursor => [
+  Date.parse(timestamp),
+  id,
+];

--- a/x-pack/platform/plugins/shared/event_bus/server/tail/node_tail_loop.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/tail/node_tail_loop.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { BROADCAST_TARGET } from '../types';
+import type { SubscriptionRegistry } from '../subscription_registry';
+import type { EsNames } from '../es/names';
+import { cursorFromNow, type Cursor } from './cursor';
+import { readBatch } from './tail_reader';
+
+export interface NodeTailLoopDeps {
+  esClient: ElasticsearchClient;
+  names: EsNames;
+  nodeId: string;
+  registry: SubscriptionRegistry;
+  logger: Logger;
+  pollIntervalMs: number;
+  safetyLagMs: number;
+  batchSize: number;
+}
+
+/**
+ * The single ephemeral tail loop per node (M1 single-node, M2 broadcast vs
+ * directed). One shared `search_after` loop reads the union of all local
+ * ephemeral subscribers' types filtered to `target ∈ {all, thisNodeId}`, then
+ * dispatches each event to the matching handlers. In-memory cursor starting at
+ * "now" → at-most-once across restart.
+ */
+export class NodeTailLoop {
+  private running = false;
+  private cursor: Cursor | null = null;
+  private controller = new AbortController();
+  private sleepTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(private readonly deps: NodeTailLoopDeps) {}
+
+  public start(): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.cursor = cursorFromNow();
+    this.controller = new AbortController();
+    void this.loop();
+  }
+
+  public stop(): void {
+    this.running = false;
+    this.controller.abort();
+    if (this.sleepTimer) {
+      clearTimeout(this.sleepTimer);
+    }
+  }
+
+  private buildFilter(): estypes.QueryDslQueryContainer[] {
+    return [
+      { terms: { target: [BROADCAST_TARGET, this.deps.nodeId] } },
+      { terms: { 'event.type': this.deps.registry.ephemeralTypes() } },
+    ];
+  }
+
+  private async loop(): Promise<void> {
+    const { esClient, names, registry, logger, pollIntervalMs, safetyLagMs, batchSize } = this.deps;
+
+    while (this.running) {
+      try {
+        if (!registry.hasEphemeral()) {
+          await this.sleep(pollIntervalMs);
+          continue;
+        }
+
+        const { events, nextCursor, hasMore } = await readBatch({
+          esClient,
+          index: names.dataStream,
+          filter: this.buildFilter(),
+          cursor: this.cursor,
+          startTs: this.cursor ? this.cursor[0] : Date.now(),
+          safetyLagMs,
+          batchSize,
+          signal: this.controller.signal,
+        });
+
+        for (const event of events) {
+          await registry.dispatchEphemeral(event, logger);
+        }
+        // Advance regardless of individual handler outcomes (at-most-once).
+        this.cursor = nextCursor;
+
+        if (!hasMore) {
+          await this.sleep(pollIntervalMs);
+        }
+      } catch (err) {
+        if (this.running) {
+          logger.error(`event bus node tail loop error: ${err.message}`);
+          await this.sleep(pollIntervalMs);
+        }
+      }
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.sleepTimer = setTimeout(resolve, ms);
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/event_bus/server/tail/tail_reader.test.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/tail/tail_reader.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { readBatch } from './tail_reader';
+
+const hit = (ts: number, id: string, type = 'rule.created') => ({
+  _source: {
+    '@timestamp': new Date(ts).toISOString(),
+    event: { id, type },
+    target: 'all',
+    source: 'node-a',
+    payload: { hello: 'world' },
+  },
+  sort: [ts, id],
+});
+
+const makeEsClient = (hits: ReturnType<typeof hit>[]) => {
+  const search = jest.fn().mockResolvedValue({ hits: { hits } });
+  return { esClient: { search } as unknown as ElasticsearchClient, search };
+};
+
+describe('readBatch', () => {
+  const NOW = 10_000;
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('applies the safety lag as an @timestamp upper bound and prunes with a lower bound', async () => {
+    const { esClient, search } = makeEsClient([]);
+
+    await readBatch({
+      esClient,
+      index: '.kibana-event-bus-ds',
+      filter: [{ terms: { 'event.type': ['rule.created'] } }],
+      cursor: [5_000, 'evt-5'],
+      startTs: 0,
+      safetyLagMs: 2_000,
+      batchSize: 500,
+      signal: undefined,
+    });
+
+    const [request, options] = search.mock.calls[0];
+    expect(request.track_total_hits).toBe(false);
+    expect(request.size).toBe(500);
+    expect(request.sort).toEqual([{ '@timestamp': 'asc' }, { 'event.id': 'asc' }]);
+    expect(request.search_after).toEqual([5_000, 'evt-5']);
+    expect(request.query.bool.filter[0]).toEqual({
+      range: {
+        '@timestamp': { gte: 5_000, lte: NOW - 2_000 },
+      },
+    });
+    // user filters are preserved after the range filter
+    expect(request.query.bool.filter[1]).toEqual({ terms: { 'event.type': ['rule.created'] } });
+    expect(options).toEqual({ signal: undefined });
+  });
+
+  it('starts from startTs (with empty tiebreaker) when there is no cursor', async () => {
+    const { esClient, search } = makeEsClient([]);
+
+    await readBatch({
+      esClient,
+      index: '.kibana-event-bus-ds',
+      filter: [],
+      cursor: null,
+      startTs: 4_242,
+      safetyLagMs: 0,
+      batchSize: 10,
+    });
+
+    const [request] = search.mock.calls[0];
+    expect(request.search_after).toEqual([4_242, '']);
+    expect(request.query.bool.filter[0].range['@timestamp'].gte).toBe(4_242);
+  });
+
+  it('maps hits to BusEvents and derives the next cursor from the last hit', async () => {
+    const { esClient } = makeEsClient([hit(6_000, 'evt-6'), hit(7_000, 'evt-7')]);
+
+    const result = await readBatch({
+      esClient,
+      index: '.kibana-event-bus-ds',
+      filter: [],
+      cursor: null,
+      startTs: 0,
+      safetyLagMs: 0,
+      batchSize: 500,
+    });
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0]).toEqual({
+      id: 'evt-6',
+      type: 'rule.created',
+      target: 'all',
+      source: 'node-a',
+      space: undefined,
+      partition: undefined,
+      payload: { hello: 'world' },
+      timestamp: new Date(6_000).toISOString(),
+    });
+    expect(result.nextCursor).toEqual([7_000, 'evt-7']);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('reports hasMore and keeps the previous cursor when the batch is empty', async () => {
+    const { esClient } = makeEsClient(
+      Array.from({ length: 3 }, (_, i) => hit(1_000 + i, `evt-${i}`))
+    );
+
+    const full = await readBatch({
+      esClient,
+      index: '.kibana-event-bus-ds',
+      filter: [],
+      cursor: null,
+      startTs: 0,
+      safetyLagMs: 0,
+      batchSize: 3,
+    });
+    expect(full.hasMore).toBe(true);
+
+    const { esClient: emptyClient } = makeEsClient([]);
+    const empty = await readBatch({
+      esClient: emptyClient,
+      index: '.kibana-event-bus-ds',
+      filter: [],
+      cursor: [9, 'evt-last'],
+      startTs: 0,
+      safetyLagMs: 0,
+      batchSize: 3,
+    });
+    expect(empty.events).toEqual([]);
+    expect(empty.nextCursor).toEqual([9, 'evt-last']);
+    expect(empty.hasMore).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/event_bus/server/tail/tail_reader.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/tail/tail_reader.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { BusEvent } from '../types';
+import type { Cursor } from './cursor';
+
+/** Raw datastream document shape. */
+interface EventBusDoc {
+  '@timestamp': string;
+  event: { id: string; type: string };
+  target: string | string[];
+  source: string;
+  space?: string;
+  partition?: string;
+  payload: unknown;
+}
+
+export interface ReadBatchParams {
+  esClient: ElasticsearchClient;
+  index: string;
+  /** Consumer-specific filters (target, event.type, ...). */
+  filter: estypes.QueryDslQueryContainer[];
+  /** Current position, or null to start from `startTs`. */
+  cursor: Cursor | null;
+  /** Fallback lower bound (epoch millis) when there is no cursor yet. */
+  startTs: number;
+  /** Safety lag Δ in millis; only events with `@timestamp <= now - Δ` are read. */
+  safetyLagMs: number;
+  batchSize: number;
+  signal?: AbortSignal;
+}
+
+export interface ReadBatchResult {
+  events: Array<BusEvent<unknown>>;
+  /** Position after the last returned event (unchanged if none returned). */
+  nextCursor: Cursor | null;
+  /** True if the batch was full — call again immediately to keep draining. */
+  hasMore: boolean;
+}
+
+const SORT: estypes.Sort = [{ '@timestamp': 'asc' }, { 'event.id': 'asc' }];
+
+const toBusEvent = (source: EventBusDoc): BusEvent<unknown> => ({
+  id: source.event.id,
+  type: source.event.type,
+  target: source.target,
+  source: source.source,
+  space: source.space,
+  partition: source.partition,
+  payload: source.payload,
+  timestamp: source['@timestamp'],
+});
+
+/**
+ * Reads one batch from the datastream using range-filtered `search_after`.
+ *
+ * The explicit `@timestamp` range is a correctness/perf requirement, not an
+ * optimization: the `lte: now - Δ` bound is the safety lag that stops the
+ * cursor from skipping documents made searchable slightly out of order, and
+ * the `gte` bound lets ES prune old backing indices/segments (search_after
+ * alone does not). `track_total_hits: false` avoids counting on every poll.
+ * Numeric bounds are interpreted by ES as epoch-millis on the date field.
+ */
+export const readBatch = async ({
+  esClient,
+  index,
+  filter,
+  cursor,
+  startTs,
+  safetyLagMs,
+  batchSize,
+  signal,
+}: ReadBatchParams): Promise<ReadBatchResult> => {
+  const nowMinusLag = Date.now() - safetyLagMs;
+  const lowerBoundTs = cursor ? cursor[0] : startTs;
+  const searchAfter: Cursor = cursor ?? [startTs, ''];
+
+  const response = await esClient.search<EventBusDoc>(
+    {
+      index,
+      size: batchSize,
+      track_total_hits: false,
+      sort: SORT,
+      search_after: searchAfter,
+      query: {
+        bool: {
+          filter: [
+            {
+              range: {
+                '@timestamp': {
+                  gte: lowerBoundTs,
+                  lte: nowMinusLag,
+                },
+              },
+            },
+            ...filter,
+          ],
+        },
+      },
+    },
+    { signal }
+  );
+
+  const hits = response.hits.hits;
+  const events = hits
+    .map((hit) => hit._source)
+    .filter((source): source is EventBusDoc => source != null)
+    .map(toBusEvent);
+
+  const lastSort = hits.length ? hits[hits.length - 1].sort : undefined;
+  const nextCursor: Cursor | null =
+    lastSort && lastSort.length >= 2 ? [Number(lastSort[0]), String(lastSort[1])] : cursor;
+
+  return {
+    events,
+    nextCursor,
+    hasMore: hits.length === batchSize,
+  };
+};

--- a/x-pack/platform/plugins/shared/event_bus/server/types.ts
+++ b/x-pack/platform/plugins/shared/event_bus/server/types.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ObjectType } from '@kbn/config-schema';
+
+/** `target` value that delivers an event to every node (broadcast). */
+export const BROADCAST_TARGET = 'all';
+
+export interface EventTypeDefinition {
+  /** Topic, e.g. `rule.created`. Subscribers filter on this. */
+  type: string;
+  /** Optional payload schema, validated at publish time. */
+  schema?: ObjectType;
+}
+
+export interface PublishEventParams<Payload = unknown> {
+  type: string;
+  payload: Payload;
+  /**
+   * `'all'` (broadcast, default) or a specific node id / list of node ids
+   * (directed). Directed delivery has no failover: if the target node is gone
+   * by the time the event is published, no one processes it.
+   */
+  target?: string | string[];
+  /** Space id, carried on the event for space-aware handlers. */
+  space?: string;
+  /** Optional routing key for per-partition ordering (future, multi-shard). */
+  partition?: string;
+}
+
+/** An event as delivered to a subscriber handler. */
+export interface BusEvent<Payload = unknown> {
+  /** Unique, time-ordered id (UUIDv7). Idempotency key for handlers. */
+  id: string;
+  type: string;
+  target: string | string[];
+  /** Publishing node id. */
+  source: string;
+  space?: string;
+  partition?: string;
+  payload: Payload;
+  /** ISO timestamp assigned at publish. */
+  timestamp: string;
+}
+
+export type EventHandler<Payload = unknown> = (event: BusEvent<Payload>) => Promise<void> | void;
+
+export interface SubscribeOptions {
+  /** Event types this subscription is interested in. */
+  types: string[];
+  /**
+   * Stable logical consumer id. Required for durable subscriptions; the cursor
+   * is persisted per consumer, not per node.
+   */
+  consumer?: string;
+  /**
+   * `true` = at-least-once durable consumer backed by a Task Manager task with
+   * a persisted cursor (single-runner with failover). `false`/omitted =
+   * at-most-once ephemeral per-node subscriber starting from "now".
+   */
+  durable?: boolean;
+}
+
+export interface Subscription {
+  unsubscribe: () => void;
+}
+
+export interface EventBusSetup {
+  registerEventType: (definition: EventTypeDefinition) => void;
+}
+
+export interface EventBusStart {
+  publish: <Payload = unknown>(event: PublishEventParams<Payload>) => Promise<void>;
+  subscribe: <Payload = unknown>(
+    options: SubscribeOptions,
+    handler: EventHandler<Payload>
+  ) => Subscription;
+}

--- a/x-pack/platform/plugins/shared/event_bus/tsconfig.json
+++ b/x-pack/platform/plugins/shared/event_bus/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+  },
+  "include": [
+    "server/**/*",
+  ],
+  "kbn_references": [
+    "@kbn/core",
+    "@kbn/config-schema",
+    "@kbn/task-manager-plugin",
+    "@kbn/core-test-helpers-kbn-server",
+    "@kbn/core-lifecycle-server-internal",
+  ],
+  "exclude": [
+    "target/**/*",
+  ]
+}

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -205,6 +205,7 @@ export default function ({ getService }: FtrProviderContext) {
         'entity_store:v2:extract_entity_task:user',
         'entity_store:v2:history_snapshot_task',
         'entity_store:v2:status_report_task',
+        'event_bus:durable_consumer',
         'fleet:agent-status-change-task',
         'fleet:agentless-deployment-sync-task',
         'fleet:auto-install-content-packages-task',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7186,6 +7186,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/event-bus-plugin@link:x-pack/platform/plugins/shared/event_bus":
+  version "0.0.0"
+  uid ""
+
 "@kbn/event-log-fixture-plugin@link:x-pack/platform/test/plugin_api_integration/plugins/event_log":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

Experimental `eventBus` server plugin providing **cross-node publish/subscribe** for Kibana, using **Elasticsearch as the only transport**: events are appended to a datastream and each consumer reads forward from its own offset (a Kafka-style shared log). No external broker, so it works on every deployment model (serverless, ECH, self-managed, air-gapped). Not yet wired into any consumer — this is a prototype for design validation.

Plugin id: `eventBus` · owner: `@elastic/response-ops` · server-only · depends on `taskManager`.

## How it works

**Transport — one append-only datastream.**
Each `publish()` writes a single document (`op_type: create`, UUIDv7 `_id`) into a datastream managed by a composable index template with **DSL retention** (default `7d`, single shard, `payload` stored but not indexed). The doc carries `@timestamp`, `event.type`, `target`, `source` (publishing node id), `space`, `partition`, and `payload`.

**Reading — a forward tail with a safety lag.**
Consumers aren't pushed to; they *tail* the datastream:
- A sorted `search_after` scan over `@timestamp` + id (tiebreak) walks events in order and stores only a small cursor `[timestamp, id]`.
- The scan is bounded to `@timestamp <= now - safetyLag (Δ)`. Δ (default `2s`) prevents skipping documents that become searchable slightly out of order (refresh delay, indexing reorder, minor cross-node clock skew). It trades a little latency for not losing events.
- `track_total_hits: false` plus the range floor let ES prune old backing indices cheaply.

**Two consumption modes.**

| | Ephemeral (default) | Durable (`durable: true`) |
|---|---|---|
| Runs on | **every node** (one shared tail loop per node) | exactly **one** logical consumer, cluster-wide |
| Cursor | in-memory, starts at *"now"* | persisted per `consumer` in Task Manager task state |
| Delivery | **at-most-once** (cursor lost on restart, no backlog) | **at-least-once** (survives restarts; single-runner with failover) |
| Backed by | the node tail loop | a recurring Task Manager task |
| Good for | cache invalidation, live UI refresh, best-effort fan-out | work that must not be dropped (handlers must be idempotent) |

- **Broadcast** (`target: 'all'`, the default): every node's tail loop matches, so every ephemeral subscriber on every node runs.
- **Directed** (`target: <nodeId>` or `string[]`): only that node's loop matches. No failover — if the node is gone when the event is published, nobody processes it.
- The **durable** task reads exactly one bounded batch per run, dispatches, then persists the advanced cursor in task state. It never loops forever and never throws, because Task Manager discards state on timeout — so the cursor always advances safely. At-least-once ⇒ dedupe on `event.id`.
- Handlers are dispatched with per-handler isolation (one throwing handler can't block the others or stall the cursor).

## How to use it

**1. Depend on the plugin** (`kibana.jsonc`):

```jsonc
"requiredPlugins": ["eventBus"]
```

**2. Register event types in `setup`** (validated at publish time):

```ts
import { schema } from '@kbn/config-schema';
import type { EventBusSetup } from '@kbn/event-bus-plugin/server';

public setup(core, { eventBus }: { eventBus: EventBusSetup }) {
  eventBus.registerEventType({
    type: 'rule.created',
    schema: schema.object({ ruleId: schema.string() }), // optional payload schema
  });
}
```

**3. Publish from `start`:**

```ts
import type { EventBusStart } from '@kbn/event-bus-plugin/server';

public start(core, { eventBus }: { eventBus: EventBusStart }) {
  // broadcast (default target: 'all')
  await eventBus.publish({ type: 'rule.created', payload: { ruleId: 'abc' } });

  // directed to a specific node
  await eventBus.publish({ type: 'cache.invalidate', payload: { key }, target: nodeId });
}
```

**4a. Subscribe — ephemeral (at-most-once, every node, from "now"):**

```ts
const sub = eventBus.subscribe<{ ruleId: string }>(
  { types: ['rule.created'] },
  async (event) => {
    // event: { id, type, target, source, space?, partition?, payload, timestamp }
    logger.info(`rule ${event.payload.ruleId} created on ${event.source}`);
  }
);
// later
sub.unsubscribe();
```

**4b. Subscribe — durable (at-least-once, cluster-wide, persisted cursor):**

```ts
eventBus.subscribe(
  { types: ['rule.created'], consumer: 'myPlugin.ruleIndexer', durable: true },
  async (event) => {
    // may be delivered more than once — make it idempotent (dedupe on event.id)
    await index(event.id, event.payload);
  }
);
```

`consumer` is required for durable subscriptions: the cursor is persisted per consumer id (not per node), which is what enables failover and at-least-once delivery.

### Configuration (`kibana.yml`, all optional)

| Setting | Default | Purpose |
|---|---|---|
| `xpack.eventBus.pollInterval` | `1s` | ephemeral tail poll interval (latency floor) |
| `xpack.eventBus.safetyLag` | `2s` | Δ; only consume events older than this |
| `xpack.eventBus.batchSize` | `1000` | max events read per poll |
| `xpack.eventBus.retention` | `7d` | DSL retention on the transport datastream |
| `xpack.eventBus.durable.pollInterval` | `3s` | durable consumer task interval (latency floor) |

## Testing

- **Unit** (18 tests): index template, cursor math, tail-reader query shape, subscription-registry isolation.
- **Integration** (`jest_integration`, real ES + Kibana): M0–M3 end-to-end — resource/mapping install, publish→tail round trip, broadcast vs directed filtering, and durable cursor resume with no gap / no duplicate.
- `type_check` + `eslint` clean.

## Known limitations / not in scope

- No backlog replay for ephemeral subscribers (they start at "now"); no `fromNow`/replay API yet.
- `space` is carried on events but not yet used for filtering.
- Directed delivery has no node discovery or "target gone" handling.
- No poison-event / DLQ handling for durable consumers.
- Single shard: ordering is global but throughput is bounded (the `partition` field is a placeholder for future multi-shard ordering).

### Checklist

- [ ] CI green (checks, unit, integration)
- [ ] Regenerate CODEOWNERS / apply release-note + team labels