### PR TITLE
[Fleet] Fix agent policy filter: use policy_base_id for versioned policy lookup

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/mappings.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/mappings.ts
@@ -275,9 +275,6 @@ export const AGENT_MAPPINGS = {
     policy_output_permissions_hash: {
       type: 'keyword',
     },
-    policy_base_id: {
-      type: 'keyword',
-    },
     policy_coordinator_idx: {
       type: 'integer',
     },

--- a/x-pack/platform/plugins/shared/fleet/common/constants/mappings.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/mappings.ts
@@ -275,6 +275,9 @@ export const AGENT_MAPPINGS = {
     policy_output_permissions_hash: {
       type: 'keyword',
     },
+    policy_base_id: {
+      type: 'keyword',
+    },
     policy_coordinator_idx: {
       type: 'integer',
     },

--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -170,4 +170,6 @@ export {
   removeVersionSuffixFromPolicyId,
   buildPolicyIdOrVariantsKuery,
   buildPolicyIdsOrVariantsKuery,
+  buildPolicyBaseIdWithFallbackKuery,
+  buildPolicyBaseIdsWithFallbackKuery,
 } from './version_specific_policies_utils';

--- a/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.test.ts
@@ -18,6 +18,7 @@ import {
   buildPolicyBaseIdWithFallbackEsFilter,
   buildPolicyBaseIdsWithFallbackEsFilter,
   buildPolicyBaseIdWithFallbackKuery,
+  buildPolicyBaseIdsWithFallbackKuery,
 } from './version_specific_policies_utils';
 
 describe('removeVersionSuffixFromPolicyId', () => {
@@ -345,5 +346,48 @@ describe('buildPolicyBaseIdsWithFallbackEsFilter', () => {
 
   it('should return match_none for an empty array', () => {
     expect(buildPolicyBaseIdsWithFallbackEsFilter([])).toEqual({ match_none: {} });
+  });
+});
+
+describe('buildPolicyBaseIdsWithFallbackKuery', () => {
+  it('should match migrated docs via policy_base_id terms', () => {
+    expect(buildPolicyBaseIdsWithFallbackKuery(['policy-a', 'policy-b'])).toContain(
+      'policy_base_id:(policy-a or policy-b)'
+    );
+  });
+
+  it('should include fallback branch for docs missing policy_base_id', () => {
+    expect(buildPolicyBaseIdsWithFallbackKuery(['policy-a', 'policy-b'])).toContain(
+      'policy_id:(policy-a or policy-b) and not policy_base_id:*'
+    );
+  });
+
+  it('should de-duplicate repeated ids', () => {
+    const result = buildPolicyBaseIdsWithFallbackKuery(['policy-a', 'policy-a', 'policy-b']);
+    expect(result).toBe(
+      '(policy_base_id:(policy-a or policy-b) or (policy_id:(policy-a or policy-b) and not policy_base_id:*))'
+    );
+  });
+
+  it('should return a never-matching kuery for an empty array', () => {
+    expect(buildPolicyBaseIdsWithFallbackKuery([])).toBe('policy_id:""');
+  });
+
+  it('should use custom field names when provided', () => {
+    expect(
+      buildPolicyBaseIdsWithFallbackKuery(
+        ['my-policy'],
+        'fleet-agents.policy_base_id',
+        'fleet-agents.policy_id'
+      )
+    ).toBe(
+      '(fleet-agents.policy_base_id:(my-policy) or (fleet-agents.policy_id:(my-policy) and not fleet-agents.policy_base_id:*))'
+    );
+  });
+
+  it('should escape special KQL characters in ids', () => {
+    expect(buildPolicyBaseIdsWithFallbackKuery(['my policy:1'])).toContain(
+      'policy_base_id:(my policy\\:1)'
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.ts
@@ -158,6 +158,22 @@ export function buildPolicyBaseIdWithFallbackKuery(
 }
 
 /**
+ * Same as {@link buildPolicyBaseIdWithFallbackKuery}, for multiple base policy ids at once.
+ */
+export function buildPolicyBaseIdsWithFallbackKuery(
+  baseIds: string[],
+  policyBaseIdField: string = 'policy_base_id',
+  policyIdField: string = DEFAULT_POLICY_ID_FIELD
+): string {
+  const uniqueIds = Array.from(new Set(baseIds));
+  if (uniqueIds.length === 0) {
+    return `${policyIdField}:""`;
+  }
+  const idList = uniqueIds.map((id) => escapeKuery(id)).join(' or ');
+  return `(${policyBaseIdField}:(${idList}) or (${policyIdField}:(${idList}) and not ${policyBaseIdField}:*))`;
+}
+
+/**
  * ES query DSL filter preferring `policy_base_id` for migrated documents, with a legacy
  * `policy_id` exact-term fallback for documents that pre-date the `policy_base_id` field.
  */

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
@@ -35,9 +35,9 @@ describe('getKuery', () => {
     );
   });
 
-  it('should return a kuery with selected agent policies', () => {
+  it('should return a kuery with selected agent policies covering versioned policy_id variants', () => {
     expect(getKuery({ selectedAgentPolicies })).toEqual(
-      'fleet-agents.policy_id : ("policy1" or "policy2" or "policy3")'
+      '(fleet-agents.policy_id:(policy1 or policy2 or policy3) or fleet-agents.policy_id:policy1#* or fleet-agents.policy_id:policy2#* or fleet-agents.policy_id:policy3#*)'
     );
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
@@ -35,9 +35,9 @@ describe('getKuery', () => {
     );
   });
 
-  it('should return a kuery with selected agent policies covering versioned policy_id variants', () => {
+  it('should return a kuery with selected agent policies using policy_base_id fallback', () => {
     expect(getKuery({ selectedAgentPolicies })).toEqual(
-      '(fleet-agents.policy_id:(policy1 or policy2 or policy3) or fleet-agents.policy_id:policy1#* or fleet-agents.policy_id:policy2#* or fleet-agents.policy_id:policy3#*)'
+      '(fleet-agents.policy_base_id:(policy1 or policy2 or policy3) or (fleet-agents.policy_id:(policy1 or policy2 or policy3) and not fleet-agents.policy_base_id:*))'
     );
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -6,6 +6,7 @@
  */
 import { i18n } from '@kbn/i18n';
 
+import { buildPolicyIdsOrVariantsKuery } from '../../../../../../../common/services/version_specific_policies_utils';
 import { AgentStatusKueryHelper } from '../../../../services';
 import { AGENTS_PREFIX } from '../../../../constants';
 
@@ -34,9 +35,10 @@ export const getKuery = ({
     if (kueryBuilder) {
       kueryBuilder = `(${kueryBuilder}) and`;
     }
-    kueryBuilder = `${kueryBuilder} ${AGENTS_PREFIX}.policy_id : (${selectedAgentPolicies
-      .map((agentPolicy) => `"${agentPolicy}"`)
-      .join(' or ')})`;
+    kueryBuilder = `${kueryBuilder} ${buildPolicyIdsOrVariantsKuery(
+      selectedAgentPolicies,
+      `${AGENTS_PREFIX}.policy_id`
+    )}`;
   }
 
   if (selectedTags?.length) {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -6,7 +6,7 @@
  */
 import { i18n } from '@kbn/i18n';
 
-import { buildPolicyIdsOrVariantsKuery } from '../../../../../../../common/services/version_specific_policies_utils';
+import { buildPolicyBaseIdsWithFallbackKuery } from '../../../../../../../common/services/version_specific_policies_utils';
 import { AgentStatusKueryHelper } from '../../../../services';
 import { AGENTS_PREFIX } from '../../../../constants';
 
@@ -35,8 +35,9 @@ export const getKuery = ({
     if (kueryBuilder) {
       kueryBuilder = `(${kueryBuilder}) and`;
     }
-    kueryBuilder = `${kueryBuilder} ${buildPolicyIdsOrVariantsKuery(
+    kueryBuilder = `${kueryBuilder} ${buildPolicyBaseIdsWithFallbackKuery(
       selectedAgentPolicies,
+      `${AGENTS_PREFIX}.policy_base_id`,
       `${AGENTS_PREFIX}.policy_id`
     )}`;
   }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -6,7 +6,7 @@
  */
 import { i18n } from '@kbn/i18n';
 
-import { buildPolicyBaseIdsWithFallbackKuery } from '../../../../../../../common/services/version_specific_policies_utils';
+import { buildPolicyBaseIdsWithFallbackKuery } from '../../../../../../../common/services';
 import { AgentStatusKueryHelper } from '../../../../services';
 import { AGENTS_PREFIX } from '../../../../constants';
 


### PR DESCRIPTION
## Summary

Closes #281093

Follow-up to #279716 (now merged).

The agent policy dropdown filter on the agents list page used an exact KQL match on `policy_id`:

```
fleet-agents.policy_id : ("fleet-server-policy")
```

When Fleet assigns agents to version-specific policies (e.g. `fleet-server-policy#9.4`), those agents have a versioned `policy_id` and do not match the exact filter — resulting in 0 agents shown.

**Fix:** use `buildPolicyBaseIdsWithFallbackKuery` so the generated KQL queries the denormalized `policy_base_id` field (term query, no prefix) for migrated agents, with an exact `policy_id` fallback for agents enrolled before the backfill ran:

```
(fleet-agents.policy_base_id:(fleet-server-policy) or (fleet-agents.policy_id:(fleet-server-policy) and not fleet-agents.policy_base_id:*))
```

This is compatible with `search.allow_expensive_queries: false` (no prefix/wildcard). Also adds `policy_base_id` to `AGENT_MAPPINGS` so the KQL route validator accepts the field.

Also adds `buildPolicyBaseIdsWithFallbackKuery` (multi-id KQL variant, counterpart of the already-merged `buildPolicyBaseIdsWithFallbackEsFilter`).

## Test plan

**Pre-requisites**
- Local Kibana + Elasticsearch + Fleet Server running with at least one enrolled agent
- Enable the version-specific policy assignment feature in `kibana.yml`:
  ```yaml
  xpack.fleet.enableExperimental:
    - versionSpecificAgentPolicies
  ```

**Setup: put an agent onto a versioned policy_id**

Either wait for the `fleet:version-specific-policy-assignment-task` to run after agent check-in, or manually update one agent doc in Elasticsearch:

```
POST .fleet-agents/_update/<agent-id>
{
  "doc": {
    "policy_id": "fleet-server-policy#9.4",
    "policy_base_id": "fleet-server-policy"
  }
}
```

**Reproduce the bug (on `main` before fix)**
1. Go to **Fleet → Agents**
2. Open the **Agent policy** dropdown filter
3. Select the policy the agent is enrolled in (e.g. `fleet-server-policy`)
4. Agent count shows 0 — the agent on `fleet-server-policy#9.4` is missed

**Verify the fix (on PR branch)**
1. Same steps — agent with `policy_id: fleet-server-policy#9.4` now appears in the filtered list
2. In browser DevTools → Network, find the `/api/fleet/agents` request and confirm the `kuery` param contains `fleet-agents.policy_base_id:(fleet-server-policy)`
3. Deselect filter → all agents visible again
4. Select a different policy → only agents on that policy are shown
5. Test with an agent that has only `policy_id` set (no `policy_base_id`) — agent still appears via the fallback branch

**Unit tests**
- [x] `get_kuery.test.ts` passes: `selectedAgentPolicies` filter now asserts `policy_base_id` fallback kuery

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<img width="1585" height="482" alt="image" src="https://github.com/user-attachments/assets/e96c89de-0245-46aa-ba94-182e42b451f1" />
<img width="1589" height="544" alt="image" src="https://github.com/user-attachments/assets/9ac2e418-a984-416a-b931-bfa94498e80a" />

Verified again after the `policy_base_id` changes:
<img width="1784" height="557" alt="image" src="https://github.com/user-attachments/assets/1eca16ba-22a3-41cf-82c4-6217f74b4320" />



<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->