### PR TITLE
[map] Fix stuck loading state after state reset

### DIFF
--- a/x-pack/platform/plugins/shared/maps/jest_setup.ts
+++ b/x-pack/platform/plugins/shared/maps/jest_setup.ts
@@ -6,3 +6,4 @@
  */
 
 jest.mock('@kbn/mapbox-gl', () => ({}));
+jest.mock('@mapbox/mapbox-gl-draw/src/lib/theme', () => ({}));

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -10,6 +10,7 @@ import type { ThunkDispatch } from 'redux-thunk-v2';
 import type { Query } from '@kbn/es-query';
 import type { Adapters } from '@kbn/inspector-plugin/common/adapters';
 import type { Writable } from '@kbn/utility-types';
+import { firstValueFrom } from 'rxjs';
 import type { MapStoreState } from '../reducers/store';
 import {
   createLayerInstance,
@@ -23,7 +24,11 @@ import {
   getSelectedLayerId,
 } from '../selectors/map_selectors';
 import { FLYOUT_STATE } from '../reducers/ui';
-import { cancelRequest, getInspectorAdapters } from '../reducers/non_serializable_instances';
+import {
+  cancelRequest,
+  getInspectorAdapters,
+  getMapSync$,
+} from '../reducers/non_serializable_instances';
 import { hideTOCDetails, setDrawMode, showTOCDetails, updateFlyout } from './ui_actions';
 import {
   ADD_LAYER,
@@ -70,7 +75,6 @@ import type { IVectorSource } from '../classes/sources/vector_source';
 import { getDrawMode, getOpenTOCDetails } from '../selectors/ui_selectors';
 import { isLayerGroup, LayerGroup } from '../classes/layers/layer_group';
 import { isSpatialJoin } from '../classes/joins/is_spatial_join';
-import { waitForMapSync } from '../connected_components/mb_map/mb_map';
 
 export function trackCurrentLayerState(layerId: string) {
   return {
@@ -119,10 +123,16 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
         type: CLEAR_WAITING_FOR_MAP_READY_LAYER_LIST,
       });
     } else {
-      getLayerListRaw(getState()).forEach(({ id }) => {
-        dispatch(removeLayerFromLayerList(id));
-      });
-      await waitForMapSync();
+      const layerDescriptors = getLayerListRaw(getState());
+      if (layerDescriptors.length) {
+        layerDescriptors.forEach(({ id }) => {
+          dispatch(removeLayerFromLayerList(id));
+        });
+        const mapSync$ = getMapSync$(getState());
+        // Wait for layer removal redux changes
+        // to get flushed to maplibre instance
+        await firstValueFrom(mapSync$);
+      }
     }
 
     newLayerList.forEach((layerDescriptor) => {

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -70,6 +70,7 @@ import type { IVectorSource } from '../classes/sources/vector_source';
 import { getDrawMode, getOpenTOCDetails } from '../selectors/ui_selectors';
 import { isLayerGroup, LayerGroup } from '../classes/layers/layer_group';
 import { isSpatialJoin } from '../classes/joins/is_spatial_join';
+import { waitForMapSync } from '../connected_components/mb_map/mb_map';
 
 export function trackCurrentLayerState(layerId: string) {
   return {
@@ -108,7 +109,7 @@ export function removeTrackedLayerStateForSelectedLayer() {
 }
 
 export function replaceLayerList(newLayerList: LayerDescriptor[]) {
-  return (
+  return async (
     dispatch: ThunkDispatch<MapStoreState, void, AnyAction>,
     getState: () => MapStoreState
   ) => {
@@ -122,6 +123,8 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
         dispatch(removeLayerFromLayerList(id));
       });
     }
+
+    await waitForMapSync();
 
     newLayerList.forEach((layerDescriptor) => {
       dispatch(addLayer(layerDescriptor));

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -122,9 +122,8 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
       getLayerListRaw(getState()).forEach(({ id }) => {
         dispatch(removeLayerFromLayerList(id));
       });
+      await waitForMapSync();
     }
-
-    await waitForMapSync();
 
     newLayerList.forEach((layerDescriptor) => {
       dispatch(addLayer(layerDescriptor));

--- a/x-pack/platform/plugins/shared/maps/public/actions/map_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/map_actions.ts
@@ -18,7 +18,7 @@ import type { Geometry, Position } from 'geojson';
 import { asyncForEach, asyncMap } from '@kbn/std';
 import { DRAW_MODE, DRAW_SHAPE, LAYER_STYLE_TYPE } from '../../common/constants';
 import type { MapExtentState, MapViewContext } from '../reducers/map/types';
-import { getInspectorAdapters } from '../reducers/non_serializable_instances';
+import { getInspectorAdapters, getMapSync$ } from '../reducers/non_serializable_instances';
 import type { MapStoreState } from '../reducers/store';
 import type { IVectorStyle } from '../classes/styles/vector/vector_style';
 import {
@@ -520,5 +520,15 @@ export function deleteFeatureFromIndex(featureId: string) {
       });
     }
     dispatch(updateEditShape(DRAW_SHAPE.DELETE));
+  };
+}
+
+export function onMapSync() {
+  return (
+    dispatch: ThunkDispatch<MapStoreState, void, AnyAction>,
+    getState: () => MapStoreState
+  ) => {
+    const mapSync$ = getMapSync$(getState());
+    mapSync$.next();
   };
 }

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/index.ts
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/index.ts
@@ -15,6 +15,7 @@ import {
   mapDestroyed,
   mapExtentChanged,
   mapReady,
+  onMapSync,
   setMapInitError,
   setMouseCoordinates,
 } from '../../actions';
@@ -55,6 +56,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<MapStoreState, void, AnyActi
   return {
     extentChanged: (mapExtentState: MapExtentState) => {
       dispatch(mapExtentChanged(mapExtentState));
+    },
+    onMapSync: () => {
+      dispatch(onMapSync());
     },
     onMapReady: (mapExtentState: MapExtentState) => {
       dispatch(clearGoto());

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/mb_map.tsx
@@ -79,25 +79,12 @@ export interface Props {
   featureModeActive: boolean;
   filterModeActive: boolean;
   onMapMove?: (lat: number, lon: number, zoom: number) => void;
+  onMapSync: () => void;
 }
 
 interface State {
   mbMap: MapboxMap | undefined;
 }
-
-const MAP_SYNC_DEBOUNCE = 256;
-
-/**
- * Waits long enough for the map's debounced sync cycle to complete.
- *
- * Redux state changes (layers, settings, etc.) are debounced by `MAP_SYNC_DEBOUNCE` ms
- * before being flushed to Maplibre instance. This helper waits 1.5× that interval,
- * giving the debounce time to fire and redux changes to flow to Maplibre instance.
- *
- * @returns A promise that resolves after the sync window elapses and redux state changes have been flushed to Maplibre instance.
- */
-export const waitForMapSync = () =>
-  new Promise((resolve) => setTimeout(resolve, MAP_SYNC_DEBOUNCE * 1.5));
 
 export class MbMap extends Component<Props, State> {
   private _isMounted: boolean = false;
@@ -144,8 +131,9 @@ export class MbMap extends Component<Props, State> {
       }
       this.props.spatialFiltersLayer.syncLayerWithMB(this.state.mbMap);
       this._syncSettings();
+      this.props.onMapSync();
     }
-  }, MAP_SYNC_DEBOUNCE);
+  }, 256);
 
   _getMapExtentState(): MapExtentState {
     const zoom = this.state.mbMap!.getZoom();

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/mb_map.tsx
@@ -131,8 +131,8 @@ export class MbMap extends Component<Props, State> {
       }
       this.props.spatialFiltersLayer.syncLayerWithMB(this.state.mbMap);
       this._syncSettings();
-      this.props.onMapSync();
     }
+    this.props.onMapSync();
   }, 256);
 
   _getMapExtentState(): MapExtentState {

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/mb_map.tsx
@@ -85,6 +85,19 @@ interface State {
   mbMap: MapboxMap | undefined;
 }
 
+const MAP_SYNC_DEBOUNCE = 256;
+
+/**
+ * Waits long enough for the map's debounced sync cycle to complete.
+ *
+ * Redux state changes (layers, settings, etc.) are debounced by `MAP_SYNC_DEBOUNCE` ms
+ * before being flushed to Maplibre instance. This helper waits 1.5× that interval,
+ * giving the debounce time to fire and redux changes to flow to Maplibre instance.
+ *
+ * @returns A promise that resolves after the sync window elapses and redux state changes have been flushed to Maplibre instance.
+ */
+export const waitForMapSync = () => new Promise((resolve) => setTimeout(resolve, MAP_SYNC_DEBOUNCE * 1.5));
+
 export class MbMap extends Component<Props, State> {
   private _isMounted: boolean = false;
   private _containerRef: HTMLDivElement | null = null;
@@ -131,7 +144,7 @@ export class MbMap extends Component<Props, State> {
       this.props.spatialFiltersLayer.syncLayerWithMB(this.state.mbMap);
       this._syncSettings();
     }
-  }, 256);
+  }, MAP_SYNC_DEBOUNCE);
 
   _getMapExtentState(): MapExtentState {
     const zoom = this.state.mbMap!.getZoom();

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/mb_map.tsx
@@ -96,7 +96,8 @@ const MAP_SYNC_DEBOUNCE = 256;
  *
  * @returns A promise that resolves after the sync window elapses and redux state changes have been flushed to Maplibre instance.
  */
-export const waitForMapSync = () => new Promise((resolve) => setTimeout(resolve, MAP_SYNC_DEBOUNCE * 1.5));
+export const waitForMapSync = () =>
+  new Promise((resolve) => setTimeout(resolve, MAP_SYNC_DEBOUNCE * 1.5));
 
 export class MbMap extends Component<Props, State> {
   private _isMounted: boolean = false;

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/initialize_data_views.test.ts
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/initialize_data_views.test.ts
@@ -54,9 +54,16 @@ describe('dataViews$', () => {
     onEmitMock.mockReset();
   });
 
-  test('Should emit when data view added', async () => {
+  test('Should emit when data view added', (done) => {
     const dataViewApi = initializeDataViews(createMapStore());
-    const subscription = dataViewApi.dataViews$.pipe(skip(1)).subscribe(onEmitMock);
+    dataViewApi.dataViews$.pipe(skip(1)).subscribe((dataViews) => {
+      expect(dataViews).toEqual([
+        {
+          id: '1234',
+        },
+      ]);
+      done();
+    });
 
     dataViewApi.setLayerList([
       createLayerDescriptor({
@@ -65,39 +72,31 @@ describe('dataViews$', () => {
         geoFieldType: ES_GEO_FIELD_TYPE.GEO_POINT,
       }),
     ]);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(onEmitMock.mock.calls).toHaveLength(1);
-    expect(onEmitMock.mock.calls[0][0]).toEqual([
-      {
-        id: '1234',
-      },
-    ]);
-
-    subscription.unsubscribe();
   });
 
-  test('Should emit when data view removed', async () => {
+  test('Should emit when data view removed', (done) => {
     const dataViewApi = initializeDataViews(createMapStore());
-    dataViewApi.setLayerList([
-      createLayerDescriptor({
-        indexPatternId: '1234',
-        geoFieldName: 'location',
-        geoFieldType: ES_GEO_FIELD_TYPE.GEO_POINT,
-      }),
-    ]);
-    const subscription = dataViewApi.dataViews$.pipe(skip(1)).subscribe(onEmitMock);
+    dataViewApi
+      .setLayerList([
+        createLayerDescriptor({
+          indexPatternId: '1234',
+          geoFieldName: 'location',
+          geoFieldType: ES_GEO_FIELD_TYPE.GEO_POINT,
+        }),
+      ])
+      .then(() => {
+        dataViewApi.dataViews$.pipe(skip(1)).subscribe((dataViews) => {
+          expect(dataViews).toEqual([]);
+          done();
+        });
 
-    dataViewApi.setLayerList([]);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(onEmitMock.mock.calls).toHaveLength(1);
-    expect(onEmitMock.mock.calls[0][0]).toEqual([]);
-
-    subscription.unsubscribe();
+        dataViewApi.setLayerList([]);
+      });
   });
 
-  test('Should emit not emit when data view ids do not change', async () => {
+  test('Should not emit when data view ids do not change', async () => {
     const dataViewApi = initializeDataViews(createMapStore());
-    dataViewApi.setLayerList([
+    await dataViewApi.setLayerList([
       createLayerDescriptor({
         indexPatternId: '1234',
         geoFieldName: 'location',
@@ -109,11 +108,10 @@ describe('dataViews$', () => {
         geoFieldType: ES_GEO_FIELD_TYPE.GEO_POINT,
       }),
     ]);
-    await new Promise((resolve) => setTimeout(resolve, 0));
 
     const subscription = dataViewApi.dataViews$.pipe(skip(1)).subscribe(onEmitMock);
 
-    dataViewApi.setLayerList([
+    await dataViewApi.setLayerList([
       createLayerDescriptor({
         indexPatternId: '4567',
         geoFieldName: 'location',
@@ -125,7 +123,6 @@ describe('dataViews$', () => {
         geoFieldType: ES_GEO_FIELD_TYPE.GEO_POINT,
       }),
     ]);
-    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onEmitMock).not.toHaveBeenCalled();
 
     subscription.unsubscribe();

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/initialize_data_views.ts
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/initialize_data_views.ts
@@ -43,8 +43,8 @@ export function initializeDataViews(store: MapStore) {
 
   return {
     dataViews$,
-    setLayerList(layerList: LayerDescriptor[]) {
-      store.dispatch<any>(replaceLayerList(layerList));
+    setLayerList: async (layerList: LayerDescriptor[]) => {
+      await store.dispatch<any>(replaceLayerList(layerList));
       updateDataViews();
     },
     updateLayerById: (layerDescriptor: LayerDescriptor) => {

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/types.ts
@@ -42,7 +42,7 @@ export type MapApi = DefaultEmbeddableApi<MapEmbeddableState> &
     getLayerList: () => ILayer[];
     reload: () => void;
     setEventHandlers: (eventHandlers: EventHandlers) => void;
-    setLayerList: (layerList: LayerDescriptor[]) => void;
+    setLayerList: (layerList: LayerDescriptor[]) => Promise<void>;
     updateLayerById: (layerDescriptor: LayerDescriptor) => void;
     onRenderComplete$: Observable<void>;
   };

--- a/x-pack/platform/plugins/shared/maps/public/reducers/non_serializable_instances.d.ts
+++ b/x-pack/platform/plugins/shared/maps/public/reducers/non_serializable_instances.d.ts
@@ -12,6 +12,10 @@ import type { AnyAction } from 'redux-v4';
 import type { MapStoreState } from './store';
 
 export type NonSerializableState = {
+  /**
+   * Emits when Redux state changes are flushed to Maplibre instance.
+   */
+  mapSync$: Subject<void>;
   inspectorAdapters: Adapters;
   cancelRequestCallbacks: Map<symbol, () => {}>; // key is request token, value is cancel callback
   eventHandlers: Partial<EventHandlers>;
@@ -77,6 +81,8 @@ export function unregisterCancelCallback(requestToken: symbol): AnyAction;
 export function getOnMapMove(
   state: MapStoreState
 ): ((lat: number, lon: number, zoom: number) => void) | undefined;
+
+export function getMapSync$(state: MapStoreState): Observable<void>;
 
 export function setOnMapMove(
   onMapMove: (lat: number, lon: number, zoom: number) => void

--- a/x-pack/platform/plugins/shared/maps/public/reducers/non_serializable_instances.js
+++ b/x-pack/platform/plugins/shared/maps/public/reducers/non_serializable_instances.js
@@ -6,6 +6,7 @@
  */
 
 import { RequestAdapter } from '@kbn/inspector-plugin/common/adapters/request';
+import { Subject } from 'rxjs';
 import { MapAdapter, VectorTileAdapter } from '../inspector';
 import { getShowMapsInspectorAdapter } from '../kibana_services';
 
@@ -30,6 +31,7 @@ function createInspectorAdapters() {
 export function nonSerializableInstances(state, action = {}) {
   if (!state) {
     return {
+      mapSync$: new Subject(),
       inspectorAdapters: createInspectorAdapters(),
       cancelRequestCallbacks: new Map(), // key is request token, value is cancel callback
       eventHandlers: {},
@@ -90,6 +92,10 @@ export function getChartsPaletteServiceGetColor({ nonSerializableInstances }) {
 
 export function getOnMapMove({ nonSerializableInstances }) {
   return nonSerializableInstances.onMapMove;
+}
+
+export function getMapSync$({ nonSerializableInstances }) {
+  return nonSerializableInstances.mapSync$;
 }
 
 // Actions

--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/saved_map/saved_map.ts
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/saved_map/saved_map.ts
@@ -232,7 +232,7 @@ export class SavedMap {
         layerList.push(...this._defaultLayers);
       }
     }
-    this._store.dispatch<any>(replaceLayerList(layerList));
+    await this._store.dispatch<any>(replaceLayerList(layerList));
     if (this._mapEmbeddableState?.hiddenLayers !== undefined) {
       this._store.dispatch<any>(setHiddenLayers(this._mapEmbeddableState.hiddenLayers));
     }


### PR DESCRIPTION
Replaces https://github.com/elastic/kibana/pull/280258

Resolves issue of stuck loading state after reset by allowing map libre instance to clean-up old layers before adding new layers. This allows map libre to re-initialize layers and sources upon refresh. For the EMS tile layer, sourcedataloading events are now fired when layer is re-added to map so layer loading status can be properly tracked.

### Test instructions
* Install sample web logs
* Open sample web logs dashboard
* Change time range to "last 24 hours"
* Click saved secondary button and select "reset"
* Verify map loading indicator goes away after map loads