### PR TITLE
[Fleet] Fix agent policy filter: include versioned policy_id variants in agents list kuery

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
@@ -35,9 +35,9 @@ describe('getKuery', () => {
     );
   });
 
-  it('should return a kuery with selected agent policies', () => {
+  it('should return a kuery with selected agent policies covering versioned policy_id variants', () => {
     expect(getKuery({ selectedAgentPolicies })).toEqual(
-      'fleet-agents.policy_id : ("policy1" or "policy2" or "policy3")'
+      '(fleet-agents.policy_id:(policy1 or policy2 or policy3) or fleet-agents.policy_id:policy1#* or fleet-agents.policy_id:policy2#* or fleet-agents.policy_id:policy3#*)'
     );
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -6,6 +6,7 @@
  */
 import { i18n } from '@kbn/i18n';
 
+import { buildPolicyIdsOrVariantsKuery } from '../../../../../../../common/services/version_specific_policies_utils';
 import { AgentStatusKueryHelper } from '../../../../services';
 import { AGENTS_PREFIX } from '../../../../constants';
 
@@ -34,9 +35,10 @@ export const getKuery = ({
     if (kueryBuilder) {
       kueryBuilder = `(${kueryBuilder}) and`;
     }
-    kueryBuilder = `${kueryBuilder} ${AGENTS_PREFIX}.policy_id : (${selectedAgentPolicies
-      .map((agentPolicy) => `"${agentPolicy}"`)
-      .join(' or ')})`;
+    kueryBuilder = `${kueryBuilder} ${buildPolicyIdsOrVariantsKuery(
+      selectedAgentPolicies,
+      `${AGENTS_PREFIX}.policy_id`
+    )}`;
   }
 
   if (selectedTags?.length) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
@@ -208,6 +208,52 @@ describe('checkFleetServerVersionsForSecretsStorage', () => {
     const kuery = mockedGetAgentsByKuery.mock.calls[0][2].kuery as string;
     expect(kuery).toContain('fleet-server-policy#*');
   });
+
+  it('should return true if a versioned-policy agent is offline but its base policy is managed', async () => {
+    // Regression: managedAgentPolicies contains base IDs (e.g. 'fleet-server-policy'),
+    // but an agent on a versioned policy has policy_id 'fleet-server-policy#9.4'.
+    // The comparison must strip the version suffix before matching.
+    const version = '10.0.0';
+
+    jest
+      .spyOn(mockedPackagePolicyService, 'list')
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: '1',
+            policy_id: 'fleet-server-policy',
+            policy_ids: ['fleet-server-policy'],
+            package: { name: 'fleet_server', version: '10.0.0' },
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ items: [] } as any);
+
+    mockedAgentPolicyService.getAllManagedAgentPolicies.mockResolvedValueOnce([
+      { id: 'fleet-server-policy', is_managed: true } as any,
+    ]);
+
+    mockedGetAgentsByKuery.mockResolvedValueOnce({
+      agents: [
+        {
+          id: 'agent-versioned',
+          policy_id: 'fleet-server-policy#9.4',
+          active: true,
+          local_metadata: { elastic: { agent: { version: '9.4.0' } } },
+        },
+      ],
+    } as any);
+
+    mockedGetAgentStatusById.mockResolvedValue('offline');
+
+    const result = await checkFleetServerVersionsForSecretsStorage(
+      esClientMock,
+      soClientMock,
+      version
+    );
+    // Offline managed versioned agent must not block secrets storage
+    expect(result).toBe(true);
+  });
 });
 
 describe('getFleetServerPolicies', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
@@ -122,7 +122,8 @@ describe('checkFleetServerVersionsForSecretsStorage', () => {
       esClientMock,
       soClientMock,
       expect.objectContaining({
-        kuery: 'policy_id:("1" or "2")',
+        // kuery must cover both base and versioned variants (e.g. policy_id:1#*)
+        kuery: expect.stringContaining('policy_id:1#*'),
       })
     );
   });
@@ -163,6 +164,49 @@ describe('checkFleetServerVersionsForSecretsStorage', () => {
       version
     );
     expect(result).toBe(true);
+  });
+
+  it('should query versioned policy_id variants when Fleet Server agent is reassigned', async () => {
+    const version = '1.0.0';
+
+    jest
+      .spyOn(mockedPackagePolicyService, 'list')
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: '1',
+            policy_id: 'fleet-server-policy',
+            policy_ids: ['fleet-server-policy'],
+            package: { name: 'fleet_server', version: '10.0.0' },
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ items: [] } as any);
+
+    mockedAgentPolicyService.getAllManagedAgentPolicies.mockResolvedValueOnce([]);
+
+    // Simulate an agent whose policy_id is the versioned variant (fleet-server-policy#9.4)
+    mockedGetAgentsByKuery.mockResolvedValueOnce({
+      agents: [
+        {
+          id: 'agent-1',
+          local_metadata: { elastic: { agent: { version: '10.0.0' } } },
+        },
+      ],
+    } as any);
+
+    mockedGetAgentStatusById.mockResolvedValue('online');
+
+    const result = await checkFleetServerVersionsForSecretsStorage(
+      esClientMock,
+      soClientMock,
+      version
+    );
+
+    expect(result).toBe(true);
+    // Kuery must include the wildcard variant so versioned agents are found
+    const kuery = mockedGetAgentsByKuery.mock.calls[0][2].kuery as string;
+    expect(kuery).toContain('fleet-server-policy#*');
   });
 });
 
