### PR TITLE
Use rspack optimizer for River prebuild warmup

### DIFF
--- a/.river/warm.sh
+++ b/.river/warm.sh
@@ -67,7 +67,10 @@ for attempt in $(seq 1 60); do
 done
 
 echo "=== Starting Kibana ==="
-NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--max-old-space-size=8192" \
+# Use the rspack optimizer: a single unified compilation instead of multiple
+# webpack worker processes, which OOM-kill on memory-constrained VMs.
+KBN_USE_RSPACK=true \
+  NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--max-old-space-size=8192" \
   yarn start --no-base-path --server.host=0.0.0.0 >target/river-kibana-warmup.log 2>&1 &
 KIBANA_PID=$!
 


### PR DESCRIPTION
## Summary

The River prebuild warmup (`.river/warm.sh`) consistently failed on the 10 vCPU / 20 GB prebuild VM with:

```
[@kbn/optimizer] fatal error  Error: worker exitted unexpectedly with code null
```

`code null` means the worker was killed by a signal — the Linux OOM killer. The webpack optimizer forks ~5 worker processes (half the vCPUs), and each inherits the `NODE_OPTIONS=--max-old-space-size=8192` set for the Kibana server, so combined with Elasticsearch and the Kibana server the VM runs out of memory partway through the 226 initial bundle builds.

This switches the warmup to the rspack optimizer (`KBN_USE_RSPACK=true`), which runs a single unified compilation in one process instead of multiple webpack workers, staying well within the VM's memory budget and completing faster.

### Checklist

- [x] This change only affects the River prebuild warmup script; no runtime Kibana behavior changes.