### PR TITLE
[Entity Analytics] Remove Filter For/Filter Out actions on Cases Attachments entity table

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/utils.ts
@@ -53,4 +53,5 @@ export const CASE_ATTACHMENT_TABLE_CONFIG: EntitiesTableConfig = {
   columnsSettingsLocalStorageKey:
     'securitySolution.entityAnalytics.cases.attachment.columns:settings',
   groupingLocalStorageKey: 'securitySolution.entityAnalytics.cases.attachment.grouping',
+  supportsFieldFiltering: false,
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
@@ -37,6 +37,7 @@ const capturedProps: {
   externalCustomRenderers?: CustomCellRenderer;
   columns?: string[];
   rowAdditionalLeadingControls?: RowControlColumn[];
+  onFilter?: unknown;
 } = {};
 
 jest.mock('@kbn/unified-data-table', () => {
@@ -47,10 +48,12 @@ jest.mock('@kbn/unified-data-table', () => {
       externalCustomRenderers?: CustomCellRenderer;
       columns?: string[];
       rowAdditionalLeadingControls?: RowControlColumn[];
+      onFilter?: unknown;
     }) => {
       capturedProps.externalCustomRenderers = props.externalCustomRenderers;
       capturedProps.columns = props.columns;
       capturedProps.rowAdditionalLeadingControls = props.rowAdditionalLeadingControls;
+      capturedProps.onFilter = props.onFilter;
       return <div data-test-subj="unifiedDataTable" />;
     },
   };
@@ -153,12 +156,13 @@ const defaultKibanaServices = {
 const renderWithProviders = (
   state: EntityURLStateResult,
   dataView: DataView = mockDataView,
-  dataViewIsLoading = false
+  dataViewIsLoading = false,
+  config = DEFAULT_ENTITIES_TABLE_CONFIG
 ) =>
   render(
     <TestProviders>
       <DataViewContext.Provider value={{ dataView, dataViewIsLoading }}>
-        <EntitiesDataTable state={state} config={DEFAULT_ENTITIES_TABLE_CONFIG} />
+        <EntitiesDataTable state={state} config={config} />
       </DataViewContext.Provider>
     </TestProviders>
   );
@@ -355,6 +359,29 @@ describe('EntitiesDataTable', () => {
       renderWithProviders(state);
 
       expect(capturedProps.columns).not.toContain('alerts');
+    });
+  });
+
+  describe('supportsFieldFiltering', () => {
+    it('passes onFilter to UnifiedDataTable when supportsFieldFiltering is not set', () => {
+      const state = createMockState();
+      (state.getRowsFromPages as jest.Mock).mockReturnValue([]);
+
+      renderWithProviders(state);
+
+      expect(capturedProps.onFilter).toBeDefined();
+    });
+
+    it('passes undefined onFilter to UnifiedDataTable when supportsFieldFiltering is false', () => {
+      const state = createMockState();
+      (state.getRowsFromPages as jest.Mock).mockReturnValue([]);
+
+      renderWithProviders(state, mockDataView, false, {
+        ...DEFAULT_ENTITIES_TABLE_CONFIG,
+        supportsFieldFiltering: false,
+      });
+
+      expect(capturedProps.onFilter).toBeUndefined();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -644,7 +644,7 @@ export const EntitiesDataTable = ({
             columns={currentColumns}
             dataView={dataView}
             loadingState={loadingState}
-            onFilter={onAddFilter as DocViewFilterFn}
+            onFilter={config.supportsFieldFiltering !== false ? (onAddFilter as DocViewFilterFn) : undefined}
             onResize={onResize}
             onSetColumns={onSetColumns}
             onSort={onSort}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -392,7 +392,7 @@ export const EntitiesDataTable = ({
 
   const onAddFilter: AddFieldFilterHandler | undefined = useMemo(
     () =>
-      filterManager && dataView
+      config.supportsFieldFiltering !== false && filterManager && dataView
         ? (clickedField, values, operation) => {
             const newFilters = generateFilters(
               filterManager,
@@ -406,7 +406,7 @@ export const EntitiesDataTable = ({
             });
           }
         : undefined,
-    [dataView, filterManager, filters, setUrlQuery]
+    [config.supportsFieldFiltering, dataView, filterManager, filters, setUrlQuery]
   );
 
   const onResize = (colSettings: { columnId: string; width: number | undefined }) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -644,7 +644,9 @@ export const EntitiesDataTable = ({
             columns={currentColumns}
             dataView={dataView}
             loadingState={loadingState}
-            onFilter={config.supportsFieldFiltering !== false ? (onAddFilter as DocViewFilterFn) : undefined}
+            onFilter={
+              config.supportsFieldFiltering !== false ? (onAddFilter as DocViewFilterFn) : undefined
+            }
             onResize={onResize}
             onSetColumns={onSetColumns}
             onSort={onSort}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/index.ts
@@ -40,6 +40,12 @@ export interface EntitiesTableConfig {
   columnsSettingsLocalStorageKey: string;
   /** `@kbn/grouping` id used to persist the active grouping selection. */
   groupingLocalStorageKey: string;
+  /**
+   * Whether "Filter For" / "Filter Out" cell actions are available. Defaults to true.
+   * Set to false in contexts (e.g. Cases attachments) where there is no filter state
+   * backing the table, to avoid showing actions that silently do nothing.
+   */
+  supportsFieldFiltering?: boolean;
 }
 
 export const DEFAULT_ENTITIES_TABLE_CONFIG: EntitiesTableConfig = {


### PR DESCRIPTION
## Summary

- On Cases → Attachments, the entity table was showing “Filter For / Filter Out” actions that had no functionality. 
- This happened because the table uses local state (not URL-driven state), so generated filters were discarded.

- This PR introduces a `supportsFieldFiltering` config flag and sets it to false for the Cases Attachments table, so onFilter is not passed and those cell actions are not rendered there.
- Default behavior remains unchanged for overview entity table, where filtering still works.

Closes #280761

## Test plan

- [ ] Navigate to Security → Cases → Attachments, hover over an entity name - confirm "Filter For" / "Filter Out" options are no longer shown
- [ ] Navigate to Security → Entity Analytics, hover over an entity name in the table - confirm "Filter For" / "Filter Out" still work as before

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->