@@ -368,7 +412,7 @@ describe('hasActiveFleetServersForPolicies', () => {
 
       await hasFleetServersForPolicies(mockEsClient, mockSoClient, [{ id: 'fleet-server-policy' }]);
 
-      const kuery = (getAgentStatusForAgentPolicy as jest.Mock).mock.calls[0][3] as string;
+      const kuery = (getAgentStatusForAgentPolicy as jest.Mock).mock.calls.at(-1)![3] as string;
       // Must match the base policy_id exactly
       expect(kuery).toContain('policy_id:"fleet-server-policy"');
       // Must also match versioned variants like fleet-server-policy#9.4

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.test.ts
@@ -349,4 +349,59 @@ describe('hasActiveFleetServersForPolicies', () => {
       expect(hasFs).toBe(true);
     });
   });
+
+  describe('kuery includes versioned policy_id variants', () => {
+    it('passes a kuery matching both the base policy_id and versioned variants', async () => {
+      (getAgentStatusForAgentPolicy as jest.Mock).mockResolvedValueOnce({
+        other: 0,
+        events: 0,
+        total: 1,
+        all: 1,
+        active: 0,
+        updating: 0,
+        offline: 0,
+        inactive: 0,
+        unenrolled: 0,
+        online: 1,
+        error: 0,
+      });
+
+      await hasFleetServersForPolicies(mockEsClient, mockSoClient, [{ id: 'fleet-server-policy' }]);
+
+      const kuery = (getAgentStatusForAgentPolicy as jest.Mock).mock.calls[0][3] as string;
+      // Must match the base policy_id exactly
+      expect(kuery).toContain('policy_id:"fleet-server-policy"');
+      // Must also match versioned variants like fleet-server-policy#9.4
+      expect(kuery).toContain('policy_id:fleet-server-policy#*');
+    });
+
+    it('returns true when the Fleet Server agent is on a versioned policy_id', async () => {
+      // Simulate: agent has policy_id "fleet-server-policy#9.4" (no exact-match on base id).
+      // The old exact-match query returned all:0; the new kuery must return all:1.
+      (getAgentStatusForAgentPolicy as jest.Mock).mockImplementationOnce(
+        (_es, _so, _id, kuery: string) => {
+          // Simulate ES matching an agent whose policy_id is "fleet-server-policy#9.4"
+          const agentMatchesVersionedVariant = kuery.includes('fleet-server-policy#*');
+          return Promise.resolve({
+            other: 0,
+            events: 0,
+            total: agentMatchesVersionedVariant ? 1 : 0,
+            all: agentMatchesVersionedVariant ? 1 : 0,
+            active: 0,
+            updating: 0,
+            offline: 0,
+            inactive: 0,
+            unenrolled: 0,
+            online: agentMatchesVersionedVariant ? 1 : 0,
+            error: 0,
+          });
+        }
+      );
+
+      const hasFs = await hasFleetServersForPolicies(mockEsClient, mockSoClient, [
+        { id: 'fleet-server-policy' },
+      ]);
+      expect(hasFs).toBe(true);
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
@@ -20,6 +20,7 @@ import { SO_SEARCH_LIMIT } from '../../constants';
 import {
   buildPolicyIdOrVariantsKuery,
   buildPolicyIdsOrVariantsKuery,
+  removeVersionSuffixFromPolicyId,
 } from '../../../common/services/version_specific_policies_utils';
 import { getAgentsByKuery, getAgentStatusById } from '../agents';
 import { packagePolicyService } from '../package_policy';
@@ -182,8 +183,9 @@ export async function checkFleetServerVersionsForSecretsStorage(
         continue;
       }
 
+      const agentPolicyBaseId = removeVersionSuffixFromPolicyId(fleetServerAgent.policy_id ?? '');
       const isManagedAgentPolicy = managedAgentPolicies.some(
-        (managedPolicy) => managedPolicy.id === fleetServerAgent.policy_id
+        (managedPolicy) => managedPolicy.id === agentPolicyBaseId
       );
 
       // If this is an agent enrolled in a managed policy, and it is no longer active then we ignore it if it's

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
@@ -7,7 +7,6 @@
 
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
-import { escapeQuotes } from '@kbn/es-query';
 import semverGte from 'semver/functions/gte';
 import semverCoerce from 'semver/functions/coerce';
 import { uniqBy } from 'lodash';
@@ -18,6 +17,7 @@ import {
   FLEET_SERVER_PACKAGE,
 } from '../../../common/constants';
 import { SO_SEARCH_LIMIT } from '../../constants';
+import { buildPolicyIdOrVariantsKuery } from '../../../common/services/version_specific_policies_utils';
 import { getAgentsByKuery, getAgentStatusById } from '../agents';
 import { packagePolicyService } from '../package_policy';
 import { agentPolicyService } from '../agent_policy';
@@ -76,7 +76,7 @@ export const hasFleetServersForPolicies = async (
               ? `namespaces:"${spaceIds?.[0]}"`
               : `not namespaces:* or namespaces:"${DEFAULT_SPACE_ID}"`;
 
-          return `(policy_id:"${escapeQuotes(id)}" and (${space}))`;
+          return `(${buildPolicyIdOrVariantsKuery(id)} and (${space}))`;
         })
         .join(' or ')
     );

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
@@ -17,7 +17,10 @@ import {
   FLEET_SERVER_PACKAGE,
 } from '../../../common/constants';
 import { SO_SEARCH_LIMIT } from '../../constants';
-import { buildPolicyIdOrVariantsKuery } from '../../../common/services/version_specific_policies_utils';
+import {
+  buildPolicyIdOrVariantsKuery,
+  buildPolicyIdsOrVariantsKuery,
+} from '../../../common/services/version_specific_policies_utils';
 import { getAgentsByKuery, getAgentStatusById } from '../agents';
 import { packagePolicyService } from '../package_policy';
 import { agentPolicyService } from '../agent_policy';
@@ -140,9 +143,7 @@ export async function checkFleetServerVersionsForSecretsStorage(
     return false;
   }
 
-  const kuery = `policy_id:(${Array.from(policyIds)
-    .map((id) => `"${escapeQuotes(id)}"`)
-    .join(' or ')})`;
+  const kuery = buildPolicyIdsOrVariantsKuery(Array.from(policyIds));
 
   const managedAgentPolicies = await agentPolicyService.getAllManagedAgentPolicies(soClient);
   const fleetServerAgents = await getAgentsByKuery(esClient, soClient, {


### PR DESCRIPTION
## Summary

Fixes #281093

The agent policy dropdown filter on the agents list page used an exact KQL match on `policy_id`:

```
fleet-agents.policy_id : ("fleet-server-policy")
```

When Fleet assigns agents to version-specific policies (e.g. `fleet-server-policy#9.4`), those agents have a versioned `policy_id` and do not match the exact filter — resulting in 0 agents shown.

**Fix:** use `buildPolicyIdsOrVariantsKuery` so the generated KQL covers both the base id and any version-suffixed variants:

```
(fleet-agents.policy_id:(fleet-server-policy) or fleet-agents.policy_id:fleet-server-policy#*)
```

This is a standalone fix that works on any Kibana version — no index schema changes required.

## Test plan

- [ ] Start Kibana with Fleet Server using the version-specific policy assignment feature enabled
- [ ] Verify that agents assigned to `fleet-server-policy#<version>` are visible when filtering by their base policy (`fleet-server-policy`) in the Agent Policy dropdown
- [ ] Unit tests updated and passing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)