### PR TITLE
[9.4] [Lens as code] Preserve custom name for ad-hoc form based dataviews (#280546)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -80486,6 +80486,12 @@ components:
         index_pattern:
           description: 'The index pattern (Elasticsearch index expression) to use as the data source. Example: "my-index-*".'
           type: string
+        name:
+          description: 'The name of the data view. Example: "Sample data view".'
+          maxLength: 256
+          minLength: 1
+          title: Data view name
+          type: string
         time_field:
           description: 'The name of the time field in the index. Used for time-based filtering. Example: "@timestamp".'
           type: string

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -91645,6 +91645,12 @@ components:
         index_pattern:
           description: 'The index pattern (Elasticsearch index expression) to use as the data source. Example: "my-index-*".'
           type: string
+        name:
+          description: 'The name of the data view. Example: "Sample data view".'
+          maxLength: 256
+          minLength: 1
+          title: Data view name
+          type: string
         time_field:
           description: 'The name of the time field in the index. Used for time-based filtering. Example: "@timestamp".'
           type: string

--- a/src/platform/packages/shared/as-code/data-views-schema/src/schema_data_view.test.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/schema_data_view.test.ts
@@ -64,3 +64,33 @@ describe('dataViewSpecSchema field_settings', () => {
     expect(dataViewSpecSchema.validate(input)).toEqual(input);
   });
 });
+
+describe('dataViewSpecSchema name', () => {
+  it('accepts an inline (adhoc) data view spec with a name', () => {
+    const input = {
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+      time_field: '@timestamp',
+      name: 'My logs',
+    };
+    expect(dataViewSpecSchema.validate(input)).toEqual(input);
+  });
+
+  it('accepts an inline data view spec without a name', () => {
+    const input = {
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+    };
+    expect(dataViewSpecSchema.validate(input)).toEqual(input);
+  });
+
+  it('rejects an empty name', () => {
+    expect(() =>
+      dataViewSpecSchema.validate({
+        type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+        index_pattern: 'logs-*',
+        name: '',
+      })
+    ).toThrow();
+  });
+});

--- a/src/platform/packages/shared/as-code/data-views-schema/src/schema_data_view.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/schema_data_view.ts
@@ -65,6 +65,16 @@ export const dataViewSpecSchema = schema.object(
     field_settings: schema.maybe(
       schema.recordOf(schema.string({ minLength: 1 }), fieldSettingsSchema)
     ),
+    name: schema.maybe(
+      schema.string({
+        minLength: 1,
+        maxLength: 256,
+        meta: {
+          title: 'Data view name',
+          description: 'The name of the data view. Example: "Sample data view".',
+        },
+      })
+    ),
   },
   { meta: { id: 'kbn-data-view-spec-schema', title: 'Data view inline spec' } }
 );

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_data_view.test.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_data_view.test.ts
@@ -43,6 +43,27 @@ describe('fromStoredDataView', () => {
     expect(api).not.toHaveProperty('allow_hidden_indices');
   });
 
