### PR TITLE
[Entity Store] Reinstall indices and data streams if missing

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.test.ts
@@ -5,17 +5,26 @@
  * 2.0.
  */
 
+import type { ElasticsearchClient } from '@kbn/core/server';
 import { loggerMock } from '@kbn/logging-mocks';
-import { uninstallElasticsearchAssets } from './install_assets';
+import {
+  uninstallElasticsearchAssets,
+  reinstallSharedElasticsearchAssetsIfMissing,
+  isIndexNotFoundError,
+} from './install_assets';
 import { getLatestEntitiesIndexName } from '../../../common/domain/entity_index';
 import { getUpdatesEntitiesDataStreamName } from './updates_data_stream';
 import { getMetadataEntitiesDataStreamName } from './metadata_data_stream';
 
 jest.mock('../../infra/elasticsearch');
 
-const { deleteIndex, deleteDataStream } = jest.requireMock('../../infra/elasticsearch') as {
+const { deleteIndex, deleteDataStream, createIndex, createDataStream } = jest.requireMock(
+  '../../infra/elasticsearch'
+) as {
   deleteIndex: jest.Mock;
   deleteDataStream: jest.Mock;
+  createIndex: jest.Mock;
+  createDataStream: jest.Mock;
 };
 
 describe('uninstallElasticsearchAssets', () => {
@@ -80,5 +89,167 @@ describe('uninstallElasticsearchAssets', () => {
 
     expect(deleteIndex).toHaveBeenCalledTimes(1);
     expect(deleteDataStream).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('reinstallSharedElasticsearchAssetsIfMissing', () => {
+  const namespace = 'default';
+  const updatesDataStream = getUpdatesEntitiesDataStreamName(namespace);
+  const metadataDataStream = getMetadataEntitiesDataStreamName(namespace);
+
+  const createEsClientMock = ({
+    latest,
+    updates,
+    metadata,
+  }: {
+    latest: boolean;
+    updates: boolean;
+    metadata: boolean;
+  }) =>
+    ({
+      indices: {
+        exists: jest.fn().mockResolvedValue(latest),
+        getDataStream: jest.fn().mockImplementation(async ({ name }: { name: string }) => {
+          const present = name === updatesDataStream ? updates : metadata;
+          if (!present) {
+            throw new Error('resource_not_found_exception');
+          }
+          return {};
+        }),
+      },
+      ingest: { putPipeline: jest.fn().mockResolvedValue(undefined) },
+      cluster: { putComponentTemplate: jest.fn().mockResolvedValue(undefined) },
+    } as unknown as ElasticsearchClient);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createIndex.mockResolvedValue(undefined);
+    createDataStream.mockResolvedValue(undefined);
+  });
+
+  it('returns false and does not reinstall when all assets are present', async () => {
+    const reinstalled = await reinstallSharedElasticsearchAssetsIfMissing({
+      esClient: createEsClientMock({ latest: true, updates: true, metadata: true }),
+      logger: loggerMock.create(),
+      namespace,
+    });
+
+    expect(reinstalled).toBe(false);
+    expect(createIndex).not.toHaveBeenCalled();
+    expect(createDataStream).not.toHaveBeenCalled();
+  });
+
+  it('reinstalls and returns true when the latest index is missing', async () => {
+    const logger = loggerMock.create();
+    const reinstalled = await reinstallSharedElasticsearchAssetsIfMissing({
+      esClient: createEsClientMock({ latest: false, updates: true, metadata: true }),
+      logger,
+      namespace,
+    });
+
+    expect(reinstalled).toBe(true);
+    expect(createIndex).toHaveBeenCalledWith(
+      expect.anything(),
+      getLatestEntitiesIndexName(namespace),
+      expect.anything()
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(getLatestEntitiesIndexName(namespace))
+    );
+  });
+
+  it('reinstalls and returns true when the updates data stream is missing', async () => {
+    const reinstalled = await reinstallSharedElasticsearchAssetsIfMissing({
+      esClient: createEsClientMock({ latest: true, updates: false, metadata: true }),
+      logger: loggerMock.create(),
+      namespace,
+    });
+
+    expect(reinstalled).toBe(true);
+    expect(createDataStream).toHaveBeenCalledWith(expect.anything(), updatesDataStream, expect.anything());
+  });
+
+  it('reinstalls and returns true when the metadata data stream is missing', async () => {
+    const reinstalled = await reinstallSharedElasticsearchAssetsIfMissing({
+      esClient: createEsClientMock({ latest: true, updates: true, metadata: false }),
+      logger: loggerMock.create(),
+      namespace,
+    });
+
+    expect(reinstalled).toBe(true);
+    expect(createDataStream).toHaveBeenCalledWith(
+      expect.anything(),
+      metadataDataStream,
+      expect.anything()
+    );
+  });
+});
+
+describe('isIndexNotFoundError', () => {
+  it('matches a top-level index_not_found_exception type', () => {
+    expect(
+      isIndexNotFoundError({ meta: { body: { error: { type: 'index_not_found_exception' } } } })
+    ).toBe(true);
+  });
+
+  it('matches an index_not_found_exception in root_cause type', () => {
+    expect(
+      isIndexNotFoundError({
+        meta: {
+          body: {
+            error: {
+              type: 'verification_exception',
+              root_cause: [{ type: 'index_not_found_exception' }],
+            },
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('matches ESQL verification_exception with "Unknown index" in root_cause reason', () => {
+    // ESQL reports a missing index as a verification_exception whose reason contains "Unknown index".
+    expect(
+      isIndexNotFoundError({
+        meta: {
+          body: {
+            error: {
+              type: 'verification_exception',
+              root_cause: [
+                {
+                  type: 'verification_exception',
+                  reason:
+                    'Found 1 problem\nline 153:15: Unknown index [.entities.v2.latest.security_default-00001]',
+                },
+              ],
+            },
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('matches an index_not_found_exception in the message', () => {
+    expect(
+      isIndexNotFoundError(new Error('Root causes: index_not_found_exception: no such index'))
+    ).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isIndexNotFoundError(new Error('boom'))).toBe(false);
+    expect(
+      isIndexNotFoundError({
+        meta: {
+          body: {
+            error: {
+              type: 'verification_exception',
+              root_cause: [{ type: 'verification_exception', reason: 'unrelated problem' }],
+            },
+          },
+        },
+      })
+    ).toBe(false);
+    expect(isIndexNotFoundError(undefined)).toBe(false);
+    expect(isIndexNotFoundError(null)).toBe(false);
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.test.ts
@@ -166,7 +166,11 @@ describe('reinstallSharedElasticsearchAssetsIfMissing', () => {
     });
 
     expect(reinstalled).toBe(true);
-    expect(createDataStream).toHaveBeenCalledWith(expect.anything(), updatesDataStream, expect.anything());
+    expect(createDataStream).toHaveBeenCalledWith(
+      expect.anything(),
+      updatesDataStream,
+      expect.anything()
+    );
   });
 
   it('reinstalls and returns true when the metadata data stream is missing', async () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.test.ts
@@ -114,7 +114,7 @@ describe('reinstallSharedElasticsearchAssetsIfMissing', () => {
           if (!present) {
             throw new Error('resource_not_found_exception');
           }
-          return {};
+          return { data_streams: [{ name }] };
         }),
       },
       ingest: { putPipeline: jest.fn().mockResolvedValue(undefined) },

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.ts
@@ -194,3 +194,83 @@ async function uninstallIndicesAndDataStreams(
     })(),
   ]);
 }
+
+const INDEX_NOT_FOUND = 'index_not_found_exception';
+
+interface EsErrorLike {
+  message?: string;
+  meta?: { body?: { error?: { type?: string; root_cause?: Array<{ type?: string }> } } };
+}
+
+/**
+ * Returns true when the error is about a missing index. Handles two cases:
+ * - Direct ES errors: top-level or root_cause type is `index_not_found_exception`.
+ * - ESQL errors: `verification_exception` with "Unknown index" in the root_cause reason
+ *   (how ESQL reports a missing index referenced in a query).
+ */
+export const isIndexNotFoundError = (error: unknown): boolean => {
+  const esError = (error as EsErrorLike)?.meta?.body?.error;
+  if (esError?.type === INDEX_NOT_FOUND) {
+    return true;
+  }
+  if (
+    esError?.root_cause?.some(
+      (cause) =>
+        cause?.type === INDEX_NOT_FOUND ||
+        (typeof (cause as { reason?: string })?.reason === 'string' &&
+          ((cause as { reason?: string }).reason!.includes(INDEX_NOT_FOUND) ||
+            (cause as { reason?: string }).reason!.includes('Unknown index')))
+    )
+  ) {
+    return true;
+  }
+  const message = (error as EsErrorLike)?.message;
+  return typeof message === 'string' && message.includes(INDEX_NOT_FOUND);
+};
+
+const dataStreamExists = async (esClient: ElasticsearchClient, name: string): Promise<boolean> => {
+  try {
+    await esClient.indices.getDataStream({ name });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Checks whether the shared index and data streams exist and recreates any that are missing.
+ * Returns true if anything was recreated, false if all were already present.
+ *
+ * Callers use the return value to distinguish a missing entity store index (heal + retry) from a
+ * missing source log index (let the error propagate). Safe to call from parallel extraction tasks —
+ * the underlying creates use `throwIfExists: false`.
+ */
+export async function reinstallSharedElasticsearchAssetsIfMissing({
+  esClient,
+  logger,
+  namespace,
+}: SharedElasticsearchAssetOptions): Promise<boolean> {
+  const latestIndex = getLatestEntitiesIndexName(namespace);
+  const updatesDataStream = getUpdatesEntitiesDataStreamName(namespace);
+  const metadataDataStream = getMetadataEntitiesDataStreamName(namespace);
+
+  const [latestExists, updatesExists, metadataExists] = await Promise.all([
+    esClient.indices.exists({ index: latestIndex }),
+    dataStreamExists(esClient, updatesDataStream),
+    dataStreamExists(esClient, metadataDataStream),
+  ]);
+
+  if (latestExists && updatesExists && metadataExists) {
+    return false;
+  }
+
+  const missing = [
+    !latestExists && latestIndex,
+    !updatesExists && updatesDataStream,
+    !metadataExists && metadataDataStream,
+  ].filter(Boolean);
+  logger.warn(`Recreating missing entity store assets in ${namespace}: ${missing.join(', ')}`);
+
+  await installSharedElasticsearchAssets({ esClient, logger, namespace });
+  return true;
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.ts
@@ -195,11 +195,17 @@ async function uninstallIndicesAndDataStreams(
   ]);
 }
 
-const INDEX_NOT_FOUND = 'index_not_found_exception';
+const INDEX_NOT_FOUND_ERR_TYPE = 'index_not_found_exception';
+const VERIFICATION_EXCEPTION_ERR_TYPE = 'verification_exception';
+
+interface EsErrorCause {
+  type?: string;
+  reason?: string;
+}
 
 interface EsErrorLike {
   message?: string;
-  meta?: { body?: { error?: { type?: string; root_cause?: Array<{ type?: string }> } } };
+  meta?: { body?: { error?: { type?: string; root_cause?: EsErrorCause[] } } };
 }
 
 /**
@@ -210,28 +216,27 @@ interface EsErrorLike {
  */
 export const isIndexNotFoundError = (error: unknown): boolean => {
   const esError = (error as EsErrorLike)?.meta?.body?.error;
-  if (esError?.type === INDEX_NOT_FOUND) {
+  if (esError?.type === INDEX_NOT_FOUND_ERR_TYPE) {
     return true;
   }
   if (
     esError?.root_cause?.some(
       (cause) =>
-        cause?.type === INDEX_NOT_FOUND ||
-        (typeof (cause as { reason?: string })?.reason === 'string' &&
-          ((cause as { reason?: string }).reason!.includes(INDEX_NOT_FOUND) ||
-            (cause as { reason?: string }).reason!.includes('Unknown index')))
+        cause?.type === INDEX_NOT_FOUND_ERR_TYPE ||
+        (cause?.type === VERIFICATION_EXCEPTION_ERR_TYPE &&
+          cause?.reason?.includes('Unknown index'))
     )
   ) {
     return true;
   }
   const message = (error as EsErrorLike)?.message;
-  return typeof message === 'string' && message.includes(INDEX_NOT_FOUND);
+  return message?.includes(INDEX_NOT_FOUND_ERR_TYPE) ?? false;
 };
 
 const dataStreamExists = async (esClient: ElasticsearchClient, name: string): Promise<boolean> => {
   try {
-    await esClient.indices.getDataStream({ name });
-    return true;
+    const response = await esClient.indices.getDataStream({ name });
+    return (response.data_streams?.length ?? 0) > 0;
   } catch {
     return false;
   }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -113,10 +113,9 @@ jest.mock('../asset_manager/install_assets', () => ({
 
 const mockExecuteEsqlQuery = executeEsqlQuery as jest.MockedFunction<typeof executeEsqlQuery>;
 const mockIngestEntities = ingestEntities as jest.MockedFunction<typeof ingestEntities>;
-const mockReinstallAssets =
-  reinstallSharedElasticsearchAssetsIfMissing as jest.MockedFunction<
-    typeof reinstallSharedElasticsearchAssetsIfMissing
-  >;
+const mockReinstallAssets = reinstallSharedElasticsearchAssetsIfMissing as jest.MockedFunction<
+  typeof reinstallSharedElasticsearchAssetsIfMissing
+>;
 
 function createMockEngineDescriptor(
   type: EntityType = 'user',

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -1826,5 +1826,23 @@ describe('LogsExtractionClient', () => {
       // Healed once, retried once, no further heal attempts (no loop).
       expect(mockReinstallAssets).toHaveBeenCalledTimes(1);
     });
+
+    it('does not self-heal when the engine was uninstalled while the task was running', async () => {
+      // Engine descriptor is gone — simulates the race where uninstall deleted the descriptor
+      // between when the task started and when the index_not_found error was caught.
+      mockEngineDescriptorClient.findOrThrow
+        .mockResolvedValueOnce(
+          createMockEngineDescriptor('user') as Awaited<
+            ReturnType<EngineDescriptorClient['findOrThrow']>
+          >
+        )
+        .mockRejectedValueOnce(new Error('Not found'));
+      mockExecuteEsqlQuery.mockRejectedValue(indexNotFoundError);
+
+      const result = await client.extractLogs('user');
+
+      expect(result.success).toBe(false);
+      expect(mockReinstallAssets).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -15,6 +15,7 @@ import type { ESQLSearchResponse } from '@kbn/es-types';
 import moment from 'moment';
 import { executeEsqlQuery } from '../../infra/elasticsearch/esql';
 import { ingestEntities } from '../../infra/elasticsearch/ingest';
+import { reinstallSharedElasticsearchAssetsIfMissing } from '../asset_manager/install_assets';
 import { HASHED_ID_FIELD } from './logs_extraction_query_builder';
 import {
   ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD,
@@ -103,8 +104,19 @@ function createMockRemoteLogsExtractionClient(): MockRemoteLogsExtractionClient 
 jest.mock('../../infra/elasticsearch/esql');
 jest.mock('../../infra/elasticsearch/ingest');
 
+// Keep the real `isIndexNotFoundError` classifier; stub only the reinstall so the heal/retry
+// wiring in `extractLogs` can be exercised without touching Elasticsearch.
+jest.mock('../asset_manager/install_assets', () => ({
+  ...jest.requireActual('../asset_manager/install_assets'),
+  reinstallSharedElasticsearchAssetsIfMissing: jest.fn(),
+}));
+
 const mockExecuteEsqlQuery = executeEsqlQuery as jest.MockedFunction<typeof executeEsqlQuery>;
 const mockIngestEntities = ingestEntities as jest.MockedFunction<typeof ingestEntities>;
+const mockReinstallAssets =
+  reinstallSharedElasticsearchAssetsIfMissing as jest.MockedFunction<
+    typeof reinstallSharedElasticsearchAssetsIfMissing
+  >;
 
 function createMockEngineDescriptor(
   type: EntityType = 'user',
@@ -1744,6 +1756,75 @@ describe('LogsExtractionClient', () => {
         'No global state found for this namespace'
       );
       expect(mockGlobalStateClient.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('extractLogs self-heal on index_not_found', () => {
+    const indexNotFoundError = {
+      meta: { body: { error: { type: 'index_not_found_exception' } } },
+    };
+
+    const successResponse: ESQLSearchResponse = {
+      columns: [
+        { name: '@timestamp', type: 'date' },
+        { name: HASHED_ID_FIELD, type: 'keyword' },
+        { name: 'user.name', type: 'keyword' },
+      ],
+      values: [['2024-01-02T10:00:00.000Z', 'hash1', 'user1']],
+    };
+
+    beforeEach(() => {
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user') as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue({
+        getIndexPattern: () => 'logs-*',
+      } as any);
+      mockIngestEntities.mockResolvedValue(undefined);
+    });
+
+    it('recreates missing assets and retries once, succeeding', async () => {
+      mockReinstallAssets.mockResolvedValue(true);
+      // First attempt throws index_not_found; the retry runs the full success sequence.
+      mockExecuteEsqlQuery.mockRejectedValueOnce(indexNotFoundError);
+      mockExtractSuccessSequence(successResponse);
+
+      const result = await client.extractLogs('user');
+
+      expect(result.success).toBe(true);
+      expect(mockReinstallAssets).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry when nothing of ours was missing (source-index error)', async () => {
+      mockReinstallAssets.mockResolvedValue(false);
+      mockExecuteEsqlQuery.mockRejectedValue(indexNotFoundError);
+
+      const result = await client.extractLogs('user');
+
+      expect(result.success).toBe(false);
+      expect(mockReinstallAssets).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not check assets for non-index_not_found errors', async () => {
+      mockExecuteEsqlQuery.mockRejectedValue(new Error('boom'));
+
+      const result = await client.extractLogs('user');
+
+      expect(result.success).toBe(false);
+      expect(mockReinstallAssets).not.toHaveBeenCalled();
+    });
+
+    it('retries only once even when the retry also fails', async () => {
+      mockReinstallAssets.mockResolvedValue(true);
+      mockExecuteEsqlQuery.mockRejectedValue(indexNotFoundError);
+
+      const result = await client.extractLogs('user');
+
+      expect(result.success).toBe(false);
+      // Healed once, retried once, no further heal attempts (no loop).
+      expect(mockReinstallAssets).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -1796,13 +1796,17 @@ describe('LogsExtractionClient', () => {
       expect(mockReinstallAssets).toHaveBeenCalledTimes(1);
     });
 
-    it('does not retry when nothing of ours was missing (source-index error)', async () => {
+    it('retries even when a sibling task already recreated the assets (reinstall is a no-op)', async () => {
+      // Extraction runs for all entity types in parallel. A sibling task can recreate the shared
+      // index between our query failing and our own reinstall check, so reinstall reports nothing
+      // was missing (false). We must still retry — the index is back and the retry can succeed.
       mockReinstallAssets.mockResolvedValue(false);
-      mockExecuteEsqlQuery.mockRejectedValue(indexNotFoundError);
+      mockExecuteEsqlQuery.mockRejectedValueOnce(indexNotFoundError);
+      mockExtractSuccessSequence(successResponse);
 
       const result = await client.extractLogs('user');
 
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
       expect(mockReinstallAssets).toHaveBeenCalledTimes(1);
     });
 
@@ -1822,7 +1826,7 @@ describe('LogsExtractionClient', () => {
       const result = await client.extractLogs('user');
 
       expect(result.success).toBe(false);
-      // Healed once, retried once, no further heal attempts (no loop).
+      // Reinstalled once, retried once, no further attempts (no loop).
       expect(mockReinstallAssets).toHaveBeenCalledTimes(1);
     });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -162,17 +162,32 @@ export class LogsExtractionClient {
       // and retry once; if nothing was missing the error was about a source index, so fall
       // through to normal handling.
       if (isIndexNotFoundError(error)) {
-        const healed = await reinstallSharedElasticsearchAssetsIfMissing({
-          esClient: this.esClient,
-          logger: this.logger,
-          namespace: this.namespace,
-        });
-        if (healed) {
-          this.logger.info(`Recreated missing entity store assets; retrying extraction for ${type}`);
-          try {
-            return await this.runExtraction(type, opts);
-          } catch (retryError) {
-            return await this.handleError(retryError, type, false);
+        // Guard: if the engine was uninstalled while this task was running, the engine
+        // descriptor SO is already gone. Skip self-heal so we don't reinstate an index
+        // that uninstall just deleted.
+        let engineStillStarted = false;
+        try {
+          const descriptor = await this.engineDescriptorClient.findOrThrow(type);
+          engineStillStarted = descriptor.status === ENGINE_STATUS.STARTED;
+        } catch {
+          // descriptor gone → engine uninstalled
+        }
+
+        if (engineStillStarted) {
+          const healed = await reinstallSharedElasticsearchAssetsIfMissing({
+            esClient: this.esClient,
+            logger: this.logger,
+            namespace: this.namespace,
+          });
+          if (healed) {
+            this.logger.info(
+              `Recreated missing entity store assets; retrying extraction for ${type}`
+            );
+            try {
+              return await this.runExtraction(type, opts);
+            } catch (retryError) {
+              return await this.handleError(retryError, type, false);
+            }
           }
         }
       }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -168,7 +168,9 @@ export class LogsExtractionClient {
           namespace: this.namespace,
         });
         if (healed) {
-          this.logger.info(`Recreated missing entity store assets; retrying extraction for ${type}`);
+          this.logger.info(
+            `Recreated missing entity store assets; retrying extraction for ${type}`
+          );
           try {
             return await this.runExtraction(type, opts);
           } catch (retryError) {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -41,6 +41,10 @@ import {
 import { capAtMaxLogsPerWindow, pickSampleProbability } from './effective_page_limits';
 import { getLatestEntitiesIndexName } from '../../../common/domain/entity_index';
 import { getUpdatesEntitiesDataStreamName } from '../asset_manager/updates_data_stream';
+import {
+  isIndexNotFoundError,
+  reinstallSharedElasticsearchAssetsIfMissing,
+} from '../asset_manager/install_assets';
 import { executeEsqlQuery } from '../../infra/elasticsearch/esql';
 import { ingestEntities } from '../../infra/elasticsearch/ingest';
 import { resolveClosedIndexAdjustments } from '../../infra/elasticsearch/resolve_closed_indices';
@@ -150,67 +154,89 @@ export class LogsExtractionClient {
   ): Promise<ExtractedLogsSummary> {
     this.logger.debug('starting entity extraction');
 
-    let isRemote = false;
-
     try {
-      const { config, engineState } = await this.getLogExtractionConfigAndState(type);
-      const entityDefinition = getEntityDefinition(type, this.namespace);
-      const {
-        isRemote: resolvedIsRemote,
-        count,
-        pages,
-        indexPatterns,
-        lastSearchTimestamp,
-        remoteError,
-        logsCapDeferred,
-        logsCapApplied,
-        logsProcessed,
-      } = await this.runQueryAndIngestDocs({
-        type,
-        config,
-        engineState,
-        opts,
-        entityDefinition,
-      });
-
-      isRemote = resolvedIsRemote;
-
-      const operationResult = {
-        success: true as const,
-        isRemote,
-        count,
-        pages,
-        scannedIndices: indexPatterns,
-        lastSearchTimestamp,
-        logsCapApplied,
-        logsProcessed,
-      };
-
-      if (opts?.specificWindow) {
-        return operationResult;
-      }
-
-      if (logsCapDeferred) {
-        // Cursor is already persisted at the last completed slice end inside runMainExtractionLoop;
-        // do not overwrite it — only clear any stale error.
-        await this.engineDescriptorClient.update(type, {
-          error: remoteError ? { message: remoteError.message, action: 'extractLogs' } : null,
-        });
-      } else {
-        await this.engineDescriptorClient.update(type, {
-          logExtractionState: {
-            checkpointTimestamp: null,
-            paginationId: null,
-            lastExecutionTimestamp: lastSearchTimestamp || moment().utc().toISOString(),
-          },
-          error: remoteError ? { message: remoteError.message, action: 'extractLogs' } : null,
-        });
-      }
-
-      return operationResult;
+      return await this.runExtraction(type, opts);
     } catch (error) {
-      return await this.handleError(error, type, isRemote);
+      // A missing shared index/data stream (e.g. deleted out from under a running engine) makes
+      // the extraction query throw `index_not_found`. Recreate our own assets if they are gone
+      // and retry once; if nothing was missing the error was about a source index, so fall
+      // through to normal handling.
+      if (isIndexNotFoundError(error)) {
+        const healed = await reinstallSharedElasticsearchAssetsIfMissing({
+          esClient: this.esClient,
+          logger: this.logger,
+          namespace: this.namespace,
+        });
+        if (healed) {
+          this.logger.info(`Recreated missing entity store assets; retrying extraction for ${type}`);
+          try {
+            return await this.runExtraction(type, opts);
+          } catch (retryError) {
+            return await this.handleError(retryError, type, false);
+          }
+        }
+      }
+      return await this.handleError(error, type, false);
     }
+  }
+
+  private async runExtraction(
+    type: EntityType,
+    opts?: LogsExtractionOptions
+  ): Promise<ExtractedLogsSummary> {
+    const { config, engineState } = await this.getLogExtractionConfigAndState(type);
+    const entityDefinition = getEntityDefinition(type, this.namespace);
+    const {
+      isRemote,
+      count,
+      pages,
+      indexPatterns,
+      lastSearchTimestamp,
+      remoteError,
+      logsCapDeferred,
+      logsCapApplied,
+      logsProcessed,
+    } = await this.runQueryAndIngestDocs({
+      type,
+      config,
+      engineState,
+      opts,
+      entityDefinition,
+    });
+
+    const operationResult = {
+      success: true as const,
+      isRemote,
+      count,
+      pages,
+      scannedIndices: indexPatterns,
+      lastSearchTimestamp,
+      logsCapApplied,
+      logsProcessed,
+    };
+
+    if (opts?.specificWindow) {
+      return operationResult;
+    }
+
+    if (logsCapDeferred) {
+      // Cursor is already persisted at the last completed slice end inside runMainExtractionLoop;
+      // do not overwrite it — only clear any stale error.
+      await this.engineDescriptorClient.update(type, {
+        error: remoteError ? { message: remoteError.message, action: 'extractLogs' } : null,
+      });
+    } else {
+      await this.engineDescriptorClient.update(type, {
+        logExtractionState: {
+          checkpointTimestamp: null,
+          paginationId: null,
+          lastExecutionTimestamp: lastSearchTimestamp || moment().utc().toISOString(),
+        },
+        error: remoteError ? { message: remoteError.message, action: 'extractLogs' } : null,
+      });
+    }
+
+    return operationResult;
   }
 
   public async updateConfig(params: LogExtractionUpdateParams): Promise<LogExtractionConfig> {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -159,8 +159,7 @@ export class LogsExtractionClient {
     } catch (error) {
       // A missing shared index/data stream (e.g. deleted out from under a running engine) makes
       // the extraction query throw `index_not_found`. Recreate our own assets if they are gone
-      // and retry once; if nothing was missing the error was about a source index, so fall
-      // through to normal handling.
+      // and retry once.
       if (isIndexNotFoundError(error)) {
         // Guard: if the engine was uninstalled while this task was running, the engine
         // descriptor SO is already gone. Skip self-heal so we don't reinstate an index
@@ -174,20 +173,23 @@ export class LogsExtractionClient {
         }
 
         if (engineStillStarted) {
-          const healed = await reinstallSharedElasticsearchAssetsIfMissing({
+          // Recreate our shared assets if they are missing. We retry regardless of whether *this*
+          // call recreated them: extraction runs for all entity types in parallel, so a sibling
+          // task (or the scheduled run) may have already recreated the shared index in the gap
+          // between our query failing and this check. Gating the retry on "did we win the heal
+          // race" would make every loser report a spurious failure even though the index is back.
+          await reinstallSharedElasticsearchAssetsIfMissing({
             esClient: this.esClient,
             logger: this.logger,
             namespace: this.namespace,
           });
-          if (healed) {
-            this.logger.info(
-              `Recreated missing entity store assets; retrying extraction for ${type}`
-            );
-            try {
-              return await this.runExtraction(type, opts);
-            } catch (retryError) {
-              return await this.handleError(retryError, type, false);
-            }
+          this.logger.info(
+            `Retrying extraction for ${type} after ensuring entity store assets exist`
+          );
+          try {
+            return await this.runExtraction(type, opts);
+          } catch (retryError) {
+            return await this.handleError(retryError, type, false);
           }
         }
       }

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/extraction_self_heal.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/extraction_self_heal.spec.ts
@@ -16,10 +16,7 @@ import {
   LATEST_INDEX,
 } from '../fixtures/constants';
 import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
-import {
-  assertEntitiesEqual,
-  expectedHostEntities,
-} from '../fixtures/entity_extraction_expected';
+import { assertEntitiesEqual, expectedHostEntities } from '../fixtures/entity_extraction_expected';
 import { clearEntityStoreIndices } from '../fixtures/helpers';
 
 // Verifies the extraction task heals itself: if the shared latest index is deleted out from

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/extraction_self_heal.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/extraction_self_heal.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import {
+  PUBLIC_HEADERS,
+  INTERNAL_HEADERS,
+  ENTITY_STORE_ROUTES,
+  ENTITY_STORE_TAGS,
+  LATEST_ALIAS,
+  LATEST_INDEX,
+} from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+import {
+  assertEntitiesEqual,
+  expectedHostEntities,
+} from '../fixtures/entity_extraction_expected';
+import { clearEntityStoreIndices } from '../fixtures/helpers';
+
+// Verifies the extraction task heals itself: if the shared latest index is deleted out from
+// under a running engine, an extraction run recreates it and still succeeds.
+apiTest.describe('Entity Store extraction self-heal', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+  let internalHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth, apiClient, esArchiver, kbnClient }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader, ...PUBLIC_HEADERS };
+    internalHeaders = { ...credentials.cookieHeader, ...INTERNAL_HEADERS };
+
+    await kbnClient.uiSettings.update({ [FF_ENABLE_ENTITY_STORE_V2]: true });
+
+    // Pre-create the `security-solution-default` data view so extraction takes its `logs-*` path
+    // (the browser sourcerer flow that normally creates it never runs in API-only tests).
+    const dataViewResponse = await apiClient.post('/api/data_views/data_view', {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {
+        override: true,
+        data_view: {
+          id: 'security-solution-default',
+          name: 'security-solution-default',
+          title: 'logs-*',
+          timeFieldName: '@timestamp',
+        },
+      },
+    });
+    expect(dataViewResponse.statusCode).toBe(200);
+
+    const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(response.statusCode).toBe(201);
+
+    await esArchiver.loadIfNeeded(
+      'x-pack/solutions/security/plugins/entity_store/test/scout/api/es_archives/updates'
+    );
+  });
+
+  apiTest.afterAll(async ({ apiClient, esClient }) => {
+    const response = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(response.statusCode).toBe(200);
+    await clearEntityStoreIndices(esClient);
+  });
+
+  apiTest(
+    'recreates the latest index and still extracts after it is deleted',
+    async ({ apiClient, esClient, log }) => {
+      // Confirm the index exists, then delete it to simulate the failure state.
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(true);
+      await esClient.indices.delete({ index: LATEST_INDEX });
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(false);
+
+      const extractionResponse = await apiClient.post(
+        ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('host'),
+        {
+          headers: internalHeaders,
+          responseType: 'json',
+          body: {
+            fromDateISO: '2026-01-20T11:00:00Z',
+            toDateISO: '2026-01-20T13:00:00Z',
+          },
+        }
+      );
+
+      expect(extractionResponse.statusCode).toBe(200);
+      expect(extractionResponse.body.success).toBe(true);
+      expect(extractionResponse.body.count).toBe(expectedHostEntities.length);
+
+      // The index was recreated by the self-heal.
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(true);
+
+      // And the entities were re-extracted into it.
+      const entities = await esClient.search({
+        index: LATEST_ALIAS,
+        query: { bool: { filter: { term: { 'entity.EngineMetadata.Type': 'host' } } } },
+        size: 1000,
+      });
+      assertEntitiesEqual(expectedHostEntities, entities.hits.hits, (msg) => log.error(msg));
+    }
+  );
+});


### PR DESCRIPTION
## Summary

The extraction task would fail permanently if the shared latest index or data streams were deleted while engines were still running — nothing would recreate them, so every subsequent run kept failing with `index_not_found_exception`.

When extraction hits that error, it now checks whether the entity store's own indices are actually missing, recreates them if so, and retries the run once. If the entity store's indices are all present, the error came from a source log index and normal handling runs unchanged.

The change covers both direct ES `index_not_found_exception` errors and ESQL's `verification_exception` shape (which is how ESQL reports a missing index referenced in a query), with unit tests for both cases and a Scout API spec that deletes the index mid-flight and verifies full recovery.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
