### PR TITLE
[Nightshift] Render real detection occurrence charts

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -63514,6 +63514,7 @@ paths:
                           - count: 7
                             date: '2025-01-15T12:00:00.000Z'
                         rule_backed: false
+                        rule_uuid: 9fdfcf5a-4e1d-5ee3-b05d-7bc2b014e81c
                         severity_score: 75
                         stream_name: logs.nginx
                         title: Error count by host

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -69722,6 +69722,7 @@ paths:
                           - count: 7
                             date: '2025-01-15T12:00:00.000Z'
                         rule_backed: false
+                        rule_uuid: 9fdfcf5a-4e1d-5ee3-b05d-7bc2b014e81c
                         severity_score: 75
                         stream_name: logs.nginx
                         title: Error count by host

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/api/significant_events/index.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/api/significant_events/index.ts
@@ -46,8 +46,8 @@ interface SignificantEventOccurrence {
 }
 
 type QueryWithOccurrences = StreamQuery & {
-  /** Alerting rule whose firings produced this occurrence series. */
-  rule_uuid: string;
+  /** Alerting rule UUID (`QueryLink.rule_id`); optional during rolling upgrades. */
+  rule_uuid?: string;
   stream_name: string;
   occurrences: SignificantEventOccurrence[];
   change_points: {

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/api/significant_events/index.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/api/significant_events/index.ts
@@ -46,6 +46,8 @@ interface SignificantEventOccurrence {
 }
 
 type QueryWithOccurrences = StreamQuery & {
+  /** Alerting rule whose firings produced this occurrence series. */
+  rule_uuid: string;
   stream_name: string;
   occurrences: SignificantEventOccurrence[];
   change_points: {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/fetch_query_occurrences_from_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/fetch_query_occurrences_from_alerts.test.ts
@@ -94,6 +94,53 @@ describe('fetchQueryOccurrencesFromAlerts', () => {
     expect(esql).not.toHaveBeenCalled();
   });
 
+  it('filters query links by rule UUID and returns the UUID with each series', async () => {
+    const linkA = makeQueryLink({ id: 'qa', rule_id: 'rule-a' });
+    const linkB = makeQueryLink({ id: 'qb', rule_id: 'rule-b' });
+    const { kiClient, esClient, esql } = createMocks([linkA, linkB]);
+
+    esql.mockResolvedValueOnce(
+      makeStatsResponse([{ rule_id: 'rule-a', bucket: '2026-01-01T00:00:00.000Z', count: 2 }])
+    );
+
+    const result = await fetchQueryOccurrencesFromAlerts(
+      {
+        from: FROM,
+        to: TO,
+        bucketSize: BUCKET,
+        ruleUuids: ['rule-a'],
+        spaceId: SPACE_ID,
+      },
+      { kiClient, esClient }
+    );
+
+    expect(result.queries).toHaveLength(1);
+    expect(result.queries[0]).toEqual(expect.objectContaining({ id: 'qa', rule_uuid: 'rule-a' }));
+    const calledWith = esql.mock.calls[0][1] as { query: string };
+    expect(calledWith.query).toContain('rule-a');
+    expect(calledWith.query).not.toContain('rule-b');
+  });
+
+  it('skips ES|QL when no query link matches the requested rule UUIDs', async () => {
+    const { kiClient, esClient, esql } = createMocks([
+      makeQueryLink({ id: 'qa', rule_id: 'rule-a' }),
+    ]);
+
+    const result = await fetchQueryOccurrencesFromAlerts(
+      {
+        from: FROM,
+        to: TO,
+        bucketSize: BUCKET,
+        ruleUuids: ['missing-rule'],
+        spaceId: SPACE_ID,
+      },
+      { kiClient, esClient }
+    );
+
+    expect(result).toEqual({ queries: [], aggregated_occurrences: [] });
+    expect(esql).not.toHaveBeenCalled();
+  });
+
   it('groups ES|QL rows into per-rule occurrences with gap filling', async () => {
     const linkA = makeQueryLink({ id: 'qa', rule_id: 'rule-a' });
     const linkB = makeQueryLink({ id: 'qb', rule_id: 'rule-b' });
@@ -116,6 +163,8 @@ describe('fetchQueryOccurrencesFromAlerts', () => {
     const ruleB = result.queries.find((e) => e.id === 'qb')!;
 
     // 6 buckets at 1m across [00:00, 00:05] inclusive
+    expect(ruleA.rule_uuid).toBe('rule-a');
+    expect(ruleB.rule_uuid).toBe('rule-b');
     expect(ruleA.occurrences).toHaveLength(6);
     expect(ruleA.occurrences.map((o) => o.count)).toEqual([2, 0, 1, 0, 0, 0]);
     expect(ruleB.occurrences).toHaveLength(6);

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/fetch_query_occurrences_from_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/fetch_query_occurrences_from_alerts.test.ts
@@ -121,10 +121,14 @@ describe('fetchQueryOccurrencesFromAlerts', () => {
     expect(calledWith.query).not.toContain('rule-b');
   });
 
-  it('skips ES|QL when no query link matches the requested rule UUIDs', async () => {
+  it('synthesizes a rule-scoped series when no query link matches the requested rule UUIDs', async () => {
     const { kiClient, esClient, esql } = createMocks([
       makeQueryLink({ id: 'qa', rule_id: 'rule-a' }),
     ]);
+
+    esql.mockResolvedValueOnce(
+      makeStatsResponse([{ rule_id: 'missing-rule', bucket: '2026-01-01T00:00:00.000Z', count: 4 }])
+    );
 
     const result = await fetchQueryOccurrencesFromAlerts(
       {
@@ -137,8 +141,20 @@ describe('fetchQueryOccurrencesFromAlerts', () => {
       { kiClient, esClient }
     );
 
-    expect(result).toEqual({ queries: [], aggregated_occurrences: [] });
-    expect(esql).not.toHaveBeenCalled();
+    expect(result.queries).toHaveLength(1);
+    expect(result.queries[0]).toEqual(
+      expect.objectContaining({
+        id: 'rule:missing-rule',
+        rule_uuid: 'missing-rule',
+      })
+    );
+    expect(result.queries[0].occurrences[0]).toEqual({
+      date: '2026-01-01T00:00:00.000Z',
+      count: 4,
+    });
+    const calledWith = esql.mock.calls[0][1] as { query: string };
+    expect(calledWith.query).toContain('missing-rule');
+    expect(calledWith.query).not.toContain('rule-a');
   });
 
   it('groups ES|QL rows into per-rule occurrences with gap filling', async () => {
@@ -159,16 +175,18 @@ describe('fetchQueryOccurrencesFromAlerts', () => {
       { kiClient, esClient }
     );
 
-    const ruleA = result.queries.find((e) => e.stream_name === 'logs.test' && e.id === 'qa')!;
-    const ruleB = result.queries.find((e) => e.id === 'qb')!;
+    const ruleA = result.queries.find((e) => e.stream_name === 'logs.test' && e.id === 'qa');
+    const ruleB = result.queries.find((e) => e.id === 'qb');
 
+    expect(ruleA).toBeDefined();
+    expect(ruleB).toBeDefined();
     // 6 buckets at 1m across [00:00, 00:05] inclusive
-    expect(ruleA.rule_uuid).toBe('rule-a');
-    expect(ruleB.rule_uuid).toBe('rule-b');
-    expect(ruleA.occurrences).toHaveLength(6);
-    expect(ruleA.occurrences.map((o) => o.count)).toEqual([2, 0, 1, 0, 0, 0]);
-    expect(ruleB.occurrences).toHaveLength(6);
-    expect(ruleB.occurrences.map((o) => o.count)).toEqual([0, 0, 0, 0, 3, 0]);
+    expect(ruleA?.rule_uuid).toBe('rule-a');
+    expect(ruleB?.rule_uuid).toBe('rule-b');
+    expect(ruleA?.occurrences).toHaveLength(6);
+    expect(ruleA?.occurrences.map((o) => o.count)).toEqual([2, 0, 1, 0, 0, 0]);
+    expect(ruleB?.occurrences).toHaveLength(6);
+    expect(ruleB?.occurrences.map((o) => o.count)).toEqual([0, 0, 0, 0, 3, 0]);
   });
 
   it('emits an empty occurrences array (not a zero-filled series) for rules absent from the result', async () => {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/fetch_query_occurrences_from_alerts.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/fetch_query_occurrences_from_alerts.ts
@@ -307,6 +307,42 @@ export async function computeOccurrences(
   return { sparseByRule, aggregatedOccurrences, timeline };
 }
 
+/** Stub query link so rule_uuid filters can return series without a KI query. */
+function createRuleScopedQueryLink(ruleUuid: string): QueryLink {
+  return {
+    query: {
+      id: `rule:${ruleUuid}`,
+      title: ruleUuid,
+      description: '',
+      type: 'match',
+      esql: { query: '' },
+    },
+    stream_name: '',
+    rule_backed: true,
+    rule_id: ruleUuid,
+  };
+}
+
+function resolveQueryLinksForOccurrences(
+  fetchedQueryLinks: QueryLink[],
+  ruleUuids: string[] | undefined
+): QueryLink[] {
+  if (!ruleUuids?.length) {
+    return fetchedQueryLinks;
+  }
+
+  const requestedRuleUuids = new Set(ruleUuids);
+  const matchedLinks = fetchedQueryLinks.filter(({ rule_id: ruleId }) =>
+    requestedRuleUuids.has(ruleId)
+  );
+  const matchedRuleIds = new Set(matchedLinks.map(({ rule_id: ruleId }) => ruleId));
+  const stubs = ruleUuids
+    .filter((ruleUuid) => !matchedRuleIds.has(ruleUuid))
+    .map((ruleUuid) => createRuleScopedQueryLink(ruleUuid));
+
+  return [...matchedLinks, ...stubs];
+}
+
 export async function getQueryOccurrences(
   params: SignificantEventsParams,
   dependencies: SignificantEventsDependencies
@@ -315,10 +351,7 @@ export async function getQueryOccurrences(
   const { from, to, bucketSize, spaceId, alertsReader = ALERTS_READER_V2 } = params;
 
   const fetchedQueryLinks = await fetchQueryLinks(params, kiClient);
-  const requestedRuleUuids = params.ruleUuids ? new Set(params.ruleUuids) : undefined;
-  const queryLinks = requestedRuleUuids
-    ? fetchedQueryLinks.filter(({ rule_id: ruleId }) => requestedRuleUuids.has(ruleId))
-    : fetchedQueryLinks;
+  const queryLinks = resolveQueryLinksForOccurrences(fetchedQueryLinks, params.ruleUuids);
   if (isEmpty(queryLinks)) {
     return {
       queryLinks: [],

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/fetch_query_occurrences_from_alerts.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/fetch_query_occurrences_from_alerts.ts
@@ -38,6 +38,7 @@ interface TimeBucket {
 
 export interface SignificantEventsParams {
   streamNames?: string[];
+  ruleUuids?: string[];
   from: Date;
   to: Date;
   bucketSize: string;
@@ -313,7 +314,11 @@ export async function getQueryOccurrences(
   const { kiClient, esClient } = dependencies;
   const { from, to, bucketSize, spaceId, alertsReader = ALERTS_READER_V2 } = params;
 
-  const queryLinks = await fetchQueryLinks(params, kiClient);
+  const fetchedQueryLinks = await fetchQueryLinks(params, kiClient);
+  const requestedRuleUuids = params.ruleUuids ? new Set(params.ruleUuids) : undefined;
+  const queryLinks = requestedRuleUuids
+    ? fetchedQueryLinks.filter(({ rule_id: ruleId }) => requestedRuleUuids.has(ruleId))
+    : fetchedQueryLinks;
   if (isEmpty(queryLinks)) {
     return {
       queryLinks: [],
@@ -353,6 +358,7 @@ export function toQueryWithOccurrences({
 }): QueryWithOccurrences {
   return {
     ...queryLink.query,
+    rule_uuid: queryLink.rule_id,
     stream_name: queryLink.stream_name,
     occurrences: buildQueryOccurrences({ queryLink, queryOccurrences }),
     change_points: EMPTY_CHANGE_POINTS,

--- a/x-pack/platform/plugins/shared/significant_events/server/oas_examples.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/oas_examples.ts
@@ -95,6 +95,7 @@ export const getQueryOccurrencesResponse: QueryOccurrencesResponse = {
         query: 'FROM logs.nginx | WHERE log.level == "error" | STATS count = COUNT(*) BY host.name',
       },
       severity_score: 75,
+      rule_uuid: '9fdfcf5a-4e1d-5ee3-b05d-7bc2b014e81c',
       stream_name: 'logs.nginx',
       occurrences: [
         { date: '2025-01-15T10:00:00.000Z', count: 42 },

--- a/x-pack/platform/plugins/shared/significant_events/server/routes/internal/knowledge_indicators/query_occurrences/route.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/routes/internal/knowledge_indicators/query_occurrences/route.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { QueryOccurrencesResponse } from '@kbn/significant-events-schema';
+import { MAX_ID_LENGTH, type QueryOccurrencesResponse } from '@kbn/significant-events-schema';
 import { MAX_STREAM_NAME_LENGTH } from '@kbn/streams-schema';
 import { z } from '@kbn/zod/v4';
 import { BUCKET_SIZE_PATTERN } from '../../../../lib/significant_events/helpers/fill_bucket_gaps';
@@ -41,6 +41,16 @@ const readQueryOccurrencesRoute = createServerRoute({
         ])
         .optional()
         .describe('Stream names to filter results by'),
+      rule_uuid: z
+        .union([
+          z
+            .string()
+            .max(MAX_ID_LENGTH)
+            .transform((value) => [value]),
+          z.array(z.string().max(MAX_ID_LENGTH)),
+        ])
+        .optional()
+        .describe('Alerting rule UUIDs to include in the occurrence response'),
       searchMode: searchModeSchema,
     }),
   }),
@@ -70,7 +80,15 @@ const readQueryOccurrencesRoute = createServerRoute({
       client: scopedClusterClient.asCurrentUser,
       logger,
     });
-    const { from, to, bucketSize, query, streamNames, searchMode } = params.query;
+    const {
+      from,
+      to,
+      bucketSize,
+      query,
+      streamNames,
+      rule_uuid: ruleUuids,
+      searchMode,
+    } = params.query;
     assertValidDateRange(from, to);
 
     const resolvedStreamNames = await resolveStreamNames(streamNames, () =>
@@ -88,6 +106,7 @@ const readQueryOccurrencesRoute = createServerRoute({
         bucketSize,
         query,
         streamNames: resolvedStreamNames,
+        ruleUuids,
         searchMode,
         alertsReader,
         spaceId: await getSpaceId(request),

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/significant_events/use_fetch_discovery_queries.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/significant_events/use_fetch_discovery_queries.ts
@@ -105,7 +105,14 @@ export const useFetchDiscoveryQueries = (
       perPage: response.perPage,
       total: response.total,
       queries: response.queries.map((series: QueryWithOccurrences) => {
-        const { occurrences, change_points, stream_name, rule_backed, ...rest } = series;
+        const {
+          occurrences,
+          change_points,
+          rule_uuid: _ruleUuid,
+          stream_name,
+          rule_backed,
+          ...rest
+        } = series;
         return {
           query: rest,
           stream_name,

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/significant_events/use_fetch_query_occurrence_stats.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/significant_events/use_fetch_query_occurrence_stats.ts
@@ -88,7 +88,14 @@ export const useFetchQueryOccurrenceStats = (
       ({ queries: queryOccurrenceSeries, aggregated_occurrences: aggregatedOccurrences }) => {
         return {
           queries: queryOccurrenceSeries.map((series) => {
-            const { occurrences, change_points, stream_name, rule_backed, ...rest } = series;
+            const {
+              occurrences,
+              change_points,
+              rule_uuid: _ruleUuid,
+              stream_name,
+              rule_backed,
+              ...rest
+            } = series;
             return {
               query: rest,
               stream_name,

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/__storybook__/nightshift_fixtures.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/__storybook__/nightshift_fixtures.ts
@@ -10,6 +10,7 @@ import type {
   Feature,
   InvestigationState,
   LifecycleDetection,
+  QueryOccurrencesResponse,
   SignalEntry,
   SignificantEvent,
 } from '@kbn/significant-events-schema';
@@ -143,6 +144,41 @@ export const checkoutDetection: LifecycleDetection = {
 export const checkoutLifecycle: EventLifecycleResponse = {
   detections: [checkoutDetection],
   events: [checkoutEventWithSignals],
+};
+
+export const checkoutOccurrences: QueryOccurrencesResponse = {
+  queries: [
+    {
+      id: 'checkout-api-p95-latency',
+      type: 'match',
+      title: 'Checkout API P95 latency',
+      description: 'Tracks checkout latency alerts.',
+      esql: {
+        query: 'FROM logs.checkout-api | STATS p95_latency = PERCENTILE(transaction.duration, 95)',
+      },
+      severity_score: 80,
+      rule_uuid: checkoutDetection.rule_uuid ?? 'checkout-latency-rule',
+      stream_name: checkoutDetection.stream_name,
+      occurrences: [
+        { date: '2026-07-24T09:20:00.000Z', count: 2 },
+        { date: '2026-07-24T09:25:00.000Z', count: 3 },
+        { date: '2026-07-24T09:30:00.000Z', count: 4 },
+        { date: '2026-07-24T09:35:00.000Z', count: 7 },
+        { date: '2026-07-24T09:40:00.000Z', count: 15 },
+        { date: '2026-07-24T09:45:00.000Z', count: 9 },
+      ],
+      change_points: { type: {} },
+      rule_backed: true,
+    },
+  ],
+  aggregated_occurrences: [
+    { date: '2026-07-24T09:20:00.000Z', count: 2 },
+    { date: '2026-07-24T09:25:00.000Z', count: 3 },
+    { date: '2026-07-24T09:30:00.000Z', count: 4 },
+    { date: '2026-07-24T09:35:00.000Z', count: 7 },
+    { date: '2026-07-24T09:40:00.000Z', count: 15 },
+    { date: '2026-07-24T09:45:00.000Z', count: 9 },
+  ],
 };
 
 export const checkoutFeature: Feature = {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/__storybook__/nightshift_storybook_provider.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/__storybook__/nightshift_storybook_provider.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
+import { css } from '@emotion/react';
 import React, { useMemo, useState } from 'react';
-import { EuiProvider } from '@elastic/eui';
+import { EuiPanel, EuiProvider } from '@elastic/eui';
 import { PerformanceContext } from '@kbn/ebt-tools';
 import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
@@ -20,6 +21,7 @@ import {
 import {
   checkoutFeature,
   checkoutLifecycle,
+  checkoutOccurrences,
   dismissedShippingEvent,
   nightshiftEvents,
   inventoryEvent,
@@ -45,6 +47,24 @@ const performanceApi = {
   onPageReady: () => undefined,
   onPageRefreshStart: () => undefined,
 };
+
+const StorybookLensEmbeddable = ({
+  attributes,
+}: {
+  attributes: { title?: string };
+}): React.ReactElement => (
+  <EuiPanel
+    hasBorder
+    hasShadow={false}
+    paddingSize="s"
+    data-test-subj="nightshiftStorybookLensEmbeddable"
+    css={css`
+      height: 200px;
+    `}
+  >
+    <strong>{attributes.title}</strong>
+  </EuiPanel>
+);
 
 export interface NightshiftStorybookProviderProps {
   children: React.ReactNode;
@@ -145,7 +165,26 @@ const createServices = ({
         useSparklineOverrides: () => ({}),
       },
     },
+    dataViews: {
+      create: async ({
+        id,
+        timeFieldName,
+        title,
+      }: {
+        id: string;
+        timeFieldName: string;
+        title: string;
+      }) => ({
+        id,
+        timeFieldName,
+        title,
+        toSpec: () => ({ id, timeFieldName, title }),
+      }),
+    },
     http,
+    lens: {
+      EmbeddableComponent: StorybookLensEmbeddable,
+    },
     notifications: {
       toasts: {
         addError: () => undefined,
@@ -167,6 +206,13 @@ const createServices = ({
           setting === 'dateFormat' ? 'MMM D, YYYY @ HH:mm:ss.SSS' : undefined,
       },
     },
+    spaces: {
+      getActiveSpace: async () => ({
+        id: 'default',
+        name: 'Default',
+        disabledFeatures: [],
+      }),
+    },
     streams: {
       streamsRepositoryClient: {
         fetch: async (route: string, options?: { params?: { path?: { id?: string } } }) => {
@@ -179,6 +225,9 @@ const createServices = ({
               ignored: 0,
               status: 'closed',
             };
+          }
+          if (route === 'GET /internal/streams/_query_occurrences') {
+            return checkoutOccurrences;
           }
           if (route === 'GET /internal/streams/{name}/features') {
             if (streamFeaturesScenario === 'loading') {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point.test.ts
@@ -6,10 +6,9 @@
  */
 
 import {
-  generateChangePointSeries,
-  getChangePointIndex,
+  filterOccurrencesForDetection,
   getChangePointLabel,
-  getChangePointTimestamp,
+  getDetectionOccurrenceTimeRange,
 } from './change_point';
 
 describe('getChangePointLabel', () => {
@@ -23,35 +22,31 @@ describe('getChangePointLabel', () => {
   });
 });
 
-describe('getChangePointIndex', () => {
-  it('marks spike and dip near the end of the window', () => {
-    expect(getChangePointIndex('spike', 20)).toBe(16);
-    expect(getChangePointIndex('dip', 20)).toBe(16);
+describe('getDetectionOccurrenceTimeRange', () => {
+  it('frames occurrence data around the detection timestamp', () => {
+    expect(getDetectionOccurrenceTimeRange('2026-07-10T12:00:00Z')).toEqual({
+      from: new Date('2026-07-10T11:00:00Z').getTime(),
+      to: new Date('2026-07-10T12:15:00Z').getTime(),
+    });
   });
 
-  it('marks trend and step changes near the middle', () => {
-    expect(getChangePointIndex('trend_change', 20)).toBe(10);
-    expect(getChangePointIndex('step_change', 20)).toBe(10);
-  });
-});
-
-describe('getChangePointTimestamp', () => {
-  it('frames the change knee relative to the detection timestamp', () => {
-    const end = new Date('2026-07-10T12:00:00Z').getTime();
-    const changeIndex = getChangePointIndex('spike', 28);
-    const expected = end - (28 - 1 - changeIndex) * 300_000;
-
-    expect(getChangePointTimestamp('2026-07-10T12:00:00Z', 'spike')).toBe(expected);
+  it('returns undefined for an invalid timestamp', () => {
+    expect(getDetectionOccurrenceTimeRange('invalid')).toBeUndefined();
   });
 });
 
-describe('generateChangePointSeries', () => {
-  it('returns a series for extended change-point types', () => {
-    expect(generateChangePointSeries('distribution_change', 10)).toHaveLength(10);
-    expect(generateChangePointSeries('non_stationary', 10)).toHaveLength(10);
-    expect(generateChangePointSeries('stationary', 10)).toHaveLength(10);
-    expect(getChangePointIndex('distribution_change', 10)).toBe(9);
-    expect(getChangePointIndex('non_stationary', 10)).toBe(9);
-    expect(getChangePointIndex('stationary', 10)).toBe(9);
+describe('filterOccurrencesForDetection', () => {
+  it('keeps only points in the detection time window', () => {
+    const occurrences = [
+      { x: new Date('2026-07-10T10:55:00Z').getTime(), y: 1 },
+      { x: new Date('2026-07-10T11:00:00Z').getTime(), y: 2 },
+      { x: new Date('2026-07-10T12:15:00Z').getTime(), y: 3 },
+      { x: new Date('2026-07-10T12:20:00Z').getTime(), y: 4 },
+    ];
+
+    expect(filterOccurrencesForDetection(occurrences, '2026-07-10T12:00:00Z')).toEqual([
+      occurrences[1],
+      occurrences[2],
+    ]);
   });
 });

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point.test.ts
@@ -9,6 +9,8 @@ import {
   filterOccurrencesForDetection,
   getChangePointLabel,
   getDetectionOccurrenceTimeRange,
+  getOccurrenceBucketIntervalMs,
+  parseOccurrenceBucketSize,
 } from './change_point';
 
 describe('getChangePointLabel', () => {
@@ -48,5 +50,33 @@ describe('filterOccurrencesForDetection', () => {
       occurrences[1],
       occurrences[2],
     ]);
+  });
+});
+
+describe('parseOccurrenceBucketSize', () => {
+  it('parses minute and hour bucket sizes', () => {
+    expect(parseOccurrenceBucketSize('5m')).toEqual({
+      value: 5,
+      unit: 'm',
+      unitLabel: 'minutes',
+    });
+    expect(parseOccurrenceBucketSize('1h')).toEqual({
+      value: 1,
+      unit: 'h',
+      unitLabel: 'hours',
+    });
+  });
+
+  it('falls back for invalid bucket sizes', () => {
+    expect(parseOccurrenceBucketSize('invalid')).toEqual({
+      value: 5,
+      unit: 'm',
+      unitLabel: 'minutes',
+    });
+  });
+
+  it('converts bucket sizes to milliseconds', () => {
+    expect(getOccurrenceBucketIntervalMs('5m')).toBe(5 * 60 * 1000);
+    expect(getOccurrenceBucketIntervalMs('1h')).toBe(60 * 60 * 1000);
   });
 });

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point.ts
@@ -47,91 +47,42 @@ export function getChangePointLabel(type?: ChangePointType): string {
   return CHANGE_POINT_LABELS[type] ?? UNKNOWN_CHANGE_POINT_LABEL;
 }
 
-/**
- * Canonical framing for illustrative time windows (matches the flyout trend).
- * Sparklines may use fewer points for layout, but tooltips share this clock so
- * list + flyout timestamps stay aligned.
- */
-export const ILLUSTRATIVE_SERIES_POINTS = 28;
-export const ILLUSTRATIVE_POINT_INTERVAL_MS = 300_000;
-
-/**
- * Index in an illustrative series where the change-point shape flips. Used to
- * place the detection annotation; with real occurrence data this becomes the
- * API's change-point bucket (#277558).
- */
-export function getChangePointIndex(
-  changePointType: ChangePointType | undefined,
-  points: number
-): number {
-  switch (changePointType) {
-    case 'spike':
-    case 'dip':
-      return points - Math.ceil(points / 5);
-    case 'trend_change':
-    case 'step_change':
-      return Math.floor(points / 2);
-    default:
-      // Flat / unknown shapes: mark the end of the window (detection time).
-      return Math.max(points - 1, 0);
-  }
+export interface OccurrencePoint {
+  x: number;
+  y: number;
 }
 
-/**
- * Timestamp of the illustrative change knee when the series window ends at
- * `endTime` (detection time). Shared by list + flyout tooltips.
- */
-export function getChangePointTimestamp(
-  endTime: string | number,
-  changePointType: ChangePointType | undefined,
-  points: number = ILLUSTRATIVE_SERIES_POINTS,
-  intervalMs: number = ILLUSTRATIVE_POINT_INTERVAL_MS
-): number {
-  const end = typeof endTime === 'number' ? endTime : new Date(endTime).getTime();
-  const changeIndex = getChangePointIndex(changePointType, points);
-  return end - (points - 1 - changeIndex) * intervalMs;
+export interface DetectionOccurrenceTimeRange {
+  from: number;
+  to: number;
 }
 
-/**
- * Illustrative series shaped by the change-point type. Real occurrence
- * timeseries need the `_query_occurrences` API (tracked in #277558).
- */
-export function generateChangePointSeries(
-  changePointType: ChangePointType | undefined,
-  points: number
-): Array<{ x: number; y: number }> {
-  const data: Array<{ x: number; y: number }> = [];
-  const rand = () => Math.random() * 0.3;
-  const changeAt = getChangePointIndex(changePointType, points);
+export const DETECTION_OCCURRENCE_LOOKBACK_MS = 60 * 60 * 1000;
+export const DETECTION_OCCURRENCE_FOLLOWUP_MS = 15 * 60 * 1000;
+export const DETECTION_OCCURRENCE_BUCKET_SIZE = '5m';
 
-  for (let i = 0; i < points; i++) {
-    let y: number;
-    switch (changePointType) {
-      case 'spike':
-        y = i >= changeAt ? 0.7 + rand() : 0.2 + rand();
-        break;
-      case 'dip':
-        y = i >= changeAt ? 0.1 + rand() : 0.6 + rand();
-        break;
-      case 'trend_change':
-        y = i < changeAt ? 0.4 + rand() : 0.4 + ((i - changeAt) * 0.8) / points + rand();
-        break;
-      case 'step_change':
-        y = i < changeAt ? 0.25 + rand() : 0.65 + rand();
-        break;
-      case 'distribution_change':
-        y = i < changeAt ? 0.25 + rand() * 0.35 : 0.35 + rand() * 0.55;
-        break;
-      case 'non_stationary':
-        y = 0.2 + (i / Math.max(points - 1, 1)) * 0.45 + rand() * 0.2;
-        break;
-      case 'stationary':
-        y = 0.45 + rand() * 0.08;
-        break;
-      default:
-        y = 0.3 + rand();
-    }
-    data.push({ x: i, y });
+export function getDetectionOccurrenceTimeRange(
+  timestamp: string | number
+): DetectionOccurrenceTimeRange | undefined {
+  const detectionTime = typeof timestamp === 'number' ? timestamp : new Date(timestamp).getTime();
+  if (!Number.isFinite(detectionTime)) {
+    return undefined;
   }
-  return data;
+
+  return {
+    from: detectionTime - DETECTION_OCCURRENCE_LOOKBACK_MS,
+    to: detectionTime + DETECTION_OCCURRENCE_FOLLOWUP_MS,
+  };
+}
+
+export function filterOccurrencesForDetection(
+  occurrences: readonly OccurrencePoint[],
+  timestamp: string
+): OccurrencePoint[] {
+  const range = getDetectionOccurrenceTimeRange(timestamp);
+  if (!range) {
+    return [];
+  }
+
+  return occurrences.filter(({ x }) => x >= range.from && x <= range.to);
 }

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point.ts
@@ -60,6 +60,46 @@ export interface DetectionOccurrenceTimeRange {
 export const DETECTION_OCCURRENCE_LOOKBACK_MS = 60 * 60 * 1000;
 export const DETECTION_OCCURRENCE_FOLLOWUP_MS = 15 * 60 * 1000;
 export const DETECTION_OCCURRENCE_BUCKET_SIZE = '5m';
+/** Matches server METRIC_SERIES_MAX_WRITE_DELAY so live charts omit unreadable trailing buckets. */
+export const DETECTION_OCCURRENCE_WRITE_HORIZON_MS = 7 * 60 * 1000;
+
+const OCCURRENCE_BUCKET_SIZE_PATTERN = /^(\d+)([smhd])$/;
+const OCCURRENCE_BUCKET_UNIT_LABELS = {
+  s: 'seconds',
+  m: 'minutes',
+  h: 'hours',
+  d: 'days',
+} as const;
+const OCCURRENCE_BUCKET_UNIT_MS = {
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+} as const;
+
+export function parseOccurrenceBucketSize(bucketSize: string): {
+  value: number;
+  unit: keyof typeof OCCURRENCE_BUCKET_UNIT_LABELS;
+  unitLabel: (typeof OCCURRENCE_BUCKET_UNIT_LABELS)[keyof typeof OCCURRENCE_BUCKET_UNIT_LABELS];
+} {
+  const match = bucketSize.match(OCCURRENCE_BUCKET_SIZE_PATTERN);
+  if (!match) {
+    return { value: 5, unit: 'm', unitLabel: 'minutes' };
+  }
+  const value = Number.parseInt(match[1], 10);
+  const unit = match[2] as keyof typeof OCCURRENCE_BUCKET_UNIT_LABELS;
+  if (value < 1 || !(unit in OCCURRENCE_BUCKET_UNIT_LABELS)) {
+    return { value: 5, unit: 'm', unitLabel: 'minutes' };
+  }
+  return { value, unit, unitLabel: OCCURRENCE_BUCKET_UNIT_LABELS[unit] };
+}
+
+export function getOccurrenceBucketIntervalMs(
+  bucketSize: string = DETECTION_OCCURRENCE_BUCKET_SIZE
+): number {
+  const { value, unit } = parseOccurrenceBucketSize(bucketSize);
+  return value * OCCURRENCE_BUCKET_UNIT_MS[unit];
+}
 
 export function getDetectionOccurrenceTimeRange(
   timestamp: string | number
@@ -69,15 +109,21 @@ export function getDetectionOccurrenceTimeRange(
     return undefined;
   }
 
-  return {
-    from: detectionTime - DETECTION_OCCURRENCE_LOOKBACK_MS,
-    to: detectionTime + DETECTION_OCCURRENCE_FOLLOWUP_MS,
-  };
+  const from = detectionTime - DETECTION_OCCURRENCE_LOOKBACK_MS;
+  const requestedTo = detectionTime + DETECTION_OCCURRENCE_FOLLOWUP_MS;
+  const writeHorizon = Date.now() - DETECTION_OCCURRENCE_WRITE_HORIZON_MS;
+  const to = Math.min(requestedTo, writeHorizon);
+
+  if (to < from) {
+    return undefined;
+  }
+
+  return { from, to };
 }
 
 export function filterOccurrencesForDetection(
   occurrences: readonly OccurrencePoint[],
-  timestamp: string
+  timestamp: string | number
 ): OccurrencePoint[] {
   const range = getDetectionOccurrenceTimeRange(timestamp);
   if (!range) {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_lens_chart.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_lens_chart.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { LifecycleDetection } from '@kbn/significant-events-schema';
+import { buildDetectionOccurrencesEsql, ChangePointLensChart } from './change_point_lens_chart';
+
+const mockBuild = jest.fn();
+const mockGetActiveSpace = jest.fn();
+const mockEmbeddableComponent = jest.fn(({ attributes }: { attributes: { title: string } }) => (
+  <div data-test-subj="mockLensEmbeddable">{attributes.title}</div>
+));
+const mockServices = {
+  dataViews: {},
+  lens: {
+    EmbeddableComponent: mockEmbeddableComponent,
+  },
+  spaces: {
+    getActiveSpace: mockGetActiveSpace,
+  },
+};
+
+jest.mock('@kbn/lens-embeddable-utils', () => ({
+  LensConfigBuilder: jest.fn().mockImplementation(() => ({
+    build: mockBuild,
+  })),
+}));
+
+jest.mock('../../../utils/kibana_react', () => ({
+  useKibana: () => ({
+    services: mockServices,
+  }),
+}));
+
+const ruleUuid = 'rule-uuid-001';
+const detection: LifecycleDetection = {
+  detection_id: 'detection-1',
+  rule_name: 'Checkout latency spike',
+  rule_uuid: ruleUuid,
+  stream_name: 'logs.checkout-api',
+  change_point_type: 'spike',
+  '@timestamp': '2026-07-10T12:00:00.000Z',
+};
+
+describe('ChangePointLensChart', () => {
+  beforeEach(() => {
+    mockBuild.mockReset().mockResolvedValue({ title: '[Logs] Spike' });
+    mockGetActiveSpace.mockReset().mockResolvedValue({ id: 'space-a' });
+    mockEmbeddableComponent.mockClear();
+  });
+
+  it('builds the occurrence query for the active space and rule', () => {
+    const query = buildDetectionOccurrencesEsql({
+      ruleUuid,
+      spaceId: 'space-a',
+    });
+
+    expect(query).toContain('FROM .rule-events');
+    expect(query).toContain('space_id == "space-a"');
+    expect(query).toContain('rule.id == "rule-uuid-001"');
+    expect(query).toContain('COUNT_DISTINCT(group_hash)');
+    expect(query).toContain('BUCKET(@timestamp, 5 minutes)');
+  });
+
+  it('renders a Lens embeddable with a bar series and change point annotation', async () => {
+    render(
+      <I18nProvider>
+        <EuiProvider>
+          <ChangePointLensChart detection={detection} />
+        </EuiProvider>
+      </I18nProvider>
+    );
+
+    await waitFor(() => expect(mockBuild).toHaveBeenCalled());
+
+    const [config, options] = mockBuild.mock.calls[0];
+    expect(config).toEqual(
+      expect.objectContaining({
+        chartType: 'xy',
+        title: '[Logs] Spike',
+        layers: [
+          expect.objectContaining({
+            type: 'series',
+            seriesType: 'bar',
+            xAxis: { field: 'timestamp', type: 'dateHistogram' },
+          }),
+          expect.objectContaining({
+            type: 'annotation',
+            events: [
+              expect.objectContaining({
+                name: 'Spike',
+                datetime: detection['@timestamp'],
+              }),
+            ],
+          }),
+        ],
+      })
+    );
+    expect(options.query.esql).toContain('space_id == "space-a"');
+
+    expect(await screen.findByTestId('mockLensEmbeddable')).toHaveTextContent('[Logs] Spike');
+    expect(mockEmbeddableComponent.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        id: 'nightshift-detection-detection-1',
+        timeRange: {
+          from: '2026-07-10T11:00:00.000Z',
+          to: '2026-07-10T12:15:00.000Z',
+        },
+        withDefaultActions: true,
+      })
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_lens_chart.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_lens_chart.test.tsx
@@ -56,17 +56,27 @@ describe('ChangePointLensChart', () => {
     mockEmbeddableComponent.mockClear();
   });
 
-  it('builds the occurrence query for the active space and rule', () => {
+  it('builds the metric-series occurrence query for the active space and rule', () => {
     const query = buildDetectionOccurrencesEsql({
       ruleUuid,
       spaceId: 'space-a',
+      from: '2026-07-10T11:00:00.000Z',
+      to: '2026-07-10T12:15:00.000Z',
     });
 
     expect(query).toContain('FROM .rule-events');
     expect(query).toContain('space_id == "space-a"');
     expect(query).toContain('rule.id == "rule-uuid-001"');
-    expect(query).toContain('COUNT_DISTINCT(group_hash)');
-    expect(query).toContain('BUCKET(@timestamp, 5 minutes)');
+    expect(query).toContain('FIELD_EXTRACT(data, "metric_value")');
+    expect(query).toContain('FIELD_EXTRACT(data, "bucket")');
+    expect(query).toContain('MAX(metric_value)');
+    expect(query).toContain('SUM(minute_value)');
+    expect(query).toContain('BUCKET(source_minute, 5 minutes)');
+    expect(query).toContain('bucket >= TO_DATETIME("2026-07-10T11:00:00.000Z")');
+    expect(query).toContain('bucket <= TO_DATETIME("2026-07-10T12:15:00.000Z")');
+    expect(query).toContain('LIMIT 100');
+    expect(query).not.toContain('COUNT_DISTINCT');
+    expect(query).not.toContain('group_hash');
   });
 
   it('renders a Lens embeddable with a bar series and change point annotation', async () => {
@@ -103,6 +113,7 @@ describe('ChangePointLensChart', () => {
         ],
       })
     );
+    expect(options.query.esql).toContain('FIELD_EXTRACT(data, "metric_value")');
     expect(options.query.esql).toContain('space_id == "space-a"');
 
     expect(await screen.findByTestId('mockLensEmbeddable')).toHaveTextContent('[Logs] Spike');
@@ -116,5 +127,18 @@ describe('ChangePointLensChart', () => {
         withDefaultActions: true,
       })
     );
+  });
+
+  it('shows the warning callout when the detection has no rule UUID', async () => {
+    render(
+      <I18nProvider>
+        <EuiProvider>
+          <ChangePointLensChart detection={{ ...detection, rule_uuid: undefined }} />
+        </EuiProvider>
+      </I18nProvider>
+    );
+
+    expect(await screen.findByText('Unable to load occurrence visualization')).toBeInTheDocument();
+    expect(mockBuild).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_lens_chart.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_lens_chart.tsx
@@ -22,12 +22,13 @@ import {
   DETECTION_OCCURRENCE_BUCKET_SIZE,
   getChangePointLabel,
   getDetectionOccurrenceTimeRange,
+  parseOccurrenceBucketSize,
 } from './change_point';
 
 const CHART_HEIGHT = 200;
 const RULE_EVENTS_INDEX = '.rule-events';
 const DEFAULT_SPACE_ID = 'default';
-const OCCURRENCE_BUCKET_MINUTES = Number.parseInt(DETECTION_OCCURRENCE_BUCKET_SIZE, 10);
+const OCCURRENCE_QUERY_LIMIT = 100;
 
 type LensESQLConfig = LensConfig & { dataset: LensESQLDataset };
 
@@ -45,16 +46,32 @@ const getStreamTypeLabel = (streamName?: string): string => {
 export const buildDetectionOccurrencesEsql = ({
   ruleUuid,
   spaceId,
+  from,
+  to,
+  bucketSize = DETECTION_OCCURRENCE_BUCKET_SIZE,
 }: {
   ruleUuid: string;
   spaceId: string;
-}): string => `FROM ${RULE_EVENTS_INDEX}
+  from: string;
+  to: string;
+  bucketSize?: string;
+}): string => {
+  const { value, unitLabel } = parseOccurrenceBucketSize(bucketSize);
+  return `FROM ${RULE_EVENTS_INDEX}
 | WHERE type == "signal"
   AND space_id == ${JSON.stringify(spaceId)}
   AND rule.id == ${JSON.stringify(ruleUuid)}
-| STATS occurrences = COUNT_DISTINCT(group_hash)
-  BY timestamp = BUCKET(@timestamp, ${OCCURRENCE_BUCKET_MINUTES} minutes)
-| SORT timestamp ASC`;
+| EVAL metric_value = TO_LONG(FIELD_EXTRACT(data, "metric_value"))
+| EVAL bucket = TO_DATETIME(TO_LONG(FIELD_EXTRACT(data, "bucket")))
+| WHERE bucket IS NOT NULL AND metric_value IS NOT NULL
+| WHERE bucket >= TO_DATETIME(${JSON.stringify(from)})
+  AND bucket <= TO_DATETIME(${JSON.stringify(to)})
+| STATS minute_value = MAX(metric_value) BY source_minute = DATE_TRUNC(1 minute, bucket)
+| STATS occurrences = SUM(minute_value)
+  BY timestamp = BUCKET(source_minute, ${value} ${unitLabel})
+| SORT timestamp ASC
+| LIMIT ${OCCURRENCE_QUERY_LIMIT}`;
+};
 
 const buildLensConfig = ({
   changePointLabel,
@@ -137,7 +154,7 @@ export function ChangePointLensChart({
     error,
     loading,
     value: attributes,
-  } = useAsync(async () => {
+  } = useAsync(async (): Promise<LensAttributes> => {
     if (!timeRange) {
       throw new Error('Invalid detection timestamp');
     }
@@ -149,6 +166,8 @@ export function ChangePointLensChart({
     const esqlQuery = buildDetectionOccurrencesEsql({
       ruleUuid,
       spaceId,
+      from: timeRange.from,
+      to: timeRange.to,
     });
     const config = buildLensConfig({
       changePointLabel,

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_lens_chart.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_lens_chart.tsx
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { css } from '@emotion/react';
+import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiLoadingChart, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  LensConfigBuilder,
+  type LensAttributes,
+  type LensConfig,
+  type LensESQLDataset,
+} from '@kbn/lens-embeddable-utils';
+import type { LifecycleDetection } from '@kbn/significant-events-schema';
+import React, { useMemo } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { useKibana } from '../../../utils/kibana_react';
+import {
+  DETECTION_OCCURRENCE_BUCKET_SIZE,
+  getChangePointLabel,
+  getDetectionOccurrenceTimeRange,
+} from './change_point';
+
+const CHART_HEIGHT = 200;
+const RULE_EVENTS_INDEX = '.rule-events';
+const DEFAULT_SPACE_ID = 'default';
+const OCCURRENCE_BUCKET_MINUTES = Number.parseInt(DETECTION_OCCURRENCE_BUCKET_SIZE, 10);
+
+type LensESQLConfig = LensConfig & { dataset: LensESQLDataset };
+
+const getStreamTypeLabel = (streamName?: string): string => {
+  if (streamName?.startsWith('metrics')) {
+    return i18n.translate('xpack.observability.nightshift.detectionFlyout.trend.metricsLabel', {
+      defaultMessage: '[Metrics]',
+    });
+  }
+  return i18n.translate('xpack.observability.nightshift.detectionFlyout.trend.logsLabel', {
+    defaultMessage: '[Logs]',
+  });
+};
+
+export const buildDetectionOccurrencesEsql = ({
+  ruleUuid,
+  spaceId,
+}: {
+  ruleUuid: string;
+  spaceId: string;
+}): string => `FROM ${RULE_EVENTS_INDEX}
+| WHERE type == "signal"
+  AND space_id == ${JSON.stringify(spaceId)}
+  AND rule.id == ${JSON.stringify(ruleUuid)}
+| STATS occurrences = COUNT_DISTINCT(group_hash)
+  BY timestamp = BUCKET(@timestamp, ${OCCURRENCE_BUCKET_MINUTES} minutes)
+| SORT timestamp ASC`;
+
+const buildLensConfig = ({
+  changePointLabel,
+  color,
+  dangerColor,
+  esqlQuery,
+  timestamp,
+  title,
+}: {
+  changePointLabel: string;
+  color: string;
+  dangerColor: string;
+  esqlQuery: string;
+  timestamp: string;
+  title: string;
+}): LensESQLConfig => ({
+  chartType: 'xy',
+  title,
+  dataset: { esql: esqlQuery },
+  layers: [
+    {
+      type: 'series',
+      seriesType: 'bar',
+      xAxis: { field: 'timestamp', type: 'dateHistogram' },
+      yAxis: [
+        {
+          label: i18n.translate(
+            'xpack.observability.nightshift.detectionFlyout.trend.valueAxisLabel',
+            { defaultMessage: 'Occurrences' }
+          ),
+          value: 'occurrences',
+          format: 'number',
+          decimals: 0,
+          seriesColor: color,
+        },
+      ],
+    },
+    {
+      type: 'annotation',
+      yAxis: [],
+      events: [
+        {
+          name: changePointLabel,
+          color: dangerColor,
+          datetime: timestamp,
+        },
+      ],
+    },
+  ],
+  legend: { show: false },
+  fittingFunction: 'Zero',
+  valueLabels: 'hide',
+  axisTitleVisibility: {
+    showXAxisTitle: false,
+    showYAxisTitle: true,
+    showYRightAxisTitle: false,
+  },
+});
+
+export function ChangePointLensChart({
+  detection,
+}: {
+  detection: LifecycleDetection;
+}): React.ReactElement {
+  const { euiTheme } = useEuiTheme();
+  const { dataViews, lens, spaces } = useKibana().services;
+  const changePointLabel = getChangePointLabel(detection.change_point_type);
+  const title = `${getStreamTypeLabel(detection.stream_name)} ${changePointLabel}`;
+  const timeRange = useMemo(() => {
+    const range = getDetectionOccurrenceTimeRange(detection['@timestamp']);
+    return range
+      ? {
+          from: new Date(range.from).toISOString(),
+          to: new Date(range.to).toISOString(),
+        }
+      : undefined;
+  }, [detection]);
+
+  const {
+    error,
+    loading,
+    value: attributes,
+  } = useAsync(async () => {
+    if (!timeRange) {
+      throw new Error('Invalid detection timestamp');
+    }
+    const { rule_uuid: ruleUuid } = detection;
+    if (!ruleUuid) {
+      throw new Error('Detection rule UUID is required');
+    }
+    const spaceId = (await spaces?.getActiveSpace())?.id ?? DEFAULT_SPACE_ID;
+    const esqlQuery = buildDetectionOccurrencesEsql({
+      ruleUuid,
+      spaceId,
+    });
+    const config = buildLensConfig({
+      changePointLabel,
+      color: euiTheme.colors.vis.euiColorVis0,
+      dangerColor: euiTheme.colors.danger,
+      esqlQuery,
+      timestamp: detection['@timestamp'],
+      title,
+    });
+    const builder = new LensConfigBuilder(dataViews);
+    return builder.build(config, {
+      query: { esql: esqlQuery },
+    }) as Promise<LensAttributes>;
+  }, [
+    changePointLabel,
+    dataViews,
+    detection,
+    euiTheme.colors.danger,
+    euiTheme.colors.vis.euiColorVis0,
+    spaces,
+    timeRange,
+    title,
+  ]);
+
+  const LensEmbeddableComponent = lens.EmbeddableComponent;
+
+  if (error || !timeRange) {
+    return (
+      <EuiCallOut
+        announceOnMount
+        color="warning"
+        iconType="warning"
+        size="s"
+        title={i18n.translate(
+          'xpack.observability.nightshift.detectionFlyout.trend.lensErrorTitle',
+          { defaultMessage: 'Unable to load occurrence visualization' }
+        )}
+      />
+    );
+  }
+
+  return (
+    <div
+      data-test-subj="nightshiftDetectionLensChart"
+      css={css`
+        min-height: ${CHART_HEIGHT}px;
+      `}
+    >
+      {loading || !attributes ? (
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="center"
+          responsive={false}
+          css={css`
+            height: ${CHART_HEIGHT}px;
+          `}
+        >
+          <EuiFlexItem grow={false}>
+            <EuiLoadingChart data-test-subj="nightshiftDetectionLensChartLoading" size="l" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : (
+        <LensEmbeddableComponent
+          id={`nightshift-detection-${detection.detection_id}`}
+          attributes={attributes}
+          timeRange={timeRange}
+          noPadding
+          withDefaultActions
+          viewMode="view"
+          style={{ height: CHART_HEIGHT }}
+          executionContext={{
+            description: 'Nightshift detection occurrence chart',
+            meta: {
+              detection_id: detection.detection_id,
+              rule_uuid: detection.rule_uuid,
+            },
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_visualization.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_visualization.tsx
@@ -6,105 +6,102 @@
  */
 
 import { css } from '@emotion/react';
-import React, { useMemo } from 'react';
-import { EuiPanel, EuiSpacer, EuiText, useEuiTheme } from '@elastic/eui';
+import React from 'react';
+import { EuiText, useEuiTheme } from '@elastic/eui';
 import {
   AnnotationDomainType,
-  Axis,
   BarSeries,
   BubbleSeries,
   Chart,
   LineAnnotation,
   PointShape,
-  Position,
   RectAnnotation,
   ScaleType,
   Settings,
   Tooltip,
   TooltipType,
 } from '@elastic/charts';
-import moment from 'moment';
 import { i18n } from '@kbn/i18n';
 import type { ChangePointType } from '@kbn/significant-events-schema';
-import {
-  generateChangePointSeries,
-  getChangePointIndex,
-  getChangePointLabel,
-  getChangePointTimestamp,
-  ILLUSTRATIVE_POINT_INTERVAL_MS,
-  ILLUSTRATIVE_SERIES_POINTS,
-} from './change_point';
+import { getChangePointLabel, type OccurrencePoint } from './change_point';
 import { useChartThemes } from '../../../hooks/use_chart_themes';
 import { ChangePointAnnotationTooltip } from './change_point_annotation_tooltip';
 
-const SPARKLINE_POINTS = 20;
 const SPARKLINE_HEIGHT = 32;
 const SPARKLINE_WIDTH = 64;
 const SPARKLINE_MARKER_MARGIN = 6;
 
-const TREND_CHART_HEIGHT = 160;
-const TREND_MARKER_MARGIN = 10;
-const TREND_VALUE_SCALE = 25;
+const DEFAULT_ANNOTATION_INTERVAL_MS = 5 * 60 * 1000;
 
-function getStreamTypeLabel(streamName?: string): string {
-  if (streamName?.startsWith('metrics')) {
-    return i18n.translate('xpack.observability.nightshift.detectionFlyout.trend.metricsLabel', {
-      defaultMessage: '[Metrics]',
-    });
+const getChangePointAnnotation = (
+  data: readonly OccurrencePoint[],
+  timestamp: string
+):
+  | {
+      changePointAt: number;
+      changePointTimestamp: number;
+      changePointMarker: OccurrencePoint[];
+      interval: number;
+    }
+  | undefined => {
+  const changePointTimestamp = new Date(timestamp).getTime();
+  if (!Number.isFinite(changePointTimestamp) || data.length === 0) {
+    return undefined;
   }
-  return i18n.translate('xpack.observability.nightshift.detectionFlyout.trend.logsLabel', {
-    defaultMessage: '[Logs]',
-  });
-}
 
-const buildTimeSeries = (
-  changePointType: ChangePointType | undefined,
-  endTime: string,
-  points: number
-): {
-  data: Array<{ x: number; y: number }>;
-  changePointAt: number;
-  changePointMarker: Array<{ x: number; y: number }>;
-} => {
-  const end = new Date(endTime).getTime();
-  if (!Number.isFinite(end)) {
-    return {
-      data: [],
-      changePointAt: end,
-      changePointMarker: [],
-    };
-  }
-  const changeIndex = getChangePointIndex(changePointType, points);
-  const series = generateChangePointSeries(changePointType, points).map(({ x, y }) => ({
-    x: end - (points - 1 - x) * ILLUSTRATIVE_POINT_INTERVAL_MS,
-    y: Math.round(y * TREND_VALUE_SCALE),
-  }));
-  const changePointAt = getChangePointTimestamp(end, changePointType, points);
+  const closestPoint = data.reduce((closest, point) =>
+    Math.abs(point.x - changePointTimestamp) < Math.abs(closest.x - changePointTimestamp)
+      ? point
+      : closest
+  );
+  const firstInterval = data.length > 1 ? Math.abs(data[1].x - data[0].x) : 0;
+
   return {
-    data: series,
-    changePointAt,
-    changePointMarker: [{ x: changePointAt, y: series[changeIndex]?.y ?? 0 }],
+    changePointAt: closestPoint.x,
+    changePointTimestamp,
+    changePointMarker: [closestPoint],
+    interval: firstInterval || DEFAULT_ANNOTATION_INTERVAL_MS,
   };
 };
 
 export function ChangePointSparkline({
   changePointType,
+  data,
   timestamp,
 }: {
   changePointType?: ChangePointType;
+  data: OccurrencePoint[];
   timestamp: string;
 }): React.ReactElement {
   const { euiTheme } = useEuiTheme();
   const { baseTheme, sparklineTheme } = useChartThemes();
   const changePointLabel = getChangePointLabel(changePointType);
+  const annotation = getChangePointAnnotation(data, timestamp);
 
-  const { data, changePointAt, changePointMarker } = useMemo(
-    () => buildTimeSeries(changePointType, timestamp, SPARKLINE_POINTS),
-    [changePointType, timestamp]
-  );
+  if (data.length === 0) {
+    return (
+      <div
+        data-test-subj="nightshiftDetectionSparklineEmpty"
+        css={css`
+          align-items: center;
+          display: flex;
+          height: ${SPARKLINE_HEIGHT}px;
+          justify-content: center;
+          width: ${SPARKLINE_WIDTH}px;
+        `}
+      >
+        <EuiText size="xs" color="subdued">
+          &mdash;
+        </EuiText>
+      </div>
+    );
+  }
 
   return (
-    <Chart size={{ height: SPARKLINE_HEIGHT, width: SPARKLINE_WIDTH }}>
+    <Chart
+      data-test-subj="nightshiftDetectionSparkline"
+      size={{ height: SPARKLINE_HEIGHT, width: SPARKLINE_WIDTH }}
+    >
       <Tooltip type={TooltipType.None} />
       <Settings
         baseTheme={baseTheme}
@@ -118,37 +115,41 @@ export function ChangePointSparkline({
         showLegend={false}
         locale={i18n.getLocale()}
       />
-      <LineAnnotation
-        id="detection-change-point"
-        domainType={AnnotationDomainType.XDomain}
-        dataValues={[{ dataValue: changePointAt }]}
-        style={{
-          line: {
-            strokeWidth: 1.5,
-            stroke: euiTheme.colors.danger,
-            opacity: 1,
-          },
-        }}
-      />
-      <RectAnnotation
-        id="detection-change-point-tooltip"
-        zIndex={10}
-        dataValues={[
-          {
-            coordinates: {
-              x0: changePointAt - ILLUSTRATIVE_POINT_INTERVAL_MS / 2,
-              x1: changePointAt + ILLUSTRATIVE_POINT_INTERVAL_MS / 2,
-            },
-          },
-        ]}
-        style={{ fill: euiTheme.colors.danger, opacity: 0 }}
-        customTooltip={() => (
-          <ChangePointAnnotationTooltip
-            changePointLabel={changePointLabel}
-            timestamp={changePointAt}
+      {annotation && (
+        <>
+          <LineAnnotation
+            id="detection-change-point"
+            domainType={AnnotationDomainType.XDomain}
+            dataValues={[{ dataValue: annotation.changePointAt }]}
+            style={{
+              line: {
+                strokeWidth: 1.5,
+                stroke: euiTheme.colors.danger,
+                opacity: 1,
+              },
+            }}
           />
-        )}
-      />
+          <RectAnnotation
+            id="detection-change-point-tooltip"
+            zIndex={10}
+            dataValues={[
+              {
+                coordinates: {
+                  x0: annotation.changePointAt - annotation.interval / 2,
+                  x1: annotation.changePointAt + annotation.interval / 2,
+                },
+              },
+            ]}
+            style={{ fill: euiTheme.colors.danger, opacity: 0 }}
+            customTooltip={() => (
+              <ChangePointAnnotationTooltip
+                changePointLabel={changePointLabel}
+                timestamp={annotation.changePointTimestamp}
+              />
+            )}
+          />
+        </>
+      )}
       <BarSeries
         id="detection-sparkline"
         xScaleType={ScaleType.Time}
@@ -158,150 +159,26 @@ export function ChangePointSparkline({
         yAccessors={['y']}
         color={euiTheme.colors.vis.euiColorVis0}
       />
-      <BubbleSeries
-        id="detection-change-point-marker"
-        xScaleType={ScaleType.Time}
-        yScaleType={ScaleType.Linear}
-        data={changePointMarker}
-        xAccessor="x"
-        yAccessors={['y']}
-        color={euiTheme.colors.danger}
-        bubbleSeriesStyle={{
-          point: {
-            shape: PointShape.Diamond,
-            radius: 3.5,
-            fill: euiTheme.colors.danger,
-            strokeWidth: 0,
-            visible: 'always',
-          },
-        }}
-      />
-    </Chart>
-  );
-}
-
-// TODO(#277558): replace with real occurrence timeseries.
-export function ChangePointTrendChart({
-  changePointType,
-  streamName,
-  endTime,
-}: {
-  changePointType?: ChangePointType;
-  streamName?: string;
-  endTime: string;
-}): React.ReactElement {
-  const { euiTheme } = useEuiTheme();
-  const { baseTheme } = useChartThemes();
-
-  const { data, changePointAt, changePointMarker } = useMemo(
-    () => buildTimeSeries(changePointType, endTime, ILLUSTRATIVE_SERIES_POINTS),
-    [changePointType, endTime]
-  );
-
-  return (
-    <EuiPanel
-      hasBorder
-      hasShadow={false}
-      paddingSize="s"
-      css={css`
-        overflow: visible;
-      `}
-    >
-      <EuiText size="xs">
-        {`${getStreamTypeLabel(streamName)} ${getChangePointLabel(changePointType)}`}
-      </EuiText>
-      <EuiSpacer size="xs" />
-      <EuiText size="xs" color="subdued">
-        {i18n.translate('xpack.observability.nightshift.detectionFlyout.trend.placeholderNote', {
-          defaultMessage: 'Illustrative preview — not based on actual occurrence data.',
-        })}
-      </EuiText>
-      <EuiSpacer size="s" />
-      <Chart size={{ height: TREND_CHART_HEIGHT }}>
-        <Tooltip type={TooltipType.None} />
-        <Settings
-          baseTheme={baseTheme}
-          theme={{
-            background: { color: 'transparent' },
-            chartMargins: { top: TREND_MARKER_MARGIN },
-          }}
-          showLegend={false}
-          locale={i18n.getLocale()}
-        />
-        <Axis
-          id="left"
-          position={Position.Left}
-          title={i18n.translate(
-            'xpack.observability.nightshift.detectionFlyout.trend.valueAxisLabel',
-            { defaultMessage: 'Illustrative count' }
-          )}
-          ticks={4}
-        />
-        <Axis
-          id="bottom"
-          position={Position.Bottom}
-          tickFormat={(value) => moment(value).format('HH:mm')}
-          ticks={4}
-        />
-        <LineAnnotation
-          id="detection-change-point"
-          domainType={AnnotationDomainType.XDomain}
-          dataValues={[{ dataValue: changePointAt }]}
-          style={{
-            line: {
-              strokeWidth: 2,
-              stroke: euiTheme.colors.danger,
-              opacity: 1,
-            },
-          }}
-        />
-        <RectAnnotation
-          id="detection-change-point-tooltip"
-          zIndex={10}
-          dataValues={[
-            {
-              coordinates: {
-                x0: changePointAt - ILLUSTRATIVE_POINT_INTERVAL_MS / 2,
-                x1: changePointAt + ILLUSTRATIVE_POINT_INTERVAL_MS / 2,
-              },
-            },
-          ]}
-          style={{ fill: euiTheme.colors.danger, opacity: 0 }}
-          customTooltip={() => (
-            <ChangePointAnnotationTooltip
-              changePointLabel={getChangePointLabel(changePointType)}
-              timestamp={changePointAt}
-            />
-          )}
-        />
-        <BarSeries
-          id="detection-trend"
-          xScaleType={ScaleType.Time}
-          yScaleType={ScaleType.Linear}
-          data={data}
-          xAccessor="x"
-          yAccessors={['y']}
-          color={euiTheme.colors.vis.euiColorVis0}
-        />
+      {annotation && (
         <BubbleSeries
           id="detection-change-point-marker"
           xScaleType={ScaleType.Time}
           yScaleType={ScaleType.Linear}
-          data={changePointMarker}
+          data={annotation.changePointMarker}
           xAccessor="x"
           yAccessors={['y']}
           color={euiTheme.colors.danger}
           bubbleSeriesStyle={{
             point: {
               shape: PointShape.Diamond,
-              radius: 5,
+              radius: 3.5,
               fill: euiTheme.colors.danger,
               strokeWidth: 0,
               visible: 'always',
             },
           }}
         />
-      </Chart>
-    </EuiPanel>
+      )}
+    </Chart>
   );
 }

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_visualization.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/change_point_visualization.tsx
@@ -23,7 +23,11 @@ import {
 } from '@elastic/charts';
 import { i18n } from '@kbn/i18n';
 import type { ChangePointType } from '@kbn/significant-events-schema';
-import { getChangePointLabel, type OccurrencePoint } from './change_point';
+import {
+  getChangePointLabel,
+  getOccurrenceBucketIntervalMs,
+  type OccurrencePoint,
+} from './change_point';
 import { useChartThemes } from '../../../hooks/use_chart_themes';
 import { ChangePointAnnotationTooltip } from './change_point_annotation_tooltip';
 
@@ -31,7 +35,7 @@ const SPARKLINE_HEIGHT = 32;
 const SPARKLINE_WIDTH = 64;
 const SPARKLINE_MARKER_MARGIN = 6;
 
-const DEFAULT_ANNOTATION_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_ANNOTATION_INTERVAL_MS = getOccurrenceBucketIntervalMs();
 
 const getChangePointAnnotation = (
   data: readonly OccurrencePoint[],

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/detection_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/detection_flyout.test.tsx
@@ -33,6 +33,14 @@ jest.mock('../hooks/use_fetch_stream_features', () => ({
   }),
 }));
 
+jest.mock('./change_point_lens_chart', () => ({
+  ChangePointLensChart: ({ detection }: { detection: LifecycleDetection }) => (
+    <div data-test-subj="nightshiftDetectionLensChart" data-rule-uuid={detection.rule_uuid}>
+      [Logs] Spike
+    </div>
+  ),
+}));
+
 jest.mock('../../../utils/kibana_react', () => ({
   useKibana: () => ({
     services: {
@@ -205,11 +213,15 @@ describe('DetectionFlyout', () => {
     expect(screen.queryByText('Impacted entities')).not.toBeInTheDocument();
   });
 
-  it('renders the trend section', () => {
+  it('renders the Lens occurrence chart in the trend section', () => {
     renderFlyout();
 
     expect(screen.getByText('Trend')).toBeInTheDocument();
     expect(screen.getByText('[Logs] Spike')).toBeInTheDocument();
+    expect(screen.getByTestId('nightshiftDetectionLensChart')).toHaveAttribute(
+      'data-rule-uuid',
+      mockDetection.rule_uuid
+    );
   });
 
   it('renders the ES|QL query with an Open in Discover button', () => {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/detection_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/detection/detection_flyout.tsx
@@ -38,7 +38,7 @@ import type {
 } from '@kbn/significant-events-schema';
 import { useFormatTimestamp } from '../common/format_timestamp';
 import { getChangePointLabel } from './change_point';
-import { ChangePointTrendChart } from './change_point_visualization';
+import { ChangePointLensChart } from './change_point_lens_chart';
 import { EntityChip } from '../entity/entity_chip';
 import { EntityFlyout } from '../entity/entity_flyout';
 import { FlyoutSectionTitle } from '../common/flyout_section_title';
@@ -290,11 +290,7 @@ export function DetectionFlyout({
             })}
           </FlyoutSectionTitle>
           <EuiSpacer size="s" />
-          <ChangePointTrendChart
-            changePointType={detection.change_point_type}
-            streamName={detection.stream_name}
-            endTime={detection['@timestamp']}
-          />
+          <ChangePointLensChart detection={detection} />
 
           {esqlQuery && (
             <>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.test.tsx
@@ -22,6 +22,11 @@ jest.mock('@kbn/kibana-react-plugin/public', () => ({
 
 jest.mock('../hooks/use_fetch_event_lifecycle');
 jest.mock('../hooks/use_fetch_stream_features');
+jest.mock('../detection/change_point_visualization', () => ({
+  ChangePointSparkline: ({ data }: { data: Array<{ x: number; y: number }> }) => (
+    <div data-test-subj="mockDetectionSparkline" data-point-count={data.length} />
+  ),
+}));
 
 jest.mock('../../../utils/kibana_react', () => ({
   useKibana: () => ({
@@ -64,6 +69,7 @@ const mockEvent = (overrides: Partial<SignificantEvent> = {}): SignificantEvent 
 const mockDetection = (overrides: Partial<LifecycleDetection> = {}): LifecycleDetection => ({
   detection_id: 'det-1',
   rule_name: 'latency-p95-spike',
+  rule_uuid: 'rule-1',
   stream_name: 'logs.web-frontend',
   change_point_type: 'spike',
   '@timestamp': '2026-07-10T12:00:00Z',
@@ -195,6 +201,31 @@ describe('DetectionsList', () => {
     expect(screen.getByText('Trend change')).toBeInTheDocument();
     expect(screen.getAllByText('web-frontend').length).toBeGreaterThan(0);
     expect(screen.queryByText('logs.web-frontend')).not.toBeInTheDocument();
+  });
+
+  it('passes real occurrences for the detection rule to its sparkline', () => {
+    setLifecycle({ detections: [mockDetection()] });
+    renderList({
+      occurrencesByRuleUuid: new Map([
+        [
+          'rule-1',
+          [
+            { x: new Date('2026-07-10T11:55:00.000Z').getTime(), y: 2 },
+            { x: new Date('2026-07-10T12:00:00.000Z').getTime(), y: 8 },
+          ],
+        ],
+      ]),
+    });
+
+    expect(screen.getByTestId('mockDetectionSparkline')).toHaveAttribute('data-point-count', '2');
+  });
+
+  it('shows a sparkline skeleton while occurrences load', () => {
+    setLifecycle({ detections: [mockDetection()] });
+    renderList({ isLoadingOccurrences: true });
+
+    expect(screen.getByTestId('nightshiftDetectionSparklineSkeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('mockDetectionSparkline')).not.toBeInTheDocument();
   });
 
   it('shows at most two entity pills plus an overflow pill', () => {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.tsx
@@ -171,16 +171,34 @@ function DetectionCard({
             flex: 1 1 ${TEXT_CONTENT_MIN_WIDTH};
           `}
         >
-          <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+          <EuiFlexGroup
+            direction="column"
+            gutterSize="none"
+            responsive={false}
+            css={css`
+              row-gap: ${euiTheme.size.s};
+            `}
+          >
             <EuiFlexItem grow={false}>
-              <EuiText size="s" textAlign="left">
-                <strong>{detection.rule_name}</strong>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiText size="xs" color="subdued" textAlign="left">
-                {formatTimestamp(detection['@timestamp'])}
-              </EuiText>
+              <EuiFlexGroup
+                direction="column"
+                gutterSize="none"
+                responsive={false}
+                css={css`
+                  row-gap: 2px;
+                `}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s" textAlign="left">
+                    <strong>{detection.rule_name}</strong>
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued" textAlign="left">
+                    {formatTimestamp(detection['@timestamp'])}
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiFlexGroup

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.tsx
@@ -185,7 +185,7 @@ function DetectionCard({
                 gutterSize="none"
                 responsive={false}
                 css={css`
-                  row-gap: 2px;
+                  row-gap: ${euiTheme.size.xxs};
                 `}
               >
                 <EuiFlexItem grow={false}>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.tsx
@@ -33,7 +33,11 @@ import type {
 import { useFetchEventLifecycle } from '../hooks/use_fetch_event_lifecycle';
 import { useFetchStreamFeaturesByStream } from '../hooks/use_fetch_stream_features';
 import { useFormatTimestamp } from '../common/format_timestamp';
-import { getChangePointLabel } from '../detection/change_point';
+import {
+  filterOccurrencesForDetection,
+  getChangePointLabel,
+  type OccurrencePoint,
+} from '../detection/change_point';
 import { ChangePointSparkline } from '../detection/change_point_visualization';
 import { getDetectionEntities } from './get_detection_entities';
 import { nightshiftBackgroundTransition } from '../common/nightshift_transition';
@@ -48,6 +52,8 @@ const MAX_VISIBLE_ENTITY_PILLS = 2;
 export interface DetectionsListProps {
   event: SignificantEvent;
   eventUuid: string;
+  occurrencesByRuleUuid?: ReadonlyMap<string, OccurrencePoint[]>;
+  isLoadingOccurrences?: boolean;
   selectedDetectionId?: string;
   onDetectionClick?: (detection: LifecycleDetection) => void;
   lifecycleQuery?: Pick<
@@ -68,13 +74,17 @@ const parseTimestamp = (timestamp: string): number => {
 function DetectionCard({
   detection,
   event,
+  occurrences,
   streamFeatures,
+  isLoadingOccurrences,
   isSelected = false,
   onClick,
 }: {
   detection: LifecycleDetection;
   event: SignificantEvent;
+  occurrences: OccurrencePoint[];
   streamFeatures: Feature[];
+  isLoadingOccurrences: boolean;
   isSelected?: boolean;
   onClick?: (detection: LifecycleDetection) => void;
 }) {
@@ -210,10 +220,20 @@ function DetectionCard({
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <ChangePointSparkline
-            changePointType={detection.change_point_type}
-            timestamp={detection['@timestamp']}
-          />
+          {isLoadingOccurrences ? (
+            <EuiSkeletonRectangle
+              data-test-subj="nightshiftDetectionSparklineSkeleton"
+              width={SPARKLINE_SKELETON_WIDTH}
+              height={SPARKLINE_SKELETON_HEIGHT}
+              borderRadius="m"
+            />
+          ) : (
+            <ChangePointSparkline
+              changePointType={detection.change_point_type}
+              data={occurrences}
+              timestamp={detection['@timestamp']}
+            />
+          )}
         </EuiFlexItem>
       </EuiFlexGroup>
     </div>
@@ -317,6 +337,8 @@ function DetectionListPanel({ items }: { items: React.ReactElement[] }): React.R
 export function DetectionsList({
   event,
   eventUuid,
+  occurrencesByRuleUuid,
+  isLoadingOccurrences = false,
   selectedDetectionId,
   onDetectionClick,
   lifecycleQuery: lifecycleQueryFromParent,
@@ -412,7 +434,12 @@ export function DetectionsList({
               key={detection.detection_id}
               detection={detection}
               event={event}
+              occurrences={filterOccurrencesForDetection(
+                detection.rule_uuid ? occurrencesByRuleUuid?.get(detection.rule_uuid) ?? [] : [],
+                detection['@timestamp']
+              )}
               streamFeatures={streamFeaturesByStream.get(detection.stream_name ?? '') ?? []}
+              isLoadingOccurrences={isLoadingOccurrences && Boolean(detection.rule_uuid)}
               isSelected={detection.detection_id === selectedDetectionId}
               onClick={onDetectionClick}
             />

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/detections_list.tsx
@@ -178,6 +178,11 @@ function DetectionCard({
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued" textAlign="left">
+                {formatTimestamp(detection['@timestamp'])}
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
               <EuiFlexGroup
                 gutterSize="xs"
                 wrap
@@ -187,11 +192,6 @@ function DetectionCard({
                   row-gap: ${euiTheme.size.xs};
                 `}
               >
-                <EuiFlexItem grow={false}>
-                  <EuiText size="xs" color="subdued" textAlign="left">
-                    {formatTimestamp(detection['@timestamp'])}
-                  </EuiText>
-                </EuiFlexItem>
                 {detection.change_point_type && (
                   <EuiFlexItem grow={false}>
                     <EuiBadge color="default">{changePointLabel}</EuiBadge>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/event_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/event_flyout.test.tsx
@@ -41,6 +41,27 @@ jest.mock('../hooks/use_fetch_stream_features', () => ({
   useFetchStreamFeaturesByStream: () => new Map<string, never[]>(),
 }));
 
+jest.mock('../detection/change_point_lens_chart', () => ({
+  ChangePointLensChart: () => <div data-test-subj="nightshiftDetectionLensChart" />,
+}));
+
+jest.mock('../hooks/use_fetch_detection_occurrences', () => ({
+  useFetchDetectionOccurrences: () => ({
+    data: new Map([
+      [
+        'rule-uuid-001',
+        [
+          { x: new Date('2026-07-10T11:55:00.000Z').getTime(), y: 2 },
+          { x: new Date('2026-07-10T12:00:00.000Z').getTime(), y: 8 },
+        ],
+      ],
+    ]),
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+  }),
+}));
+
 jest.mock('../hooks/use_fetch_event_lifecycle', () => ({
   useFetchEventLifecycle: () => ({
     data: {
@@ -48,6 +69,7 @@ jest.mock('../hooks/use_fetch_event_lifecycle', () => ({
         {
           detection_id: 'det-1',
           rule_name: 'latency-p95-spike',
+          rule_uuid: 'rule-uuid-001',
           stream_name: 'logs.web-frontend',
           change_point_type: 'spike',
           '@timestamp': '2026-07-10T12:00:00Z',

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/event_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/event/event_flyout.tsx
@@ -39,6 +39,7 @@ import { useFlyoutShareUrlCustomAction } from '../common/flyout_share_url_button
 import { buildNightshiftEventFlyoutShareUrl } from '../common/nightshift_url_params';
 import { NightshiftMarkIcon } from '../app/nightshift_mark_icon';
 import { useFormatTimestamp } from '../common/format_timestamp';
+import { useFetchDetectionOccurrences } from '../hooks/use_fetch_detection_occurrences';
 import { useFetchEventLifecycle } from '../hooks/use_fetch_event_lifecycle';
 import { markEventInvestigationCompleteInCache } from '../hooks/use_fetch_significant_events';
 import { findDetectionSignal } from '../detection/resolve_detection_signal';
@@ -62,6 +63,7 @@ export function EventFlyout({ event, onClose }: EventFlyoutProps): React.ReactEl
   const { agentBuilder, http } = useKibana().services;
   const [selectedDetectionId, setSelectedDetectionId] = useState<string>();
   const lifecycleQuery = useFetchEventLifecycle(event.event_uuid);
+  const occurrencesQuery = useFetchDetectionOccurrences(lifecycleQuery.data?.detections ?? []);
   const latestInvestigation = useMemo(() => event.investigations?.at(-1), [event.investigations]);
 
   const {
@@ -230,6 +232,8 @@ export function EventFlyout({ event, onClose }: EventFlyoutProps): React.ReactEl
           event={event}
           eventUuid={event.event_uuid}
           lifecycleQuery={lifecycleQuery}
+          occurrencesByRuleUuid={occurrencesQuery.data}
+          isLoadingOccurrences={occurrencesQuery.isLoading}
           selectedDetectionId={selectedDetectionId}
           onDetectionClick={(detection) => handleDetectionClick(detection.detection_id)}
         />

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/hooks/use_fetch_detection_occurrences.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/hooks/use_fetch_detection_occurrences.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LifecycleDetection } from '@kbn/significant-events-schema';
+import { buildDetectionOccurrencesRequest } from './use_fetch_detection_occurrences';
+
+const detection = (overrides: Partial<LifecycleDetection> = {}): LifecycleDetection => ({
+  detection_id: 'detection-1',
+  rule_name: 'Error spike',
+  rule_uuid: 'rule-1',
+  stream_name: 'logs.api',
+  change_point_type: 'spike',
+  '@timestamp': '2026-07-10T12:00:00.000Z',
+  ...overrides,
+});
+
+describe('buildDetectionOccurrencesRequest', () => {
+  it('batches rules and streams across the complete detection time range', () => {
+    expect(
+      buildDetectionOccurrencesRequest([
+        detection(),
+        detection({
+          detection_id: 'detection-2',
+          rule_uuid: 'rule-2',
+          stream_name: 'logs.worker',
+          '@timestamp': '2026-07-10T13:00:00.000Z',
+        }),
+      ])
+    ).toEqual({
+      from: '2026-07-10T11:00:00.000Z',
+      to: '2026-07-10T13:15:00.000Z',
+      ruleUuids: ['rule-1', 'rule-2'],
+      streamNames: ['logs.api', 'logs.worker'],
+    });
+  });
+
+  it('returns undefined when no detection has a rule UUID', () => {
+    expect(buildDetectionOccurrencesRequest([detection({ rule_uuid: undefined })])).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/hooks/use_fetch_detection_occurrences.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/hooks/use_fetch_detection_occurrences.test.ts
@@ -6,7 +6,10 @@
  */
 
 import type { LifecycleDetection } from '@kbn/significant-events-schema';
-import { buildDetectionOccurrencesRequest } from './use_fetch_detection_occurrences';
+import {
+  buildDetectionOccurrencesRequest,
+  mapOccurrencesByRuleUuid,
+} from './use_fetch_detection_occurrences';
 
 const detection = (overrides: Partial<LifecycleDetection> = {}): LifecycleDetection => ({
   detection_id: 'detection-1',
@@ -40,5 +43,76 @@ describe('buildDetectionOccurrencesRequest', () => {
 
   it('returns undefined when no detection has a rule UUID', () => {
     expect(buildDetectionOccurrencesRequest([detection({ rule_uuid: undefined })])).toBeUndefined();
+  });
+});
+
+describe('mapOccurrencesByRuleUuid', () => {
+  it('maps occurrence series by rule UUID and skips rows without one', () => {
+    expect(
+      mapOccurrencesByRuleUuid([
+        {
+          rule_uuid: 'rule-1',
+          occurrences: [
+            { date: '2026-07-10T11:55:00.000Z', count: 2 },
+            { date: '2026-07-10T12:00:00.000Z', count: 8 },
+          ],
+        },
+        {
+          occurrences: [{ date: '2026-07-10T12:00:00.000Z', count: 1 }],
+        },
+      ])
+    ).toEqual(
+      new Map([
+        [
+          'rule-1',
+          [
+            { x: new Date('2026-07-10T11:55:00.000Z').getTime(), y: 2 },
+            { x: new Date('2026-07-10T12:00:00.000Z').getTime(), y: 8 },
+          ],
+        ],
+      ])
+    );
+  });
+
+  it('keeps the longer series when multiple query links share a rule UUID', () => {
+    expect(
+      mapOccurrencesByRuleUuid([
+        {
+          rule_uuid: 'rule-1',
+          occurrences: [{ date: '2026-07-10T12:00:00.000Z', count: 1 }],
+        },
+        {
+          rule_uuid: 'rule-1',
+          occurrences: [
+            { date: '2026-07-10T11:55:00.000Z', count: 2 },
+            { date: '2026-07-10T12:00:00.000Z', count: 8 },
+          ],
+        },
+      ])
+    ).toEqual(
+      new Map([
+        [
+          'rule-1',
+          [
+            { x: new Date('2026-07-10T11:55:00.000Z').getTime(), y: 2 },
+            { x: new Date('2026-07-10T12:00:00.000Z').getTime(), y: 8 },
+          ],
+        ],
+      ])
+    );
+  });
+
+  it('filters invalid occurrence dates', () => {
+    expect(
+      mapOccurrencesByRuleUuid([
+        {
+          rule_uuid: 'rule-1',
+          occurrences: [
+            { date: 'invalid', count: 1 },
+            { date: '2026-07-10T12:00:00.000Z', count: 3 },
+          ],
+        },
+      ])
+    ).toEqual(new Map([['rule-1', [{ x: new Date('2026-07-10T12:00:00.000Z').getTime(), y: 3 }]]]));
   });
 });

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/hooks/use_fetch_detection_occurrences.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/hooks/use_fetch_detection_occurrences.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useQuery, type UseQueryResult } from '@kbn/react-query';
+import type { RouteRepositoryClient } from '@kbn/server-route-repository';
+import type { SignificantEventsRouteRepository } from '@kbn/significant-events-plugin/server';
+import type { LifecycleDetection } from '@kbn/significant-events-schema';
+import type { StreamsRouteRepository } from '@kbn/streams-plugin/server';
+import type { StreamsRepositoryClientOptions } from '@kbn/streams-plugin/public/api';
+import {
+  DETECTION_OCCURRENCE_BUCKET_SIZE,
+  getDetectionOccurrenceTimeRange,
+  type OccurrencePoint,
+} from '../detection/change_point';
+import { useKibana } from '../../../utils/kibana_react';
+
+type MergedStreamsRepositoryClient = RouteRepositoryClient<
+  StreamsRouteRepository & SignificantEventsRouteRepository,
+  StreamsRepositoryClientOptions
+>;
+
+export type DetectionOccurrencesByRuleUuid = ReadonlyMap<string, OccurrencePoint[]>;
+
+interface DetectionOccurrencesRequest {
+  from: string;
+  to: string;
+  ruleUuids: string[];
+  streamNames: string[];
+}
+
+export const buildDetectionOccurrencesRequest = (
+  detections: readonly LifecycleDetection[]
+): DetectionOccurrencesRequest | undefined => {
+  const fetchableDetections = detections.flatMap((detection) => {
+    const { rule_uuid: ruleUuid, '@timestamp': timestamp } = detection;
+    const range = getDetectionOccurrenceTimeRange(timestamp);
+    return ruleUuid && range ? [{ detection, range, ruleUuid }] : [];
+  });
+
+  if (fetchableDetections.length === 0) {
+    return undefined;
+  }
+
+  return {
+    from: new Date(Math.min(...fetchableDetections.map(({ range }) => range.from))).toISOString(),
+    to: new Date(Math.max(...fetchableDetections.map(({ range }) => range.to))).toISOString(),
+    ruleUuids: [...new Set(fetchableDetections.map(({ ruleUuid }) => ruleUuid))].sort(),
+    streamNames: [
+      ...new Set(
+        fetchableDetections
+          .map(({ detection }) => detection.stream_name)
+          .filter((streamName): streamName is string => Boolean(streamName))
+      ),
+    ].sort(),
+  };
+};
+
+export const useFetchDetectionOccurrences = (
+  detections: readonly LifecycleDetection[]
+): UseQueryResult<DetectionOccurrencesByRuleUuid, Error> => {
+  const { streams } = useKibana().services;
+  const streamsRepositoryClient = streams.streamsRepositoryClient as MergedStreamsRepositoryClient;
+  const request = useMemo(() => buildDetectionOccurrencesRequest(detections), [detections]);
+
+  return useQuery<DetectionOccurrencesByRuleUuid, Error>({
+    queryKey: ['nightshift.detectionOccurrences', request],
+    enabled: request != null,
+    queryFn: async ({ signal }) => {
+      if (!request) {
+        return new Map();
+      }
+
+      const response = await streamsRepositoryClient.fetch(
+        'GET /internal/streams/_query_occurrences',
+        {
+          params: {
+            query: {
+              from: request.from,
+              to: request.to,
+              bucketSize: DETECTION_OCCURRENCE_BUCKET_SIZE,
+              rule_uuid: request.ruleUuids,
+              streamNames: request.streamNames,
+            },
+          },
+          signal: signal ?? null,
+        }
+      );
+
+      return new Map(
+        response.queries.map(({ rule_uuid: ruleUuid, occurrences }) => [
+          ruleUuid,
+          occurrences
+            .map(({ date, count }) => ({ x: new Date(date).getTime(), y: count }))
+            .filter(({ x }) => Number.isFinite(x)),
+        ])
+      );
+    },
+  });
+};

--- a/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/hooks/use_fetch_detection_occurrences.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/nightshift/hooks/use_fetch_detection_occurrences.ts
@@ -60,6 +60,35 @@ export const buildDetectionOccurrencesRequest = (
   };
 };
 
+const toOccurrencePoints = (
+  occurrences: ReadonlyArray<{ date: string; count: number }>
+): OccurrencePoint[] =>
+  occurrences
+    .map(({ date, count }) => ({ x: new Date(date).getTime(), y: count }))
+    .filter(({ x }) => Number.isFinite(x));
+
+export const mapOccurrencesByRuleUuid = (
+  queries: ReadonlyArray<{
+    rule_uuid?: string;
+    occurrences: ReadonlyArray<{ date: string; count: number }>;
+  }>
+): DetectionOccurrencesByRuleUuid => {
+  const byRuleUuid = new Map<string, OccurrencePoint[]>();
+
+  for (const { rule_uuid: ruleUuid, occurrences } of queries) {
+    if (!ruleUuid) {
+      continue;
+    }
+    const points = toOccurrencePoints(occurrences);
+    const existing = byRuleUuid.get(ruleUuid);
+    if (!existing || points.length > existing.length) {
+      byRuleUuid.set(ruleUuid, points);
+    }
+  }
+
+  return byRuleUuid;
+};
+
 export const useFetchDetectionOccurrences = (
   detections: readonly LifecycleDetection[]
 ): UseQueryResult<DetectionOccurrencesByRuleUuid, Error> => {
@@ -91,14 +120,7 @@ export const useFetchDetectionOccurrences = (
         }
       );
 
-      return new Map(
-        response.queries.map(({ rule_uuid: ruleUuid, occurrences }) => [
-          ruleUuid,
-          occurrences
-            .map(({ date, count }) => ({ x: new Date(date).getTime(), y: count }))
-            .filter(({ x }) => Number.isFinite(x)),
-        ])
-      );
+      return mapOccurrencesByRuleUuid(response.queries);
     },
   });
 };

--- a/x-pack/solutions/observability/plugins/observability/scripts/nightshift/seed_nightshift.sh
+++ b/x-pack/solutions/observability/plugins/observability/scripts/nightshift/seed_nightshift.sh
@@ -2,12 +2,12 @@
 #
 # One-command demo seed for the Nightshift landing page.
 #
-# Seeds significant events, discoveries, detections, backing stream data, and
-# Knowledge Indicator (KI) entity features, then triggers an investigation for
-# every event so the full UI is populated:
+# Seeds significant events, discoveries, detections, backing stream data,
+# Knowledge Indicator (KI) entity/query links, and rule-event occurrence series,
+# then triggers an investigation for every event so the full UI is populated:
 #   - Landing page (Need action / Resolved, blast-radius stream chips)
-#   - Event flyout (summary, detections list, lifecycle)
-#   - Detection flyout (trend chart, ES|QL evidence, entity pills)
+#   - Event flyout (summary, detections list, real occurrence sparklines, lifecycle)
+#   - Detection flyout (real occurrence trend chart, ES|QL evidence, entity pills)
 #   - Entity flyout (summary, evidence, raw document)
 #
 # Summaries use backtick-wrapped entity names for inline code styling in flyouts (see
@@ -113,6 +113,13 @@ print(lengthen_significant_events_ndjson(os.environ["BODY"]), end="")
 '
 }
 
+normalize_evidence_bucket_size() {
+  local body="$1"
+  body="${body//BUCKET(@timestamp, 1 minute)/BUCKET(@timestamp, 5 minutes)}"
+  body="${body//BUCKET(@timestamp, 5 minute)/BUCKET(@timestamp, 5 minutes)}"
+  printf "%s" "$body"
+}
+
 trigger_investigation() {
   local event_uuid="$1"
   local response_file
@@ -149,6 +156,7 @@ trigger_investigation() {
 if [[ "$CLEAN" == "true" ]]; then
   echo "Cleaning prior Nightshift seed indices ..."
   for idx in "$INDEX" "$DETECTIONS_INDEX" "$DISCOVERIES_INDEX"; do
+    curl -s -u "$ES_AUTH" -X DELETE "${ES_URL}/_data_stream/${idx}" >/dev/null || true
     curl -s -u "$ES_AUTH" -X DELETE "${ES_URL}/${idx}" >/dev/null || true
     echo "  deleted ${idx} (if it existed)"
   done
@@ -214,6 +222,7 @@ EVENTS_BODY=$(cat <<NDJSON
 NDJSON
 )
 
+EVENTS_BODY="$(normalize_evidence_bucket_size "$EVENTS_BODY")"
 EVENTS_BODY="$(lengthen_significant_events_ndjson "$EVENTS_BODY")"
 
 bulk_index "9 significant events" "$INDEX" "$EVENTS_BODY"
@@ -280,18 +289,23 @@ DISCOVERIES_BODY=$(cat <<NDJSON
 NDJSON
 )
 
+DISCOVERIES_BODY="$(normalize_evidence_bucket_size "$DISCOVERIES_BODY")"
 DISCOVERIES_BODY="$(lengthen_significant_events_ndjson "$DISCOVERIES_BODY")"
 
 bulk_index "9 discoveries" "$DISCOVERIES_INDEX" "$DISCOVERIES_BODY"
 echo "Successfully indexed 9 discoveries."
 
 # ---------------------------------------------------------------------------
-# Backing stream indices + KI entity features (Python)
+# Backing streams + KI features/query links + rule-event occurrences (Python)
 # ---------------------------------------------------------------------------
 echo ""
-echo "Seeding backing stream indices and KI entity features ..."
+echo "Seeding backing streams, Knowledge Indicators, and detection occurrences ..."
 
-ES_URL="$ES_URL" ES_AUTH="$ES_AUTH" KIBANA_URL="$KIBANA_URL" python3 "${SCRIPT_DIR}/seed_nightshift_helpers.py"
+ES_URL="$ES_URL" \
+  ES_AUTH="$ES_AUTH" \
+  KIBANA_URL="$KIBANA_URL" \
+  DETECTIONS_BODY="$DETECTIONS_BODY" \
+  python3 "${SCRIPT_DIR}/seed_nightshift_helpers.py"
 
 echo ""
 echo "Triggering investigations for open landing-visible significant events ..."
@@ -313,6 +327,7 @@ echo "Done! Open Nightshift to explore:"
 echo "  - Need action: open critical events (evt-001, evt-002, evt-003, evt-006, evt-008, evt-009)"
 echo "  - Resolved: closed critical events (evt-004, evt-005) and dismissed evt-007"
 echo "  - Investigations: triggered for all 9 seeded events"
+echo "  - Detections: real occurrence sparklines backed by .rule-events"
 echo "  - Event flyout → detection flyout → entity pill for KI-backed entities"
 echo ""
 echo "Tip: re-run with --clean to wipe and re-seed from scratch."

--- a/x-pack/solutions/observability/plugins/observability/scripts/nightshift/seed_nightshift_helpers.py
+++ b/x-pack/solutions/observability/plugins/observability/scripts/nightshift/seed_nightshift_helpers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Backing stream docs + Knowledge Indicator entity features for seed_nightshift.sh.
+Backing stream docs, Knowledge Indicators, and rule occurrences for seed_nightshift.sh.
 
 Invoked by seed_nightshift.sh; not meant to be run standalone unless for debugging.
 """
@@ -20,6 +20,7 @@ import urllib.request
 ES_URL = os.environ["ES_URL"]
 ES_AUTH = os.environ["ES_AUTH"]
 KIBANA_URL = os.environ["KIBANA_URL"]
+DETECTIONS_BODY = os.environ.get("DETECTIONS_BODY", "")
 
 AUTH_HEADER = "Basic " + base64.b64encode(ES_AUTH.encode()).decode()
 
@@ -541,6 +542,18 @@ BUCKET_MINUTES = 5
 WINDOW_BEFORE_MIN = 190
 WINDOW_AFTER_MIN = 25
 
+
+def parse_seed_detections() -> list[dict]:
+    detections: list[dict] = []
+    for line in DETECTIONS_BODY.splitlines():
+        if not line:
+            continue
+        document = json.loads(line)
+        if "detection_id" in document:
+            detections.append(document)
+    return detections
+
+
 KI_FEATURES_BY_STREAM: dict[str, list[dict]] = {
     "logs.web-frontend": [
         {
@@ -838,6 +851,20 @@ def docs_per_bucket(shape: str, minutes_to_anchor: float, rng: random.Random) ->
     return baseline
 
 
+def occurrence_count(shape: str, minutes_from_anchor: float, rng: random.Random) -> int:
+    baseline = 2 + rng.randint(0, 2)
+    if shape == "spike":
+        return 12 + rng.randint(-2, 3) if -15 <= minutes_from_anchor <= 0 else baseline
+    if shape == "dip":
+        return rng.randint(0, 1) if -15 <= minutes_from_anchor <= 0 else baseline + 3
+    if shape == "step_change":
+        return 10 + rng.randint(-1, 2) if minutes_from_anchor >= -15 else baseline
+    if shape == "trend_change":
+        progress = min(max((minutes_from_anchor + 60) / 60, 0), 1)
+        return baseline + round(progress * 10)
+    return 5 + rng.randint(-1, 1)
+
+
 def enrich_doc(index: str, ts: dt.datetime, minutes_to_anchor: float, seq: int) -> dict:
     """Shape docs so ES|QL evidence queries in signals return meaningful fields."""
     base = {"@timestamp": ts.strftime("%Y-%m-%dT%H:%M:%SZ")}
@@ -1036,11 +1063,114 @@ def seed_ki_features() -> None:
     print(f"Successfully upserted {feature_count} KI entity features via Kibana.")
 
 
+def bulk_create(index: str, documents: list[dict]) -> int:
+    lines: list[str] = []
+    for document in documents:
+        lines.append(json.dumps({"create": {}}))
+        lines.append(json.dumps(document))
+
+    result = es_request(
+        "POST", f"/{index}/_bulk?refresh=true", "\n".join(lines) + "\n"
+    )
+    if result is None or result.get("errors"):
+        raise SystemExit(
+            f"ERROR: bulk index into {index} failed: {json.dumps(result)[:500]}"
+        )
+    return len(documents)
+
+
+def seed_detection_occurrences() -> None:
+    detections = parse_seed_detections()
+    if not detections:
+        raise SystemExit("ERROR: no Nightshift detections were provided for occurrence seeding")
+    rule_uuids = [detection["rule_uuid"] for detection in detections]
+
+    es_request(
+        "POST",
+        "/.significant_events-knowledge_indicators/_delete_by_query"
+        "?refresh=true&conflicts=proceed",
+        {"query": {"terms": {"query.rule_id": rule_uuids}}},
+    )
+    es_request(
+        "POST",
+        "/.rule-events/_delete_by_query?refresh=true&conflicts=proceed",
+        {"query": {"prefix": {"group_hash": "nightshift-seed-"}}},
+    )
+
+    now = dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    query_documents: list[dict] = []
+    occurrence_documents: list[dict] = []
+
+    for detection in detections:
+        detection_id = detection["detection_id"]
+        rule_uuid = detection["rule_uuid"]
+        rule_name = detection["rule_name"]
+        stream_name = detection["stream_name"]
+        change_point_type = detection["change_point_type"]
+        anchor = dt.datetime.fromisoformat(
+            detection["@timestamp"].replace("Z", "+00:00")
+        )
+
+        query_documents.append(
+            {
+                "@timestamp": now,
+                "id": f"nightshift-occurrences-{detection_id}",
+                "type": "query",
+                "title": rule_name,
+                "description": "Nightshift seeded detection occurrence query",
+                "stream.name": stream_name,
+                "query": {
+                    "esql": f"FROM {stream_name} | KEEP @timestamp",
+                    "query_type": "match",
+                    "severity_score": 80,
+                    "rule_backed": True,
+                    "rule_id": rule_uuid,
+                },
+            }
+        )
+
+        rng = random.Random(rule_uuid)
+        bucket = anchor - dt.timedelta(minutes=60)
+        end = anchor + dt.timedelta(minutes=15)
+        while bucket < end:
+            minutes_from_anchor = (bucket - anchor).total_seconds() / 60
+            count = occurrence_count(change_point_type, minutes_from_anchor, rng)
+            timestamp = (bucket + dt.timedelta(seconds=10)).isoformat().replace(
+                "+00:00", "Z"
+            )
+            bucket_id = int(bucket.timestamp())
+            for occurrence_index in range(count):
+                occurrence_documents.append(
+                    {
+                        "@timestamp": timestamp,
+                        "type": "signal",
+                        "space_id": "default",
+                        "rule": {"id": rule_uuid},
+                        "group_hash": (
+                            f"nightshift-seed-{rule_uuid}-{bucket_id}-{occurrence_index}"
+                        ),
+                    }
+                )
+            bucket += dt.timedelta(minutes=BUCKET_MINUTES)
+
+    query_count = bulk_create(
+        ".significant_events-knowledge_indicators", query_documents
+    )
+    occurrence_count_value = bulk_create(".rule-events", occurrence_documents)
+    print(
+        f"Successfully indexed {query_count} detection query links and "
+        f"{occurrence_count_value} rule-event occurrences."
+    )
+
+
 def main() -> None:
     seed_backing_streams()
     print("")
     print("Seeding KI entity features via Kibana ...")
     seed_ki_features()
+    print("")
+    print("Seeding real detection occurrence series ...")
+    seed_detection_occurrences()
 
 
 if __name__ == "__main__":

--- a/x-pack/solutions/observability/plugins/observability/scripts/nightshift/seed_nightshift_helpers.py
+++ b/x-pack/solutions/observability/plugins/observability/scripts/nightshift/seed_nightshift_helpers.py
@@ -1135,22 +1135,24 @@ def seed_detection_occurrences() -> None:
         while bucket < end:
             minutes_from_anchor = (bucket - anchor).total_seconds() / 60
             count = occurrence_count(change_point_type, minutes_from_anchor, rng)
-            timestamp = (bucket + dt.timedelta(seconds=10)).isoformat().replace(
-                "+00:00", "Z"
+            bucket_ms = int(bucket.timestamp() * 1000)
+            write_time = bucket.isoformat().replace("+00:00", "Z")
+            occurrence_documents.append(
+                {
+                    "@timestamp": write_time,
+                    "scheduled_timestamp": write_time,
+                    "type": "signal",
+                    "space_id": "default",
+                    "status": "breached",
+                    "source": "internal",
+                    "rule": {"id": rule_uuid, "version": 1},
+                    "group_hash": f"nightshift-seed-{rule_uuid}-{bucket_ms}",
+                    "data": {
+                        "bucket": bucket_ms,
+                        "metric_value": count,
+                    },
+                }
             )
-            bucket_id = int(bucket.timestamp())
-            for occurrence_index in range(count):
-                occurrence_documents.append(
-                    {
-                        "@timestamp": timestamp,
-                        "type": "signal",
-                        "space_id": "default",
-                        "rule": {"id": rule_uuid},
-                        "group_hash": (
-                            f"nightshift-seed-{rule_uuid}-{bucket_id}-{occurrence_index}"
-                        ),
-                    }
-                )
             bucket += dt.timedelta(minutes=BUCKET_MINUTES)
 
     query_count = bulk_create(


### PR DESCRIPTION
## Summary

Closes #277558

<img width="428" height="176" alt="image" src="https://github.com/user-attachments/assets/1ebbc366-cae8-440c-97f2-c921ae20dc9c" />
<img width="879" height="712" alt="image" src="https://github.com/user-attachments/assets/323be138-8f3f-4dcf-922f-1ec60f318eb0" />


- Replaces decorative detection-card sparklines with real, rule-backed occurrence series from `_query_occurrences`.
- Adds rule UUID filtering and correlation to the occurrence API so all card series can be fetched in one batched request.
- Renders the detection flyout trend as an interactive Lens embeddable backed by `.rule-events` with a five-minute bucket and change-point annotation.
- Extends the Nightshift seed script, Storybook fixtures, loading states, and focused tests to cover real occurrence data.
- Aligns detection-card metadata so the timestamp has its own row and the change-point badge sits with impacted entities.