+  it('maps inline name and round-trips', () => {
+    const stored = {
+      title: 'logs-*',
+      timeFieldName: '@timestamp',
+      name: 'My logs',
+    };
+    const api = fromStoredDataView(stored);
+    expect(api).toEqual({
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+      time_field: '@timestamp',
+      name: 'My logs',
+    });
+    expect(toStoredDataView(api)).toEqual(stored);
+  });
+
+  it('omits name when the stored spec has no name', () => {
+    const api = fromStoredDataView({ title: 'logs-*', timeFieldName: '@timestamp' });
+    expect(api).not.toHaveProperty('name');
+  });
+
   it('maps inline spec with indexed field formats and attrs to field_settings', () => {
     expect(
       fromStoredDataView({

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_data_view.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/from_stored_data_view.ts
@@ -41,5 +41,6 @@ export function fromStoredDataView(
     time_field: index.timeFieldName,
     ...(index.allowHidden !== undefined ? { allow_hidden_indices: index.allowHidden } : {}),
     ...(fieldSettings && { field_settings: fieldSettings }),
+    ...(index.name && { name: index.name }),
   };
 }

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_data_view.test.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_data_view.test.ts
@@ -69,6 +69,31 @@ describe('toStoredDataView', () => {
     });
   });
 
+  it('preserves name on an inline (adhoc) data view spec', () => {
+    const dataView: AsCodeDataViewSpec = {
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+      time_field: '@timestamp',
+      name: 'My logs',
+    };
+    const result = toStoredDataView(dataView);
+    expect(result).toEqual({
+      title: 'logs-*',
+      timeFieldName: '@timestamp',
+      name: 'My logs',
+    });
+  });
+
+  it('omits name on an inline data view spec when not provided', () => {
+    const dataView: AsCodeDataViewSpec = {
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+      time_field: '@timestamp',
+    };
+    const result = toStoredDataView(dataView);
+    expect(result).not.toHaveProperty('name');
+  });
+
   it('converts index-pattern data_source without runtime fields', () => {
     const dataView: AsCodeDataViewSpec = {
       type: AS_CODE_DATA_VIEW_SPEC_TYPE,

--- a/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_data_view.ts
+++ b/src/platform/packages/shared/as-code/data-views-transforms/src/to_stored_data_view.ts
@@ -41,5 +41,6 @@ export function toStoredDataView(dataView: AsCodeDataView): string | DataViewSpe
     ...(runtimeFieldMap && Object.keys(runtimeFieldMap).length > 0 && { runtimeFieldMap }),
     ...(fieldFormats && Object.keys(fieldFormats).length > 0 && { fieldFormats }),
     ...(fieldAttrs && Object.keys(fieldAttrs).length > 0 && { fieldAttrs }),
+    ...(dataView.name && { name: dataView.name }),
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/common.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/common.ts
@@ -134,8 +134,14 @@ function normalizeESQLAdHocDataViews(
 
       layer.index = newId;
       adHocDataView.id = newId;
-      adHocDataView.name = indexPattern;
       adHocDataView.title = indexPattern;
+      // An ES|QL ad-hoc data view has no dedicated `name` in the `{ type: 'esql', query }` data
+      // source; the transform re-derives both title and name from the query's index pattern
+      // (getAdHocDataViewSpec: `name = dataView.name ?? dataView.index`). This mirrors the DataView
+      // runtime, where `getName() = name || title` and a freshly created ES|QL data view
+      // (getESQLAdHocDataview) sets only `title = queryIndexPattern`, so the effective name is the
+      // query index pattern.
+      adHocDataView.name = adHocDataView.title;
       // The transform re-derives the time field from the ES|QL query rather than trusting the
       // persisted value (getAdHocDataViewSpec <- getDataSourceIndex.esql), so align the stored
       // timeFieldName here instead of skipping it entirely.
@@ -207,8 +213,10 @@ function normalizeFormBasedAdHocDataViews(
 
       delete adHocDataViews[adHocId];
       adHocDataView.id = newId;
-      adHocDataView.name = adHocDataView.title ?? adHocDataView.name;
+      // A custom form-based name round-trips verbatim
       adHocDataViews[newId] = adHocDataView;
+      // mirror the transform's `name = name ?? index` (title === index for form-based)
+      adHocDataView.name = adHocDataView.name ?? adHocDataView.title;
 
       if (ref) {
         ref.id = newId;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/types.ts
@@ -84,6 +84,7 @@ export interface APIDataView {
 export interface APIAdHocDataView {
   type: 'adHocDataView';
   index: string;
+  name?: string;
   timeFieldName: string | undefined;
   dataSourceType?: string;
   esqlQuery?: string;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -108,6 +108,29 @@ describe('getDatasetIndex', () => {
     });
     expect(result).not.toHaveProperty('allowHidden');
   });
+
+  test('threads name into the adhoc dataview index when set', () => {
+    const result = getDataSourceIndex({
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+      time_field: '@timestamp',
+      name: 'My logs',
+    });
+    expect(result).toEqual({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      name: 'My logs',
+    });
+  });
+
+  test('omits name when not set', () => {
+    const result = getDataSourceIndex({
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+      time_field: '@timestamp',
+    });
+    expect(result).not.toHaveProperty('name');
+  });
 });
 
 describe('addLayerColumn', () => {
@@ -459,13 +482,13 @@ describe('buildDataSourceState', () => {
 });
 
 describe('buildDataSourceStateNoESQL', () => {
-  test('emits allow_hidden_indices for an adhoc dataview with allowHidden', () => {
-    const formBasedLayer = {
-      indexPatternId: 'my-adhoc-dataview-id',
-      columns: {},
-      columnOrder: [],
-    } as FormBasedLayer;
+  const formBasedLayer = {
+    indexPatternId: 'my-adhoc-dataview-id',
+    columns: {},
+    columnOrder: [],
+  } as FormBasedLayer;
 
+  test('emits allow_hidden_indices for an adhoc dataview with allowHidden', () => {
     const result = buildDataSourceStateNoESQL(
       formBasedLayer,
       'layer_1',
@@ -495,12 +518,6 @@ describe('buildDataSourceStateNoESQL', () => {
   });
 
   test('omits allow_hidden_indices for an adhoc dataview without allowHidden', () => {
-    const formBasedLayer = {
-      indexPatternId: 'my-adhoc-dataview-id',
-      columns: {},
-      columnOrder: [],
-    } as FormBasedLayer;
-
     const result = buildDataSourceStateNoESQL(
       formBasedLayer,
       'layer_1',
@@ -522,6 +539,58 @@ describe('buildDataSourceStateNoESQL', () => {
     );
     expect(result).not.toHaveProperty('allow_hidden_indices');
   });
+
+  test('emits name for an adhoc dataview with a name', () => {
+    const result = buildDataSourceStateNoESQL(
+      formBasedLayer,
+      'layer_1',
+      {
+        'my-adhoc-dataview-id': {
+          index: 'test-id',
+          title: 'logs-*',
+          name: 'My logs',
+          timeFieldName: '@timestamp',
+        },
+      },
+      [],
+      [
+        {
+          type: 'index-pattern',
+          id: 'my-adhoc-dataview-id',
+          name: 'indexpattern-datasource-layer-layer_1',
+        },
+      ]
+    );
+    expect(result).toEqual({
+      type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+      index_pattern: 'logs-*',
+      name: 'My logs',
+      time_field: '@timestamp',
+    });
+  });
+
+  test('omits name for an adhoc dataview without a name', () => {
+    const result = buildDataSourceStateNoESQL(
+      formBasedLayer,
+      'layer_1',
+      {
+        'my-adhoc-dataview-id': {
+          index: 'test-id',
+          title: 'logs-*',
+          timeFieldName: '@timestamp',
+        },
+      },
+      [],
+      [
+        {
+          type: 'index-pattern',
+          id: 'my-adhoc-dataview-id',
+          name: 'indexpattern-datasource-layer-layer_1',
+        },
+      ]
+    );
+    expect(result).not.toHaveProperty('name');
+  });
 });
 
 describe('getAdHocDataViewSpec', () => {
@@ -542,6 +611,37 @@ describe('getAdHocDataViewSpec', () => {
       timeFieldName: '@timestamp',
     });
     expect(spec).not.toHaveProperty('allowHidden');
+  });
+
+  test('preserves name when provided', () => {
+    const spec = getAdHocDataViewSpec({
+      type: 'adHocDataView',
+      index: 'logs-*',
+      name: 'My logs',
+      timeFieldName: '@timestamp',
+    });
+    expect(spec).toHaveProperty('name', 'My logs');
+  });
+
+  test('defaults name to the index when not provided', () => {
+    const spec = getAdHocDataViewSpec({
+      type: 'adHocDataView',
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+    });
+    expect(spec).toHaveProperty('name', 'logs-*');
+  });
+
+  test('derives name from the index for ES|QL adhoc dataviews (no name field on the esql source)', () => {
+    const spec = getAdHocDataViewSpec({
+      type: 'adHocDataView',
+      index: 'kibana_sample_data_logs',
+      dataSourceType: 'esql',
+      esqlQuery: 'FROM kibana_sample_data_logs',
+      timeFieldName: undefined,
+    });
+    expect(spec).toHaveProperty('name', 'kibana_sample_data_logs');
+    expect(spec).toHaveProperty('title', 'kibana_sample_data_logs');
   });
 });
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -151,7 +151,7 @@ export function getAdHocDataViewSpec(dataView: APIAdHocDataView) {
     // Improve id genertation to be more predictable and hit cache more often
     id: generateAdHocDataViewId(dataView),
     title: dataView.index,
-    name: dataView.index,
+    name: dataView.name ?? dataView.index,
     timeFieldName: dataView.timeFieldName,
     sourceFilters: [],
     ...fromApiFieldSettings(dataView.fieldSettings),
@@ -225,6 +225,7 @@ export function buildDataSourceStateNoESQL(
       return {
         type: AS_CODE_DATA_VIEW_SPEC_TYPE,
         index_pattern: dataViewSpec.title,
+        ...(dataViewSpec.name ? { name: dataViewSpec.name } : {}),
         time_field: dataViewSpec.timeFieldName,
         ...(dataViewSpec.allowHidden !== undefined
           ? { allow_hidden_indices: dataViewSpec.allowHidden }
@@ -298,6 +299,7 @@ export function getDataSourceIndex(dataSource: DataSourceType) {
       return {
         index: dataSource.index_pattern,
         timeFieldName: dataSource.time_field ?? timeFieldName,
+        ...(dataSource.name ? { name: dataSource.name } : {}),
         ...(dataSource.allow_hidden_indices !== undefined
           ? { allowHidden: dataSource.allow_hidden_indices }
           : {}),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens as code] Preserve custom name for ad-hoc form based dataviews (#280546)](https://github.com/elastic/kibana/pull/280546)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"andreana.malama@elastic.co"},"sourceCommit":{"committedDate":"2026-07-28T08:36:34Z","message":"[Lens as code] Preserve custom name for ad-hoc form based dataviews (#280546)\n\n## Summary\n\nPart of #279517\nFollow up to #280086 \n\nThis PR preserves the custom display `name` of inline / ad-hoc data\nviews through the \"as-code\" transformation round trip. More here:\nhttps://github.com/elastic/kibana/pull/280086#discussion_r3632524217.\n\nPreviously the name field was only handled for saved data views. For\ninline data views it was dropped on the way in and re-derived as the\nindex pattern on the way out.\n\nThis meant a form-based ad-hoc data view with a custom name (e.g. My\nlogs) would lose that name when round-tripped through the API path.\n\nES|QL ad-hoc data views are intentionally unaffected: their `{ type:\n'esql', query }` data source has no dedicated name, so the name\ncontinues to derive from the query's index pattern (mirroring the\nDataView runtime where `getName() = name || title`).\n\n## Changes\n\nas-code/data-views-schema:\n\n- Extracted a shared `nameSchema` into `common.ts.`\n- Added name to `dataViewSpecSchema` (inline/embedded data views).\n- Reused `nameSchema` in `savedDataViewSpecSchema`.\n\nas-code/data-views-transforms:\n\n- `fromStoredDataView`: maps `index.name` → API name when present.\n- `toStoredDataView`: writes `name` for inline specs, and removed `name`\nfrom the \"is this a saved data view check\"\n\nkbn-lens-embeddable-utils/config_builder\n\n- Added optional `name` to `APIAdHocDataView`.\n- `getAdHocDataViewSpec`: `name: dataView.name ?? dataView.index` (falls\nback to index, preserving prior behavior when unset).\n- `buildDataSourceStateNoESQL` and `getDataSourceIndex`: thread `name`\nthrough when set, omit it otherwise.\n- Updated the strict round-trip normalizer\n(`normalizeFormBasedAdHocDataViews`) so a custom form-based name\nround-trips verbatim, with a clarifying comment on the ES|QL derivation\ncase.\n\n## Release Note\nFixes the Lens as-code API path dropping the custom display name of\ninline (ad-hoc) data views. The name is now preserved end-to-end.\n\n## Screenshots\n\n\n- Before (Left: API flag OFF, Right: API flag ON)\n<img width=\"1495\" height=\"727\" alt=\"Screenshot 2026-07-23 at 6 29 35 PM\"\nsrc=\"https://github.com/user-attachments/assets/aca74e65-fc93-461a-9084-3d6bb58ca54d\"\n/>\n\n\n- After (Left: API flag OFF, Right: API flag ON)\n<img width=\"1499\" height=\"734\" alt=\"Screenshot 2026-07-23 at 5 17 22 PM\"\nsrc=\"https://github.com/user-attachments/assets/9eab35eb-66fa-4909-89a6-fbf9c097d15c\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c8f33529dad8ad2ff6224dbafab3036dd75ba5ae","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:version","v9.6.0","v9.4.5","v9.5.1"],"title":"[Lens as code] Preserve custom name for ad-hoc form based dataviews","number":280546,"url":"https://github.com/elastic/kibana/pull/280546","mergeCommit":{"message":"[Lens as code] Preserve custom name for ad-hoc form based dataviews (#280546)\n\n## Summary\n\nPart of #279517\nFollow up to #280086 \n\nThis PR preserves the custom display `name` of inline / ad-hoc data\nviews through the \"as-code\" transformation round trip. More here:\nhttps://github.com/elastic/kibana/pull/280086#discussion_r3632524217.\n\nPreviously the name field was only handled for saved data views. For\ninline data views it was dropped on the way in and re-derived as the\nindex pattern on the way out.\n\nThis meant a form-based ad-hoc data view with a custom name (e.g. My\nlogs) would lose that name when round-tripped through the API path.\n\nES|QL ad-hoc data views are intentionally unaffected: their `{ type:\n'esql', query }` data source has no dedicated name, so the name\ncontinues to derive from the query's index pattern (mirroring the\nDataView runtime where `getName() = name || title`).\n\n## Changes\n\nas-code/data-views-schema:\n\n- Extracted a shared `nameSchema` into `common.ts.`\n- Added name to `dataViewSpecSchema` (inline/embedded data views).\n- Reused `nameSchema` in `savedDataViewSpecSchema`.\n\nas-code/data-views-transforms:\n\n- `fromStoredDataView`: maps `index.name` → API name when present.\n- `toStoredDataView`: writes `name` for inline specs, and removed `name`\nfrom the \"is this a saved data view check\"\n\nkbn-lens-embeddable-utils/config_builder\n\n- Added optional `name` to `APIAdHocDataView`.\n- `getAdHocDataViewSpec`: `name: dataView.name ?? dataView.index` (falls\nback to index, preserving prior behavior when unset).\n- `buildDataSourceStateNoESQL` and `getDataSourceIndex`: thread `name`\nthrough when set, omit it otherwise.\n- Updated the strict round-trip normalizer\n(`normalizeFormBasedAdHocDataViews`) so a custom form-based name\nround-trips verbatim, with a clarifying comment on the ES|QL derivation\ncase.\n\n## Release Note\nFixes the Lens as-code API path dropping the custom display name of\ninline (ad-hoc) data views. The name is now preserved end-to-end.\n\n## Screenshots\n\n\n- Before (Left: API flag OFF, Right: API flag ON)\n<img width=\"1495\" height=\"727\" alt=\"Screenshot 2026-07-23 at 6 29 35 PM\"\nsrc=\"https://github.com/user-attachments/assets/aca74e65-fc93-461a-9084-3d6bb58ca54d\"\n/>\n\n\n- After (Left: API flag OFF, Right: API flag ON)\n<img width=\"1499\" height=\"734\" alt=\"Screenshot 2026-07-23 at 5 17 22 PM\"\nsrc=\"https://github.com/user-attachments/assets/9eab35eb-66fa-4909-89a6-fbf9c097d15c\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c8f33529dad8ad2ff6224dbafab3036dd75ba5ae"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280546","number":280546,"mergeCommit":{"message":"[Lens as code] Preserve custom name for ad-hoc form based dataviews (#280546)\n\n## Summary\n\nPart of #279517\nFollow up to #280086 \n\nThis PR preserves the custom display `name` of inline / ad-hoc data\nviews through the \"as-code\" transformation round trip. More here:\nhttps://github.com/elastic/kibana/pull/280086#discussion_r3632524217.\n\nPreviously the name field was only handled for saved data views. For\ninline data views it was dropped on the way in and re-derived as the\nindex pattern on the way out.\n\nThis meant a form-based ad-hoc data view with a custom name (e.g. My\nlogs) would lose that name when round-tripped through the API path.\n\nES|QL ad-hoc data views are intentionally unaffected: their `{ type:\n'esql', query }` data source has no dedicated name, so the name\ncontinues to derive from the query's index pattern (mirroring the\nDataView runtime where `getName() = name || title`).\n\n## Changes\n\nas-code/data-views-schema:\n\n- Extracted a shared `nameSchema` into `common.ts.`\n- Added name to `dataViewSpecSchema` (inline/embedded data views).\n- Reused `nameSchema` in `savedDataViewSpecSchema`.\n\nas-code/data-views-transforms:\n\n- `fromStoredDataView`: maps `index.name` → API name when present.\n- `toStoredDataView`: writes `name` for inline specs, and removed `name`\nfrom the \"is this a saved data view check\"\n\nkbn-lens-embeddable-utils/config_builder\n\n- Added optional `name` to `APIAdHocDataView`.\n- `getAdHocDataViewSpec`: `name: dataView.name ?? dataView.index` (falls\nback to index, preserving prior behavior when unset).\n- `buildDataSourceStateNoESQL` and `getDataSourceIndex`: thread `name`\nthrough when set, omit it otherwise.\n- Updated the strict round-trip normalizer\n(`normalizeFormBasedAdHocDataViews`) so a custom form-based name\nround-trips verbatim, with a clarifying comment on the ES|QL derivation\ncase.\n\n## Release Note\nFixes the Lens as-code API path dropping the custom display name of\ninline (ad-hoc) data views. The name is now preserved end-to-end.\n\n## Screenshots\n\n\n- Before (Left: API flag OFF, Right: API flag ON)\n<img width=\"1495\" height=\"727\" alt=\"Screenshot 2026-07-23 at 6 29 35 PM\"\nsrc=\"https://github.com/user-attachments/assets/aca74e65-fc93-461a-9084-3d6bb58ca54d\"\n/>\n\n\n- After (Left: API flag OFF, Right: API flag ON)\n<img width=\"1499\" height=\"734\" alt=\"Screenshot 2026-07-23 at 5 17 22 PM\"\nsrc=\"https://github.com/user-attachments/assets/9eab35eb-66fa-4909-89a6-fbf9c097d15c\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c8f33529dad8ad2ff6224dbafab3036dd75ba5ae"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->