### PR TITLE
[VectorDB] Count populated vector fields in deployment stats

### DIFF
--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/api_paths.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/api_paths.tsx
@@ -17,7 +17,7 @@ export interface OnboardingApiPaths {
    *  Returns `{ id, name, encoded }` when a new key is created.
    *  Returns `{ id: null, name: null, encoded: null }` when an active onboarding key already exists. */
   apiKey: string;
-  /** GET endpoint returning `{ indicesCount, vectorDocsCount, storeSizeBytes }`. */
+  /** GET endpoint returning `{ indicesCount, vectorsCount, storeSizeBytes }`. */
   deploymentStats: string;
 }
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page.tsx
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page.tsx
@@ -69,7 +69,7 @@ export const HomePage = () => {
   const { stats, isLoading } = useDeploymentStats();
   const { agentsCount, isLoading: isAgentsCountLoading } = useAgentsCount();
   const { elasticsearchUrl, apiKey, isLoading: isCredentialsLoading } = useOnboardingCredentials();
-  const hasData = (stats.vectorDocsCount ?? 0) > 0 || (stats.indicesCount ?? 0) > 0;
+  const hasData = (stats.vectorsCount ?? 0) > 0 || (stats.indicesCount ?? 0) > 0;
 
   const statTiles = [
     {
@@ -81,7 +81,7 @@ export const HomePage = () => {
     {
       key: 'vectors',
       label: STAT_TILE_LABELS.vectors,
-      value: formatNumber(stats.vectorDocsCount),
+      value: formatNumber(stats.vectorsCount),
       isLoading,
     },
     {

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
@@ -15,7 +15,7 @@ interface WorkflowsStats {
 
 interface DeploymentStatsResponse {
   indicesCount: number | null;
-  vectorDocsCount: number | null;
+  vectorsCount: number | null;
   storeSizeBytes: number | null;
   dashboardsCount: number | null;
 }
@@ -25,7 +25,7 @@ interface DeploymentStats extends DeploymentStatsResponse {
 
 const initialStats: DeploymentStats = {
   indicesCount: null,
-  vectorDocsCount: null,
+  vectorsCount: null,
   storeSizeBytes: null,
   workflowsCount: null,
   dashboardsCount: null,
@@ -46,7 +46,7 @@ export const useDeploymentStats = () => {
 
       return {
         indicesCount: esStats?.indicesCount ?? null,
-        vectorDocsCount: esStats?.vectorDocsCount ?? null,
+        vectorsCount: esStats?.vectorsCount ?? null,
         storeSizeBytes: esStats?.storeSizeBytes ?? null,
         workflowsCount: workflowsResponse?.workflows
           ? (workflowsResponse.workflows.enabled ?? 0) + (workflowsResponse.workflows.disabled ?? 0)

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
@@ -11,6 +11,7 @@ import {
   loggingSystemMock,
   savedObjectsClientMock,
 } from '@kbn/core/server/mocks';
+import type { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
 import { fetchDashboardsCount, fetchIndexStats } from './deployment_stats';
 
 describe('fetchIndexStats', () => {
@@ -42,29 +43,44 @@ describe('fetchIndexStats', () => {
   };
 
   /**
-   * Derives the ES|QL count from the indices named in the `FROM` clause so that `vectorDocsCount`
-   * assertions fail when the wrong indices are selected. A fixed count would pass no matter which
-   * indices were queried, leaving misclassification detectable only via the query string.
+   * Derives each `exists` aggregation's `doc_count` from the searched indices and field so that
+   * `vectorsCount` assertions fail when the wrong indices or fields are counted. Fixed counts would
+   * pass no matter what was requested, leaving misclassification detectable only via the request.
    */
-  const mockEsqlDocCounts = (docCountsByIndex: Record<string, number>) => {
-    client.asCurrentUser.esql.query.mockImplementation((async (request: { query: string }) => {
-      const [, fromClause] = /^FROM (.+) \| STATS/.exec(request.query) ?? [];
-      if (!fromClause) throw new Error(`Unparseable ES|QL query: ${request.query}`);
+  const mockVectorFieldDocCounts = (docCountsByIndex: Record<string, Record<string, number>>) => {
+    client.asCurrentUser.search.mockImplementation((async (request: SearchRequest) => {
+      const indices = request.index as string[];
 
-      const totalDocCount = fromClause
-        .split(',')
-        .map((name) => name.replace(/^"|"$/g, ''))
-        .reduce((sum, name) => {
-          const indexDocCount = docCountsByIndex[name];
-          if (indexDocCount === undefined) {
-            throw new Error(`ES|QL queried an index that is not a vector index: ${name}`);
+      const aggregations = Object.entries(request.aggs ?? {}).map(([aggName, aggregation]) => {
+        const { field } = (aggregation as { filter: { exists: { field: string } } }).filter.exists;
+
+        const docCount = indices.reduce((sum, indexName) => {
+          const docCountsByField = docCountsByIndex[indexName];
+          if (docCountsByField === undefined) {
+            throw new Error(`Searched an index that is not a vector index: ${indexName}`);
           }
-          return sum + indexDocCount;
+          return sum + (docCountsByField[field] ?? 0);
         }, 0);
 
-      return { columns: [{ name: 'doc_count', type: 'long' }], values: [[totalDocCount]] };
+        return [aggName, { doc_count: docCount }];
+      });
+
+      return { aggregations: Object.fromEntries(aggregations) };
     }) as any);
   };
+
+  /** The indices and vector fields each search counted, in call order. */
+  const searchedIndicesAndFields = () =>
+    client.asCurrentUser.search.mock.calls.map(([request]) => {
+      const { index, aggs } = request as SearchRequest;
+      return {
+        indices: index as string[],
+        fields: Object.values(aggs ?? {}).map(
+          (aggregation) =>
+            (aggregation as { filter: { exists: { field: string } } }).filter.exists.field
+        ),
+      };
+    });
 
   it('excludes dot-prefixed indices and aggregates count/size', async () => {
     mockMetering([
@@ -78,8 +94,8 @@ describe('fetchIndexStats', () => {
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(result).toEqual({ indicesCount: 1, storeSizeBytes: 100, vectorDocsCount: 0 });
-    expect(client.asCurrentUser.esql.query).not.toHaveBeenCalled();
+    expect(result).toEqual({ indicesCount: 1, storeSizeBytes: 100, vectorsCount: 0 });
+    expect(client.asCurrentUser.search).not.toHaveBeenCalled();
   });
 
   it('restricts field caps to vector-relevant field types and skips metadata fields', async () => {
@@ -99,8 +115,9 @@ describe('fetchIndexStats', () => {
     });
   });
 
-  it('detects semantic_text via the field caps inference flag and counts docs via ES|QL', async () => {
-    // metering over-reports num_docs (20) for the semantic_text index; ES|QL returns the real 10.
+  it('counts documents holding a value for the field with an exists aggregation', async () => {
+    // metering over-reports num_docs (20) for the semantic_text index because it counts the nested
+    // chunk documents; aggregations only see the 10 top-level documents.
     // `semantic_text` is reported as `text` by field caps, so it is detected via `inference: true`.
     mockMetering([{ name: 'vectordb', num_docs: 20, size_in_bytes: 500 }]);
     mockFieldCaps({
@@ -108,21 +125,66 @@ describe('fetchIndexStats', () => {
         text: { type: 'text', searchable: true, aggregatable: false, inference: true },
       },
     });
-    mockEsqlDocCounts({ vectordb: 10 });
+    mockVectorFieldDocCounts({ vectordb: { semantic_content: 10 } });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(10);
+    expect(client.asCurrentUser.search).toHaveBeenCalledWith({
+      index: ['vectordb'],
+      size: 0,
+      track_total_hits: false,
+      ignore_unavailable: true,
+      aggs: { vector_field_0: { filter: { exists: { field: 'semantic_content' } } } },
+    });
+    expect(result.vectorsCount).toBe(10);
   });
 
-  it('counts docs from every vector index when only one of them uses semantic_text', async () => {
-    // Three indices holding 5 docs each. `content` is `semantic_text` in `semantic-index` and plain
-    // `text` in the other two, so field caps merges all three into one `text` capability with
+  it('counts each populated vector field of a document separately', async () => {
+    mockMetering([{ name: 'vectordb', num_docs: 10, size_in_bytes: 500 }]);
+    mockFieldCaps({
+      embedding: {
+        dense_vector: { type: 'dense_vector', searchable: true, aggregatable: false },
+      },
+      content: {
+        text: { type: 'text', searchable: true, aggregatable: false, inference: true },
+      },
+    });
+    // All 10 documents carry an embedding; 7 of them also carry semantic content.
+    mockVectorFieldDocCounts({ vectordb: { embedding: 10, content: 7 } });
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(searchedIndicesAndFields()).toEqual([
+      { indices: ['vectordb'], fields: ['content', 'embedding'] },
+    ]);
+    // 17 rather than 10 proves the second field of each document is counted too.
+    expect(result.vectorsCount).toBe(17);
+  });
+
+  it('ignores the internal chunk subfields a semantic_text field indexes its embeddings in', async () => {
+    mockMetering([{ name: 'vectordb', num_docs: 30, size_in_bytes: 500 }]);
+    mockFieldCaps({
+      content: {
+        text: { type: 'text', searchable: true, aggregatable: false, inference: true },
+      },
+      'content.inference.chunks.embeddings': {
+        sparse_vector: { type: 'sparse_vector', searchable: true, aggregatable: false },
+      },
+    });
+    mockVectorFieldDocCounts({ vectordb: { content: 10 } });
+
+    const result = await fetchIndexStats(client, logger);
+
+    // Counting the chunk subfield as well would report the same 10 values twice.
+    expect(searchedIndicesAndFields()).toEqual([{ indices: ['vectordb'], fields: ['content'] }]);
+    expect(result.vectorsCount).toBe(10);
+  });
+
+  it('counts every vector index when only one of them uses semantic_text', async () => {
+    // Three indices holding 5 documents each. `content` is `semantic_text` in `semantic-index` and
+    // plain `text` in the other two, so field caps merges all three into one `text` capability with
     // `inference: false` and no `indices` list. Reading only `inference` dropped `semantic-index`
-    // and under-reported the 15 docs as 10.
+    // and under-reported the 15 vectors as 10.
     mockMetering([
       // metering num_docs is inflated for semantic_text indices by the nested chunk documents.
       { name: 'semantic-index', num_docs: 10, size_in_bytes: 500 },
@@ -154,11 +216,20 @@ describe('fetchIndexStats', () => {
         },
       },
     });
-    mockEsqlDocCounts({ 'semantic-index': 5, 'dense-index': 5, 'byoe-index': 5 });
+    mockVectorFieldDocCounts({
+      'semantic-index': { content: 5 },
+      'dense-index': { embedding: 5 },
+      'byoe-index': { embedding: 5 },
+    });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(result.vectorDocsCount).toBe(15);
+    // The two indices mapping the same vector field are counted in a single search.
+    expect(searchedIndicesAndFields()).toEqual([
+      { indices: ['semantic-index'], fields: ['content'] },
+      { indices: ['dense-index', 'byoe-index'], fields: ['embedding'] },
+    ]);
+    expect(result.vectorsCount).toBe(15);
   });
 
   it('detects semantic_text when the same field is plain text in other indices', async () => {
@@ -181,14 +252,14 @@ describe('fetchIndexStats', () => {
         },
       },
     });
-    mockEsqlDocCounts({ 'semantic-only': 5, 'plain-a': 5, 'plain-b': 5 });
+    mockVectorFieldDocCounts({ 'semantic-only': { content: 5 } });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "semantic-only" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(5);
+    expect(searchedIndicesAndFields()).toEqual([
+      { indices: ['semantic-only'], fields: ['content'] },
+    ]);
+    expect(result.vectorsCount).toBe(5);
   });
 
   it('excludes non-inference indices from a partially mapped mixed inference field', async () => {
@@ -218,14 +289,14 @@ describe('fetchIndexStats', () => {
         },
       },
     });
-    mockEsqlDocCounts({ 'semantic-only': 5, 'plain-a': 5, 'no-content': 5 });
+    mockVectorFieldDocCounts({ 'semantic-only': { content: 5 } });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "semantic-only" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(5);
+    expect(searchedIndicesAndFields()).toEqual([
+      { indices: ['semantic-only'], fields: ['content'] },
+    ]);
+    expect(result.vectorsCount).toBe(5);
   });
 
   it('detects an inference field reported by its own `type` (no inference flag)', async () => {
@@ -237,14 +308,14 @@ describe('fetchIndexStats', () => {
         semantic_text: { type: 'semantic_text', searchable: true, aggregatable: false },
       },
     });
-    mockEsqlDocCounts({ vectordb: 10 });
+    mockVectorFieldDocCounts({ vectordb: { semantic_content: 10 } });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(10);
+    expect(searchedIndicesAndFields()).toEqual([
+      { indices: ['vectordb'], fields: ['semantic_content'] },
+    ]);
+    expect(result.vectorsCount).toBe(10);
   });
 
   it('detects a `semantic` field by its own reported type', async () => {
@@ -254,17 +325,15 @@ describe('fetchIndexStats', () => {
         semantic: { type: 'semantic', searchable: true, aggregatable: false },
       },
     });
-    mockEsqlDocCounts({ vectordb: 10 });
+    mockVectorFieldDocCounts({ vectordb: { body: 10 } });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(10);
+    expect(searchedIndicesAndFields()).toEqual([{ indices: ['vectordb'], fields: ['body'] }]);
+    expect(result.vectorsCount).toBe(10);
   });
 
-  it('only queries indices whose field caps report a vector field', async () => {
+  it('only searches indices whose field caps report a vector field', async () => {
     mockMetering([
       { name: 'vectordb', num_docs: 10, size_in_bytes: 500 },
       { name: 'plain-text', num_docs: 5, size_in_bytes: 50 },
@@ -282,15 +351,12 @@ describe('fetchIndexStats', () => {
       },
       title: { text: { type: 'text', searchable: true, aggregatable: false, inference: false } },
     });
-    mockEsqlDocCounts({ vectordb: 10, 'plain-text': 5 });
+    mockVectorFieldDocCounts({ vectordb: { embedding: 10 } });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
-    );
-    // 10 rather than 15 proves `plain-text` docs are excluded.
-    expect(result.vectorDocsCount).toBe(10);
+    expect(searchedIndicesAndFields()).toEqual([{ indices: ['vectordb'], fields: ['embedding'] }]);
+    expect(result.vectorsCount).toBe(10);
   });
 
   it('does not classify indices where the vector field is unmapped', async () => {
@@ -316,14 +382,14 @@ describe('fetchIndexStats', () => {
         },
       },
     });
-    mockEsqlDocCounts({ 'test-vector': 10, 'test-plain': 5000 });
+    mockVectorFieldDocCounts({ 'test-vector': { embedding: 10 } });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "test-vector" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(10);
+    expect(searchedIndicesAndFields()).toEqual([
+      { indices: ['test-vector'], fields: ['embedding'] },
+    ]);
+    expect(result.vectorsCount).toBe(10);
   });
 
   it('treats a vector field with no `indices` as present in every requested index', async () => {
@@ -342,19 +408,20 @@ describe('fetchIndexStats', () => {
         },
       },
     });
-    mockEsqlDocCounts({ 'vectordb-a': 10, 'vectordb-b': 10 });
+    mockVectorFieldDocCounts({
+      'vectordb-a': { embedding: 10 },
+      'vectordb-b': { embedding: 10 },
+    });
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: 'FROM "vectordb-a","vectordb-b" | STATS doc_count = COUNT(*)',
-      })
-    );
-    expect(result.vectorDocsCount).toBe(20);
+    expect(searchedIndicesAndFields()).toEqual([
+      { indices: ['vectordb-a', 'vectordb-b'], fields: ['embedding'] },
+    ]);
+    expect(result.vectorsCount).toBe(20);
   });
 
-  it('batches the ES|QL count when there are more than 500 vector indices', async () => {
+  it('batches the search when there are more than 500 vector indices', async () => {
     const indices = Array.from({ length: 501 }, (_, i) => ({
       name: `vectordb-${i}`,
       num_docs: 1,
@@ -367,29 +434,29 @@ describe('fetchIndexStats', () => {
         dense_vector: { type: 'dense_vector', searchable: true, aggregatable: false },
       },
     });
-    mockEsqlDocCounts(Object.fromEntries(indices.map(({ name }) => [name, 1])));
+    mockVectorFieldDocCounts(
+      Object.fromEntries(indices.map(({ name }) => [name, { embedding: 1 }]))
+    );
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledTimes(2);
-    const queries = client.asCurrentUser.esql.query.mock.calls.map(
-      ([request]) => (request as { query: string }).query
-    );
-    expect(queries[0]).toContain('"vectordb-0"');
-    expect(queries[0]).toContain('"vectordb-499"');
-    expect(queries[0]).not.toContain('"vectordb-500"');
-    expect(queries[1]).toBe('FROM "vectordb-500" | STATS doc_count = COUNT(*)');
-    expect(result.vectorDocsCount).toBe(501);
+    const [firstSearch, secondSearch] = searchedIndicesAndFields();
+    expect(client.asCurrentUser.search).toHaveBeenCalledTimes(2);
+    expect(firstSearch.indices).toHaveLength(500);
+    expect(firstSearch.indices[0]).toBe('vectordb-0');
+    expect(firstSearch.indices[499]).toBe('vectordb-499');
+    expect(secondSearch.indices).toEqual(['vectordb-500']);
+    expect(result.vectorsCount).toBe(501);
   });
 
-  it('returns a null vectorDocsCount (not 0) when the vector lookup fails', async () => {
+  it('returns a null vectorsCount (not 0) when the vector lookup fails', async () => {
     mockMetering([{ name: 'vectordb', num_docs: 10, size_in_bytes: 500 }]);
     client.asCurrentUser.fieldCaps.mockRejectedValue(new Error('boom'));
 
     const result = await fetchIndexStats(client, logger);
 
-    // index/size counts are still valid; only the vector doc count is unavailable
-    expect(result).toEqual({ indicesCount: 1, storeSizeBytes: 500, vectorDocsCount: null });
+    // index/size counts are still valid; only the vector count is unavailable
+    expect(result).toEqual({ indicesCount: 1, storeSizeBytes: 500, vectorsCount: null });
     expect(logger.warn).toHaveBeenCalled();
   });
 
@@ -401,7 +468,7 @@ describe('fetchIndexStats', () => {
     expect(result).toEqual({
       indicesCount: null,
       storeSizeBytes: null,
-      vectorDocsCount: null,
+      vectorsCount: null,
     });
     expect(logger.warn).toHaveBeenCalled();
   });
@@ -412,7 +479,7 @@ describe('fetchIndexStats', () => {
     const result = await fetchIndexStats(client, logger);
 
     // a genuinely empty deployment reports real zeros, not null
-    expect(result).toEqual({ indicesCount: 0, storeSizeBytes: 0, vectorDocsCount: 0 });
+    expect(result).toEqual({ indicesCount: 0, storeSizeBytes: 0, vectorsCount: 0 });
     expect(client.asCurrentUser.fieldCaps).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
@@ -41,11 +41,29 @@ describe('fetchIndexStats', () => {
     client.asCurrentUser.fieldCaps.mockResolvedValue({ indices: [], fields } as any);
   };
 
-  const mockEsqlCount = (count: number) => {
-    client.asCurrentUser.esql.query.mockResolvedValue({
-      columns: [{ name: 'doc_count', type: 'long' }],
-      values: [[count]],
-    } as any);
+  /**
+   * Derives the ES|QL count from the indices named in the `FROM` clause so that `vectorDocsCount`
+   * assertions fail when the wrong indices are selected. A fixed count would pass no matter which
+   * indices were queried, leaving misclassification detectable only via the query string.
+   */
+  const mockEsqlDocCounts = (docCountsByIndex: Record<string, number>) => {
+    client.asCurrentUser.esql.query.mockImplementation((async (request: { query: string }) => {
+      const [, fromClause] = /^FROM (.+) \| STATS/.exec(request.query) ?? [];
+      if (!fromClause) throw new Error(`Unparseable ES|QL query: ${request.query}`);
+
+      const totalDocCount = fromClause
+        .split(',')
+        .map((name) => name.replace(/^"|"$/g, ''))
+        .reduce((sum, name) => {
+          const indexDocCount = docCountsByIndex[name];
+          if (indexDocCount === undefined) {
+            throw new Error(`ES|QL queried an index that is not a vector index: ${name}`);
+          }
+          return sum + indexDocCount;
+        }, 0);
+
+      return { columns: [{ name: 'doc_count', type: 'long' }], values: [[totalDocCount]] };
+    }) as any);
   };
 
   it('excludes dot-prefixed indices and aggregates count/size', async () => {
@@ -90,7 +108,7 @@ describe('fetchIndexStats', () => {
         text: { type: 'text', searchable: true, aggregatable: false, inference: true },
       },
     });
-    mockEsqlCount(10);
+    mockEsqlDocCounts({ vectordb: 10 });
 
     const result = await fetchIndexStats(client, logger);
 
@@ -98,6 +116,116 @@ describe('fetchIndexStats', () => {
       expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
     );
     expect(result.vectorDocsCount).toBe(10);
+  });
+
+  it('counts docs from every vector index when only one of them uses semantic_text', async () => {
+    // Three indices holding 5 docs each. `content` is `semantic_text` in `semantic-index` and plain
+    // `text` in the other two, so field caps merges all three into one `text` capability with
+    // `inference: false` and no `indices` list. Reading only `inference` dropped `semantic-index`
+    // and under-reported the 15 docs as 10.
+    mockMetering([
+      // metering num_docs is inflated for semantic_text indices by the nested chunk documents.
+      { name: 'semantic-index', num_docs: 10, size_in_bytes: 500 },
+      { name: 'dense-index', num_docs: 5, size_in_bytes: 500 },
+      { name: 'byoe-index', num_docs: 5, size_in_bytes: 500 },
+    ]);
+    mockFieldCaps({
+      content: {
+        text: {
+          type: 'text',
+          searchable: true,
+          aggregatable: false,
+          inference: false,
+          non_inference_indices: ['dense-index', 'byoe-index'],
+        },
+      },
+      embedding: {
+        unmapped: {
+          type: 'unmapped',
+          searchable: false,
+          aggregatable: false,
+          indices: ['semantic-index'],
+        },
+        dense_vector: {
+          type: 'dense_vector',
+          searchable: true,
+          aggregatable: false,
+          indices: ['dense-index', 'byoe-index'],
+        },
+      },
+    });
+    mockEsqlDocCounts({ 'semantic-index': 5, 'dense-index': 5, 'byoe-index': 5 });
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(result.vectorDocsCount).toBe(15);
+  });
+
+  it('detects semantic_text when the same field is plain text in other indices', async () => {
+    // A field that is `semantic_text` in one index and `text` in others is merged by field caps into
+    // a single `text` capability with `inference: false` and no `indices` list (the `text` type
+    // family is uniform). Only `non_inference_indices` reveals which indices are not inference.
+    mockMetering([
+      { name: 'semantic-only', num_docs: 10, size_in_bytes: 500 },
+      { name: 'plain-a', num_docs: 5, size_in_bytes: 50 },
+      { name: 'plain-b', num_docs: 5, size_in_bytes: 50 },
+    ]);
+    mockFieldCaps({
+      content: {
+        text: {
+          type: 'text',
+          searchable: true,
+          aggregatable: false,
+          inference: false,
+          non_inference_indices: ['plain-a', 'plain-b'],
+        },
+      },
+    });
+    mockEsqlDocCounts({ 'semantic-only': 5, 'plain-a': 5, 'plain-b': 5 });
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM "semantic-only" | STATS doc_count = COUNT(*)' })
+    );
+    expect(result.vectorDocsCount).toBe(5);
+  });
+
+  it('excludes non-inference indices from a partially mapped mixed inference field', async () => {
+    // When the field is absent from some indices the `text` capability carries both an explicit
+    // `indices` list and `non_inference_indices`; the vector indices are the difference.
+    mockMetering([
+      { name: 'semantic-only', num_docs: 10, size_in_bytes: 500 },
+      { name: 'plain-a', num_docs: 5, size_in_bytes: 50 },
+      { name: 'no-content', num_docs: 5, size_in_bytes: 50 },
+    ]);
+    mockFieldCaps({
+      content: {
+        unmapped: {
+          type: 'unmapped',
+          searchable: false,
+          aggregatable: false,
+          inference: false,
+          indices: ['no-content'],
+        },
+        text: {
+          type: 'text',
+          searchable: true,
+          aggregatable: false,
+          inference: false,
+          indices: ['semantic-only', 'plain-a'],
+          non_inference_indices: ['plain-a'],
+        },
+      },
+    });
+    mockEsqlDocCounts({ 'semantic-only': 5, 'plain-a': 5, 'no-content': 5 });
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM "semantic-only" | STATS doc_count = COUNT(*)' })
+    );
+    expect(result.vectorDocsCount).toBe(5);
   });
 
   it('detects an inference field reported by its own `type` (no inference flag)', async () => {
@@ -109,7 +237,7 @@ describe('fetchIndexStats', () => {
         semantic_text: { type: 'semantic_text', searchable: true, aggregatable: false },
       },
     });
-    mockEsqlCount(10);
+    mockEsqlDocCounts({ vectordb: 10 });
 
     const result = await fetchIndexStats(client, logger);
 
@@ -126,7 +254,7 @@ describe('fetchIndexStats', () => {
         semantic: { type: 'semantic', searchable: true, aggregatable: false },
       },
     });
-    mockEsqlCount(10);
+    mockEsqlDocCounts({ vectordb: 10 });
 
     const result = await fetchIndexStats(client, logger);
 
@@ -154,13 +282,15 @@ describe('fetchIndexStats', () => {
       },
       title: { text: { type: 'text', searchable: true, aggregatable: false, inference: false } },
     });
-    mockEsqlCount(10);
+    mockEsqlDocCounts({ vectordb: 10, 'plain-text': 5 });
 
-    await fetchIndexStats(client, logger);
+    const result = await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
       expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
     );
+    // 10 rather than 15 proves `plain-text` docs are excluded.
+    expect(result.vectorDocsCount).toBe(10);
   });
 
   it('does not classify indices where the vector field is unmapped', async () => {
@@ -186,7 +316,7 @@ describe('fetchIndexStats', () => {
         },
       },
     });
-    mockEsqlCount(10);
+    mockEsqlDocCounts({ 'test-vector': 10, 'test-plain': 5000 });
 
     const result = await fetchIndexStats(client, logger);
 
@@ -212,15 +342,16 @@ describe('fetchIndexStats', () => {
         },
       },
     });
-    mockEsqlCount(20);
+    mockEsqlDocCounts({ 'vectordb-a': 10, 'vectordb-b': 10 });
 
-    await fetchIndexStats(client, logger);
+    const result = await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
       expect.objectContaining({
         query: 'FROM "vectordb-a","vectordb-b" | STATS doc_count = COUNT(*)',
       })
     );
+    expect(result.vectorDocsCount).toBe(20);
   });
 
   it('batches the ES|QL count when there are more than 500 vector indices', async () => {
@@ -236,15 +367,7 @@ describe('fetchIndexStats', () => {
         dense_vector: { type: 'dense_vector', searchable: true, aggregatable: false },
       },
     });
-    client.asCurrentUser.esql.query
-      .mockResolvedValueOnce({
-        columns: [{ name: 'doc_count', type: 'long' }],
-        values: [[500]],
-      } as any)
-      .mockResolvedValueOnce({
-        columns: [{ name: 'doc_count', type: 'long' }],
-        values: [[1]],
-      } as any);
+    mockEsqlDocCounts(Object.fromEntries(indices.map(({ name }) => [name, 1])));
 
     const result = await fetchIndexStats(client, logger);
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { chunk } from 'lodash';
 import type { IScopedClusterClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { FieldCapsFieldCapability, Indices } from '@elastic/elasticsearch/lib/api/types';
 
@@ -28,13 +29,13 @@ interface MeteringStatsResponse {
 interface IndexStats {
   indicesCount: number | null;
   storeSizeBytes: number | null;
-  vectorDocsCount: number | null;
+  vectorsCount: number | null;
 }
 
 const INDEX_STATS_UNAVAILABLE: IndexStats = {
   indicesCount: null,
   storeSizeBytes: null,
-  vectorDocsCount: null,
+  vectorsCount: null,
 };
 
 const VECTOR_FIELD_TYPES = new Set(['dense_vector', 'sparse_vector', 'semantic_text', 'semantic']);
@@ -43,19 +44,25 @@ const VECTOR_FIELD_TYPES = new Set(['dense_vector', 'sparse_vector', 'semantic_t
 // must be requested alongside the vector types.
 const FIELD_CAPS_TYPES = [...VECTOR_FIELD_TYPES, 'text'];
 
+// A `semantic_text` field indexes its embeddings in internal nested chunk subfields, which field
+// caps reports as vector fields of their own. They belong to their parent field, so counting them
+// would report a single `semantic_text` value as several vectors.
+const SEMANTIC_TEXT_CHUNK_FIELD = /\.inference\.chunks(\.|$)/;
+
 const toIndexArray = (indices: Indices | undefined): string[] | undefined => {
   if (indices === undefined) return undefined;
   return Array.isArray(indices) ? indices : [indices];
 };
 
 /**
- * Returns which of the given indices contain a vector field. Uses `_field_caps` rather than full
- * mappings as it's far lighter and flattens nested/multi-fields for free.
+ * Maps each of the given indices to the names of the vector fields it maps, omitting indices with
+ * none. Uses `_field_caps` rather than full mappings as it's far lighter and flattens
+ * nested/multi-fields for free.
  */
-const getVectorIndexNames = async (
+const getVectorFieldsByIndex = async (
   client: IScopedClusterClient,
   indexNames: string[]
-): Promise<string[]> => {
+): Promise<Map<string, Set<string>>> => {
   const fieldCaps = await client.asCurrentUser.fieldCaps({
     index: indexNames,
     fields: '*',
@@ -66,9 +73,11 @@ const getVectorIndexNames = async (
     include_unmapped: true,
   });
 
-  const vectorIndexNames = new Set<string>();
+  const vectorFieldsByIndex = new Map<string, Set<string>>();
 
-  for (const capabilitiesByType of Object.values(fieldCaps.fields)) {
+  for (const [fieldName, capabilitiesByType] of Object.entries(fieldCaps.fields)) {
+    if (SEMANTIC_TEXT_CHUNK_FIELD.test(fieldName)) continue;
+
     for (const capability of Object.values(capabilitiesByType) as FieldCapability[]) {
       // `include_unmapped: true` adds pseudo-entries listing indices where the field is absent.
       if (capability.type === 'unmapped') continue;
@@ -91,43 +100,87 @@ const getVectorIndexNames = async (
 
       for (const name of capabilityIndices) {
         if (nonInferenceIndices?.includes(name)) continue;
-        vectorIndexNames.add(name);
-      }
 
-      if (vectorIndexNames.size === indexNames.length) return indexNames;
+        const fields = vectorFieldsByIndex.get(name);
+        if (fields) fields.add(fieldName);
+        else vectorFieldsByIndex.set(name, new Set([fieldName]));
+      }
     }
   }
 
-  return [...vectorIndexNames];
+  return vectorFieldsByIndex;
 };
 
-// Caps indices per ES|QL query so the `FROM` clause can't grow unbounded.
-const ESQL_INDICES_PER_QUERY = 500;
+// Caps indices per search so a single request can't fan out over an unbounded number of shards.
+const INDICES_PER_SEARCH = 500;
 
-const countTopLevelDocs = async (
+interface VectorCountSearch {
+  indices: string[];
+  fields: string[];
+}
+
+type VectorFieldAggregations = Record<string, { doc_count: number }>;
+
+/**
+ * Plans the searches needed to count vector values. Indices mapping the same vector fields are
+ * counted together, as one search can only scope its aggregations to its whole index list.
+ */
+const planVectorCountSearches = (
+  vectorFieldsByIndex: Map<string, Set<string>>
+): VectorCountSearch[] => {
+  const searchesByFields = new Map<string, VectorCountSearch>();
+
+  for (const [indexName, fields] of vectorFieldsByIndex) {
+    const sortedFields = [...fields].sort();
+    const key = JSON.stringify(sortedFields);
+    const search = searchesByFields.get(key);
+
+    if (search) search.indices.push(indexName);
+    else searchesByFields.set(key, { indices: [indexName], fields: sortedFields });
+  }
+
+  return [...searchesByFields.values()].flatMap(({ indices, fields }) =>
+    chunk(indices, INDICES_PER_SEARCH).map((batch) => ({ indices: batch, fields }))
+  );
+};
+
+/**
+ * Counts how many vector fields hold a value across all documents: a document populating three of
+ * its vector fields contributes three. A `semantic_text` field counts once however many chunks it
+ * is split into.
+ */
+const countVectorValues = async (
   client: IScopedClusterClient,
-  indexNames: string[]
+  vectorFieldsByIndex: Map<string, Set<string>>
 ): Promise<number> => {
   let total = 0;
 
-  for (let i = 0; i < indexNames.length; i += ESQL_INDICES_PER_QUERY) {
-    const batch = indexNames.slice(i, i + ESQL_INDICES_PER_QUERY);
-    const esqlResult = await client.asCurrentUser.esql.query({
-      query: `FROM ${batch.map((name) => `"${name}"`).join(',')} | STATS doc_count = COUNT(*)`,
-      allow_partial_results: true,
+  for (const { indices, fields } of planVectorCountSearches(vectorFieldsByIndex)) {
+    // An `exists` filter per field yields the number of documents in which that field holds a
+    // value. Aggregations only see top-level documents, so unlike `_metering/stats` num_docs they
+    // aren't inflated by the nested chunk documents that `semantic_text` fields generate.
+    const response = await client.asCurrentUser.search<unknown, VectorFieldAggregations>({
+      index: indices,
+      size: 0,
+      track_total_hits: false,
+      // Indices reported by metering may be deleted before this runs.
+      ignore_unavailable: true,
+      aggs: Object.fromEntries(
+        fields.map((field, i) => [`vector_field_${i}`, { filter: { exists: { field } } }])
+      ),
     });
 
-    const countColumnIndex = esqlResult.columns.findIndex((col) => col.name === 'doc_count');
-    const [row] = esqlResult.values ?? [];
-    total += (row?.[countColumnIndex] as number) ?? 0;
+    for (const { doc_count: docCount } of Object.values(response.aggregations ?? {})) {
+      total += docCount;
+    }
   }
 
   return total;
 };
 
 /**
- * Fetches index-level stats: user index count, aggregate store size, and doc count across indices
- * with a vector field. Failures are logged and surfaced as `null` so callers can
+ * Fetches index-level stats: user index count, aggregate store size, and the number of populated
+ * vector fields across all documents. Failures are logged and surfaced as `null` so callers can
  * distinguish "unavailable" from a genuine `0`.
  */
 export const fetchIndexStats = async (
@@ -150,29 +203,26 @@ export const fetchIndexStats = async (
     const indicesCount = userIndices.length;
     const storeSizeBytes = userIndices.reduce((sum, index) => sum + (index.size_in_bytes ?? 0), 0);
 
-    let vectorDocsCount: number | null = 0;
+    let vectorsCount: number | null = 0;
     if (indicesCount > 0) {
       const indexNames = userIndices.map((i) => i.name);
 
       try {
-        const vectorIndexNames = await getVectorIndexNames(client, indexNames);
+        const vectorFieldsByIndex = await getVectorFieldsByIndex(client, indexNames);
 
-        if (vectorIndexNames.length > 0) {
-          // `_metering/stats` num_docs counts Lucene documents, which includes the nested chunk
-          // documents that `semantic_text` fields generate, inflating the count. Count top-level
-          // documents with ES|QL instead, matching the index management plugin's workaround.
-          vectorDocsCount = await countTopLevelDocs(client, vectorIndexNames);
+        if (vectorFieldsByIndex.size > 0) {
+          vectorsCount = await countVectorValues(client, vectorFieldsByIndex);
         }
       } catch (error) {
-        // Index/size counts are still valid; only the vector doc count is unavailable.
+        // Index/size counts are still valid; only the vector count is unavailable.
         logger.warn(
-          `Failed to compute vector doc count for vectordb deployment stats. Returning partial stats: ${error.message}`
+          `Failed to compute vector count for vectordb deployment stats. Returning partial stats: ${error.message}`
         );
-        vectorDocsCount = null;
+        vectorsCount = null;
       }
     }
 
-    return { indicesCount, storeSizeBytes, vectorDocsCount };
+    return { indicesCount, storeSizeBytes, vectorsCount };
   } catch (error) {
     logger.warn(`Failed to fetch index stats for vectordb deployment stats: ${error.message}`);
     return INDEX_STATS_UNAVAILABLE;

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -6,11 +6,12 @@
  */
 
 import type { IScopedClusterClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
-import type { FieldCapsFieldCapability } from '@elastic/elasticsearch/lib/api/types';
+import type { FieldCapsFieldCapability, Indices } from '@elastic/elasticsearch/lib/api/types';
 
-// The `inference` flag isn't yet in the Elasticsearch package types.
+// The inference flags aren't yet in the Elasticsearch package types.
 type FieldCapability = FieldCapsFieldCapability & {
   inference?: boolean;
+  non_inference_indices?: Indices;
 };
 
 interface MeteringIndexStat {
@@ -42,6 +43,11 @@ const VECTOR_FIELD_TYPES = new Set(['dense_vector', 'sparse_vector', 'semantic_t
 // must be requested alongside the vector types.
 const FIELD_CAPS_TYPES = [...VECTOR_FIELD_TYPES, 'text'];
 
+const toIndexArray = (indices: Indices | undefined): string[] | undefined => {
+  if (indices === undefined) return undefined;
+  return Array.isArray(indices) ? indices : [indices];
+};
+
 /**
  * Returns which of the given indices contain a vector field. Uses `_field_caps` rather than full
  * mappings as it's far lighter and flattens nested/multi-fields for free.
@@ -67,17 +73,26 @@ const getVectorIndexNames = async (
       // `include_unmapped: true` adds pseudo-entries listing indices where the field is absent.
       if (capability.type === 'unmapped') continue;
 
+      // A field mapped as `semantic_text` in some indices and plain `text` in others collapses into
+      // a single `text` capability with `inference: false`, because both share the `text` type
+      // family and `inference` only reports `true` when it holds for every index. The indices where
+      // the field is *not* an inference field are listed in `non_inference_indices`, so its mere
+      // presence means the field is a vector field in the remaining indices.
+      const nonInferenceIndices = toIndexArray(capability.non_inference_indices);
+
       const isVectorField =
-        VECTOR_FIELD_TYPES.has(capability.type) || capability.inference === true;
+        VECTOR_FIELD_TYPES.has(capability.type) ||
+        capability.inference === true ||
+        nonInferenceIndices !== undefined;
       if (!isVectorField) continue;
 
       // Absent `indices` means the field is mapped in every requested index.
-      if (capability.indices === undefined) return indexNames;
+      const capabilityIndices = toIndexArray(capability.indices) ?? indexNames;
 
-      const capabilityIndices = Array.isArray(capability.indices)
-        ? capability.indices
-        : [capability.indices];
-      capabilityIndices.forEach((name) => vectorIndexNames.add(name));
+      for (const name of capabilityIndices) {
+        if (nonInferenceIndices?.includes(name)) continue;
+        vectorIndexNames.add(name);
+      }
 
       if (vectorIndexNames.size === indexNames.length) return indexNames;
     }

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
@@ -62,7 +62,7 @@ describe('registerDeploymentStatsRoute', () => {
     mockFetchIndexStats.mockResolvedValue({
       indicesCount: 3,
       storeSizeBytes: 1024,
-      vectorDocsCount: 5,
+      vectorsCount: 5,
     });
     mockFetchDashboardsCount.mockResolvedValue(2);
 
@@ -75,7 +75,7 @@ describe('registerDeploymentStatsRoute', () => {
       body: {
         indicesCount: 3,
         storeSizeBytes: 1024,
-        vectorDocsCount: 5,
+        vectorsCount: 5,
         dashboardsCount: 2,
       },
     });
@@ -85,7 +85,7 @@ describe('registerDeploymentStatsRoute', () => {
     mockFetchIndexStats.mockResolvedValue({
       indicesCount: 0,
       storeSizeBytes: 0,
-      vectorDocsCount: 0,
+      vectorsCount: 0,
     });
     mockFetchDashboardsCount.mockResolvedValue(0);
 
@@ -102,7 +102,7 @@ describe('registerDeploymentStatsRoute', () => {
     mockFetchIndexStats.mockResolvedValue({
       indicesCount: null,
       storeSizeBytes: null,
-      vectorDocsCount: null,
+      vectorsCount: null,
     });
     mockFetchDashboardsCount.mockResolvedValue(null);
 
@@ -115,7 +115,7 @@ describe('registerDeploymentStatsRoute', () => {
       body: {
         indicesCount: null,
         storeSizeBytes: null,
-        vectorDocsCount: null,
+        vectorsCount: null,
         dashboardsCount: null,
       },
     });

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
@@ -25,17 +25,15 @@ export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) =>
         const client = core.elasticsearch.client;
         const savedObjectsClient = core.savedObjects.getClient();
 
-        const [{ indicesCount, storeSizeBytes, vectorDocsCount }, dashboardsCount] =
-          await Promise.all([
-            fetchIndexStats(client, logger),
-            fetchDashboardsCount(savedObjectsClient, logger),
-          ]);
+        const [{ indicesCount, storeSizeBytes, vectorsCount }, dashboardsCount] = await Promise.all(
+          [fetchIndexStats(client, logger), fetchDashboardsCount(savedObjectsClient, logger)]
+        );
 
         return response.ok({
           body: {
             indicesCount,
             storeSizeBytes,
-            vectorDocsCount,
+            vectorsCount,
             dashboardsCount,
           },
         });


### PR DESCRIPTION
## Summary

Fixes the "Vectors" stat on the serverless VectorDB home page, which was reporting document counts rather than vector counts and overcounting `semantic_text` fields.

Previously the deployment stats endpoint counted every top-level document in any index containing a vector field (`vectorDocsCount`). This PR changes it to count populated vector fields across documents (`vectorsCount`): a document with three populated vector fields now contributes three, and a document in a vector index with no populated vector fields contributes zero.

Changes in `fetchIndexStats`:

- Field caps discovery now maps each index to its vector field names instead of just flagging vector indices, and skips the internal `.inference.chunks` subfields that `semantic_text` generates, which field caps reports as vector fields of their own.
- Handles fields mapped as `semantic_text` in some indices and plain `text` in others: field caps collapses these into a single `text` capability with `inference: false`, so the code now uses `non_inference_indices` to attribute the field to the correct indices.
- Counting switched from an ES|QL `COUNT(*)` over vector indices to `_search` aggregations with one `exists` filter per vector field, batched by shared field sets and capped at 500 indices per search. Aggregations only see top-level documents, so counts aren't inflated by nested `semantic_text` chunk documents.
- The response field is renamed from `vectorDocsCount` to `vectorsCount` throughout the route, client hook, and home page.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

- Counting now issues one `_search` with `exists`-filter aggregations per group of indices sharing the same vector field set (capped at 500 indices per request), replacing a single ES|QL count per batch. On deployments with many heterogeneous index mappings this means more requests, though each is a cheap `size: 0` filter aggregation.
- The `vectorsCount` rename changes the internal deployment stats endpoint's response shape; the only consumer (the VectorDB home page hook) is updated in this PR.
