### PR TITLE
[Response Ops] Prototype event router (HTTP ingest, in-memory fan-out)

### DIFF
--- a/package.json
+++ b/package.json
@@ -702,6 +702,7 @@
     "@kbn/event-annotation-plugin": "link:src/platform/plugins/private/event_annotation",
     "@kbn/event-log-fixture-plugin": "link:x-pack/platform/test/plugin_api_integration/plugins/event_log",
     "@kbn/event-log-plugin": "link:x-pack/platform/plugins/shared/event_log",
+    "@kbn/event-router-plugin": "link:x-pack/platform/plugins/shared/event_router",
     "@kbn/event-stacktrace": "link:x-pack/platform/packages/shared/kbn-event-stacktrace",
     "@kbn/expandable-flyout": "link:x-pack/solutions/security/packages/expandable-flyout",
     "@kbn/exploratory-view-example-plugin": "link:x-pack/examples/exploratory_view_example",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1347,6 +1347,8 @@
       "@kbn/event-log-fixture-plugin/*": ["./x-pack/platform/test/plugin_api_integration/plugins/event_log/*"],
       "@kbn/event-log-plugin": ["./x-pack/platform/plugins/shared/event_log"],
       "@kbn/event-log-plugin/*": ["./x-pack/platform/plugins/shared/event_log/*"],
+      "@kbn/event-router-plugin": ["./x-pack/platform/plugins/shared/event_router"],
+      "@kbn/event-router-plugin/*": ["./x-pack/platform/plugins/shared/event_router/*"],
       "@kbn/event-stacktrace": ["./x-pack/platform/packages/shared/kbn-event-stacktrace"],
       "@kbn/event-stacktrace/*": ["./x-pack/platform/packages/shared/kbn-event-stacktrace/*"],
       "@kbn/expandable-flyout": ["./x-pack/solutions/security/packages/expandable-flyout"],

--- a/x-pack/platform/plugins/shared/event_router/jest.config.js
+++ b/x-pack/platform/plugins/shared/event_router/jest.config.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/platform/plugins/shared/event_router'],
+  coverageDirectory:
+    '<rootDir>/target/kibana-coverage/jest/x-pack/platform/plugins/shared/event_router',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/platform/plugins/shared/event_router/server/**/*.{ts,tsx}',
+  ],
+};

--- a/x-pack/platform/plugins/shared/event_router/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/event_router/kibana.jsonc
@@ -1,0 +1,22 @@
+{
+  "type": "plugin",
+  "id": "@kbn/event-router-plugin",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
+  "description": "Prototype: accepts events from external systems over HTTP and fans them out in-process to filtered listeners, which enqueue their own durable work. The router owns no poller and no queue.",
+  "plugin": {
+    "id": "eventRouter",
+    "browser": false,
+    "server": true,
+    "configPath": [
+      "xpack",
+      "eventRouter"
+    ],
+    "optionalPlugins": [
+      "taskManager"
+    ]
+  }
+}

