### PR TITLE
[9.5] [Osquery] Fix disabled pack still executing on agents post-upgrade (#279252)

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/server/lib/update_global_packs.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/update_global_packs.test.ts
@@ -260,4 +260,50 @@ describe('updateGlobalPacksCreateCallback', () => {
       },
     });
   });
+
+  it('should NOT attach a disabled global pack to a newly created package policy', async () => {
+    // Regression for #279224: a disabled global pack must not be re-scheduled
+    // onto a new agent when the osquery integration is added.
+    const disabledGlobalPack: PackSavedObject = {
+      name: 'disabled-global-pack',
+      description: 'A disabled global pack',
+      enabled: false,
+      queries: [
+        {
+          id: 'query1',
+          name: 'query1',
+          query: 'SELECT * FROM processes;',
+          interval: 3600,
+        },
+      ],
+      shards: [{ key: '*', value: 100 }],
+      saved_object_id: 'pack-so-id-disabled',
+      created_at: '2024-01-01T00:00:00.000Z',
+      created_by: 'test-user',
+      updated_at: '2024-01-01T00:00:00.000Z',
+      updated_by: 'test-user',
+      references: [],
+    };
+
+    const newPackagePolicy: NewPackagePolicy = {
+      name: 'osquery-integration',
+      namespace: 'default',
+      description: '',
+      package: { name: 'osquery_manager', title: 'Osquery Manager', version: '1.0.0' },
+      enabled: true,
+      policy_ids: ['policy-1'],
+      inputs: [],
+    };
+
+    const result = await updateGlobalPacksCreateCallback(
+      newPackagePolicy,
+      mockPacksClient,
+      [disabledGlobalPack],
+      mockOsqueryContext
+    );
+
+    expect(mockPacksClient.update).not.toHaveBeenCalled();
+    expect(result).toEqual(newPackagePolicy);
+    expect(result.inputs[0]?.config?.osquery?.value?.packs).toBeUndefined();
+  });
 });

