### PR TITLE
[9.5] [Synthetics] Scope remote-monitor CCS queries to the target cluster (#278141)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/get_synthetics_indices.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/get_synthetics_indices.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { SYNTHETICS_INDEX_PATTERN } from './constants';
-import { getSyntheticsCcsIndex, getSyntheticsIndices } from './get_synthetics_indices';
+import {
+  getSyntheticsCcsIndex,
+  getSyntheticsIndices,
+  getSyntheticsScopedIndex,
+} from './get_synthetics_indices';
 
 describe('getSyntheticsCcsIndex', () => {
   it('defaults to the local synthetics index pattern when no remoteName is provided', () => {
@@ -31,6 +35,28 @@ describe('getSyntheticsCcsIndex', () => {
     expect(getSyntheticsCcsIndex(undefined, '.alerts-observability*')).toBe(
       '.alerts-observability*'
     );
+  });
+});
+
+describe('getSyntheticsScopedIndex', () => {
+  it('queries the heartbeatIndices unchanged for a local monitor', () => {
+    expect(
+      getSyntheticsScopedIndex(
+        undefined,
+        `${SYNTHETICS_INDEX_PATTERN},*:${SYNTHETICS_INDEX_PATTERN}`
+      )
+    ).toBe(`${SYNTHETICS_INDEX_PATTERN},*:${SYNTHETICS_INDEX_PATTERN}`);
+  });
+
+  it('scopes a remote monitor to that single cluster, ignoring a multi-cluster heartbeatIndices', () => {
+    // Prefixing the multi-cluster value directly would leave a trailing
+    // `*:synthetics-*` that fans back out to every remote cluster.
+    expect(
+      getSyntheticsScopedIndex(
+        'cluster1',
+        `${SYNTHETICS_INDEX_PATTERN},*:${SYNTHETICS_INDEX_PATTERN}`
+      )
+    ).toBe(`cluster1:${SYNTHETICS_INDEX_PATTERN}`);
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/common/get_synthetics_indices.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/get_synthetics_indices.ts
@@ -18,6 +18,11 @@ import { SYNTHETICS_INDEX_PATTERN } from './constants';
  * different base, e.g. the alerts index (`.alerts-observability*`) or a
  * `SyntheticsEsClient`'s configurable `heartbeatIndices`.
  *
+ * Note: `indexPattern` must be a single pattern. Passing a comma-joined
+ * multi-cluster value (e.g. a `SyntheticsEsClient`'s `heartbeatIndices`) with a
+ * `remoteName` only prefixes the first sub-pattern; use
+ * {@link getSyntheticsScopedIndex} for that case instead.
+ *
  * @example
  *   getSyntheticsCcsIndex();                          // 'synthetics-*'
  *   getSyntheticsCcsIndex('cluster');                 // 'cluster:synthetics-*'
@@ -27,6 +32,20 @@ export const getSyntheticsCcsIndex = (
   remoteName?: string,
   indexPattern: string = SYNTHETICS_INDEX_PATTERN
 ): string => (remoteName ? `${remoteName}:${indexPattern}` : indexPattern);
+
+/**
+ * Resolves the index a server-side query should target from a
+ * `SyntheticsEsClient`. For a remote monitor, scopes to that single cluster via
+ * {@link getSyntheticsCcsIndex} — deliberately *not* reusing `heartbeatIndices`,
+ * which may be a comma-joined multi-cluster pattern (e.g.
+ * `synthetics-*,*:synthetics-*`). Prefixing such a value would only tag the
+ * first sub-pattern, letting the rest fan back out to every remote cluster. For
+ * a local monitor, queries `heartbeatIndices` unchanged.
+ */
+export const getSyntheticsScopedIndex = (
+  remoteName: string | undefined,
+  heartbeatIndices: string
+): string => (remoteName ? getSyntheticsCcsIndex(remoteName) : heartbeatIndices);
 
 export interface RemoteCluster {
   name: string;

--- a/x-pack/solutions/observability/plugins/synthetics/server/common/pings/monitor_status_heatmap.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/common/pings/monitor_status_heatmap.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SyntheticsEsClient } from '../../lib';
-import { getSyntheticsCcsIndex } from '../../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../../common/get_synthetics_indices';
 
 export async function queryMonitorHeatmap({
   syntheticsEsClient,
@@ -26,7 +26,7 @@ export async function queryMonitorHeatmap({
   remoteName?: string;
 }) {
   return syntheticsEsClient.search({
-    index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
+    index: getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices),
     size: 0,
     query: {
       bool: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_details.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_details.ts
@@ -9,7 +9,7 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 import type { SyntheticsEsClient } from '../lib';
 import { createEsParams } from '../lib';
 import { getCheckGroupTimeRangeFilter } from '../../common/constants/client_defaults';
-import { getSyntheticsCcsIndex } from '../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../common/get_synthetics_indices';
 import type { JourneyStep, Ping, SyntheticsJourneyApiResponse } from '../../common/runtime_types';
 
 export interface GetJourneyDetails {
@@ -28,7 +28,7 @@ export const getJourneyDetails = async ({
 }: GetJourneyDetails & {
   syntheticsEsClient: SyntheticsEsClient;
 }): Promise<SyntheticsJourneyApiResponse['details']> => {
-  const index = getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices);
+  const index = getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices);
 
   const params = createEsParams({
     index,

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_screenshot.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_screenshot.ts
@@ -8,7 +8,7 @@
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { SyntheticsEsClient } from '../lib';
 import { getCheckGroupTimeRangeFilter } from '../../common/constants/client_defaults';
-import { getSyntheticsCcsIndex } from '../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../common/get_synthetics_indices';
 import type { RefResult, FullScreenshot } from '../../common/runtime_types/ping/synthetics';
 
 interface ResultType {
@@ -34,7 +34,7 @@ export const getJourneyScreenshot = async ({
   syntheticsEsClient: SyntheticsEsClient;
 }): Promise<ScreenshotReturnTypesUnion> => {
   const body = {
-    index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
+    index: getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices),
     track_total_hits: true,
     size: 0,
     query: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_screenshot_blocks.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_screenshot_blocks.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SyntheticsEsClient } from '../lib';
-import { getSyntheticsCcsIndex } from '../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../common/get_synthetics_indices';
 import type { ScreenshotBlockDoc } from '../../common/runtime_types';
 
 interface ScreenshotBlockResultType {
@@ -30,7 +30,7 @@ export const getJourneyScreenshotBlocks = async ({
   syntheticsEsClient: SyntheticsEsClient;
 }): Promise<ScreenshotBlockDoc[]> => {
   const body = {
-    index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
+    index: getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices),
     query: {
       bool: {
         filter: [

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_steps.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_steps.ts
@@ -9,7 +9,7 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 import type { SyntheticsEsClient } from '../lib';
 import { asMutableArray } from '../../common/utils/as_mutable_array';
 import { getCheckGroupTimeRangeFilter } from '../../common/constants/client_defaults';
-import { getSyntheticsCcsIndex } from '../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../common/get_synthetics_indices';
 import type { JourneyStep } from '../../common/runtime_types/ping/synthetics';
 
 export interface GetJourneyStepsParams {
@@ -29,7 +29,7 @@ export const getJourneySteps = async ({
   syntheticsEsClient: SyntheticsEsClient;
 }): Promise<JourneyStep[]> => {
   const params = {
-    index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
+    index: getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices),
     query: {
       bool: {
         filter: [

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_last_successful_check.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_last_successful_check.ts
@@ -7,7 +7,7 @@
 
 import type { estypes } from '@elastic/elasticsearch';
 import type { SyntheticsEsClient } from '../lib';
-import { getSyntheticsCcsIndex } from '../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../common/get_synthetics_indices';
 import type { Ping } from '../../common/runtime_types/ping';
 
 export interface GetStepScreenshotParams {
@@ -117,7 +117,7 @@ export const getLastSuccessfulCheck = async ({
   });
 
   const { body: result } = await syntheticsEsClient.search({
-    index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
+    index: getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices),
     ...lastSuccessCheckParams,
   });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.ts
@@ -7,7 +7,7 @@
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { getCheckGroupTimeRangeFilter } from '../../common/constants/client_defaults';
-import { getSyntheticsCcsIndex } from '../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../common/get_synthetics_indices';
 import type { SyntheticsEsClient } from '../lib';
 import type { NetworkEvent } from '../../common/runtime_types';
 
@@ -37,7 +37,7 @@ export const getNetworkEvents = async ({
   hasNavigationRequest: boolean;
 }> => {
   const params = {
-    index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
+    index: getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices),
     track_total_hits: true,
     query: {
       bool: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/query_pings.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/query_pings.ts
@@ -18,7 +18,7 @@ import type {
 } from '../../common/runtime_types';
 import type { SyntheticsEsClient } from '../lib';
 import { getRemoteMonitorInfo } from '../lib/remote_result_utils';
-import { getSyntheticsCcsIndex } from '../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../common/get_synthetics_indices';
 import { SUMMARY_FILTER } from '../../common/constants/client_defaults';
 
 const DEFAULT_PAGE_SIZE = 25;
@@ -59,7 +59,7 @@ export async function queryPings<F>(
   const size = sizeParam ?? DEFAULT_PAGE_SIZE;
 
   const searchBody = {
-    index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
+    index: getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices),
     size,
     from: pageIndex !== undefined ? pageIndex * size : 0,
     ...(index ? { from: index * size } : {}),

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_monitor_summary_stats.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_monitor_summary_stats.ts
@@ -11,7 +11,7 @@ import {
   EXCLUDE_RUN_ONCE_FILTER,
   FINAL_SUMMARY_FILTER,
 } from '../../../common/constants/client_defaults';
-import { getSyntheticsCcsIndex } from '../../../common/get_synthetics_indices';
+import { getSyntheticsScopedIndex } from '../../../common/get_synthetics_indices';
 import type { SyntheticsRestApiRouteFactory } from '../types';
 
 export interface MonitorSummaryStats {
@@ -46,7 +46,7 @@ export const getMonitorSummaryStatsRoute: SyntheticsRestApiRouteFactory<
     };
 
     const { body: result } = await syntheticsEsClient.search({
-      index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
+      index: getSyntheticsScopedIndex(remoteName, syntheticsEsClient.heartbeatIndices),
       size: 0,
       query: {
         bool: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- [[Synthetics] Scope remote-monitor CCS queries to the target cluster (#278141)](https://github.com/elastic/kibana/pull/278141)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

---

## Summary

Follow-up to #274333.

Server-side synthetics queries resolved their index with `getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices)`. `heartbeatIndices` is resolved per-request from the CCS settings and can be a comma-joined multi-cluster pattern (e.g. `synthetics-*,*:synthetics-*` under `useAllRemoteClusters`). `getSyntheticsCcsIndex` only prefixes the first sub-pattern, so for a remote monitor the trailing `*:synthetics-*` fans back out to every remote cluster instead of scoping to `remoteName`, defeating `can_match` shard pruning.

Adds `getSyntheticsScopedIndex(remoteName, heartbeatIndices)` and uses it across the affected server query paths so remote-monitor queries are correctly scoped to the target cluster.

## Notes

Clean cherry-pick; the only conflict (`query_pings.ts`) was resolved with content identical to the original change. Verified locally on `9.5`: ESLint clean, `get_synthetics_indices.test.ts` 12/12 passing, and synthetics `tsconfig` type-check passing.
