### PR TITLE
[Entity Analytics] Fix entity table Select All count and selection mismatch

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
@@ -20,11 +20,7 @@ import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useKibana } from '../../../../common/lib/kibana';
 import type { EntityURLStateResult } from './hooks/use_entity_url_state';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import {
-  TEST_SUBJ_DATA_GRID,
-  TEST_SUBJ_EMPTY_STATE,
-  DEFAULT_VISIBLE_ROWS_PER_PAGE,
-} from './constants';
+import { TEST_SUBJ_DATA_GRID, TEST_SUBJ_EMPTY_STATE } from './constants';
 
 const mockUseFetchGridData = jest.mocked(useFetchGridData);
 const mockUseInvestigateInTimeline = jest.mocked(useInvestigateInTimeline);
@@ -262,7 +258,6 @@ describe('EntitiesDataTable', () => {
         query: { bool: { filter: [{ term: { test: true } }], must: [], must_not: [], should: [] } },
         sort: [['entity.name', 'asc']],
         enabled: true,
-        pageSize: DEFAULT_VISIBLE_ROWS_PER_PAGE,
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -253,7 +253,6 @@ export const EntitiesDataTable = ({
     query,
     sort,
     enabled: !queryError,
-    pageSize: DEFAULT_VISIBLE_ROWS_PER_PAGE,
   });
 
   const rows = getRowsFromPages(rowsData?.pages);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -79,7 +79,6 @@ import type { EntityURLStateResult } from './hooks/use_entity_url_state';
 import {
   ENTITY_FIELDS,
   ENTITY_GROUPING_OPTIONS,
-  DEFAULT_VISIBLE_ROWS_PER_PAGE,
   MAX_ENTITIES_TO_LOAD,
   TEST_SUBJ_DATA_GRID,
   TEST_SUBJ_GROUPING,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.test.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { buildInspectData, getEntitiesQuery } from './use_fetch_grid_data';
+import { buildInspectData, getEntitiesNextPageParam, getEntitiesQuery } from './use_fetch_grid_data';
+import { MAX_ENTITIES_TO_LOAD } from '../constants';
 
 describe('buildInspectData', () => {
   const queryParams = {
@@ -47,12 +48,43 @@ describe('buildInspectData', () => {
   });
 });
 
+describe('getEntitiesNextPageParam', () => {
+  const fullPage = { page: Array(MAX_ENTITIES_TO_LOAD).fill({}) };
+  const partialPage = { page: Array(MAX_ENTITIES_TO_LOAD - 1).fill({}) };
+  const emptyPage = { page: [] };
+
+  it('returns undefined when the last page has fewer than MAX_ENTITIES_TO_LOAD records', () => {
+    expect(getEntitiesNextPageParam(partialPage, [partialPage])).toBeUndefined();
+  });
+
+  it('returns undefined for an empty last page', () => {
+    expect(getEntitiesNextPageParam(emptyPage, [emptyPage])).toBeUndefined();
+  });
+
+  it('returns MAX_ENTITIES_TO_LOAD as the next offset after the first full page', () => {
+    expect(getEntitiesNextPageParam(fullPage, [fullPage])).toBe(MAX_ENTITIES_TO_LOAD);
+  });
+
+  it('advances the offset by MAX_ENTITIES_TO_LOAD per page', () => {
+    expect(getEntitiesNextPageParam(fullPage, [fullPage, fullPage])).toBe(
+      MAX_ENTITIES_TO_LOAD * 2
+    );
+  });
+
+  it('does not use the UI page size (25) for the offset', () => {
+    // Regression guard: the bug was allPages.length * options.pageSize (25),
+    // producing from=25 on page 2 instead of from=500, causing massive overlap.
+    const nextOffset = getEntitiesNextPageParam(fullPage, [fullPage]);
+    expect(nextOffset).toBe(500);
+    expect(nextOffset).not.toBe(25);
+  });
+});
+
 describe('getEntitiesQuery', () => {
   const options = {
     query: undefined,
     sort: [['entity.name', 'asc']] as Array<[string, string]>,
     enabled: true,
-    pageSize: 25,
   };
 
   it('throws when no index pattern is provided', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.test.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { buildInspectData, getEntitiesNextPageParam, getEntitiesQuery } from './use_fetch_grid_data';
+import {
+  buildInspectData,
+  getEntitiesNextPageParam,
+  getEntitiesQuery,
+} from './use_fetch_grid_data';
 import { MAX_ENTITIES_TO_LOAD } from '../constants';
 
 describe('buildInspectData', () => {
@@ -66,9 +70,7 @@ describe('getEntitiesNextPageParam', () => {
   });
 
   it('advances the offset by MAX_ENTITIES_TO_LOAD per page', () => {
-    expect(getEntitiesNextPageParam(fullPage, [fullPage, fullPage])).toBe(
-      MAX_ENTITIES_TO_LOAD * 2
-    );
+    expect(getEntitiesNextPageParam(fullPage, [fullPage, fullPage])).toBe(MAX_ENTITIES_TO_LOAD * 2);
   });
 
   it('does not use the UI page size (25) for the offset', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
@@ -29,7 +29,6 @@ import { DataViewContext } from '..';
 interface UseEntitiesOptions extends BaseEsQuery {
   sort: string[][];
   enabled: boolean;
-  pageSize: number;
 }
 
 const ENTITY_TABLE_RUNTIME_MAPPING_FIELDS: string[] = [
@@ -75,6 +74,19 @@ interface Entity {
 type LatestEntitiesRequest = IKibanaSearchRequest<estypes.SearchRequest>;
 type LatestEntitiesResponse = IKibanaSearchResponse<estypes.SearchResponse<Entity, never>>;
 
+// Each ES request fetches MAX_ENTITIES_TO_LOAD (500) records. We stop when the
+// last page returns fewer than that (end of data), and advance the next `from`
+// offset by 500 per page so pages don't overlap.
+export const getEntitiesNextPageParam = (
+  lastPage: { page: unknown[] },
+  allPages: unknown[]
+): number | undefined => {
+  if (lastPage.page.length < MAX_ENTITIES_TO_LOAD) {
+    return undefined;
+  }
+  return allPages.length * MAX_ENTITIES_TO_LOAD;
+};
+
 export const buildInspectData = (queryParams: object, rawResponse: object) => ({
   dsl: [JSON.stringify(queryParams)],
   response: [JSON.stringify(rawResponse, null, 2)],
@@ -115,12 +127,7 @@ export function useFetchGridData(options: UseEntitiesOptions) {
       enabled: options.enabled && !!dataViewIndexPattern,
       keepPreviousData: true,
       onError: (err: Error) => showErrorToast(toasts, err),
-      getNextPageParam: (lastPage, allPages) => {
-        if (lastPage.page.length < MAX_ENTITIES_TO_LOAD) {
-          return undefined;
-        }
-        return allPages.length * MAX_ENTITIES_TO_LOAD;
-      },
+      getNextPageParam: getEntitiesNextPageParam,
     }
   );
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
@@ -116,10 +116,10 @@ export function useFetchGridData(options: UseEntitiesOptions) {
       keepPreviousData: true,
       onError: (err: Error) => showErrorToast(toasts, err),
       getNextPageParam: (lastPage, allPages) => {
-        if (lastPage.page.length < options.pageSize) {
+        if (lastPage.page.length < MAX_ENTITIES_TO_LOAD) {
           return undefined;
         }
-        return allPages.length * options.pageSize;
+        return allPages.length * MAX_ENTITIES_TO_LOAD;
       },
     }
   );


### PR DESCRIPTION
## Summary

- Fixes `getNextPageParam` in `use_fetch_grid_data.ts` using the UI visible page size (25) instead of the ES fetch size (`MAX_ENTITIES_TO_LOAD = 500`) for both the end-of-data check and the next page offset
- This caused successive page requests to start at `from=25` instead of `from=500`, producing massively overlapping results and inflating `rows.length` with duplicates
- "Select all N" label showed the wrong count (e.g. 1000 instead of 762) because it derives from `rows.length`
- "Select All" selected the wrong set of entities for the same reason

Closes #280424
Closes #280425

## Test plan

- [ ] Navigate to Security → Entity Analytics, scroll to Entities table
- [ ] With >500 entities, click Load More — confirm loaded row count matches actual entity count, not a larger inflated number
- [ ] Select a full page via the header checkbox — confirm "Select all N" shows the correct total (matching actual entity count, not 1000)
- [ ] Click "Select all N" — confirm selected count matches the number shown in the label

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->