### PR TITLE
Attempt to fix metric dimension selection flakiness

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/components/dimension_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/components/dimension_editor.tsx
@@ -51,6 +51,8 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
     esqlVariables,
     isApproximate,
     enableFormatSelector,
+    isMetricDimension,
+    filterOperations,
   } = props;
 
   useEffect(() => {
@@ -78,8 +80,8 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
               meta: col?.meta ?? { type: 'number' },
               variable: col.variable,
               compatible:
-                props.isMetricDimension && hasNumberTypeColumns
-                  ? props.filterOperations({
+                isMetricDimension && hasNumberTypeColumns
+                  ? filterOperations({
                       dataType: col?.meta?.type as DataType,
                       isBucketed: Boolean(isNotNumeric(col)),
                       scale: 'ordinal',
@@ -99,7 +101,8 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
     isApproximate,
     expressions,
     indexPatterns,
-    props,
+    isMetricDimension,
+    filterOperations,
     query,
   ]);
 
@@ -172,7 +175,7 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
                 meta: column?.meta,
                 variable: column?.variable,
                 label: choice.field,
-                ...(props.isMetricDimension && { inMetricDimension: true }),
+                ...(isMetricDimension && { inMetricDimension: true }),
               };
               return props.setState(
                 !selectedField


### PR DESCRIPTION
## Summary

I am not hundred percent convinced that this is the sole issue, but it can definitely contribute to it. Hope this fix will avoid future flakiness 🤞🏻 

Example failure: [Lens ESQL dashboard inline editing - should keep the table type when the user adds a limit via Try ESQL](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/13354)

**Error**
```
TimeoutError: locator.click: Timeout 10000ms exceeded.
Call log:
  - waiting for locator('[data-test-subj~="text-based-dimension-field-optionsList"]').getByRole('option').first()
    - locator resolved to <li role="option" compatible="1" aria-setsize="2" aria-posinset="2" aria-selected="false" data-test-subj="euiListItemLayout" id="ib7381700-8a71-11f1-9f85-372c370411b9__option--1" class="euiListItemLayout euiComboBoxOption css-175va54-euiListItemLayout-isInteractive">…</li>
  - attempting click action
    - waiting for element to be visible, enabled and stable
    - element is visible, enabled and stable
    - scrolling into view if needed
    - done scrolling
  - element was detached from the DOM, retrying
  ```


Here you can see number of re-rendering before and after when selecting a metric dimension:

|State|Screenshot|
|---|---|
|Before|<img width="1505" height="585" alt="image" src="https://github.com/user-attachments/assets/b8961eff-5874-412d-9f10-ccf8ffbcb304" />|
|After|<img width="1500" height="622" alt="image" src="https://github.com/user-attachments/assets/2a3bf095-d851-49b3-b594-1437bf77f706" />|