### PR TITLE
[8.19] [ResponseOps] enforce auth permissions on requested namespaces (#277679)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/authorization/alerting_authorization.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/authorization/alerting_authorization.test.ts
@@ -137,18 +137,53 @@ type CheckPrivilegesResponseWithoutES = Omit<CheckPrivilegesResponse, 'privilege
 };
 
 describe('AlertingAuthorization', () => {
+  const spaceId = 'space1';
   const getSpace = jest.fn();
-  const getSpaceId = () => 'space1';
+  const getSpaceId = () => spaceId;
   const allRegisteredConsumers = new Set<string>();
   const ruleTypesConsumersMap = new Map<string, Set<string>>();
 
-  const checkPrivileges = jest.fn<Promise<CheckPrivilegesResponseWithoutES>, []>(async () => ({
+  const checkPrivileges = jest.fn<
+    Promise<CheckPrivilegesResponseWithoutES>,
+    [{ kibana: string[] }]
+  >(async () => ({
     username: 'elastic',
     hasAllRequested: true,
     privileges: { kibana: [] },
   }));
+  const atSpacesMock = jest.fn((_spaces: string[], privileges: { kibana: string[] }) =>
+    checkPrivileges(privileges)
+  );
 
   const ruleTypeIds = ['rule-type-id-1', 'rule-type-id-2', 'rule-type-id-3', 'rule-type-id-4'];
+  const requiredPrivileges = {
+    kibana: [
+      'rule-type-id-1/alerts/rule/get',
+      'rule-type-id-1/alerts/rule/create',
+      'rule-type-id-1/consumer-a/rule/get',
+      'rule-type-id-1/consumer-a/rule/create',
+      'rule-type-id-1/consumer-b/rule/get',
+      'rule-type-id-1/consumer-b/rule/create',
+      'rule-type-id-2/alerts/rule/get',
+      'rule-type-id-2/alerts/rule/create',
+      'rule-type-id-2/consumer-b/rule/get',
+      'rule-type-id-2/consumer-b/rule/create',
+      'rule-type-id-3/alerts/rule/get',
+      'rule-type-id-3/alerts/rule/create',
+      'rule-type-id-3/consumer-c/rule/get',
+      'rule-type-id-3/consumer-c/rule/create',
+      'rule-type-id-4/consumer-d/rule/get',
+      'rule-type-id-4/consumer-d/rule/create',
+    ],
+  };
+  const allAuthorized = {
+    all: true,
+    read: true,
+  };
+  const readonlyAuthorized = {
+    all: false,
+    read: true,
+  };
 
   let request: KibanaRequest;
   let ruleTypeRegistry = ruleTypeRegistryMock.create();
@@ -164,6 +199,9 @@ describe('AlertingAuthorization', () => {
     securityStart = securityMock.createStart();
     securityStart.authz.mode.useRbacForRequest.mockReturnValue(true);
     securityStart.authz.checkPrivilegesDynamicallyWithRequest.mockReturnValue(checkPrivileges);
+    securityStart.authz.checkPrivilegesWithRequest.mockReturnValue({
+      atSpaces: atSpacesMock,
+    });
     request = httpServerMock.createKibanaRequest();
     getSpace.mockResolvedValue(undefined);
 
@@ -769,22 +807,18 @@ describe('AlertingAuthorization', () => {
       ).filter;
 
       expect(checkPrivileges).toBeCalledTimes(1);
-      expect(checkPrivileges.mock.calls[0]).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "kibana": Array [
-              "rule-type-id-1/alerts/rule/find",
-              "rule-type-id-1/consumer-a/rule/find",
-              "rule-type-id-1/consumer-b/rule/find",
-              "rule-type-id-2/alerts/rule/find",
-              "rule-type-id-2/consumer-b/rule/find",
-              "rule-type-id-3/alerts/rule/find",
-              "rule-type-id-3/consumer-c/rule/find",
-              "rule-type-id-4/consumer-d/rule/find",
-            ],
-          },
-        ]
-      `);
+      expect(atSpacesMock).toHaveBeenCalledWith([spaceId], {
+        kibana: [
+          'rule-type-id-1/alerts/rule/find',
+          'rule-type-id-1/consumer-a/rule/find',
+          'rule-type-id-1/consumer-b/rule/find',
+          'rule-type-id-2/alerts/rule/find',
+          'rule-type-id-2/consumer-b/rule/find',
+          'rule-type-id-3/alerts/rule/find',
+          'rule-type-id-3/consumer-c/rule/find',
+          'rule-type-id-4/consumer-d/rule/find',
+        ],
+      });
 
       expect(toKqlExpression(filter as KueryNode)).toMatchInlineSnapshot(
         `"((path.to.rule_type_id: rule-type-id-1 AND (consumer-field: alerts OR consumer-field: consumer-a OR consumer-field: consumer-b)) OR (path.to.rule_type_id: rule-type-id-2 AND (consumer-field: alerts OR consumer-field: consumer-b)) OR (path.to.rule_type_id: rule-type-id-3 AND (consumer-field: consumer-c OR consumer-field: alerts)))"`
@@ -890,9 +924,7 @@ describe('AlertingAuthorization', () => {
           operation: ReadOperations.Get,
         });
 
-        expect(toKqlExpression(filter as KueryNode)).toMatchInlineSnapshot(
-          `"path.to.space.id: space1"`
-        );
+        expect(toKqlExpression(filter as KueryNode)).toEqual(`path.to.space.id: ${spaceId}`);
       });
 
       it('gets the filter correctly with security disabled', async () => {
@@ -1009,7 +1041,7 @@ describe('AlertingAuthorization', () => {
             operation: ReadOperations.Get,
           })
         ).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"Unauthorized to get rules for any rule types"`
+          `"Unauthorized to get rules for any rule types."`
         );
       });
     });
@@ -1188,6 +1220,54 @@ describe('AlertingAuthorization', () => {
           `"Unauthorized by \\"consumer-b\\" to get \\"rule-type-id-1\\" rule"`
         );
       });
