### PR TITLE
[9.5] [SecuritySolution][OneDiscover] update all flyout entry points to conditionally fork (#279324)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_agent_navigation_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_agent_navigation_context.tsx
@@ -25,6 +25,7 @@ interface EntityAnalyticsAgentNavigationContextValue {
   chrome?: SecurityAgentBuilderChrome;
   openSidebarConversation?: () => void;
   searchSession?: ISessionService;
+  isNewFlyoutEnabled?: boolean;
   /**
    * Dismisses the Agent Builder canvas overlay. Navigation helpers call this
    * before updating the Entity Analytics URL so that the canvas doesn't sit
@@ -44,6 +45,7 @@ export const EntityAnalyticsAgentNavigationProvider: React.FC<
   chrome,
   openSidebarConversation,
   searchSession,
+  isNewFlyoutEnabled,
   closeCanvas,
   children,
 }) => {
@@ -54,9 +56,18 @@ export const EntityAnalyticsAgentNavigationProvider: React.FC<
       chrome,
       openSidebarConversation,
       searchSession,
+      isNewFlyoutEnabled,
       closeCanvas,
     }),
-    [application, agentBuilder, chrome, openSidebarConversation, searchSession, closeCanvas]
+    [
+      application,
+      agentBuilder,
+      chrome,
+      openSidebarConversation,
+      searchSession,
+      isNewFlyoutEnabled,
+      closeCanvas,
+    ]
   );
   return (
     <EntityAnalyticsAgentNavigationContext.Provider value={value}>
@@ -67,14 +78,22 @@ export const EntityAnalyticsAgentNavigationProvider: React.FC<
 
 interface EntityAnalyticsAgentNavigation {
   canNavigate: boolean;
+  isNewFlyoutEnabled: boolean;
   navigateWithFlyout: (flyout: EntityAnalyticsFlyoutNavigationState) => void;
   navigateToHome: (opts?: { watchlistId?: string; watchlistName?: string }) => void;
   closeCanvas?: () => void;
 }
 
 export const useEntityAnalyticsAgentNavigation = (): EntityAnalyticsAgentNavigation => {
-  const { application, agentBuilder, chrome, openSidebarConversation, searchSession, closeCanvas } =
-    useContext(EntityAnalyticsAgentNavigationContext);
+  const {
+    application,
+    agentBuilder,
+    chrome,
+    openSidebarConversation,
+    searchSession,
+    isNewFlyoutEnabled,
+    closeCanvas,
+  } = useContext(EntityAnalyticsAgentNavigationContext);
 
   const canNavigate = application != null;
 
@@ -90,9 +109,18 @@ export const useEntityAnalyticsAgentNavigation = (): EntityAnalyticsAgentNavigat
         chrome,
         openSidebarConversation,
         searchSession,
+        isNewFlyoutEnabled,
       });
     },
-    [application, agentBuilder, chrome, openSidebarConversation, searchSession, closeCanvas]
+    [
+      application,
+      agentBuilder,
+      chrome,
+      openSidebarConversation,
+      searchSession,
+      isNewFlyoutEnabled,
+      closeCanvas,
+    ]
   );
 
   const navigateToHome = useCallback(
@@ -112,5 +140,11 @@ export const useEntityAnalyticsAgentNavigation = (): EntityAnalyticsAgentNavigat
     [application, agentBuilder, chrome, openSidebarConversation, searchSession, closeCanvas]
   );
 
-  return { canNavigate, navigateWithFlyout, navigateToHome, closeCanvas };
+  return {
+    canNavigate,
+    isNewFlyoutEnabled: isNewFlyoutEnabled ?? false,
+    navigateWithFlyout,
+    navigateToHome,
+    closeCanvas,
+  };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.test.tsx
@@ -9,7 +9,9 @@ import React, { type ReactElement } from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { applicationServiceMock } from '@kbn/core-application-browser-mocks';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
+import type { ExperimentalFeatures } from '../../../common/experimental_features';
 import type { EntityAnalyticsDashboardAttachment } from './entity_analytics_dashboard_attachment';
 import { createEntityAnalyticsDashboardAttachmentDefinition } from './entity_analytics_dashboard_attachment';
 import { navigateToEntityAnalyticsHomePageInApp } from './entity_explore_navigation';
@@ -20,6 +22,10 @@ interface ResizeDimensions {
 }
 
 const RESIZE_CALLBACK_KEY = '__eaDashboardOnResize';
+
+const experimentalFeatures = {
+  newFlyoutSystemDisabled: false,
+} as ExperimentalFeatures;
 
 jest.mock('@elastic/eui', () => {
   const React_ = jest.requireActual('react');
@@ -130,6 +136,7 @@ const renderCanvas = (
   const application = applicationServiceMock.createStartContract();
   const definition = createEntityAnalyticsDashboardAttachmentDefinition({
     application,
+    experimentalFeatures,
     searchSession: overrides.searchSession,
   });
   return render(
@@ -159,6 +166,7 @@ describe('EntityAnalyticsDashboardCanvasContent', () => {
     const application = applicationServiceMock.createStartContract();
     const definition = createEntityAnalyticsDashboardAttachmentDefinition({
       application,
+      experimentalFeatures,
       searchSession,
     });
 
@@ -189,7 +197,10 @@ describe('EntityAnalyticsDashboardCanvasContent', () => {
   it('returns a Preview action from getActionButtons when not in canvas mode', () => {
     const application = applicationServiceMock.createStartContract();
     const openCanvas = jest.fn();
-    const definition = createEntityAnalyticsDashboardAttachmentDefinition({ application });
+    const definition = createEntityAnalyticsDashboardAttachmentDefinition({
+      application,
+      experimentalFeatures,
+    });
 
     const buttons = definition.getActionButtons!({
       attachment: makeAttachment(),
@@ -241,14 +252,20 @@ describe('EntityAnalyticsDashboardCanvasContent', () => {
 
   it('sets canvasWidth to 50vw so the dashboard uses the full canvas flyout width', () => {
     const application = applicationServiceMock.createStartContract();
-    const definition = createEntityAnalyticsDashboardAttachmentDefinition({ application });
+    const definition = createEntityAnalyticsDashboardAttachmentDefinition({
+      application,
+      experimentalFeatures,
+    });
     expect(definition.canvasWidth).toBe('50vw');
   });
 
   it('forwards closeCanvas from the canvas render callbacks into the navigation provider so per-row navigation can dismiss the canvas overlay', () => {
     const closeCanvas = jest.fn();
     const application = applicationServiceMock.createStartContract();
-    const definition = createEntityAnalyticsDashboardAttachmentDefinition({ application });
+    const definition = createEntityAnalyticsDashboardAttachmentDefinition({
+      application,
+      experimentalFeatures,
+    });
 
     const providerElement = definition.renderCanvasContent!(
       {
@@ -261,5 +278,29 @@ describe('EntityAnalyticsDashboardCanvasContent', () => {
     ) as ReactElement<{ closeCanvas?: () => void }>;
 
     expect(providerElement.props.closeCanvas).toBe(closeCanvas);
+  });
+
+  it('forwards the new flyout setting to entity navigation in the canvas preview', () => {
+    const application = applicationServiceMock.createStartContract();
+    const uiSettings = {
+      get: jest.fn(() => true),
+    } as unknown as IUiSettingsClient;
+    const definition = createEntityAnalyticsDashboardAttachmentDefinition({
+      application,
+      experimentalFeatures,
+      uiSettings,
+    });
+
+    const providerElement = definition.renderCanvasContent!(
+      {
+        attachment: makeAttachment(),
+      } as unknown as Parameters<NonNullable<typeof definition.renderCanvasContent>>[0],
+      {
+        closeCanvas: jest.fn(),
+        registerActionButtons: jest.fn(),
+      } as unknown as Parameters<NonNullable<typeof definition.renderCanvasContent>>[1]
+    ) as ReactElement<{ isNewFlyoutEnabled?: boolean }>;
+
+    expect(providerElement.props.isNewFlyoutEnabled).toBe(true);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.tsx
@@ -30,9 +30,15 @@ import type {
 import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
-import { APP_UI_ID, SecurityAgentBuilderAttachments } from '../../../common/constants';
+import {
+  APP_UI_ID,
+  ENABLE_NEW_FLYOUT_SETTING,
+  SecurityAgentBuilderAttachments,
+} from '../../../common/constants';
+import type { ExperimentalFeatures } from '../../../common/experimental_features';
 import { EMPTY_SEVERITY_COUNT, RiskSeverity } from '../../../common/search_strategy';
 import type { SeverityCount } from '../../entity_analytics/components/severity/types';
 import { RiskLevelBreakdownTable } from '../../entity_analytics/components/home/risk_level_breakdown_table';
@@ -487,13 +493,17 @@ export const registerEntityAnalyticsDashboardAttachment = ({
   application,
   agentBuilder,
   chrome,
+  experimentalFeatures,
   searchSession,
+  uiSettings,
 }: {
   attachments: AttachmentServiceStartContract;
   application: ApplicationStart;
   agentBuilder?: AgentBuilderPluginStart;
   chrome?: SecurityAgentBuilderChrome;
+  experimentalFeatures: ExperimentalFeatures;
   searchSession?: ISessionService;
+  uiSettings: IUiSettingsClient;
 }): void => {
   attachments.addAttachmentType(
     SecurityAgentBuilderAttachments.entityAnalyticsDashboard,
@@ -501,7 +511,9 @@ export const registerEntityAnalyticsDashboardAttachment = ({
       application,
       agentBuilder,
       chrome,
+      experimentalFeatures,
       searchSession,
+      uiSettings,
     })
   );
 };
@@ -510,13 +522,21 @@ export const createEntityAnalyticsDashboardAttachmentDefinition = ({
   application,
   agentBuilder,
   chrome,
+  experimentalFeatures,
   searchSession,
+  uiSettings,
 }: {
   application: ApplicationStart;
   agentBuilder?: AgentBuilderPluginStart;
   chrome?: SecurityAgentBuilderChrome;
+  experimentalFeatures: ExperimentalFeatures;
   searchSession?: ISessionService;
+  uiSettings?: IUiSettingsClient;
 }): AttachmentUIDefinition<EntityAnalyticsDashboardAttachment> => {
+  const getIsNewFlyoutEnabled = (): boolean =>
+    !experimentalFeatures.newFlyoutSystemDisabled &&
+    (uiSettings?.get<boolean>(ENABLE_NEW_FLYOUT_SETTING, true) ?? false);
+
   return {
     getLabel: (attachment) =>
       attachment.data.attachmentLabel ??
@@ -533,6 +553,7 @@ export const createEntityAnalyticsDashboardAttachmentDefinition = ({
         chrome={chrome}
         openSidebarConversation={props.openSidebarConversation}
         searchSession={searchSession}
+        isNewFlyoutEnabled={getIsNewFlyoutEnabled()}
         closeCanvas={closeCanvas}
       >
         <EntityAnalyticsDashboardCanvasContent {...props} />

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_canvas_content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_canvas_content.test.tsx
@@ -12,6 +12,7 @@ import type { ExperimentalFeatures } from '../../../../common/experimental_featu
 import type { EntityAttachment } from './types';
 import type { SecurityCanvasEmbeddedBundle } from '../../components/security_redux_embedded_provider';
 import { EntityAttachmentCanvasContent } from './entity_attachment_canvas_content';
+import { useEntityAnalyticsAgentNavigation } from '../entity_analytics_agent_navigation_context';
 
 /**
  * Canvas-content dispatcher tests.
@@ -36,11 +37,11 @@ jest.mock('../../components/security_redux_embedded_provider', () => ({
 
 jest.mock('../../components/entity_card_flyout_overview_canvas', () => ({
   EntityCardFlyoutOverviewCanvas: (props: Record<string, unknown>) => (
-    <div data-test-subj="entityCardFlyoutOverviewCanvasMock">
-      {JSON.stringify(props.identifier)}
-    </div>
+    <div data-test-subj="entityCardFlyoutOverviewCanvasMock">{JSON.stringify(props)}</div>
   ),
 }));
+
+jest.mock('../entity_analytics_agent_navigation_context');
 
 jest.mock('./entity_card/entity_card', () => ({
   EntityCard: (props: Record<string, unknown>) => (
@@ -75,6 +76,9 @@ const renderCanvas = (data: unknown) =>
 describe('EntityAttachmentCanvasContent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useEntityAnalyticsAgentNavigation as jest.Mock).mockReturnValue({
+      isNewFlyoutEnabled: false,
+    });
   });
 
   it('renders the flyout canvas inside SecurityReduxEmbeddedProvider for a single host entity', () => {
@@ -85,6 +89,18 @@ describe('EntityAttachmentCanvasContent', () => {
       'host-1'
     );
     expect(screen.queryByTestId('entityCardMock')).not.toBeInTheDocument();
+  });
+
+  it('hides section-header arrows when the new flyout is enabled', () => {
+    (useEntityAnalyticsAgentNavigation as jest.Mock).mockReturnValue({
+      isNewFlyoutEnabled: true,
+    });
+
+    renderCanvas({ identifierType: 'host', identifier: 'host-1' });
+
+    expect(screen.getByTestId('entityCardFlyoutOverviewCanvasMock')).toHaveTextContent(
+      '"hideHeaderIcons":true'
+    );
   });
 
   it('renders the flyout canvas inside SecurityReduxEmbeddedProvider for single user / service entities', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_canvas_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_canvas_content.tsx
@@ -20,6 +20,7 @@ import {
   type SecurityCanvasEmbeddedBundle,
 } from '../../components/security_redux_embedded_provider';
 import { EntityCardFlyoutOverviewCanvas } from '../../components/entity_card_flyout_overview_canvas';
+import { useEntityAnalyticsAgentNavigation } from '../entity_analytics_agent_navigation_context';
 
 export interface EntityAttachmentCanvasContentProps
   extends AttachmentRenderProps<EntityAttachment> {
@@ -45,6 +46,7 @@ export const EntityAttachmentCanvasContent: React.FC<EntityAttachmentCanvasConte
   experimentalFeatures,
   resolveSecurityCanvasContext,
 }) => {
+  const { isNewFlyoutEnabled } = useEntityAnalyticsAgentNavigation();
   const parsed = normaliseEntityAttachment(attachment);
   const watchlistsEnabled = experimentalFeatures.entityAnalyticsWatchlistEnabled;
   const privmonModifierEnabled = experimentalFeatures.enableRiskScorePrivmonModifier;
@@ -92,6 +94,7 @@ export const EntityAttachmentCanvasContent: React.FC<EntityAttachmentCanvasConte
             identifier={identifier}
             riskStats={parsed.riskStats}
             resolutionRiskStats={parsed.resolutionRiskStats}
+            hideHeaderIcons={isNewFlyoutEnabled}
           />
         </QueryClientProvider>
       </EuiPanel>

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.test.tsx
@@ -7,6 +7,7 @@
 
 import type { ReactElement } from 'react';
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
 import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import type { ExperimentalFeatures } from '../../../../common/experimental_features';
@@ -37,12 +38,21 @@ const resolveSecurityCanvasContext = jest.fn();
 const buildDefinition = ({
   withCanvas = true,
   searchSession,
-}: { withCanvas?: boolean; searchSession?: ISessionService } = {}) =>
+  newFlyoutEnabled,
+}: {
+  withCanvas?: boolean;
+  searchSession?: ISessionService;
+  newFlyoutEnabled?: boolean;
+} = {}) =>
   createEntityAttachmentDefinition({
     experimentalFeatures,
     application: withCanvas ? application : undefined,
     resolveSecurityCanvasContext: withCanvas ? resolveSecurityCanvasContext : undefined,
     searchSession,
+    uiSettings:
+      newFlyoutEnabled == null
+        ? undefined
+        : ({ get: jest.fn(() => newFlyoutEnabled) } as unknown as IUiSettingsClient),
   });
 
 const attachmentOf = (data: unknown): EntityAttachment =>
@@ -187,6 +197,28 @@ describe('createEntityAttachmentDefinition', () => {
       );
       expect(navigateToEntityAnalyticsHomePageInApp).toHaveBeenCalledTimes(1);
       expect(navigateToEntityAnalyticsWithFlyoutInApp).not.toHaveBeenCalled();
+    });
+
+    it('uses the v2 flyout URL contract when the new flyout setting is enabled', () => {
+      (navigateToEntityAnalyticsWithFlyoutInApp as jest.Mock).mockClear();
+      const def = buildDefinition({ newFlyoutEnabled: true });
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({
+          identifierType: 'host',
+          identifier: 'alpha',
+          entityStoreId: 'host:alpha@default',
+        }),
+        isSidebar: false,
+        isCanvas: true,
+        updateOrigin: jest.fn(),
+        closeCanvas: jest.fn(),
+      });
+
+      buttons[0].handler();
+
+      expect(navigateToEntityAnalyticsWithFlyoutInApp).toHaveBeenCalledWith(
+        expect.objectContaining({ isNewFlyoutEnabled: true })
+      );
     });
 
     it('returns no buttons in Canvas mode for multi-entity attachments', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.tsx
@@ -15,6 +15,7 @@ import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiSkeletonText } from '@elastic/eui';
 import type { ExperimentalFeatures } from '../../../../common/experimental_features';
 import type { EntityAttachment } from './types';
@@ -28,7 +29,7 @@ import {
   type SecurityAgentBuilderChrome,
 } from '../entity_explore_navigation';
 import { EntityAnalyticsAgentNavigationProvider } from '../entity_analytics_agent_navigation_context';
-import { APP_UI_ID } from '../../../../common/constants';
+import { APP_UI_ID, ENABLE_NEW_FLYOUT_SETTING } from '../../../../common/constants';
 
 const DEFAULT_LABEL = i18n.translate(
   'xpack.securitySolution.agentBuilder.attachments.entity.label',
@@ -99,6 +100,7 @@ export const createEntityAttachmentDefinition = ({
   chrome,
   resolveSecurityCanvasContext,
   searchSession,
+  uiSettings,
 }: {
   experimentalFeatures: ExperimentalFeatures;
   application?: ApplicationStart;
@@ -106,7 +108,12 @@ export const createEntityAttachmentDefinition = ({
   chrome?: SecurityAgentBuilderChrome;
   resolveSecurityCanvasContext?: () => Promise<SecurityCanvasEmbeddedBundle>;
   searchSession?: ISessionService;
+  uiSettings?: IUiSettingsClient;
 }): AttachmentUIDefinition<EntityAttachment> => {
+  const getIsNewFlyoutEnabled = (): boolean =>
+    !experimentalFeatures.newFlyoutSystemDisabled &&
+    (uiSettings?.get<boolean>(ENABLE_NEW_FLYOUT_SETTING, true) ?? false);
+
   const baseDefinition: AttachmentUIDefinition<EntityAttachment> = {
     getLabel: (attachment) => {
       const customLabel = attachment?.data?.attachmentLabel;
@@ -124,6 +131,7 @@ export const createEntityAttachmentDefinition = ({
         chrome={chrome}
         openSidebarConversation={props.openSidebarConversation}
         searchSession={searchSession}
+        isNewFlyoutEnabled={getIsNewFlyoutEnabled()}
       >
         <React.Suspense fallback={<EuiSkeletonText lines={4} />}>
           <LazyEntityAttachmentInlineContent
@@ -152,6 +160,7 @@ export const createEntityAttachmentDefinition = ({
         chrome={chrome}
         openSidebarConversation={props.openSidebarConversation}
         searchSession={searchSession}
+        isNewFlyoutEnabled={getIsNewFlyoutEnabled()}
         closeCanvas={closeCanvas}
       >
         <React.Suspense
@@ -204,6 +213,7 @@ export const createEntityAttachmentDefinition = ({
                   chrome,
                   openSidebarConversation,
                   searchSession,
+                  isNewFlyoutEnabled: getIsNewFlyoutEnabled(),
                 });
                 return;
               }

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.test.tsx
@@ -36,7 +36,11 @@ const buildApplicationMock = (): ApplicationStart =>
 
 const renderActions = (
   identifier: EntityAttachmentIdentifier,
-  providerProps: { application?: ApplicationStart; searchSession?: ISessionService } = {}
+  providerProps: {
+    application?: ApplicationStart;
+    searchSession?: ISessionService;
+    isNewFlyoutEnabled?: boolean;
+  } = {}
 ) => {
   const application = providerProps.application ?? buildApplicationMock();
   const utils = render(
@@ -44,6 +48,7 @@ const renderActions = (
       <EntityAnalyticsAgentNavigationProvider
         application={application}
         searchSession={providerProps.searchSession}
+        isNewFlyoutEnabled={providerProps.isNewFlyoutEnabled}
       >
         <EntityCardActions identifier={identifier} />
       </EntityAnalyticsAgentNavigationProvider>
@@ -169,6 +174,23 @@ describe('EntityCardActions', () => {
 
       expect(mockedNavigateToFlyout).toHaveBeenCalledWith(
         expect.objectContaining({ searchSession })
+      );
+    });
+
+    it('uses the new flyout URL contract when enabled by the navigation provider', () => {
+      renderActions(
+        {
+          identifierType: 'host',
+          identifier: 'macbook-01',
+          entityStoreId: 'host:macbook-01@default',
+        },
+        { isNewFlyoutEnabled: true }
+      );
+
+      clickOpen();
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledWith(
+        expect.objectContaining({ isNewFlyoutEnabled: true })
       );
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.test.ts
@@ -10,6 +10,13 @@ import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import {
+  decodeFlyoutV2UrlParam,
+  FLYOUT_V2_URL_PARAM,
+} from '../../flyout_v2/shared/url_state/flyout_v2_url_param';
+import { subscribeToFlyoutV2Navigation } from '../../flyout_v2/shared/url_state/flyout_v2_navigation';
+import { FLYOUT_ORIGIN } from '../../common/lib/telemetry/events/flyout_v2/types';
+import {
+  buildEntityFlyoutV2NavigationState,
   getAgentBuilderLastAgentIdForSecurityOpenChat,
   getHostNameForHostDetailsUrl,
   getServiceNameForServiceDetailsUrl,
@@ -162,6 +169,72 @@ describe('entity_explore_navigation', () => {
     });
   });
 
+  describe('buildEntityFlyoutV2NavigationState', () => {
+    it.each([
+      ['host-panel', 'hostName', 'web-01', 'host'],
+      ['user-panel', 'userName', 'alice', 'user'],
+      ['service-panel', 'serviceName', 'auth-api', 'service'],
+    ] as const)('maps %s to a %s descriptor', (panelId, nameParam, entityName, kind) => {
+      expect(
+        buildEntityFlyoutV2NavigationState({
+          preview: [],
+          right: {
+            id: panelId,
+            params: {
+              [nameParam]: entityName,
+              entityId: `${kind}:entity-id`,
+              scopeId: 'agent-builder-entity-card',
+            },
+          },
+        })
+      ).toEqual([
+        {
+          kind,
+          [`${kind}Name`]: entityName,
+          entityId: `${kind}:entity-id`,
+          scopeId: 'agent-builder-entity-card',
+          origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+        },
+      ]);
+    });
+
+    it('maps an entity investigation panel to a v2 tool and child entity stack', () => {
+      expect(
+        buildEntityFlyoutV2NavigationState({
+          preview: [],
+          left: {
+            id: 'host_details',
+            params: { path: { tab: 'graph_view' } },
+          },
+          right: {
+            id: 'host-panel',
+            params: {
+              hostName: 'web-01',
+              entityId: 'host:web-01',
+              scopeId: 'agent-builder-entity-card',
+            },
+          },
+        })
+      ).toEqual([
+        {
+          kind: 'entityGraphView',
+          entityId: 'host:web-01',
+          scopeId: 'agent-builder-entity-card',
+          entityName: 'web-01',
+          entityType: 'host',
+          origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+        },
+        {
+          kind: 'host',
+          hostName: 'web-01',
+          entityId: 'host:web-01',
+          scopeId: 'agent-builder-entity-card',
+          origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+        },
+      ]);
+    });
+  });
+
   describe('navigation helpers', () => {
     const EA_HOME_PATH = '/app/security/entity_analytics_home_page';
     const OTHER_PATH = '/app/security/alerts';
@@ -226,6 +299,44 @@ describe('entity_explore_navigation', () => {
         expect(params.get('flyout')).toContain('right');
       });
 
+      it('writes flyoutV2 and removes a stale legacy flyout when the new flyout is enabled', () => {
+        const application = buildApplicationMock();
+        window.history.replaceState({}, '', `${EA_HOME_PATH}?flyout=stale&watchlistId=wl-123`);
+
+        navigateToEntityAnalyticsWithFlyoutInApp({
+          application,
+          appId: 'securitySolutionUI',
+          flyout: {
+            preview: [],
+            right: {
+              id: 'user-panel',
+              params: {
+                userName: 'alice',
+                entityId: 'user:alice@default',
+                scopeId: 'agent-builder-entity-card',
+              },
+            },
+          },
+          isNewFlyoutEnabled: true,
+        });
+
+        const [, options] = application.navigateToApp.mock.calls[0];
+        const path = (options as { path?: string }).path ?? '';
+        const params = new URLSearchParams(path.startsWith('?') ? path.slice(1) : path);
+
+        expect(params.get('flyout')).toBeNull();
+        expect(params.get('watchlistId')).toBe('wl-123');
+        expect(decodeFlyoutV2UrlParam(params.get(FLYOUT_V2_URL_PARAM))).toEqual([
+          {
+            kind: 'user',
+            userName: 'alice',
+            entityId: 'user:alice@default',
+            scopeId: 'agent-builder-entity-card',
+            origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+          },
+        ]);
+      });
+
       it('clears the search session before navigateToApp is called (cross-app)', () => {
         const application = buildApplicationMock();
         const searchSession = buildSearchSessionMock();
@@ -263,6 +374,44 @@ describe('entity_explore_navigation', () => {
           })
         ).not.toThrow();
         expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+      });
+
+      it('notifies the mounted app when navigating from another Security page', () => {
+        const application = buildApplicationMock();
+        const listener = jest.fn();
+        const unsubscribe = subscribeToFlyoutV2Navigation(listener);
+
+        navigateToEntityAnalyticsWithFlyoutInApp({
+          application,
+          appId: 'securitySolutionUI',
+          flyout: {
+            preview: [],
+            right: {
+              id: 'host-panel',
+              params: {
+                hostName: 'web-01',
+                entityId: 'host:web-01',
+                scopeId: 'agent-builder-entity-card',
+              },
+            },
+          },
+          isNewFlyoutEnabled: true,
+        });
+
+        expect(listener).toHaveBeenCalledWith({
+          urlParamKey: FLYOUT_V2_URL_PARAM,
+          descriptors: [
+            {
+              kind: 'host',
+              hostName: 'web-01',
+              entityId: 'host:web-01',
+              scopeId: 'agent-builder-entity-card',
+              origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+            },
+          ],
+        });
+
+        unsubscribe();
       });
 
       describe('when already on the EA home page', () => {
@@ -318,6 +467,47 @@ describe('entity_explore_navigation', () => {
           });
 
           expect(searchSession.clear).not.toHaveBeenCalled();
+        });
+
+        it('notifies the mounted app to open the v2 flyout without waiting for a remount', () => {
+          jest.useFakeTimers();
+          const application = buildApplicationMock();
+          const listener = jest.fn();
+          const unsubscribe = subscribeToFlyoutV2Navigation(listener);
+
+          navigateToEntityAnalyticsWithFlyoutInApp({
+            application,
+            appId: 'securitySolutionUI',
+            flyout: {
+              preview: [],
+              right: {
+                id: 'host-panel',
+                params: {
+                  hostName: 'web-01',
+                  entityId: 'host:web-01',
+                  scopeId: 'agent-builder-entity-card',
+                },
+              },
+            },
+            isNewFlyoutEnabled: true,
+          });
+          jest.runAllTimers();
+
+          expect(listener).toHaveBeenCalledWith({
+            urlParamKey: FLYOUT_V2_URL_PARAM,
+            descriptors: [
+              {
+                kind: 'host',
+                hostName: 'web-01',
+                entityId: 'host:web-01',
+                scopeId: 'agent-builder-entity-card',
+                origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+              },
+            ],
+          });
+
+          unsubscribe();
+          jest.useRealTimers();
         });
       });
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.ts
@@ -11,9 +11,18 @@ import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
 import { encodeFlyout, FLYOUT_PARAM_KEY } from '@kbn/cloud-security-posture/src/utils/query_utils';
 import {
+  encodeFlyoutV2UrlParam,
+  FLYOUT_DESCRIPTOR_KIND,
+  FLYOUT_V2_URL_PARAM,
+  type FlyoutDescriptor,
+  type FlyoutV2UrlParamValue,
+} from '../../flyout_v2/shared/url_state/flyout_v2_url_param';
+import { notifyFlyoutV2Navigation } from '../../flyout_v2/shared/url_state/flyout_v2_navigation';
+import {
   markPreserveAgentBuilderSessionDuringNextSecurityNavigation,
   readLastAgentBuilderAgentIdForSecuritySession,
 } from '../../../common/agent_builder_navigation_gate';
+import { FLYOUT_ORIGIN } from '../../common/lib/telemetry/events/flyout_v2/types';
 
 import { SecurityPageName, ENTITY_ANALYTICS_HOME_PAGE_PATH } from '../../../common/constants';
 import {
@@ -55,9 +64,158 @@ export interface EntityAnalyticsFlyoutNavigationState {
   };
 }
 
-const getEntityAnalyticsNavigationPathWithFlyout = (
+interface EntityDescriptorContext {
+  entityType: 'host' | 'user' | 'service';
+  entityName: string;
+  entityId?: string;
+  scopeId?: string;
+}
+
+const getEntityDescriptorContext = (
+  right: EntityAnalyticsFlyoutNavigationState['right']
+): { descriptor: FlyoutDescriptor; context: EntityDescriptorContext } | null => {
+  const { id, params } = right;
+  const entityId = params.entityId as string | undefined;
+  const scopeId = params.scopeId as string | undefined;
+
+  if (id === HostPanelKey) {
+    const hostName = params.hostName as string | undefined;
+    if (!hostName) return null;
+    return {
+      descriptor: { kind: FLYOUT_DESCRIPTOR_KIND.host, hostName, entityId, scopeId },
+      context: { entityType: 'host', entityName: hostName, entityId, scopeId },
+    };
+  }
+
+  if (id === UserPanelKey) {
+    const userName = params.userName as string | undefined;
+    if (!userName) return null;
+    return {
+      descriptor: { kind: FLYOUT_DESCRIPTOR_KIND.user, userName, entityId, scopeId },
+      context: { entityType: 'user', entityName: userName, entityId, scopeId },
+    };
+  }
+
+  if (id === ServicePanelKey) {
+    const serviceName = params.serviceName as string | undefined;
+    if (!serviceName) return null;
+    return {
+      descriptor: { kind: FLYOUT_DESCRIPTOR_KIND.service, serviceName, entityId, scopeId },
+      context: { entityType: 'service', entityName: serviceName, entityId, scopeId },
+    };
+  }
+
+  return null;
+};
+
+const getEntityToolDescriptor = (
+  left: EntityAnalyticsFlyoutNavigationState['left'],
+  context: EntityDescriptorContext
+): FlyoutDescriptor | null => {
+  const path = left?.params.path as { tab?: string; subTab?: string } | undefined;
+  if (!path?.tab) return null;
+
+  const { entityType, entityName, entityId, scopeId } = context;
+  switch (path.tab) {
+    case 'risk_inputs':
+      return {
+        kind: FLYOUT_DESCRIPTOR_KIND.entityRiskInputs,
+        entityType,
+        entityName,
+        entityId,
+      };
+    case 'anomalies':
+      return entityType === 'host' || entityType === 'user'
+        ? {
+            kind: FLYOUT_DESCRIPTOR_KIND.entityAnomalyInsights,
+            entityType,
+            value: entityName,
+            entityId,
+          }
+        : null;
+    case 'csp_insights':
+      if (path.subTab === 'vulnerabilitiesTabId') {
+        return {
+          kind: FLYOUT_DESCRIPTOR_KIND.entityVulnerabilityInsights,
+          value: entityName,
+          entityId,
+          entityType,
+        };
+      }
+      if (path.subTab === 'alertsTabId') {
+        return {
+          kind: FLYOUT_DESCRIPTOR_KIND.entityAlertsInsights,
+          entityType,
+          value: entityName,
+          entityId,
+        };
+      }
+      return {
+        kind: FLYOUT_DESCRIPTOR_KIND.entityMisconfigurationInsights,
+        entityType,
+        value: entityName,
+        entityId,
+      };
+    case 'graph_view':
+      return entityId && scopeId
+        ? {
+            kind: FLYOUT_DESCRIPTOR_KIND.entityGraphView,
+            entityId,
+            scopeId,
+            entityName,
+            entityType,
+          }
+        : null;
+    case 'resolution_group':
+      return entityId && scopeId
+        ? {
+            kind: FLYOUT_DESCRIPTOR_KIND.entityResolution,
+            entityId,
+            entityType,
+            entityName,
+            scopeId,
+          }
+        : null;
+    default:
+      return null;
+  }
+};
+
+/**
+ * Converts the entity-only legacy panel payload used by Agent Builder into the equivalent
+ * flyout-v2 descriptor stack. Tool views are restored as the root with the entity overview as
+ * its child, matching the v2 URL restore contract.
+ */
+export const buildEntityFlyoutV2NavigationState = (
   flyout: EntityAnalyticsFlyoutNavigationState
+): FlyoutV2UrlParamValue | null => {
+  const entity = getEntityDescriptorContext(flyout.right);
+  if (!entity) return null;
+
+  const toolDescriptor = getEntityToolDescriptor(flyout.left, entity.context);
+  const withAiChatOrigin = (descriptor: FlyoutDescriptor): FlyoutDescriptor => ({
+    ...descriptor,
+    origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+  });
+  const entityDescriptor = withAiChatOrigin(entity.descriptor);
+  return toolDescriptor ? [withAiChatOrigin(toolDescriptor), entityDescriptor] : [entityDescriptor];
+};
+
+const getEntityAnalyticsNavigationPathWithFlyout = (
+  flyout: EntityAnalyticsFlyoutNavigationState,
+  isNewFlyoutEnabled: boolean,
+  descriptors?: FlyoutV2UrlParamValue | null
 ): string | undefined => {
+  const searchParams = getEntityAnalyticsStateSearchParams();
+  searchParams.delete(FLYOUT_PARAM_KEY);
+  searchParams.delete(FLYOUT_V2_URL_PARAM);
+
+  if (isNewFlyoutEnabled) {
+    if (!descriptors) return undefined;
+    searchParams.set(FLYOUT_V2_URL_PARAM, encodeFlyoutV2UrlParam(descriptors));
+    return `?${searchParams.toString()}`;
+  }
+
   const encodedFlyoutSearch = encodeFlyout(flyout);
   if (encodedFlyoutSearch == null) {
     return undefined;
@@ -68,7 +226,6 @@ const getEntityAnalyticsNavigationPathWithFlyout = (
     return undefined;
   }
 
-  const searchParams = getEntityAnalyticsStateSearchParams();
   searchParams.set(FLYOUT_PARAM_KEY, flyoutValue);
   return `?${searchParams.toString()}`;
 };
@@ -288,6 +445,7 @@ export const navigateToEntityAnalyticsWithFlyoutInApp = ({
   chrome,
   openSidebarConversation,
   searchSession,
+  isNewFlyoutEnabled = false,
 }: {
   application: ApplicationStart;
   appId: string;
@@ -300,8 +458,11 @@ export const navigateToEntityAnalyticsWithFlyoutInApp = ({
    * navigating. See `clearSearchSessionBeforeSecurityNavigation` below for the rationale.
    */
   searchSession?: ISessionService;
+  /** Whether to encode the destination using the new EUI flyout URL contract. */
+  isNewFlyoutEnabled?: boolean;
 }): void => {
-  const path = getEntityAnalyticsNavigationPathWithFlyout(flyout);
+  const descriptors = isNewFlyoutEnabled ? buildEntityFlyoutV2NavigationState(flyout) : null;
+  const path = getEntityAnalyticsNavigationPathWithFlyout(flyout, isNewFlyoutEnabled, descriptors);
   if (path == null) {
     return;
   }
@@ -322,6 +483,10 @@ export const navigateToEntityAnalyticsWithFlyoutInApp = ({
     path,
     replace: true,
   });
+
+  if (isNewFlyoutEnabled && descriptors) {
+    notifyFlyoutV2Navigation({ urlParamKey: FLYOUT_V2_URL_PARAM, descriptors });
+  }
 
   if (!alreadyOnEaHomePage) {
     scheduleReopenAgentBuilderAfterSecurityNavigation({ agentBuilder, openSidebarConversation });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.ts
@@ -110,6 +110,7 @@ export const registerEntityAttachment = ({
   experimentalFeatures,
   resolveSecurityCanvasContext,
   searchSession,
+  uiSettings,
 }: {
   attachments: AttachmentServiceStartContract;
   application: ApplicationStart;
@@ -118,6 +119,7 @@ export const registerEntityAttachment = ({
   experimentalFeatures: ExperimentalFeatures;
   resolveSecurityCanvasContext: () => Promise<SecurityCanvasEmbeddedBundle>;
   searchSession?: ISessionService;
+  uiSettings: IUiSettingsClient;
 }): void => {
   void import(
     /* webpackChunkName: "security_entity_attachment_rich" */
@@ -132,6 +134,7 @@ export const registerEntityAttachment = ({
         chrome,
         resolveSecurityCanvasContext,
         searchSession,
+        uiSettings,
       })
     );
   });
@@ -186,19 +189,31 @@ export const registerEntityAnalyticsDashboardAttachment = ({
   application,
   agentBuilder,
   chrome,
+  experimentalFeatures,
   searchSession,
+  uiSettings,
 }: {
   attachments: AttachmentServiceStartContract;
   application: ApplicationStart;
   agentBuilder?: AgentBuilderPluginStart;
   chrome?: SecurityAgentBuilderChrome;
+  experimentalFeatures: ExperimentalFeatures;
   searchSession?: ISessionService;
+  uiSettings: IUiSettingsClient;
 }): void => {
   void import(
     /* webpackChunkName: "security_entity_analytics_dashboard_attachment" */
     './entity_analytics_dashboard_attachment'
   ).then(({ registerEntityAnalyticsDashboardAttachment: register }) => {
-    register({ attachments, application, agentBuilder, chrome, searchSession });
+    register({
+      attachments,
+      application,
+      agentBuilder,
+      chrome,
+      experimentalFeatures,
+      searchSession,
+      uiSettings,
+    });
   });
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.tsx
@@ -233,7 +233,14 @@ const HostEntityFlyoutOverviewCanvas: React.FC<{
   entityId?: string;
   attachmentRiskStats?: EntityAttachmentRiskStats;
   attachmentResolutionRiskStats?: EntityAttachmentRiskStats;
-}> = ({ hostName, entityId, attachmentRiskStats, attachmentResolutionRiskStats }) => {
+  hideHeaderIcons: boolean;
+}> = ({
+  hostName,
+  entityId,
+  attachmentRiskStats,
+  attachmentResolutionRiskStats,
+  hideHeaderIcons,
+}) => {
   const euidApi = useEntityStoreEuidApi();
 
   const safeContextID = AGENT_BUILDER_ENTITY_CARD_SCOPE;
@@ -451,6 +458,7 @@ const HostEntityFlyoutOverviewCanvas: React.FC<{
             entityStoreEntityId={entityStoreEntityId}
             prefetchedResolutionRisk={prefetchedResolutionRisk}
             riskScoreQueryId={AGENT_BUILDER_HOST_PANEL_RISK_SCORE_QUERY_ID}
+            hideHeaderIcons={hideHeaderIcons}
           />
         )}
       </FlyoutBody>
@@ -536,7 +544,14 @@ const UserEntityFlyoutOverviewCanvas: React.FC<{
   entityId?: string;
   attachmentRiskStats?: EntityAttachmentRiskStats;
   attachmentResolutionRiskStats?: EntityAttachmentRiskStats;
-}> = ({ userName, entityId: entityIdProp, attachmentRiskStats, attachmentResolutionRiskStats }) => {
+  hideHeaderIcons: boolean;
+}> = ({
+  userName,
+  entityId: entityIdProp,
+  attachmentRiskStats,
+  attachmentResolutionRiskStats,
+  hideHeaderIcons,
+}) => {
   const euidApi = useEntityStoreEuidApi();
 
   const safeContextID = AGENT_BUILDER_ENTITY_CARD_SCOPE;
@@ -754,6 +769,7 @@ const UserEntityFlyoutOverviewCanvas: React.FC<{
             entityStoreEntityId={entityStoreEntityId}
             prefetchedResolutionRisk={prefetchedResolutionRisk}
             riskScoreQueryId={AGENT_BUILDER_USER_PANEL_RISK_SCORE_QUERY_ID}
+            hideHeaderIcons={hideHeaderIcons}
           />
         )}
       </FlyoutBody>
@@ -830,7 +846,14 @@ const ServiceEntityFlyoutOverviewCanvas: React.FC<{
   entityId: string;
   attachmentRiskStats?: EntityAttachmentRiskStats;
   attachmentResolutionRiskStats?: EntityAttachmentRiskStats;
-}> = ({ serviceName, entityId, attachmentRiskStats, attachmentResolutionRiskStats }) => {
+  hideHeaderIcons: boolean;
+}> = ({
+  serviceName,
+  entityId,
+  attachmentRiskStats,
+  attachmentResolutionRiskStats,
+  hideHeaderIcons,
+}) => {
   const safeContextID = AGENT_BUILDER_ENTITY_CARD_SCOPE;
   const scopeId = AGENT_BUILDER_ENTITY_CARD_SCOPE;
   const isPreviewMode = false;
@@ -1004,6 +1027,7 @@ const ServiceEntityFlyoutOverviewCanvas: React.FC<{
             entityStoreEntityId={entityStoreEntityId}
             prefetchedResolutionRisk={prefetchedResolutionRisk}
             riskScoreQueryId={AGENT_BUILDER_SERVICE_PANEL_RISK_SCORE_QUERY_ID}
+            hideHeaderIcons={hideHeaderIcons}
           />
         )}
       </FlyoutBody>
@@ -1022,6 +1046,8 @@ export interface EntityCardFlyoutOverviewCanvasProps {
   riskStats?: EntityAttachmentRiskStats;
   /** Resolution-group risk fallback; threaded through to {@link FlyoutRiskSummary}. */
   resolutionRiskStats?: EntityAttachmentRiskStats;
+  /** Hides redundant section-header arrows when navigation targets the v2 flyout. */
+  hideHeaderIcons?: boolean;
 }
 
 /**
@@ -1038,6 +1064,7 @@ export const EntityCardFlyoutOverviewCanvas: React.FC<EntityCardFlyoutOverviewCa
   identifier,
   riskStats,
   resolutionRiskStats,
+  hideHeaderIcons = false,
 }) => {
   const { data, isLoading } = useEntityForAttachment(identifier);
 
@@ -1063,6 +1090,7 @@ export const EntityCardFlyoutOverviewCanvas: React.FC<EntityCardFlyoutOverviewCa
         entityId={entityId}
         attachmentRiskStats={riskStats}
         attachmentResolutionRiskStats={resolutionRiskStats}
+        hideHeaderIcons={hideHeaderIcons}
       />
     );
   }
@@ -1075,6 +1103,7 @@ export const EntityCardFlyoutOverviewCanvas: React.FC<EntityCardFlyoutOverviewCa
         entityId={entityId}
         attachmentRiskStats={riskStats}
         attachmentResolutionRiskStats={resolutionRiskStats}
+        hideHeaderIcons={hideHeaderIcons}
       />
     );
   }
@@ -1087,6 +1116,7 @@ export const EntityCardFlyoutOverviewCanvas: React.FC<EntityCardFlyoutOverviewCa
         entityId={entityId}
         attachmentRiskStats={riskStats}
         attachmentResolutionRiskStats={resolutionRiskStats}
+        hideHeaderIcons={hideHeaderIcons}
       />
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_dynamic_entity_flyout.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_dynamic_entity_flyout.test.ts
@@ -10,12 +10,9 @@ import { useDynamicEntityFlyout } from './use_dynamic_entity_flyout';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useKibana } from '../../common/lib/kibana';
 import { useOnExpandableFlyoutClose } from '../../flyout/shared/hooks/use_on_expandable_flyout_close';
-import {
-  GenericEntityPanelKey,
-  UserPanelKey,
-  HostPanelKey,
-  ServicePanelKey,
-} from '../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../common/lib/telemetry';
+import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
 
 jest.mock('@kbn/expandable-flyout', () => ({
   useExpandableFlyoutApi: jest.fn(),
@@ -29,15 +26,31 @@ jest.mock('../../flyout/shared/hooks/use_on_expandable_flyout_close', () => ({
   useOnExpandableFlyoutClose: jest.fn(),
 }));
 
+jest.mock('../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: jest.fn(),
+}));
+
+jest.mock('../../flyout_v2/use_flyout_api', () => ({
+  useFlyoutApi: jest.fn(),
+}));
+
 describe('useDynamicEntityFlyout', () => {
   let openFlyoutMock: jest.Mock;
   let closeFlyoutMock: jest.Mock;
+  let openHostFlyoutMock: jest.Mock;
+  let openUserFlyoutMock: jest.Mock;
+  let openServiceFlyoutMock: jest.Mock;
+  let openGenericEntityFlyoutMock: jest.Mock;
   let toastsMock: { addDanger: jest.Mock };
   let onFlyoutCloseMock: jest.Mock;
 
   beforeEach(() => {
     openFlyoutMock = jest.fn();
     closeFlyoutMock = jest.fn();
+    openHostFlyoutMock = jest.fn();
+    openUserFlyoutMock = jest.fn();
+    openServiceFlyoutMock = jest.fn();
+    openGenericEntityFlyoutMock = jest.fn();
     toastsMock = { addDanger: jest.fn() };
     onFlyoutCloseMock = jest.fn();
 
@@ -45,13 +58,118 @@ describe('useDynamicEntityFlyout', () => {
       openFlyout: openFlyoutMock,
       closeFlyout: closeFlyoutMock,
     });
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+    (useFlyoutApi as jest.Mock).mockReturnValue({
+      openHostFlyout: openHostFlyoutMock,
+      openUserFlyout: openUserFlyoutMock,
+      openServiceFlyout: openServiceFlyoutMock,
+      openGenericEntityFlyout: openGenericEntityFlyoutMock,
+    });
     (useKibana as jest.Mock).mockReturnValue({
       services: { notifications: { toasts: toastsMock } },
     });
     (useOnExpandableFlyoutClose as jest.Mock).mockImplementation(({ callback }) => callback);
   });
 
-  it('should open the flyout with correct params for a generic entity', () => {
+  it('should open the generic entity flyout for a generic entity', () => {
+    const { result } = renderHook(() =>
+      useDynamicEntityFlyout({ onFlyoutClose: onFlyoutCloseMock })
+    );
+
+    act(() => {
+      result.current.openDynamicFlyout({
+        entityDocId: '123',
+        entityId: '123',
+        entityType: 'container',
+        scopeId: 'scope1',
+        contextId: 'context1',
+      });
+    });
+
+    expect(openGenericEntityFlyoutMock).toHaveBeenCalledWith({
+      entityDocId: '123',
+      entityId: '123',
+      scopeId: 'scope1',
+      contextID: 'context1',
+      origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+    });
+  });
+
+  it('should open the user flyout for a user entity', () => {
+    const { result } = renderHook(() =>
+      useDynamicEntityFlyout({ onFlyoutClose: onFlyoutCloseMock })
+    );
+
+    act(() => {
+      result.current.openDynamicFlyout({
+        entityType: 'user',
+        entityName: 'testUser',
+        entityId: '123',
+        scopeId: 'scope1',
+        contextId: 'context1',
+      });
+    });
+
+    expect(openUserFlyoutMock).toHaveBeenCalledWith({
+      userName: 'testUser',
+      entityId: '123',
+      scopeId: 'scope1',
+      contextID: 'context1',
+      origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+    });
+  });
+
+  it('should open the host flyout for a host entity', () => {
+    const { result } = renderHook(() =>
+      useDynamicEntityFlyout({ onFlyoutClose: onFlyoutCloseMock })
+    );
+
+    act(() => {
+      result.current.openDynamicFlyout({
+        entityType: 'host',
+        entityName: 'testHost',
+        entityId: '123',
+        scopeId: 'scope1',
+        contextId: 'context1',
+      });
+    });
+
+    expect(openHostFlyoutMock).toHaveBeenCalledWith({
+      hostName: 'testHost',
+      entityId: '123',
+      scopeId: 'scope1',
+      contextID: 'context1',
+      origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+    });
+  });
+
+  it('should open the service flyout for a service entity', () => {
+    const { result } = renderHook(() =>
+      useDynamicEntityFlyout({ onFlyoutClose: onFlyoutCloseMock })
+    );
+
+    act(() => {
+      result.current.openDynamicFlyout({
+        entityType: 'service',
+        entityName: 'testService',
+        entityId: '123',
+        scopeId: 'scope1',
+        contextId: 'context1',
+      });
+    });
+
+    expect(openServiceFlyoutMock).toHaveBeenCalledWith({
+      serviceName: 'testService',
+      entityId: '123',
+      scopeId: 'scope1',
+      contextID: 'context1',
+      origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+    });
+  });
+
+  it('should open the legacy generic entity panel when the new flyout is disabled', () => {
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(false);
+
     const { result } = renderHook(() =>
       useDynamicEntityFlyout({ onFlyoutClose: onFlyoutCloseMock })
     );
@@ -68,100 +186,17 @@ describe('useDynamicEntityFlyout', () => {
 
     expect(openFlyoutMock).toHaveBeenCalledWith({
       right: {
-        id: GenericEntityPanelKey,
+        id: 'generic-entity-panel',
         params: {
           entityDocId: '123',
           entityId: '123',
+          contextID: 'context1',
           scopeId: 'scope1',
-          contextId: 'context1',
           isEngineMetadataExist: true,
         },
       },
     });
-  });
-
-  it('should open the flyout with correct params for a user entity', () => {
-    const { result } = renderHook(() =>
-      useDynamicEntityFlyout({ onFlyoutClose: onFlyoutCloseMock })
-    );
-
-    act(() => {
-      result.current.openDynamicFlyout({
-        entityType: 'user',
-        entityName: 'testUser',
-        entityId: '123',
-        scopeId: 'scope1',
-        contextId: 'context1',
-      });
-    });
-
-    expect(openFlyoutMock).toHaveBeenCalledWith({
-      right: {
-        id: UserPanelKey,
-        params: {
-          userName: 'testUser',
-          entityId: '123',
-          scopeId: 'scope1',
-          contextId: 'context1',
-        },
-      },
-    });
-  });
-
-  it('should open the flyout with correct params for a host entity', () => {
-    const { result } = renderHook(() =>
-      useDynamicEntityFlyout({ onFlyoutClose: onFlyoutCloseMock })
-    );
-
-    act(() => {
-      result.current.openDynamicFlyout({
-        entityType: 'host',
-        entityName: 'testHost',
-        entityId: '123',
-        scopeId: 'scope1',
-        contextId: 'context1',
-      });
-    });
-
-    expect(openFlyoutMock).toHaveBeenCalledWith({
-      right: {
-        id: HostPanelKey,
-        params: {
-          hostName: 'testHost',
-          entityId: '123',
-          scopeId: 'scope1',
-          contextId: 'context1',
-        },
-      },
-    });
-  });
-
-  it('should open the flyout with correct params for a service entity', () => {
-    const { result } = renderHook(() =>
-      useDynamicEntityFlyout({ onFlyoutClose: onFlyoutCloseMock })
-    );
-
-    act(() => {
-      result.current.openDynamicFlyout({
-        entityType: 'service',
-        entityName: 'testService',
-        entityId: '123',
-        scopeId: 'scope1',
-        contextId: 'context1',
-      });
-    });
-
-    expect(openFlyoutMock).toHaveBeenCalledWith({
-      right: {
-        id: ServicePanelKey,
-        params: {
-          serviceName: 'testService',
-          entityId: '123',
-          scopeId: 'scope1',
-          contextId: 'context1',
-        },
-      },
-    });
+    expect(openGenericEntityFlyoutMock).not.toHaveBeenCalled();
   });
 
   it('should show an error toast if entity name is missing for user, host, or service entities', () => {
@@ -170,12 +205,12 @@ describe('useDynamicEntityFlyout', () => {
     );
 
     act(() => {
-      result.current.openDynamicFlyout({ entityType: 'user', entityId: '123' });
+      result.current.openDynamicFlyout({ entityType: 'user', entityId: '123', scopeId: 'scope1' });
     });
 
     expect(toastsMock.addDanger).toHaveBeenCalled();
     expect(onFlyoutCloseMock).toHaveBeenCalled();
-    expect(openFlyoutMock).not.toHaveBeenCalled();
+    expect(openUserFlyoutMock).not.toHaveBeenCalled();
   });
 
   it('should close the flyout when closeDynamicFlyout is called', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_dynamic_entity_flyout.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_dynamic_entity_flyout.ts
@@ -14,11 +14,14 @@ import {
 import { METRIC_TYPE } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '../../common/lib/kibana';
+import { FLYOUT_ORIGIN } from '../../common/lib/telemetry';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
 import {
   HostPanelKey,
+  UserPanelKey,
   ServicePanelKey,
   GenericEntityPanelKey,
-  UserPanelKey,
 } from '../../flyout/entity_details/shared/constants';
 import { useOnExpandableFlyoutClose } from '../../flyout/shared/hooks/use_on_expandable_flyout_close';
 
@@ -28,12 +31,15 @@ interface InventoryFlyoutProps {
   entityDocId?: string;
   entityType?: string;
   entityName?: string;
-  scopeId?: string;
+  scopeId: string;
   contextId?: string;
 }
 
 export const useDynamicEntityFlyout = ({ onFlyoutClose }: { onFlyoutClose: () => void }) => {
-  const { openFlyout, closeFlyout } = useExpandableFlyoutApi();
+  const { closeFlyout, openFlyout } = useExpandableFlyoutApi();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openHostFlyout, openUserFlyout, openServiceFlyout, openGenericEntityFlyout } =
+    useFlyoutApi();
   const { notifications } = useKibana().services;
   useOnExpandableFlyoutClose({ callback: onFlyoutClose });
 
@@ -63,46 +69,103 @@ export const useDynamicEntityFlyout = ({ onFlyoutClose }: { onFlyoutClose: () =>
       return;
     }
 
-    switch (entityType) {
-      case 'user':
-        openFlyout({
-          right: {
-            id: UserPanelKey,
-            params: { userName: entityName, entityId, scopeId, contextId },
-          },
-        });
-        break;
-      case 'host':
-        openFlyout({
-          right: {
-            id: HostPanelKey,
-            params: { hostName: entityName, entityId, scopeId, contextId },
-          },
-        });
-        break;
-      case 'service':
-        openFlyout({
-          right: {
-            id: ServicePanelKey,
-            params: { serviceName: entityName, entityId, scopeId, contextId },
-          },
-        });
-        break;
-
-      default:
-        openFlyout({
-          right: {
-            id: GenericEntityPanelKey,
-            params: {
+    if (enableNewFlyout) {
+      switch (entityType) {
+        case 'user':
+          openUserFlyout({
+            userName: entityName ?? '',
+            entityId,
+            scopeId,
+            contextID: contextId,
+            origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+          });
+          break;
+        case 'host':
+          openHostFlyout({
+            hostName: entityName ?? '',
+            entityId,
+            scopeId,
+            contextID: contextId,
+            origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+          });
+          break;
+        case 'service':
+          openServiceFlyout({
+            serviceName: entityName ?? '',
+            entityId,
+            scopeId,
+            contextID: contextId,
+            origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+          });
+          break;
+        default:
+          if (entityDocId && entityId) {
+            openGenericEntityFlyout({
               entityDocId,
               entityId,
               scopeId,
-              contextId,
-              isEngineMetadataExist: Boolean(entityType), // Pass whether entityType exists to avoid error state in generic flyout
+              contextID: contextId,
+              origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+            });
+          } else if (entityId) {
+            openGenericEntityFlyout({
+              entityId,
+              scopeId,
+              contextID: contextId,
+              origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+            });
+          } else if (entityDocId) {
+            openGenericEntityFlyout({
+              entityDocId,
+              scopeId,
+              contextID: contextId,
+              origin: FLYOUT_ORIGIN.ASSET_INVENTORY,
+            });
+          }
+          break;
+      }
+    } else {
+      switch (entityType) {
+        case 'user':
+          openFlyout({
+            right: {
+              id: UserPanelKey,
+              params: { userName: entityName, entityId, contextID: contextId, scopeId },
             },
-          },
-        });
-        break;
+          });
+          break;
+        case 'host':
+          openFlyout({
+            right: {
+              id: HostPanelKey,
+              params: { hostName: entityName, entityId, contextID: contextId, scopeId },
+            },
+          });
+          break;
+        case 'service':
+          openFlyout({
+            right: {
+              id: ServicePanelKey,
+              params: { serviceName: entityName, entityId, contextID: contextId, scopeId },
+            },
+          });
+          break;
+        default:
+          openFlyout({
+            right: {
+              id: GenericEntityPanelKey,
+              params: {
+                entityDocId,
+                entityId,
+                contextID: contextId,
+                scopeId,
+                // Pass whether entityType exists to avoid error state in generic flyout
+                isEngineMetadataExist: Boolean(entityType),
+              },
+            },
+          });
+          break;
+      }
     }
 
     uiMetricService.trackUiMetric(METRIC_TYPE.CLICK, ASSET_INVENTORY_EXPAND_FLYOUT_SUCCESS);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/flyout_v2/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/flyout_v2/types.ts
@@ -163,6 +163,40 @@ export const FLYOUT_ORIGIN = {
   NOTE_PREVIEW: 'note_preview',
   // Threat intelligence table row.
   THREAT_INTEL_TABLE: 'threat_intel_table',
+  // Asset Inventory grid row.
+  ASSET_INVENTORY: 'asset_inventory',
+  // Explore > Hosts table host link.
+  HOSTS_TABLE: 'hosts_table',
+  // Explore > Hosts > Uncommon processes table host link.
+  UNCOMMON_PROCESSES_TABLE: 'uncommon_processes_table',
+  // Explore > Hosts/Users > Authentications table entity link.
+  AUTHENTICATIONS_TABLE: 'authentications_table',
+  // Explore > Hosts > Host risk table host link.
+  HOST_RISK_TABLE: 'host_risk_table',
+  // Explore > Users table user link.
+  USERS_TABLE: 'users_table',
+  // Explore > Users > User risk table user link.
+  USER_RISK_TABLE: 'user_risk_table',
+  // Entity Analytics entities table row or grouped-row preview.
+  ENTITIES_TABLE: 'entities_table',
+  // Entity Analytics Entity Store list preview button.
+  ENTITY_STORE_LIST: 'entity_store_list',
+  // Entity Analytics dashboard risk score table entity link.
+  ENTITY_ANALYTICS_RISK_SCORE: 'entity_analytics_risk_score',
+  // Risk score management preview table entity link.
+  RISK_SCORE_PREVIEW: 'risk_score_preview',
+  // Entity attachment action in AI chat.
+  AI_CHAT_ENTITY_ATTACHMENT: 'ai_chat_entity_attachment',
+  // Privileged user monitoring users table.
+  PRIVILEGED_USERS_TABLE: 'privileged_users_table',
+  // Privileged access detection chart entity link.
+  PRIVILEGED_ACCESS_DETECTION: 'privileged_access_detection',
+  // Recent anomalies chart entity link.
+  RECENT_ANOMALIES: 'recent_anomalies',
+  // Threat hunting lead entity badge.
+  THREAT_HUNTING_LEADS: 'threat_hunting_leads',
+  // Flyout reconstructed from URL state during application mount.
+  URL_RESTORE: 'url_restore',
   // "Analyze event" row-action button, shared across alerts table, timeline, and rule preview.
   ROW_ACTION: 'row_action',
 } as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.test.tsx
@@ -20,6 +20,8 @@ import { useEntityStoreRiskScoreKpi } from '../../api/hooks/use_entity_store_ris
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { RiskSeverity } from '../../../../common/search_strategy';
 import { capitalize } from 'lodash/fp';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 
 const mockedTelemetry = createTelemetryServiceMock();
 const mockedUseKibana = mockUseKibana();
@@ -87,6 +89,13 @@ jest.mock('../../../common/hooks/use_navigate_to_alerts_page_with_filters', () =
 
 const mockOpenRightPanel = jest.fn();
 jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('../../../flyout_v2/use_flyout_api');
+
+const mockOpenHostFlyout = jest.fn();
+const mockOpenUserFlyout = jest.fn();
+const mockOpenServiceFlyout = jest.fn();
+const mockUseIsNewFlyoutEnabled = useIsNewFlyoutEnabled as jest.Mock;
 
 describe.each([EntityType.host, EntityType.user, EntityType.service])(
   'EntityAnalyticsRiskScores entityType: %s',
@@ -94,6 +103,12 @@ describe.each([EntityType.host, EntityType.user, EntityType.service])(
     beforeEach(() => {
       (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
         openRightPanel: mockOpenRightPanel,
+      });
+      mockUseIsNewFlyoutEnabled.mockReturnValue(false);
+      (useFlyoutApi as jest.Mock).mockReturnValue({
+        openHostFlyout: mockOpenHostFlyout,
+        openUserFlyout: mockOpenUserFlyout,
+        openServiceFlyout: mockOpenServiceFlyout,
       });
       jest.clearAllMocks();
       mockUseRiskScoreKpi.mockReturnValue({
@@ -378,5 +393,63 @@ describe.each([EntityType.host, EntityType.user, EntityType.service])(
         });
       }
     );
+
+    it('opens the new entity flyout when entity name is clicked', async () => {
+      mockUseIsNewFlyoutEnabled.mockReturnValue(true);
+      mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: jest.fn() });
+      mockUseRiskScoreKpi.mockReturnValue({
+        severityCount: mockSeverityCount,
+        loading: false,
+      });
+      const name = 'testName';
+      setRiskScoreReturn({
+        ...defaultProps,
+        data: [
+          {
+            '@timestamp': '1234567899',
+            [riskEntity]: {
+              name,
+              risk: {
+                rule_risks: [],
+                calculated_level: RiskSeverity.High,
+                calculated_score_norm: 75,
+                multipliers: [],
+              },
+            },
+            alertsCount: 0,
+          },
+        ],
+      });
+
+      const { getByText } = render(
+        <TestProviders>
+          <EntityAnalyticsRiskScores riskEntity={riskEntity} />
+        </TestProviders>
+      );
+
+      fireEvent.click(getByText(name));
+
+      const openFlyoutByType = {
+        [EntityType.host]: mockOpenHostFlyout,
+        [EntityType.user]: mockOpenUserFlyout,
+        [EntityType.service]: mockOpenServiceFlyout,
+      };
+      const nameParamByType = {
+        [EntityType.host]: { hostName: name },
+        [EntityType.user]: { userName: name },
+        [EntityType.service]: { serviceName: name },
+      };
+      const testedRiskEntity = riskEntity as Exclude<EntityType, EntityType.generic>;
+
+      await waitFor(() => {
+        expect(openFlyoutByType[testedRiskEntity]).toHaveBeenCalledWith({
+          ...nameParamByType[testedRiskEntity],
+          scopeId: 'entity-risk-score-table',
+          contextID: 'entity-risk-score-table',
+          origin: 'entity_analytics_risk_score',
+        });
+      });
+      expect(mockOpenRightPanel).not.toHaveBeenCalled();
+    });
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
@@ -39,6 +39,9 @@ import { useEntityAnalyticsRiskScorePanelData } from './use_entity_analytics_ris
 import { RiskEnginePrivilegesCallOut } from '../risk_engine_privileges_callout';
 import { useMissingRiskEnginePrivileges } from '../../hooks/use_missing_risk_engine_privileges';
 import { EntityEventTypes } from '../../../common/lib/telemetry';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry/events/flyout_v2/types';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import { RiskScoresNoDataDetected } from '../risk_score_no_data_detected';
 import { RiskScoreHeaderTitle } from '../risk_score_header_title';
 import { RiskScoreDonutChart } from '../risk_score_donut_chart';
@@ -56,6 +59,8 @@ const EntityAnalyticsRiskScoresComponent = <T extends EntityType>({
   const openAlertsPageWithFilters = useNavigateToAlertsPageWithFilters();
   const { telemetry } = useKibana().services;
   const { openRightPanel } = useExpandableFlyoutApi();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openHostFlyout, openUserFlyout, openServiceFlyout } = useFlyoutApi();
   const entityNameField = EntityTypeToIdentifierField[riskEntity];
 
   const openEntityOnAlertsPage = useCallback(
@@ -74,6 +79,23 @@ const EntityAnalyticsRiskScoresComponent = <T extends EntityType>({
 
   const openEntityOnExpandableFlyout = useCallback(
     (entityName: string) => {
+      if (enableNewFlyout) {
+        const sharedParams = {
+          scopeId: ENTITY_RISK_SCORE_TABLE_ID,
+          contextID: ENTITY_RISK_SCORE_TABLE_ID,
+          origin: FLYOUT_ORIGIN.ENTITY_ANALYTICS_RISK_SCORE,
+        };
+
+        if (riskEntity === 'host') {
+          openHostFlyout({ hostName: entityName, ...sharedParams });
+        } else if (riskEntity === 'user') {
+          openUserFlyout({ userName: entityName, ...sharedParams });
+        } else if (riskEntity === 'service') {
+          openServiceFlyout({ serviceName: entityName, ...sharedParams });
+        }
+        return;
+      }
+
       const panelKey = EntityPanelKeyByType[riskEntity];
       const panelParam = EntityPanelParamByType[riskEntity];
       if (panelKey && panelParam) {
@@ -87,7 +109,7 @@ const EntityAnalyticsRiskScoresComponent = <T extends EntityType>({
         });
       }
     },
-    [openRightPanel, riskEntity]
+    [enableNewFlyout, openHostFlyout, openRightPanel, openServiceFlyout, openUserFlyout, riskEntity]
   );
 
   const { toggleStatus, setToggleStatus } = useQueryToggle(entity.tableQueryId);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_tab.test.tsx
@@ -25,6 +25,17 @@ jest.mock('../../../common/lib/kibana/kibana_react', () => ({
   useKibana: jest.fn(),
 }));
 jest.mock('../../../common/hooks/use_app_toasts');
+jest.mock('@kbn/expandable-flyout', () => ({
+  useExpandableFlyoutApi: () => ({ openFlyout: jest.fn(), closeFlyout: jest.fn() }),
+}));
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: () => false,
+}));
+jest.mock('../../../flyout_v2/use_flyout_api', () => ({
+  useFlyoutApi: () => ({
+    openEntityFlyout: jest.fn(),
+  }),
+}));
 
 const mockUseResolutionGroup = useResolutionGroup as jest.Mock;
 const mockUseLinkEntities = useLinkEntities as jest.Mock;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_tab.tsx
@@ -7,13 +7,16 @@
 
 import React, { useState, useCallback, useMemo } from 'react';
 import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { EntityType } from '@kbn/entity-store/public';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { API_VERSIONS } from '../../../../common/entity_analytics/constants';
 import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import type { EntityType as SecurityEntityType } from '../../../../common/entity_analytics/types';
 import { useKibana } from '../../../common/lib/kibana/kibana_react';
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
@@ -60,7 +63,9 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({
 }) => {
   const { http } = useKibana().services;
   const { addError } = useAppToasts();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openEntityFlyout } = useFlyoutApi();
   const { data: group, isLoading, isFetching, isError } = useResolutionGroup(entityId);
   const linkEntities = useLinkEntities();
   const createGroup = useLinkEntities({
@@ -105,24 +110,28 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({
         return;
       }
 
-      const panelKey = EntityPanelKeyByType[entityType as SecurityEntityType];
-      const panelParam = EntityPanelParamByType[entityType as SecurityEntityType];
+      const secEntityType = entityType as SecurityEntityType;
+      const sharedParams = { entityId: clickedEntityId, contextID: scopeId, scopeId };
 
-      if (!panelKey || !panelParam) return;
+      if (enableNewFlyout) {
+        openEntityFlyout({
+          engineType: secEntityType,
+          entityName: clickedEntityName,
+          origin: FLYOUT_ORIGIN.RESOLUTION_ENTITY_LINK,
+          ...sharedParams,
+        });
+        return;
+      }
 
-      openFlyout({
-        right: {
-          id: panelKey,
-          params: {
-            [panelParam]: clickedEntityName,
-            entityId: clickedEntityId,
-            contextID: scopeId,
-            scopeId,
-          },
-        },
-      });
+      const panelKey = EntityPanelKeyByType[secEntityType];
+      const paramName = EntityPanelParamByType[secEntityType];
+      if (panelKey && paramName) {
+        openFlyout({
+          right: { id: panelKey, params: { [paramName]: clickedEntityName, ...sharedParams } },
+        });
+      }
     },
-    [onShowEntity, openFlyout, entityType, scopeId]
+    [onShowEntity, enableNewFlyout, openFlyout, openEntityFlyout, entityType, scopeId]
   );
 
   const handleRemoveEntity = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_section.tsx
@@ -16,6 +16,9 @@ import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import { useResolutionGroup } from './hooks/use_resolution_group';
 import { ResolutionGroupTable } from './resolution_group_table';
 import {
@@ -62,7 +65,9 @@ export const ResolutionSection: React.FC<ResolutionSectionProps> = ({
     enabled: !!entityId,
   });
 
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openEntityFlyout } = useFlyoutApi();
 
   const handleOpenResolutionTab = useCallback(() => {
     openDetailsPanel?.({ tab: EntityDetailsLeftPanelTab.RESOLUTION_GROUP });
@@ -82,24 +87,27 @@ export const ResolutionSection: React.FC<ResolutionSectionProps> = ({
         return;
       }
 
+      const sharedParams = { entityId: clickedEntityId, contextID: scopeId, scopeId };
+
+      if (enableNewFlyout) {
+        openEntityFlyout({
+          engineType: entityType,
+          entityName: clickedEntityName,
+          origin: FLYOUT_ORIGIN.RESOLUTION_ENTITY_LINK,
+          ...sharedParams,
+        });
+        return;
+      }
+
       const panelKey = EntityPanelKeyByType[entityType];
-      const panelParam = EntityPanelParamByType[entityType];
-
-      if (!panelKey || !panelParam) return;
-
-      openFlyout({
-        right: {
-          id: panelKey,
-          params: {
-            [panelParam]: clickedEntityName,
-            entityId: clickedEntityId,
-            contextID: scopeId,
-            scopeId,
-          },
-        },
-      });
+      const paramName = EntityPanelParamByType[entityType];
+      if (panelKey && paramName) {
+        openFlyout({
+          right: { id: panelKey, params: { [paramName]: clickedEntityName, ...sharedParams } },
+        });
+      }
     },
-    [onShowEntity, openFlyout, entityType, scopeId]
+    [onShowEntity, enableNewFlyout, openFlyout, openEntityFlyout, entityType, scopeId]
   );
 
   const targetEntityId = group?.target ? getEntityId(group.target) : undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_columns.tsx
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EuiButtonIcon, EuiIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { get } from 'lodash/fp';
 import type { Entity } from '@kbn/entity-store/common';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import {
   EntityTypeToLevelField,
   EntityTypeToScoreField,
@@ -21,6 +21,9 @@ import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
 import { RiskScoreLevel } from '../../severity/common';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
@@ -47,7 +50,9 @@ export type EntitiesListColumns = [
 ];
 
 export const useEntitiesListColumns = (): EntitiesListColumns => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openEntityFlyout } = useFlyoutApi();
   const { euiTheme } = useEuiTheme();
 
   return [
@@ -64,24 +69,34 @@ export const useEntitiesListColumns = (): EntitiesListColumns => {
 
         const value = record.entity?.name;
         const onClick = () => {
-          const id = EntityPanelKeyByType[entityType];
+          const sharedParams = {
+            entityId: record.entity?.id,
+            contextID: ENTITIES_LIST_TABLE_ID,
+            scopeId: ENTITIES_LIST_TABLE_ID,
+          };
 
-          if (id) {
+          if (enableNewFlyout) {
+            openEntityFlyout({
+              engineType: entityType,
+              entityName: value ?? '',
+              entityId: record.entity?.id ?? '',
+              contextID: ENTITIES_LIST_TABLE_ID,
+              scopeId: ENTITIES_LIST_TABLE_ID,
+              origin: FLYOUT_ORIGIN.ENTITY_STORE_LIST,
+            });
+            return;
+          }
+
+          const panelKey = EntityPanelKeyByType[entityType];
+          const paramName = EntityPanelParamByType[entityType];
+          if (panelKey && paramName) {
             openFlyout({
-              right: {
-                id,
-                params: {
-                  [EntityPanelParamByType[entityType] ?? '']: value,
-                  contextID: ENTITIES_LIST_TABLE_ID,
-                  scopeId: ENTITIES_LIST_TABLE_ID,
-                  entityId: record.entity?.id,
-                },
-              },
+              right: { id: panelKey, params: { [paramName]: value, ...sharedParams } },
             });
           }
         };
 
-        if (!value || !EntityPanelKeyByType[entityType]) {
+        if (!value || (!enableNewFlyout && !EntityPanelKeyByType[entityType])) {
           return null;
         }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
@@ -59,8 +59,19 @@ jest.mock('@kbn/unified-data-table', () => {
 jest.mock('@kbn/expandable-flyout', () => ({
   useExpandableFlyoutApi: jest.fn(() => ({
     openRightPanel: jest.fn(),
+    openFlyout: jest.fn(),
     closeFlyout: jest.fn(),
   })),
+}));
+
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: () => false,
+}));
+
+jest.mock('../../../../flyout_v2/use_flyout_api', () => ({
+  useFlyoutApi: () => ({
+    openEntityFlyout: jest.fn(),
+  }),
 }));
 
 jest.mock('../../../../common/hooks/timeline/use_investigate_in_timeline');

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -54,6 +54,9 @@ import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import {
   EntitySourceValue,
   toEntitySourceArray,
@@ -194,7 +197,9 @@ export const EntitiesDataTable = ({
     setUrlQuery,
   } = state;
 
-  const { openFlyout, closeFlyout } = useExpandableFlyoutApi();
+  const { closeFlyout, openFlyout } = useExpandableFlyoutApi();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openEntityFlyout } = useFlyoutApi();
   const {
     timelinePrivileges: { read: canUseTimeline },
     alertsPrivileges: {
@@ -212,25 +217,30 @@ export const EntitiesDataTable = ({
       }
 
       const { entityType, entityName, entityId } = getEntityFields(doc);
-      if (!entityType || !entityName) return;
+      if (!entityType || !entityName || !entityId) return;
 
+      const sharedParams = { entityId, contextID: tableId, scopeId: tableId };
+
+      if (enableNewFlyout) {
+        openEntityFlyout({
+          engineType: entityType,
+          entityName,
+          origin: FLYOUT_ORIGIN.ENTITIES_TABLE,
+          ...sharedParams,
+        });
+        return;
+      }
+
+      // Generic entities have no dedicated panel in the legacy flyout.
       const panelKey = EntityPanelKeyByType[entityType];
-      const panelParam = EntityPanelParamByType[entityType];
-      if (!panelKey || !panelParam) return;
-
-      openFlyout({
-        right: {
-          id: panelKey,
-          params: {
-            [panelParam]: entityName,
-            entityId,
-            contextID: tableId,
-            scopeId: tableId,
-          },
-        },
-      });
+      const paramName = EntityPanelParamByType[entityType];
+      if (panelKey && paramName) {
+        openFlyout({
+          right: { id: panelKey, params: { [paramName]: entityName, ...sharedParams } },
+        });
+      }
     },
-    [openFlyout, closeFlyout, tableId]
+    [enableNewFlyout, openFlyout, openEntityFlyout, closeFlyout, tableId]
   );
 
   const {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.test.tsx
@@ -19,7 +19,18 @@ const mockOpenRightPanel = jest.fn();
 jest.mock('@kbn/expandable-flyout', () => ({
   useExpandableFlyoutApi: () => ({
     openRightPanel: mockOpenRightPanel,
+    openFlyout: jest.fn(),
     closeFlyout: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: () => false,
+}));
+
+jest.mock('../../../../../flyout_v2/use_flyout_api', () => ({
+  useFlyoutApi: () => ({
+    openEntityFlyout: jest.fn(),
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.tsx
@@ -24,6 +24,9 @@ import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { ENTITY_ANALYTICS_TABLE_ID } from '../../constants';
 import { RISK_SCORE_NOT_AVAILABLE } from '../../../entity_resolution/translations';
 import { getRiskLevel } from '../../../../../../common/entity_analytics/risk_engine';
@@ -56,7 +59,9 @@ const ResolutionGroupPanel = ({
   targetMetadata: TargetMetadataMap;
   tableId: string;
 }) => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openEntityFlyout } = useFlyoutApi();
 
   const entityId = String(bucket.key_as_string ?? bucket.key);
   const metadata = targetMetadata.get(entityId);
@@ -72,23 +77,27 @@ const ResolutionGroupPanel = ({
       e.stopPropagation();
       if (!targetEntityName || !entityType) return;
 
-      const panelKey = EntityPanelKeyByType[entityType];
-      const panelParam = EntityPanelParamByType[entityType];
-      if (!panelKey || !panelParam) return;
+      const sharedParams = { entityId, contextID: tableId, scopeId: tableId };
 
-      openFlyout({
-        right: {
-          id: panelKey,
-          params: {
-            [panelParam]: targetEntityName,
-            entityId,
-            contextID: tableId,
-            scopeId: tableId,
-          },
-        },
-      });
+      if (enableNewFlyout) {
+        openEntityFlyout({
+          engineType: entityType,
+          entityName: targetEntityName,
+          origin: FLYOUT_ORIGIN.ENTITIES_TABLE,
+          ...sharedParams,
+        });
+        return;
+      }
+
+      const panelKey = EntityPanelKeyByType[entityType];
+      const paramName = EntityPanelParamByType[entityType];
+      if (panelKey && paramName) {
+        openFlyout({
+          right: { id: panelKey, params: { [paramName]: targetEntityName, ...sharedParams } },
+        });
+      }
     },
-    [openFlyout, targetEntityName, entityType, entityId, tableId]
+    [enableNewFlyout, openFlyout, openEntityFlyout, targetEntityName, entityType, entityId, tableId]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/host_risk_score_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/host_risk_score_table/index.tsx
@@ -7,8 +7,11 @@
 
 import React, { useMemo, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EuiFilterGroup, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import { HostPanelKey } from '../../../flyout/entity_details/shared/constants';
 import type {
   Columns,
@@ -83,7 +86,9 @@ const HostRiskScoreTableComponent: React.FC<HostRiskScoreTableProps> = ({
   type,
 }) => {
   const dispatch = useDispatch();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openHostFlyout } = useFlyoutApi();
   const getHostRiskScoreSelector = useMemo(() => hostsSelectors.hostRiskScoreSelector(), []);
   const { activePage, limit, sort } = useDeepEqualSelector((state: State) =>
     getHostRiskScoreSelector(state, hostsModel.HostsType.page)
@@ -139,26 +144,31 @@ const HostRiskScoreTableComponent: React.FC<HostRiskScoreTableProps> = ({
     },
     [dispatch, type]
   );
-  const openHostFlyout = useCallback(
+  const openHostDetails = useCallback(
     (hostName: string) => {
+      if (enableNewFlyout) {
+        openHostFlyout({
+          hostName,
+          contextID: tableType,
+          scopeId: tableType,
+          origin: FLYOUT_ORIGIN.HOST_RISK_TABLE,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: HostPanelKey,
-          params: {
-            hostName,
-            contextID: tableType,
-            scopeId: tableType,
-            isPreviewMode: false,
-          },
+          params: { hostName, contextID: tableType, scopeId: tableType },
         },
       });
     },
-    [openFlyout]
+    [enableNewFlyout, openFlyout, openHostFlyout]
   );
 
   const columns = useMemo(
-    () => getHostRiskScoreColumns({ dispatchSeverityUpdate, openHostFlyout }),
-    [dispatchSeverityUpdate, openHostFlyout]
+    () => getHostRiskScoreColumns({ dispatchSeverityUpdate, openHostFlyout: openHostDetails }),
+    [dispatchSeverityUpdate, openHostDetails]
   );
 
   const risk = (

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/pad_chart/pad_user_name_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/pad_chart/pad_user_name_list.tsx
@@ -6,24 +6,39 @@
  */
 
 import React from 'react';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiText } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { anomalyChartStyling } from '../../../../recent_anomalies/anomaly_chart_styling';
+import { useIsNewFlyoutEnabled } from '../../../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../../../flyout_v2/use_flyout_api';
 import { UserPanelKey } from '../../../../../../flyout/entity_details/shared/constants';
 
 const PRIVILEGED_ACCESS_DETECTION_TABLE_ID = 'PadAnomalies-table';
 
 export const UserNameList: React.FC<{ userNames: string[] }> = ({ userNames }) => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openUserFlyout } = useFlyoutApi();
 
-  const openUserFlyout = (userName: string) => {
+  const openUserDetails = (userName: string) => {
+    if (enableNewFlyout) {
+      openUserFlyout({
+        userName,
+        scopeId: PRIVILEGED_ACCESS_DETECTION_TABLE_ID,
+        contextID: PRIVILEGED_ACCESS_DETECTION_TABLE_ID,
+        origin: FLYOUT_ORIGIN.PRIVILEGED_ACCESS_DETECTION,
+      });
+      return;
+    }
+
     openFlyout({
       right: {
         id: UserPanelKey,
         params: {
-          contextID: PRIVILEGED_ACCESS_DETECTION_TABLE_ID,
           userName,
+          contextID: PRIVILEGED_ACCESS_DETECTION_TABLE_ID,
           scopeId: PRIVILEGED_ACCESS_DETECTION_TABLE_ID,
         },
       },
@@ -51,7 +66,7 @@ export const UserNameList: React.FC<{ userNames: string[] }> = ({ userNames }) =
             <EuiText textAlign={'right'}>
               <EuiLink
                 onClick={() => {
-                  openUserFlyout(userName);
+                  openUserDetails(userName);
                 }}
               >
                 {userName}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   useEuiTheme,
   EuiPanel,
@@ -20,12 +20,15 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { i18n } from '@kbn/i18n';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { InspectButtonContainer } from '../../../../../common/components/inspect';
 import { useGlobalTime } from '../../../../../common/containers/use_global_time';
 import { useQueryInspector } from '../../../../../common/components/page/manage_query';
 import { useQueryToggle } from '../../../../../common/containers/query_toggle';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { UserPanelKey } from '../../../../../flyout/entity_details/shared/constants';
 
 import { buildPrivilegedUsersTableColumns } from './columns';
@@ -44,20 +47,35 @@ const TITLE = i18n.translate(
 const PRIVILEGED_USERS_TABLE_ID = 'PrivilegedUsers-table';
 
 const useOpenUserFlyout = () => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openUserFlyout } = useFlyoutApi();
 
-  return (userName: string) => {
-    openFlyout({
-      right: {
-        id: UserPanelKey,
-        params: {
-          contextID: PRIVILEGED_USERS_TABLE_ID,
+  return useCallback(
+    (userName: string) => {
+      if (enableNewFlyout) {
+        openUserFlyout({
           userName,
           scopeId: PRIVILEGED_USERS_TABLE_ID,
+          contextID: PRIVILEGED_USERS_TABLE_ID,
+          origin: FLYOUT_ORIGIN.PRIVILEGED_USERS_TABLE,
+        });
+        return;
+      }
+
+      openFlyout({
+        right: {
+          id: UserPanelKey,
+          params: {
+            userName,
+            contextID: PRIVILEGED_USERS_TABLE_ID,
+            scopeId: PRIVILEGED_USERS_TABLE_ID,
+          },
         },
-      },
-    });
-  };
+      });
+    },
+    [enableNewFlyout, openFlyout, openUserFlyout]
+  );
 };
 
 export const PrivilegedUsersTable: React.FC<{ spaceId: string }> = ({ spaceId }) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/entity_name_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/entity_name_list.tsx
@@ -6,15 +6,18 @@
  */
 
 import React from 'react';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiText } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { getAnomalyChartStyling } from './anomaly_chart_styling';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import type { EntityMetadata } from './hooks/recent_anomalies_query_hooks';
 
 interface EntityNameListProps {
@@ -28,26 +31,36 @@ export const EntityNameList: React.FC<EntityNameListProps> = ({
   contextId,
   compressed = false,
 }) => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openEntityFlyout } = useFlyoutApi();
   const styling = getAnomalyChartStyling(compressed);
 
-  const openEntityFlyout = (entity: EntityMetadata) => {
+  const handleOpenEntityFlyout = (entity: EntityMetadata) => {
     const entityType = entity.entityType as EntityType;
+    const sharedParams = {
+      entityId: entity.entityId,
+      contextID: contextId,
+      scopeId: contextId,
+    };
+
+    if (enableNewFlyout) {
+      openEntityFlyout({
+        engineType: entityType,
+        entityName: entity.entityName,
+        origin: FLYOUT_ORIGIN.RECENT_ANOMALIES,
+        ...sharedParams,
+      });
+      return;
+    }
+
     const panelKey = EntityPanelKeyByType[entityType];
     const paramName = EntityPanelParamByType[entityType];
-    if (!panelKey || !paramName) return;
-
-    openFlyout({
-      right: {
-        id: panelKey,
-        params: {
-          contextID: contextId,
-          [paramName]: entity.entityName,
-          entityId: entity.entityId,
-          scopeId: contextId,
-        },
-      },
-    });
+    if (panelKey && paramName) {
+      openFlyout({
+        right: { id: panelKey, params: { [paramName]: entity.entityName, ...sharedParams } },
+      });
+    }
   };
 
   return (
@@ -71,7 +84,7 @@ export const EntityNameList: React.FC<EntityNameListProps> = ({
             <EuiText textAlign={'right'} size={'s'}>
               <EuiLink
                 onClick={() => {
-                  openEntityFlyout(entity);
+                  handleOpenEntityFlyout(entity);
                 }}
               >
                 {entity.entityId}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_table.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react';
+import { EuiProvider } from '@elastic/eui';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { EntityRiskScoreRecord } from '../../../../common/api/entity_analytics/common';
+import { EntityType } from '../../../../common/entity_analytics/types';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry/events/flyout_v2/types';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
+import { RiskScorePreviewTable } from './risk_score_preview_table';
+
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('../../../flyout_v2/use_flyout_api');
+
+const mockOpenEntityFlyout = jest.fn();
+const mockOpenRightPanel = jest.fn();
+const TestProviders: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <I18nProvider>
+    <EuiProvider>{children}</EuiProvider>
+  </I18nProvider>
+);
+const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: TestProviders });
+
+const riskScoreRecord: EntityRiskScoreRecord = {
+  '@timestamp': '2026-07-24T12:00:00.000Z',
+  id_field: 'entity.id',
+  id_value: 'host:web-01',
+  calculated_level: 'Low',
+  calculated_score: 20,
+  calculated_score_norm: 20,
+  category_1_score: 20,
+  category_1_count: 1,
+  inputs: [],
+  notes: [],
+};
+
+describe('RiskScorePreviewTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+    (useFlyoutApi as jest.Mock).mockReturnValue({
+      openEntityFlyout: mockOpenEntityFlyout,
+    });
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
+      openRightPanel: mockOpenRightPanel,
+    });
+  });
+
+  it('attributes v2 entity flyouts to the risk score preview', () => {
+    render(<RiskScorePreviewTable items={[riskScoreRecord]} type={EntityType.host} />);
+
+    fireEvent.click(screen.getByText('host:web-01'));
+
+    expect(mockOpenEntityFlyout).toHaveBeenCalledWith({
+      engineType: EntityType.host,
+      entityId: 'host:web-01',
+      entityName: 'host:web-01',
+      contextID: 'risk-score-preview',
+      scopeId: 'risk-score-preview',
+      origin: FLYOUT_ORIGIN.RISK_SCORE_PREVIEW,
+    });
+    expect(mockOpenRightPanel).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_table.tsx
@@ -20,6 +20,9 @@ import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry/events/flyout_v2/types';
 
 type RiskScoreColumn = EuiBasicTableColumn<EntityRiskScoreRecord> & {
   field: keyof EntityRiskScoreRecord;
@@ -36,11 +39,25 @@ const EntityFlyoutLink = ({
   displayName: string;
   entityType: EntityType;
 }) => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openRightPanel } = useExpandableFlyoutApi();
+  const { openEntityFlyout } = useFlyoutApi();
   const panelKey = EntityPanelKeyByType[entityType];
   const paramName = EntityPanelParamByType[entityType];
 
   const onClick = useCallback(() => {
+    if (enableNewFlyout) {
+      openEntityFlyout({
+        engineType: entityType,
+        entityId,
+        entityName: displayName,
+        contextID: PREVIEW_TABLE_SCOPE_ID,
+        scopeId: PREVIEW_TABLE_SCOPE_ID,
+        origin: FLYOUT_ORIGIN.RISK_SCORE_PREVIEW,
+      });
+      return;
+    }
+
     if (panelKey && paramName) {
       openRightPanel({
         id: panelKey,
@@ -52,9 +69,18 @@ const EntityFlyoutLink = ({
         },
       });
     }
-  }, [openRightPanel, panelKey, paramName, displayName, entityId]);
+  }, [
+    displayName,
+    enableNewFlyout,
+    entityId,
+    entityType,
+    openEntityFlyout,
+    openRightPanel,
+    panelKey,
+    paramName,
+  ]);
 
-  if (!panelKey) {
+  if (!enableNewFlyout && !panelKey) {
     return <>{displayName}</>;
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.test.tsx
@@ -33,6 +33,16 @@ jest.mock('@kbn/expandable-flyout', () => ({
   }),
 }));
 
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: () => false,
+}));
+
+jest.mock('../../../../flyout_v2/use_flyout_api', () => ({
+  useFlyoutApi: () => ({
+    openEntityFlyout: jest.fn(),
+  }),
+}));
+
 const createMockObservation = (overrides: Partial<Observation> = {}): Observation => ({
   entityId: 'entity-1',
   moduleId: 'risk_analysis',

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/shared_lead_components.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/shared_lead_components.tsx
@@ -14,6 +14,9 @@ import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../../flyout/entity_details/shared/constants';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { getOpenEntityFlyoutLabel, VIEW_ENTITY_DETAILS } from './translations';
 import { getEntityIcon } from './utils';
 
@@ -44,7 +47,9 @@ interface EntityBadgeProps {
  * the Agent Builder chat).
  */
 export const EntityBadge: React.FC<EntityBadgeProps> = ({ entity, scopeId }) => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openEntityFlyout } = useFlyoutApi();
   const { euiTheme } = useEuiTheme();
 
   const badgeContent = (
@@ -86,10 +91,7 @@ export const EntityBadge: React.FC<EntityBadgeProps> = ({ entity, scopeId }) => 
     );
   }
 
-  const panelKey = EntityPanelKeyByType[entity.type];
-  const panelParam = EntityPanelParamByType[entity.type];
-
-  if (!panelKey || !panelParam) {
+  if (!enableNewFlyout && !EntityPanelKeyByType[entity.type]) {
     return (
       <EuiBadge color="hollow" css={entityBadgeContainerCss}>
         {badgeContent}
@@ -104,18 +106,27 @@ export const EntityBadge: React.FC<EntityBadgeProps> = ({ entity, scopeId }) => 
   // friendly name) — best-effort, but strictly better than a name-only match.
   const entityId = entity.id ?? `${entity.type}:${entity.name}`;
 
-  const openEntityFlyout = () => {
-    openFlyout({
-      right: {
-        id: panelKey,
-        params: {
-          [panelParam]: entity.name,
-          entityId,
-          contextID: scopeId,
-          scopeId,
-        },
-      },
-    });
+  const handleOpenEntityFlyout = () => {
+    const sharedParams = { entityId, contextID: scopeId, scopeId };
+
+    if (enableNewFlyout) {
+      openEntityFlyout({
+        engineType: entity.type,
+        entityName: entity.name,
+        origin: FLYOUT_ORIGIN.THREAT_HUNTING_LEADS,
+        ...sharedParams,
+      });
+      return;
+    }
+
+    const entityType = entity.type as EntityType;
+    const panelKey = EntityPanelKeyByType[entityType];
+    const paramName = EntityPanelParamByType[entityType];
+    if (panelKey && paramName) {
+      openFlyout({
+        right: { id: panelKey, params: { [paramName]: entity.name, ...sharedParams } },
+      });
+    }
   };
 
   // Rendered as a `span[role=button]` (rather than passing `onClick` to
@@ -150,13 +161,13 @@ export const EntityBadge: React.FC<EntityBadgeProps> = ({ entity, scopeId }) => 
         `}
         onClick={(e) => {
           e.stopPropagation();
-          openEntityFlyout();
+          handleOpenEntityFlyout();
         }}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             e.stopPropagation();
-            openEntityFlyout();
+            handleOpenEntityFlyout();
           }
         }}
       >

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/threat_hunting_leads_flyout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/threat_hunting_leads_flyout.test.tsx
@@ -29,6 +29,16 @@ jest.mock('@kbn/expandable-flyout', () => ({
   }),
 }));
 
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: () => false,
+}));
+
+jest.mock('../../../../flyout_v2/use_flyout_api', () => ({
+  useFlyoutApi: () => ({
+    openEntityFlyout: jest.fn(),
+  }),
+}));
+
 jest.mock('../../../../common/lib/kibana', () => ({
   useKibana: () => ({
     services: {},

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_name.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_name.tsx
@@ -6,10 +6,13 @@
  */
 
 import React, { useCallback } from 'react';
-
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+
 import { UserDetailsLink } from '../../common/components/links';
 import { getEmptyTagValue } from '../../common/components/empty_value';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../common/lib/telemetry';
+import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
 import { UserPanelKey } from '../../flyout/entity_details/shared/constants';
 
 interface Props {
@@ -19,24 +22,32 @@ interface Props {
 }
 
 const UserNameComponent: React.FC<Props> = ({ userName, scopeId, contextId }) => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openUserFlyout } = useFlyoutApi();
 
   const openUserDetailsSidePanel = useCallback(
     (e: React.SyntheticEvent) => {
       e.preventDefault();
 
+      if (enableNewFlyout) {
+        openUserFlyout({
+          userName: userName ?? '',
+          scopeId,
+          contextID: contextId,
+          origin: FLYOUT_ORIGIN.TABLE_FIELD_LINK,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: UserPanelKey,
-          params: {
-            userName,
-            contextID: contextId,
-            scopeId,
-          },
+          params: { userName: userName ?? undefined, contextID: contextId, scopeId },
         },
       });
     },
-    [contextId, openFlyout, scopeId, userName]
+    [contextId, enableNewFlyout, openFlyout, openUserFlyout, scopeId, userName]
   );
 
   if (!userName) {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_risk_score_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_risk_score_table/index.tsx
@@ -7,8 +7,11 @@
 
 import React, { useMemo, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EuiFilterGroup, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import { UserPanelKey } from '../../../flyout/entity_details/shared/constants';
 import type {
   Columns,
@@ -83,7 +86,9 @@ const UserRiskScoreTableComponent: React.FC<UserRiskScoreTableProps> = ({
   type,
 }) => {
   const dispatch = useDispatch();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openUserFlyout } = useFlyoutApi();
 
   const getUserRiskScoreSelector = useMemo(() => usersSelectors.userRiskScoreSelector(), []);
   const { activePage, limit, sort } = useDeepEqualSelector((state: State) =>
@@ -142,26 +147,31 @@ const UserRiskScoreTableComponent: React.FC<UserRiskScoreTableProps> = ({
     [dispatch]
   );
 
-  const openUserFlyout = useCallback(
+  const openUserDetails = useCallback(
     (userName: string) => {
+      if (enableNewFlyout) {
+        openUserFlyout({
+          userName,
+          contextID: tableType,
+          scopeId: tableType,
+          origin: FLYOUT_ORIGIN.USER_RISK_TABLE,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: UserPanelKey,
-          params: {
-            userName,
-            contextID: tableType,
-            scopeId: tableType,
-            isPreviewMode: false,
-          },
+          params: { userName, contextID: tableType, scopeId: tableType },
         },
       });
     },
-    [openFlyout]
+    [enableNewFlyout, openFlyout, openUserFlyout]
   );
 
   const columns = useMemo(
-    () => getUserRiskScoreColumns({ dispatchSeverityUpdate, openUserFlyout }),
-    [dispatchSeverityUpdate, openUserFlyout]
+    () => getUserRiskScoreColumns({ dispatchSeverityUpdate, openUserFlyout: openUserDetails }),
+    [dispatchSeverityUpdate, openUserDetails]
   );
 
   const risk = (

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_host_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_host_table.tsx
@@ -10,6 +10,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { getOr } from 'lodash/fp';
 import { useDispatch } from 'react-redux';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import { UserPanelKey, HostPanelKey } from '../../../flyout/entity_details/shared/constants';
 import type { SiemTables } from '../paginated_table';
 import { PaginatedTable } from '../paginated_table';
@@ -43,40 +46,52 @@ const AuthenticationsHostTableComponent: React.FC<HostsComponentsQueryProps> = (
   deleteQuery,
 }) => {
   const dispatch = useDispatch();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openUserFlyout, openHostFlyout } = useFlyoutApi();
 
-  const openUserFlyout = useCallback(
+  const openUserDetails = useCallback(
     (userName: string) => {
+      if (enableNewFlyout) {
+        openUserFlyout({
+          userName,
+          contextID: 'authentications',
+          scopeId: 'authentications',
+          origin: FLYOUT_ORIGIN.AUTHENTICATIONS_TABLE,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: UserPanelKey,
-          params: {
-            userName,
-            contextID: 'authentications',
-            scopeId: 'authentications',
-            isPreviewMode: false,
-          },
+          params: { userName, contextID: 'authentications', scopeId: 'authentications' },
         },
       });
     },
-    [openFlyout]
+    [enableNewFlyout, openFlyout, openUserFlyout]
   );
 
-  const openHostFlyout = useCallback(
+  const openHostDetails = useCallback(
     (hostName: string) => {
+      if (enableNewFlyout) {
+        openHostFlyout({
+          hostName,
+          contextID: 'authentications',
+          scopeId: 'authentications',
+          origin: FLYOUT_ORIGIN.AUTHENTICATIONS_TABLE,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: HostPanelKey,
-          params: {
-            hostName,
-            contextID: 'authentications',
-            scopeId: 'authentications',
-            isPreviewMode: false,
-          },
+          params: { hostName, contextID: 'authentications', scopeId: 'authentications' },
         },
       });
     },
-    [openFlyout]
+    [enableNewFlyout, openFlyout, openHostFlyout]
   );
   const { toggleStatus } = useQueryToggle(TABLE_QUERY_ID);
   const [querySkip, setQuerySkip] = useState(skip || !toggleStatus);
@@ -105,8 +120,8 @@ const AuthenticationsHostTableComponent: React.FC<HostsComponentsQueryProps> = (
 
   const columns =
     type === hostsModel.HostsType.details
-      ? getHostDetailsAuthenticationColumns(openUserFlyout)
-      : getHostsPageAuthenticationColumns(openUserFlyout, openHostFlyout);
+      ? getHostDetailsAuthenticationColumns(openUserDetails)
+      : getHostsPageAuthenticationColumns(openUserDetails, openHostDetails);
 
   const updateLimitPagination = useCallback<SiemTables['updateLimitPagination']>(
     (newLimit) =>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_user_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_user_table.tsx
@@ -10,6 +10,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { getOr } from 'lodash/fp';
 import { useDispatch } from 'react-redux';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import { UserPanelKey, HostPanelKey } from '../../../flyout/entity_details/shared/constants';
 import { AuthStackByField } from '../../../../common/search_strategy/security_solution/users/authentications';
 import type { SiemTables } from '../paginated_table';
@@ -42,40 +45,52 @@ const AuthenticationsUserTableComponent: React.FC<AuthenticationsUserTableProps>
   userName,
 }) => {
   const dispatch = useDispatch();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openUserFlyout, openHostFlyout } = useFlyoutApi();
 
-  const openUserFlyout = useCallback(
+  const openUserDetails = useCallback(
     (name: string) => {
+      if (enableNewFlyout) {
+        openUserFlyout({
+          userName: name,
+          contextID: 'authentications',
+          scopeId: 'authentications',
+          origin: FLYOUT_ORIGIN.AUTHENTICATIONS_TABLE,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: UserPanelKey,
-          params: {
-            userName: name,
-            contextID: 'authentications',
-            scopeId: 'authentications',
-            isPreviewMode: false,
-          },
+          params: { userName: name, contextID: 'authentications', scopeId: 'authentications' },
         },
       });
     },
-    [openFlyout]
+    [enableNewFlyout, openFlyout, openUserFlyout]
   );
 
-  const openHostFlyout = useCallback(
+  const openHostDetails = useCallback(
     (hostName: string) => {
+      if (enableNewFlyout) {
+        openHostFlyout({
+          hostName,
+          contextID: 'authentications',
+          scopeId: 'authentications',
+          origin: FLYOUT_ORIGIN.AUTHENTICATIONS_TABLE,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: HostPanelKey,
-          params: {
-            hostName,
-            contextID: 'authentications',
-            scopeId: 'authentications',
-            isPreviewMode: false,
-          },
+          params: { hostName, contextID: 'authentications', scopeId: 'authentications' },
         },
       });
     },
-    [openFlyout]
+    [enableNewFlyout, openFlyout, openHostFlyout]
   );
   const { toggleStatus } = useQueryToggle(TABLE_QUERY_ID);
   const [querySkip, setQuerySkip] = useState(skip || !toggleStatus);
@@ -103,9 +118,9 @@ const AuthenticationsUserTableComponent: React.FC<AuthenticationsUserTableProps>
   const columns = useMemo(
     () =>
       userName
-        ? getUserDetailsAuthenticationColumns(openHostFlyout)
-        : getUsersPageAuthenticationColumns(openUserFlyout, openHostFlyout),
-    [userName, openUserFlyout, openHostFlyout]
+        ? getUserDetailsAuthenticationColumns(openHostDetails)
+        : getUsersPageAuthenticationColumns(openUserDetails, openHostDetails),
+    [userName, openUserDetails, openHostDetails]
   );
 
   const updateLimitPagination = useCallback<SiemTables['updateLimitPagination']>(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/hosts_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/hosts_table/index.test.tsx
@@ -11,9 +11,9 @@ import { screen, render, fireEvent, waitFor } from '@testing-library/react';
 import { TestProviders, createMockStore } from '../../../../common/mock';
 import { hostsModel } from '../../store';
 import { HostsTableType } from '../../store/model';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
 import { HostsTable } from '.';
 import { mockData } from './mock';
-import { HostPanelKey } from '../../../../flyout/entity_details/shared/constants';
 
 jest.mock('../../../../common/lib/kibana');
 
@@ -45,9 +45,21 @@ jest.mock('../../../../helper_hooks', () => ({
   useHasSecurityCapability: () => mockUseHasSecurityCapability(),
 }));
 
+const mockOpenHostFlyout = jest.fn();
 const mockOpenFlyout = jest.fn();
 jest.mock('@kbn/expandable-flyout', () => ({
-  useExpandableFlyoutApi: jest.fn(() => ({ openFlyout: mockOpenFlyout })),
+  useExpandableFlyoutApi: () => ({ openFlyout: mockOpenFlyout, closeFlyout: jest.fn() }),
+}));
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: () => true,
+}));
+jest.mock('../../../../flyout_v2/use_flyout_api', () => ({
+  useFlyoutApi: () => ({
+    openHostFlyout: mockOpenHostFlyout,
+    openUserFlyout: jest.fn(),
+    openServiceFlyout: jest.fn(),
+    openGenericEntityFlyout: jest.fn(),
+  }),
 }));
 
 const mockUseUiSetting = jest.fn().mockReturnValue([false]);
@@ -65,6 +77,7 @@ describe('Hosts Table', () => {
   const store = createMockStore();
 
   beforeEach(() => {
+    mockOpenHostFlyout.mockClear();
     mockOpenFlyout.mockClear();
   });
 
@@ -220,17 +233,12 @@ describe('Hosts Table', () => {
 
       fireEvent.click(screen.getByTestId('host-details-button'));
 
-      expect(mockOpenFlyout).toHaveBeenCalledWith({
-        right: {
-          id: HostPanelKey,
-          params: {
-            hostName,
-            entityId,
-            contextID: 'allHosts',
-            scopeId: 'allHosts',
-            isPreviewMode: false,
-          },
-        },
+      expect(mockOpenHostFlyout).toHaveBeenCalledWith({
+        hostName,
+        entityId,
+        contextID: 'allHosts',
+        scopeId: 'allHosts',
+        origin: FLYOUT_ORIGIN.HOSTS_TABLE,
       });
     });
 
@@ -254,6 +262,7 @@ describe('Hosts Table', () => {
 
       fireEvent.click(screen.getByTestId('host-details-button'));
 
+      expect(mockOpenHostFlyout).not.toHaveBeenCalled();
       expect(mockOpenFlyout).not.toHaveBeenCalled();
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/hosts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/hosts_table/index.tsx
@@ -35,6 +35,9 @@ import { HostsTableType } from '../../store/model';
 import { useNavigateTo } from '../../../../common/lib/kibana/hooks';
 import { useMlCapabilities } from '../../../../common/components/ml/hooks/use_ml_capabilities';
 import { useHasSecurityCapability } from '../../../../helper_hooks';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { HostPanelKey } from '../../../../flyout/entity_details/shared/constants';
 
 const tableType = hostsModel.HostsTableType.hosts;
@@ -90,7 +93,9 @@ const HostsTableComponent: React.FC<HostsTableProps> = ({
 }) => {
   const dispatch = useDispatch();
   const { navigateTo } = useNavigateTo();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openHostFlyout } = useFlyoutApi();
   const getHostsSelector = useMemo(() => hostsSelectors.hostsSelector(), []);
   const { activePage, direction, limit, sortField } = useDeepEqualSelector((state) =>
     getHostsSelector(state, type)
@@ -143,22 +148,27 @@ const HostsTableComponent: React.FC<HostsTableProps> = ({
   const hasEntityAnalyticsCapability = useHasSecurityCapability('entity-analytics');
   const isPlatinumOrTrialLicense = useMlCapabilities().isPlatinumOrTrialLicense;
 
-  const openHostFlyout = useCallback(
+  const openHostDetails = useCallback(
     (hostName: string, entityId: string) => {
+      if (enableNewFlyout) {
+        openHostFlyout({
+          hostName,
+          entityId,
+          contextID: tableType,
+          scopeId: tableType,
+          origin: FLYOUT_ORIGIN.HOSTS_TABLE,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: HostPanelKey,
-          params: {
-            hostName,
-            entityId,
-            contextID: tableType,
-            scopeId: tableType,
-            isPreviewMode: false,
-          },
+          params: { hostName, entityId, contextID: tableType, scopeId: tableType },
         },
       });
     },
-    [openFlyout]
+    [enableNewFlyout, openFlyout, openHostFlyout]
   );
 
   const dispatchSeverityUpdate = useCallback(
@@ -182,9 +192,14 @@ const HostsTableComponent: React.FC<HostsTableProps> = ({
       getHostsColumns(
         isPlatinumOrTrialLicense && hasEntityAnalyticsCapability,
         dispatchSeverityUpdate,
-        openHostFlyout
+        openHostDetails
       ),
-    [dispatchSeverityUpdate, isPlatinumOrTrialLicense, hasEntityAnalyticsCapability, openHostFlyout]
+    [
+      dispatchSeverityUpdate,
+      isPlatinumOrTrialLicense,
+      hasEntityAnalyticsCapability,
+      openHostDetails,
+    ]
   );
   const sorting = useMemo(() => getSorting(sortField, direction), [sortField, direction]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/uncommon_process_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/uncommon_process_table/index.tsx
@@ -7,8 +7,8 @@
 
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { HostsUncommonProcessesEdges } from '../../../../../common/search_strategy';
 import { hostsActions, hostsModel, hostsSelectors } from '../../store';
 import type { ItemsPerRow } from '../../../components/paginated_table';
@@ -16,6 +16,9 @@ import { PaginatedTable } from '../../../components/paginated_table';
 import * as i18n from './translations';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { getUncommonColumnsCurated } from './columns';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { HostPanelKey } from '../../../../flyout/entity_details/shared/constants';
 
 const tableType = hostsModel.HostsTableType.uncommonProcesses;
@@ -65,23 +68,30 @@ const UncommonProcessTableComponent = React.memo<UncommonProcessTableProps>(
       getUncommonProcessesSelector(state, type)
     );
 
+    const enableNewFlyout = useIsNewFlyoutEnabled();
     const { openFlyout } = useExpandableFlyoutApi();
+    const { openHostFlyout } = useFlyoutApi();
 
-    const openHostFlyout = useCallback(
+    const openHostDetails = useCallback(
       (hostName: string) => {
+        if (enableNewFlyout) {
+          openHostFlyout({
+            hostName,
+            contextID: tableType,
+            scopeId: tableType,
+            origin: FLYOUT_ORIGIN.UNCOMMON_PROCESSES_TABLE,
+          });
+          return;
+        }
+
         openFlyout({
           right: {
             id: HostPanelKey,
-            params: {
-              hostName,
-              contextID: tableType,
-              scopeId: tableType,
-              isPreviewMode: false,
-            },
+            params: { hostName, contextID: tableType, scopeId: tableType },
           },
         });
       },
-      [openFlyout]
+      [enableNewFlyout, openFlyout, openHostFlyout]
     );
 
     const updateLimitPagination = useCallback(
@@ -109,8 +119,8 @@ const UncommonProcessTableComponent = React.memo<UncommonProcessTableProps>(
     );
 
     const columns = useMemo(
-      () => getUncommonColumnsCurated(type, openHostFlyout),
-      [type, openHostFlyout]
+      () => getUncommonColumnsCurated(type, openHostDetails),
+      [type, openHostDetails]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/all_users/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/all_users/index.test.tsx
@@ -14,7 +14,7 @@ import { usersModel } from '../../store';
 import { Direction, RiskSeverity } from '../../../../../common/search_strategy';
 import { UsersFields } from '../../../../../common/search_strategy/security_solution/users/common';
 import { fireEvent, render } from '@testing-library/react';
-import { UserPanelKey } from '../../../../flyout/entity_details/shared/constants';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
 
 const mockUseMlCapabilities = jest.fn().mockReturnValue({ isPlatinumOrTrialLicense: false });
 
@@ -22,16 +22,29 @@ jest.mock('../../../../common/components/ml/hooks/use_ml_capabilities', () => ({
   useMlCapabilities: () => mockUseMlCapabilities(),
 }));
 
+const mockOpenUserFlyout = jest.fn();
 const mockOpenFlyout = jest.fn();
 
 jest.mock('@kbn/expandable-flyout', () => ({
-  useExpandableFlyoutApi: jest.fn(() => ({ openFlyout: mockOpenFlyout })),
+  useExpandableFlyoutApi: () => ({ openFlyout: mockOpenFlyout, closeFlyout: jest.fn() }),
+}));
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: () => true,
+}));
+jest.mock('../../../../flyout_v2/use_flyout_api', () => ({
+  useFlyoutApi: () => ({
+    openUserFlyout: mockOpenUserFlyout,
+    openHostFlyout: jest.fn(),
+    openServiceFlyout: jest.fn(),
+    openGenericEntityFlyout: jest.fn(),
+  }),
 }));
 
 describe('Users Table Component', () => {
   const loadPage = jest.fn();
 
   beforeEach(() => {
+    mockOpenUserFlyout.mockClear();
     mockOpenFlyout.mockClear();
   });
 
@@ -190,17 +203,12 @@ describe('Users Table Component', () => {
 
       fireEvent.click(getByTestId('users-link-anchor'));
 
-      expect(mockOpenFlyout).toHaveBeenCalledWith({
-        right: {
-          id: UserPanelKey,
-          params: {
-            userName,
-            entityId,
-            contextID: 'allUsers',
-            scopeId: 'allUsers',
-            isPreviewMode: false,
-          },
-        },
+      expect(mockOpenUserFlyout).toHaveBeenCalledWith({
+        userName,
+        entityId,
+        contextID: 'allUsers',
+        scopeId: 'allUsers',
+        origin: FLYOUT_ORIGIN.USERS_TABLE,
       });
     });
 
@@ -233,6 +241,7 @@ describe('Users Table Component', () => {
 
       fireEvent.click(getByTestId('users-link-anchor'));
 
+      expect(mockOpenUserFlyout).not.toHaveBeenCalled();
       expect(mockOpenFlyout).not.toHaveBeenCalled();
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/all_users/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/all_users/index.tsx
@@ -10,8 +10,8 @@ import type { SyntheticEvent } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { EuiLink, EuiText } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { AssetCriticalityBadge } from '../../../../entity_analytics/components/asset_criticality';
 import type { CriticalityLevelWithUnassigned } from '../../../../../common/entity_analytics/asset_criticality/types';
 import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
@@ -44,6 +44,9 @@ import { VIEW_USERS_BY_SEVERITY } from '../../../../entity_analytics/components/
 import { SecurityPageName } from '../../../../app/types';
 import { UsersTableType } from '../../store/model';
 import { useNavigateTo } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { UserPanelKey } from '../../../../flyout/entity_details/shared/constants';
 
 const tableType = usersModel.UsersTableType.allUsers;
@@ -209,24 +212,31 @@ const UsersTableComponent: React.FC<UsersTableProps> = ({
   const { activePage, limit } = useDeepEqualSelector((state) => getUsersSelector(state));
   const isPlatinumOrTrialLicense = useMlCapabilities().isPlatinumOrTrialLicense;
   const { navigateTo } = useNavigateTo();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openUserFlyout } = useFlyoutApi();
 
-  const openUserFlyout = useCallback(
+  const openUserDetails = useCallback(
     (userName: string, entityId: string) => {
+      if (enableNewFlyout) {
+        openUserFlyout({
+          userName,
+          entityId,
+          contextID: tableType,
+          scopeId: tableType,
+          origin: FLYOUT_ORIGIN.USERS_TABLE,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: UserPanelKey,
-          params: {
-            userName,
-            entityId,
-            contextID: tableType,
-            scopeId: tableType,
-            isPreviewMode: false,
-          },
+          params: { userName, entityId, contextID: tableType, scopeId: tableType },
         },
       });
     },
-    [openFlyout]
+    [enableNewFlyout, openFlyout, openUserFlyout]
   );
 
   const updateLimitPagination = useCallback<SiemTables['updateLimitPagination']>(
@@ -288,8 +298,8 @@ const UsersTableComponent: React.FC<UsersTableProps> = ({
   );
 
   const columns = useMemo(
-    () => getUsersColumns(isPlatinumOrTrialLicense, dispatchSeverityUpdate, openUserFlyout),
-    [isPlatinumOrTrialLicense, dispatchSeverityUpdate, openUserFlyout]
+    () => getUsersColumns(isPlatinumOrTrialLicense, dispatchSeverityUpdate, openUserDetails),
+    [isPlatinumOrTrialLicense, dispatchSeverityUpdate, openUserDetails]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/content.tsx
@@ -57,6 +57,11 @@ interface GenericEntityFlyoutContentProps {
    * in the EUI system flyout). Legacy callers omit this and keep the default.
    */
   flyoutBodyProps?: Omit<React.ComponentProps<typeof FlyoutBody>, 'children'>;
+  /**
+   * When true, hides the "open in tool" header icons on the section panels. Used by the new EUI
+   * system flyout, where sections are opened via {@link openGenericEntityDetailsPanelByPath}.
+   */
+  hideHeaderIcons?: boolean;
 }
 
 export const GenericEntityFlyoutContent = ({
@@ -65,6 +70,7 @@ export const GenericEntityFlyoutContent = ({
   identityFields,
   onAssetCriticalityChange,
   flyoutBodyProps,
+  hideHeaderIcons = false,
 }: GenericEntityFlyoutContentProps) => {
   const { euiTheme } = useEuiTheme();
   const entityDisplayValue = Object.values(identityFields)[0] ?? '';
@@ -116,6 +122,7 @@ export const GenericEntityFlyoutContent = ({
         isPreviewMode={false}
         openDetailsPanel={openGenericEntityDetailsPanelByPath}
         entityType={EntityType.generic}
+        hideHeaderIcons={hideHeaderIcons}
       />
       <ExpandableSection
         title={

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
@@ -55,6 +55,11 @@ interface ServicePanelContentProps {
    * their `useQueryInspector` registration
    */
   riskScoreQueryId: string;
+  /**
+   * When true, hides the "open in tool" header icons on the section panels. Used by the new EUI
+   * system flyout, where sections are opened via {@link openDetailsPanel} instead.
+   */
+  hideHeaderIcons?: boolean;
 }
 
 export const ServicePanelContent = ({
@@ -74,6 +79,7 @@ export const ServicePanelContent = ({
   prefetchedResolutionRisk,
   onShowEntity,
   riskScoreQueryId,
+  hideHeaderIcons = false,
 }: ServicePanelContentProps) => {
   const observedFields = useObservedServiceItems(observedService);
   const hasEntityResolutionLicense = useHasEntityResolutionLicense();
@@ -98,6 +104,7 @@ export const ServicePanelContent = ({
             entityType={EntityType.service}
             entityId={entityRecord?.entity?.id}
             prefetchedResolutionRisk={prefetchedResolutionRisk}
+            hideHeaderIcon={hideHeaderIcons}
           />
           <EuiHorizontalRule />
         </>
@@ -109,6 +116,7 @@ export const ServicePanelContent = ({
             isPreviewMode={isPreviewMode}
             scopeId={scopeId}
             openDetailsPanel={openDetailsPanel}
+            hideHeaderIcons={hideHeaderIcons}
           />
           <EuiHorizontalRule margin="m" />
         </>
@@ -121,6 +129,7 @@ export const ServicePanelContent = ({
             scopeId={scopeId}
             openDetailsPanel={openDetailsPanel}
             onShowEntity={onShowEntity}
+            hideHeaderIcons={hideHeaderIcons}
           />
           <EuiHorizontalRule />
         </>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/prevalence/components/prevalence_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/prevalence/components/prevalence_details_view.tsx
@@ -168,6 +168,7 @@ export const PrevalenceDetailsView: React.FC<PrevalenceDetailsViewProps> = ({
         canUseTimeline,
         documentHostEntityIdentifiers,
         documentUserEntityIdentifiers,
+        documentHit: hit,
       })),
     [
       data,
@@ -178,6 +179,7 @@ export const PrevalenceDetailsView: React.FC<PrevalenceDetailsViewProps> = ({
       scopeId,
       documentHostEntityIdentifiers,
       documentUserEntityIdentifiers,
+      hit,
     ]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/prevalence/utils/get_columns.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/prevalence/utils/get_columns.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils';
 import { TestProviders } from '../../../../../common/mock';
 import type { CellActionRenderer } from '../../../../shared/components/cell_actions';
 import {
@@ -44,13 +45,15 @@ jest.mock('../../../../../common/components/event_details/use_action_cell_data_p
 const MockChildLink = ({
   field,
   value,
+  hit,
   children,
 }: {
   field: string;
   value: string;
+  hit?: DataTableRecord;
   children?: React.ReactNode;
 }) => (
-  <div data-test-subj="mockChildLink" data-field={field} data-value={value}>
+  <div data-test-subj="mockChildLink" data-field={field} data-value={value} data-hit-id={hit?.id}>
     {children}
   </div>
 );
@@ -339,13 +342,19 @@ describe('getColumns', () => {
         MockChildLink
       );
       const valueColumn = columns[1];
-      const row = { ...defaultRow, field: 'source.ip', values: ['10.0.0.1'] };
+      const row = {
+        ...defaultRow,
+        field: 'source.ip',
+        values: ['10.0.0.1'],
+        documentHit: { id: 'document-1' } as DataTableRecord,
+      };
 
       renderComponent(callRender(valueColumn, row));
 
       const previewLink = screen.getByTestId('mockChildLink');
       expect(previewLink).toHaveAttribute('data-field', 'source.ip');
       expect(previewLink).toHaveAttribute('data-value', '10.0.0.1');
+      expect(previewLink).toHaveAttribute('data-hit-id', 'document-1');
     });
 
     it('renders plain text without ChildLink when RenderChildLink is not provided', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/prevalence/utils/get_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/prevalence/utils/get_columns.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { IS_OPERATOR } from '@kbn/timelines-plugin/common';
 import type { IdentityFields } from '../../../../../flyout/document_details/shared/utils';
@@ -75,6 +76,10 @@ export interface PrevalenceDetailsRow extends PrevalenceData {
    * User entity identifiers from the current document (for EUID / entity store).
    */
   documentUserEntityIdentifiers?: IdentityFields | null;
+  /**
+   * Source document used to resolve host/user identity in v2 entity flyouts.
+   */
+  documentHit?: DataTableRecord;
 }
 
 export const fieldColumn: EuiBasicTableColumn<PrevalenceDetailsRow> = {
@@ -335,7 +340,7 @@ export const getColumns = (
         const text = <EuiText size="xs">{value}</EuiText>;
         if (RenderFlyoutLink) {
           return (
-            <RenderFlyoutLink field={data.field} value={value}>
+            <RenderFlyoutLink field={data.field} value={value} hit={data.documentHit}>
               {text}
             </RenderFlyoutLink>
           );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/generic/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/generic/main/index.tsx
@@ -219,6 +219,7 @@ export const GenericEntity: FC<GenericEntityProps> = memo(function GenericEntity
         identityFields={identityFields}
         onAssetCriticalityChange={calculateEntityRiskScore}
         flyoutBodyProps={{ panelProps: { paddingSize: 'none' } }}
+        hideHeaderIcons
       />
       <GenericEntityFlyoutFooter
         scopeId={scopeId}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
@@ -277,7 +277,6 @@ export const Host: FC<HostProps> = memo(function Host({
         entityId: params.entityId,
         entityName: params.entityName,
         scopeId,
-        title: params.entityName ?? params.entityId,
         origin,
       }),
     [openEntityDetailsAsChild, scopeId]

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
@@ -178,7 +178,6 @@ export const Service: FC<ServiceProps> = memo(function Service({
         entityId: params.entityId,
         entityName: params.entityName,
         scopeId,
-        title: params.entityName ?? params.entityId,
         origin,
       }),
     [openEntityDetailsAsChild, scopeId]
@@ -316,6 +315,7 @@ export const Service: FC<ServiceProps> = memo(function Service({
             entityStoreEntityId={entityStoreEntityId}
             onShowEntity={onShowRelatedEntityFromResolution}
             riskScoreQueryId={SERVICE_PANEL_RISK_SCORE_QUERY_ID}
+            hideHeaderIcons
           />
         )}
       </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.mock.ts
@@ -21,6 +21,7 @@ export const createEntityFlyoutApiMock = (): jest.Mocked<EntityFlyoutApi> => ({
   openServiceFlyoutAsChild: jest.fn(),
   openGenericEntityFlyout: jest.fn(),
   openGenericEntityFlyoutAsChild: jest.fn(),
+  openEntityFlyout: jest.fn(),
   openEntityDetailsAsChild: jest.fn(),
   openEntityRiskInputs: jest.fn(),
   openEntityAnomalyInsights: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.test.tsx
@@ -15,6 +15,13 @@ import { flyoutProviders } from '../shared/components/flyout_provider';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
 import { FLYOUT_DESCRIPTOR_KIND } from '../shared/url_state/flyout_v2_url_param';
+import {
+  FlyoutV2EventTypes,
+  FLYOUT_ORIGIN,
+  FLYOUT_SESSION_KIND,
+  FLYOUT_SURFACE,
+  FLYOUT_TYPE,
+} from '../../common/lib/telemetry';
 
 jest.mock('../shared/utils/build_flyout_nav_title', () => ({
   buildFlyoutNavTitle: jest.fn((title: string) => `NAV:${title}`),
@@ -215,6 +222,25 @@ describe('useEntityFlyoutApi', () => {
     expect(mockBuildOnClose).toHaveBeenCalledWith(null);
   });
 
+  it('openEntityFlyout reports the caller-provided origin', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityFlyout({
+      engineType: 'host',
+      entityId: 'entity-1',
+      entityName: 'host-1',
+      scopeId: 'scope-1',
+      origin: FLYOUT_ORIGIN.ENTITIES_TABLE,
+    });
+
+    expect(mockReportEvent).toHaveBeenCalledWith(FlyoutV2EventTypes.FlyoutOpened, {
+      surface: FLYOUT_SURFACE.FLYOUT,
+      flyoutType: FLYOUT_TYPE.HOST,
+      tool: undefined,
+      session: FLYOUT_SESSION_KIND.START,
+      origin: FLYOUT_ORIGIN.ENTITIES_TABLE,
+    });
+  });
+
   it('openEntityDetailsAsChild opens the matching entity flyout that inherits the current session', () => {
     const { result } = renderHook(() => useEntityFlyoutApi());
     result.current.openEntityDetailsAsChild({
@@ -230,7 +256,7 @@ describe('useEntityFlyoutApi', () => {
     );
   });
 
-  it('openEntityDetailsAsChild composes the nav title from the entity name', () => {
+  it('openEntityDetailsAsChild composes a type-specific nav title from the entity name', () => {
     const { result } = renderHook(() => useEntityFlyoutApi());
     result.current.openEntityDetailsAsChild({
       engineType: 'host',
@@ -239,8 +265,8 @@ describe('useEntityFlyoutApi', () => {
       scopeId: 'scopeId',
     });
 
-    expect(buildFlyoutNavTitle).toHaveBeenCalledWith('host-1');
-    expect(mockOpenSystemFlyout.mock.calls[0][1].title).toBe('NAV:host-1');
+    expect(buildFlyoutNavTitle).toHaveBeenCalledWith('Host: host-1');
+    expect(mockOpenSystemFlyout.mock.calls[0][1].title).toBe('NAV:Host: host-1');
   });
 
   it('openEntityDetailsAsChild falls back to entityId when entityName is absent', () => {
@@ -252,7 +278,23 @@ describe('useEntityFlyoutApi', () => {
       scopeId: 'scopeId',
     });
 
-    expect(buildFlyoutNavTitle).toHaveBeenCalledWith('entity-1');
+    expect(buildFlyoutNavTitle).toHaveBeenCalledWith('Host: entity-1');
+  });
+
+  it.each([
+    ['user', 'User: name-1'],
+    ['service', 'Service: name-1'],
+    ['unknown', 'Entity'],
+  ] as const)('openEntityDetailsAsChild formats the %s nav title', (engineType, expectedTitle) => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityDetailsAsChild({
+      engineType,
+      entityId: 'entity-1',
+      entityName: 'name-1',
+      scopeId: 'scopeId',
+    });
+
+    expect(buildFlyoutNavTitle).toHaveBeenCalledWith(expectedTitle);
   });
 
   it.each([
@@ -272,7 +314,7 @@ describe('useEntityFlyoutApi', () => {
       });
 
       expect(mockWriteOnOpen).toHaveBeenCalledWith(
-        expect.objectContaining({ kind: expectedKind }),
+        expect.objectContaining({ kind: expectedKind, scopeId: 'scope-1' }),
         'inherit'
       );
       expect(mockBuildOnClose).toHaveBeenCalledWith(null);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
@@ -127,6 +127,8 @@ export interface OpenEntityDetailsParams extends WithTitle {
   entityName: string | undefined;
   /** Scope id for downstream containers and queries. */
   scopeId: string;
+  /** Optional context ID forwarded to cell-action filters inside the flyout. */
+  contextID?: string;
 }
 
 // Entity tool flyouts — each reuses the tool component's own props, plus an optional title.
@@ -165,6 +167,11 @@ export interface EntityFlyoutApi {
   openGenericEntityFlyout: (params: OpenGenericEntityFlyoutParams) => void;
   /** Opens the generic entity details flyout as a child of the currently open flyout. */
   openGenericEntityFlyoutAsChild: (params: OpenGenericEntityFlyoutParams) => void;
+  /**
+   * Opens the matching entity details flyout (host/user/service/generic, by `engineType`) as a
+   * new, top-level flyout. Use when navigating to an entity from a table or list.
+   */
+  openEntityFlyout: (params: OpenEntityDetailsParams) => void;
   /**
    * Opens the matching entity details flyout (host/user/service/generic, by `engineType`) as a
    * child of the currently open flyout. Use for related-entity navigation (graph, resolution).
@@ -468,37 +475,177 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
     [open, mainProperties, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
 
-  const openEntityDetailsAsChild = useCallback(
-    ({ engineType, entityId, entityName, scopeId, title, origin }: OpenEntityDetailsParams) => {
+  const openEntityFlyout = useCallback(
+    ({
+      engineType,
+      entityId,
+      entityName,
+      scopeId,
+      contextID,
+      title,
+      origin,
+    }: OpenEntityDetailsParams) => {
       let children: ReactNode;
       let descriptor: FlyoutDescriptor;
       switch (engineType) {
         case 'host':
-          children = <Host hostName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />;
-          descriptor = { kind: FLYOUT_DESCRIPTOR_KIND.host, hostName: entityName ?? '', entityId };
+          children = (
+            <Host
+              hostName={entityName ?? ''}
+              entityId={entityId}
+              scopeId={scopeId}
+              contextID={contextID}
+            />
+          );
+          descriptor = {
+            kind: FLYOUT_DESCRIPTOR_KIND.host,
+            hostName: entityName ?? '',
+            entityId,
+            scopeId,
+          };
           break;
         case 'user':
-          children = <User userName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />;
-          descriptor = { kind: FLYOUT_DESCRIPTOR_KIND.user, userName: entityName ?? '', entityId };
+          children = (
+            <User
+              userName={entityName ?? ''}
+              entityId={entityId}
+              scopeId={scopeId}
+              contextID={contextID}
+            />
+          );
+          descriptor = {
+            kind: FLYOUT_DESCRIPTOR_KIND.user,
+            userName: entityName ?? '',
+            entityId,
+            scopeId,
+          };
           break;
         case 'service':
           children = (
-            <Service serviceName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />
+            <Service
+              serviceName={entityName ?? ''}
+              entityId={entityId}
+              scopeId={scopeId}
+              contextID={contextID}
+            />
           );
           descriptor = {
             kind: FLYOUT_DESCRIPTOR_KIND.service,
             serviceName: entityName ?? '',
             entityId,
+            scopeId,
           };
           break;
         default:
-          children = <GenericEntity entityId={entityId} scopeId={scopeId} />;
+          children = <GenericEntity entityId={entityId} scopeId={scopeId} contextID={contextID} />;
+          descriptor = { kind: FLYOUT_DESCRIPTOR_KIND.genericEntity, entityId, scopeId };
+      }
+      const flyoutTitle =
+        title ??
+        (engineType === 'host'
+          ? formatFlyoutTitle(HOST_TITLE, entityName)
+          : engineType === 'user'
+          ? formatFlyoutTitle(USER_TITLE, entityName)
+          : engineType === 'service'
+          ? formatFlyoutTitle(SERVICE_TITLE, entityName)
+          : GENERIC_ENTITY_TITLE);
+      writeOnOpen(descriptor);
+      const onClose = buildOnClose(null);
+      open(
+        children,
+        { ...mainProperties(undefined, flyoutTitle), onClose },
+        {
+          surface: FLYOUT_SURFACE.FLYOUT,
+          flyoutType:
+            engineType === 'host' || engineType === 'user' || engineType === 'service'
+              ? (engineType as FlyoutType)
+              : FLYOUT_TYPE.GENERIC,
+          session: sessionMode,
+          origin,
+        }
+      );
+    },
+    [open, mainProperties, sessionMode, writeOnOpen, buildOnClose]
+  );
+
+  const openEntityDetailsAsChild = useCallback(
+    ({
+      engineType,
+      entityId,
+      entityName,
+      scopeId,
+      contextID,
+      title,
+      origin,
+    }: OpenEntityDetailsParams) => {
+      let children: ReactNode;
+      let descriptor: FlyoutDescriptor;
+      switch (engineType) {
+        case 'host':
+          children = (
+            <Host
+              hostName={entityName ?? ''}
+              entityId={entityId}
+              scopeId={scopeId}
+              contextID={contextID}
+            />
+          );
+          descriptor = {
+            kind: FLYOUT_DESCRIPTOR_KIND.host,
+            hostName: entityName ?? '',
+            entityId,
+            scopeId,
+          };
+          break;
+        case 'user':
+          children = (
+            <User
+              userName={entityName ?? ''}
+              entityId={entityId}
+              scopeId={scopeId}
+              contextID={contextID}
+            />
+          );
+          descriptor = {
+            kind: FLYOUT_DESCRIPTOR_KIND.user,
+            userName: entityName ?? '',
+            entityId,
+            scopeId,
+          };
+          break;
+        case 'service':
+          children = (
+            <Service
+              serviceName={entityName ?? ''}
+              entityId={entityId}
+              scopeId={scopeId}
+              contextID={contextID}
+            />
+          );
+          descriptor = {
+            kind: FLYOUT_DESCRIPTOR_KIND.service,
+            serviceName: entityName ?? '',
+            entityId,
+            scopeId,
+          };
+          break;
+        default:
+          children = <GenericEntity entityId={entityId} scopeId={scopeId} contextID={contextID} />;
           descriptor = { kind: FLYOUT_DESCRIPTOR_KIND.genericEntity, entityId, scopeId };
       }
       const parentDescriptor = readFirstDescriptor();
       writeOnOpen(descriptor, 'inherit');
       const onClose = buildOnClose(parentDescriptor);
-      const childTitle = title ?? entityName ?? entityId;
+      const titleValue = entityName ?? entityId;
+      const childTitle =
+        title ??
+        (engineType === 'host'
+          ? formatFlyoutTitle(HOST_TITLE, titleValue)
+          : engineType === 'user'
+          ? formatFlyoutTitle(USER_TITLE, titleValue)
+          : engineType === 'service'
+          ? formatFlyoutTitle(SERVICE_TITLE, titleValue)
+          : GENERIC_ENTITY_TITLE);
       open(
         children,
         {
@@ -789,6 +936,7 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       openServiceFlyoutAsChild,
       openGenericEntityFlyout,
       openGenericEntityFlyoutAsChild,
+      openEntityFlyout,
       openEntityDetailsAsChild,
       openEntityRiskInputs,
       openEntityAnomalyInsights,
@@ -810,6 +958,7 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       openServiceFlyoutAsChild,
       openGenericEntityFlyout,
       openGenericEntityFlyoutAsChild,
+      openEntityFlyout,
       openEntityDetailsAsChild,
       openEntityRiskInputs,
       openEntityAnomalyInsights,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
@@ -279,7 +279,6 @@ export const User: FC<UserProps> = memo(function User({
         entityId: params.entityId,
         entityName: params.entityName,
         scopeId,
-        title: params.entityName ?? params.entityId,
         origin,
       }),
     [openEntityDetailsAsChild, scopeId]

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TimelineId } from '../../../../common/types/timeline';
+import { PageScope } from '../../../data_view_manager/constants';
+import { cellActionRenderer, createCellActionRenderer } from './cell_actions';
+
+const mockSecurityCellActions = jest.fn((props: Record<string, unknown>) => (
+  <div data-test-subj="cell-actions">{props.children as React.ReactNode}</div>
+));
+
+jest.mock('../../../common/components/cell_actions', () => ({
+  SecurityCellActions: (props: Record<string, unknown>) => mockSecurityCellActions(props),
+  CellActionsMode: { HOVER_DOWN: 'hover-down' },
+}));
+
+const renderCellAction = (renderer: ReturnType<typeof createCellActionRenderer>, scopeId: string) =>
+  render(
+    <>
+      {renderer({
+        field: 'host.name',
+        value: ['host-1'],
+        scopeId,
+        children: <span>{'child'}</span>,
+      })}
+    </>
+  );
+
+describe('cellActionRenderer', () => {
+  beforeEach(() => {
+    mockSecurityCellActions.mockClear();
+  });
+
+  describe('createCellActionRenderer', () => {
+    it('uses the bound scopeId for metadata and sourcerer scope', () => {
+      renderCellAction(createCellActionRenderer(TimelineId.active), '');
+
+      expect(mockSecurityCellActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { scopeId: TimelineId.active },
+          sourcererScopeId: PageScope.timeline,
+        })
+      );
+    });
+
+    it('lets the bound scopeId win over the per-render scopeId', () => {
+      renderCellAction(createCellActionRenderer(TimelineId.active), 'some-other-scope');
+
+      expect(mockSecurityCellActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { scopeId: TimelineId.active },
+          sourcererScopeId: PageScope.timeline,
+        })
+      );
+    });
+
+    it('falls back to the per-render scopeId when no scope is bound', () => {
+      renderCellAction(createCellActionRenderer(''), TimelineId.active);
+
+      expect(mockSecurityCellActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { scopeId: TimelineId.active },
+          sourcererScopeId: PageScope.timeline,
+        })
+      );
+    });
+  });
+
+  describe('cellActionRenderer (default)', () => {
+    it('renders with the per-render scopeId and preserves empty-scope behavior', () => {
+      renderCellAction(cellActionRenderer, '');
+
+      expect(mockSecurityCellActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { scopeId: '' },
+          sourcererScopeId: PageScope.default,
+        })
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
@@ -32,29 +32,46 @@ export type CellActionRenderer = (props: CellActionRendererProps) => React.React
 export const noopCellActionRenderer: CellActionRenderer = ({ children }) => <>{children}</>;
 
 /**
+ * Creates a default Security Solution cell action renderer bound to a specific scope.
+ *
+ * `boundScopeId` takes precedence over the per-render `scopeId` when non-empty. This lets callers
+ * that know the scope up front (e.g. Timeline, which opens the flyout from `timeline-1`) ensure every
+ * cell action inside the flyout reports the correct scope, so Filter In/Out route to the Timeline's
+ * own filter manager instead of the page's global one. When `boundScopeId` is empty, it falls back to
+ * the per-render `scopeId`, preserving the default behavior.
+ */
+export const createCellActionRenderer = (boundScopeId: string): CellActionRenderer => {
+  const boundCellActionRenderer: CellActionRenderer = ({
+    field,
+    value,
+    children,
+    scopeId,
+  }: CellActionRendererProps) => {
+    const effectiveScopeId = boundScopeId || scopeId;
+    return (
+      <SecurityCellActions
+        data={{
+          field,
+          value: value ?? [],
+        }}
+        triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
+        mode={CellActionsMode.HOVER_DOWN}
+        visibleCellActions={5}
+        sourcererScopeId={getSourcererScopeId(effectiveScopeId)}
+        metadata={{ scopeId: effectiveScopeId }}
+      >
+        {children}
+      </SecurityCellActions>
+    );
+  };
+  return boundCellActionRenderer;
+};
+
+/**
  * Default cell action renderer for Security Solution. This component is used to render cell actions for fields in Security Solution.
  * This is used in the expandable flyout and in the new flyout (though only when used in Security Solution).
  */
-export const cellActionRenderer: CellActionRenderer = ({
-  field,
-  value,
-  children,
-  scopeId,
-}: CellActionRendererProps) => (
-  <SecurityCellActions
-    data={{
-      field,
-      value: value ?? [],
-    }}
-    triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
-    mode={CellActionsMode.HOVER_DOWN}
-    visibleCellActions={5}
-    sourcererScopeId={getSourcererScopeId(scopeId)}
-    metadata={{ scopeId }}
-  >
-    {children}
-  </SecurityCellActions>
-);
+export const cellActionRenderer: CellActionRenderer = createCellActionRenderer('');
 
 /**
  * Cell action renderer for Cases.

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_navigation.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FlyoutV2UrlParamValue } from './flyout_v2_url_param';
+
+interface FlyoutV2Navigation {
+  urlParamKey: string;
+  descriptors: FlyoutV2UrlParamValue;
+}
+
+type FlyoutV2NavigationListener = (navigation: FlyoutV2Navigation) => void;
+
+const listeners = new Set<FlyoutV2NavigationListener>();
+
+/**
+ * Notifies the mounted Security app that same-app navigation wrote a new flyout-v2 URL.
+ * Cross-app navigation is restored normally when the Security app mounts.
+ */
+export const notifyFlyoutV2Navigation = (navigation: FlyoutV2Navigation): void => {
+  listeners.forEach((listener) => listener(navigation));
+};
+
+export const subscribeToFlyoutV2Navigation = (
+  listener: FlyoutV2NavigationListener
+): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.ts
@@ -7,6 +7,7 @@
 
 import { decode, encode } from '@kbn/rison';
 import { timelineFlyoutHistoryKey } from '../constants/flyout_history';
+import type { FlyoutOrigin } from '../../../common/lib/telemetry/events/flyout_v2/types';
 
 /**
  * URL parameter that carries the currently-open flyout chain for the page (non-Timeline) context.
@@ -362,7 +363,7 @@ export interface CspVulnerabilityDescriptor {
 // Discriminated union
 // ---------------------------------------------------------------------------
 
-export type FlyoutDescriptor =
+export type FlyoutDescriptor = (
   | DocumentDescriptor
   | DocumentFromPatternDescriptor
   | AnalyzerDescriptor
@@ -395,7 +396,11 @@ export type FlyoutDescriptor =
   | RuleDescriptor
   | IocDescriptor
   | CspMisconfigurationDescriptor
-  | CspVulnerabilityDescriptor;
+  | CspVulnerabilityDescriptor
+) & {
+  /** UI trigger to attribute when this descriptor is restored from URL state. */
+  origin?: FlyoutOrigin;
+};
 
 /** Ordered array of up to 2 descriptors representing the current open flyout chain. */
 export type FlyoutV2UrlParamValue = FlyoutDescriptor[];

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.test.tsx
@@ -20,6 +20,8 @@ import { useEsDocSearch } from '@kbn/unified-doc-viewer-plugin/public';
 import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { PageScope } from '../../../data_view_manager/constants';
+import { notifyFlyoutV2Navigation } from './flyout_v2_navigation';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry/events/flyout_v2/types';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -143,6 +145,75 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
   });
 
+  it('opens a flyout notified by same-app navigation after the restore hook is mounted', () => {
+    renderRestore('/');
+
+    act(() => {
+      notifyFlyoutV2Navigation({
+        urlParamKey: FLYOUT_V2_URL_PARAM,
+        descriptors: [
+          {
+            kind: 'host',
+            hostName: 'web-01',
+            entityId: 'host:web-01',
+            scopeId: 'agent-builder-entity-card',
+            origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+          },
+        ],
+      });
+    });
+
+    expect(mockFlyoutApi.openHostFlyout).not.toHaveBeenCalled();
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(mockFlyoutApi.openHostFlyout).toHaveBeenCalledWith({
+      hostName: 'web-01',
+      entityId: 'host:web-01',
+      scopeId: 'agent-builder-entity-card',
+      origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+    });
+  });
+
+  it('forwards the navigation origin to a restored entity tool and its child', () => {
+    renderRestore('/');
+
+    act(() => {
+      notifyFlyoutV2Navigation({
+        urlParamKey: FLYOUT_V2_URL_PARAM,
+        descriptors: [
+          {
+            kind: 'entityGraphView',
+            entityId: 'host:web-01',
+            scopeId: 'agent-builder-entity-card',
+            entityName: 'web-01',
+            entityType: 'host',
+            origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+          },
+          {
+            kind: 'host',
+            hostName: 'web-01',
+            entityId: 'host:web-01',
+            scopeId: 'agent-builder-entity-card',
+            origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+          },
+        ],
+      });
+    });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(mockFlyoutApi.openEntityGraphView).toHaveBeenCalledWith(
+      expect.objectContaining({ origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT })
+    );
+    expect(mockFlyoutApi.openHostFlyoutAsChild).toHaveBeenCalledWith(
+      expect.objectContaining({ origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT })
+    );
+  });
+
   // -----------------------------------------------------------------------
   // Single-main descriptors (no fetch required)
   // -----------------------------------------------------------------------
@@ -156,6 +227,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
       documentId: 'doc-1',
       indexName: 'logs-*',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -169,6 +241,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openDocumentFlyoutFromPattern).toHaveBeenCalledWith({
       documentId: 'doc-1',
       indexName: '.siem-signals-*',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -180,6 +253,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openAttackFlyout).toHaveBeenCalledWith({
       attackId: 'atk-1',
       indexName: '.alerts-*',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -203,12 +277,37 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     );
   });
 
+  it('attributes a restored generic entity flyout to URL restoration', () => {
+    renderRestore(
+      buildUrl([
+        {
+          kind: 'genericEntity',
+          entityId: 'entity-1',
+          scopeId: 'scope-1',
+          origin: FLYOUT_ORIGIN.AI_CHAT_ENTITY_ATTACHMENT,
+        },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(mockFlyoutApi.openGenericEntityFlyout).toHaveBeenCalledWith({
+      entityId: 'entity-1',
+      scopeId: 'scope-1',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
+    });
+  });
+
   it('opens a rule flyout', () => {
     renderRestore(buildUrl([{ kind: 'rule', ruleId: 'rule-1' }]));
     act(() => {
       jest.runAllTimers();
     });
-    expect(mockFlyoutApi.openRuleFlyout).toHaveBeenCalledWith({ ruleId: 'rule-1' });
+    expect(mockFlyoutApi.openRuleFlyout).toHaveBeenCalledWith({
+      ruleId: 'rule-1',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
+    });
   });
 
   it('opens a network flyout', () => {
@@ -219,6 +318,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openNetworkFlyout).toHaveBeenCalledWith({
       ip: '1.2.3.4',
       flowTarget: 'source',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -232,6 +332,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openMisconfigurationFinding).toHaveBeenCalledWith({
       resourceId: 'res-1',
       ruleId: 'csp-1',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -391,6 +492,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
       documentId: 'doc-1',
       indexName: 'logs-*',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -533,6 +635,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
       documentId: 'doc-1',
       indexName: 'i',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -590,6 +693,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openAttackFlyout).toHaveBeenCalledWith({
       attackId: 'atk-1',
       indexName: '.alerts-*',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -801,6 +905,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
       documentId: 'doc-1',
       indexName: 'i',
+      origin: FLYOUT_ORIGIN.URL_RESTORE,
     });
   });
 
@@ -833,6 +938,7 @@ describe('useFlyoutV2RestoreFromUrl', () => {
       expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
         documentId: 'tl-doc-1',
         indexName: 'i',
+        origin: FLYOUT_ORIGIN.URL_RESTORE,
       });
     });
 
@@ -921,7 +1027,10 @@ describe('useFlyoutV2RestoreFromUrl', () => {
       });
 
       // Only the Timeline flyout (rule) should have been opened.
-      expect(mockFlyoutApi.openRuleFlyout).toHaveBeenCalledWith({ ruleId: 'r-tl' });
+      expect(mockFlyoutApi.openRuleFlyout).toHaveBeenCalledWith({
+        ruleId: 'r-tl',
+        origin: FLYOUT_ORIGIN.URL_RESTORE,
+      });
       // openHostFlyout and other page-context openers should not have been called.
       expect(mockFlyoutApi.openHostFlyout).not.toHaveBeenCalled();
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.ts
@@ -16,6 +16,7 @@ import type { EntityType } from '../../../../common/entity_analytics/types';
 import type { FlowTargetSourceDest } from '../../../../common/search_strategy/security_solution/network';
 import type { ManagedUserHit } from '../../../../common/search_strategy/security_solution/users/managed_details';
 import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN, type FlyoutOrigin } from '../../../common/lib/telemetry';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { PageScope } from '../../../data_view_manager/constants';
 import type { FlyoutApi } from '../../use_flyout_api';
@@ -58,6 +59,7 @@ import type {
   UserDescriptor,
 } from './flyout_v2_url_param';
 import { decodeFlyoutV2UrlParam } from './flyout_v2_url_param';
+import { subscribeToFlyoutV2Navigation } from './flyout_v2_navigation';
 
 // ---------------------------------------------------------------------------
 // Constants — which descriptor kinds require an async data fetch
@@ -150,20 +152,23 @@ const buildShowEntityCallback = (
 export const openDescriptorAsStart = (
   descriptor: FlyoutDescriptor,
   ctx: RestoreContext,
-  api: FlyoutApi
+  api: FlyoutApi,
+  originOverride?: FlyoutOrigin
 ): void => {
   const { kind } = descriptor;
+  const origin = originOverride ?? descriptor.origin;
+  const originParams = origin ? { origin } : {};
 
   switch (kind) {
     // --- Document main flyouts ---
     case 'document': {
       const { documentId, indexName } = descriptor as DocumentDescriptor;
-      api.openDocumentFlyoutFromIndex({ documentId, indexName });
+      api.openDocumentFlyoutFromIndex({ documentId, indexName, ...originParams });
       break;
     }
     case 'documentFromPattern': {
       const { documentId, indexName } = descriptor as DocumentFromPatternDescriptor;
-      api.openDocumentFlyoutFromPattern({ documentId, indexName });
+      api.openDocumentFlyoutFromPattern({ documentId, indexName, ...originParams });
       break;
     }
 
@@ -171,9 +176,13 @@ export const openDescriptorAsStart = (
     case 'analyzer': {
       const d = descriptor as AnalyzerDescriptor;
       if (ctx.docHit) {
-        api.openAnalyzer({ hit: ctx.docHit });
+        api.openAnalyzer({ hit: ctx.docHit, ...originParams });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
@@ -184,18 +193,27 @@ export const openDescriptorAsStart = (
           hit: ctx.docHit,
           jumpToCursor: d.jumpToCursor,
           jumpToEntityId: d.jumpToEntityId,
+          ...originParams,
         });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
     case 'documentEntities': {
       const d = descriptor as DocumentEntitiesDescriptor;
       if (ctx.docHit) {
-        api.openDocumentEntities({ hit: ctx.docHit, scopeId: d.scopeId });
+        api.openDocumentEntities({ hit: ctx.docHit, scopeId: d.scopeId, ...originParams });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
@@ -206,12 +224,17 @@ export const openDescriptorAsStart = (
           hit: ctx.docHit,
           scopeId: d.scopeId,
           isRulePreview: d.isRulePreview,
+          ...originParams,
           // Provide a default onShowAlert that opens the alert as a child flyout.
           onShowAlert: (alertId, indexName) =>
             api.openDocumentFlyoutFromIndexAsChild({ documentId: alertId, indexName }),
         });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
@@ -222,54 +245,79 @@ export const openDescriptorAsStart = (
           hit: ctx.docHit,
           scopeId: d.scopeId,
           investigationFields: d.investigationFields,
+          ...originParams,
         });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
     case 'documentResponse': {
       const d = descriptor as DocumentResponseDescriptor;
       if (ctx.docHit) {
-        api.openDocumentResponse({ hit: ctx.docHit });
+        api.openDocumentResponse({ hit: ctx.docHit, ...originParams });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
     case 'documentThreatIntelligence': {
       const d = descriptor as DocumentThreatIntelligenceDescriptor;
       if (ctx.docHit) {
-        api.openDocumentThreatIntelligence({ hit: ctx.docHit });
+        api.openDocumentThreatIntelligence({ hit: ctx.docHit, ...originParams });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
     case 'documentInvestigationGuide': {
       const d = descriptor as DocumentInvestigationGuideDescriptor;
       if (ctx.docHit) {
-        api.openDocumentInvestigationGuide({ hit: ctx.docHit });
+        api.openDocumentInvestigationGuide({ hit: ctx.docHit, ...originParams });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
     case 'documentGraph': {
       const d = descriptor as DocumentGraphDescriptor;
       if (ctx.docHit) {
-        api.openDocumentGraph({ hit: ctx.docHit });
+        api.openDocumentGraph({ hit: ctx.docHit, ...originParams });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
     case 'notes': {
       const d = descriptor as NotesDescriptor;
       if (ctx.docHit) {
-        api.openNotes({ hit: ctx.docHit });
+        api.openNotes({ hit: ctx.docHit, ...originParams });
       } else {
-        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+        api.openDocumentFlyoutFromIndex({
+          documentId: d.documentId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
@@ -277,24 +325,32 @@ export const openDescriptorAsStart = (
     // --- Attack main flyout + tools ---
     case 'attack': {
       const { attackId, indexName } = descriptor as AttackDescriptor;
-      api.openAttackFlyout({ attackId, indexName });
+      api.openAttackFlyout({ attackId, indexName, ...originParams });
       break;
     }
     case 'attackCorrelations': {
       const d = descriptor as AttackCorrelationsDescriptor;
       if (ctx.attackHit) {
-        api.openAttackCorrelations({ hit: ctx.attackHit, alertIds: d.alertIds });
+        api.openAttackCorrelations({ hit: ctx.attackHit, alertIds: d.alertIds, ...originParams });
       } else {
-        api.openAttackFlyout({ attackId: d.attackId, indexName: d.indexName });
+        api.openAttackFlyout({
+          attackId: d.attackId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
     case 'attackEntities': {
       const d = descriptor as AttackEntitiesDescriptor;
       if (ctx.attackHit) {
-        api.openAttackEntities({ hit: ctx.attackHit, alertIds: d.alertIds });
+        api.openAttackEntities({ hit: ctx.attackHit, alertIds: d.alertIds, ...originParams });
       } else {
-        api.openAttackFlyout({ attackId: d.attackId, indexName: d.indexName });
+        api.openAttackFlyout({
+          attackId: d.attackId,
+          indexName: d.indexName,
+          ...originParams,
+        });
       }
       break;
     }
@@ -302,17 +358,17 @@ export const openDescriptorAsStart = (
     // --- Entity main flyouts ---
     case 'host': {
       const { hostName, entityId, scopeId } = descriptor as HostDescriptor;
-      api.openHostFlyout({ hostName, entityId, scopeId });
+      api.openHostFlyout({ hostName, entityId, scopeId, ...originParams });
       break;
     }
     case 'user': {
       const { userName, entityId, scopeId } = descriptor as UserDescriptor;
-      api.openUserFlyout({ userName, entityId, scopeId });
+      api.openUserFlyout({ userName, entityId, scopeId, ...originParams });
       break;
     }
     case 'service': {
       const { serviceName, entityId, scopeId } = descriptor as ServiceDescriptor;
-      api.openServiceFlyout({ serviceName, entityId, scopeId });
+      api.openServiceFlyout({ serviceName, entityId, scopeId, ...originParams });
       break;
     }
     case 'genericEntity': {
@@ -324,7 +380,7 @@ export const openDescriptorAsStart = (
           : entityId
           ? { entityId }
           : { entityDocId: entityDocId as string };
-      api.openGenericEntityFlyout({ scopeId, ...idProps });
+      api.openGenericEntityFlyout({ scopeId, ...idProps, ...originParams });
       break;
     }
 
@@ -338,6 +394,7 @@ export const openDescriptorAsStart = (
           | EntityType.service,
         entityName: d.entityName,
         entityId: d.entityId,
+        ...originParams,
         onShowEntity: buildShowEntityCallback(api, {
           entityType: d.entityType,
           entityName: d.entityName,
@@ -352,6 +409,7 @@ export const openDescriptorAsStart = (
         entityType: d.entityType as unknown as EntityType.host | EntityType.user,
         value: d.value,
         entityId: d.entityId,
+        ...originParams,
         onOpenEntity: buildShowEntityCallback(api, {
           entityType: d.entityType,
           entityName: d.value,
@@ -369,6 +427,7 @@ export const openDescriptorAsStart = (
           | EntityType.generic,
         value: d.value,
         entityId: d.entityId,
+        ...originParams,
         onShowEntity: buildShowEntityCallback(api, {
           entityType: d.entityType,
           entityName: d.value,
@@ -386,6 +445,7 @@ export const openDescriptorAsStart = (
           | EntityType.generic,
         value: d.value,
         entityId: d.entityId,
+        ...originParams,
         onShowEntity: buildShowEntityCallback(api, {
           entityType: d.entityType,
           entityName: d.value,
@@ -400,6 +460,7 @@ export const openDescriptorAsStart = (
         value: d.value,
         entityId: d.entityId,
         entityType: d.entityType as unknown as EntityType.host | EntityType.generic | undefined,
+        ...originParams,
         onShowHost: buildShowEntityCallback(api, {
           entityType: d.entityType,
           entityName: d.value,
@@ -414,6 +475,7 @@ export const openDescriptorAsStart = (
         entityId: d.entityId,
         scopeId: d.scopeId,
         entityName: d.entityName,
+        ...originParams,
         onShowEntity: noop,
         onShowOriginatingEntity: buildShowEntityCallback(api, {
           entityType: d.entityType,
@@ -431,6 +493,7 @@ export const openDescriptorAsStart = (
         entityType: d.entityType as EntityType,
         entityName: d.entityName,
         scopeId: d.scopeId,
+        ...originParams,
         onShowEntity: buildShowEntityCallback(api, {
           entityType: d.entityType,
           entityName: d.entityName,
@@ -448,7 +511,7 @@ export const openDescriptorAsStart = (
         _id: d.managedUserId,
         _index: d.managedUserIndex,
       };
-      api.openEntityEntraInsights({ managedUser, value: d.value });
+      api.openEntityEntraInsights({ managedUser, value: d.value, ...originParams });
       break;
     }
     case 'entityOktaInsights': {
@@ -457,26 +520,30 @@ export const openDescriptorAsStart = (
         _id: d.managedUserId,
         _index: d.managedUserIndex,
       };
-      api.openEntityOktaInsights({ managedUser, value: d.value });
+      api.openEntityOktaInsights({ managedUser, value: d.value, ...originParams });
       break;
     }
 
     // --- Network / Rule ---
     case 'network': {
       const { ip, flowTarget } = descriptor as NetworkDescriptor;
-      api.openNetworkFlyout({ ip, flowTarget: flowTarget as FlowTargetSourceDest });
+      api.openNetworkFlyout({
+        ip,
+        flowTarget: flowTarget as FlowTargetSourceDest,
+        ...originParams,
+      });
       break;
     }
     case 'rule': {
       const { ruleId } = descriptor as RuleDescriptor;
-      api.openRuleFlyout({ ruleId });
+      api.openRuleFlyout({ ruleId, ...originParams });
       break;
     }
 
     // --- IOC ---
     case 'ioc': {
       if (ctx.iocIndicator) {
-        api.openIocFlyout({ indicator: ctx.iocIndicator });
+        api.openIocFlyout({ indicator: ctx.iocIndicator, ...originParams });
       }
       // If indicator could not be fetched: skip rather than open with empty data.
       break;
@@ -485,7 +552,7 @@ export const openDescriptorAsStart = (
     // --- CSP ---
     case 'cspMisconfiguration': {
       const { resourceId, ruleId } = descriptor as CspMisconfigurationDescriptor;
-      api.openMisconfigurationFinding({ resourceId, ruleId });
+      api.openMisconfigurationFinding({ resourceId, ruleId, ...originParams });
       break;
     }
     case 'cspVulnerability': {
@@ -496,6 +563,7 @@ export const openDescriptorAsStart = (
         packageName: d.packageName,
         packageVersion: d.packageVersion,
         eventId: d.eventId,
+        ...originParams,
       });
       break;
     }
@@ -512,41 +580,44 @@ export const openDescriptorAsStart = (
 export const openDescriptorAsChild = (
   descriptor: FlyoutDescriptor,
   ctx: RestoreContext,
-  api: FlyoutApi
+  api: FlyoutApi,
+  originOverride?: FlyoutOrigin
 ): void => {
   const { kind } = descriptor;
+  const origin = originOverride ?? descriptor.origin;
+  const originParams = origin ? { origin } : {};
 
   switch (kind) {
     // Main flyouts that have an explicit AsChild variant
     case 'document': {
       const { documentId, indexName } = descriptor as DocumentDescriptor;
-      api.openDocumentFlyoutFromIndexAsChild({ documentId, indexName });
+      api.openDocumentFlyoutFromIndexAsChild({ documentId, indexName, ...originParams });
       break;
     }
     case 'documentFromPattern': {
       // No AsChild variant exists — open as main (best-effort fallback)
       const { documentId, indexName } = descriptor as DocumentFromPatternDescriptor;
-      api.openDocumentFlyoutFromPattern({ documentId, indexName });
+      api.openDocumentFlyoutFromPattern({ documentId, indexName, ...originParams });
       break;
     }
     case 'attack': {
       const { attackId, indexName } = descriptor as AttackDescriptor;
-      api.openAttackFlyoutAsChild({ attackId, indexName });
+      api.openAttackFlyoutAsChild({ attackId, indexName, ...originParams });
       break;
     }
     case 'host': {
       const { hostName, entityId, scopeId } = descriptor as HostDescriptor;
-      api.openHostFlyoutAsChild({ hostName, entityId, scopeId });
+      api.openHostFlyoutAsChild({ hostName, entityId, scopeId, ...originParams });
       break;
     }
     case 'user': {
       const { userName, entityId, scopeId } = descriptor as UserDescriptor;
-      api.openUserFlyoutAsChild({ userName, entityId, scopeId });
+      api.openUserFlyoutAsChild({ userName, entityId, scopeId, ...originParams });
       break;
     }
     case 'service': {
       const { serviceName, entityId, scopeId } = descriptor as ServiceDescriptor;
-      api.openServiceFlyoutAsChild({ serviceName, entityId, scopeId });
+      api.openServiceFlyoutAsChild({ serviceName, entityId, scopeId, ...originParams });
       break;
     }
     case 'genericEntity': {
@@ -558,28 +629,32 @@ export const openDescriptorAsChild = (
           : entityId
           ? { entityId }
           : { entityDocId: entityDocId as string };
-      api.openGenericEntityFlyoutAsChild({ scopeId, ...idProps });
+      api.openGenericEntityFlyoutAsChild({ scopeId, ...idProps, ...originParams });
       break;
     }
     case 'network': {
       const { ip, flowTarget } = descriptor as NetworkDescriptor;
-      api.openNetworkFlyoutAsChild({ ip, flowTarget: flowTarget as FlowTargetSourceDest });
+      api.openNetworkFlyoutAsChild({
+        ip,
+        flowTarget: flowTarget as FlowTargetSourceDest,
+        ...originParams,
+      });
       break;
     }
     case 'rule': {
       const { ruleId } = descriptor as RuleDescriptor;
-      api.openRuleFlyoutAsChild({ ruleId });
+      api.openRuleFlyoutAsChild({ ruleId, ...originParams });
       break;
     }
     case 'ioc': {
       if (ctx.iocIndicator) {
-        api.openIocFlyoutAsChild({ indicator: ctx.iocIndicator });
+        api.openIocFlyoutAsChild({ indicator: ctx.iocIndicator, ...originParams });
       }
       break;
     }
     case 'cspMisconfiguration': {
       const { resourceId, ruleId } = descriptor as CspMisconfigurationDescriptor;
-      api.openMisconfigurationFindingAsChild({ resourceId, ruleId });
+      api.openMisconfigurationFindingAsChild({ resourceId, ruleId, ...originParams });
       break;
     }
     case 'cspVulnerability': {
@@ -590,13 +665,14 @@ export const openDescriptorAsChild = (
         packageName: d.packageName,
         packageVersion: d.packageVersion,
         eventId: d.eventId,
+        ...originParams,
       });
       break;
     }
 
     // Tool kinds and everything else: re-use the 'start' path (tools have no child variants).
     default:
-      openDescriptorAsStart(descriptor, ctx, api);
+      openDescriptorAsStart(descriptor, ctx, api, originOverride);
       break;
   }
 };
@@ -637,6 +713,31 @@ export const useFlyoutV2RestoreFromUrl = (urlParamKey: string): void => {
     const raw = new URLSearchParams(history.location.search).get(urlParamKey);
     return raw != null && decodeFlyoutV2UrlParam(raw) === null;
   });
+
+  // The restore state above is intentionally mount-only. Agent Builder can also navigate to a
+  // different entity while Entity Analytics is already mounted, so handle that same-app signal
+  // directly instead of waiting for a remount that will not happen.
+  useEffect(() => {
+    let pendingOpen: ReturnType<typeof setTimeout> | undefined;
+    const unsubscribe = subscribeToFlyoutV2Navigation(
+      ({ urlParamKey: navigationParamKey, descriptors: next }) => {
+        if (!isNewFlyoutEnabled || navigationParamKey !== urlParamKey) return;
+        const [first, second] = next;
+        clearTimeout(pendingOpen);
+        pendingOpen = setTimeout(() => {
+          openDescriptorAsStart(first, {}, flyoutApi);
+          if (second) {
+            openDescriptorAsChild(second, {}, flyoutApi);
+          }
+        }, 0);
+      }
+    );
+
+    return () => {
+      unsubscribe();
+      clearTimeout(pendingOpen);
+    };
+  }, [flyoutApi, isNewFlyoutEnabled, urlParamKey]);
 
   // Strip malformed param once on mount.
   useEffect(() => {
@@ -777,9 +878,9 @@ export const useFlyoutV2RestoreFromUrl = (urlParamKey: string): void => {
     // Defer to a macrotask to avoid z-index ordering races with Timeline restore, which also
     // fires on mount and claims its slot in the same render cycle.
     setTimeout(() => {
-      openDescriptorAsStart(first, ctx, flyoutApi);
+      openDescriptorAsStart(first, ctx, flyoutApi, FLYOUT_ORIGIN.URL_RESTORE);
       if (second) {
-        openDescriptorAsChild(second, ctx, flyoutApi);
+        openDescriptorAsChild(second, ctx, flyoutApi, FLYOUT_ORIGIN.URL_RESTORE);
       }
     }, 0);
   }, [

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -343,7 +343,9 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         application: core.application,
         agentBuilder: plugins.agentBuilder,
         chrome: core.chrome,
+        experimentalFeatures: this.experimentalFeatures,
         searchSession: plugins.data.search.session,
+        uiSettings: core.uiSettings,
       });
       registerEntityAttachment({
         attachments: plugins.agentBuilder.attachments,
@@ -354,6 +356,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         resolveSecurityCanvasContext: () =>
           this.getSecurityCanvasContext(core, plugins as StartPluginsDependencies),
         searchSession: plugins.data.search.session,
+        uiSettings: core.uiSettings,
       });
       if (this.experimentalFeatures.rulePreviewAttachmentEnabled) {
         registerRulePreviewAttachment({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/service_name.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/service_name.tsx
@@ -8,12 +8,15 @@
 import React, { useCallback, useContext, useMemo } from 'react';
 import type { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui';
 import { isString } from 'lodash/fp';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useEntityFromStore } from '../../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
 import { EntityType } from '../../../../../../common/search_strategy';
 import { EntityDetailsLink } from '../../../../../common/components/links';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { ServicePanelKey } from '../../../../../flyout/entity_details/shared/constants';
 import { StatefulEventContext } from '../../../../../common/components/events_viewer/stateful_event_context';
 import { getEmptyTagValue } from '../../../../../common/components/empty_value';
@@ -42,7 +45,9 @@ const ServiceNameComponent: React.FC<Props> = ({
   const eventContext = useContext(StatefulEventContext);
   const serviceName = `${value}`;
   const isInTimelineContext = serviceName && eventContext?.timelineID;
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openFlyout } = useExpandableFlyoutApi();
+  const { openServiceFlyout } = useFlyoutApi();
 
   const isInSecurityApp = useIsInSecurityApp();
 
@@ -70,6 +75,17 @@ const ServiceNameComponent: React.FC<Props> = ({
 
       const { timelineID } = eventContext;
 
+      if (enableNewFlyout) {
+        openServiceFlyout({
+          serviceName,
+          entityId: resolvedEntityId,
+          contextID: contextId,
+          scopeId: timelineID,
+          origin: FLYOUT_ORIGIN.TABLE_FIELD_LINK,
+        });
+        return;
+      }
+
       openFlyout({
         right: {
           id: ServicePanelKey,
@@ -86,7 +102,9 @@ const ServiceNameComponent: React.FC<Props> = ({
       onClick,
       eventContext,
       isInTimelineContext,
+      enableNewFlyout,
       openFlyout,
+      openServiceFlyout,
       serviceName,
       resolvedEntityId,
       contextId,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -22,6 +22,7 @@ import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
+import { PageScope } from '../../../../../data_view_manager/constants';
 
 jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
   useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
@@ -220,6 +221,38 @@ describe('unified data table', () => {
 
       // the document (non-attack) new flyout no longer goes through the inline system flyout
       expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
+    },
+    SPECIAL_TEST_TIMEOUT
+  );
+
+  it(
+    'opens the new document flyout with a cell-action renderer bound to the timeline scope',
+    async () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+      render(<TestComponent />);
+      expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+      fireEvent.click(screen.getAllByTestId('docTableExpandToggleColumn')[0]);
+
+      await waitFor(() => {
+        expect(flyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalled();
+      });
+
+      const { renderCellActions } = jest.mocked(flyoutApi.openDocumentFlyoutFromIndex).mock
+        .calls[0][0];
+
+      // Even when a cell passes an empty scopeId, the bound timeline scope must win so Filter
+      // In/Out target the timeline's own filter manager instead of the page behind it.
+      const cellAction = renderCellActions?.({
+        field: 'host.name',
+        value: ['host-1'],
+        scopeId: '',
+        children: null,
+      }) as React.ReactElement;
+
+      expect(cellAction.props.metadata).toEqual({ scopeId: TimelineId.test });
+      expect(cellAction.props.sourcererScopeId).toEqual(PageScope.timeline);
     },
     SPECIAL_TEST_TIMEOUT
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -21,7 +21,7 @@ import type {
 } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
-import { cellActionRenderer } from '../../../../../flyout_v2/shared/components/cell_actions';
+import { createCellActionRenderer } from '../../../../../flyout_v2/shared/components/cell_actions';
 import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { JEST_ENVIRONMENT } from '../../../../../../common/constants';
 import { useOnExpandableFlyoutClose } from '../../../../../flyout/shared/hooks/use_on_expandable_flyout_close';
@@ -181,6 +181,11 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       [events, dataView]
     );
 
+    const timelineCellActionRenderer = useMemo(
+      () => createCellActionRenderer(timelineId),
+      [timelineId]
+    );
+
     const handleOnEventDetailPanelOpened = useCallback(
       (eventData: DataTableRecord & TimelineItem) => {
         if (enableNewFlyout) {
@@ -197,7 +202,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
             openDocumentFlyoutFromIndex({
               documentId: eventData._id,
               indexName: eventData.ecs._index,
-              renderCellActions: cellActionRenderer,
+              renderCellActions: timelineCellActionRenderer,
               onAlertUpdated: refetch,
               origin: FLYOUT_ORIGIN.TIMELINE,
               title: getDocumentHistoryTitle(eventData),
@@ -235,6 +240,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
         enableNewFlyout,
         openAttackFlyout,
         openDocumentFlyoutFromIndex,
+        timelineCellActionRenderer,
         refetch,
         timelineId,
         openFlyout,

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entities_table.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entities_table.cy.ts
@@ -7,6 +7,7 @@
 
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
+import { disableNewFlyout } from '../../../tasks/api_calls/kibana_advanced_settings';
 import {
   interceptEntityStoreStatus,
   setGrouping,
@@ -61,6 +62,7 @@ describe(
     beforeEach(() => {
       interceptEntityStoreStatus('running');
       login();
+      disableNewFlyout();
       setGrouping(['none']);
       visit(ENTITY_ANALYTICS_HOME_PAGE_URL);
       cy.wait('@entityStoreStatus', { timeout: 20000 });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entities_table_grouping.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entities_table_grouping.cy.ts
@@ -7,6 +7,7 @@
 
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
+import { disableNewFlyout } from '../../../tasks/api_calls/kibana_advanced_settings';
 import {
   setGrouping,
   waitForGroupingTable,
@@ -64,6 +65,7 @@ describe(
     describe('Group by Resolution', () => {
       beforeEach(() => {
         login();
+        disableNewFlyout();
         interceptEntityStoreStatus('running');
         interceptEntityStoreSearch();
         visit(ENTITY_ANALYTICS_HOME_PAGE_URL);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout/resolution_section.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout/resolution_section.cy.ts
@@ -7,6 +7,7 @@
 
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
+import { disableNewFlyout } from '../../../tasks/api_calls/kibana_advanced_settings';
 import {
   interceptEntityStoreStatus,
   setGrouping,
@@ -94,6 +95,7 @@ describe(
       interceptResolutionGroup();
       interceptResolutionMutations();
       login();
+      disableNewFlyout();
       // Flat data-grid mode so we can click the row-expand button to open the entity flyout.
       setGrouping(['none']);
       visit(ENTITY_ANALYTICS_HOME_PAGE_URL);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[SecuritySolution][OneDiscover] update all flyout entry points to conditionally fork (#279324)](https://github.com/elastic/kibana/pull/279324)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-28T11:14:02Z","message":"[SecuritySolution][OneDiscover] update all flyout entry points to conditionally fork (#279324)\n\n## Summary\n\n- All v1 flyout entry points are forked to use the v2 flyout.\n- Extends the conditional v2 routing to the remaining Security Solution\nsurfaces, including Agent Builder entity cards, canvases, and attachment\ntables.\n- Preserves the v1 fallback when the new flyout setting is disabled.\n- Supports Agent Builder navigation both across apps and between\nalready-mounted Security Solution pages.\n- Attributes v2 flyout telemetry to the originating surface, including\nAI chat entity attachments, risk-score surfaces, and URL restoration.\n- Preserves entity identity and scope context so child flyouts,\nprevalence links, and restored flyouts resolve the correct entity.\n\n### Enabling flyout v2\n\nTo exercise the v2 flyout, enable it in **Stack Management → Advanced\nSettings**:\n\n- Set **`securitySolution:enableNewFlyout`** to **On**.\n\n### Where to reach it in the UI\n\n| Area | Navigate to | Action that opens the flyout |\n| --- | --- | --- |\n| Explore → Hosts | **All hosts** table | Click a host name |\n| Explore → Hosts | **Uncommon processes** tab | Click a host name |\n| Explore → Hosts | **Authentications** tab | Click a user / host name |\n| Explore → Hosts | **Host risk** view | Click a host name |\n| Explore → Users | **All users** table | Click a user name |\n| Explore → Users | **Authentications** tab | Click a user / host name |\n| Explore → Users | **User risk** view | Click a user name |\n| Entity Analytics | **Entities** table | Click an entity row / name |\n| Entity Analytics | **Entities** table (grouped view) | Expand a\nresolution group → open button |\n| Entity Analytics | **Entity Store** list panel | Actions column →\n\"preview entity\" button |\n| Entity Analytics | **Risk score management** preview | Click an entity\nname |\n| Privileged user monitoring | **Privileged users** table | Click a user\nname |\n| Privileged user monitoring | **Privileged access detection** chart |\nClick a username in the entity list |\n| Privileged user monitoring | **Recent anomalies** chart | Click an\nentity id / name |\n| Entity Analytics | **Threat hunting leads** cards | Click an entity\nbadge |\n| Any entity flyout | **Resolution** section / left-panel tab | Click a\nrelated / alias entity name |\n| Alerts table / Timeline | A `service.name` cell | Click the service\nname |\n| Asset Inventory | Inventory grid | Click a row (entity →\nuser/host/service, else generic) |\n| Agent Builder | Entity card attachment | **Open in Entity Analytics**\n|\n| Agent Builder | Entity attachment canvas | Secondary action → **Open\nin Entity Analytics** |\n| Agent Builder | Entity attachment / entity list tables | Click an\nentity |\n| Agent Builder | Entity card canvas overview | Open entity details |\n\n### Telemetry\n\n- Page-load restoration uses the dedicated `url_restore` telemetry\norigin; live Agent Builder navigation retains\n`ai_chat_entity_attachment`.\n- Entity Analytics and risk-score entry points report their own origins\nso usage remains attributable after the v2 rollout.\n\n### Validation\n\n- Scoped Security Solution TypeScript check.\n- Targeted Jest coverage for Agent Builder navigation, entity flyout\nAPIs, URL restoration, prevalence identity resolution, and risk-score\norigins.\n- ESLint validation for changed files.\n\n### Example\n\n\nhttps://github.com/user-attachments/assets/29bdc41f-960e-4b77-8a8f-a04c3e0df809\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d0537cc2a4d31e3cf612f4e38e35794a0ececb5c","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","backport:version","v9.5.0","OneDiscover","v9.6.0"],"title":"[SecuritySolution][OneDiscover] update all flyout entry points to conditionally fork","number":279324,"url":"https://github.com/elastic/kibana/pull/279324","mergeCommit":{"message":"[SecuritySolution][OneDiscover] update all flyout entry points to conditionally fork (#279324)\n\n## Summary\n\n- All v1 flyout entry points are forked to use the v2 flyout.\n- Extends the conditional v2 routing to the remaining Security Solution\nsurfaces, including Agent Builder entity cards, canvases, and attachment\ntables.\n- Preserves the v1 fallback when the new flyout setting is disabled.\n- Supports Agent Builder navigation both across apps and between\nalready-mounted Security Solution pages.\n- Attributes v2 flyout telemetry to the originating surface, including\nAI chat entity attachments, risk-score surfaces, and URL restoration.\n- Preserves entity identity and scope context so child flyouts,\nprevalence links, and restored flyouts resolve the correct entity.\n\n### Enabling flyout v2\n\nTo exercise the v2 flyout, enable it in **Stack Management → Advanced\nSettings**:\n\n- Set **`securitySolution:enableNewFlyout`** to **On**.\n\n### Where to reach it in the UI\n\n| Area | Navigate to | Action that opens the flyout |\n| --- | --- | --- |\n| Explore → Hosts | **All hosts** table | Click a host name |\n| Explore → Hosts | **Uncommon processes** tab | Click a host name |\n| Explore → Hosts | **Authentications** tab | Click a user / host name |\n| Explore → Hosts | **Host risk** view | Click a host name |\n| Explore → Users | **All users** table | Click a user name |\n| Explore → Users | **Authentications** tab | Click a user / host name |\n| Explore → Users | **User risk** view | Click a user name |\n| Entity Analytics | **Entities** table | Click an entity row / name |\n| Entity Analytics | **Entities** table (grouped view) | Expand a\nresolution group → open button |\n| Entity Analytics | **Entity Store** list panel | Actions column →\n\"preview entity\" button |\n| Entity Analytics | **Risk score management** preview | Click an entity\nname |\n| Privileged user monitoring | **Privileged users** table | Click a user\nname |\n| Privileged user monitoring | **Privileged access detection** chart |\nClick a username in the entity list |\n| Privileged user monitoring | **Recent anomalies** chart | Click an\nentity id / name |\n| Entity Analytics | **Threat hunting leads** cards | Click an entity\nbadge |\n| Any entity flyout | **Resolution** section / left-panel tab | Click a\nrelated / alias entity name |\n| Alerts table / Timeline | A `service.name` cell | Click the service\nname |\n| Asset Inventory | Inventory grid | Click a row (entity →\nuser/host/service, else generic) |\n| Agent Builder | Entity card attachment | **Open in Entity Analytics**\n|\n| Agent Builder | Entity attachment canvas | Secondary action → **Open\nin Entity Analytics** |\n| Agent Builder | Entity attachment / entity list tables | Click an\nentity |\n| Agent Builder | Entity card canvas overview | Open entity details |\n\n### Telemetry\n\n- Page-load restoration uses the dedicated `url_restore` telemetry\norigin; live Agent Builder navigation retains\n`ai_chat_entity_attachment`.\n- Entity Analytics and risk-score entry points report their own origins\nso usage remains attributable after the v2 rollout.\n\n### Validation\n\n- Scoped Security Solution TypeScript check.\n- Targeted Jest coverage for Agent Builder navigation, entity flyout\nAPIs, URL restoration, prevalence identity resolution, and risk-score\norigins.\n- ESLint validation for changed files.\n\n### Example\n\n\nhttps://github.com/user-attachments/assets/29bdc41f-960e-4b77-8a8f-a04c3e0df809\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d0537cc2a4d31e3cf612f4e38e35794a0ececb5c"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279324","number":279324,"mergeCommit":{"message":"[SecuritySolution][OneDiscover] update all flyout entry points to conditionally fork (#279324)\n\n## Summary\n\n- All v1 flyout entry points are forked to use the v2 flyout.\n- Extends the conditional v2 routing to the remaining Security Solution\nsurfaces, including Agent Builder entity cards, canvases, and attachment\ntables.\n- Preserves the v1 fallback when the new flyout setting is disabled.\n- Supports Agent Builder navigation both across apps and between\nalready-mounted Security Solution pages.\n- Attributes v2 flyout telemetry to the originating surface, including\nAI chat entity attachments, risk-score surfaces, and URL restoration.\n- Preserves entity identity and scope context so child flyouts,\nprevalence links, and restored flyouts resolve the correct entity.\n\n### Enabling flyout v2\n\nTo exercise the v2 flyout, enable it in **Stack Management → Advanced\nSettings**:\n\n- Set **`securitySolution:enableNewFlyout`** to **On**.\n\n### Where to reach it in the UI\n\n| Area | Navigate to | Action that opens the flyout |\n| --- | --- | --- |\n| Explore → Hosts | **All hosts** table | Click a host name |\n| Explore → Hosts | **Uncommon processes** tab | Click a host name |\n| Explore → Hosts | **Authentications** tab | Click a user / host name |\n| Explore → Hosts | **Host risk** view | Click a host name |\n| Explore → Users | **All users** table | Click a user name |\n| Explore → Users | **Authentications** tab | Click a user / host name |\n| Explore → Users | **User risk** view | Click a user name |\n| Entity Analytics | **Entities** table | Click an entity row / name |\n| Entity Analytics | **Entities** table (grouped view) | Expand a\nresolution group → open button |\n| Entity Analytics | **Entity Store** list panel | Actions column →\n\"preview entity\" button |\n| Entity Analytics | **Risk score management** preview | Click an entity\nname |\n| Privileged user monitoring | **Privileged users** table | Click a user\nname |\n| Privileged user monitoring | **Privileged access detection** chart |\nClick a username in the entity list |\n| Privileged user monitoring | **Recent anomalies** chart | Click an\nentity id / name |\n| Entity Analytics | **Threat hunting leads** cards | Click an entity\nbadge |\n| Any entity flyout | **Resolution** section / left-panel tab | Click a\nrelated / alias entity name |\n| Alerts table / Timeline | A `service.name` cell | Click the service\nname |\n| Asset Inventory | Inventory grid | Click a row (entity →\nuser/host/service, else generic) |\n| Agent Builder | Entity card attachment | **Open in Entity Analytics**\n|\n| Agent Builder | Entity attachment canvas | Secondary action → **Open\nin Entity Analytics** |\n| Agent Builder | Entity attachment / entity list tables | Click an\nentity |\n| Agent Builder | Entity card canvas overview | Open entity details |\n\n### Telemetry\n\n- Page-load restoration uses the dedicated `url_restore` telemetry\norigin; live Agent Builder navigation retains\n`ai_chat_entity_attachment`.\n- Entity Analytics and risk-score entry points report their own origins\nso usage remains attributable after the v2 rollout.\n\n### Validation\n\n- Scoped Security Solution TypeScript check.\n- Targeted Jest coverage for Agent Builder navigation, entity flyout\nAPIs, URL restoration, prevalence identity resolution, and risk-score\norigins.\n- ESLint validation for changed files.\n\n### Example\n\n\nhttps://github.com/user-attachments/assets/29bdc41f-960e-4b77-8a8f-a04c3e0df809\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d0537cc2a4d31e3cf612f4e38e35794a0ececb5c"}}]}] BACKPORT-->