### PR TITLE
update data federation badge to experimental

### DIFF
--- a/x-pack/platform/plugins/private/data_federation/public/main.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/main.tsx
@@ -105,7 +105,7 @@ export const Main: FunctionComponent = () => {
           <>
             <span data-test-subj="dataSetsPageTitle">{mainTranslations.pageTitle}</span>
             &nbsp;
-            <EuiBetaBadge label={mainTranslations.technicalPreview} size="m" />
+            <EuiBetaBadge label={mainTranslations.experimental} size="m" />
           </>
         }
         description={

--- a/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
@@ -17,8 +17,8 @@ export const mainTranslations = {
       'Connect to external data sources and add specific datasets to query with ES|QL, just like your indexed data. No ingestion required.',
   }),
 
-  technicalPreview: i18n.translate('xpack.dataFederation.technicalPreview', {
-    defaultMessage: 'Technical Preview',
+  experimental: i18n.translate('xpack.dataFederation.experimental', {
+    defaultMessage: 'Experimental',
   }),
 
   docsLink: i18n.translate('xpack.dataFederation.docsLink', {


### PR DESCRIPTION
This PR updates the badge in ES|QL Data Federation UI from "technical preview" to "experimental" following the decision to disable by default.

Related to: https://github.com/elastic/kibana/pull/280968

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->