### PR TITLE
[Cases] Extend assignee fields in Cases saved object

### DIFF
--- a/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/cases/10.10.0.json
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/cases/10.10.0.json
@@ -1,0 +1,92 @@
+{
+  "10.9.0": [
+    {
+      "assignees": [
+        {
+          "uid": "user-profile-1"
+        }
+      ],
+      "category": null,
+      "closed_at": null,
+      "closed_by": null,
+      "created_at": "2026-02-18T00:00:00.000Z",
+      "created_by": {
+        "email": "test@elastic.co",
+        "full_name": "Elastic",
+        "username": "elastic",
+        "profile_uid": null
+      },
+      "connector": {
+        "name": "none",
+        "type": ".none",
+        "fields": []
+      },
+      "customFields": [],
+      "description": "Fixture case document for model version checks",
+      "duration": null,
+      "external_service": null,
+      "owner": "securitySolution",
+      "severity": 10,
+      "status": 0,
+      "tags": [
+        "fixture"
+      ],
+      "title": "Cases SO fixture",
+      "total_alerts": 0,
+      "total_comments": 0,
+      "total_events": 0,
+      "total_observables": 0,
+      "updated_at": null,
+      "updated_by": null,
+      "observables": [],
+      "settings": {
+        "extractObservables": false
+      }
+    }
+  ],
+  "10.10.0": [
+    {
+      "assignees": [
+        {
+          "uid": "user-profile-1"
+        }
+      ],
+      "category": null,
+      "closed_at": null,
+      "closed_by": null,
+      "created_at": "2026-02-18T00:00:00.000Z",
+      "created_by": {
+        "email": "test@elastic.co",
+        "full_name": "Elastic",
+        "username": "elastic",
+        "profile_uid": null
+      },
+      "connector": {
+        "name": "none",
+        "type": ".none",
+        "fields": []
+      },
+      "customFields": [],
+      "description": "Fixture case document for model version checks",
+      "duration": null,
+      "external_service": null,
+      "owner": "securitySolution",
+      "severity": 10,
+      "status": 0,
+      "tags": [
+        "fixture"
+      ],
+      "title": "Cases SO fixture",
+      "total_alerts": 0,
+      "total_comments": 0,
+      "total_events": 0,
+      "total_observables": 0,
+      "updated_at": null,
+      "updated_by": null,
+      "observables": [],
+      "settings": {
+        "extractObservables": false
+      }
+    }
+  ]
+}

--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -197,6 +197,7 @@ export const MAX_BULK_CREATE_ATTACHMENTS = 100 as const;
 export const MAX_USER_ACTIONS_PER_CASE = 10000 as const;
 export const MAX_PERSISTABLE_STATE_AND_EXTERNAL_REFERENCES = 100 as const;
 export const MAX_CUSTOM_FIELDS_PER_CASE = 10 as const;
+export const MAX_CONNECTOR_FIELDS_PER_CASE = 100 as const;
 export const MAX_CUSTOM_FIELD_KEY_LENGTH = 36 as const; // uuidv4 length
 export const MAX_CUSTOM_FIELD_LABEL_LENGTH = 50 as const;
 export const MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH = 160 as const;

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/cases.ts
@@ -27,6 +27,7 @@ import {
   modelVersion7,
   modelVersion8,
   modelVersion9,
+  modelVersion10,
 } from './model_versions';
 import { handleImport } from '../import_export/import';
 import type { ConfigType } from '../../config';
@@ -48,6 +49,18 @@ export const createCaseSavedObjectType = (
         properties: {
           uid: {
             type: 'keyword',
+          },
+          username: {
+            type: 'keyword',
+            ignore_above: 1024,
+          },
+          full_name: {
+            type: 'keyword',
+            ignore_above: 1024,
+          },
+          email: {
+            type: 'keyword',
+            ignore_above: 1024,
           },
         },
       },
