### PR TITLE
[8.19] fix(fleet): fix hasChanged() in fleet_proxies.ts always returning truthy (#281059)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FleetProxy } from '../../../common/types';
+
+import { hasChanged } from './fleet_proxies';
+
+const baseProxy: FleetProxy = {
+  id: 'proxy-1',
+  name: 'My Proxy',
+  url: 'http://proxy.example.com:3128',
+  is_preconfigured: true,
+  proxy_headers: null,
+  certificate_authorities: null,
+  certificate: null,
+  certificate_key: null,
+};
+
+describe('hasChanged()', () => {
+  it('returns false when existing proxy is identical to preconfigured one', () => {
+    expect(hasChanged(baseProxy, { ...baseProxy })).toBe(false);
+  });
+
+  it('returns true when existing proxy is not preconfigured', () => {
+    expect(hasChanged({ ...baseProxy, is_preconfigured: false }, baseProxy)).toBe(true);
+  });
+
+  it('returns true when name differs', () => {
+    expect(hasChanged(baseProxy, { ...baseProxy, name: 'Other Proxy' })).toBe(true);
+  });
+
+  it('returns true when url differs', () => {
+    expect(hasChanged(baseProxy, { ...baseProxy, url: 'http://other.example.com:3128' })).toBe(
+      true
+    );
+  });
+
+  describe('proxy_headers', () => {
+    it('returns false when both proxy_headers are null', () => {
+      expect(
+        hasChanged({ ...baseProxy, proxy_headers: null }, { ...baseProxy, proxy_headers: null })
+      ).toBe(false);
+    });
+
+    it('returns false when proxy_headers are deeply equal', () => {
+      const headers = { Authorization: 'Bearer token', 'X-Custom': 1 };
+      expect(
+        hasChanged(
+          { ...baseProxy, proxy_headers: headers },
+          { ...baseProxy, proxy_headers: { ...headers } }
+        )
+      ).toBe(false);
+    });
+
+    it('returns true when proxy_headers differ', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, proxy_headers: { Authorization: 'Bearer old' } },
+          { ...baseProxy, proxy_headers: { Authorization: 'Bearer new' } }
+        )
+      ).toBe(true);
+    });
+
+    it('returns true when one proxy_headers is null and other is not', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, proxy_headers: null },
+          { ...baseProxy, proxy_headers: { 'X-Header': 'value' } }
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('certificate_authorities', () => {
+    it('returns true when certificate_authorities differs', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate_authorities: 'old-ca' },
+          { ...baseProxy, certificate_authorities: 'new-ca' }
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when undefined and null (normalized equal)', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate_authorities: undefined },
+          { ...baseProxy, certificate_authorities: null }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('certificate', () => {
+    it('returns true when certificate differs', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate: 'old-cert' },
+          { ...baseProxy, certificate: 'new-cert' }
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when undefined and null (normalized equal)', () => {
+      expect(
+        hasChanged({ ...baseProxy, certificate: undefined }, { ...baseProxy, certificate: null })
+      ).toBe(false);
+    });
+  });
+
+  describe('certificate_key', () => {
+    it('returns true when certificate_key differs', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate_key: 'old-key' },
+          { ...baseProxy, certificate_key: 'new-key' }
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when undefined and null (normalized equal)', () => {
+      expect(
+        hasChanged(
+          { ...baseProxy, certificate_key: undefined },
+          { ...baseProxy, certificate_key: null }
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/fleet_proxies.ts
@@ -31,27 +31,19 @@ export function getPreconfiguredFleetProxiesFromConfig(config?: FleetConfigType)
   }));
 }
 
-function hasChanged(existingProxy: FleetProxy, preconfiguredFleetProxy: FleetProxy) {
+export function hasChanged(
+  existingProxy: FleetProxy,
+  preconfiguredFleetProxy: FleetProxy
+): boolean {
   return (
-    (!existingProxy.is_preconfigured ||
-      existingProxy.name !== existingProxy.name ||
-      existingProxy.url !== preconfiguredFleetProxy.name ||
-      !isEqual(
-        existingProxy.proxy_headers ?? null,
-        preconfiguredFleetProxy.proxy_headers ?? null
-      ) ||
-      existingProxy.certificate_authorities) ??
-    // @ts-expect-error upgrade typescript v5.9.3
-    null !== preconfiguredFleetProxy.certificate_authorities ??
-    // @ts-expect-error upgrade typescript v5.9.3
-    (null || existingProxy.certificate) ??
-    // @ts-expect-error upgrade typescript v5.9.3
-    null !== preconfiguredFleetProxy.certificate ??
-    // @ts-expect-error upgrade typescript v5.9.3
-    (null || existingProxy.certificate_key) ??
-    // @ts-expect-error upgrade typescript v5.9.3
-    null !== preconfiguredFleetProxy.certificate_key ??
-    null
+    !existingProxy.is_preconfigured ||
+    existingProxy.name !== preconfiguredFleetProxy.name ||
+    existingProxy.url !== preconfiguredFleetProxy.url ||
+    !isEqual(existingProxy.proxy_headers ?? null, preconfiguredFleetProxy.proxy_headers ?? null) ||
+    (existingProxy.certificate_authorities ?? null) !==
+      (preconfiguredFleetProxy.certificate_authorities ?? null) ||
+    (existingProxy.certificate ?? null) !== (preconfiguredFleetProxy.certificate ?? null) ||
+    (existingProxy.certificate_key ?? null) !== (preconfiguredFleetProxy.certificate_key ?? null)
   );
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.19`:
- [fix(fleet): fix hasChanged() in fleet_proxies.ts always returning truthy (#281059)](https://github.com/elastic/kibana/pull/281059)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":281059,"url":"https://github.com/elastic/kibana/pull/281059","title":"fix(fleet): fix hasChanged() in fleet_proxies.ts always returning truthy"},"sourceBranch":"master","suggestedTargetBranches":["8.19"],"sourceCommit":{"sha":"d8286c8b7fa96b5c986b0cc9045b0e485e109023"}}] BACKPORT-->