### PR TITLE
[SLO] Fix welcome page displayed for remote-only spaces

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_definitions_with_remote.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_definitions_with_remote.ts
@@ -37,21 +37,17 @@ export function useFetchSloDefinitionsWithRemote({
   const { isLoading, isError, isSuccess, data, refetch } = useQuery({
     queryKey: sloKeys.searchDefinitions({ search: searchTerm, size, searchAfter, remoteName }),
     queryFn: async ({ signal }) => {
-      try {
-        return await sloClient.fetch('GET /internal/observability/slos/_search_definitions', {
-          params: {
-            query: {
-              ...(searchTerm !== undefined && { search: searchTerm }),
-              ...(size !== undefined && { size }),
-              ...(searchAfter !== undefined && { searchAfter }),
-              ...(remoteName !== undefined && { remoteName }),
-            },
+      return await sloClient.fetch('GET /internal/observability/slos/_search_definitions', {
+        params: {
+          query: {
+            ...(searchTerm !== undefined && { search: searchTerm }),
+            ...(size !== undefined && { size }),
+            ...(searchAfter !== undefined && { searchAfter }),
+            ...(remoteName !== undefined && { remoteName }),
           },
-          signal,
-        });
-      } catch (error) {
-        throw new Error(`Something went wrong. Error: ${error}`);
-      }
+        },
+        signal,
+      });
     },
     retry: false,
     refetchOnWindowFocus: false,

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.test.ts
@@ -38,10 +38,11 @@ describe('useHasSlos', () => {
       isError: false,
     });
 
-    const { hasSlos, isLoading } = useHasSlos();
+    const { hasSlos, isLoading, isError } = useHasSlos();
 
     expect(hasSlos).toBe(false);
     expect(isLoading).toBe(false);
+    expect(isError).toBe(false);
   });
 
   it('returns hasSlos: true when at least one local SLO exists', () => {
@@ -77,6 +78,7 @@ describe('useHasSlos', () => {
     const { hasSlos } = useHasSlos();
 
     expect(hasSlos).toBe(true);
+    expect(useFetchSloDefinitionsWithRemoteMock).toHaveBeenCalledWith({ size: 1 });
   });
 
   it('returns isError: true and hasSlos: false on request failure', () => {

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useFetchSloDefinitionsWithRemote } from './use_fetch_slo_definitions_with_remote';
+import { useHasSlos } from './use_has_slos';
+
+jest.mock('./use_fetch_slo_definitions_with_remote');
+
+const useFetchSloDefinitionsWithRemoteMock = useFetchSloDefinitionsWithRemote as jest.Mock;
+
+describe('useHasSlos', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns hasSlos: false and isLoading: true while the request is in flight', () => {
+    useFetchSloDefinitionsWithRemoteMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    const { hasSlos, isLoading, isError } = useHasSlos();
+
+    expect(hasSlos).toBe(false);
+    expect(isLoading).toBe(true);
+    expect(isError).toBe(false);
+  });
+
+  it('returns hasSlos: false when the results array is empty (no local or remote SLOs)', () => {
+    useFetchSloDefinitionsWithRemoteMock.mockReturnValue({
+      data: { results: [] },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { hasSlos, isLoading } = useHasSlos();
+
+    expect(hasSlos).toBe(false);
+    expect(isLoading).toBe(false);
+  });
+
+  it('returns hasSlos: true when at least one local SLO exists', () => {
+    useFetchSloDefinitionsWithRemoteMock.mockReturnValue({
+      data: {
+        results: [{ id: 'slo-1', name: 'My SLO', groupBy: [] }],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { hasSlos } = useHasSlos();
+
+    expect(hasSlos).toBe(true);
+  });
+
+  it('returns hasSlos: true when at least one remote SLO exists', () => {
+    useFetchSloDefinitionsWithRemoteMock.mockReturnValue({
+      data: {
+        results: [
+          {
+            id: 'remote-slo-1',
+            name: 'Remote SLO',
+            groupBy: [],
+            remote: { remoteName: 'remote-cluster', kibanaUrl: 'https://remote.kibana' },
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { hasSlos } = useHasSlos();
+
+    expect(hasSlos).toBe(true);
+  });
+
+  it('returns isError: true and hasSlos: false on request failure', () => {
+    useFetchSloDefinitionsWithRemoteMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    const { hasSlos, isError } = useHasSlos();
+
+    expect(hasSlos).toBe(false);
+    expect(isError).toBe(true);
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.ts
@@ -13,13 +13,6 @@ export interface UseHasSlosResponse {
   isError: boolean;
 }
 
-/**
- * Returns whether any SLO exists in the current space, including SLOs on
- * remote clusters surfaced via cross-cluster search.
- *
- * Uses the remote-aware definitions search endpoint so that spaces containing
- * only remote SLOs are not incorrectly treated as empty.
- */
 export const useHasSlos = (): UseHasSlosResponse => {
   const { data, isLoading, isError } = useFetchSloDefinitionsWithRemote({ size: 1 });
   const hasSlos = !!data?.results?.length;

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useFetchSloDefinitionsWithRemote } from './use_fetch_slo_definitions_with_remote';
+
+export interface UseHasSlosResponse {
+  hasSlos: boolean;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * Returns whether any SLO exists in the current space, including SLOs on
+ * remote clusters surfaced via cross-cluster search.
+ *
+ * Uses the remote-aware definitions search endpoint so that spaces containing
+ * only remote SLOs are not incorrectly treated as empty.
+ */
+export const useHasSlos = (): UseHasSlosResponse => {
+  const { data, isLoading, isError } = useFetchSloDefinitionsWithRemote({ size: 1 });
+  const hasSlos = !!data?.results?.length;
+  return { hasSlos, isLoading, isError };
+};

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/slos.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/slos.test.tsx
@@ -31,6 +31,7 @@ import { useFetchHistoricalSummary } from '../../hooks/use_fetch_historical_summ
 import { useFetchRulesForSlo } from '../../hooks/use_fetch_rules_for_slo';
 import { useFetchSloDefinitions } from '../../hooks/use_fetch_slo_definitions';
 import { useFetchSloList } from '../../hooks/use_fetch_slo_list';
+import { useHasSlos } from '../../hooks/use_has_slos';
 import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
 import { useKibana } from '../../hooks/use_kibana';
 import { useLicense } from '../../hooks/use_license';
@@ -59,6 +60,7 @@ jest.mock('../../hooks/use_composite_slo_enabled', () => ({
 jest.mock('../../hooks/use_license');
 jest.mock('../../hooks/use_fetch_slo_list');
 jest.mock('../../hooks/use_fetch_slo_definitions');
+jest.mock('../../hooks/use_has_slos');
 jest.mock('../../hooks/use_create_slo');
 jest.mock('../slo_settings/hooks/use_get_settings');
 jest.mock('../../hooks/use_delete_slo');
@@ -81,6 +83,7 @@ const useKibanaMock = useKibana as jest.Mock;
 const useLicenseMock = useLicense as jest.Mock;
 const useFetchSloListMock = useFetchSloList as jest.Mock;
 const useFetchSloDefinitionsMock = useFetchSloDefinitions as jest.Mock;
+const useHasSlosMock = useHasSlos as jest.Mock;
 const useCreateSloMock = useCreateSlo as jest.Mock;
 const useDeleteSloMock = useDeleteSlo as jest.Mock;
 const useDeleteSloInstanceMock = useDeleteSloInstance as jest.Mock;
@@ -233,7 +236,7 @@ describe('SLOs Page', () => {
         isLoading: false,
         data: emptySloDefinitionList,
       });
-      useFetchSloListMock.mockReturnValue({ isLoading: false, sloList: emptySloList });
+      useHasSlosMock.mockReturnValue({ hasSlos: false, isLoading: false, isError: false });
       useLicenseMock.mockReturnValue({ hasAtLeast: () => false });
       useFetchHistoricalSummaryMock.mockReturnValue({
         isLoading: false,
@@ -255,9 +258,11 @@ describe('SLOs Page', () => {
   describe('when the correct license is found', () => {
     beforeEach(() => {
       useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+      useHasSlosMock.mockReturnValue({ hasSlos: true, isLoading: false, isError: false });
     });
 
     it('redirects to the SLOs Welcome Page when the API has finished loading and there are no results', async () => {
+      useHasSlosMock.mockReturnValue({ hasSlos: false, isLoading: false, isError: false });
       useFetchSloDefinitionsMock.mockReturnValue({
         isLoading: false,
         data: emptySloDefinitionList,

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/slos.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/slos.tsx
@@ -19,7 +19,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { HeaderMenu } from '../../components/header_menu/header_menu';
 import { SloOutdatedCallout } from '../../components/slo/slo_outdated_callout';
 import { useCompositeSloEnabled } from '../../hooks/use_composite_slo_enabled';
-import { useFetchSloDefinitions } from '../../hooks/use_fetch_slo_definitions';
+import { useHasSlos } from '../../hooks/use_has_slos';
 import { useKibana } from '../../hooks/use_kibana';
 import { useLicense } from '../../hooks/use_license';
 import { usePermissions } from '../../hooks/use_permissions';
@@ -71,11 +71,7 @@ export function SlosPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCompositePath, isCompositeSloEnabled]);
 
-  const {
-    data: { total } = { total: 0 },
-    isLoading,
-    isError,
-  } = useFetchSloDefinitions({ perPage: 0 });
+  const { hasSlos, isLoading, isError } = useHasSlos();
 
   useBreadcrumbs(
     [
@@ -91,14 +87,14 @@ export function SlosPage() {
   );
 
   useEffect(() => {
-    if ((!isLoading && total === 0) || hasAtLeast('platinum') === false || isError) {
+    if ((!isLoading && !hasSlos) || hasAtLeast('platinum') === false || isError) {
       history.replace(SLOS_WELCOME_PATH);
     }
 
     if (permissions?.hasAllReadRequested === false) {
       history.replace(SLOS_WELCOME_PATH);
     }
-  }, [history, basePath, hasAtLeast, isError, isLoading, total, permissions]);
+  }, [history, basePath, hasAtLeast, isError, isLoading, hasSlos, permissions]);
 
   if (isLoading) {
     return <LoadingPage dataTestSubj="sloListPageLoading" />;

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos_welcome/slos_welcome.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos_welcome/slos_welcome.test.tsx
@@ -11,8 +11,7 @@ import { paths } from '@kbn/slo-shared-plugin/common/locators/paths';
 import { act, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import Router from 'react-router-dom';
-import { emptySloDefinitionList, sloDefinitionList } from '../../data/slo/slo';
-import { useFetchSloDefinitions } from '../../hooks/use_fetch_slo_definitions';
+import { useHasSlos } from '../../hooks/use_has_slos';
 import { useKibana } from '../../hooks/use_kibana';
 import { useLicense } from '../../hooks/use_license';
 import { usePermissions } from '../../hooks/use_permissions';
@@ -31,8 +30,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@kbn/observability-shared-plugin/public');
 jest.mock('../../hooks/use_kibana');
 jest.mock('../../hooks/use_license');
-jest.mock('../../hooks/use_fetch_slo_list');
-jest.mock('../../hooks/use_fetch_slo_definitions');
+jest.mock('../../hooks/use_has_slos');
 jest.mock('../../hooks/use_permissions');
 
 const HeaderMenuPortalMock = HeaderMenuPortal as jest.Mock;
@@ -40,7 +38,7 @@ HeaderMenuPortalMock.mockReturnValue(<div>Portal node</div>);
 
 const useKibanaMock = useKibana as jest.Mock;
 const useLicenseMock = useLicense as jest.Mock;
-const useFetchSloDefinitionsMock = useFetchSloDefinitions as jest.Mock;
+const useHasSlosMock = useHasSlos as jest.Mock;
 const usePermissionsMock = usePermissions as jest.Mock;
 
 const mockNavigate = jest.fn();
@@ -90,10 +88,7 @@ describe('SLOs Welcome Page', () => {
 
   describe('when the incorrect license is found', () => {
     it('renders the welcome message with subscription buttons', async () => {
-      useFetchSloDefinitionsMock.mockReturnValue({
-        isLoading: false,
-        data: emptySloDefinitionList,
-      });
+      useHasSlosMock.mockReturnValue({ hasSlos: false, isLoading: false, isError: false });
       useLicenseMock.mockReturnValue({ hasAtLeast: () => false });
       usePermissionsMock.mockReturnValue({
         isLoading: false,
@@ -127,10 +122,7 @@ describe('SLOs Welcome Page', () => {
 
     describe('when loading is done and no results are found', () => {
       beforeEach(() => {
-        useFetchSloDefinitionsMock.mockReturnValue({
-          isLoading: false,
-          data: emptySloDefinitionList,
-        });
+        useHasSlosMock.mockReturnValue({ hasSlos: false, isLoading: false, isError: false });
       });
 
       it('disables the create slo button when no write capabilities', async () => {
@@ -200,7 +192,7 @@ describe('SLOs Welcome Page', () => {
 
     describe('when loading is done and results are found', () => {
       beforeEach(() => {
-        useFetchSloDefinitionsMock.mockReturnValue({ isLoading: false, data: sloDefinitionList });
+        useHasSlosMock.mockReturnValue({ hasSlos: true, isLoading: false, isError: false });
         usePermissionsMock.mockReturnValue({
           isLoading: false,
           data: {

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos_welcome/slos_welcome.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos_welcome/slos_welcome.tsx
@@ -23,7 +23,7 @@ import { useHistory } from 'react-router-dom';
 import { HeaderMenu } from '../../components/header_menu/header_menu';
 import { SloOutdatedCallout } from '../../components/slo/slo_outdated_callout';
 import { SloPermissionsCallout } from '../../components/slo/slo_permissions_callout';
-import { useFetchSloDefinitions } from '../../hooks/use_fetch_slo_definitions';
+import { useHasSlos } from '../../hooks/use_has_slos';
 import { useKibana } from '../../hooks/use_kibana';
 import { useLicense } from '../../hooks/use_license';
 import { usePermissions } from '../../hooks/use_permissions';
@@ -45,10 +45,10 @@ export function SlosWelcomePage() {
   const hasRightLicense = hasAtLeast('platinum');
   const history = useHistory();
 
-  const { data: { total } = { total: 0 }, isLoading } = useFetchSloDefinitions({ perPage: 0 });
+  const { hasSlos, isLoading } = useHasSlos();
 
   const hasSlosAndPermissions =
-    !isLoading && total > 0 && hasRightLicense && permissions?.hasAllReadRequested === true;
+    !isLoading && hasSlos && hasRightLicense && permissions?.hasAllReadRequested === true;
 
   const handleClickCreateSlo = () => {
     navigateToUrl(basePath.prepend(paths.sloCreate));


### PR DESCRIPTION
## Summary

resolves https://github.com/elastic/kibana/issues/281361

- The SLO welcome (empty-state) page was incorrectly shown to users whose space had SLOs on remote clusters only. The presence check used `useFetchSloDefinitions` which queries local saved objects only and has no visibility into cross-cluster summary indices.
- Both the list page (`slos.tsx`) and the welcome page (`slos_welcome.tsx`) form a mutual redirect pair — both needed fixing simultaneously to avoid an infinite redirect loop for remote-only users.
- Introduces a shared `useHasSlos` hook that wraps the existing remote-aware `useFetchSloDefinitionsWithRemote` hook (CCS over summary indices, local + remote), using `size: 1` for a presence-only check.

## Test plan

- [ ] Unit tests: `node scripts/jest x-pack/solutions/observability/plugins/slo/public/hooks/use_has_slos.test.ts`
- [ ] Unit tests: `node scripts/jest x-pack/solutions/observability/plugins/slo/public/pages/slos_welcome/slos_welcome.test.tsx`
- [ ] Unit tests: `node scripts/jest x-pack/solutions/observability/plugins/slo/public/pages/slos/slos.test.tsx`
- [ ] Manual (with a remote cluster configured): space with zero local SLOs but ≥1 remote SLO → SLO list renders, no redirect to `/welcome`, no redirect flicker/loop
- [ ] Regression: local-only space with SLOs → still shows the list
- [ ] Regression: truly empty space (no local, no remote SLOs) → still shows the welcome page

🤖 Generated with [Claude Code](https://claude.com/claude-code)