--- a/x-pack/platform/plugins/shared/osquery/server/lib/update_global_packs.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/update_global_packs.ts
@@ -38,6 +38,16 @@ export const updateGlobalPacksCreateCallback = async (
 
   const packsContainingShardForPolicy: PackSavedObject[] = [];
   allPacks.map((pack) => {
+    // Never (re)attach a disabled global pack to a newly created package policy;
+    // otherwise enrolling a new agent silently re-schedules a pack the user
+    // already turned off. Fail closed on a falsy `enabled` — an unset
+    // (`undefined`) `enabled` is intentionally treated as "do not attach",
+    // matching how create_pack_route (`if (enabled && ...)`) and the reconciler
+    // (`pack.attributes.enabled && ...`) gate wire writes.
+    if (!pack.enabled) {
+      return;
+    }
+
     const shards = convertShardsToObject(pack.shards);
 
     return map(shards, (shard, shardName) => {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/pack/update_pack_route.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/pack/update_pack_route.test.ts
@@ -2497,4 +2497,611 @@ describe('updatePackRoute', () => {
       expect(Object.keys(writtenPacks)).toEqual(['default--renamed-pack']);
     });
   });
+
+  describe('disable branch — removes from every wire-attached package policy', () => {
+    // Regression for #279224: post-upgrade (9.4.3 → 9.5.0) the wire attachments
+    // and the pack SO references can diverge. Disable must scan the wire
+    // (policyHasPack), not the references, or the pack keeps running on agents
+    // while the SO reads `enabled: false`.
+    const buildDisableClient = (currentSO: typeof basePackSO) => {
+      const updatedSO = {
+        ...currentSO,
+        attributes: { ...currentSO.attributes, enabled: false },
+      };
+      let getCallCount = 0;
+
+      return {
+        get: jest.fn().mockImplementation(() => {
+          getCallCount += 1;
+
+          return Promise.resolve(getCallCount === 1 ? currentSO : updatedSO);
+        }),
+        find: jest.fn().mockResolvedValue({ saved_objects: [] }),
+        update: jest.fn().mockResolvedValue({
+          id: 'pack-id',
+          attributes: updatedSO.attributes,
+          references: currentSO.references,
+        }),
+        list: jest.fn().mockResolvedValue({ items: [] }),
+      };
+    };
+
+    const buildWirePolicy = (id: string, policyIds: string[], packKey = 'default--my-pack') => ({
+      id,
+      policy_ids: policyIds,
+      package: { name: 'osquery_manager', version: '1.0.0' },
+      inputs: [
+        {
+          type: 'osquery',
+          streams: [],
+          config: {
+            osquery: {
+              value: {
+                packs: {
+                  [packKey]: {
+                    shard: 100,
+                    pack_id: 'pack-id',
+                    default_native_schedule: { interval: 60 },
+                    queries: {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const runDisable = async (currentSO: typeof basePackSO, wirePolicies: unknown[]) => {
+      const mockClient = buildDisableClient(currentSO);
+      const packagePolicyUpdate = jest.fn().mockResolvedValue({});
+      const packagePolicyList = jest.fn().mockResolvedValue({ items: wirePolicies });
+
+      (createInternalSavedObjectsClientForSpaceId as jest.Mock).mockResolvedValue(mockClient);
+
+      const mockRouter = createMockRouter();
+      mockOsqueryContext = {
+        logFactory: { get: jest.fn().mockReturnValue(loggingSystemMock.createLogger()) },
+        security: {},
+        getStartServices: jest.fn().mockResolvedValue([{}, { security: {} }, {}]),
+        experimentalFeatures: { rruleScheduling: true },
+        service: {
+          getActiveSpace: jest.fn().mockResolvedValue({ id: 'default' }),
+          getAgentPolicyService: jest.fn().mockReturnValue({
+            getByIds: jest.fn().mockResolvedValue([]),
+          }),
+          getPackagePolicyService: jest.fn().mockReturnValue({
+            list: packagePolicyList,
+            fetchAllItems: fetchAllItemsFromListMock(packagePolicyList),
+            update: packagePolicyUpdate,
+          }),
+        },
+      } as unknown as OsqueryAppContext;
+
+      updatePackRoute(mockRouter, mockOsqueryContext);
+      const route = mockRouter.versioned.getRoute('put', '/api/osquery/packs/{id}');
+      const routeVersion = route.versions[API_VERSIONS.public.v1];
+      if (!routeVersion) throw new Error('no route version');
+      routeHandler = routeVersion.handler;
+
+      const mockRequest = httpServerMock.createKibanaRequest({
+        params: { id: 'pack-id' },
+        body: { enabled: false },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(buildMockContext() as any, mockRequest, mockResponse);
+
+      return { packagePolicyUpdate, mockResponse };
+    };
+
+    it('removes the pack from a wire policy NOT covered by SO references (post-upgrade drift)', async () => {
+      const currentSO = {
+        ...basePackSO,
+        // Diverged: wire carries the pack but the SO no longer references the
+        // agent policy that owns the package policy.
+        references: [],
+        attributes: { ...basePackSO.attributes, name: 'my-pack', enabled: true },
+      };
+
+      const { packagePolicyUpdate, mockResponse } = await runDisable(currentSO, [
+        buildWirePolicy('package-policy-1', ['policy-1']),
+      ]);
+
+      expect(mockResponse.badRequest).not.toHaveBeenCalled();
+      expect(packagePolicyUpdate).toHaveBeenCalledTimes(1);
+
+      const [, , packagePolicyId, updatedPackagePolicy] = packagePolicyUpdate.mock.calls[0];
+      expect(packagePolicyId).toBe('package-policy-1');
+      const writtenPacks = updatedPackagePolicy.inputs[0].config.osquery.value.packs;
+      expect(writtenPacks).not.toHaveProperty('default--my-pack');
+    });
+
+    it('removes the pack from EVERY wire-attached policy (global/shard pack, empty references)', async () => {
+      const currentSO = {
+        ...basePackSO,
+        references: [],
+        attributes: {
+          ...basePackSO.attributes,
+          name: 'my-pack',
+          enabled: true,
+          shards: [{ key: '*', value: 100 }],
+        },
+      };
+
+      const { packagePolicyUpdate } = await runDisable(currentSO, [
+        buildWirePolicy('package-policy-1', ['policy-1']),
+        buildWirePolicy('package-policy-2', ['policy-2']),
+      ]);
+
+      expect(packagePolicyUpdate).toHaveBeenCalledTimes(2);
+      const updatedIds = packagePolicyUpdate.mock.calls.map((call) => call[2]).sort();
+      expect(updatedIds).toEqual(['package-policy-1', 'package-policy-2']);
+      packagePolicyUpdate.mock.calls.forEach((call) => {
+        const writtenPacks = call[3].inputs[0].config.osquery.value.packs;
+        expect(writtenPacks).not.toHaveProperty('default--my-pack');
+      });
+    });
+
+    it('still removes the pack when references are aligned with the wire (no regression)', async () => {
+      const currentSO = {
+        ...basePackSO,
+        references: [{ id: 'policy-1', name: 'policy-1', type: 'ingest-agent-policies' }],
+        attributes: { ...basePackSO.attributes, name: 'my-pack', enabled: true },
+      };
+
+      const { packagePolicyUpdate } = await runDisable(currentSO, [
+        buildWirePolicy('package-policy-1', ['policy-1']),
+      ]);
+
+      expect(packagePolicyUpdate).toHaveBeenCalledTimes(1);
+      const writtenPacks =
+        packagePolicyUpdate.mock.calls[0][3].inputs[0].config.osquery.value.packs;
+      expect(writtenPacks).not.toHaveProperty('default--my-pack');
+    });
+
+    it('updates a package policy shared by multiple agent policies exactly once', async () => {
+      const currentSO = {
+        ...basePackSO,
+        // Both owning agent policies are referenced, so the pre-fix
+        // reference-driven loop resolved the same shared package policy twice
+        // and wrote it twice. Keep them populated or this asserts the wire scan
+        // rather than the dedup.
+        references: [
+          { id: 'policy-1', name: 'policy-1', type: 'ingest-agent-policies' },
+          { id: 'policy-2', name: 'policy-2', type: 'ingest-agent-policies' },
+        ],
+        attributes: { ...basePackSO.attributes, name: 'my-pack', enabled: true },
+      };
+
+      // One package policy owned by two agent policies. The wire scan iterates
+      // package policies (not agent-policy references), so it must be updated a
+      // single time rather than once per owning agent policy.
+      const { packagePolicyUpdate } = await runDisable(currentSO, [
+        buildWirePolicy('shared-package-policy', ['policy-1', 'policy-2']),
+      ]);
+
+      expect(packagePolicyUpdate).toHaveBeenCalledTimes(1);
+      expect(packagePolicyUpdate.mock.calls[0][2]).toBe('shared-package-policy');
+      const writtenPacks =
+        packagePolicyUpdate.mock.calls[0][3].inputs[0].config.osquery.value.packs;
+      expect(writtenPacks).not.toHaveProperty('default--my-pack');
+    });
+
+    it('removes a pack stored on the wire under a legacy (unprefixed) key', async () => {
+      const currentSO = {
+        ...basePackSO,
+        references: [],
+        attributes: { ...basePackSO.attributes, name: 'my-pack', enabled: true },
+      };
+
+      // Pre-namespacing wire configs keyed packs by bare name (`my-pack`)
+      // rather than `default--my-pack`. Disable must clean these up too.
+      const { packagePolicyUpdate } = await runDisable(currentSO, [
+        buildWirePolicy('package-policy-1', ['policy-1'], 'my-pack'),
+      ]);
+
+      expect(packagePolicyUpdate).toHaveBeenCalledTimes(1);
+      const writtenPacks =
+        packagePolicyUpdate.mock.calls[0][3].inputs[0].config.osquery.value.packs;
+      expect(writtenPacks).not.toHaveProperty('my-pack');
+      expect(writtenPacks).not.toHaveProperty('default--my-pack');
+    });
+  });
+
+  describe('policy-diff branch — wire-based detach (drifted references)', () => {
+    const buildWirePolicyWithPack = (id: string, policyIds: string[]) => ({
+      id,
+      policy_ids: policyIds,
+      package: { name: 'osquery_manager', version: '1.0.0' },
+      inputs: [
+        {
+          type: 'osquery',
+          streams: [],
+          config: {
+            osquery: {
+              value: {
+                packs: {
+                  'default--my-pack': {
+                    shard: 100,
+                    pack_id: 'pack-id',
+                    default_native_schedule: { interval: 60 },
+                    queries: {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    it('detaches the pack from a wire policy no longer targeted even when SO references are stale', async () => {
+      const currentSO = {
+        ...basePackSO,
+        // Stale references: the wire carries the pack on two package policies,
+        // but the SO only references one agent policy (post-upgrade drift).
+        references: [{ id: 'policy-1', name: 'policy-1', type: 'ingest-agent-policies' }],
+        attributes: {
+          ...basePackSO.attributes,
+          name: 'my-pack',
+          enabled: true,
+          queries: [{ id: 'q1', name: 'q1', query: 'SELECT 1', interval: 60 }],
+          shards: [],
+          schedule_type: 'interval' as const,
+          interval: 60,
+          rrule_schedule: null,
+        },
+      };
+      const updatedSO = { ...currentSO };
+
+      let getCallCount = 0;
+      const mockClient = {
+        get: jest.fn().mockImplementation(() => {
+          getCallCount += 1;
+
+          return Promise.resolve(getCallCount === 1 ? currentSO : updatedSO);
+        }),
+        find: jest.fn().mockResolvedValue({ saved_objects: [] }),
+        update: jest.fn().mockResolvedValue({
+          id: 'pack-id',
+          attributes: updatedSO.attributes,
+          references: currentSO.references,
+        }),
+        list: jest.fn().mockResolvedValue({ items: [] }),
+      };
+
+      const packagePolicyUpdate = jest.fn().mockResolvedValue({});
+      const packagePolicyList = jest.fn().mockResolvedValue({
+        items: [
+          buildWirePolicyWithPack('package-policy-1', ['policy-1']),
+          // Drifted attachment: pack is on the wire but this agent policy is no
+          // longer targeted and is absent from the SO references.
+          buildWirePolicyWithPack('package-policy-2', ['policy-2']),
+        ],
+      });
+
+      (createInternalSavedObjectsClientForSpaceId as jest.Mock).mockResolvedValue(mockClient);
+
+      const mockRouter = createMockRouter();
+      mockOsqueryContext = {
+        logFactory: { get: jest.fn().mockReturnValue(loggingSystemMock.createLogger()) },
+        security: {},
+        getStartServices: jest.fn().mockResolvedValue([{}, { security: {} }, {}]),
+        experimentalFeatures: { rruleScheduling: true },
+        service: {
+          getActiveSpace: jest.fn().mockResolvedValue({ id: 'default' }),
+          getAgentPolicyService: jest.fn().mockReturnValue({
+            getByIds: jest.fn().mockResolvedValue([{ id: 'policy-1', name: 'policy-1' }]),
+          }),
+          getPackagePolicyService: jest.fn().mockReturnValue({
+            list: packagePolicyList,
+            fetchAllItems: fetchAllItemsFromListMock(packagePolicyList),
+            update: packagePolicyUpdate,
+          }),
+        },
+      } as unknown as OsqueryAppContext;
+
+      updatePackRoute(mockRouter, mockOsqueryContext);
+      const route = mockRouter.versioned.getRoute('put', '/api/osquery/packs/{id}');
+      const routeVersion = route.versions[API_VERSIONS.public.v1];
+      if (!routeVersion) throw new Error('no route version');
+      routeHandler = routeVersion.handler;
+
+      const mockRequest = httpServerMock.createKibanaRequest({
+        params: { id: 'pack-id' },
+        // `enabled` omitted (unchanged) so this hits the add/update/remove
+        // diff branch rather than the enable-flip branch.
+        body: { policy_ids: ['policy-1'] },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(buildMockContext() as any, mockRequest, mockResponse);
+
+      expect(mockResponse.badRequest).not.toHaveBeenCalled();
+
+      const callsById = new Map(
+        packagePolicyUpdate.mock.calls.map((call) => [call[2] as string, call[3]])
+      );
+      expect(callsById.has('package-policy-1')).toBe(true);
+      expect(callsById.has('package-policy-2')).toBe(true);
+
+      // Still-targeted policy keeps the pack on the wire.
+      expect(callsById.get('package-policy-1').inputs[0].config.osquery.value.packs).toHaveProperty(
+        'default--my-pack'
+      );
+
+      // Drifted, no-longer-targeted policy has the pack removed even though it
+      // was not reachable through the SO references.
+      expect(
+        callsById.get('package-policy-2').inputs[0].config.osquery.value.packs
+      ).not.toHaveProperty('default--my-pack');
+    });
+
+    it('keeps an enabled pack on the wire when an edit-only PUT hits the empty-reference drift state', async () => {
+      // Drift state: SO references are empty but the wire still carries the
+      // pack. An edit that never mentions policy_ids or shards is not a
+      // retarget request, so it must leave the wire alone — detaching here
+      // would unschedule an enabled pack on every agent.
+      const currentSO = {
+        ...basePackSO,
+        references: [],
+        attributes: {
+          ...basePackSO.attributes,
+          name: 'my-pack',
+          enabled: true,
+          queries: [{ id: 'q1', name: 'q1', query: 'SELECT 1', interval: 60 }],
+          shards: [],
+          schedule_type: 'interval' as const,
+          interval: 60,
+          rrule_schedule: null,
+        },
+      };
+      const updatedSO = { ...currentSO };
+
+      let getCallCount = 0;
+      const mockClient = {
+        get: jest.fn().mockImplementation(() => {
+          getCallCount += 1;
+
+          return Promise.resolve(getCallCount === 1 ? currentSO : updatedSO);
+        }),
+        find: jest.fn().mockResolvedValue({ saved_objects: [] }),
+        update: jest.fn().mockResolvedValue({
+          id: 'pack-id',
+          attributes: updatedSO.attributes,
+          references: currentSO.references,
+        }),
+        list: jest.fn().mockResolvedValue({ items: [] }),
+      };
+
+      const packagePolicyUpdate = jest.fn().mockResolvedValue({});
+      const packagePolicyList = jest.fn().mockResolvedValue({
+        items: [
+          buildWirePolicyWithPack('package-policy-1', ['policy-1']),
+          buildWirePolicyWithPack('package-policy-2', ['policy-2']),
+        ],
+      });
+
+      (createInternalSavedObjectsClientForSpaceId as jest.Mock).mockResolvedValue(mockClient);
+
+      const mockRouter = createMockRouter();
+      mockOsqueryContext = {
+        logFactory: { get: jest.fn().mockReturnValue(loggingSystemMock.createLogger()) },
+        security: {},
+        getStartServices: jest.fn().mockResolvedValue([{}, { security: {} }, {}]),
+        experimentalFeatures: { rruleScheduling: true },
+        service: {
+          getActiveSpace: jest.fn().mockResolvedValue({ id: 'default' }),
+          getAgentPolicyService: jest.fn().mockReturnValue({
+            getByIds: jest.fn().mockResolvedValue([]),
+          }),
+          getPackagePolicyService: jest.fn().mockReturnValue({
+            list: packagePolicyList,
+            fetchAllItems: fetchAllItemsFromListMock(packagePolicyList),
+            update: packagePolicyUpdate,
+          }),
+        },
+      } as unknown as OsqueryAppContext;
+
+      updatePackRoute(mockRouter, mockOsqueryContext);
+      const route = mockRouter.versioned.getRoute('put', '/api/osquery/packs/{id}');
+      const routeVersion = route.versions[API_VERSIONS.public.v1];
+      if (!routeVersion) throw new Error('no route version');
+      routeHandler = routeVersion.handler;
+
+      const mockRequest = httpServerMock.createKibanaRequest({
+        params: { id: 'pack-id' },
+        body: { description: 'edit-only-drifted-pack-probe' },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(buildMockContext() as any, mockRequest, mockResponse);
+
+      expect(mockResponse.badRequest).not.toHaveBeenCalled();
+      expect(packagePolicyUpdate).not.toHaveBeenCalled();
+    });
+
+    it('still detaches drifted policies when the request does ask to retarget', async () => {
+      // Counterpart to the guard above: an explicit `policy_ids: []` IS a
+      // retarget request, so the wire must be cleaned even though the resolved
+      // write-target set is empty.
+      const currentSO = {
+        ...basePackSO,
+        references: [],
+        attributes: {
+          ...basePackSO.attributes,
+          name: 'my-pack',
+          enabled: true,
+          queries: [{ id: 'q1', name: 'q1', query: 'SELECT 1', interval: 60 }],
+          shards: [],
+          schedule_type: 'interval' as const,
+          interval: 60,
+          rrule_schedule: null,
+        },
+      };
+      const updatedSO = { ...currentSO };
+
+      let getCallCount = 0;
+      const mockClient = {
+        get: jest.fn().mockImplementation(() => {
+          getCallCount += 1;
+
+          return Promise.resolve(getCallCount === 1 ? currentSO : updatedSO);
+        }),
+        find: jest.fn().mockResolvedValue({ saved_objects: [] }),
+        update: jest.fn().mockResolvedValue({
+          id: 'pack-id',
+          attributes: updatedSO.attributes,
+          references: currentSO.references,
+        }),
+        list: jest.fn().mockResolvedValue({ items: [] }),
+      };
+
+      const packagePolicyUpdate = jest.fn().mockResolvedValue({});
+      const packagePolicyList = jest.fn().mockResolvedValue({
+        items: [buildWirePolicyWithPack('package-policy-1', ['policy-1'])],
+      });
+
+      (createInternalSavedObjectsClientForSpaceId as jest.Mock).mockResolvedValue(mockClient);
+
+      const mockRouter = createMockRouter();
+      mockOsqueryContext = {
+        logFactory: { get: jest.fn().mockReturnValue(loggingSystemMock.createLogger()) },
+        security: {},
+        getStartServices: jest.fn().mockResolvedValue([{}, { security: {} }, {}]),
+        experimentalFeatures: { rruleScheduling: true },
+        service: {
+          getActiveSpace: jest.fn().mockResolvedValue({ id: 'default' }),
+          getAgentPolicyService: jest.fn().mockReturnValue({
+            getByIds: jest.fn().mockResolvedValue([]),
+          }),
+          getPackagePolicyService: jest.fn().mockReturnValue({
+            list: packagePolicyList,
+            fetchAllItems: fetchAllItemsFromListMock(packagePolicyList),
+            update: packagePolicyUpdate,
+          }),
+        },
+      } as unknown as OsqueryAppContext;
+
+      updatePackRoute(mockRouter, mockOsqueryContext);
+      const route = mockRouter.versioned.getRoute('put', '/api/osquery/packs/{id}');
+      const routeVersion = route.versions[API_VERSIONS.public.v1];
+      if (!routeVersion) throw new Error('no route version');
+      routeHandler = routeVersion.handler;
+
+      const mockRequest = httpServerMock.createKibanaRequest({
+        params: { id: 'pack-id' },
+        body: { policy_ids: [] },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(buildMockContext() as any, mockRequest, mockResponse);
+
+      expect(mockResponse.badRequest).not.toHaveBeenCalled();
+      expect(packagePolicyUpdate).toHaveBeenCalledTimes(1);
+      expect(packagePolicyUpdate.mock.calls[0][2]).toBe('package-policy-1');
+      expect(
+        packagePolicyUpdate.mock.calls[0][3].inputs[0].config.osquery.value.packs
+      ).not.toHaveProperty('default--my-pack');
+    });
+
+    it('keeps a global pack on the wire when the request omits policy_ids and shards', async () => {
+      // A global pack targets policies through its stored `*` shard, not
+      // through policy_ids. An edit-only PUT must not resolve to zero write
+      // targets and detach the pack from every agent.
+      const currentSO = {
+        ...basePackSO,
+        references: [],
+        attributes: {
+          ...basePackSO.attributes,
+          name: 'my-pack',
+          enabled: true,
+          queries: [{ id: 'q1', name: 'q1', query: 'SELECT 1', interval: 60 }],
+          shards: [{ key: '*', value: 100 }],
+          schedule_type: 'interval' as const,
+          interval: 60,
+          rrule_schedule: null,
+        },
+      };
+      const updatedSO = { ...currentSO };
+
+      let getCallCount = 0;
+      const mockClient = {
+        get: jest.fn().mockImplementation(() => {
+          getCallCount += 1;
+
+          return Promise.resolve(getCallCount === 1 ? currentSO : updatedSO);
+        }),
+        find: jest.fn().mockResolvedValue({ saved_objects: [] }),
+        update: jest.fn().mockResolvedValue({
+          id: 'pack-id',
+          attributes: updatedSO.attributes,
+          references: currentSO.references,
+        }),
+        list: jest.fn().mockResolvedValue({ items: [] }),
+      };
+
+      const packagePolicyUpdate = jest.fn().mockResolvedValue({});
+      const packagePolicyList = jest.fn().mockResolvedValue({
+        items: [
+          buildWirePolicyWithPack('package-policy-1', ['policy-1']),
+          buildWirePolicyWithPack('package-policy-2', ['policy-2']),
+        ],
+      });
+
+      (createInternalSavedObjectsClientForSpaceId as jest.Mock).mockResolvedValue(mockClient);
+
+      const mockRouter = createMockRouter();
+      mockOsqueryContext = {
+        logFactory: { get: jest.fn().mockReturnValue(loggingSystemMock.createLogger()) },
+        security: {},
+        getStartServices: jest.fn().mockResolvedValue([{}, { security: {} }, {}]),
+        experimentalFeatures: { rruleScheduling: true },
+        service: {
+          getActiveSpace: jest.fn().mockResolvedValue({ id: 'default' }),
+          getAgentPolicyService: jest.fn().mockReturnValue({
+            getByIds: jest.fn().mockResolvedValue([
+              { id: 'policy-1', name: 'policy-1' },
+              { id: 'policy-2', name: 'policy-2' },
+            ]),
+          }),
+          getPackagePolicyService: jest.fn().mockReturnValue({
+            list: packagePolicyList,
+            fetchAllItems: fetchAllItemsFromListMock(packagePolicyList),
+            update: packagePolicyUpdate,
+          }),
+        },
+      } as unknown as OsqueryAppContext;
+
+      updatePackRoute(mockRouter, mockOsqueryContext);
+      const route = mockRouter.versioned.getRoute('put', '/api/osquery/packs/{id}');
+      const routeVersion = route.versions[API_VERSIONS.public.v1];
+      if (!routeVersion) throw new Error('no route version');
+      routeHandler = routeVersion.handler;
+
+      const mockRequest = httpServerMock.createKibanaRequest({
+        params: { id: 'pack-id' },
+        body: { description: 'edit-only-global-pack-probe' },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(buildMockContext() as any, mockRequest, mockResponse);
+
+      expect(mockResponse.badRequest).not.toHaveBeenCalled();
+
+      const callsById = new Map(
+        packagePolicyUpdate.mock.calls.map((call) => [call[2] as string, call[3]])
+      );
+      expect([...callsById.keys()].sort()).toEqual(['package-policy-1', 'package-policy-2']);
+      callsById.forEach((updatedPackagePolicy) => {
+        expect(updatedPackagePolicy.inputs[0].config.osquery.value.packs).toHaveProperty(
+          'default--my-pack'
+        );
+      });
+
+      // The stored `*` shard must survive an edit that never mentions shards.
+      expect(mockClient.update.mock.calls[0][2].shards).toEqual([{ key: '*', value: 100 }]);
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/osquery/server/routes/pack/update_pack_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/pack/update_pack_route.ts
@@ -8,19 +8,7 @@
 import moment from 'moment-timezone';
 import { v4 as uuidv4 } from 'uuid';
 import { set } from '@kbn/safer-lodash-set';
-import {
-  unset,
-  has,
-  difference,
-  filter,
-  map,
-  mapKeys,
-  mapValues,
-  uniq,
-  some,
-  isEmpty,
-  keyBy,
-} from 'lodash';
+import { unset, has, filter, map, mapKeys, mapValues, some, isEmpty, keyBy } from 'lodash';
 import { produce } from 'immer';
 import type { PackagePolicy } from '@kbn/fleet-plugin/common';
 import { LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
@@ -292,10 +280,26 @@ export const updatePackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
         );
         const effectivePolicyIds = policy_ids ?? currentAgentPolicyIds;
 
+        // Same preserve rule for shards: an omitted `shards` must not clear the
+        // stored shard map, or a global (`*`) pack silently stops resolving to
+        // any policy and the wire detach below strips it from every agent.
+        // An explicit `{}` still clears.
+        const effectiveShards =
+          request.body.shards === undefined
+            ? convertShardsToObject(currentPackSO.attributes.shards ?? [])
+            : shards;
+
+        // A PUT that mentions neither `policy_ids` nor `shards` is not asking to
+        // retarget the pack, so both the SO references and the wire attachments
+        // must survive it. Drives the references guard and the wire detach from
+        // one predicate so the two can't disagree and leave the pack scheduled
+        // on agents it is no longer referenced by (or vice versa).
+        const targetingChangeRequested = Boolean(policy_ids) || !isEmpty(shards);
+
         const { policiesList, invalidPolicies } = getInitialPolicies(
           packagePolicies,
           effectivePolicyIds,
-          shards
+          effectiveShards
         );
 
         if (invalidPolicies?.length) {
@@ -306,7 +310,7 @@ export const updatePackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
 
         const agentPolicies = await agentPolicyService?.getByIds(spaceScopedClient, policiesList);
 
-        const policyShards = findMatchingShards(agentPolicies, shards);
+        const policyShards = findMatchingShards(agentPolicies, effectiveShards);
 
         const agentPoliciesIdMap = mapKeys(agentPolicies, 'id');
 
@@ -315,7 +319,7 @@ export const updatePackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
           (reference) => reference.type !== LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE
         );
         const getUpdatedReferences = () => {
-          if (!policy_ids && isEmpty(shards)) {
+          if (!targetingChangeRequested) {
             return currentPackSO.references;
           }
 
@@ -361,7 +365,7 @@ export const updatePackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
             updated_at: moment().toISOString(),
             updated_by: username,
             updated_by_profile_uid: profileUid,
-            shards: convertShardsToArray(shards),
+            shards: convertShardsToArray(effectiveShards),
             ...scheduleSoPatch,
           },
           {
@@ -448,7 +452,7 @@ export const updatePackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
           if (enabled != null && enabled !== currentPackSO.attributes.enabled) {
             if (enabled) {
               const policyIds =
-                policy_ids || !isEmpty(shards) ? policiesList : currentAgentPolicyIds;
+                policy_ids || !isEmpty(effectiveShards) ? policiesList : currentAgentPolicyIds;
               // Dedup by resolved package-policy id before writing: a
               // shared package policy must be written exactly once.
               const packagePolicyWriteTargets = groupAgentPolicyIdsByPackagePolicy(
@@ -483,14 +487,16 @@ export const updatePackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
                 )
               );
             } else {
+              // Remove the pack from EVERY package policy that carries it on
+              // the wire (the `policyHasPack` scan in `currentPackagePolicies`),
+              // not just the ones reachable through the pack SO's agent-policy
+              // references. Post-upgrade (9.4.3 → 9.5.0) the wire attachments and
+              // the SO references can diverge; matching by references left the
+              // pack block on the wire, so agents kept running the schedule while
+              // the SO read `enabled: false`. This mirrors delete_pack_route.
               await Promise.all(
-                currentAgentPolicyIds.map((agentPolicyId) => {
-                  const packagePolicy = currentPackagePolicies.find((policy) =>
-                    policy.policy_ids.includes(agentPolicyId)
-                  );
-                  if (!packagePolicy) return;
-
-                  return packagePolicyService?.update(
+                currentPackagePolicies.map((packagePolicy) =>
+                  packagePolicyService?.update(
                     spaceScopedClient,
                     esClient,
                     packagePolicy.id,
@@ -500,40 +506,50 @@ export const updatePackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
 
                       return draft;
                     })
-                  );
-                })
+                  )
+                )
               );
             }
           } else {
-            // Diff current vs. target: remove the pack from policies no longer
-            // targeted, then (re)write every still-targeted package policy once.
-            const agentPolicyIdsToRemove = uniq(difference(currentAgentPolicyIds, policiesList));
-
-            await Promise.all(
-              agentPolicyIdsToRemove.map((agentPolicyId) => {
-                const packagePolicy = currentPackagePolicies.find((policy) =>
-                  policy.policy_ids.includes(agentPolicyId)
-                );
-                if (packagePolicy) {
-                  return packagePolicyService?.update(
-                    spaceScopedClient,
-                    esClient,
-                    packagePolicy.id,
-                    produce<PackagePolicy>(packagePolicy, (draft) => {
-                      unset(draft, 'id');
-                      removePackFromPolicy(draft, currentPackSO.attributes.name, spaceId);
-
-                      return draft;
-                    })
-                  );
-                }
-              })
-            );
-
+            // Diff current vs. target. Resolve the still-targeted package
+            // policies (write targets) first, then remove the pack from every
+            // package policy that currently carries it on the wire but is no
+            // longer targeted. Scanning the wire (`currentPackagePolicies`)
+            // rather than resolving the SO's agent-policy references keeps
+            // detach correct even when references and wire attachments have
+            // diverged (e.g. after a 9.4.3 → 9.5.0 upgrade); see #279224.
+            // Gated on an actual retarget request: in the same drift state an
+            // edit-only PUT resolves to zero write targets, and detaching on
+            // that would silently unschedule an enabled pack everywhere.
             const packagePolicyWriteTargets = groupAgentPolicyIdsByPackagePolicy(
               policiesList,
               packagePolicies
             );
+            const writeTargetIds = new Set(
+              Array.from(packagePolicyWriteTargets.values()).map(
+                ({ packagePolicy }) => packagePolicy.id
+              )
+            );
+
+            if (targetingChangeRequested) {
+              await Promise.all(
+                currentPackagePolicies
+                  .filter((packagePolicy) => !writeTargetIds.has(packagePolicy.id))
+                  .map((packagePolicy) =>
+                    packagePolicyService?.update(
+                      spaceScopedClient,
+                      esClient,
+                      packagePolicy.id,
+                      produce<PackagePolicy>(packagePolicy, (draft) => {
+                        unset(draft, 'id');
+                        removePackFromPolicy(draft, currentPackSO.attributes.name, spaceId);
+
+                        return draft;
+                      })
+                    )
+                  )
+              );
+            }
 
             await Promise.all(
               Array.from(packagePolicyWriteTargets.values()).map(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Osquery] Fix disabled pack still executing on agents post-upgrade (#279252)](https://github.com/elastic/kibana/pull/279252)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2026-07-27T23:01:55Z","message":"[Osquery] Fix disabled pack still executing on agents post-upgrade (#279252)\n\n## Summary\n\nFixes elastic/kibana#279224. After upgrading 9.4.3 → 9.5.0, disabling an\nOsquery pack showed it as disabled in the API/UI but the agent kept\nexecuting its scheduled queries and reporting \"Scheduled\" results.\n\nRoot cause: the pack **disable** path removed the pack only from package\npolicies reachable through the pack Saved Object's agent-policy\n`references`, while **delete** (correctly) scans the wire. Post-upgrade\nthe references and the wire attachments diverge, so the disable was a\nsilent no-op on the wire while the SO flipped to `enabled: false`. The\n9.5.0 reconciler only *adds* enabled packs, so nothing self-healed.\n\n## Key changes\n- `update_pack_route.ts`: disable now removes the pack from **every**\npackage policy carrying it on the wire (`policyHasPack` scan), mirroring\n`delete_pack_route.ts`. Also writes each package policy exactly once.\n- `update_global_packs.ts`: the create callback skips packs with a falsy\n`enabled`, so a disabled global pack is not re-attached to newly\nenrolled agents (fail-closed, matching `create_pack_route`/reconciler\nsemantics).\n\n<details><summary>Verification</summary>\n\nReproduced and fixed on a live cluster. With the pack SO in the\npost-upgrade divergent state (references empty, wire still carrying the\npack), the API reports `enabled: false` in both cases:\n\n- **Before:** wire after disable still contains `default--<pack>` →\nagent keeps running.\n- **After:** wire after disable no longer contains `default--<pack>` →\nagent un-schedules.\n\nScoped checks: eslint clean; full osquery jest suite 183 suites / 2170\ntests pass (incl. 4 new regression tests); osquery type surface clean.\n</details>\n\n## Test plan\n- [ ] Disable a pack attached to a policy → its queries are removed from\nthe `osquery_manager` package policy.\n- [ ] Disable a global (shard `*`) pack → removed from all package\npolicies carrying it.\n- [ ] Enroll a new agent while a global pack is disabled → the pack is\nnot scheduled.\n\n**AI-Assisted**: This PR was assisted by **Claude Code**\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: konrad.szwarc <konrad.szwarc@elastic.co>","sha":"30d92cfe60f320b44ebacc44adca78338a543fc2","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","Osquery","backport:version","v9.5.0","v9.6.0"],"title":"[Osquery] Fix disabled pack still executing on agents post-upgrade","number":279252,"url":"https://github.com/elastic/kibana/pull/279252","mergeCommit":{"message":"[Osquery] Fix disabled pack still executing on agents post-upgrade (#279252)\n\n## Summary\n\nFixes elastic/kibana#279224. After upgrading 9.4.3 → 9.5.0, disabling an\nOsquery pack showed it as disabled in the API/UI but the agent kept\nexecuting its scheduled queries and reporting \"Scheduled\" results.\n\nRoot cause: the pack **disable** path removed the pack only from package\npolicies reachable through the pack Saved Object's agent-policy\n`references`, while **delete** (correctly) scans the wire. Post-upgrade\nthe references and the wire attachments diverge, so the disable was a\nsilent no-op on the wire while the SO flipped to `enabled: false`. The\n9.5.0 reconciler only *adds* enabled packs, so nothing self-healed.\n\n## Key changes\n- `update_pack_route.ts`: disable now removes the pack from **every**\npackage policy carrying it on the wire (`policyHasPack` scan), mirroring\n`delete_pack_route.ts`. Also writes each package policy exactly once.\n- `update_global_packs.ts`: the create callback skips packs with a falsy\n`enabled`, so a disabled global pack is not re-attached to newly\nenrolled agents (fail-closed, matching `create_pack_route`/reconciler\nsemantics).\n\n<details><summary>Verification</summary>\n\nReproduced and fixed on a live cluster. With the pack SO in the\npost-upgrade divergent state (references empty, wire still carrying the\npack), the API reports `enabled: false` in both cases:\n\n- **Before:** wire after disable still contains `default--<pack>` →\nagent keeps running.\n- **After:** wire after disable no longer contains `default--<pack>` →\nagent un-schedules.\n\nScoped checks: eslint clean; full osquery jest suite 183 suites / 2170\ntests pass (incl. 4 new regression tests); osquery type surface clean.\n</details>\n\n## Test plan\n- [ ] Disable a pack attached to a policy → its queries are removed from\nthe `osquery_manager` package policy.\n- [ ] Disable a global (shard `*`) pack → removed from all package\npolicies carrying it.\n- [ ] Enroll a new agent while a global pack is disabled → the pack is\nnot scheduled.\n\n**AI-Assisted**: This PR was assisted by **Claude Code**\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: konrad.szwarc <konrad.szwarc@elastic.co>","sha":"30d92cfe60f320b44ebacc44adca78338a543fc2"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279252","number":279252,"mergeCommit":{"message":"[Osquery] Fix disabled pack still executing on agents post-upgrade (#279252)\n\n## Summary\n\nFixes elastic/kibana#279224. After upgrading 9.4.3 → 9.5.0, disabling an\nOsquery pack showed it as disabled in the API/UI but the agent kept\nexecuting its scheduled queries and reporting \"Scheduled\" results.\n\nRoot cause: the pack **disable** path removed the pack only from package\npolicies reachable through the pack Saved Object's agent-policy\n`references`, while **delete** (correctly) scans the wire. Post-upgrade\nthe references and the wire attachments diverge, so the disable was a\nsilent no-op on the wire while the SO flipped to `enabled: false`. The\n9.5.0 reconciler only *adds* enabled packs, so nothing self-healed.\n\n## Key changes\n- `update_pack_route.ts`: disable now removes the pack from **every**\npackage policy carrying it on the wire (`policyHasPack` scan), mirroring\n`delete_pack_route.ts`. Also writes each package policy exactly once.\n- `update_global_packs.ts`: the create callback skips packs with a falsy\n`enabled`, so a disabled global pack is not re-attached to newly\nenrolled agents (fail-closed, matching `create_pack_route`/reconciler\nsemantics).\n\n<details><summary>Verification</summary>\n\nReproduced and fixed on a live cluster. With the pack SO in the\npost-upgrade divergent state (references empty, wire still carrying the\npack), the API reports `enabled: false` in both cases:\n\n- **Before:** wire after disable still contains `default--<pack>` →\nagent keeps running.\n- **After:** wire after disable no longer contains `default--<pack>` →\nagent un-schedules.\n\nScoped checks: eslint clean; full osquery jest suite 183 suites / 2170\ntests pass (incl. 4 new regression tests); osquery type surface clean.\n</details>\n\n## Test plan\n- [ ] Disable a pack attached to a policy → its queries are removed from\nthe `osquery_manager` package policy.\n- [ ] Disable a global (shard `*`) pack → removed from all package\npolicies carrying it.\n- [ ] Enroll a new agent while a global pack is disabled → the pack is\nnot scheduled.\n\n**AI-Assisted**: This PR was assisted by **Claude Code**\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: konrad.szwarc <konrad.szwarc@elastic.co>","sha":"30d92cfe60f320b44ebacc44adca78338a543fc2"}}]}] BACKPORT-->