@@ -301,6 +314,7 @@ export const createCaseSavedObjectType = (
     7: modelVersion7,
     8: modelVersion8,
     9: modelVersion9,
+    10: modelVersion10,
   },
   management: {
     importableAndExportable: true,

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/create_schema_overrides.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/create_schema_overrides.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { MAX_CONNECTOR_FIELDS_PER_CASE } from '../../../../common/constants';
 
 /**
  * Create-schema relaxations shared across model versions >= 9. Each model
@@ -21,7 +22,8 @@ export const createSchemaOverrides = {
         schema.object({
           key: schema.string(),
           value: schema.nullable(schema.any()),
-        })
+        }),
+        { maxSize: MAX_CONNECTOR_FIELDS_PER_CASE }
       )
     ),
   }),

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/create_schema_overrides.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/create_schema_overrides.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+/**
+ * Create-schema relaxations shared across model versions >= 9. Each model
+ * version's `create` schema is standalone, so these must be re-applied on every
+ * new version to avoid regressing what earlier versions already accept.
+ */
+export const createSchemaOverrides = {
+  connector: schema.object({
+    name: schema.string(),
+    type: schema.string(),
+    fields: schema.nullable(
+      schema.arrayOf(
+        schema.object({
+          key: schema.string(),
+          value: schema.nullable(schema.any()),
+        })
+      )
+    ),
+  }),
+  // NOTE: this aligns the SO schema with persisted severity here
+  // x-pack/platform/plugins/shared/cases/server/common/types/case.ts
+  severity: schema.oneOf([
+    schema.literal(0),
+    schema.literal(10),
+    schema.literal(20),
+    schema.literal(30),
+    // NOTE: this is required for legacy reasons
+    schema.literal(40),
+  ]),
+};

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/index.ts
@@ -14,3 +14,4 @@ export { modelVersion6 } from './model_version_6';
 export { modelVersion7 } from './model_version_7';
 export { modelVersion8 } from './model_version_8';
 export { modelVersion9 } from './model_version_9';
+export { modelVersion10 } from './model_version_10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/model_version_10.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/model_version_10.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
+import { casesSchemaV10 } from '../schemas';
+import { createSchemaOverrides } from './create_schema_overrides';
+
+/**
+ * Adds the `username`, `full_name` and `email` mappings to `assignees`,
+ * mirroring the `User` shape stored on `created_by`/`closed_by`
+ */
+export const modelVersion10: SavedObjectsModelVersion = {
+  changes: [
+    {
+      type: 'mappings_addition',
+      addedMappings: {
+        assignees: {
+          properties: {
+            username: {
+              type: 'keyword',
+              ignore_above: 1024,
+            },
+            full_name: {
+              type: 'keyword',
+              ignore_above: 1024,
+            },
+            email: {
+              type: 'keyword',
+              ignore_above: 1024,
+            },
+          },
+        },
+      },
+    },
+  ],
+  schemas: {
+    forwardCompatibility: casesSchemaV10.extends({}, { unknowns: 'ignore' }),
+    create: casesSchemaV10.extends(createSchemaOverrides, { unknowns: 'ignore' }),
+  },
+};

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/model_version_9.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/model_version_9.ts
@@ -6,9 +6,9 @@
  */
 
 import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
-import { schema } from '@kbn/config-schema';
 import { CASE_EXTENDED_FIELDS } from '../../../../common/constants';
 import { casesSchemaV9 } from '../schemas';
+import { createSchemaOverrides } from './create_schema_overrides';
 
 export const modelVersion9: SavedObjectsModelVersion = {
   changes: [
@@ -34,32 +34,6 @@ export const modelVersion9: SavedObjectsModelVersion = {
   ],
   schemas: {
     forwardCompatibility: casesSchemaV9.extends({}, { unknowns: 'ignore' }),
-    create: casesSchemaV9.extends(
-      {
-        connector: schema.object({
-          name: schema.string(),
-          type: schema.string(),
-          fields: schema.nullable(
-            schema.arrayOf(
-              schema.object({
-                key: schema.string(),
-                value: schema.nullable(schema.any()),
-              })
-            )
-          ),
-        }),
-        // NOTE: this aligns the SO schema with persisted severity here
-        // x-pack/platform/plugins/shared/cases/server/common/types/case.ts
-        severity: schema.oneOf([
-          schema.literal(0),
-          schema.literal(10),
-          schema.literal(20),
-          schema.literal(30),
-          // NOTE: this is required for legacy reasons
-          schema.literal(40),
-        ]),
-      },
-      { unknowns: 'ignore' }
-    ),
+    create: casesSchemaV9.extends(createSchemaOverrides, { unknowns: 'ignore' }),
   },
 };

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/index.ts
@@ -16,3 +16,4 @@ export { casesSchema as casesSchemaV6 } from './v6';
 export { casesSchema as casesSchemaV7 } from './v7';
 export { casesSchema as casesSchemaV8 } from './v8';
 export { casesSchema as casesSchemaV9 } from './v9';
+export { casesSchema as casesSchemaV10 } from './v10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/latest.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/latest.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export * from './v9';
+export * from './v10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/v10.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/v10.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { casesSchema as casesSchemaV9 } from './v9';
+
+/**
+ * Assignees gain the optional `username`, `full_name` and `email` identity
+ * fields alongside `uid`, matching the new mapping
+ */
+const AssigneeSchema = schema.object({
+  uid: schema.string(),
+  username: schema.maybe(schema.nullable(schema.string())),
+  full_name: schema.maybe(schema.nullable(schema.string())),
+  email: schema.maybe(schema.nullable(schema.string())),
+});
+
+export const casesSchema = casesSchemaV9.extends({
+  assignees: schema.arrayOf(AssigneeSchema),
+});

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/v10.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/v10.ts
@@ -21,4 +21,10 @@ const AssigneeSchema = schema.object({
 
 export const casesSchema = casesSchemaV9.extends({
   assignees: schema.arrayOf(AssigneeSchema),
+  // `settings.syncAlerts` is mapped since v1, but the v5 override dropped it from
+  // the schema; re-declare it so the latest MV schema covers the mapping.
+  settings: schema.object({
+    syncAlerts: schema.maybe(schema.boolean()),
+    extractObservables: schema.maybe(schema.boolean()),
+  }),
 });

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/versioning.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/versioning.test.ts
@@ -197,4 +197,20 @@ describe('caseSavedObjectType model version transformations', () => {
       expect(() => createSchema!.validate(attributes)).not.toThrow();
     });
   });
+
+  describe('Model version 9 to 10', () => {
+    it('does not modify existing assignees when migrating from v9 to v10', () => {
+      const caseObj = createCaseSavedObjectResponse({
+        overrides: { assignees: [{ uid: '123' }] },
+      });
+
+      const migrated = migrator.migrate({
+        document: caseObj,
+        fromVersion: 9,
+        toVersion: 10,
+      });
+
+      expect(migrated.attributes).toEqual(expect.objectContaining({ assignees: [{ uid: '123' }] }));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds model version 10 to cases saved object, which extends assignee field to include `username`, `email` and `full_name`. Only schema changes, no data is populated for these fields.


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->