### PR TITLE
Fix missing 'managed' field in context engine test fixtures and update task priority snapshot

### DIFF
--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/automations_panel.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/automations_panel.test.tsx
@@ -61,6 +61,7 @@ const summariesResult = (summaries: Array<[string, WorkflowSummary]> = [], isLoa
 
 const aiIndex: GetAiIndexResponse = {
   id: 'my-ai-index',
+  managed: false,
   dest: { type: 'data_stream', value: 'ai-index-ds-my-ai-index' },
   automations: [],
   sources: [{ type: 'esql', value: 'FROM My view' }],

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_automations_editor.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_automations_editor.test.ts
@@ -31,6 +31,7 @@ jest.mock('./use_create_workflow', () => ({
 
 const aiIndex: GetAiIndexResponse = {
   id: 'my-ai-index',
+  managed: false,
   dest: { type: 'data_stream', value: 'ai-index-ds-my-ai-index' },
   automations: [{ type: 'workflow', value: 'wf-saved' }],
   sources: [{ type: 'esql', value: 'FROM logs-*' }],

--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/__snapshots__/task_priority_check.test.ts.snap
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/__snapshots__/task_priority_check.test.ts.snap
@@ -4,15 +4,15 @@ exports[`Task priority checks detects tasks with priority definitions 1`] = `
 Array [
   Object {
     "priority": 1,
-    "taskType": "agent_builder_sml:sml_crawler",
-  },
-  Object {
-    "priority": 1,
     "taskType": "ad_hoc_run-backfill",
   },
   Object {
     "priority": 50,
     "taskType": "autoImport-dataStream-task",
+  },
+  Object {
+    "priority": 1,
+    "taskType": "agent_builder_sml:sml_crawler",
   },
   Object {
     "priority": 40,


### PR DESCRIPTION
## Summary
- Adds the required `managed: false` field to `GetAiIndexResponse` test fixtures in `automations_panel.test.tsx` and `use_automations_editor.test.ts` (fixes TS2741 type errors)
- Updates the `task_priority_check` snapshot to reflect the new alphabetical sort order of task types

## Test plan
- [x] Type check passes: `node scripts/type_check --project x-pack/platform/plugins/shared/context_engine/tsconfig.json`
- [x] Snapshot test passes: `node scripts/jest_integration x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_priority_check.test.ts`

## Release note
skip

## Backport
skip