### PR TITLE
[9.4] [Console] Retry Play click until console request starts (#277705)

### DIFF
--- a/src/platform/test/functional/page_objects/console_page.ts
+++ b/src/platform/test/functional/page_objects/console_page.ts
@@ -248,33 +248,15 @@ export class ConsolePageObject extends FtrService {
   }
 
   public async clickPlayAndWaitForResults() {
-    const hadStatusBadge = await this.testSubjects.exists('consoleResponseStatusBadge');
-    const initialStatusText = hadStatusBadge
-      ? await this.testSubjects.getVisibleText('consoleResponseStatusBadge')
-      : '';
-    const hadOutput = await this.testSubjects.exists('consoleMonacoOutput');
-    const initialOutputText = hadOutput ? await this.getOutputText() : '';
-
-    await this.clickPlay();
-
-    // Wait for the UI to reflect request progress or completion.
-    // We capture state before clicking to correctly detect "already done" results.
+    // Retry the Play click until the request starts. A single click can be a no-op if the editor
+    // hasn't finished registering the current request (see #240147).
     await this.retry.try(async () => {
-      const loadingIndicatorsVisible =
+      await this.clickPlay();
+      const started =
         (await this.testSubjects.exists('consoleEditorContentSpinner')) ||
-        (await this.testSubjects.exists('consoleRequestInProgressBadge'));
-      const hasStatusBadge = await this.testSubjects.exists('consoleResponseStatusBadge');
-      const currentStatusText = hasStatusBadge
-        ? await this.testSubjects.getVisibleText('consoleResponseStatusBadge')
-        : '';
-      const statusChanged = currentStatusText !== initialStatusText;
-      const hasOutput = await this.testSubjects.exists('consoleMonacoOutput');
-      const currentOutputText = hasOutput ? await this.getOutputText() : '';
-      const outputChanged = currentOutputText !== initialOutputText;
-
-      if (!loadingIndicatorsVisible && !statusChanged && !outputChanged) {
-        throw new Error('Expected console request to update the UI');
-      }
+        (await this.testSubjects.exists('consoleRequestInProgressBadge')) ||
+        (await this.testSubjects.exists('consoleMonacoOutput'));
+      if (!started) throw new Error('Console request did not start after clicking Play');
     });
 
     // Wait for the request to finish: loading indicators go away and output/status are present.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Console] Retry Play click until console request starts (#277705)](https://github.com/elastic/kibana/pull/277705)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kibana Machine","email":"42973632+kibanamachine@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-16T07:58:37Z","message":"[Console] Retry Play click until console request starts (#277705)\n\nFixes #240154\nFixes #240147\n\n### Summary\n- The console FTR tests intermittently timed out waiting for\n`consoleMonacoOutput` because a single `Play` click could be a no-op\nwhen the Monaco editor had not yet registered the current request —\nnothing was dispatched and the output panel stayed in its empty \"Enter a\nnew request\" state.\n- `clickPlayAndWaitForResults` now retries the `Play` click itself (any\nin-flight spinner/badge or the output panel appearing proves the request\nwas sent), then waits for completion.\n\nThis re-applies the exact change the failed-test investigator proposed\nand that passed the flaky-test runner 50/50 as the first commit of the\nnow-closed #277647. That PR was closed after a second commit added a\n`clickClearOutput()` call ahead of the retry (on review feedback about a\ntheoretical stale-output false positive), which regressed the console\nsuite to 2/25: clearing the output deselects the request in the\nrepeated-call `_output_filter.ts` `beforeEach`, turning the next `Play`\nclick into a genuine no-op with no output left to fall back on. This PR\nkeeps only the proven retry-click and drops the regressing clear step.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n- `node scripts/eslint\nsrc/platform/test/functional/page_objects/console_page.ts` — passed.\n- This diff is identical to the first commit of #277647, which passed\nthe flaky-test runner 50/50 (`kibana-flaky-test-suite-runner#13066`).\n\n#### Not verified locally\n\n- `node scripts/type_check --project src/platform/test/tsconfig.json` —\nthe TS project-ref build was SIGKILLed (out of memory) in the sandbox\nbefore completing; this is an environment resource limit, not a type\nerror. The change only substitutes `retry.try(...)` for the previous\n`retry.tryForTime(...).catch(...)` chain, matching the pattern already\nused by `waitForRequestToComplete` in the same file.\n- The FTR tests (`_vector_tile.ts` and the other console specs using\nthis page object) require a live Elasticsearch + Kibana and cannot be\nrun in this environment.\n\n</details>\n\n> [!NOTE]\n> Requested by @SoniaSanzV. Share feedback in #kibana-qa.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/29241607439) for\n#240154 · 274.8 AIC · ⌖ 28.8 AIC · ⊞ 4.2K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\n---------\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>","sha":"d65989a000a8243d0aaf07ca162051549a793ffc","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:version","v9.5.0","flaky-test-fixer","flaky-fix-check:passed","v9.6.0","v9.4.5","v9.5.1"],"title":"[Console] Retry Play click until console request starts","number":277705,"url":"https://github.com/elastic/kibana/pull/277705","mergeCommit":{"message":"[Console] Retry Play click until console request starts (#277705)\n\nFixes #240154\nFixes #240147\n\n### Summary\n- The console FTR tests intermittently timed out waiting for\n`consoleMonacoOutput` because a single `Play` click could be a no-op\nwhen the Monaco editor had not yet registered the current request —\nnothing was dispatched and the output panel stayed in its empty \"Enter a\nnew request\" state.\n- `clickPlayAndWaitForResults` now retries the `Play` click itself (any\nin-flight spinner/badge or the output panel appearing proves the request\nwas sent), then waits for completion.\n\nThis re-applies the exact change the failed-test investigator proposed\nand that passed the flaky-test runner 50/50 as the first commit of the\nnow-closed #277647. That PR was closed after a second commit added a\n`clickClearOutput()` call ahead of the retry (on review feedback about a\ntheoretical stale-output false positive), which regressed the console\nsuite to 2/25: clearing the output deselects the request in the\nrepeated-call `_output_filter.ts` `beforeEach`, turning the next `Play`\nclick into a genuine no-op with no output left to fall back on. This PR\nkeeps only the proven retry-click and drops the regressing clear step.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n- `node scripts/eslint\nsrc/platform/test/functional/page_objects/console_page.ts` — passed.\n- This diff is identical to the first commit of #277647, which passed\nthe flaky-test runner 50/50 (`kibana-flaky-test-suite-runner#13066`).\n\n#### Not verified locally\n\n- `node scripts/type_check --project src/platform/test/tsconfig.json` —\nthe TS project-ref build was SIGKILLed (out of memory) in the sandbox\nbefore completing; this is an environment resource limit, not a type\nerror. The change only substitutes `retry.try(...)` for the previous\n`retry.tryForTime(...).catch(...)` chain, matching the pattern already\nused by `waitForRequestToComplete` in the same file.\n- The FTR tests (`_vector_tile.ts` and the other console specs using\nthis page object) require a live Elasticsearch + Kibana and cannot be\nrun in this environment.\n\n</details>\n\n> [!NOTE]\n> Requested by @SoniaSanzV. Share feedback in #kibana-qa.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/29241607439) for\n#240154 · 274.8 AIC · ⌖ 28.8 AIC · ⊞ 4.2K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\n---------\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>","sha":"d65989a000a8243d0aaf07ca162051549a793ffc"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/280981","number":280981,"state":"MERGED","mergeCommit":{"sha":"eeb70ae23c2207f8525d56a6e5bb78a6fa428e27","message":"[9.5] [Console] Retry Play click until console request starts (#277705) (#280981)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Console] Retry Play click until console request starts\n(#277705)](https://github.com/elastic/kibana/pull/277705)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277705","number":277705,"mergeCommit":{"message":"[Console] Retry Play click until console request starts (#277705)\n\nFixes #240154\nFixes #240147\n\n### Summary\n- The console FTR tests intermittently timed out waiting for\n`consoleMonacoOutput` because a single `Play` click could be a no-op\nwhen the Monaco editor had not yet registered the current request —\nnothing was dispatched and the output panel stayed in its empty \"Enter a\nnew request\" state.\n- `clickPlayAndWaitForResults` now retries the `Play` click itself (any\nin-flight spinner/badge or the output panel appearing proves the request\nwas sent), then waits for completion.\n\nThis re-applies the exact change the failed-test investigator proposed\nand that passed the flaky-test runner 50/50 as the first commit of the\nnow-closed #277647. That PR was closed after a second commit added a\n`clickClearOutput()` call ahead of the retry (on review feedback about a\ntheoretical stale-output false positive), which regressed the console\nsuite to 2/25: clearing the output deselects the request in the\nrepeated-call `_output_filter.ts` `beforeEach`, turning the next `Play`\nclick into a genuine no-op with no output left to fall back on. This PR\nkeeps only the proven retry-click and drops the regressing clear step.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n- `node scripts/eslint\nsrc/platform/test/functional/page_objects/console_page.ts` — passed.\n- This diff is identical to the first commit of #277647, which passed\nthe flaky-test runner 50/50 (`kibana-flaky-test-suite-runner#13066`).\n\n#### Not verified locally\n\n- `node scripts/type_check --project src/platform/test/tsconfig.json` —\nthe TS project-ref build was SIGKILLed (out of memory) in the sandbox\nbefore completing; this is an environment resource limit, not a type\nerror. The change only substitutes `retry.try(...)` for the previous\n`retry.tryForTime(...).catch(...)` chain, matching the pattern already\nused by `waitForRequestToComplete` in the same file.\n- The FTR tests (`_vector_tile.ts` and the other console specs using\nthis page object) require a live Elasticsearch + Kibana and cannot be\nrun in this environment.\n\n</details>\n\n> [!NOTE]\n> Requested by @SoniaSanzV. Share feedback in #kibana-qa.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/29241607439) for\n#240154 · 274.8 AIC · ⌖ 28.8 AIC · ⊞ 4.2K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\n---------\n\nCo-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>","sha":"d65989a000a8243d0aaf07ca162051549a793ffc"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->