### PR TITLE
[Entity Analytics] Fix entity name search broken on Cases Attachments page

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
@@ -12,6 +12,7 @@ import {
   LENS_ATTACHMENT_TYPE,
   MAP_ATTACHMENT_TYPE,
   SECURITY_ALERT_ATTACHMENT_TYPE,
+  SECURITY_ENTITY_ATTACHMENT_TYPE,
   SECURITY_EVENT_ATTACHMENT_TYPE,
   SECURITY_TIMELINE_ATTACHMENT_TYPE,
 } from '../../../../common/constants/attachments';
@@ -506,6 +507,76 @@ describe('Case view helpers', () => {
 
       expect(result.comments).toHaveLength(1);
       expect(result.comments[0]).toEqual(fileComment);
+    });
+
+    describe('security.entity attachment search', () => {
+      const buildEntityAttachment = (overrides: {
+        attachmentId?: string;
+        entityName?: string;
+        entityType?: string;
+        riskLevel?: string;
+      } = {}) =>
+        ({
+          id: 'entity-1',
+          type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+          attachmentId: overrides.attachmentId ?? 'host:web01',
+          metadata: {
+            entityName: overrides.entityName ?? 'web01',
+            entityType: overrides.entityType ?? 'host',
+            riskLevel: overrides.riskLevel ?? 'Critical',
+          },
+          owner: basicCase.owner,
+          createdAt: basicCase.createdAt,
+          createdBy: basicCase.createdBy,
+          pushedAt: null,
+          pushedBy: null,
+          updatedAt: null,
+          updatedBy: null,
+          version: 'WzQ3LDFc',
+        } as unknown as AttachmentUIV2);
+
+      it('matches on entityName', () => {
+        const caseData = { ...basicCase, comments: [buildEntityAttachment()] };
+        expect(filterCaseAttachmentsBySearchTerm(caseData, 'web01').comments).toHaveLength(1);
+      });
+
+      it('matches on entityType', () => {
+        const caseData = { ...basicCase, comments: [buildEntityAttachment()] };
+        expect(filterCaseAttachmentsBySearchTerm(caseData, 'host').comments).toHaveLength(1);
+      });
+
+      it('matches on riskLevel', () => {
+        const caseData = { ...basicCase, comments: [buildEntityAttachment()] };
+        expect(filterCaseAttachmentsBySearchTerm(caseData, 'critical').comments).toHaveLength(1);
+      });
+
+      it('matches on attachmentId', () => {
+        const caseData = { ...basicCase, comments: [buildEntityAttachment()] };
+        expect(
+          filterCaseAttachmentsBySearchTerm(caseData, 'host:web01').comments
+        ).toHaveLength(1);
+      });
+
+      it('matches case-insensitively', () => {
+        const caseData = { ...basicCase, comments: [buildEntityAttachment()] };
+        expect(filterCaseAttachmentsBySearchTerm(caseData, 'WEB01').comments).toHaveLength(1);
+      });
+
+      it('excludes the attachment when nothing matches', () => {
+        const caseData = { ...basicCase, comments: [buildEntityAttachment()] };
+        expect(
+          filterCaseAttachmentsBySearchTerm(caseData, 'nonexistent').comments
+        ).toHaveLength(0);
+      });
+
+      it('excludes a malformed entity attachment (no attachmentId)', () => {
+        const malformed = {
+          ...buildEntityAttachment(),
+          attachmentId: undefined,
+        } as unknown as AttachmentUIV2;
+        const caseData = { ...basicCase, comments: [malformed] };
+        expect(filterCaseAttachmentsBySearchTerm(caseData, 'web01').comments).toHaveLength(0);
+      });
     });
 
     it('filters non-event unified reference attachments by attachmentId', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
@@ -510,12 +510,14 @@ describe('Case view helpers', () => {
     });
 
     describe('security.entity attachment search', () => {
-      const buildEntityAttachment = (overrides: {
-        attachmentId?: string;
-        entityName?: string;
-        entityType?: string;
-        riskLevel?: string;
-      } = {}) =>
+      const buildEntityAttachment = (
+        overrides: {
+          attachmentId?: string;
+          entityName?: string;
+          entityType?: string;
+          riskLevel?: string;
+        } = {}
+      ) =>
         ({
           id: 'entity-1',
           type: SECURITY_ENTITY_ATTACHMENT_TYPE,
@@ -552,9 +554,7 @@ describe('Case view helpers', () => {
 
       it('matches on attachmentId', () => {
         const caseData = { ...basicCase, comments: [buildEntityAttachment()] };
-        expect(
-          filterCaseAttachmentsBySearchTerm(caseData, 'host:web01').comments
-        ).toHaveLength(1);
+        expect(filterCaseAttachmentsBySearchTerm(caseData, 'host:web01').comments).toHaveLength(1);
       });
 
       it('matches case-insensitively', () => {
@@ -564,9 +564,7 @@ describe('Case view helpers', () => {
 
       it('excludes the attachment when nothing matches', () => {
         const caseData = { ...basicCase, comments: [buildEntityAttachment()] };
-        expect(
-          filterCaseAttachmentsBySearchTerm(caseData, 'nonexistent').comments
-        ).toHaveLength(0);
+        expect(filterCaseAttachmentsBySearchTerm(caseData, 'nonexistent').comments).toHaveLength(0);
       });
 
       it('excludes a malformed entity attachment (no attachmentId)', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -126,6 +126,33 @@ const filterUnifiedAttachment = (
   return comment;
 };
 
+/**
+ * Filter security entity attachment by searchable metadata fields.
+ * Entity attachmentId is always a single string.
+ * Duplicates matchesSearchTerm in security_solution/cases/attachments/entity/utils.ts —
+ * cases cannot import from security_solution.
+ */
+const filterSecurityEntityAttachment = (
+  comment: UnifiedReferenceAttachmentPayload,
+  searchTerm: string
+): UnifiedReferenceAttachmentPayload | null => {
+  const meta = (comment.metadata ?? {}) as {
+    entityName?: string;
+    entityType?: string;
+    riskLevel?: string;
+  };
+  const term = searchTerm.toLowerCase();
+  const text = [
+    typeof comment.attachmentId === 'string' ? comment.attachmentId : '',
+    meta.entityName ?? '',
+    meta.entityType ?? '',
+    meta.riskLevel ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+  return text.includes(term) ? comment : null;
+};
+
 export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: string): CaseUI => {
   if (!searchTerm) {
     return caseData;
@@ -153,23 +180,7 @@ export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: 
           comment.type === SECURITY_ENTITY_ATTACHMENT_TYPE &&
           isUnifiedReferenceAttachmentRequest(comment)
         ) {
-          // Duplicates matchesSearchTerm in security_solution/cases/attachments/entity/utils.ts —
-          // cases cannot import from security_solution. Entity attachmentId is always a single string.
-          const meta = (comment.metadata ?? {}) as {
-            entityName?: string;
-            entityType?: string;
-            riskLevel?: string;
-          };
-          const term = searchTerm.toLowerCase();
-          const text = [
-            typeof comment.attachmentId === 'string' ? comment.attachmentId : '',
-            meta.entityName ?? '',
-            meta.entityType ?? '',
-            meta.riskLevel ?? '',
-          ]
-            .join(' ')
-            .toLowerCase();
-          return text.includes(term) ? comment : null;
+          return filterSecurityEntityAttachment(comment, searchTerm);
         }
         // Malformed security.entity attachment (no attachmentId) — exclude rather than pass through.
         if (comment.type === SECURITY_ENTITY_ATTACHMENT_TYPE) return null;

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -19,7 +19,10 @@ import {
   isUnifiedReferenceAttachmentRequest,
 } from '../../../../common/utils/attachments';
 import { isSavedObjectAttachment } from '../../attachments/common/saved_object/helpers';
-import { LENS_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
+import {
+  LENS_ATTACHMENT_TYPE,
+  SECURITY_ENTITY_ATTACHMENT_TYPE,
+} from '../../../../common/constants/attachments';
 import { FILE_ATTACHMENT_TYPE } from '../../../../common/constants';
 import { resolveUnifiedAttachmentType } from '../../../../common/utils/attachments/migration_utils';
 import { UNKNOWN } from '../../../common/translations';
@@ -145,6 +148,23 @@ export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: 
         // title, so keep them here and let the files API drive the results.
         if (resolveUnifiedAttachmentType(comment, owner) === FILE_ATTACHMENT_TYPE) {
           return comment;
+        }
+        if (comment.type === SECURITY_ENTITY_ATTACHMENT_TYPE && isUnifiedReferenceAttachmentRequest(comment)) {
+          const meta = (comment.metadata ?? {}) as {
+            entityName?: string;
+            entityType?: string;
+            riskLevel?: string;
+          };
+          const term = searchTerm.toLowerCase();
+          const text = [
+            typeof comment.attachmentId === 'string' ? comment.attachmentId : '',
+            meta.entityName ?? '',
+            meta.entityType ?? '',
+            meta.riskLevel ?? '',
+          ]
+            .join(' ')
+            .toLowerCase();
+          return text.includes(term) ? comment : null;
         }
         if (isUnifiedReferenceAttachmentRequest(comment)) {
           return filterUnifiedAttachment(comment, searchTerm);

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -153,6 +153,8 @@ export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: 
           comment.type === SECURITY_ENTITY_ATTACHMENT_TYPE &&
           isUnifiedReferenceAttachmentRequest(comment)
         ) {
+          // Duplicates matchesSearchTerm in security_solution/cases/attachments/entity/utils.ts —
+          // cases cannot import from security_solution. Entity attachmentId is always a single string.
           const meta = (comment.metadata ?? {}) as {
             entityName?: string;
             entityType?: string;
@@ -169,6 +171,8 @@ export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: 
             .toLowerCase();
           return text.includes(term) ? comment : null;
         }
+        // Malformed security.entity attachment (no attachmentId) — exclude rather than pass through.
+        if (comment.type === SECURITY_ENTITY_ATTACHMENT_TYPE) return null;
         if (isUnifiedReferenceAttachmentRequest(comment)) {
           return filterUnifiedAttachment(comment, searchTerm);
         }

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -149,7 +149,10 @@ export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: 
         if (resolveUnifiedAttachmentType(comment, owner) === FILE_ATTACHMENT_TYPE) {
           return comment;
         }
-        if (comment.type === SECURITY_ENTITY_ATTACHMENT_TYPE && isUnifiedReferenceAttachmentRequest(comment)) {
+        if (
+          comment.type === SECURITY_ENTITY_ATTACHMENT_TYPE &&
+          isUnifiedReferenceAttachmentRequest(comment)
+        ) {
           const meta = (comment.metadata ?? {}) as {
             entityName?: string;
             entityType?: string;


### PR DESCRIPTION
## Summary

**Fixes Bug:** Searching by entity name on the Cases Attachments page returned no results and hid the Entity accordion.

**Root cause:** Entity attachments have different metadata fields (`entityName`, `entityType`, `riskLevel`) than other unified attachments, but the search filter only checked `metadata.title` - a field entity attachments don't have.

**Fix:** Add a dedicated search filter for entity attachments that checks all their relevant fields (`attachmentId`, `entityName`, `entityType`, `riskLevel`) instead of routing them through the generic filter. No changes to other attachment types.

Closes #280760

## Test plan
- [ ] [Security Documents generator ](https://github.com/elastic/security-documents-generator)- `yarn start org-data --size small` generate some entities
- [ ] Navigate to Security → Cases → Attachments with an entity attached to a case
- [ ] Search by entity display name (e.g. `"web01"`) — confirm the entity accordion remains visible and shows the matching entity
- [ ] Search by risk level (e.g. `"Critical"`) — confirm matching entities are shown
- [ ] Search by entity type (e.g. `"host"`, `"user"`) — confirm matching entities are shown
- [ ] Search for a term with no matches — confirm the accordion disappears
- [ ] Clear the search — confirm all entities reappear
- [ ] Confirm other attachment types (alerts, files, timelines) are unaffected by the change

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->