--- a/x-pack/platform/plugins/shared/event_router/server/config.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/config.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema, type TypeOf } from '@kbn/config-schema';
+
+export const configSchema = schema.object({
+  /** Maximum number of events accepted in a single publish request. */
+  maxEventsPerRequest: schema.number({ defaultValue: 100, min: 1, max: 1000 }),
+  /**
+   * Upper bound on a single listener's turnaround. Listeners are only meant to
+   * enqueue durable work, so exceeding this is reported as a failure rather
+   * than allowed to hold the ingest request open.
+   */
+  listenerTimeout: schema.duration({ defaultValue: '10s' }),
+  exampleListener: schema.object({
+    /**
+     * Registers a demo event type and a listener that enqueues a Task Manager
+     * task, so the end-to-end path can be exercised without wiring a real
+     * consumer such as Workflows.
+     */
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
+});
+
+export type EventRouterConfig = TypeOf<typeof configSchema>;

--- a/x-pack/platform/plugins/shared/event_router/server/dispatcher.test.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/dispatcher.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core/server/mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import { Dispatcher } from './dispatcher';
+import { ListenerRegistry } from './listener_registry';
+import type { RouterEvent } from './types';
+
+const LISTENER_TIMEOUT_MS = 50;
+
+const event: RouterEvent = {
+  id: 'event-1',
+  type: 'a.b',
+  attributes: { repo: 'elastic/kibana' },
+  payload: { count: 1 },
+  receivedAt: '2026-07-28T00:00:00.000Z',
+  spaceId: 'default',
+};
+
+describe('Dispatcher', () => {
+  const request = httpServerMock.createKibanaRequest();
+  let listeners: ListenerRegistry;
+  let logger: ReturnType<typeof loggerMock.create>;
+  let dispatcher: Dispatcher;
+
+  beforeEach(() => {
+    listeners = new ListenerRegistry();
+    logger = loggerMock.create();
+    dispatcher = new Dispatcher({ listeners, logger, listenerTimeoutMs: LISTENER_TIMEOUT_MS });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does nothing when no listener matches', async () => {
+    const handler = jest.fn();
+    listeners.register({ id: 'other', filter: { types: ['c.d'] }, handler });
+
+    await expect(dispatcher.dispatch(event, request)).resolves.toEqual({
+      enqueued: [],
+      failures: [],
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('hands the event and the publishing request to every matching listener', async () => {
+    const one = jest.fn();
+    const two = jest.fn();
+    listeners.register({ id: 'one', filter: { types: ['a.b'] }, handler: one });
+    listeners.register({
+      id: 'two',
+      filter: { types: ['a.b'], attributes: { repo: 'elastic/kibana' } },
+      handler: two,
+    });
+
+    await expect(dispatcher.dispatch(event, request)).resolves.toEqual({
+      enqueued: ['one', 'two'],
+      failures: [],
+    });
+    expect(one).toHaveBeenCalledWith(event, { request });
+    expect(two).toHaveBeenCalledWith(event, { request });
+  });
+
+  it('isolates a failing listener from the others', async () => {
+    listeners.register({
+      id: 'bad',
+      filter: { types: ['a.b'] },
+      handler: jest.fn().mockRejectedValue(new Error('task manager unavailable')),
+    });
+    const good = jest.fn();
+    listeners.register({ id: 'good', filter: { types: ['a.b'] }, handler: good });
+
+    await expect(dispatcher.dispatch(event, request)).resolves.toEqual({
+      enqueued: ['good'],
+      failures: [{ listenerId: 'bad', message: 'task manager unavailable' }],
+    });
+    expect(good).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Listener "bad" failed to enqueue work for event event-1 of type "a.b": task manager unavailable'
+    );
+  });
+
+  it('fails a listener that does not enqueue its work in time', async () => {
+    jest.useFakeTimers();
+    listeners.register({
+      id: 'slow',
+      filter: { types: ['a.b'] },
+      handler: () => new Promise<void>(() => {}),
+    });
+
+    const dispatched = dispatcher.dispatch(event, request);
+    await jest.advanceTimersByTimeAsync(LISTENER_TIMEOUT_MS);
+
+    await expect(dispatched).resolves.toEqual({
+      enqueued: [],
+      failures: [
+        {
+          listenerId: 'slow',
+          message: `Listener "slow" did not enqueue its work within ${LISTENER_TIMEOUT_MS}ms`,
+        },
+      ],
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/event_router/server/dispatcher.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/dispatcher.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import { errorMessage } from './errors';
+import type { ListenerRegistry } from './listener_registry';
+import type { ListenerFailure, RouterEvent } from './types';
+
+export interface DispatchOutcome {
+  enqueued: string[];
+  failures: ListenerFailure[];
+}
+
+type ListenerOutcome =
+  | { listenerId: string; ok: true }
+  | { listenerId: string; ok: false; message: string };
+
+const withTimeout = async (
+  work: Promise<void>,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<void> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    // `Promise.race` keeps a handler attached to `work`, so a late rejection
+    // after the timeout wins is still observed rather than going unhandled.
+    await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+interface DispatcherDeps {
+  listeners: ListenerRegistry;
+  logger: Logger;
+  listenerTimeoutMs: number;
+}
+
+/**
+ * Fans one event out to every listener whose filter matches. Listeners are
+ * isolated from each other: one failing or hanging listener must not stop the
+ * others from being given the event.
+ */
+export class Dispatcher {
+  private readonly listeners: ListenerRegistry;
+  private readonly logger: Logger;
+  private readonly listenerTimeoutMs: number;
+
+  constructor({ listeners, logger, listenerTimeoutMs }: DispatcherDeps) {
+    this.listeners = listeners;
+    this.logger = logger;
+    this.listenerTimeoutMs = listenerTimeoutMs;
+  }
+
+  public async dispatch(event: RouterEvent, request: KibanaRequest): Promise<DispatchOutcome> {
+    const matched = this.listeners.match(event);
+
+    if (matched.length === 0) {
+      return { enqueued: [], failures: [] };
+    }
+
+    const outcomes = await Promise.all(
+      matched.map(async (listener): Promise<ListenerOutcome> => {
+        try {
+          await withTimeout(
+            listener.handler(event, { request }),
+            this.listenerTimeoutMs,
+            `Listener "${listener.id}" did not enqueue its work within ${this.listenerTimeoutMs}ms`
+          );
+          return { listenerId: listener.id, ok: true };
+        } catch (error) {
+          const message = errorMessage(error);
+          this.logger.error(
+            `Listener "${listener.id}" failed to enqueue work for event ${event.id} of type "${event.type}": ${message}`
+          );
+          return { listenerId: listener.id, ok: false, message };
+        }
+      })
+    );
+
+    const enqueued: string[] = [];
+    const failures: ListenerFailure[] = [];
+
+    for (const outcome of outcomes) {
+      if (outcome.ok) {
+        enqueued.push(outcome.listenerId);
+      } else {
+        failures.push({ listenerId: outcome.listenerId, message: outcome.message });
+      }
+    }
+
+    return { enqueued, failures };
+  }
+}

--- a/x-pack/platform/plugins/shared/event_router/server/errors.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/errors.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * The producer sent something the router cannot accept (unknown event type,
+ * payload that fails its schema). Retrying the same request fails the same way,
+ * so this maps to a 4xx rather than a retryable 5xx.
+ */
+export class InvalidEventError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidEventError';
+  }
+}
+
+export const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);

--- a/x-pack/platform/plugins/shared/event_router/server/event_router.test.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/event_router.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { httpServerMock } from '@kbn/core/server/mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import { Dispatcher } from './dispatcher';
+import { InvalidEventError } from './errors';
+import { EventRouter } from './event_router';
+import { EventTypeRegistry } from './event_type_registry';
+import { ListenerRegistry } from './listener_registry';
+
+describe('EventRouter', () => {
+  const request = httpServerMock.createKibanaRequest();
+  let handler: jest.Mock;
+  let eventRouter: EventRouter;
+
+  beforeEach(() => {
+    const eventTypes = new EventTypeRegistry();
+    eventTypes.register({
+      type: 'a.b',
+      payloadSchema: schema.object({ count: schema.number() }),
+    });
+
+    const listeners = new ListenerRegistry();
+    handler = jest.fn();
+    listeners.register({ id: 'one', filter: { types: ['a.b'] }, handler });
+
+    eventRouter = new EventRouter({
+      eventTypes,
+      dispatcher: new Dispatcher({
+        listeners,
+        logger: loggerMock.create(),
+        listenerTimeoutMs: 1000,
+      }),
+    });
+  });
+
+  describe('publish', () => {
+    it('rejects an unknown event type without dispatching', async () => {
+      await expect(eventRouter.publish({ type: 'nope' }, request)).rejects.toThrow(
+        InvalidEventError
+      );
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('rejects a payload that violates the event type schema without dispatching', async () => {
+      await expect(
+        eventRouter.publish({ type: 'a.b', payload: { count: 'one' } }, request)
+      ).rejects.toThrow(InvalidEventError);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('stamps the event and reports which listeners enqueued it', async () => {
+      const result = await eventRouter.publish(
+        { type: 'a.b', attributes: { repo: 'elastic/kibana' }, payload: { count: 1 } },
+        request
+      );
+
+      expect(result).toEqual({
+        id: expect.any(String),
+        type: 'a.b',
+        enqueued: ['one'],
+        failures: [],
+      });
+      expect(handler).toHaveBeenCalledWith(
+        {
+          id: result.id,
+          type: 'a.b',
+          attributes: { repo: 'elastic/kibana' },
+          payload: { count: 1 },
+          receivedAt: expect.any(String),
+          spaceId: request.spaceId,
+        },
+        { request }
+      );
+    });
+
+    it('reports a listener failure rather than throwing', async () => {
+      handler.mockRejectedValue(new Error('task manager unavailable'));
+
+      const result = await eventRouter.publish({ type: 'a.b', payload: { count: 1 } }, request);
+
+      expect(result.enqueued).toEqual([]);
+      expect(result.failures).toEqual([{ listenerId: 'one', message: 'task manager unavailable' }]);
+    });
+  });
+
+  describe('publishBatch', () => {
+    it('validates the whole batch before delivering any of it', async () => {
+      await expect(
+        eventRouter.publishBatch(
+          [{ type: 'a.b', payload: { count: 1 } }, { type: 'nope' }],
+          request
+        )
+      ).rejects.toThrow(InvalidEventError);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns a result per event, each with its own id', async () => {
+      const results = await eventRouter.publishBatch(
+        [
+          { type: 'a.b', payload: { count: 1 } },
+          { type: 'a.b', payload: { count: 2 } },
+        ],
+        request
+      );
+
+      expect(results).toHaveLength(2);
+      expect(results[0].id).not.toEqual(results[1].id);
+      expect(results.every(({ enqueued }) => enqueued.includes('one'))).toBe(true);
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/event_router/server/event_router.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/event_router.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import { v4 as uuidv4 } from 'uuid';
+import type { Dispatcher } from './dispatcher';
+import type { EventTypeRegistry } from './event_type_registry';
+import type { PublishEventParams, PublishResult, RouterEvent } from './types';
+
+interface EventRouterDeps {
+  eventTypes: EventTypeRegistry;
+  dispatcher: Dispatcher;
+}
+
+/**
+ * The whole delivery path: validate, then hand the event to matching listeners.
+ * Nothing is written to Elasticsearch and nothing is polled, so an event that
+ * interests no listener costs a map lookup.
+ */
+export class EventRouter {
+  private readonly eventTypes: EventTypeRegistry;
+  private readonly dispatcher: Dispatcher;
+
+  constructor({ eventTypes, dispatcher }: EventRouterDeps) {
+    this.eventTypes = eventTypes;
+    this.dispatcher = dispatcher;
+  }
+
+  public async publish(params: PublishEventParams, request: KibanaRequest): Promise<PublishResult> {
+    this.eventTypes.validate(params.type, params.payload);
+    return this.deliver(params, request);
+  }
+
+  /**
+   * Validates the whole batch before delivering any of it, so a rejected batch
+   * leaves no partially delivered events for the producer to duplicate on retry.
+   */
+  public async publishBatch(
+    events: PublishEventParams[],
+    request: KibanaRequest
+  ): Promise<PublishResult[]> {
+    for (const event of events) {
+      this.eventTypes.validate(event.type, event.payload);
+    }
+
+    const results: PublishResult[] = [];
+    for (const event of events) {
+      results.push(await this.deliver(event, request));
+    }
+
+    return results;
+  }
+
+  private async deliver(
+    params: PublishEventParams,
+    request: KibanaRequest
+  ): Promise<PublishResult> {
+    const event: RouterEvent = {
+      id: uuidv4(),
+      type: params.type,
+      attributes: params.attributes ?? {},
+      payload: params.payload ?? {},
+      receivedAt: new Date().toISOString(),
+      spaceId: request.spaceId,
+    };
+
+    const { enqueued, failures } = await this.dispatcher.dispatch(event, request);
+
+    return { id: event.id, type: event.type, enqueued, failures };
+  }
+}

--- a/x-pack/platform/plugins/shared/event_router/server/event_type_registry.test.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/event_type_registry.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { EventTypeRegistry } from './event_type_registry';
+import { InvalidEventError } from './errors';
+
+describe('EventTypeRegistry', () => {
+  let registry: EventTypeRegistry;
+
+  beforeEach(() => {
+    registry = new EventTypeRegistry();
+  });
+
+  describe('register', () => {
+    it('registers a type', () => {
+      registry.register({ type: 'a.b' });
+
+      expect(registry.has('a.b')).toBe(true);
+      expect(registry.getTypes()).toEqual(['a.b']);
+    });
+
+    it('rejects a duplicate type', () => {
+      registry.register({ type: 'a.b' });
+
+      expect(() => registry.register({ type: 'a.b' })).toThrowErrorMatchingInlineSnapshot(
+        `"Event type \\"a.b\\" is already registered"`
+      );
+    });
+
+    it('rejects an empty type', () => {
+      expect(() => registry.register({ type: '  ' })).toThrowErrorMatchingInlineSnapshot(
+        `"Event type must be a non-empty string"`
+      );
+    });
+  });
+
+  describe('validate', () => {
+    it('rejects an unknown type', () => {
+      expect(() => registry.validate('nope', {})).toThrow(InvalidEventError);
+      expect(() => registry.validate('nope', {})).toThrowErrorMatchingInlineSnapshot(
+        `"Unknown event type \\"nope\\""`
+      );
+    });
+
+    it('accepts any payload when the type has no schema', () => {
+      registry.register({ type: 'a.b' });
+
+      expect(() => registry.validate('a.b', { anything: true })).not.toThrow();
+      expect(() => registry.validate('a.b', undefined)).not.toThrow();
+    });
+
+    it('accepts a payload that satisfies the schema', () => {
+      registry.register({
+        type: 'a.b',
+        payloadSchema: schema.object({ count: schema.number() }),
+      });
+
+      expect(() => registry.validate('a.b', { count: 1 })).not.toThrow();
+    });
+
+    it('rejects a payload that violates the schema', () => {
+      registry.register({
+        type: 'a.b',
+        payloadSchema: schema.object({ count: schema.number() }),
+      });
+
+      expect(() => registry.validate('a.b', { count: 'one' })).toThrow(InvalidEventError);
+      expect(() => registry.validate('a.b', { count: 'one' })).toThrow(
+        /Invalid payload for event type "a.b"/
+      );
+    });
+
+    it('validates a missing payload as an empty object', () => {
+      registry.register({
+        type: 'a.b',
+        payloadSchema: schema.object({ count: schema.number() }),
+      });
+
+      expect(() => registry.validate('a.b', undefined)).toThrow(InvalidEventError);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/event_router/server/event_type_registry.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/event_type_registry.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { InvalidEventError, errorMessage } from './errors';
+import type { EventTypeDefinition } from './types';
+
+/**
+ * Event types must be declared up front so that an unknown type is rejected at
+ * the edge instead of being accepted and silently matching no listener.
+ */
+export class EventTypeRegistry {
+  private readonly definitions = new Map<string, EventTypeDefinition>();
+
+  public register(definition: EventTypeDefinition): void {
+    const { type } = definition;
+
+    if (type.trim().length === 0) {
+      throw new Error('Event type must be a non-empty string');
+    }
+
+    if (this.definitions.has(type)) {
+      throw new Error(`Event type "${type}" is already registered`);
+    }
+
+    this.definitions.set(type, definition);
+  }
+
+  public has(type: string): boolean {
+    return this.definitions.has(type);
+  }
+
+  public getTypes(): string[] {
+    return [...this.definitions.keys()];
+  }
+
+  /** Throws {@link InvalidEventError} when the type is unknown or the payload is invalid. */
+  public validate(type: string, payload: unknown): void {
+    const definition = this.definitions.get(type);
+
+    if (!definition) {
+      throw new InvalidEventError(`Unknown event type "${type}"`);
+    }
+
+    if (!definition.payloadSchema) {
+      return;
+    }
+
+    try {
+      definition.payloadSchema.validate(payload ?? {});
+    } catch (error) {
+      throw new InvalidEventError(
+        `Invalid payload for event type "${type}": ${errorMessage(error)}`
+      );
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/event_router/server/example_listener.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/example_listener.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { Logger } from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import { TaskCost } from '@kbn/task-manager-plugin/server';
+import type { EventTypeDefinition, ListenerDefinition } from './types';
+
+export const EXAMPLE_EVENT_TYPE = 'example.event';
+export const EXAMPLE_TASK_TYPE = 'event_router:example_work';
+
+const paramsSchema = schema.object({
+  eventId: schema.string(),
+  eventType: schema.string(),
+  spaceId: schema.string(),
+});
+
+export const exampleEventType: EventTypeDefinition = {
+  type: EXAMPLE_EVENT_TYPE,
+  payloadSchema: schema.object({ message: schema.maybe(schema.string()) }, { unknowns: 'allow' }),
+};
+
+/**
+ * The work a listener hands off. It runs on whichever node Task Manager claims
+ * it on, exactly once, which is the guarantee the router itself never tries to
+ * provide.
+ */
+export const registerExampleTaskType = ({
+  taskManager,
+  logger,
+}: {
+  taskManager: TaskManagerSetupContract;
+  logger: Logger;
+}): void => {
+  taskManager.registerTaskDefinitions({
+    [EXAMPLE_TASK_TYPE]: {
+      title: 'Event router example work',
+      description:
+        'Prototype consumer for the event router: proves a routed event results in a durable task that runs on exactly one node.',
+      // The task only logs, so it either finishes immediately or is wedged.
+      timeout: '30s',
+      // One-shot work: a duplicate run would mean the event is processed twice.
+      maxAttempts: 1,
+      cost: TaskCost.Tiny,
+      paramsSchema,
+      createTaskRunner: ({ taskInstance }) => ({
+        run: async () => {
+          const { eventId, eventType, spaceId } = taskInstance.params;
+          logger.info(
+            `Processed routed event ${eventId} of type "${eventType}" in space "${spaceId}"`
+          );
+          return { state: {} };
+        },
+      }),
+    },
+  });
+};
+
+export const createExampleListener = ({
+  getTaskManager,
+}: {
+  getTaskManager: () => TaskManagerStartContract;
+}): ListenerDefinition => ({
+  id: 'exampleWork',
+  filter: { types: [EXAMPLE_EVENT_TYPE] },
+  handler: async (event) => {
+    // Deriving the task id from the event id makes the enqueue idempotent:
+    // a producer retry after a partial failure re-enqueues nothing.
+    await getTaskManager().ensureScheduled({
+      id: `${EXAMPLE_TASK_TYPE}:${event.id}`,
+      taskType: EXAMPLE_TASK_TYPE,
+      params: { eventId: event.id, eventType: event.type, spaceId: event.spaceId },
+      state: {},
+    });
+  },
+});

--- a/x-pack/platform/plugins/shared/event_router/server/filter.test.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/filter.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { matchesFilter } from './filter';
+
+describe('matchesFilter', () => {
+  const event = {
+    type: 'github.pull_request.opened',
+    attributes: { repo: 'elastic/kibana', team: 'response-ops' },
+  };
+
+  it('matches when the event type is subscribed to', () => {
+    expect(matchesFilter({ types: [event.type] }, event)).toBe(true);
+    expect(matchesFilter({ types: ['other.type', event.type] }, event)).toBe(true);
+  });
+
+  it('does not match a different event type', () => {
+    expect(matchesFilter({ types: ['github.pull_request.closed'] }, event)).toBe(false);
+  });
+
+  it('matches on type alone when the filter has no attributes', () => {
+    expect(matchesFilter({ types: [event.type] }, { type: event.type, attributes: {} })).toBe(true);
+  });
+
+  it('requires every filtered attribute to match', () => {
+    expect(
+      matchesFilter({ types: [event.type], attributes: { repo: 'elastic/kibana' } }, event)
+    ).toBe(true);
+    expect(
+      matchesFilter(
+        { types: [event.type], attributes: { repo: 'elastic/kibana', team: 'response-ops' } },
+        event
+      )
+    ).toBe(true);
+    expect(
+      matchesFilter(
+        { types: [event.type], attributes: { repo: 'elastic/kibana', team: 'platform' } },
+        event
+      )
+    ).toBe(false);
+  });
+
+  it('treats an array of attribute values as membership', () => {
+    expect(
+      matchesFilter(
+        { types: [event.type], attributes: { team: ['platform', 'response-ops'] } },
+        event
+      )
+    ).toBe(true);
+    expect(
+      matchesFilter({ types: [event.type], attributes: { team: ['platform', 'security'] } }, event)
+    ).toBe(false);
+  });
+
+  it('does not match when the event is missing a filtered attribute', () => {
+    expect(matchesFilter({ types: [event.type], attributes: { branch: 'main' } }, event)).toBe(
+      false
+    );
+    expect(matchesFilter({ types: [event.type], attributes: { branch: ['main'] } }, event)).toBe(
+      false
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/event_router/server/filter.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/filter.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ListenerFilter } from './types';
+
+interface MatchableEvent {
+  type: string;
+  attributes: Record<string, string>;
+}
+
+/**
+ * Decides whether an event is relevant to a listener. This runs once per
+ * (event x candidate listener) on the ingesting node, which is what keeps the
+ * firehose off the listeners that do not care about it.
+ */
+export const matchesFilter = (filter: ListenerFilter, event: MatchableEvent): boolean => {
+  if (!filter.types.includes(event.type)) {
+    return false;
+  }
+
+  if (!filter.attributes) {
+    return true;
+  }
+
+  return Object.entries(filter.attributes).every(([key, expected]) => {
+    const actual = event.attributes[key];
+    if (actual === undefined) {
+      return false;
+    }
+    return Array.isArray(expected) ? expected.includes(actual) : actual === expected;
+  });
+};

--- a/x-pack/platform/plugins/shared/event_router/server/index.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  PluginConfigDescriptor,
+  PluginInitializer,
+  PluginInitializerContext,
+} from '@kbn/core/server';
+import { configSchema, type EventRouterConfig } from './config';
+import type {
+  EventRouterSetup,
+  EventRouterSetupDeps,
+  EventRouterStart,
+  EventRouterStartDeps,
+} from './types';
+
+export const config: PluginConfigDescriptor<EventRouterConfig> = {
+  schema: configSchema,
+};
+
+export const plugin: PluginInitializer<
+  EventRouterSetup,
+  EventRouterStart,
+  EventRouterSetupDeps,
+  EventRouterStartDeps
+> = async (initializerContext: PluginInitializerContext<EventRouterConfig>) => {
+  const { EventRouterPlugin } = await import('./plugin');
+  return new EventRouterPlugin(initializerContext);
+};
+
+export type {
+  EventRouterSetup,
+  EventRouterStart,
+  EventTypeDefinition,
+  ListenerContext,
+  ListenerDefinition,
+  ListenerFilter,
+  ListenerHandler,
+  PublishEventParams,
+  PublishResult,
+  RouterEvent,
+} from './types';

--- a/x-pack/platform/plugins/shared/event_router/server/listener_registry.test.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/listener_registry.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ListenerRegistry } from './listener_registry';
+import type { ListenerDefinition, ListenerFilter, RouterEvent } from './types';
+
+const createEvent = (overrides: Partial<RouterEvent> = {}): RouterEvent => ({
+  id: 'event-1',
+  type: 'a.b',
+  attributes: {},
+  payload: {},
+  receivedAt: '2026-07-28T00:00:00.000Z',
+  spaceId: 'default',
+  ...overrides,
+});
+
+const createListener = (id: string, filter: ListenerFilter): ListenerDefinition => ({
+  id,
+  filter,
+  handler: jest.fn(),
+});
+
+describe('ListenerRegistry', () => {
+  let registry: ListenerRegistry;
+
+  beforeEach(() => {
+    registry = new ListenerRegistry();
+  });
+
+  describe('register', () => {
+    it('rejects a duplicate listener id', () => {
+      registry.register(createListener('one', { types: ['a.b'] }));
+
+      expect(() =>
+        registry.register(createListener('one', { types: ['c.d'] }))
+      ).toThrowErrorMatchingInlineSnapshot(`"Listener \\"one\\" is already registered"`);
+    });
+
+    it('rejects a listener that subscribes to nothing', () => {
+      expect(() =>
+        registry.register(createListener('one', { types: [] }))
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Listener \\"one\\" must subscribe to at least one event type"`
+      );
+    });
+
+    it('reports registered ids and subscribed types', () => {
+      registry.register(createListener('one', { types: ['a.b', 'c.d'] }));
+      registry.register(createListener('two', { types: ['a.b'] }));
+
+      expect(registry.getIds()).toEqual(['one', 'two']);
+      expect(registry.getSubscribedTypes()).toEqual(['a.b', 'c.d']);
+    });
+  });
+
+  describe('match', () => {
+    it('returns every listener subscribed to the event type', () => {
+      const one = createListener('one', { types: ['a.b'] });
+      const two = createListener('two', { types: ['a.b', 'c.d'] });
+      registry.register(one);
+      registry.register(two);
+
+      expect(registry.match(createEvent())).toEqual([one, two]);
+    });
+
+    it('returns nothing when no listener subscribes to the type', () => {
+      registry.register(createListener('one', { types: ['c.d'] }));
+
+      expect(registry.match(createEvent())).toEqual([]);
+    });
+
+    it('returns a listener once even when it subscribes to the type twice', () => {
+      const one = createListener('one', { types: ['a.b', 'a.b'] });
+      registry.register(one);
+
+      expect(registry.match(createEvent())).toEqual([one]);
+    });
+
+    it('applies attribute filters', () => {
+      const scoped = createListener('scoped', {
+        types: ['a.b'],
+        attributes: { repo: 'elastic/kibana' },
+      });
+      const broad = createListener('broad', { types: ['a.b'] });
+      registry.register(scoped);
+      registry.register(broad);
+
+      expect(registry.match(createEvent({ attributes: { repo: 'elastic/kibana' } }))).toEqual([
+        scoped,
+        broad,
+      ]);
+      expect(registry.match(createEvent({ attributes: { repo: 'elastic/eui' } }))).toEqual([broad]);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/event_router/server/listener_registry.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/listener_registry.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { matchesFilter } from './filter';
+import type { ListenerDefinition, RouterEvent } from './types';
+
+/**
+ * Holds every listener on every node. Candidates are indexed by event type so
+ * that a burst of events nobody subscribes to costs a single map lookup.
+ */
+export class ListenerRegistry {
+  private readonly listeners = new Map<string, ListenerDefinition>();
+  private readonly byType = new Map<string, ListenerDefinition[]>();
+
+  public register(definition: ListenerDefinition): void {
+    const { id, filter } = definition;
+
+    if (this.listeners.has(id)) {
+      throw new Error(`Listener "${id}" is already registered`);
+    }
+
+    if (filter.types.length === 0) {
+      throw new Error(`Listener "${id}" must subscribe to at least one event type`);
+    }
+
+    this.listeners.set(id, definition);
+
+    for (const type of new Set(filter.types)) {
+      const candidates = this.byType.get(type);
+      if (candidates) {
+        candidates.push(definition);
+      } else {
+        this.byType.set(type, [definition]);
+      }
+    }
+  }
+
+  public match(event: RouterEvent): ListenerDefinition[] {
+    const candidates = this.byType.get(event.type);
+
+    if (!candidates) {
+      return [];
+    }
+
+    return candidates.filter((listener) => matchesFilter(listener.filter, event));
+  }
+
+  public getIds(): string[] {
+    return [...this.listeners.keys()];
+  }
+
+  public getSubscribedTypes(): string[] {
+    return [...this.byType.keys()];
+  }
+}

--- a/x-pack/platform/plugins/shared/event_router/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/plugin.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CoreSetup,
+  CoreStart,
+  Logger,
+  Plugin,
+  PluginInitializerContext,
+} from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { EventRouterConfig } from './config';
+import { Dispatcher } from './dispatcher';
+import { EventRouter } from './event_router';
+import { EventTypeRegistry } from './event_type_registry';
+import {
+  createExampleListener,
+  exampleEventType,
+  registerExampleTaskType,
+} from './example_listener';
+import { ListenerRegistry } from './listener_registry';
+import { registerPublishEventsRoute } from './routes/publish_events';
+import type {
+  EventRouterSetup,
+  EventRouterSetupDeps,
+  EventRouterStart,
+  EventRouterStartDeps,
+} from './types';
+
+/**
+ * Everything this plugin owns is in memory: two registries and a dispatcher.
+ * There is no index to install, no cursor to persist and no timer to cancel,
+ * which is why there is no `stop` lifecycle. Durability belongs to the work
+ * listeners enqueue, not to the router.
+ */
+export class EventRouterPlugin
+  implements Plugin<EventRouterSetup, EventRouterStart, EventRouterSetupDeps, EventRouterStartDeps>
+{
+  private readonly logger: Logger;
+  private readonly config: EventRouterConfig;
+  private readonly eventTypes: EventTypeRegistry;
+  private readonly listeners: ListenerRegistry;
+  private readonly eventRouter: EventRouter;
+  private taskManager?: TaskManagerStartContract;
+
+  constructor(initializerContext: PluginInitializerContext<EventRouterConfig>) {
+    this.logger = initializerContext.logger.get();
+    this.config = initializerContext.config.get();
+    this.eventTypes = new EventTypeRegistry();
+    this.listeners = new ListenerRegistry();
+    this.eventRouter = new EventRouter({
+      eventTypes: this.eventTypes,
+      dispatcher: new Dispatcher({
+        listeners: this.listeners,
+        logger: this.logger.get('dispatcher'),
+        listenerTimeoutMs: this.config.listenerTimeout.asMilliseconds(),
+      }),
+    });
+  }
+
+  public setup(core: CoreSetup, plugins: EventRouterSetupDeps): EventRouterSetup {
+    registerPublishEventsRoute({
+      router: core.http.createRouter(),
+      eventRouter: this.eventRouter,
+      maxEventsPerRequest: this.config.maxEventsPerRequest,
+    });
+
+    this.setupExample(plugins.taskManager);
+
+    return {
+      registerEventType: (definition) => this.eventTypes.register(definition),
+      registerListener: (definition) => this.listeners.register(definition),
+    };
+  }
+
+  public start(core: CoreStart, plugins: EventRouterStartDeps): EventRouterStart {
+    this.taskManager = plugins.taskManager;
+
+    this.logger.debug(
+      `Routing ${this.eventTypes.getTypes().length} event type(s) to ${
+        this.listeners.getIds().length
+      } listener(s)`
+    );
+
+    return {
+      publish: (params, request) => this.eventRouter.publish(params, request),
+    };
+  }
+
+  private setupExample(taskManager: TaskManagerSetupContract | undefined): void {
+    if (!taskManager) {
+      if (this.config.exampleListener.enabled) {
+        this.logger.warn(
+          'xpack.eventRouter.exampleListener.enabled is true but the taskManager plugin is unavailable, so the example listener was not registered.'
+        );
+      }
+      return;
+    }
+
+    // Registered unconditionally so the set of task types does not vary with
+    // config; nothing schedules it unless the example listener is enabled.
+    registerExampleTaskType({ taskManager, logger: this.logger.get('example') });
+
+    if (!this.config.exampleListener.enabled) {
+      return;
+    }
+
+    this.eventTypes.register(exampleEventType);
+    this.listeners.register(
+      createExampleListener({
+        getTaskManager: () => {
+          if (!this.taskManager) {
+            throw new Error('Task Manager is not available until the start lifecycle has run');
+          }
+          return this.taskManager;
+        },
+      })
+    );
+  }
+}

--- a/x-pack/platform/plugins/shared/event_router/server/routes/publish_events.test.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/routes/publish_events.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema, type Type } from '@kbn/config-schema';
+import type { RequestHandlerContext } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { httpServerMock, httpServiceMock } from '@kbn/core/server/mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import { Dispatcher } from '../dispatcher';
+import { EventRouter } from '../event_router';
+import { EventTypeRegistry } from '../event_type_registry';
+import { ListenerRegistry } from '../listener_registry';
+import { registerPublishEventsRoute } from './publish_events';
+
+const MAX_EVENTS_PER_REQUEST = 3;
+
+const context = {} as unknown as RequestHandlerContext;
+
+describe('POST /api/event_router/events', () => {
+  let handler: jest.Mock;
+
+  const setup = () => {
+    const eventTypes = new EventTypeRegistry();
+    eventTypes.register({
+      type: 'a.b',
+      payloadSchema: schema.object({ count: schema.number() }),
+    });
+
+    const listeners = new ListenerRegistry();
+    handler = jest.fn();
+    listeners.register({ id: 'one', filter: { types: ['a.b'] }, handler });
+
+    const router = httpServiceMock.createSetupContract().createRouter();
+
+    registerPublishEventsRoute({
+      router,
+      eventRouter: new EventRouter({
+        eventTypes,
+        dispatcher: new Dispatcher({
+          listeners,
+          logger: loggerMock.create(),
+          listenerTimeoutMs: 1000,
+        }),
+      }),
+      maxEventsPerRequest: MAX_EVENTS_PER_REQUEST,
+    });
+
+    const [routeDefinition, routeHandler] =
+      router.versioned.post.mock.results[0].value.addVersion.mock.calls[0];
+
+    return { routeDefinition, routeHandler };
+  };
+
+  const bodySchemaOf = (routeDefinition: { validate: unknown }): Type<unknown> =>
+    (routeDefinition.validate as { request: { body: Type<unknown> } }).request.body;
+
+  it('accepts the events and reports which listeners enqueued them', async () => {
+    const { routeHandler } = setup();
+    const request = httpServerMock.createKibanaRequest({
+      method: 'post',
+      body: {
+        events: [{ type: 'a.b', attributes: { repo: 'elastic/kibana' }, payload: { count: 1 } }],
+      },
+    });
+
+    const response = await routeHandler(context, request, kibanaResponseFactory);
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual({
+      results: [{ id: expect.any(String), type: 'a.b', enqueued: ['one'], failures: [] }],
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an unknown event type without delivering any of the batch', async () => {
+    const { routeHandler } = setup();
+    const request = httpServerMock.createKibanaRequest({
+      method: 'post',
+      body: { events: [{ type: 'a.b', payload: { count: 1 } }, { type: 'nope' }] },
+    });
+
+    const response = await routeHandler(context, request, kibanaResponseFactory);
+
+    expect(response.status).toBe(400);
+    expect(response.payload).toEqual({ message: 'Unknown event type "nope"' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('asks the producer to retry when a listener does not accept the event', async () => {
+    const { routeHandler } = setup();
+    handler.mockRejectedValue(new Error('task manager unavailable'));
+    const request = httpServerMock.createKibanaRequest({
+      method: 'post',
+      body: { events: [{ type: 'a.b', payload: { count: 1 } }] },
+    });
+
+    const response = await routeHandler(context, request, kibanaResponseFactory);
+
+    expect(response.status).toBe(500);
+    expect(response.payload).toEqual({
+      message:
+        '1 of 1 event(s) were not accepted by every listener. Retry the request; listeners that already accepted an event will see it again.',
+      attributes: {
+        results: [
+          {
+            id: expect.any(String),
+            type: 'a.b',
+            enqueued: [],
+            failures: [{ listenerId: 'one', message: 'task manager unavailable' }],
+          },
+        ],
+      },
+    });
+  });
+
+  it('caps how many events a single request may carry', () => {
+    const { routeDefinition } = setup();
+    const bodySchema = bodySchemaOf(routeDefinition);
+    const event = { type: 'a.b', payload: { count: 1 } };
+
+    expect(() =>
+      bodySchema.validate({ events: new Array(MAX_EVENTS_PER_REQUEST).fill(event) })
+    ).not.toThrow();
+    expect(() =>
+      bodySchema.validate({ events: new Array(MAX_EVENTS_PER_REQUEST + 1).fill(event) })
+    ).toThrow('[events]: array size is [4], but cannot be greater than [3]');
+    expect(() => bodySchema.validate({ events: [] })).toThrow(
+      '[events]: array size is [0], but cannot be smaller than [1]'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/event_router/server/routes/publish_events.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/routes/publish_events.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { IRouter } from '@kbn/core/server';
+import { ApiPrivileges } from '@kbn/core-security-server';
+import type { EventRouter } from '../event_router';
+import { InvalidEventError } from '../errors';
+import type { PublishResult } from '../types';
+
+export const PUBLISH_EVENTS_PATH = '/api/event_router/events';
+
+/**
+ * Granted to no role by default, so only a superuser can publish until an
+ * operator grants it explicitly.
+ */
+export const EVENT_ROUTER_FEATURE_ID = 'event_router';
+
+interface RegisterPublishEventsRouteDeps {
+  router: IRouter;
+  eventRouter: EventRouter;
+  maxEventsPerRequest: number;
+}
+
+export const registerPublishEventsRoute = ({
+  router,
+  eventRouter,
+  maxEventsPerRequest,
+}: RegisterPublishEventsRouteDeps): void => {
+  router.versioned
+    .post({
+      path: PUBLISH_EVENTS_PATH,
+      access: 'public',
+      summary: 'Publish events to the event router',
+      description:
+        'Accepts events from an external system and hands each one to every listener whose filter matches. Returns a non-2xx status if any listener did not accept an event, so the producer can retry.',
+      security: {
+        authz: {
+          requiredPrivileges: [ApiPrivileges.manage(EVENT_ROUTER_FEATURE_ID)],
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: schema.object({
+              events: schema.arrayOf(
+                schema.object({
+                  type: schema.string({ minLength: 1 }),
+                  attributes: schema.maybe(schema.recordOf(schema.string(), schema.string())),
+                  payload: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+                }),
+                { minSize: 1, maxSize: maxEventsPerRequest }
+              ),
+            }),
+          },
+        },
+      },
+      async (context, request, response) => {
+        let results: PublishResult[];
+
+        try {
+          results = await eventRouter.publishBatch(request.body.events, request);
+        } catch (error) {
+          if (error instanceof InvalidEventError) {
+            return response.badRequest({ body: { message: error.message } });
+          }
+          throw error;
+        }
+
+        const undelivered = results.filter(({ failures }) => failures.length > 0);
+
+        if (undelivered.length > 0) {
+          return response.customError({
+            statusCode: 500,
+            body: {
+              message: `${undelivered.length} of ${results.length} event(s) were not accepted by every listener. Retry the request; listeners that already accepted an event will see it again.`,
+              attributes: { results },
+            },
+          });
+        }
+
+        return response.ok({ body: { results } });
+      }
+    );
+};

--- a/x-pack/platform/plugins/shared/event_router/server/types.ts
+++ b/x-pack/platform/plugins/shared/event_router/server/types.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ObjectType } from '@kbn/config-schema';
+import type { KibanaRequest } from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+
+export interface EventTypeDefinition {
+  /** Dot-delimited identifier, e.g. `github.pull_request.opened`. */
+  type: string;
+  /** When provided, validates the event payload at publish time. */
+  payloadSchema?: ObjectType;
+}
+
+/** An event as submitted by a producer. */
+export interface PublishEventParams {
+  type: string;
+  /** Flat key/values used to route the event to listeners. */
+  attributes?: Record<string, string>;
+  payload?: unknown;
+}
+
+/** An event as delivered to a listener. */
+export interface RouterEvent {
+  id: string;
+  type: string;
+  attributes: Record<string, string>;
+  /**
+   * Validated against the event type's `payloadSchema` when one is registered,
+   * otherwise opaque. Listeners narrow this themselves.
+   */
+  payload: unknown;
+  /** ISO timestamp assigned when the event was accepted. */
+  receivedAt: string;
+  spaceId: string;
+}
+
+/**
+ * Declarative subscription filter, evaluated in memory on the node that
+ * accepted the event, so it must stay cheap and side-effect free.
+ */
+export interface ListenerFilter {
+  /** Matches when the event type is one of these. At least one is required. */
+  types: string[];
+  /**
+   * Every entry must match: a string requires equality, an array requires
+   * membership. An event missing the attribute never matches.
+   */
+  attributes?: Record<string, string | string[]>;
+}
+
+export interface ListenerContext {
+  /**
+   * The request that published the event. Pass it to `taskManager.schedule` so
+   * the enqueued work runs with the publisher's privileges.
+   */
+  request: KibanaRequest;
+}
+
+/**
+ * Handlers run inline on the ingest request, so they must only enqueue durable
+ * work (schedule a task, emit a workflow trigger) and return. Anything slower
+ * belongs in the work they enqueue, not here.
+ */
+export type ListenerHandler = (event: RouterEvent, context: ListenerContext) => Promise<void>;
+
+export interface ListenerDefinition {
+  id: string;
+  filter: ListenerFilter;
+  handler: ListenerHandler;
+}
+
+export interface ListenerFailure {
+  listenerId: string;
+  message: string;
+}
+
+export interface PublishResult {
+  id: string;
+  type: string;
+  /** Listeners that accepted the event and enqueued their work. */
+  enqueued: string[];
+  /**
+   * Listeners that did not accept the event. A non-empty list means the event
+   * was only partially delivered and the producer should retry.
+   */
+  failures: ListenerFailure[];
+}
+
+export interface EventRouterSetup {
+  registerEventType: (definition: EventTypeDefinition) => void;
+  registerListener: (definition: ListenerDefinition) => void;
+}
+
+export interface EventRouterStart {
+  /** Publishes an event through the same path the HTTP route uses. */
+  publish: (params: PublishEventParams, request: KibanaRequest) => Promise<PublishResult>;
+}
+
+export interface EventRouterSetupDeps {
+  taskManager?: TaskManagerSetupContract;
+}
+
+export interface EventRouterStartDeps {
+  taskManager?: TaskManagerStartContract;
+}

--- a/x-pack/platform/plugins/shared/event_router/tsconfig.json
+++ b/x-pack/platform/plugins/shared/event_router/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types"
+  },
+  "include": [
+    "server/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/core",
+    "@kbn/config-schema",
+    "@kbn/core-security-server",
+    "@kbn/logging-mocks",
+    "@kbn/task-manager-plugin"
+  ],
+  "exclude": [
+    "target/**/*"
+  ]
+}

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -205,6 +205,7 @@ export default function ({ getService }: FtrProviderContext) {
         'entity_store:v2:extract_entity_task:user',
         'entity_store:v2:history_snapshot_task',
         'entity_store:v2:status_report_task',
+        'event_router:example_work',
         'fleet:agent-status-change-task',
         'fleet:agentless-deployment-sync-task',
         'fleet:auto-install-content-packages-task',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7194,6 +7194,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/event-router-plugin@link:x-pack/platform/plugins/shared/event_router":
+  version "0.0.0"
+  uid ""
+
 "@kbn/event-stacktrace@link:x-pack/platform/packages/shared/kbn-event-stacktrace":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

Prototype `eventRouter` server plugin exploring a **different shape** from the ES-backed event bus in #281160. Instead of a shared log that consumers tail, external systems **POST events to Kibana** and the receiving node **fans each event out in memory** to the listeners whose filters match. Listeners only ever *enqueue* durable work — the router itself owns **no poller, no queue and no ledger**.

Plugin id: `eventRouter` · owner: `@elastic/response-ops` · server-only · `taskManager` optional. Not wired into a real consumer yet; this is for design validation.

The use case driving it: take one event from an external system and fan it out to several independent processors (one workflow, one for agent builder, …), where each processor cares about only a small slice of a high-volume/bursty stream, and where **exactly one node** must do each unit of work.

## How it works

**Ingest.** A producer POSTs a batch to `POST /api/event_router/events` (public, versioned `2023-10-31`). The entire batch is validated against the registered event types *before* any of it is delivered, so a rejected batch never leaves half its events delivered for a retry to duplicate.

**Matching.** Listeners register a declarative filter: required `types`, optional `attributes` (a string requires equality, an array requires membership). Candidates are indexed by event type, so an event nobody subscribes to costs a single `Map` lookup. This is the "push the filter down" part — each listener only sees its slice, never the firehose.

**Fan-out.** Matching listeners run concurrently, each isolated in its own `try`/`catch` and bounded by `listenerTimeout` (default `10s`). A listener that throws or hangs can neither block its peers nor hold the ingest request open.

**Durability belongs to the listener, via Task Manager.** A listener's contract is *enqueue and return*; it must never do the work inline. Single-node execution, retries, backoff and failover therefore stay Task Manager's existing guarantees, reached at the moment of ingest instead of by another poller asking Elasticsearch "is there anything for me?". That is the "one less poller" goal: nothing in the delivery path polls, and nothing is written to Elasticsearch unless a listener chooses to.

**Delivery semantics — producer retry.** The route returns 2xx only once *every* matched listener has accepted the event:

| Situation | Status | Why |
|---|---|---|
| every matched listener enqueued its work | `200` | fully delivered |
| unknown event type, or payload fails its schema | `400` | producer error; a retry cannot help, and nothing was delivered |
| a listener failed to enqueue | `500` | retryable; the body names each failed listener and why |

Consequences worth stating plainly:

- **Handlers must be idempotent.** A retry re-delivers to listeners that already succeeded. The example listener shows the mitigation: derive the task id from the event id so re-enqueueing is a no-op.
- **No ledger means no audit trail.** An event matching no listener is dropped by design. Deliberate here, and the obvious next step if we want to answer "what did we receive, and who got it?".
- **Fan-out is not atomic.** If the node dies part-way through, the producer's retry is the recovery path.

There is no `stop` lifecycle, because there is genuinely nothing to cancel.

## How to use it

**1. Depend on the plugin** (`kibana.jsonc`):

```jsonc
"requiredPlugins": ["eventRouter"]
```

**2. Register an event type and a listener in `setup`:**

```ts
import { schema } from '@kbn/config-schema';
import type { EventRouterSetup } from '@kbn/event-router-plugin/server';

public setup(core, { eventRouter }: { eventRouter: EventRouterSetup }) {
  eventRouter.registerEventType({
    type: 'github.pull_request.opened',
    payloadSchema: schema.object({ number: schema.number() }), // optional
  });

  eventRouter.registerListener({
    id: 'myWorkflowTrigger',
    filter: {
      types: ['github.pull_request.opened'],
      attributes: { repo: 'elastic/kibana' }, // only my slice
    },
    // Enqueue only. Never work inline; return fast.
    handler: async (event, { request }) => {
      await taskManager.schedule(
        {
          id: `my-plugin:handle:${event.id}`, // idempotent on retry
          taskType: 'my-plugin:handle',
          params: { eventId: event.id, payload: event.payload },
          state: {},
        },
        { request } // Task Manager stores an API key so the task runs as the publisher
      );
    },
  });
}
```

**3. Or publish in-process** from `start`, through the same path the route uses:

```ts
await eventRouter.publish({ type: 'github.pull_request.opened', attributes: { repo: 'elastic/kibana' }, payload: { number: 1 } }, request);
```

**Try it end to end.** Enable the bundled example listener, which registers an `example.event` type and enqueues a Task Manager task:

```yaml
# kibana.dev.yml
xpack.eventRouter.exampleListener.enabled: true
```

```bash
curl -u elastic:changeme -X POST 'http://localhost:5601/api/event_router/events' \
  -H 'kbn-xsrf: true' -H 'Content-Type: application/json' \
  -d '{"events":[{"type":"example.event","attributes":{"repo":"elastic/kibana"},"payload":{"message":"hello"}}]}'
```

The response reports which listeners enqueued each event, and shortly after the task logs `Processed routed event <id> of type "example.event" in space "default"` — the full path, on whichever node Task Manager claimed the task.

The route requires the `event_router` manage API privilege, which no role is granted by default, so publish as a superuser until it is wired into a feature.

## Configuration

| Setting | Default | Purpose |
|---|---|---|
| `xpack.eventRouter.maxEventsPerRequest` | `100` | cap on events in one publish request |
| `xpack.eventRouter.listenerTimeout` | `10s` | per-listener ceiling for enqueueing |
| `xpack.eventRouter.exampleListener.enabled` | `false` | register the demo event type and listener |

## Testing

35 Jest unit tests covering the filter matcher, both registries, per-listener isolation and the timeout path, batch-before-delivery validation, and the route's `200`/`400`/`500` contract. Type check and lint are clean. Not yet exercised against a live stack, and no FTR/integration coverage.

## Open questions for review

- **Is producer retry the right durability stance**, or should the router persist accepted events itself (at the cost of the write and poller this design avoids)?
- **Do we need an audit record** of received events and their fan-out, and if so, matched-only or everything?
- **Real adapters are deliberately absent.** A Workflows listener drops straight in following the Cases bridge (`workflowsExtensions.getClient(request).emitEvent(...)`), but it also needs a registered trigger definition, so it was left out rather than guessed at.

Made with [Cursor](https://cursor.com)