### PR TITLE
[9.5] [Security Solution][OneDiscover] Prevent duplicate risk inputs flyout telemetry (#281130)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
@@ -15,6 +15,8 @@ import {
 import { HostDetailsPanelKey } from '../../host_details_left';
 import { createTelemetryServiceMock } from '../../../../common/lib/telemetry/telemetry_service.mock';
 import { HostPanelKey } from '../../shared/constants';
+import { EntityEventTypes } from '../../../../common/lib/telemetry';
+import { EntityType } from '../../../../../common/search_strategy';
 
 jest.mock('@kbn/expandable-flyout');
 
@@ -66,8 +68,14 @@ describe('useNavigateToHostDetails', () => {
   it('returns callback that opens details panel when not in preview mode', () => {
     const { result } = renderHook(() => useNavigateToHostDetails(mockProps));
 
+    expect(mockedTelemetry.reportEvent).not.toHaveBeenCalled();
+
     result.current({ tab, subTab });
 
+    expect(mockedTelemetry.reportEvent).toHaveBeenCalledWith(
+      EntityEventTypes.RiskInputsExpandedFlyoutOpened,
+      { entity: EntityType.host }
+    );
     expect(mockOpenLeftPanel).toHaveBeenCalledWith({
       id: HostDetailsPanelKey,
       params: {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.ts
@@ -42,12 +42,12 @@ export const useNavigateToHostDetails = ({
   const { telemetry } = useKibana().services;
   const { openLeftPanel, openFlyout } = useExpandableFlyoutApi();
 
-  telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
-    entity: EntityType.host,
-  });
-
   return useCallback(
     (path?: EntityDetailsPath) => {
+      telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
+        entity: EntityType.host,
+      });
+
       const left = {
         id: HostDetailsPanelKey,
         params: {
@@ -92,6 +92,7 @@ export const useNavigateToHostDetails = ({
       hasNonClosedAlerts,
       contextID,
       entityStoreEntityId,
+      telemetry,
     ]
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Security Solution][OneDiscover] Prevent duplicate risk inputs flyout telemetry (#281130)](https://github.com/elastic/kibana/pull/281130)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-27T19:23:54Z","message":"[Security Solution][OneDiscover] Prevent duplicate risk inputs flyout telemetry (#281130)\n\n## Summary\n\nEntityEventTypes.RiskInputsExpandedFlyoutOpened was being spammed\n(especially in within discover) and sending erroneous logs when the v2\nflyout is opened. It should only be sent in v1.\n\n- Reports `RiskInputsExpandedFlyoutOpened` only when the v1 host details\nflyout navigation callback runs.\n- Prevents v2 flyout renders from repeatedly emitting the v1 event.\n- Adds unit coverage confirming render does not report the event and\nnavigation does.\n\n### Testing\n1. Look at the telemetry network calls when opening a v2 flyout (either\nfrom discover or security solution).\n2. Check that `EntityEventTypes.RiskInputsExpandedFlyoutOpened`\nevent_type is no longer sent\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/bdf07c99-bd5f-4464-85a8-7acb06250c2f\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/d6973a60-3554-4451-988e-cd2362070e9b\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"c0ed0a12775743f28f13989d2d7bfd9ed349e245","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team: SecuritySolution","telemetry","backport:version","v9.5.0","OneDiscover","v9.6.0"],"title":"[Security Solution][OneDiscover] Prevent duplicate risk inputs flyout telemetry","number":281130,"url":"https://github.com/elastic/kibana/pull/281130","mergeCommit":{"message":"[Security Solution][OneDiscover] Prevent duplicate risk inputs flyout telemetry (#281130)\n\n## Summary\n\nEntityEventTypes.RiskInputsExpandedFlyoutOpened was being spammed\n(especially in within discover) and sending erroneous logs when the v2\nflyout is opened. It should only be sent in v1.\n\n- Reports `RiskInputsExpandedFlyoutOpened` only when the v1 host details\nflyout navigation callback runs.\n- Prevents v2 flyout renders from repeatedly emitting the v1 event.\n- Adds unit coverage confirming render does not report the event and\nnavigation does.\n\n### Testing\n1. Look at the telemetry network calls when opening a v2 flyout (either\nfrom discover or security solution).\n2. Check that `EntityEventTypes.RiskInputsExpandedFlyoutOpened`\nevent_type is no longer sent\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/bdf07c99-bd5f-4464-85a8-7acb06250c2f\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/d6973a60-3554-4451-988e-cd2362070e9b\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"c0ed0a12775743f28f13989d2d7bfd9ed349e245"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281130","number":281130,"mergeCommit":{"message":"[Security Solution][OneDiscover] Prevent duplicate risk inputs flyout telemetry (#281130)\n\n## Summary\n\nEntityEventTypes.RiskInputsExpandedFlyoutOpened was being spammed\n(especially in within discover) and sending erroneous logs when the v2\nflyout is opened. It should only be sent in v1.\n\n- Reports `RiskInputsExpandedFlyoutOpened` only when the v1 host details\nflyout navigation callback runs.\n- Prevents v2 flyout renders from repeatedly emitting the v1 event.\n- Adds unit coverage confirming render does not report the event and\nnavigation does.\n\n### Testing\n1. Look at the telemetry network calls when opening a v2 flyout (either\nfrom discover or security solution).\n2. Check that `EntityEventTypes.RiskInputsExpandedFlyoutOpened`\nevent_type is no longer sent\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/bdf07c99-bd5f-4464-85a8-7acb06250c2f\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/d6973a60-3554-4451-988e-cd2362070e9b\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"c0ed0a12775743f28f13989d2d7bfd9ed349e245"}}]}] BACKPORT-->