+
+      it('throws when it is authorized in some of the requested namespaces but not all', async () => {
+        checkPrivileges.mockResolvedValueOnce({
+          username: 'some-user',
+          hasAllRequested: false,
+          privileges: {
+            kibana: [
+              {
+                privilege: mockAuthorizationAction('rule-type-id-1', 'alerts', 'rule', 'get'),
+                authorized: true,
+                resource: 'space1',
+              },
+              {
+                privilege: mockAuthorizationAction('rule-type-id-1', 'alerts', 'rule', 'get'),
+                authorized: false,
+                resource: 'space2',
+              },
+            ],
+          },
+        });
+
+        const auth = await AlertingAuthorization.create({
+          request,
+          ruleTypeRegistry,
+          getSpaceId,
+          features,
+          getSpace,
+          authorization: securityStart.authz,
+        });
+
+        const getAuthorizationFilter = auth.getAuthorizationFilter({
+          authorizationEntity: AlertingAuthorizationEntity.Rule,
+          filterOpts: {
+            type: AlertingAuthorizationFilterType.KQL,
+            fieldNames: {
+              ruleTypeId: 'ruleId',
+              consumer: 'consumer',
+            },
+            namespaces: ['space1', 'space2'],
+          },
+          operation: ReadOperations.Get,
+        });
+
+        await expect(getAuthorizationFilter).rejects.toThrow(
+          'Unauthorized to get rules for any rule types. Validate that you have permissions to access spaces: space1,space2'
+        );
+        expect(atSpacesMock).toHaveBeenCalledWith(['space1', 'space2'], expect.any(Object));
+      });
     });
   });
 
@@ -1361,30 +1441,8 @@ describe('AlertingAuthorization', () => {
       });
 
       expect(checkPrivileges).toBeCalledTimes(1);
