### PR TITLE
[Fleet] Fix ML transform Cypress test (2nd attempt)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/cypress/e2e/assets_integration_with_ml_and_transforms.cy.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/e2e/assets_integration_with_ml_and_transforms.cy.ts
@@ -94,24 +94,19 @@ describe('Assets - Real API for integration with ML and transforms', () => {
     // lmd 3.3.0+ changed the transform source from `logs-*` to
     // `logs-endpoint.events.process-*`. Without a matching index, Fleet silently
     // skips starting the transform and the destination index is never created.
-    // Create a minimal index here so the transform can start during installation.
-    request({
-      method: 'POST',
-      url: `/api/console/proxy?method=PUT&path=${encodeURIComponent(
-        '/logs-endpoint.events.process-default'
-      )}`,
-      body: {},
-      failOnStatusCode: false,
+    // Insert a document into a matching index so the transform can start.
+    cy.task('insertDoc', {
+      index: 'logs-endpoint.events.process-default',
+      doc: { '@timestamp': new Date().toISOString() },
+      id: 'lmd-transform-source-doc',
     });
   });
 
   after(() => {
-    request({
-      method: 'POST',
-      url: `/api/console/proxy?method=DELETE&path=${encodeURIComponent(
-        '/logs-endpoint.events.process-default'
-      )}`,
-      failOnStatusCode: false,
+    cy.task('deleteDocsByQuery', {
+      index: 'logs-endpoint.events.process-default',
+      query: { match_all: {} },
+      ignoreUnavailable: true,
     });
   });
 


### PR DESCRIPTION
## Summary

Followup to https://github.com/elastic/kibana/pull/280960 which did not address the failures seen on https://github.com/elastic/kibana/pull/277223.

Instead of using Kibana's console proxy (which seems could fail silently) and creating an empty index, this change calls ES to insert actual data so the transform has something to process and can reach green health.

### Checklist

Check the PR satisfies following conditions. 

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

N/A: fixes a failing Cypress test.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->