### PR TITLE
[9.3] fix(ccr): clear follower index selection after a manage action (#273576)

### DIFF
--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/__jest__/client_integration/follower_indices_list.test.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/__jest__/client_integration/follower_indices_list.test.js
@@ -225,7 +225,7 @@ describe('<FollowerIndicesList />', () => {
       });
 
       test('should clear the selection after confirming an action', async () => {
-        const firstCheckbox = within(table.getRows()[0]).getByRole('checkbox');
+        const firstCheckbox = within(table.rows[0]).getByRole('checkbox');
         await user.click(firstCheckbox);
         expect(firstCheckbox).toBeChecked();
 
@@ -246,11 +246,11 @@ describe('<FollowerIndicesList />', () => {
 
         // The selection is reset, so the manage button is gone and the row is unchecked.
         expect(screen.queryByTestId('contextMenuButton')).not.toBeInTheDocument();
-        expect(within(table.getRows()[0]).getByRole('checkbox')).not.toBeChecked();
+        expect(within(table.rows[0]).getByRole('checkbox')).not.toBeChecked();
       });
 
       test('should clear the selection after confirming an action from the detail flyout', async () => {
-        const firstCheckbox = within(table.getRows()[0]).getByRole('checkbox');
+        const firstCheckbox = within(table.rows[0]).getByRole('checkbox');
         await user.click(firstCheckbox);
         expect(firstCheckbox).toBeChecked();
 
@@ -276,7 +276,7 @@ describe('<FollowerIndicesList />', () => {
         // The selection is reset through the detail flyout too, so the bulk manage button
         // is gone and the row is unchecked.
         expect(screen.queryByTestId('contextMenuButton')).not.toBeInTheDocument();
-        expect(within(table.getRows()[0]).getByRole('checkbox')).not.toBeChecked();
+        expect(within(table.rows[0]).getByRole('checkbox')).not.toBeChecked();
       });
     });
 

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/__jest__/client_integration/follower_indices_list.test.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/__jest__/client_integration/follower_indices_list.test.js
@@ -223,6 +223,61 @@ describe('<FollowerIndicesList />', () => {
 
         expect(await screen.findByTestId('unfollowLeaderConfirmation')).toBeInTheDocument();
       });
+
+      test('should clear the selection after confirming an action', async () => {
+        const firstCheckbox = within(table.getRows()[0]).getByRole('checkbox');
+        await user.click(firstCheckbox);
+        expect(firstCheckbox).toBeChecked();
+
+        const contextMenuButton = await screen.findByTestId('contextMenuButton');
+        await user.click(contextMenuButton);
+
+        const contextMenu = await screen.findByTestId('contextMenu');
+        const pauseButton = within(contextMenu).queryAllByRole('button')[0];
+        await user.click(pauseButton);
+
+        const confirmation = await screen.findByTestId('pauseReplicationConfirmation');
+        const confirmButton = within(confirmation).getByTestId('confirmModalConfirmButton');
+        await user.click(confirmButton);
+
+        await act(async () => {
+          await jest.runOnlyPendingTimersAsync();
+        });
+
+        // The selection is reset, so the manage button is gone and the row is unchecked.
+        expect(screen.queryByTestId('contextMenuButton')).not.toBeInTheDocument();
+        expect(within(table.getRows()[0]).getByRole('checkbox')).not.toBeChecked();
+      });
+
+      test('should clear the selection after confirming an action from the detail flyout', async () => {
+        const firstCheckbox = within(table.getRows()[0]).getByRole('checkbox');
+        await user.click(firstCheckbox);
+        expect(firstCheckbox).toBeChecked();
+
+        // Open the detail flyout for the selected follower index via its name link.
+        await actions.clickFollowerIndexAt(0);
+
+        const detailPanel = await screen.findByTestId('followerIndexDetail');
+        const manageButton = within(detailPanel).getByTestId('manageButton');
+        await user.click(manageButton);
+
+        const contextMenu = await screen.findByTestId('contextMenu');
+        const pauseButton = within(contextMenu).queryAllByRole('button')[0];
+        await user.click(pauseButton);
+
+        const confirmation = await screen.findByTestId('pauseReplicationConfirmation');
+        const confirmButton = within(confirmation).getByTestId('confirmModalConfirmButton');
+        await user.click(confirmButton);
+
+        await act(async () => {
+          await jest.runOnlyPendingTimersAsync();
+        });
+
+        // The selection is reset through the detail flyout too, so the bulk manage button
+        // is gone and the row is unchecked.
+        expect(screen.queryByTestId('contextMenuButton')).not.toBeInTheDocument();
+        expect(within(table.getRows()[0]).getByRole('checkbox')).not.toBeChecked();
+      });
     });
 
     describe('table row action menu', () => {

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/context_menu/context_menu.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/context_menu/context_menu.js
@@ -32,6 +32,7 @@ export class ContextMenu extends PureComponent {
     label: PropTypes.node,
     followerIndices: PropTypes.array.isRequired,
     isPollingStatus: PropTypes.bool,
+    onActionComplete: PropTypes.func,
   };
 
   state = {
@@ -50,6 +51,11 @@ export class ContextMenu extends PureComponent {
     this.setState({
       isPopoverOpen: false,
     });
+  };
+
+  onActionComplete = () => {
+    this.closePopover();
+    this.props.onActionComplete?.();
   };
 
   editFollowerIndex = (id) => {
@@ -111,7 +117,7 @@ export class ContextMenu extends PureComponent {
         </EuiPopoverTitle>
         <EuiContextMenuPanel data-test-subj="contextMenu">
           {activeFollowerIndices.length ? (
-            <FollowerIndexPauseProvider onConfirm={this.closePopover}>
+            <FollowerIndexPauseProvider onConfirm={this.onActionComplete}>
               {(pauseFollowerIndex) => (
                 <EuiContextMenuItem
                   icon="pause"
@@ -128,7 +134,7 @@ export class ContextMenu extends PureComponent {
           ) : null}
 
           {pausedFollowerIndexNames.length && !isPollingStatus ? (
-            <FollowerIndexResumeProvider onConfirm={this.closePopover}>
+            <FollowerIndexResumeProvider onConfirm={this.onActionComplete}>
               {(resumeFollowerIndex) => (
                 <EuiContextMenuItem
                   icon="play"
@@ -160,7 +166,7 @@ export class ContextMenu extends PureComponent {
             </Fragment>
           )}
 
-          <FollowerIndexUnfollowProvider onConfirm={this.closePopover}>
+          <FollowerIndexUnfollowProvider onConfirm={this.onActionComplete}>
             {(unfollowLeaderIndex) => (
               <EuiContextMenuItem
                 icon="indexFlush"

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/detail_panel/detail_panel.tsx
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/detail_panel/detail_panel.tsx
@@ -409,6 +409,7 @@ export interface DetailPanelProps {
   followerIndex?: FollowerIndexWithPausedStatus;
   closeDetailPanel: () => void;
   getFollowerIndex: (id: string) => void;
+  onActionComplete?: () => void;
 }
 
 export const DetailPanel = ({
@@ -417,6 +418,7 @@ export const DetailPanel = ({
   followerIndex,
   apiStatus,
   getFollowerIndex,
+  onActionComplete,
 }: DetailPanelProps) => {
   const [isInitialLoad, setInitialLoad] = useState(true);
   const { isPolling, startPolling, stopPolling } = usePolling();
@@ -580,6 +582,7 @@ export const DetailPanel = ({
                     followerIndices={[followerIndex]}
                     testSubj="manageButton"
                     isPollingStatus={isPolling}
+                    onActionComplete={onActionComplete}
                   />
                 </EuiFlexItem>
               )}

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/follower_indices_table/follower_indices_table.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/follower_indices_table/follower_indices_table.js
@@ -83,6 +83,9 @@ export class FollowerIndicesTable extends PureComponent {
   static propTypes = {
     followerIndices: PropTypes.array,
     selectFollowerIndex: PropTypes.func.isRequired,
+    selectedItems: PropTypes.array,
+    onSelectionChange: PropTypes.func,
+    resetSelection: PropTypes.func,
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -105,7 +108,6 @@ export class FollowerIndicesTable extends PureComponent {
 
     this.state = {
       prevFollowerIndices: props.followerIndices,
-      selectedItems: [],
       filteredIndices: props.followerIndices,
       queryText: '',
     };
@@ -270,7 +272,8 @@ export class FollowerIndicesTable extends PureComponent {
   };
 
   render() {
-    const { selectedItems, filteredIndices } = this.state;
+    const { filteredIndices } = this.state;
+    const { selectedItems, onSelectionChange, resetSelection } = this.props;
 
     const sorting = {
       sort: {
@@ -285,12 +288,17 @@ export class FollowerIndicesTable extends PureComponent {
     };
 
     const selection = {
-      onSelectionChange: (newSelectedItems) => this.setState({ selectedItems: newSelectedItems }),
+      selected: selectedItems,
+      onSelectionChange,
     };
 
     const search = {
       toolsLeft: selectedItems.length ? (
-        <ContextMenu followerIndices={selectedItems} testSubj="contextMenuButton" />
+        <ContextMenu
+          followerIndices={selectedItems}
+          testSubj="contextMenuButton"
+          onActionComplete={resetSelection}
+        />
       ) : undefined,
       toolsRight: (
         <EuiButton

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/follower_indices_list.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/follower_indices_list.js
@@ -46,6 +46,15 @@ export class FollowerIndicesList extends PureComponent {
   state = {
     lastFollowerIndexId: null,
     isDetailPanelOpen: false,
+    selectedItems: [],
+  };
+
+  onSelectionChange = (selectedItems) => {
+    this.setState({ selectedItems });
+  };
+
+  resetSelection = () => {
+    this.setState({ selectedItems: [] });
   };
 
   componentDidMount() {
@@ -141,7 +150,7 @@ export class FollowerIndicesList extends PureComponent {
   renderList() {
     const { selectFollowerIndex, followerIndices } = this.props;
 
-    const { isDetailPanelOpen } = this.state;
+    const { isDetailPanelOpen, selectedItems } = this.state;
 
     return (
       <>
@@ -156,9 +165,19 @@ export class FollowerIndicesList extends PureComponent {
 
         <EuiSpacer size="l" />
 
-        <FollowerIndicesTable followerIndices={followerIndices} />
+        <FollowerIndicesTable
+          followerIndices={followerIndices}
+          selectedItems={selectedItems}
+          onSelectionChange={this.onSelectionChange}
+          resetSelection={this.resetSelection}
+        />
 
-        {isDetailPanelOpen && <DetailPanel closeDetailPanel={() => selectFollowerIndex(null)} />}
+        {isDetailPanelOpen && (
+          <DetailPanel
+            closeDetailPanel={() => selectFollowerIndex(null)}
+            onActionComplete={this.resetSelection}
+          />
+        )}
       </>
     );
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [fix(ccr): clear follower index selection after a manage action (#273576)](https://github.com/elastic/kibana/pull/273576)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"wilmerdooley","email":"wilmer@snovon.com"},"sourceCommit":{"committedDate":"2026-07-27T10:52:10Z","message":"fix(ccr): clear follower index selection after a manage action (#273576)\n\n## Summary\n\nWhen a user performed an action from the **Manage follower index**\nbutton (pause, resume, or unfollow), the popover closed but the row(s)\nremained selected. Reopening the menu showed the same action as still\navailable, even though it was no longer valid for the updated state,\nleading to confusing confirmation dialogs and errors.\n\nThis change clears the table selection after any pause/resume/unfollow\naction is confirmed. `ContextMenu` now exposes an `onActionComplete`\ncallback that closes the popover and notifies the parent, and\n`FollowerIndicesTable` provides a `resetSelection` handler that resets\n`selectedItems` to an empty array. The selection is also passed\nexplicitly to `EuiInMemoryTable` so the checkboxes stay in sync with the\nstate after a reset. A new integration test covers the\nselection-clearing behavior after confirming a pause action.\n\nResolves #63765\n\n## Release Note\n\nCCR now clears selected follower indices after pause, resume, or\nunfollow actions so the Manage menu reflects the updated state.\n\nSigned-off-by: wilmerdooley <wilmerdooley1@gmail.com>\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>","sha":"d94e46fbb851b1d741aafe19dadea1ca92516348","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:CCR and Remote Clusters","Team:Kibana Management","💝community","backport:all-open","v9.5.0","v9.6.0"],"title":"fix(ccr): clear follower index selection after a manage action","number":273576,"url":"https://github.com/elastic/kibana/pull/273576","mergeCommit":{"message":"fix(ccr): clear follower index selection after a manage action (#273576)\n\n## Summary\n\nWhen a user performed an action from the **Manage follower index**\nbutton (pause, resume, or unfollow), the popover closed but the row(s)\nremained selected. Reopening the menu showed the same action as still\navailable, even though it was no longer valid for the updated state,\nleading to confusing confirmation dialogs and errors.\n\nThis change clears the table selection after any pause/resume/unfollow\naction is confirmed. `ContextMenu` now exposes an `onActionComplete`\ncallback that closes the popover and notifies the parent, and\n`FollowerIndicesTable` provides a `resetSelection` handler that resets\n`selectedItems` to an empty array. The selection is also passed\nexplicitly to `EuiInMemoryTable` so the checkboxes stay in sync with the\nstate after a reset. A new integration test covers the\nselection-clearing behavior after confirming a pause action.\n\nResolves #63765\n\n## Release Note\n\nCCR now clears selected follower indices after pause, resume, or\nunfollow actions so the Manage menu reflects the updated state.\n\nSigned-off-by: wilmerdooley <wilmerdooley1@gmail.com>\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>","sha":"d94e46fbb851b1d741aafe19dadea1ca92516348"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/280990","number":280990,"state":"MERGED","mergeCommit":{"sha":"95bbb15082a426d8196a9b6532bfe07642877c4e","message":"[9.5] fix(ccr): clear follower index selection after a manage action (#273576) (#280990)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [fix(ccr): clear follower index selection after a manage action\n(#273576)](https://github.com/elastic/kibana/pull/273576)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nSigned-off-by: wilmerdooley <wilmerdooley1@gmail.com>\nCo-authored-by: wilmerdooley <wilmer@snovon.com>\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273576","number":273576,"mergeCommit":{"message":"fix(ccr): clear follower index selection after a manage action (#273576)\n\n## Summary\n\nWhen a user performed an action from the **Manage follower index**\nbutton (pause, resume, or unfollow), the popover closed but the row(s)\nremained selected. Reopening the menu showed the same action as still\navailable, even though it was no longer valid for the updated state,\nleading to confusing confirmation dialogs and errors.\n\nThis change clears the table selection after any pause/resume/unfollow\naction is confirmed. `ContextMenu` now exposes an `onActionComplete`\ncallback that closes the popover and notifies the parent, and\n`FollowerIndicesTable` provides a `resetSelection` handler that resets\n`selectedItems` to an empty array. The selection is also passed\nexplicitly to `EuiInMemoryTable` so the checkboxes stay in sync with the\nstate after a reset. A new integration test covers the\nselection-clearing behavior after confirming a pause action.\n\nResolves #63765\n\n## Release Note\n\nCCR now clears selected follower indices after pause, resume, or\nunfollow actions so the Manage menu reflects the updated state.\n\nSigned-off-by: wilmerdooley <wilmerdooley1@gmail.com>\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>","sha":"d94e46fbb851b1d741aafe19dadea1ca92516348"}}]}] BACKPORT-->