### PR TITLE
[Observability Onboarding] Delete legacy onboarding flows without an owner

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/moon.yml
@@ -61,6 +61,7 @@ dependsOn:
   - '@kbn/core-chrome-layout-constants'
   - '@kbn/zod'
   - '@kbn/zod-helpers'
+  - '@kbn/logging-mocks'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/state/delete_legacy_onboarding_flows.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/state/delete_legacy_onboarding_flows.test.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart } from '@kbn/core/server';
+import { savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import { deleteLegacyOnboardingFlows } from './delete_legacy_onboarding_flows';
+import { OBSERVABILITY_ONBOARDING_STATE_SAVED_OBJECT_TYPE } from '../../saved_objects/observability_onboarding_status';
+
+const TYPE = OBSERVABILITY_ONBOARDING_STATE_SAVED_OBJECT_TYPE;
+
+const createMocks = () => {
+  const repository = savedObjectsRepositoryMock.create();
+  const coreStart = {
+    savedObjects: {
+      createInternalRepository: jest.fn().mockReturnValue(repository),
+    },
+  } as unknown as CoreStart;
+  const logger = loggerMock.create();
+  return { repository, coreStart, logger };
+};
+
+const findPage = (ids: string[]) =>
+  ({
+    saved_objects: ids.map((id) => ({ id, type: TYPE })),
+    total: ids.length,
+    per_page: 1000,
+    page: 1,
+  } as never);
+
+const deleteResponse = (
+  statuses: Array<{ id: string; success: boolean; statusCode?: number; message?: string }>
+) =>
+  ({
+    statuses: statuses.map(({ id, success, statusCode, message }) => ({
+      id,
+      type: TYPE,
+      success,
+      ...(statusCode
+        ? { error: { error: 'error', message: message ?? 'failure', statusCode } }
+        : {}),
+    })),
+  } as never);
+
+describe('deleteLegacyOnboardingFlows', () => {
+  it('queries page 1 with the legacy flow filter', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    repository.find.mockResolvedValue(findPage([]));
+
+    await deleteLegacyOnboardingFlows({ coreStart, logger });
+
+    expect(repository.find).toHaveBeenCalledTimes(1);
+    expect(repository.find).toHaveBeenCalledWith({
+      type: TYPE,
+      filter: `not ${TYPE}.attributes.createdBy: *`,
+      page: 1,
+      perPage: 1000,
+      sortField: 'created_at',
+      sortOrder: 'asc',
+      fields: ['type'],
+    });
+  });
+
+  it('does nothing when no legacy flows exist', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    repository.find.mockResolvedValue(findPage([]));
+
+    await deleteLegacyOnboardingFlows({ coreStart, logger });
+
+    expect(repository.bulkDelete).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('deletes a single page of legacy flows and stops on the empty page', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    repository.find.mockResolvedValueOnce(findPage(['a', 'b'])).mockResolvedValueOnce(findPage([]));
+    repository.bulkDelete.mockResolvedValue(
+      deleteResponse([
+        { id: 'a', success: true },
+        { id: 'b', success: true },
+      ])
+    );
+
+    await deleteLegacyOnboardingFlows({ coreStart, logger });
+
+    expect(repository.bulkDelete).toHaveBeenCalledTimes(1);
+    expect(repository.bulkDelete).toHaveBeenCalledWith(
+      [
+        { type: TYPE, id: 'a' },
+        { type: TYPE, id: 'b' },
+      ],
+      { refresh: 'wait_for' }
+    );
+    expect(repository.find).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenCalledWith(
+      'Deleted 2 legacy onboarding flow(s) without an owner'
+    );
+  });
+
+  it('keeps deleting until the filtered result set is empty', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    repository.find
+      .mockResolvedValueOnce(findPage(['a']))
+      .mockResolvedValueOnce(findPage(['b']))
+      .mockResolvedValueOnce(findPage([]));
+    repository.bulkDelete
+      .mockResolvedValueOnce(deleteResponse([{ id: 'a', success: true }]))
+      .mockResolvedValueOnce(deleteResponse([{ id: 'b', success: true }]));
+
+    await deleteLegacyOnboardingFlows({ coreStart, logger });
+
+    expect(repository.bulkDelete).toHaveBeenCalledTimes(2);
+    expect(repository.find).toHaveBeenCalledTimes(3);
+    expect(logger.info).toHaveBeenCalledWith(
+      'Deleted 2 legacy onboarding flow(s) without an owner'
+    );
+  });
+
+  it('ignores 404 statuses, warns on other failures, and stops via the guard when only failures remain', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    // 'a' deletes, 'b' was already deleted by a concurrent node (404), 'c' persistently
+    // fails with 500 so it still matches the filter on the next iteration.
+    repository.find
+      .mockResolvedValueOnce(findPage(['a', 'b', 'c']))
+      .mockResolvedValueOnce(findPage(['c']));
+    repository.bulkDelete
+      .mockResolvedValueOnce(
+        deleteResponse([
+          { id: 'a', success: true },
+          { id: 'b', success: false, statusCode: 404 },
+          { id: 'c', success: false, statusCode: 500, message: 'boom' },
+        ])
+      )
+      .mockResolvedValueOnce(
+        deleteResponse([{ id: 'c', success: false, statusCode: 500, message: 'boom' }])
+      );
+
+    await deleteLegacyOnboardingFlows({ coreStart, logger });
+
+    expect(repository.find).toHaveBeenCalledTimes(2);
+    expect(repository.bulkDelete).toHaveBeenCalledTimes(2);
+    // One warn per failed deletion of 'c' plus the zero-progress guard warn.
+    expect(logger.warn).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('[c]'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Legacy onboarding flow cleanup made no progress, stopping'
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Deleted 1 legacy onboarding flow(s) without an owner'
+    );
+  });
+
+  it('continues when a concurrent node already deleted the whole batch (all 404s)', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    repository.find
+      .mockResolvedValueOnce(findPage(['a', 'b']))
+      .mockResolvedValueOnce(findPage(['c']))
+      .mockResolvedValueOnce(findPage([]));
+    repository.bulkDelete
+      .mockResolvedValueOnce(
+        deleteResponse([
+          { id: 'a', success: false, statusCode: 404 },
+          { id: 'b', success: false, statusCode: 404 },
+        ])
+      )
+      .mockResolvedValueOnce(deleteResponse([{ id: 'c', success: true }]));
+
+    await deleteLegacyOnboardingFlows({ coreStart, logger });
+
+    expect(repository.find).toHaveBeenCalledTimes(3);
+    expect(repository.bulkDelete).toHaveBeenCalledTimes(2);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      'Deleted 1 legacy onboarding flow(s) without an owner'
+    );
+  });
+
+  it('stops without looping when an iteration deletes nothing', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    repository.find.mockResolvedValue(findPage(['a']));
+    repository.bulkDelete.mockResolvedValue(
+      deleteResponse([{ id: 'a', success: false, statusCode: 500, message: 'boom' }])
+    );
+
+    await deleteLegacyOnboardingFlows({ coreStart, logger });
+
+    expect(repository.find).toHaveBeenCalledTimes(1);
+    expect(repository.bulkDelete).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Legacy onboarding flow cleanup made no progress, stopping'
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('logs and resolves when repository construction fails', async () => {
+    const logger = loggerMock.create();
+    const coreStart = {
+      savedObjects: {
+        createInternalRepository: jest.fn(() => {
+          throw new Error('type not registered');
+        }),
+      },
+    } as unknown as CoreStart;
+
+    await expect(deleteLegacyOnboardingFlows({ coreStart, logger })).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and resolves when find fails', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    repository.find.mockRejectedValue(new Error('es down'));
+
+    await expect(deleteLegacyOnboardingFlows({ coreStart, logger })).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and resolves when bulkDelete fails', async () => {
+    const { repository, coreStart, logger } = createMocks();
+    repository.find.mockResolvedValueOnce(findPage(['a']));
+    repository.bulkDelete.mockRejectedValue(new Error('es down'));
+
+    await expect(deleteLegacyOnboardingFlows({ coreStart, logger })).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/state/delete_legacy_onboarding_flows.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/state/delete_legacy_onboarding_flows.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, Logger } from '@kbn/core/server';
+import { OBSERVABILITY_ONBOARDING_STATE_SAVED_OBJECT_TYPE } from '../../saved_objects/observability_onboarding_status';
+import { createObservabilityOnboardingInternalRepository } from './flow_ownership';
+
+const LEGACY_FLOW_FILTER = `not ${OBSERVABILITY_ONBOARDING_STATE_SAVED_OBJECT_TYPE}.attributes.createdBy: *`;
+const PER_PAGE = 1000;
+
+/**
+ * Deletes onboarding flows created before flow ownership was introduced (#276743). Those flows
+ * have no `createdBy`, so the fail-closed ownership check hides them from everyone forever.
+ * Self-extinguishing: stops at the first empty page, so once the orphans are gone the
+ * steady-state cost is a single filtered find per startup. Remove this once every branch that
+ * ever wrote ownerless flows is out of maintenance.
+ *
+ * Release constraint: must not ship in the release that first delivers #276743 on a branch.
+ * During a mixed-version rollout old nodes still create flows without `createdBy` that this
+ * sweep would delete while they are in use, and the KQL filter requires the `createdBy` mapping
+ * to already be applied to the index.
+ */
+export async function deleteLegacyOnboardingFlows({
+  coreStart,
+  logger,
+}: {
+  coreStart: CoreStart;
+  logger: Logger;
+}): Promise<void> {
+  try {
+    const repository = createObservabilityOnboardingInternalRepository(coreStart);
+    let totalDeleted = 0;
+
+    while (true) {
+      // Always page 1: deletions (by this node or a concurrent one) shrink the filtered
+      // result set, so re-querying the first page never skips documents.
+      const { saved_objects: savedObjects } = await repository.find({
+        type: OBSERVABILITY_ONBOARDING_STATE_SAVED_OBJECT_TYPE,
+        filter: LEGACY_FLOW_FILTER,
+        page: 1,
+        perPage: PER_PAGE,
+        sortField: 'created_at',
+        sortOrder: 'asc',
+        // An empty fields array is treated as unspecified and would fetch all attributes,
+        // so request the smallest attribute instead. Only the ids are used.
+        fields: ['type'],
+      });
+
+      if (savedObjects.length === 0) {
+        break;
+      }
+
+      // The loop's termination depends on deletions being visible to the next find.
+      const { statuses } = await repository.bulkDelete(
+        savedObjects.map(({ id }) => ({
+          type: OBSERVABILITY_ONBOARDING_STATE_SAVED_OBJECT_TYPE,
+          id,
+        })),
+        { refresh: 'wait_for' }
+      );
+
+      let deletedThisIteration = 0;
+      let progressThisIteration = 0;
+      for (const status of statuses) {
+        if (status.success) {
+          deletedThisIteration++;
+          progressThisIteration++;
+        } else if (status.error?.statusCode === 404) {
+          // A concurrent node already deleted the document. Not deleted by this node,
+          // but the filtered result set shrank, so the loop is progressing.
+          progressThisIteration++;
+        } else {
+          logger.warn(
+            `Failed to delete legacy onboarding flow [${status.id}]: ${status.error?.message}`
+          );
+        }
+      }
+
+      totalDeleted += deletedThisIteration;
+
+      if (progressThisIteration === 0) {
+        logger.warn('Legacy onboarding flow cleanup made no progress, stopping');
+        break;
+      }
+    }
+
+    if (totalDeleted > 0) {
+      logger.info(`Deleted ${totalDeleted} legacy onboarding flow(s) without an owner`);
+    }
+  } catch (error) {
+    logger.error(`Failed to clean up legacy onboarding flows: ${error}`);
+  }
+}

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/state/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/state/index.ts
@@ -8,3 +8,4 @@
 export * from './get_observability_onboarding_flow';
 export * from './save_observability_onboarding_flow';
 export * from './flow_ownership';
+export * from './delete_legacy_onboarding_flows';

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/plugin.ts
@@ -25,6 +25,7 @@ import type {
   ObservabilityOnboardingPluginStartDependencies,
 } from './types';
 import { observabilityOnboardingFlow } from './saved_objects/observability_onboarding_status';
+import { deleteLegacyOnboardingFlows } from './lib/state';
 import { EsLegacyConfigService } from './services/es_legacy_config_service';
 import type { ObservabilityOnboardingConfig } from './config';
 import { OBSERVABILITY_ONBOARDING_TELEMETRY_EVENT } from '../common/telemetry_events';
@@ -135,6 +136,10 @@ export class ObservabilityOnboardingPlugin
   }
 
   public start(core: CoreStart) {
+    // One-time cleanup of flows created before ownership tracking (createdBy) existed.
+    // Self-extinguishing no-op once the legacy flows are gone. Remove when every branch
+    // that ever wrote ownerless flows is out of maintenance.
+    void deleteLegacyOnboardingFlows({ coreStart: core, logger: this.logger });
     return {};
   }
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/tsconfig.json
@@ -56,7 +56,8 @@
     "@kbn/dashboard-plugin",
     "@kbn/core-chrome-layout-constants",
     "@kbn/zod",
-    "@kbn/zod-helpers"
+    "@kbn/zod-helpers",
+    "@kbn/logging-mocks"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Summary

Follow-up to #276743. Onboarding flows created before that fix have no `createdBy`. The ownership check is fail-closed, so those flows are now hidden from every user, including whoever created them. There is no way to backfill the owner because the username was never recorded, so this PR deletes them. A startup sweep removes `observability-onboarding-state` saved objects that lack `createdBy` and were last updated more than a day ago, then stops running once they are gone.

The policy decision is tracked in elastic/security#12250.

## What changed

- Added `deleteLegacyOnboardingFlows`. It runs a filtered `find` on page 1, `bulkDelete`s the results, and repeats until the query comes back empty. A zero-progress guard stops the loop if an iteration deletes nothing. A 404 from a concurrent node counts as already done rather than a failure. The whole function sits inside one error boundary, so a failure never breaks startup.
- The filter has an age gate: only flows with `updated_at` older than one day are candidates. Every step of a flow refreshes `updated_at`, so a flow that is still in use is never selected.
- The plugin calls it fire-and-forget from `start()`. After the orphans are gone, each boot costs one filtered `find`.

## Rollout safety

The sweep does not depend on release ordering relative to #276743. Both failure modes raised in review are closed in code rather than by process:

- **Missing `createdBy` mapping.** The saved objects migrator applies the `mappings_addition` from model version 3 before any plugin `start()` runs, in both the v2 and ZDT algorithms. The sweep ships in the same build as that model version, so the mapping is always present when it runs. As a second layer, the saved objects `find` API validates KQL filter keys against the registered type mappings before querying Elasticsearch. An unknown attribute is a 400, which the error boundary logs, and nothing is deleted.
- **Mixed-version rollout.** During a rolling deploy a not-yet-upgraded node can still create flows without `createdBy`. The one day age gate keeps those out of the sweep while they are in use. By the time a flow is a day old and still ownerless, the rollout has finished and the flow is unreachable anyway.

Backports to 8.19, 9.3, and 9.4 can therefore ship in any release that already contains, or ships together with, the corresponding backport of #276743.

## Release note

Onboarding flows started before the fix for ownership checks in #276743 are no longer accessible and are deleted on Kibana startup. Users who had an onboarding flow in progress across the upgrade need to start it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