-      expect(checkPrivileges.mock.calls[0]).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "kibana": Array [
-              "rule-type-id-1/alerts/rule/get",
-              "rule-type-id-1/alerts/rule/create",
-              "rule-type-id-1/consumer-a/rule/get",
-              "rule-type-id-1/consumer-a/rule/create",
-              "rule-type-id-1/consumer-b/rule/get",
-              "rule-type-id-1/consumer-b/rule/create",
-              "rule-type-id-2/alerts/rule/get",
-              "rule-type-id-2/alerts/rule/create",
-              "rule-type-id-2/consumer-b/rule/get",
-              "rule-type-id-2/consumer-b/rule/create",
-              "rule-type-id-3/alerts/rule/get",
-              "rule-type-id-3/alerts/rule/create",
-              "rule-type-id-3/consumer-c/rule/get",
-              "rule-type-id-3/consumer-c/rule/create",
-              "rule-type-id-4/consumer-d/rule/get",
-              "rule-type-id-4/consumer-d/rule/create",
-            ],
-          },
-        ]
-      `);
+      expect(checkPrivileges).toHaveBeenCalledWith(requiredPrivileges);
+      expect(atSpacesMock).toHaveBeenCalledWith([spaceId], requiredPrivileges);
     });
   });
 
@@ -1405,109 +1463,59 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-            "rule-type-id-2" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-2',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-            "rule-type-id-3" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-3',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-            "rule-type-id-4" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-4',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+      });
     });
 
     it('filters out rule types with no authorization', async () => {
@@ -1526,61 +1534,35 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-            "rule-type-id-2" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-2',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+      });
     });
 
     it('returns all rule types with all consumers as authorized with disabled authorization', async () => {
@@ -1602,109 +1584,59 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-            "rule-type-id-2" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-2',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-            "rule-type-id-3" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-3',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-            "rule-type-id-4" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-4',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+      });
     });
 
     it('filters out rule types with disabled authorization', async () => {
@@ -1726,61 +1658,35 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-            "rule-type-id-2" => Object {
-              "authorizedConsumers": Object {
-                "alerts": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-c": Object {
-                  "all": true,
-                  "read": true,
-                },
-                "consumer-d": Object {
-                  "all": true,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-2',
+            {
+              authorizedConsumers: {
+                alerts: allAuthorized,
+                'consumer-a': allAuthorized,
+                'consumer-b': allAuthorized,
+                'consumer-c': allAuthorized,
+                'consumer-d': allAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+      });
     });
 
     it('get authorized rule types with authorized consumers with read access only', async () => {
@@ -1813,22 +1719,20 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "consumer-a": Object {
-                  "all": false,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                'consumer-a': readonlyAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-          "username": "some-user",
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
 
     it('get authorized rule types with authorized consumers with full access', async () => {
@@ -1865,22 +1769,20 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                'consumer-a': allAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-          "username": "some-user",
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
 
     it('filters out not requested rule types', async () => {
@@ -1921,26 +1823,21 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "consumer-a": Object {
-                  "all": false,
-                  "read": true,
-                },
-                "consumer-b": Object {
-                  "all": true,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                'consumer-a': readonlyAuthorized,
+                'consumer-b': allAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-          "username": "some-user",
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
 
     it('returns an empty map with no requested rule types', async () => {
@@ -1977,13 +1874,11 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {},
-          "hasAllRequested": true,
-          "username": "some-user",
-        }
-      `);
+      ).toEqual({
+        authorizedRuleTypes: new Map(),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
 
     it('get authorized rule types with authorized consumers when some rule types are not authorized', async () => {
@@ -2028,30 +1923,28 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                'consumer-a': allAuthorized,
               },
             },
-            "rule-type-id-3" => Object {
-              "authorizedConsumers": Object {
-                "consumer-c": Object {
-                  "all": false,
-                  "read": true,
-                },
+          ],
+          [
+            'rule-type-id-3',
+            {
+              authorizedConsumers: {
+                'consumer-c': readonlyAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-          "username": "some-user",
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
 
     it('get authorized rule types with authorized consumers when consumers are not valid for a rule type', async () => {
@@ -2096,22 +1989,20 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {
-            "rule-type-id-1" => Object {
-              "authorizedConsumers": Object {
-                "consumer-a": Object {
-                  "all": true,
-                  "read": true,
-                },
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                'consumer-a': allAuthorized,
               },
             },
-          },
-          "hasAllRequested": true,
-          "username": "some-user",
-        }
-      `);
+          ],
+        ]),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
 
     it('filters out rule types that are not in the rule type registry but registered in the feature', async () => {
@@ -2146,13 +2037,11 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {},
-          "hasAllRequested": true,
-          "username": "some-user",
-        }
-      `);
+      ).toEqual({
+        authorizedRuleTypes: new Map(),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
 
     it('filters out rule types that are registered in the rule type registry but not in the feature', async () => {
@@ -2187,13 +2076,11 @@ describe('AlertingAuthorization', () => {
           operations: [ReadOperations.Get, WriteOperations.Create],
           authorizationEntity: AlertingAuthorizationEntity.Rule,
         })
-      ).toMatchInlineSnapshot(`
-        Object {
-          "authorizedRuleTypes": Map {},
-          "hasAllRequested": true,
-          "username": "some-user",
-        }
-      `);
+      ).toEqual({
+        authorizedRuleTypes: new Map(),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
 
     it('call checkPrivileges with the correct actions', async () => {
@@ -2214,30 +2101,8 @@ describe('AlertingAuthorization', () => {
       });
 
       expect(checkPrivileges).toBeCalledTimes(1);
-      expect(checkPrivileges.mock.calls[0]).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "kibana": Array [
-              "rule-type-id-1/alerts/rule/get",
-              "rule-type-id-1/alerts/rule/create",
-              "rule-type-id-1/consumer-a/rule/get",
-              "rule-type-id-1/consumer-a/rule/create",
-              "rule-type-id-1/consumer-b/rule/get",
-              "rule-type-id-1/consumer-b/rule/create",
-              "rule-type-id-2/alerts/rule/get",
-              "rule-type-id-2/alerts/rule/create",
-              "rule-type-id-2/consumer-b/rule/get",
-              "rule-type-id-2/consumer-b/rule/create",
-              "rule-type-id-3/alerts/rule/get",
-              "rule-type-id-3/alerts/rule/create",
-              "rule-type-id-3/consumer-c/rule/get",
-              "rule-type-id-3/consumer-c/rule/create",
-              "rule-type-id-4/consumer-d/rule/get",
-              "rule-type-id-4/consumer-d/rule/create",
-            ],
-          },
-        ]
-      `);
+      expect(checkPrivileges).toHaveBeenCalledWith(requiredPrivileges);
+      expect(atSpacesMock).toHaveBeenLastCalledWith([spaceId], requiredPrivileges);
     });
 
     it('call checkPrivileges with the correct actions when the rule type does not exist in the registry', async () => {
@@ -2260,13 +2125,7 @@ describe('AlertingAuthorization', () => {
       });
 
       expect(checkPrivileges).toBeCalledTimes(1);
-      expect(checkPrivileges.mock.calls[0]).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "kibana": Array [],
-          },
-        ]
-      `);
+      expect(checkPrivileges).toHaveBeenCalledWith({ kibana: [] });
     });
 
     it('call checkPrivileges with the correct actions when the rule type does not exist in the feature', async () => {
@@ -2289,13 +2148,173 @@ describe('AlertingAuthorization', () => {
       });
 
       expect(checkPrivileges).toBeCalledTimes(1);
-      expect(checkPrivileges.mock.calls[0]).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "kibana": Array [],
-          },
-        ]
-      `);
+      expect(atSpacesMock).toHaveBeenCalledWith([spaceId], { kibana: [] });
+    });
+
+    it('calls checkPrivileges with the correct spaces when namespaces are defined', async () => {
+      const auth = await AlertingAuthorization.create({
+        request,
+        ruleTypeRegistry,
+        getSpaceId,
+        features,
+        getSpace,
+        authorization: securityStart.authz,
+      });
+
+      // @ts-expect-error: need to test the private method
+      await auth._getAuthorizedRuleTypesWithAuthorizedConsumers({
+        ruleTypeIds: [...ruleTypeIds, 'rule-type-not-exist'],
+        operations: [ReadOperations.Get, WriteOperations.Create],
+        authorizationEntity: AlertingAuthorizationEntity.Rule,
+        namespaces: ['a-random-space'],
+      });
+
+      expect(checkPrivileges).toBeCalledTimes(1);
+      expect(checkPrivileges).toBeCalledWith(requiredPrivileges);
+      expect(atSpacesMock).toHaveBeenCalledWith(['a-random-space'], requiredPrivileges);
+    });
+
+    // namespaces = ['default', 'test'] gets mapped to [undefined, 'test']. This ensures that 'default' space privileges are checked
+    it(`doesn't skip the check to the "default" space on checkPrivileges when included with other spaces`, async () => {
+      const auth = await AlertingAuthorization.create({
+        request,
+        ruleTypeRegistry,
+        getSpaceId,
+        features,
+        getSpace,
+        authorization: securityStart.authz,
+      });
+
+      // @ts-expect-error: need to test the private method
+      await auth._getAuthorizedRuleTypesWithAuthorizedConsumers({
+        ruleTypeIds: [...ruleTypeIds, 'rule-type-not-exist'],
+        operations: [ReadOperations.Get, WriteOperations.Create],
+        authorizationEntity: AlertingAuthorizationEntity.Rule,
+        namespaces: ['default', 'a-random-space'],
+      });
+
+      expect(checkPrivileges).toBeCalledTimes(1);
+      expect(checkPrivileges).toBeCalledWith(requiredPrivileges);
+      expect(atSpacesMock).toHaveBeenCalledWith(['default', 'a-random-space'], requiredPrivileges);
+    });
+
+    it('calls checkPrivileges when in the default space', async () => {
+      const auth = await AlertingAuthorization.create({
+        request,
+        ruleTypeRegistry,
+        getSpaceId: () => undefined,
+        features,
+        getSpace,
+        authorization: securityStart.authz,
+      });
+
+      // @ts-expect-error: need to test the private method
+      await auth._getAuthorizedRuleTypesWithAuthorizedConsumers({
+        ruleTypeIds: [...ruleTypeIds, 'rule-type-not-exist'],
+        operations: [ReadOperations.Get, WriteOperations.Create],
+        authorizationEntity: AlertingAuthorizationEntity.Rule,
+      });
+
+      expect(atSpacesMock).toHaveBeenCalledWith(['default'], requiredPrivileges);
+    });
+
+    it('excludes a rule type when its privilege is authorized in some requested spaces but not all', async () => {
+      const auth = await AlertingAuthorization.create({
+        request,
+        ruleTypeRegistry,
+        getSpaceId,
+        features,
+        getSpace,
+        authorization: securityStart.authz,
+      });
+
+      // atSpaces returns one entry per (space, privilege) pair. Simulate the user
+      // having access in space-a but not space-b for consumer-a.
+      atSpacesMock.mockResolvedValueOnce({
+        username: 'some-user',
+        hasAllRequested: false,
+        privileges: {
+          kibana: [
+            {
+              resource: 'space-a',
+              privilege: mockAuthorizationAction('rule-type-id-1', 'consumer-a', 'rule', 'get'),
+              authorized: true,
+            },
+            {
+              resource: 'space-b',
+              privilege: mockAuthorizationAction('rule-type-id-1', 'consumer-a', 'rule', 'get'),
+              authorized: false,
+            },
+          ],
+        },
+      });
+
+      expect(
+        // @ts-expect-error: need to test the private method
+        await auth._getAuthorizedRuleTypesWithAuthorizedConsumers({
+          ruleTypeIds: ['rule-type-id-1'],
+          operations: [ReadOperations.Get],
+          authorizationEntity: AlertingAuthorizationEntity.Rule,
+          namespaces: ['space-a', 'space-b'],
+        })
+      ).toEqual({
+        authorizedRuleTypes: new Map(),
+        hasAllRequested: false,
+        username: 'some-user',
+      });
+    });
+
+    it('includes a rule type when its privilege is authorized in all requested spaces', async () => {
+      const auth = await AlertingAuthorization.create({
+        request,
+        ruleTypeRegistry,
+        getSpaceId,
+        features,
+        getSpace,
+        authorization: securityStart.authz,
+      });
+
+      atSpacesMock.mockResolvedValueOnce({
+        username: 'some-user',
+        hasAllRequested: true,
+        privileges: {
+          kibana: [
+            {
+              resource: 'space-a',
+              privilege: mockAuthorizationAction('rule-type-id-1', 'consumer-a', 'rule', 'get'),
+              authorized: true,
+            },
+            {
+              resource: 'space-b',
+              privilege: mockAuthorizationAction('rule-type-id-1', 'consumer-a', 'rule', 'get'),
+              authorized: true,
+            },
+          ],
+        },
+      });
+
+      expect(
+        // @ts-expect-error: need to test the private method
+        await auth._getAuthorizedRuleTypesWithAuthorizedConsumers({
+          ruleTypeIds: ['rule-type-id-1'],
+          operations: [ReadOperations.Get],
+          authorizationEntity: AlertingAuthorizationEntity.Rule,
+          namespaces: ['space-a', 'space-b'],
+        })
+      ).toEqual({
+        authorizedRuleTypes: new Map([
+          [
+            'rule-type-id-1',
+            {
+              authorizedConsumers: {
+                'consumer-a': readonlyAuthorized,
+              },
+            },
+          ],
+        ]),
+        hasAllRequested: true,
+        username: 'some-user',
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/authorization/alerting_authorization.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/authorization/alerting_authorization.ts
@@ -66,6 +66,7 @@ interface GetAuthorizedRuleTypesWithAuthorizedConsumersParams {
   ruleTypeIds?: string[];
   operations: Array<ReadOperations | WriteOperations>;
   authorizationEntity: AlertingAuthorizationEntity;
+  namespaces?: Array<string | undefined>;
 }
 
 interface GetAllAuthorizedRuleTypesFindOperationParams {
@@ -296,15 +297,22 @@ export class AlertingAuthorization {
     ensureRuleTypeIsAuthorized: (ruleTypeId: string, consumer: string, auth: string) => void;
   }> {
     if (this.authorization && this.shouldCheckAuthorization()) {
+      const { namespaces } = params.filterOpts;
       const { authorizedRuleTypes } = await this._getAuthorizedRuleTypesWithAuthorizedConsumers({
         operations: [params.operation],
         authorizationEntity: params.authorizationEntity,
+        namespaces,
       });
 
       if (!authorizedRuleTypes.size) {
-        throw Boom.forbidden(
-          `Unauthorized to ${params.operation} ${params.authorizationEntity}s for any rule types`
-        );
+        const baseMessage = `Unauthorized to ${params.operation} ${params.authorizationEntity}s for any rule types.`;
+        const errorMessage =
+          (namespaces ?? []).length > 0
+            ? `${baseMessage} Validate that you have permissions to access spaces: ${(
+                namespaces ?? []
+              ).map((space) => (space === undefined ? 'default' : space))}`
+            : baseMessage;
+        throw Boom.forbidden(errorMessage);
       }
 
       return {
@@ -362,7 +370,7 @@ export class AlertingAuthorization {
     hasAllRequested: boolean;
     authorizedRuleTypes: Map<string, { authorizedConsumers: AuthorizedConsumers }>;
   }> {
-    const { operations, authorizationEntity } = params;
+    const { operations, authorizationEntity, namespaces } = params;
     const ruleTypeIds = params.ruleTypeIds
       ? new Set(params.ruleTypeIds)
       : new Set(this.ruleTypeRegistry.getAllTypes());
@@ -374,10 +382,6 @@ export class AlertingAuthorization {
 
     if (this.authorization && this.shouldCheckAuthorization()) {
       const authorizedRuleTypes = new Map<string, { authorizedConsumers: AuthorizedConsumers }>();
-
-      const checkPrivileges = this.authorization.checkPrivilegesDynamicallyWithRequest(
-        this.request
-      );
 
       for (const ruleTypeId of ruleTypeIds) {
         /**
@@ -410,31 +414,44 @@ export class AlertingAuthorization {
         }
       }
 
-      const { username, hasAllRequested, privileges } = await checkPrivileges({
+      const checkPrivileges = this.authorization.checkPrivilegesWithRequest(this.request);
+      const spaces = (namespaces ? namespaces : [this.spaceId]).map((space) =>
+        space === undefined ? 'default' : space
+      );
+
+      const { username, hasAllRequested, privileges } = await checkPrivileges.atSpaces(spaces, {
         kibana: [...requiredPrivileges.keys()],
       });
 
+      const privilegeAuthResults = new Map<string, boolean[]>();
       for (const { authorized, privilege } of privileges.kibana) {
-        if (authorized && requiredPrivileges.has(privilege)) {
-          const { ruleTypeId, consumer, operation } = requiredPrivileges.get(privilege)!;
-
-          const authorizedRuleType = authorizedRuleTypes.get(ruleTypeId) ?? {
-            authorizedConsumers: {},
-          };
-
-          const authorizedConsumers = authorizedRuleType.authorizedConsumers;
-          const mergedOperations = mergeHasPrivileges(
-            getPrivilegesFromOperation(operation),
-            authorizedConsumers[consumer]
-          );
-
-          authorizedRuleTypes.set(ruleTypeId, {
-            authorizedConsumers: {
-              ...authorizedConsumers,
-              [consumer]: mergedOperations,
-            },
-          });
+        if (requiredPrivileges.has(privilege)) {
+          const auths = privilegeAuthResults.get(privilege) ?? [];
+          auths.push(authorized);
+          privilegeAuthResults.set(privilege, auths);
         }
+      }
+
+      for (const [privilege, auths] of privilegeAuthResults) {
+        if (!auths.every(Boolean)) continue;
+
+        const { ruleTypeId, consumer, operation } = requiredPrivileges.get(privilege)!;
+        const authorizedRuleType = authorizedRuleTypes.get(ruleTypeId) ?? {
+          authorizedConsumers: {},
+        };
+
+        const authorizedConsumers = authorizedRuleType.authorizedConsumers;
+        const mergedOperations = mergeHasPrivileges(
+          getPrivilegesFromOperation(operation),
+          authorizedConsumers[consumer]
+        );
+
+        authorizedRuleTypes.set(ruleTypeId, {
+          authorizedConsumers: {
+            ...authorizedConsumers,
+            [consumer]: mergedOperations,
+          },
+        });
       }
 
       return {

--- a/x-pack/platform/plugins/shared/alerting/server/authorization/alerting_authorization_kuery.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/authorization/alerting_authorization_kuery.ts
@@ -19,6 +19,7 @@ export enum AlertingAuthorizationFilterType {
 export interface AlertingAuthorizationFilterOpts {
   type: AlertingAuthorizationFilterType;
   fieldNames: AlertingAuthorizationFilterFieldNames;
+  namespaces?: Array<string | undefined>;
 }
 
 interface AlertingAuthorizationFilterFieldNames {

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_execution_kpi.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_execution_kpi.ts
@@ -113,6 +113,7 @@ export async function getGlobalExecutionKpiWithAuth(
           ruleTypeId: 'kibana.alert.rule.rule_type_id',
           consumer: 'kibana.alert.rule.consumer',
         },
+        namespaces,
       },
     });
   } catch (error) {

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_execution_log.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_execution_log.ts
@@ -126,6 +126,7 @@ export async function getGlobalExecutionLogWithAuth(
           ruleTypeId: 'kibana.alert.rule.rule_type_id',
           consumer: 'kibana.alert.rule.consumer',
         },
+        namespaces,
       },
     });
   } catch (error) {

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/find.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/find.ts
@@ -412,7 +412,7 @@ export default function findBackfillTests({ getService }: FtrProviderContext) {
                 expect(response.statusCode).to.eql(403);
                 expect(response.body).to.eql({
                   error: 'Forbidden',
-                  message: `Failed to find backfills: Unauthorized to find rules for any rule types`,
+                  message: `Failed to find backfills: Unauthorized to find rules for any rule types.`,
                   statusCode: 403,
                 });
               });

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/schedule.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/schedule.ts
@@ -173,7 +173,7 @@ export default function scheduleBackfillTests({ getService }: FtrProviderContext
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -362,7 +362,7 @@ export default function scheduleBackfillTests({ getService }: FtrProviderContext
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -777,7 +777,7 @@ export default function scheduleBackfillTests({ getService }: FtrProviderContext
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -880,7 +880,7 @@ export default function scheduleBackfillTests({ getService }: FtrProviderContext
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -1210,7 +1210,7 @@ export default function scheduleBackfillTests({ getService }: FtrProviderContext
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/find.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/find.ts
@@ -76,7 +76,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -190,7 +190,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -286,7 +286,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -386,7 +386,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -463,7 +463,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -523,7 +523,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/find_internal.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/find_internal.ts
@@ -61,7 +61,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -150,7 +150,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -247,7 +247,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -359,7 +359,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -447,7 +447,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -517,7 +517,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;
@@ -560,7 +560,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: `Unauthorized to find rules for any rule types`,
+                message: `Unauthorized to find rules for any rule types.`,
                 statusCode: 403,
               });
               break;

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/get_gaps_summary_by_rule_ids.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/get_gaps_summary_by_rule_ids.ts
@@ -118,7 +118,7 @@ export default function getGapsSummaryByRuleIdsTests({ getService }: FtrProvider
                 expect(response.body).to.eql({
                   error: 'Forbidden',
                   message:
-                    'Failed to find gaps summary for rules: Unauthorized to find rules for any rule types',
+                    'Failed to find gaps summary for rules: Unauthorized to find rules for any rule types.',
                   statusCode: 403,
                 });
                 break;
@@ -175,7 +175,7 @@ export default function getGapsSummaryByRuleIdsTests({ getService }: FtrProvider
                 expect(response.body).to.eql({
                   error: 'Forbidden',
                   message:
-                    'Failed to find gaps summary for rules: Unauthorized to find rules for any rule types',
+                    'Failed to find gaps summary for rules: Unauthorized to find rules for any rule types.',
                   statusCode: 403,
                 });
                 break;

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/get_rules_with_gaps.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/get_rules_with_gaps.ts
@@ -113,7 +113,7 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
                 expect(response.body).to.eql({
                   error: 'Forbidden',
                   message:
-                    'Failed to find rules with gaps: Unauthorized to find rules for any rule types',
+                    'Failed to find rules with gaps: Unauthorized to find rules for any rule types.',
                   statusCode: 403,
                 });
                 break;

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/gap/get_rules_with_gaps.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/gap/get_rules_with_gaps.ts
@@ -115,7 +115,7 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
                 expect(response.body).to.eql({
                   error: 'Forbidden',
                   message:
-                    'Failed to find rules with gaps: Unauthorized to find rules for any rule types',
+                    'Failed to find rules with gaps: Unauthorized to find rules for any rule types.',
                   statusCode: 403,
                 });
                 return;

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/aggregate.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/aggregate.ts
@@ -126,7 +126,7 @@ export default function createAggregateTests({ getService }: FtrProviderContext)
                 expectedStatusCode: 403,
                 expectedResponse: {
                   error: 'Forbidden',
-                  message: 'Unauthorized to find rules for any rule types',
+                  message: 'Unauthorized to find rules for any rule types.',
                   statusCode: 403,
                 },
               });

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_delete.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_delete.ts
@@ -121,7 +121,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -186,7 +186,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -271,7 +271,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -335,7 +335,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -407,7 +407,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -504,7 +504,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all_with_restricted_fixture at space1':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_disable.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_disable.ts
@@ -91,7 +91,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -140,7 +140,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -210,7 +210,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -270,7 +270,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -325,7 +325,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -387,7 +387,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all_with_restricted_fixture at space1':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_edit.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_edit.ts
@@ -82,7 +82,7 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -176,7 +176,7 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -243,7 +243,7 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -310,7 +310,7 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -375,7 +375,7 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -599,7 +599,7 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
             case 'space_1_all_with_restricted_fixture at space1':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -647,7 +647,7 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
 

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_enable.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_enable.ts
@@ -62,7 +62,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -149,7 +149,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -251,7 +251,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -343,7 +343,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -512,7 +512,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all at space2':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);
@@ -734,7 +734,7 @@ export default ({ getService }: FtrProviderContext) => {
             case 'space_1_all_with_restricted_fixture at space1':
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               expect(response.statusCode).to.eql(403);

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/suggestions_value_rule.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/suggestions_value_rule.ts
@@ -67,7 +67,7 @@ export default function createRuleSuggestionValuesTests({ getService }: FtrProvi
               expect(response.statusCode).toEqual(403);
               expect(response.body).toEqual({
                 error: 'Forbidden',
-                message: 'Unauthorized to find rules for any rule types',
+                message: 'Unauthorized to find rules for any rule types.',
                 statusCode: 403,
               });
               break;

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/get_global_execution_kpi.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/get_global_execution_kpi.ts
@@ -159,6 +159,28 @@ export default function getGlobalExecutionKpiTests({ getService }: FtrProviderCo
       expect(kpiLogs.failure).to.be.above(0);
     });
 
+    it('should return 403 when requesting namespaces the user has no privileges for', async () => {
+      const startDate = new Date().toISOString();
+      const { user, space } = UserAtSpaceScenarios[3]; // space_1_all: privileges only in space1
+      const spaceId = space.id;
+
+      const logResponse = await supertestWithoutAuth
+        .get(
+          `${getUrlPrefix(
+            spaceId
+          )}/internal/alerting/_global_execution_kpi?date_start=${startDate}&namespaces=${JSON.stringify(
+            ['space1', 'space2']
+          )}`
+        )
+        .set('kbn-xsrf', 'foo')
+        .auth(user.username, user.password);
+
+      expect(logResponse.statusCode).to.be(403);
+      expect(logResponse.body.message).to.be(
+        'Unauthorized to find alerts for any rule types. Validate that you have permissions to access spaces: space1,space2'
+      );
+    });
+
     it('should return KPI from all spaces in the namespaces param', async () => {
       const startTime = new Date().toISOString();
 

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/global_execution_log.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/global_execution_log.ts
@@ -78,6 +78,28 @@ export default function globalExecutionLogTests({ getService }: FtrProviderConte
       expect(allLogsSpace0).to.be(true);
     });
 
+    it('should return 403 when requesting namespaces the user has no privileges for', async () => {
+      const startDate = new Date().toISOString();
+      const { user, space } = UserAtSpaceScenarios[3]; // space_1_all: privileges only in space1
+      const spaceId = space.id;
+
+      const logResponse = await supertestWithoutAuth
+        .get(
+          `${getUrlPrefix(
+            spaceId
+          )}/internal/alerting/_global_execution_logs?date_start=${startDate}&namespaces=${JSON.stringify(
+            ['space1', 'space2']
+          )}`
+        )
+        .set('kbn-xsrf', 'foo')
+        .auth(user.username, user.password);
+
+      expect(logResponse.statusCode).to.be(403);
+      expect(logResponse.body.message).to.be(
+        'Unauthorized to find alerts for any rule types. Validate that you have permissions to access spaces: space1,space2'
+      );
+    });
+
     it('should return logs from multiple spaces when passed the namespaces param', async () => {
       const startTime = new Date().toISOString();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps] enforce auth permissions on requested namespaces (#277679)](https://github.com/elastic/kibana/pull/277679)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"lu(cia)","email":"lucia.petracca@elastic.co"},"sourceCommit":{"committedDate":"2026-07-28T12:31:31Z","message":"[ResponseOps] enforce auth permissions on requested namespaces (#277679)\n\n## Summary\n\nResolves https://github.com/elastic/response-ops-team/issues/640\n\n\nAdds namespace auth validation when query param is passed to the\n`_global_execution_*` endpoints:\n\nGET /internal/alerting/_global_execution_logs\nGET /internal/alerting/_global_execution_kpi\n\n<img width=\"550\" height=\"181\" alt=\"Screenshot 2026-07-14 at 12 06 35\"\nsrc=\"https://github.com/user-attachments/assets/c68319d7-ee45-48c3-b7e5-f59358e6bc45\"\n/>\n\n### Testing steps (taken from original task)\n1. Create a non-default space `space1`.\n2. Seed an index and create an `.index-threshold` rule in `space1` (as\nadmin).\n3. Create a low-privilege user with only `stackAlerts:[\"read\"]` and\ndevTools access in default.\n4. _run_soon the rule so it produces execution logs.\n5. As the low-privilege user, GET /api/alerting/rule/{id} → 404 (correct\n— cannot read the rule).\n6. Same user, global execution-log route without namespace override →\n`{\"total\":0,\"data\":[]}` (correct).\n7. Same user, global execution-log route with `namespaces=[\"space1\"]` →\nShould throw error\n8. Same for _global_execution_kpi with `namespaces=[\"space1\"]` → Should\nthrow error\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bff703ee9edecb4a5393ad6da24adfb3ed88c76c","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:all-open","v9.6.0"],"title":"[ResponseOps] enforce auth permissions on requested namespaces","number":277679,"url":"https://github.com/elastic/kibana/pull/277679","mergeCommit":{"message":"[ResponseOps] enforce auth permissions on requested namespaces (#277679)\n\n## Summary\n\nResolves https://github.com/elastic/response-ops-team/issues/640\n\n\nAdds namespace auth validation when query param is passed to the\n`_global_execution_*` endpoints:\n\nGET /internal/alerting/_global_execution_logs\nGET /internal/alerting/_global_execution_kpi\n\n<img width=\"550\" height=\"181\" alt=\"Screenshot 2026-07-14 at 12 06 35\"\nsrc=\"https://github.com/user-attachments/assets/c68319d7-ee45-48c3-b7e5-f59358e6bc45\"\n/>\n\n### Testing steps (taken from original task)\n1. Create a non-default space `space1`.\n2. Seed an index and create an `.index-threshold` rule in `space1` (as\nadmin).\n3. Create a low-privilege user with only `stackAlerts:[\"read\"]` and\ndevTools access in default.\n4. _run_soon the rule so it produces execution logs.\n5. As the low-privilege user, GET /api/alerting/rule/{id} → 404 (correct\n— cannot read the rule).\n6. Same user, global execution-log route without namespace override →\n`{\"total\":0,\"data\":[]}` (correct).\n7. Same user, global execution-log route with `namespaces=[\"space1\"]` →\nShould throw error\n8. Same for _global_execution_kpi with `namespaces=[\"space1\"]` → Should\nthrow error\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bff703ee9edecb4a5393ad6da24adfb3ed88c76c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277679","number":277679,"mergeCommit":{"message":"[ResponseOps] enforce auth permissions on requested namespaces (#277679)\n\n## Summary\n\nResolves https://github.com/elastic/response-ops-team/issues/640\n\n\nAdds namespace auth validation when query param is passed to the\n`_global_execution_*` endpoints:\n\nGET /internal/alerting/_global_execution_logs\nGET /internal/alerting/_global_execution_kpi\n\n<img width=\"550\" height=\"181\" alt=\"Screenshot 2026-07-14 at 12 06 35\"\nsrc=\"https://github.com/user-attachments/assets/c68319d7-ee45-48c3-b7e5-f59358e6bc45\"\n/>\n\n### Testing steps (taken from original task)\n1. Create a non-default space `space1`.\n2. Seed an index and create an `.index-threshold` rule in `space1` (as\nadmin).\n3. Create a low-privilege user with only `stackAlerts:[\"read\"]` and\ndevTools access in default.\n4. _run_soon the rule so it produces execution logs.\n5. As the low-privilege user, GET /api/alerting/rule/{id} → 404 (correct\n— cannot read the rule).\n6. Same user, global execution-log route without namespace override →\n`{\"total\":0,\"data\":[]}` (correct).\n7. Same user, global execution-log route with `namespaces=[\"space1\"]` →\nShould throw error\n8. Same for _global_execution_kpi with `namespaces=[\"space1\"]` → Should\nthrow error\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bff703ee9edecb4a5393ad6da24adfb3ed88c76c"}},{"url":"https://github.com/elastic/kibana/pull/281269","number":281269,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/281270","number":281270,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->