### PR TITLE
[DOCS] Standardize connector reference page structure

### DIFF
--- a/docs/action-type-template.md
+++ b/docs/action-type-template.md
@@ -1,18 +1,19 @@
 ---
 navigation_title: <CONNECTOR_NAME>
+type: reference
+description: "One factual sentence of about 150 characters that describes what the connector does."
 applies_to:
   stack: ga
   serverless: ga
-description: Instructions and best practices for creating <CONNECTOR_NAME> in Elastic.
 ---
 
 % For each new connector, also update the connector TOC at https://github.com/elastic/kibana/blob/main/docs/reference/toc.yml and the list of available connectors at https://github.com/elastic/kibana/blob/main/docs/reference/connectors-kibana.md
 
-# {{CONNECTOR_NAME}} connector and action [connector-name-action-type]
+# {{CONNECTOR_NAME}} connector [connector-name-action-type]
 
-Include a short description of the connector type.
+Include a short description of the connector type: what it connects to, what it does, and how it authenticates.
 
-## Create connectors in {{kib}} [define-connector-name-type]
+## Create connectors in {{kib}} [define-connector-name-ui]
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you're creating a rule.
 
@@ -39,15 +40,28 @@ Property2
 
 ## Test connectors [connector-name-action-configuration]
 
-The {{CONNECTOR-NAME}} actions have the following configuration properties.
+You can test connectors when you create or edit the connector in {{kib}}.
 
-Property1
-:   A short description of this property.
+% Describe what the test verifies, if it is specific to this connector type. Keep the action catalog out of this section.
 
-Property2
-:   A short description of this property with format hints. This can be specified in `this specific format`.
+## Connector actions [connector-name-connector-actions]
 
+The {{CONNECTOR-NAME}} connector has the following actions:
 
-% Provide additional configuration details here. 
+% Mark the actions that write to or modify the third-party service.
 
-% ## Connector networking configuration [connector-name-connector-networking-configuration]
+Action1
+:   A short description of this action and its parameters.
+
+Action2
+:   A short description of this action and its parameters. This can be specified in `this specific format`.
+
+% Only for connectors that call an external service:
+
+## Connector networking configuration [connector-name-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
+
+## Get credentials [connector-name-credentials]
+
+% State the authentication mechanism (API key, OAuth 2.0, Basic, or PKI) in the prose, then describe how to obtain the credentials.

--- a/docs/reference/connectors-kibana/abuseipdb-action-type.md
+++ b/docs/reference/connectors-kibana/abuseipdb-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "AbuseIPDB"
+type: reference
+description: "Use the AbuseIPDB connector to check the reputation of IP addresses and report abusive IP addresses."
 applies_to:
   stack: preview 9.3
   serverless: preview
@@ -23,6 +25,8 @@ API Key
 ## Test connectors [abuseipdb-action-configuration]
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
+
+## Connector actions [abuseipdb-connector-actions]
 
 The AbuseIPDB connector has the following actions:
 
@@ -50,7 +54,7 @@ Bulk Check
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [abuseipdb-api-credentials]
+## Get credentials [abuseipdb-api-credentials]
 
 To use the AbuseIPDB connector, you need an API key:
 

--- a/docs/reference/connectors-kibana/alienvault-otx-action-type.md
+++ b/docs/reference/connectors-kibana/alienvault-otx-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "AlienVault OTX"
+type: reference
+description: "Use the AlienVault OTX connector to retrieve community-driven threat intelligence about indicators and pulses."
 applies_to:
   stack: preview 9.3
   serverless: preview
@@ -23,6 +25,8 @@ API Key
 ## Test connectors [alienvault-otx-action-configuration]
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
+
+## Connector actions [alienvault-otx-connector-actions]
 
 The AlienVault OTX connector has the following actions:
 
@@ -51,7 +55,7 @@ Get Related Pulses
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [alienvault-otx-api-credentials]
+## Get credentials [alienvault-otx-api-credentials]
 
 To use the AlienVault OTX connector, you need an API key:
 

--- a/docs/reference/connectors-kibana/amazon-s3-action-type.md
+++ b/docs/reference/connectors-kibana/amazon-s3-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Amazon S3"
+type: reference
+description: "Use the Amazon S3 connector to list buckets, list the objects in a bucket, and download bucket objects."
 applies_to:
   stack: preview 9.4
   serverless: preview
@@ -31,6 +33,8 @@ AWS Region
 
 You can test connectors as you're creating or editing the connector in {{kib}}. The test verifies connectivity by trying to access a list of available buckets for your authenticated account.
 
+## Connector actions [amazon-s3-connector-actions]
+
 The Amazon S3 connector has the following actions:
 
 List buckets
@@ -53,7 +57,11 @@ Download file
     - **maximumDownloadSizeBytes** (optional) the size in bytes that the connector is allowed to download the content for. Default of 128 KB. If the file to download exceeds this amount, a link to the object in the AWS S3 Bucket will be returned instead of the content.
 
 
-## Get API credentials [amazon-s3-api-credentials]
+## Connector networking configuration [amazon-s3-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
+
+## Get credentials [amazon-s3-api-credentials]
 
 To use the Amazon S3 connector, you need an AWS Access Key ID, Secret Access Key, and Region for the account. Follow these steps to create or view your credentials:
 

--- a/docs/reference/connectors-kibana/azure-blob-action-type.md
+++ b/docs/reference/connectors-kibana/azure-blob-action-type.md
@@ -23,11 +23,13 @@ Storage account URL
 :   The blob service endpoint for your storage account (for example, `https://myaccount.blob.core.windows.net`). Find this in the Azure Portal under your storage account **Endpoints**.
 
 Storage account name and key (Shared Key)
-:   The connector uses **Shared Key** authentication. Provide your storage account name and one of its account keys (from Azure Portal → Storage account → **Access keys**). The connector signs each request with HMAC-SHA256 per the [Azure REST API](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key). When creating a connector via the data source API, credentials must be in the form `accountName:accountKey` (one line, first colon separates name from key; the key is base64 and must not contain colons). See [Get API credentials](#azure-blob-api-credentials).
+:   The connector uses **Shared Key** authentication. Provide your storage account name and one of its account keys (from Azure Portal → Storage account → **Access keys**). The connector signs each request with HMAC-SHA256 per the [Azure REST API](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key). When creating a connector via the data source API, credentials must be in the form `accountName:accountKey` (one line, first colon separates name from key; the key is base64 and must not contain colons). See [Get credentials](#azure-blob-api-credentials).
 
 ## Test connectors [azure-blob-action-configuration]
 
 You can test connectors as you're creating or editing the connector in {{kib}}. The test verifies connectivity by calling the List Containers API with `maxresults=1`.
+
+## Connector actions [azure-blob-connector-actions]
 
 The Azure Blob Storage connector has the following actions:
 
@@ -54,7 +56,11 @@ Get blob properties
     - **container** (required): Container name.
     - **blobName** (required): Blob name (path).
 
-## Get API credentials [azure-blob-api-credentials]
+## Connector networking configuration [azure-blob-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
+
+## Get credentials [azure-blob-api-credentials]
 
 The connector uses **Shared Key** (storage account key) authentication.
 

--- a/docs/reference/connectors-kibana/bedrock-action-type.md
+++ b/docs/reference/connectors-kibana/bedrock-action-type.md
@@ -1,12 +1,14 @@
 ---
 navigation_title: "{{bedrock}}"
+type: reference
+description: "Use the Amazon Bedrock connector to send requests to the Amazon Bedrock API."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/bedrock-action-type.html
 applies_to:
   stack: deprecated 9.5
   serverless: deprecated
 ---
-# {{bedrock}} connector and action [bedrock-action-type]
+# {{bedrock}} connector [bedrock-action-type]
 
 The {{bedrock}} connector uses [axios](https://github.com/axios/axios) to send a POST request to {{bedrock}}.
 

--- a/docs/reference/connectors-kibana/bigquery-action-type.md
+++ b/docs/reference/connectors-kibana/bigquery-action-type.md
@@ -32,6 +32,8 @@ Maximum bytes billed
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies BigQuery API access by running a lightweight `SELECT 1` query in the configured project.
 
+## Connector actions [bigquery-connector-actions]
+
 The BigQuery connector has the following actions:
 
 Run query
@@ -80,7 +82,7 @@ For defense in depth, grant the connector service account only the BigQuery perm
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [bigquery-api-credentials]
+## Get credentials [bigquery-api-credentials]
 
 The BigQuery connector uses a Google Cloud service account JSON key.
 

--- a/docs/reference/connectors-kibana/box-action-type.md
+++ b/docs/reference/connectors-kibana/box-action-type.md
@@ -23,7 +23,7 @@ MCP Server URL
 :   The URL of the remote Box MCP server. Defaults to `https://mcp.box.com`.
 
 Authentication
-:   Connects through Box's OAuth 2.0 Authorization Code flow. Requires a Client ID and Client Secret from the Box MCP server integration in the Admin Console. Refer to [OAuth credentials](#box-oauth-credentials) for setup instructions.
+:   Connects through Box's OAuth 2.0 Authorization Code flow. Requires a Client ID and Client Secret from the Box MCP server integration in the Admin Console. Refer to [Get credentials](#box-oauth-credentials) for setup instructions.
 
 ## Test connectors [box-test-connector]
 
@@ -109,7 +109,7 @@ Box Hubs are curated collections of files and folders organized around a topic o
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get OAuth credentials [box-oauth-credentials]
+## Get credentials [box-oauth-credentials]
 
 :::{important}
 The Box MCP server requires a Box enterprise account or a Box developer account. Personal (individual) Box accounts are not supported and will fail during authentication or when calling tools. However, all individual accounts can be turned into developer accounts by creating a custom OAuth app.

--- a/docs/reference/connectors-kibana/brave-search-action-type.md
+++ b/docs/reference/connectors-kibana/brave-search-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Brave Search"
+type: reference
+description: "Use the Brave Search connector to search the web for privacy-focused results with the Brave Search API."
 applies_to:
   stack: preview 9.3
   serverless: preview
@@ -24,6 +26,8 @@ API Key
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
 
+## Connector actions [brave-search-connector-actions]
+
 The Brave Search connector has the following action:
 
 Web Search
@@ -37,7 +41,7 @@ Web Search
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings.
 You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [brave-search-api-credentials]
+## Get credentials [brave-search-api-credentials]
 
 To use the Brave Search connector, you need an API key:
 

--- a/docs/reference/connectors-kibana/cases-action-type.md
+++ b/docs/reference/connectors-kibana/cases-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Cases"
+type: reference
+description: "Use the Cases connector to create cases in Kibana when alerts occur."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/cases-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: ga
 ---
 
-# Cases connector and action [cases-action-type]
+# Cases connector [cases-action-type]
 
 The Cases connector creates [Cases](docs-content://explore-analyze/alerts-cases/cases.md) in {{kib}} when alerts occur.
 

--- a/docs/reference/connectors-kibana/cases-webhook-action-type.md
+++ b/docs/reference/connectors-kibana/cases-webhook-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "{{webhook-cm}}"
+type: reference
+description: "Use the Webhook - Case Management connector to create and update cases in an external case management web service."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/cases-webhook-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# {{webhook-cm}} connector and action [cases-webhook-action-type]
+# {{webhook-cm}} connector [cases-webhook-action-type]
 
 The {{webhook-cm}} connector uses [axios](https://github.com/axios/axios) to send POST, PUT, and GET requests to a case management RESTful API web service.
 

--- a/docs/reference/connectors-kibana/confluence-cloud-action-type.md
+++ b/docs/reference/connectors-kibana/confluence-cloud-action-type.md
@@ -26,11 +26,13 @@ Subdomain
 :   Your Atlassian subdomain (for example, `your-domain` for `https://your-domain.atlassian.net`).
 
 API token
-:   Your Atlassian API token for authentication. Refer to [Get API credentials](#confluence-cloud-api-credentials) for instructions.
+:   Your Atlassian API token for authentication. Refer to [Get credentials](#confluence-cloud-api-credentials) for instructions.
 
 ## Test connectors [confluence-cloud-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}.
+
+## Connector actions [confluence-cloud-connector-actions]
 
 The Confluence Cloud connector has the following actions:
 
@@ -65,7 +67,7 @@ Get space
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [confluence-cloud-api-credentials]
+## Get credentials [confluence-cloud-api-credentials]
 
 To use the Confluence Cloud connector, you need an Atlassian API token:
 

--- a/docs/reference/connectors-kibana/crowdstrike-action-type.md
+++ b/docs/reference/connectors-kibana/crowdstrike-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "CrowdStrike"
+type: reference
+description: "Use the CrowdStrike connector to run host actions and retrieve host information from the CrowdStrike Management Console."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/crowdstrike-action-type.html
 applies_to:
@@ -51,3 +53,6 @@ The CrowdStrike action has the following configuration properties:
 Agent IDs
 :   Get details about one or more CrowdStrike agent IDs.
 
+## Connector networking configuration [crowdstrike-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.

--- a/docs/reference/connectors-kibana/d3security-action-type.md
+++ b/docs/reference/connectors-kibana/d3security-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "D3 Security"
+type: reference
+description: "Use the D3 Security connector to send events to a D3 SOAR endpoint from rule actions."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/d3security-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# D3 Security connector and action [d3security-action-type]
+# D3 Security connector [d3security-action-type]
 
 The D3 Security connector uses [axios](https://github.com/axios/axios) to send a POST request to a D3 Security endpoint. You can use the connector for rule actions.
 

--- a/docs/reference/connectors-kibana/defender-action-type.md
+++ b/docs/reference/connectors-kibana/defender-action-type.md
@@ -1,16 +1,18 @@
 ---
 navigation_title: "Microsoft Defender for Endpoint"
+type: reference
+description: "Use the Microsoft Defender for Endpoint connector to run response actions on Microsoft Defender-enrolled hosts."
 applies_to:
   stack: ga
   serverless:
     observability: ga
     security: ga
 ---
-# Microsoft Defender for Endpoint connector and action
+# Microsoft Defender for Endpoint connector [defender-action-type]
 
 The Microsoft Defender for Endpoint connector enables you to perform actions on Microsoft Defender-enrolled hosts.
 
-## Create connectors in {{kib}}
+## Create connectors in {{kib}} [define-defender-ui]
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you're creating a rule. For example:
 
@@ -19,7 +21,7 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as 
 :screenshot:
 :::
 
-### Connector configuration
+### Connector configuration [defender-connector-configuration]
 
 Microsoft Defender for Endpoint connectors have the following configuration properties:
 
@@ -44,7 +46,7 @@ OAuth Server URL
 Tenant ID
 :   The tenant identifier for your app in the Azure portal.
 
-## Test connectors
+## Test connectors [defender-action-configuration]
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
 For example:
@@ -54,7 +56,11 @@ For example:
 :screenshot:
 :::
 
-## Configure Microsoft Defender for Endpoint
+## Connector networking configuration [defender-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
+
+## Get credentials [defender-credentials]
 
 Before you create the connector, you must create a new application on your Azure domain.
 The procedure to create an application is found in the [Microsoft Defender documentation](https://learn.microsoft.com/en-us/defender-endpoint/api/exposed-apis-create-app-webapp).

--- a/docs/reference/connectors-kibana/dropbox-action-type.md
+++ b/docs/reference/connectors-kibana/dropbox-action-type.md
@@ -20,7 +20,7 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 Dropbox connectors have the following configuration properties:
 
 **Authentication**
-:   Authenticates through Dropbox OAuth 2.0 Authorization Code flow. Requires a Client ID and Client Secret from a registered Dropbox app. For setup instructions, see [OAuth credentials](#dropbox-oauth-credentials).
+:   Authenticates through Dropbox OAuth 2.0 Authorization Code flow. Requires a Client ID and Client Secret from a registered Dropbox app. For setup instructions, see [Get credentials](#dropbox-oauth-credentials).
 
 ## Test connectors [dropbox-test-connector]
 
@@ -69,7 +69,7 @@ The Dropbox connector exposes the following actions:
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get OAuth credentials [dropbox-oauth-credentials]
+## Get credentials [dropbox-oauth-credentials]
 
 To use the Dropbox connector, you must register an app in the Dropbox App Console to obtain a Client ID and Client Secret.
 

--- a/docs/reference/connectors-kibana/email-action-type.md
+++ b/docs/reference/connectors-kibana/email-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Email"
+type: reference
+description: "Use the email connector to send email messages with the SMTP protocol."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/email-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: all
 ---
 
-# Email connector and action [email-action-type]
+# Email connector [email-action-type]
 
 The email connector uses the SMTP protocol to send mail messages. Email message text is sent as both plain text and html text.
 

--- a/docs/reference/connectors-kibana/figma-action-type.md
+++ b/docs/reference/connectors-kibana/figma-action-type.md
@@ -22,19 +22,21 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 Figma connectors support **API key (header)** authentication (a Figma personal access token sent in the `X-Figma-Token` header) or **OAuth 2.0 authorization code** (Figma signs the user in through {{kib}} and {{kib}} stores refreshable tokens). Select the authentication type when you create or edit the connector.
 
 API key (header)
-:   A Figma personal access token sent in the `X-Figma-Token` header. See [Get API credentials](#figma-api-credentials).
+:   A Figma personal access token sent in the `X-Figma-Token` header. See [Get credentials](#figma-api-credentials).
 
 OAuth 2.0 authorization code
 :   Uses an **OAuth app** registered in Figma. In {{kib}} you provide:
 
     - **Client ID** and **Client Secret**: from your Figma OAuth app
-    - **Redirect URI**: register {{kib}}'s OAuth callback in your Figma OAuth app (see [Get API credentials](#figma-api-credentials))
+    - **Redirect URI**: register {{kib}}'s OAuth callback in your Figma OAuth app (see [Get credentials](#figma-api-credentials))
 
     The connector automatically uses the correct Figma OAuth endpoints and scopes (`current_user:read`, `file_content:read`, and `projects:read`).
 
 ## Test connectors [figma-action-configuration]
 
 You can test connectors when creating or editing the connector in {{kib}}. The test verifies connectivity by calling the Figma API to fetch the current user (for example handle or email).
+
+## Connector actions [figma-connector-actions]
 
 The Figma connector has the following actions:
 
@@ -72,7 +74,7 @@ Figma does not provide a full-text search over files. Discovery is **hierarchica
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
 <a id="figma-api-credentials"></a>
-## Get API credentials [figma-api-credentials]
+## Get credentials [figma-api-credentials]
 
 The Figma connector supports two authentication methods: **OAuth 2.0 authorization code** (recommended) and **API key (header)** using a personal access token.
 

--- a/docs/reference/connectors-kibana/firecrawl-action-type.md
+++ b/docs/reference/connectors-kibana/firecrawl-action-type.md
@@ -26,6 +26,8 @@ API Key (Bearer token)
 
 You can test connectors when you create or edit the connector in {{kib}}.
 
+## Connector actions [firecrawl-connector-actions]
+
 The Firecrawl connector has the following actions:
 
 `scrape`
@@ -63,7 +65,7 @@ The Firecrawl connector has the following actions:
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [firecrawl-api-credentials]
+## Get credentials [firecrawl-api-credentials]
 
 To use the Firecrawl connector:
 

--- a/docs/reference/connectors-kibana/gemini-action-type.md
+++ b/docs/reference/connectors-kibana/gemini-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "{{gemini}}"
+type: reference
+description: "Use the Google Gemini connector to send requests to the Google Gemini API."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/gemini-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: deprecated
 ---
 
-# {{gemini}} connector and action [gemini-action-type]
+# {{gemini}} connector [gemini-action-type]
 
 The {{gemini}} connector uses [axios](https://github.com/axios/axios) to send a POST request to {{gemini}}.
 

--- a/docs/reference/connectors-kibana/github-action-type.md
+++ b/docs/reference/connectors-kibana/github-action-type.md
@@ -24,12 +24,14 @@ MCP Server URL
 
 Authentication
 :   Choose one of the following authentication methods:
-    - **Bearer Token**: A GitHub personal access token. Refer to [Get API credentials](#github-api-credentials) for instructions.
-    - **OAuth Authorization Code**: Connects via GitHub's OAuth flow. Requires a GitHub OAuth App with an authorization URL (`https://github.com/login/oauth/authorize`) and token URL (`https://github.com/login/oauth/access_token`). The default scope is `repo`. Refer to [OAuth credentials](#github-oauth-credentials) for setup instructions.
+    - **Bearer Token**: A GitHub personal access token. Refer to [Get credentials](#github-api-credentials) for instructions.
+    - **OAuth Authorization Code**: Connects via GitHub's OAuth flow. Requires a GitHub OAuth App with an authorization URL (`https://github.com/login/oauth/authorize`) and token URL (`https://github.com/login/oauth/access_token`). The default scope is `repo`. Refer to [Get credentials](#github-oauth-credentials) for setup instructions.
 
 ## Test connectors [github-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}.
+
+## Connector actions [github-connector-actions]
 
 The GitHub connector exposes the following actions:
 
@@ -97,7 +99,7 @@ The GitHub connector exposes the following actions:
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [github-api-credentials]
+## Get credentials (personal access token) [github-api-credentials]
 
 To use the GitHub connector with a personal access token:
 
@@ -116,7 +118,7 @@ To use the GitHub connector with a personal access token:
 Classic personal access tokens also work. When using a classic token, select the `repo` scope for full repository access, or `public_repo` for public repositories only.
 ::::
 
-## Get OAuth credentials [github-oauth-credentials]
+## Get credentials (OAuth) [github-oauth-credentials]
 
 To use the GitHub connector with OAuth:
 

--- a/docs/reference/connectors-kibana/gmail-action-type.md
+++ b/docs/reference/connectors-kibana/gmail-action-type.md
@@ -20,13 +20,13 @@ You can create a Gmail connector in **{{stack-manage-app}} > {{connectors-ui}}**
 Gmail connectors use the following configuration:
 
 Bearer Token
-:   A Google OAuth 2.0 access token with Gmail API scopes. See [Get API credentials](#gmail-api-credentials) for instructions.
+:   A Google OAuth 2.0 access token with Gmail API scopes. See [Get credentials](#gmail-api-credentials) for instructions.
 
 ## Test connectors [gmail-action-configuration]
 
 You can test connectors when creating or editing the connector in {{kib}}. The test verifies connectivity by fetching the authenticated user's profile from the Gmail API.
 
-## Available actions [gmail-available-actions]
+## Connector actions [gmail-connector-actions]
 
 | Action | Description |
 |--------|-------------|
@@ -43,7 +43,7 @@ You can test connectors when creating or editing the connector in {{kib}}. The t
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [gmail-api-credentials]
+## Get credentials [gmail-api-credentials]
 
 To use the Gmail connector, you need a Google OAuth 2.0 access token with Gmail API scopes. You can obtain one using the [Google OAuth 2.0 Playground](https://developers.google.com/oauthplayground/):
 

--- a/docs/reference/connectors-kibana/google-calendar-action-type.md
+++ b/docs/reference/connectors-kibana/google-calendar-action-type.md
@@ -20,19 +20,21 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 Google Calendar connectors have the following configuration properties:
 
 Bearer Token
-:   A Google OAuth 2.0 access token with Google Calendar API scopes. See **Get API credentials**.
+:   A Google OAuth 2.0 access token with Google Calendar API scopes. See **Get credentials**.
 
 OAuth 2.0 authorization code
 :   Uses a **Web application** OAuth client in Google Cloud. In {{kib}} you provide:
 
     - **Client ID** and **Client Secret**: from that OAuth client
-    - **Redirect URI**: register {{kib}}’s OAuth callback in Google Cloud (see **Get API credentials**)
+    - **Redirect URI**: register {{kib}}’s OAuth callback in Google Cloud (see **Get credentials**)
 
     The connector automatically uses the correct Google OAuth endpoints and scope (`https://www.googleapis.com/auth/calendar.readonly`).
 
 ## Test connectors [google-calendar-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies connectivity by fetching the authenticated user's calendar list from the Google Calendar API.
+
+## Connector actions [google-calendar-connector-actions]
 
 The Google Calendar connector has the following actions:
 
@@ -75,7 +77,7 @@ Use the **Action configuration settings** in the configuration reference for ale
 such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use
 `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [google-calendar-api-credentials]
+## Get credentials [google-calendar-api-credentials]
 
 ### OAuth 2.0 authorization code (recommended for ongoing use)
 

--- a/docs/reference/connectors-kibana/google-cloud-storage-action-type.md
+++ b/docs/reference/connectors-kibana/google-cloud-storage-action-type.md
@@ -20,19 +20,21 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 Google Cloud Storage connectors support **Bearer Token** or **OAuth 2.0 authorization code** authentication.
 
 Bearer Token
-:   A Google OAuth 2.0 access token with Cloud Storage and Resource Manager API scopes. See **Get API credentials**.
+:   A Google OAuth 2.0 access token with Cloud Storage and Resource Manager API scopes. See **Get credentials**.
 
 OAuth 2.0 authorization code
 :   Uses a **Web application** OAuth client in Google Cloud. In {{kib}} you provide:
 
     - **Client ID** and **Client Secret**: from that OAuth client
-    - **Redirect URI**: register {{kib}}’s OAuth callback in Google Cloud (see **Get API credentials**)
+    - **Redirect URI**: register {{kib}}’s OAuth callback in Google Cloud (see **Get credentials**)
 
     The connector automatically uses the correct Google OAuth endpoints and scopes (`https://www.googleapis.com/auth/devstorage.read_only` and `https://www.googleapis.com/auth/cloudplatformprojects.readonly`).
 
 ## Test connectors [google-cloud-storage-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies connectivity by calling the Google Cloud Storage API with the provided token.
+
+## Connector actions [google-cloud-storage-connector-actions]
 
 The Google Cloud Storage connector has the following actions:
 
@@ -71,7 +73,7 @@ Download object
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [google-cloud-storage-api-credentials]
+## Get credentials [google-cloud-storage-api-credentials]
 
 ### OAuth 2.0 authorization code (recommended for ongoing use)
 

--- a/docs/reference/connectors-kibana/google-drive-action-type.md
+++ b/docs/reference/connectors-kibana/google-drive-action-type.md
@@ -22,19 +22,21 @@ Google Drive connectors support **Bearer Token** (a static access token you supp
 create or edit the connector.
 
 Bearer Token
-:   A Google OAuth 2.0 access token with Google Drive API scopes. See **Get API credentials**.
+:   A Google OAuth 2.0 access token with Google Drive API scopes. See **Get credentials**.
 
 OAuth 2.0 authorization code
 :   Uses a **Web application** OAuth client in Google Cloud. In {{kib}} you provide:
 
     - **Client ID** and **Client Secret**: from that OAuth client
-    - **Redirect URI**: register {{kib}}’s OAuth callback in Google Cloud (see **Get API credentials**)
+    - **Redirect URI**: register {{kib}}’s OAuth callback in Google Cloud (see **Get credentials**)
 
     The connector automatically uses the correct Google OAuth endpoints and scopes (`https://www.googleapis.com/auth/drive.readonly` and `https://www.googleapis.com/auth/drive.metadata.readonly`).
 
 ## Test connectors [google-drive-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies connectivity by fetching the authenticated user's information from the Google Drive API.
+
+## Connector actions [google-drive-connector-actions]
 
 The Google Drive connector has the following actions:
 
@@ -65,7 +67,7 @@ Get file metadata
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [google-drive-api-credentials]
+## Get credentials [google-drive-api-credentials]
 
 ### OAuth 2.0 authorization code (recommended for ongoing use)
 

--- a/docs/reference/connectors-kibana/greynoise-action-type.md
+++ b/docs/reference/connectors-kibana/greynoise-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "GreyNoise"
+type: reference
+description: "Use the GreyNoise connector to detect and classify the Internet scanning noise that is associated with an IP address."
 applies_to:
   stack: preview 9.3
   serverless: preview
@@ -24,6 +26,8 @@ API Key
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
 
+## Connector actions [greynoise-connector-actions]
+
 The GreyNoise connector has the following actions:
 
 Get IP Context
@@ -46,7 +50,7 @@ RIOT Lookup
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [greynoise-api-credentials]
+## Get credentials [greynoise-api-credentials]
 
 To use the GreyNoise connector, you need an API key:
 

--- a/docs/reference/connectors-kibana/hubspot-action-type.md
+++ b/docs/reference/connectors-kibana/hubspot-action-type.md
@@ -1,5 +1,6 @@
 ---
 navigation_title: "HubSpot"
+type: reference
 description: "Use the HubSpot connector to search and retrieve contacts, companies, deals, tickets, and engagements from HubSpot CRM."
 applies_to:
   stack: preview 9.4
@@ -19,7 +20,7 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 HubSpot connectors support two authentication methods:
 
 **Access token (bearer)**
-:   Authenticates using a static token. Use a **Service Key** (recommended) from HubSpot Development, or a **Private App** access token (starts with `pat-`). See [Get API credentials](#hubspot-api-credentials) for both options.
+:   Authenticates using a static token. Use a **Service Key** (recommended) from HubSpot Development, or a **Private App** access token (starts with `pat-`). See [Get credentials](#hubspot-api-credentials) for both options.
 
     - **Private App Access Token**: The HubSpot access token.
 
@@ -29,6 +30,8 @@ HubSpot connectors support two authentication methods:
 ## Test connectors [hubspot-action-configuration]
 
 You can test connectors while creating or editing them in {{kib}}.
+
+## Connector actions [hubspot-connector-actions]
 
 The HubSpot connector has the following actions:
 
@@ -71,7 +74,7 @@ The HubSpot connector has the following actions:
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [hubspot-api-credentials]
+## Get credentials [hubspot-api-credentials]
 
 The connector supports three credential types: a Service Key (recommended for token auth), a Private App access token (legacy token auth), or OAuth via a Public App. Use a Service Key or OAuth when possible.
 

--- a/docs/reference/connectors-kibana/index-action-type.md
+++ b/docs/reference/connectors-kibana/index-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Index"
+type: reference
+description: "Use the index connector to index a document into Elasticsearch."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/index-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: all
 ---
 
-# Index connector and action [index-action-type]
+# Index connector [index-action-type]
 
 An index connector indexes a document into {{es}}.
 

--- a/docs/reference/connectors-kibana/jina-action-type.md
+++ b/docs/reference/connectors-kibana/jina-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Jina Reader"
+type: reference
+description: "Use the Jina Reader connector to turn web pages into markdown and to search the web for better LLM grounding."
 applies_to:
   stack: preview 9.4+
   serverless: preview
@@ -29,6 +31,8 @@ Search URL
 ## Test connectors [jina-action-configuration]
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
+
+## Connector actions [jina-connector-actions]
 
 The Jina Reader connector has the following actions:
 
@@ -70,7 +74,7 @@ File to Rendered Image
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings.
 You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [jina-api-credentials]
+## Get credentials [jina-api-credentials]
 
 To use the Jina Reader connector, you need an API key:
 

--- a/docs/reference/connectors-kibana/jira-action-type.md
+++ b/docs/reference/connectors-kibana/jira-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Jira"
+type: reference
+description: "Use the Jira connector to create Atlassian Jira issues from rule actions and cases."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/jira-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: all
 ---
 
-# Jira connector and action [jira-action-type]
+# Jira connector [jira-action-type]
 
 The Jira connector uses the [REST API v2](https://developer.atlassian.com/cloud/jira/platform/rest/v2/) to create Atlassian Jira issues.
 

--- a/docs/reference/connectors-kibana/jira-cloud-action-type.md
+++ b/docs/reference/connectors-kibana/jira-cloud-action-type.md
@@ -24,7 +24,7 @@ Subdomain
 
 Authentication type
 :   The method used to authenticate with Jira Cloud. Choose one of the following:
-    - **Basic**: Uses an email address and API token. Refer to [Get API credentials](#jira-cloud-api-credentials).
+    - **Basic**: Uses an email address and API token. Refer to [Get credentials](#jira-cloud-api-credentials).
     - **OAuth 2.0 Authorization Code**: Uses an OAuth app for delegated, per-user access. Refer to [Set up OAuth authentication](#jira-cloud-oauth-setup).
 
 #### Basic authentication fields
@@ -33,7 +33,7 @@ Email
 :   The email address associated with your Atlassian account.
 
 API token
-:   A Jira API token for authentication. Refer to [Get API credentials](#jira-cloud-api-credentials) for instructions.
+:   A Jira API token for authentication. Refer to [Get credentials](#jira-cloud-api-credentials) for instructions.
 
 #### OAuth 2.0 authentication fields
 
@@ -49,6 +49,8 @@ Cloud ID
 ## Test connectors [jira-cloud-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}.
+
+## Connector actions [jira-cloud-connector-actions]
 
 The Jira Cloud connector has the following actions:
 
@@ -82,7 +84,7 @@ Search users
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [jira-cloud-api-credentials]
+## Get credentials [jira-cloud-api-credentials]
 
 To use the Jira Cloud connector with Basic authentication, you need a Jira API token:
 

--- a/docs/reference/connectors-kibana/jsm-action-type.md
+++ b/docs/reference/connectors-kibana/jsm-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Jira Service Management"
+type: reference
+description: "Use the Jira Service Management connector to create and close Jira Service Management alerts."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/jsm-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# Jira Service Management connector and action [jsm-action-type]
+# Jira Service Management connector [jsm-action-type]
 
 An {{jsm}} connector enables you to create and close alerts in {{jsm}}. In particular, it uses the [{{jsm}} Integration Events API](https://developer.atlassian.com/cloud/jira/service-desk-ops/rest/v1/api-group-integration-events/#api-group-integration-events).
 

--- a/docs/reference/connectors-kibana/kubernetes-action-type.md
+++ b/docs/reference/connectors-kibana/kubernetes-action-type.md
@@ -87,6 +87,8 @@ Use the `RBAC Reader`, `RBAC Writer`, or `RBAC Admin` built-in roles depending o
 
 You can test connectors when you create or edit the connector in {{kib}}. The test requests the API server version (`GET /version`) to verify connectivity and authentication.
 
+## Connector actions [kubernetes-connector-actions]
+
 The Kubernetes connector has the following actions:
 
 `request`
@@ -137,7 +139,7 @@ All mutating actions accept `dryRun: true`, which sends `?dryRun=All` so the API
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations. Because Kubernetes API servers are often reachable only on private hostnames or IP addresses, make sure the API server URL is permitted by `xpack.actions.allowedHosts`.
 
-## Get API credentials [kubernetes-api-credentials]
+## Get credentials [kubernetes-api-credentials]
 
 For managed clusters (GKE, EKS, AKS), use the cloud provider credentials described in [Authentication](#kubernetes-connector-authentication) instead of a cluster token. To use the **Service account token** method, create a service account and a scoped token:
 

--- a/docs/reference/connectors-kibana/mcp-action-type.md
+++ b/docs/reference/connectors-kibana/mcp-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "MCP"
+type: reference
+description: "Use the MCP connector to retrieve and call the tools that remote Model Context Protocol (MCP) servers provide."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/mcp-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: preview
 ---
 
-# MCP connector and action [mcp-action-type]
+# MCP connector [mcp-action-type]
 The Model Context Protocol (MCP) connector communicates with remote [MCP](https://modelcontextprotocol.io/docs/getting-started/intro) servers to retrieve and call their tools. This connector is required to use external MCP tools in [Elastic Agent Builder](docs-content://explore-analyze/ai-features/elastic-agent-builder.md).
 
 ## Create connectors in {{kib}} [define-mcp-ui]
@@ -47,6 +49,8 @@ You can test connectors as you’re creating or editing the connector in {{kib}}
 :screenshot:
 :::
 
+## Connector actions [mcp-connector-actions]
+
 MCP connectors offer three actions:
 
 `test`
@@ -61,3 +65,7 @@ MCP connectors offer three actions:
 :::{tip}
 Call `listTools` first to understand how to correctly call an MCP server's tools, before using the `callTool` action. 
 :::
+
+## Connector networking configuration [mcp-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.

--- a/docs/reference/connectors-kibana/microsoft-teams-action-type.md
+++ b/docs/reference/connectors-kibana/microsoft-teams-action-type.md
@@ -7,7 +7,7 @@ applies_to:
   serverless: preview
 ---
 
-# Microsoft Teams connector [microsoft-teams-connector]
+# Microsoft Teams connector [microsoft-teams-action-type]
 
 The Microsoft Teams connector enables Workplace AI to search messages and browse teams, channels, and chats in Microsoft Teams using the Microsoft Graph API.
 
@@ -47,6 +47,8 @@ Tenant ID
 
 You can test connectors while creating or editing them in {{kib}}. The test verifies connectivity by listing the authenticated user's joined teams when using delegated auth, or all teams in the tenant when using app-only auth.
 
+## Connector actions [microsoft-teams-connector-actions]
+
 The Microsoft Teams connector has the following actions:
 
 **List joined teams**
@@ -84,7 +86,7 @@ The Microsoft Teams connector has the following actions:
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. If you use [`xpack.actions.allowedHosts`](/reference/configuration-reference/alerting-settings.md#action-settings), add `graph.microsoft.com` and `login.microsoftonline.com` to the list.
 
-## Get API credentials [microsoft-teams-api-credentials]
+## Get credentials [microsoft-teams-api-credentials]
 
 To use the Microsoft Teams connector, you need a Microsoft Azure AD application with the required Graph API permissions.
 

--- a/docs/reference/connectors-kibana/monday-com-action-type.md
+++ b/docs/reference/connectors-kibana/monday-com-action-type.md
@@ -22,8 +22,8 @@ Monday.com connectors have the following configuration properties:
 **Authentication** (recommended: OAuth 2.0)
 :   Choose one of two authentication methods:
 
-    - **OAuth 2.0** (recommended): Authenticates through Monday.com OAuth 2.0 Authorization Code flow. Requires a Client ID and Client Secret from a registered Monday.com app. For setup instructions, see [OAuth credentials](#monday-com-oauth-credentials).
-    - **Personal API Token**: Authenticates using a Monday.com personal API token sent as a Bearer token. Simpler to set up but scoped to a single user account. For setup instructions, see [Personal API token](#monday-com-personal-api-token).
+    - **OAuth 2.0** (recommended): Authenticates through Monday.com OAuth 2.0 Authorization Code flow. Requires a Client ID and Client Secret from a registered Monday.com app. For setup instructions, see [Get credentials](#monday-com-oauth-credentials).
+    - **Personal API Token**: Authenticates using a Monday.com personal API token sent as a Bearer token. Simpler to set up but scoped to a single user account. For setup instructions, see [Get credentials](#monday-com-personal-api-token).
 
 ## Test connectors [monday-com-test-connector]
 
@@ -101,7 +101,7 @@ The Monday.com connector exposes the following actions:
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get OAuth credentials [monday-com-oauth-credentials]
+## Get credentials (OAuth) [monday-com-oauth-credentials]
 
 To use the Monday.com connector, you must register an app in the Monday.com Developer Center to obtain a Client ID and Client Secret.
 
@@ -127,7 +127,7 @@ To use the Monday.com connector, you must register an app in the Monday.com Deve
 7. In {{kib}}, enter the values from the preceding table.
 8. Complete the authorization flow to connect your Monday.com account.
 
-## Get a Personal API token [monday-com-personal-api-token]
+## Get credentials (personal API token) [monday-com-personal-api-token]
 
 To use Personal API Token authentication:
 

--- a/docs/reference/connectors-kibana/notion-action-type.md
+++ b/docs/reference/connectors-kibana/notion-action-type.md
@@ -20,19 +20,21 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 Notion connectors support **Bearer Token** (a static API token from an internal integration) or **OAuth 2.0 authorization code** (Notion signs the user in through {{kib}} and {{kib}} stores refreshable tokens). Select the authentication type when you create or edit the connector.
 
 Bearer Token
-:   A Notion internal integration token. See **Get API credentials**.
+:   A Notion internal integration token. See **Get credentials**.
 
 OAuth 2.0 authorization code
 :   Uses a **public integration** in Notion. In {{kib}} you provide:
 
     - **Client ID** and **Client Secret**: from your Notion public integration
-    - **Redirect URI**: register {{kib}}'s OAuth callback in your Notion integration settings (see **Get API credentials**)
+    - **Redirect URI**: register {{kib}}'s OAuth callback in your Notion integration settings (see **Get credentials**)
 
     The connector automatically uses the correct Notion OAuth endpoints and scopes.
 
 ## Test connectors [notion-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}.
+
+## Connector actions [notion-connector-actions]
 
 The Notion connector has the following actions:
 
@@ -62,7 +64,7 @@ Query Data Source
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [notion-api-credentials]
+## Get credentials [notion-api-credentials]
 
 ### OAuth Authorization Code (recommended)
 

--- a/docs/reference/connectors-kibana/obs-ai-assistant-action-type.md
+++ b/docs/reference/connectors-kibana/obs-ai-assistant-action-type.md
@@ -3,11 +3,13 @@ applies_to:
   serverless: preview
   stack: preview
 navigation_title: "Observability AI Assistant"
+type: reference
+description: "Use the Observability AI Assistant connector to send alerts to the AI Assistant for AI-driven insights and custom actions."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/obs-ai-assistant-action-type.html
 ---
 
-# Observability AI Assistant connector and action [obs-ai-assistant-action-type]
+# Observability AI Assistant connector [obs-ai-assistant-action-type]
 
 The Observability AI Assistant connector sends alerts to the AI Assistant, to enable adding AI-driven insights and custom actions to your workflows.
 

--- a/docs/reference/connectors-kibana/one-drive-action-type.md
+++ b/docs/reference/connectors-kibana/one-drive-action-type.md
@@ -37,6 +37,10 @@ Token URL
 
 ## Test connectors [one-drive-action-configuration]
 
+You can test connectors when you create or edit the connector in {{kib}}.
+
+## Connector actions [one-drive-connector-actions]
+
 The OneDrive connector has the following actions:
 
 Get me
@@ -75,7 +79,11 @@ List recent files
 :   List files the authenticated user has recently accessed or modified.
     - `pageToken` (optional): Continuation token from a previous response's `nextPageToken` field to fetch the next page.
 
-## Get API credentials [one-drive-api-credentials]
+## Connector networking configuration [one-drive-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
+
+## Get credentials [one-drive-api-credentials]
 
 To use the OneDrive connector, register an application in Microsoft Azure and grant it the required Microsoft Graph API permissions.
 

--- a/docs/reference/connectors-kibana/one-password-action-type.md
+++ b/docs/reference/connectors-kibana/one-password-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "1Password"
+type: reference
+description: "Use the 1Password connector to manage the users of a 1Password Enterprise Password Manager account."
 applies_to:
   stack: preview 9.4
   serverless: preview
@@ -32,6 +34,8 @@ The connector authenticates using the OAuth 2.0 Client Credentials flow with `cl
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
 
+## Connector actions [one-password-connector-actions]
+
 The 1Password connector has the following actions:
 
 List Users
@@ -56,7 +60,7 @@ Reactivate User
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [one-password-api-credentials]
+## Get credentials [one-password-api-credentials]
 
 To use the 1Password connector, you need OAuth 2.0 client credentials from a 1Password Enterprise Password Manager account:
 

--- a/docs/reference/connectors-kibana/openai-action-type.md
+++ b/docs/reference/connectors-kibana/openai-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "OpenAI"
+type: reference
+description: "Use the OpenAI connector to send requests to OpenAI, Azure OpenAI, and other OpenAI-compatible providers."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/openai-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: deprecated
 ---
 
-# OpenAI connector and action [openai-action-type]
+# OpenAI connector [openai-action-type]
 
 The OpenAI connector uses [axios](https://github.com/axios/axios) to send a POST request to an OpenAI provider: 
 

--- a/docs/reference/connectors-kibana/opsgenie-action-type.md
+++ b/docs/reference/connectors-kibana/opsgenie-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Opsgenie"
+type: reference
+description: "Use the Opsgenie connector to create and close Opsgenie alerts."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/opsgenie-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# Opsgenie connector and action [opsgenie-action-type]
+# Opsgenie connector [opsgenie-action-type]
 
 An {{opsgenie}} connector enables you to create and close alerts in {{opsgenie}}. In particular, it uses the [{{opsgenie}} alert API](https://docs.opsgenie.com/docs/alert-api).
 

--- a/docs/reference/connectors-kibana/outlook-action-type.md
+++ b/docs/reference/connectors-kibana/outlook-action-type.md
@@ -33,7 +33,7 @@ Token URL
 
 You can test connectors when creating or editing the connector in {{kib}}. The test verifies connectivity by fetching the authenticated user's profile from Microsoft Graph.
 
-## Available actions [outlook-available-actions]
+## Connector actions [outlook-connector-actions]
 
 | Action | Description |
 |--------|-------------|
@@ -106,7 +106,7 @@ Parameters:
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. If you use [`xpack.actions.allowedHosts`](/reference/configuration-reference/alerting-settings.md#action-settings), add `graph.microsoft.com` and `login.microsoftonline.com` to the list.
 
-## Get API credentials [outlook-api-credentials]
+## Get credentials [outlook-api-credentials]
 
 To use the Outlook connector, you need a Microsoft Entra ID application registration with the required Graph API permissions.
 

--- a/docs/reference/connectors-kibana/pagerduty-action-type.md
+++ b/docs/reference/connectors-kibana/pagerduty-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "PagerDuty"
+type: reference
+description: "Use the PagerDuty connector to trigger, acknowledge, and resolve PagerDuty alerts."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/pagerduty-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# PagerDuty connector and action [pagerduty-action-type]
+# PagerDuty connector [pagerduty-action-type]
 
 The PagerDuty connector enables you to trigger, acknowledge, and resolve PagerDuty alerts. In particular, it uses the [v2 Events API](https://v2.developer.pagerduty.com/docs/events-api-v2).
 

--- a/docs/reference/connectors-kibana/pagerduty-mcp-action-type.md
+++ b/docs/reference/connectors-kibana/pagerduty-mcp-action-type.md
@@ -11,11 +11,15 @@ applies_to:
 
 The PagerDuty data source connects to PagerDuty through the PagerDuty MCP server to access incidents, escalation policies, schedules, on-calls, users, and teams. Use it in data and context sources and agentic workflows to search and retrieve PagerDuty data.
 
-## Add the PagerDuty data source
+## Create connectors in {{kib}} [define-pagerduty-mcp-ui]
 
-You add and configure the PagerDuty data source when setting up a data or context source in {{kib}}. You are prompted for an **API token**. Refer to [Get API credentials](#pagerduty-mcp-api-credentials) for instructions.
+You add and configure the PagerDuty data source when setting up a data or context source in {{kib}}. You are prompted for an **API token**. Refer to [Get credentials](#pagerduty-mcp-api-credentials) for instructions.
 
-## Get API credentials [pagerduty-mcp-api-credentials]
+## Connector networking configuration [pagerduty-mcp-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
+
+## Get credentials [pagerduty-mcp-api-credentials]
 
 To use the PagerDuty data source, you need a PagerDuty **API token** (REST API). This is not the same as an integration key used for the alerting connector.
 

--- a/docs/reference/connectors-kibana/resilient-action-type.md
+++ b/docs/reference/connectors-kibana/resilient-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "{{ibm-r}}"
+type: reference
+description: "Use the IBM Resilient connector to create IBM Resilient incidents from rule actions and cases."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/resilient-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# {{ibm-r}} connector and action [resilient-action-type]
+# {{ibm-r}} connector [resilient-action-type]
 
 The {{ibm-r}} connector uses the [RESILIENT REST v2](https://developer.ibm.com/security/resilient/rest/) to create {{ibm-r}} incidents.
 

--- a/docs/reference/connectors-kibana/salesforce-action-type.md
+++ b/docs/reference/connectors-kibana/salesforce-action-type.md
@@ -34,7 +34,7 @@ Authorization URL
     credentials only.
 
 Client ID
-:   The **Consumer Key** from your Salesforce External Client App OAuth settings (see **Get API credentials**).
+:   The **Consumer Key** from your Salesforce External Client App OAuth settings (see **Get credentials**).
 
 Client Secret
 :   The **Consumer Secret** from your Salesforce External Client App OAuth settings.
@@ -45,6 +45,8 @@ authorization URL is used only for the browser-based authorization step in the a
 ## Test connectors [salesforce-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies connectivity by running a simple SOQL query (`SELECT Id FROM User LIMIT 1`).
+
+## Connector actions [salesforce-connector-actions]
 
 The Salesforce connector has the following actions:
 
@@ -84,7 +86,7 @@ Use the **Action configuration settings** in the configuration reference for ale
 such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use
 `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [salesforce-api-credentials]
+## Get credentials [salesforce-api-credentials]
 
 Use the following steps to obtain credentials for the connector’s OAuth 2.0 Client Credentials authentication. The
 steps below are subject to change as the Salesforce UI updates.

--- a/docs/reference/connectors-kibana/sentinelone-action-type.md
+++ b/docs/reference/connectors-kibana/sentinelone-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "SentinelOne"
+type: reference
+description: "Use the SentinelOne connector to run response actions through the SentinelOne Management Console REST API."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/sentinelone-action-type.html
 applies_to:
@@ -44,3 +46,6 @@ For example:
 :screenshot:
 :::
 
+## Connector networking configuration [sentinelone-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.

--- a/docs/reference/connectors-kibana/server-log-action-type.md
+++ b/docs/reference/connectors-kibana/server-log-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Server log"
+type: reference
+description: "Use the server log connector to write an entry to the Kibana server log."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/server-log-action-type.html
 applies_to:
@@ -8,7 +10,7 @@ applies_to:
     security: ga
 ---
 
-# Server log connector and action [server-log-action-type]
+# Server log connector [server-log-action-type]
 
 A server log connector writes an entry to the {{kib}} server log.
 

--- a/docs/reference/connectors-kibana/servicenow-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "{{sn-itsm}}"
+type: reference
+description: "Use the ServiceNow ITSM connector to create ServiceNow incidents from rule actions and cases."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/servicenow-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: all
 ---
 
-# {{sn-itsm}} connector and action [servicenow-action-type]
+# {{sn-itsm}} connector [servicenow-action-type]
 
 The {{sn-itsm}} connector uses the [import set API](https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI) to create {{sn}} incidents. You can use the connector for rule actions and cases.
 

--- a/docs/reference/connectors-kibana/servicenow-itom-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-itom-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "{{sn-itom}}"
+type: reference
+description: "Use the ServiceNow ITOM connector to create ServiceNow events from rule actions."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/servicenow-itom-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# {{sn-itom}} connector and action [servicenow-itom-action-type]
+# {{sn-itom}} connector [servicenow-itom-action-type]
 
 The {{sn-itom}} connector uses the [event API](https://docs.servicenow.com/bundle/rome-it-operations-management/page/product/event-management/task/send-events-via-web-service.md) to create {{sn}} events. You can use the connector for rule actions.
 

--- a/docs/reference/connectors-kibana/servicenow-search-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-search-action-type.md
@@ -53,6 +53,8 @@ The connector automatically uses the correct ServiceNow OAuth endpoints for your
 You can test connectors when you create or edit the connector in {{kib}}.
 The test verifies connectivity by querying the `sys_user` table, which any authenticated user can access.
 
+## Connector actions [servicenow-search-connector-actions]
+
 The ServiceNow connector has the following actions:
 
 Search
@@ -105,7 +107,7 @@ Get attachment
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [servicenow-search-api-credentials]
+## Get credentials [servicenow-search-api-credentials]
 
 ### OAuth 2.0 Client Credentials
 

--- a/docs/reference/connectors-kibana/servicenow-sir-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-sir-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "{{sn-sir}}"
+type: reference
+description: "Use the ServiceNow SecOps connector to create ServiceNow security incidents from rule actions and cases."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/servicenow-sir-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# {{sn-sir}} connector and action [servicenow-sir-action-type]
+# {{sn-sir}} connector [servicenow-sir-action-type]
 
 The {{sn-sir}} connector uses the [import set API](https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI) to create {{sn}} security incidents. You can use the connector for rule actions and cases.
 

--- a/docs/reference/connectors-kibana/sharepoint-online-action-type.md
+++ b/docs/reference/connectors-kibana/sharepoint-online-action-type.md
@@ -59,6 +59,8 @@ Token URL
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies connectivity by accessing the root SharePoint site.
 
+## Connector actions [sharepoint-online-connector-actions]
+
 The SharePoint Online connector has the following actions:
 
 Search
@@ -129,7 +131,7 @@ Use `getDriveItems` to fetch metadata and `downloadUrl`, decide which items are 
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [sharepoint-online-api-credentials]
+## Get credentials [sharepoint-online-api-credentials]
 
 ### OAuth client credentials (app-only auth)
 

--- a/docs/reference/connectors-kibana/sharepoint-server-action-type.md
+++ b/docs/reference/connectors-kibana/sharepoint-server-action-type.md
@@ -33,6 +33,8 @@ Password
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
 
+## Connector actions [sharepoint-server-connector-actions]
+
 The SharePoint Server connector has the following actions:
 
 Get Web
@@ -72,7 +74,11 @@ Call REST API
     - **Body** (optional): Request body for POST requests.
 
 
-## Get API credentials [sharepoint-server-api-credentials]
+## Connector networking configuration [sharepoint-server-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
+
+## Get credentials [sharepoint-server-api-credentials]
 
 To use the SharePoint Server connector, you need:
 

--- a/docs/reference/connectors-kibana/shodan-action-type.md
+++ b/docs/reference/connectors-kibana/shodan-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Shodan"
+type: reference
+description: "Use the Shodan connector to discover Internet-wide assets and vulnerabilities with the Shodan API."
 applies_to:
   stack: preview 9.3
   serverless: preview
@@ -24,6 +26,8 @@ API Key
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
 
+## Connector actions [shodan-connector-actions]
+
 The Shodan connector has the following actions:
 
 Search Hosts
@@ -47,7 +51,7 @@ Get Services
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [shodan-api-credentials]
+## Get credentials [shodan-api-credentials]
 
 To use the Shodan connector, you need an API key:
 

--- a/docs/reference/connectors-kibana/slack-action-type.md
+++ b/docs/reference/connectors-kibana/slack-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Slack"
+type: reference
+description: "Use the Slack connector to send Slack messages with an incoming webhook or the Slack web API."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/slack-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: all
 ---
 
-# Slack connector and action [slack-action-type]
+# Slack connector [slack-action-type]
 
 The Slack connector uses incoming webhooks or an API method to send Slack messages.
 

--- a/docs/reference/connectors-kibana/slack-v2-action-type.md
+++ b/docs/reference/connectors-kibana/slack-v2-action-type.md
@@ -23,10 +23,10 @@ EARS (recommended)
 :   Elastic's managed OAuth flow. Select this option and authorize access to your Slack workspace through Elastic. No app setup is required.
 
 OAuth Authorization Code
-:   Slack's OAuth v2 flow using your own Slack app. You will be redirected to Slack to authorize access to your workspace. Requires a Slack app with a Client ID, Client Secret, and the appropriate user token scopes. See [Get API credentials (OAuth)](#slack-v2-api-credentials-oauth) for setup steps.
+:   Slack's OAuth v2 flow using your own Slack app. You will be redirected to Slack to authorize access to your workspace. Requires a Slack app with a Client ID, Client Secret, and the appropriate user token scopes. See [Get credentials (OAuth)](#slack-v2-api-credentials-oauth) for setup steps.
 
 Bot Token
-:   A long-lived Slack bot token (format: `xoxb-...`) from a Slack app. Paste the token directly — no OAuth redirect is required. See [Get API credentials (Bot Token)](#slack-v2-api-credentials-bot-token) for setup steps.
+:   A long-lived Slack bot token (format: `xoxb-...`) from a Slack app. Paste the token directly — no OAuth redirect is required. See [Get credentials (bot token)](#slack-v2-api-credentials-bot-token) for setup steps.
 
 ::::{note}
 The **Search messages** action requires a user token and is not available when using Bot Token authentication. Use **Get conversation history** to read messages from a specific channel instead.
@@ -35,6 +35,8 @@ The **Search messages** action requires a user token and is not available when u
 ## Test connectors [slack-v2-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies connectivity by calling Slack `auth.test`.
+
+## Connector actions [slack-v2-connector-actions]
 
 The Slack (v2) connector has the following actions:
 
@@ -152,7 +154,7 @@ Send message
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. If you use [`xpack.actions.allowedHosts`](/reference/configuration-reference/alerting-settings.md#action-settings), include `slack.com` in the list.
 
-## Get API credentials (OAuth) [slack-v2-api-credentials-oauth]
+## Get credentials (OAuth) [slack-v2-api-credentials-oauth]
 
 To use OAuth Authorization Code authentication, you need a Slack app configured for OAuth.
 
@@ -184,7 +186,7 @@ To use OAuth Authorization Code authentication, you need a Slack app configured 
 Additional scopes may be required for certain actions. For example, `groups:write` is needed to create private channels or invite users. Add scopes as needed under **User Token Scopes** in your Slack app configuration.
 ::::
 
-## Get API credentials (Bot Token) [slack-v2-api-credentials-bot-token]
+## Get credentials (bot token) [slack-v2-api-credentials-bot-token]
 
 To use Bot Token authentication, you need a Slack app with a bot token.
 

--- a/docs/reference/connectors-kibana/snowflake-action-type.md
+++ b/docs/reference/connectors-kibana/snowflake-action-type.md
@@ -38,6 +38,8 @@ Default Role
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies connectivity by running `SELECT CURRENT_VERSION()` and returning the Snowflake version.
 
+## Connector actions [snowflake-connector-actions]
+
 The Snowflake connector has the following actions:
 
 Run query
@@ -145,7 +147,7 @@ For defense in depth, grant the connector credentials only the Snowflake privile
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [snowflake-api-credentials]
+## Get credentials [snowflake-api-credentials]
 
 The Snowflake connector supports two authentication methods: **OAuth Authorization Code** (recommended) and **Programmatic Access Token** (PAT).
 

--- a/docs/reference/connectors-kibana/sublime-security-action-type.md
+++ b/docs/reference/connectors-kibana/sublime-security-action-type.md
@@ -27,6 +27,10 @@ API key
 
 ## Test connectors [sublime-security-action-configuration]
 
+You can test connectors when you create or edit the connector in {{kib}}.
+
+## Connector actions [sublime-security-connector-actions]
+
 The Sublime Security connector has the following actions:
 
 Search message groups

--- a/docs/reference/connectors-kibana/swimlane-action-type.md
+++ b/docs/reference/connectors-kibana/swimlane-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Swimlane"
+type: reference
+description: "Use the Swimlane connector to create Swimlane records from rule actions and cases."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/swimlane-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# Swimlane connector and action [swimlane-action-type]
+# Swimlane connector [swimlane-action-type]
 
 The Swimlane connector uses the [Swimlane REST API](https://swimlane.com/knowledge-center/docs/developer-guide/rest-api/) to create Swimlane records.
 
@@ -58,3 +60,7 @@ Severity
 ::::{note}
 Alert ID and Rule Name are filled automatically. Specifically, Alert ID is set to `{{alert.id}}` and Rule Name to `{{rule.name}}`.
 ::::
+
+## Connector networking configuration [swimlane-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.

--- a/docs/reference/connectors-kibana/tavily-action-type.md
+++ b/docs/reference/connectors-kibana/tavily-action-type.md
@@ -26,6 +26,8 @@ API Key
 
 You can test connectors when you create or edit the connector in {{kib}}.
 
+## Connector actions [tavily-connector-actions]
+
 The Tavily connector has the following actions:
 
 Search
@@ -63,7 +65,7 @@ Map
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [tavily-api-credentials]
+## Get credentials [tavily-api-credentials]
 
 To use the Tavily connector:
 

--- a/docs/reference/connectors-kibana/teams-action-type.md
+++ b/docs/reference/connectors-kibana/teams-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Microsoft Teams"
+type: reference
+description: "Use the Microsoft Teams connector to send notifications to a Microsoft Teams channel with a webhook."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/teams-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: all
 ---
 
-# Microsoft Teams connector and action [teams-action-type]
+# Microsoft Teams connector [teams-action-type]
 
 The Microsoft Teams connector uses a webhook to send notifications.
 

--- a/docs/reference/connectors-kibana/thehive-action-type.md
+++ b/docs/reference/connectors-kibana/thehive-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "{{hive}}"
+type: reference
+description: "Use the TheHive connector to create TheHive cases and alerts from rule actions and cases."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/thehive-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# {{hive}} connector and action [thehive-action-type]
+# {{hive}} connector [thehive-action-type]
 
 {{hive}} connector uses the [{{hive}} (v1) REST API](https://docs.strangebee.com/thehive/api-docs/) to create cases and alerts. [8.16.0]
 
@@ -117,7 +119,7 @@ Body {applies_to}`stack: ga 9.1`
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Configure {{hive}} [configure-thehive]
+## Get credentials [configure-thehive]
 
 To generate an API key in {{hive}}:
 

--- a/docs/reference/connectors-kibana/tines-action-type.md
+++ b/docs/reference/connectors-kibana/tines-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Tines"
+type: reference
+description: "Use the Tines connector to send events to a Tines story with a webhook action."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/tines-action-type.html
 applies_to:
@@ -77,3 +79,7 @@ The message contains fields such as `alertId`, `date`, `_index`, `kibanaBaseUrl`
 The number of alerts (signals) can be found at `state.signals_count`.
 
 The alerts (signals) data is stored in the `context.alerts` array, following the [ECS](ecs://reference/ecs-field-reference.md) format.
+
+## Connector networking configuration [tines-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.

--- a/docs/reference/connectors-kibana/torq-action-type.md
+++ b/docs/reference/connectors-kibana/torq-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Torq"
+type: reference
+description: "Use the Torq connector to trigger Torq workflows with a Torq webhook."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/torq-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# Torq connector and action [torq-action-type]
+# Torq connector [torq-action-type]
 
 The Torq connector uses a Torq webhook to trigger workflows with Kibana actions.
 
@@ -48,3 +50,7 @@ Torq actions have the following configuration properties.
 
 Body
 :   JSON payload to send to Torq.
+
+## Connector networking configuration [torq-connector-networking-configuration]
+
+Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.

--- a/docs/reference/connectors-kibana/urlvoid-action-type.md
+++ b/docs/reference/connectors-kibana/urlvoid-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "URLVoid"
+type: reference
+description: "Use the URLVoid connector to check domain and URL reputation with multi-engine scanning."
 applies_to:
   stack: preview 9.3
   serverless: preview
@@ -24,6 +26,8 @@ API Key
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
 
+## Connector actions [urlvoid-connector-actions]
+
 The URLVoid connector has the following actions:
 
 Scan Domain
@@ -45,7 +49,7 @@ Scan Domain Stats
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [urlvoid-api-credentials]
+## Get credentials [urlvoid-api-credentials]
 
 To use the URLVoid connector, you need an API key:
 

--- a/docs/reference/connectors-kibana/virustotal-action-type.md
+++ b/docs/reference/connectors-kibana/virustotal-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "VirusTotal"
+type: reference
+description: "Use the VirusTotal connector to scan files, analyze URLs and domains, and look up threat intelligence."
 applies_to:
   stack: preview 9.4
   serverless: preview
@@ -23,6 +25,8 @@ API Key
 ## Test connectors [virustotal-action-configuration]
 
 You can test connectors as you're creating or editing the connector in {{kib}}.
+
+## Connector actions [virustotal-connector-actions]
 
 The VirusTotal connector has the following actions:
 
@@ -94,7 +98,7 @@ steps:
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking configurations, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [virustotal-api-credentials]
+## Get credentials [virustotal-api-credentials]
 
 To use the VirusTotal connector, you need an API key:
 

--- a/docs/reference/connectors-kibana/webhook-action-type.md
+++ b/docs/reference/connectors-kibana/webhook-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Webhook"
+type: reference
+description: "Use the Webhook connector to send a request to a web service from rule actions."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/webhook-action-type.html
 applies_to:
@@ -7,7 +9,7 @@ applies_to:
   serverless: all
 ---
 
-# Webhook connector and action [webhook-action-type]
+# Webhook connector [webhook-action-type]
 
 The Webhook connector uses [axios](https://github.com/axios/axios) to send a request to a web service.
 

--- a/docs/reference/connectors-kibana/xmatters-action-type.md
+++ b/docs/reference/connectors-kibana/xmatters-action-type.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "xMatters"
+type: reference
+description: "Use the xMatters connector to send actionable alerts to on-call xMatters resources."
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/xmatters-action-type.html
 applies_to:
@@ -9,7 +11,7 @@ applies_to:
     security: ga
 ---
 
-# xMatters connector and action [xmatters-action-type]
+# xMatters connector [xmatters-action-type]
 
 The xMatters connector uses the [xMatters Workflow for Elastic](https://help.xmatters.com/integrations/#cshid=Elastic) to send actionable alerts to on-call xMatters resources.
 

--- a/docs/reference/connectors-kibana/xsoar-action-type.md
+++ b/docs/reference/connectors-kibana/xsoar-action-type.md
@@ -9,7 +9,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/xsoar-action-type.html
 ---
 
-# {{xsoar}} connector and action [xsoar-action-type]
+# {{xsoar}} connector [xsoar-action-type]
 
 The {{xsoar}} connector uses the [{{xsoar}} REST API](https://cortex-panw.stoplight.io/docs/cortex-xsoar-8/m0qlgh9inh4vk-create-or-update-an-incident) to create Cortex {{xsoar}} incidents from Elastic rules, cases, and Workflows. Use the `xsoar.run` workflow step when a workflow needs to open an incident in {{xsoar}} and optionally associate it with an {{xsoar}} playbook.
 
@@ -58,6 +58,8 @@ You can test connectors as you’re creating or editing the connector in {{kib}}
 :alt: {{xsoar}} params test
 :screenshot:
 ::::
+
+## Connector actions [xsoar-connector-actions]
 
 The {{xsoar}} connector has the following actions:
 

--- a/docs/reference/connectors-kibana/zendesk-action-type.md
+++ b/docs/reference/connectors-kibana/zendesk-action-type.md
@@ -7,11 +7,9 @@ applies_to:
   serverless: preview
 ---
 
-# Zendesk data source connector [zendesk-action-type]
+# Zendesk connector [zendesk-action-type]
 
 The Zendesk connector connects directly to the Zendesk API. It enables federated search of tickets, users, and organizations from Zendesk Support in Workplace AI and Agent Builder.
-
-## Overview
 
 This is a **custom connector** that uses Zendesk's REST API with Basic authentication (email and API token). You configure your Zendesk subdomain and credentials when creating the connector.
 
@@ -27,7 +25,7 @@ Subdomain
 Authentication
 :   Basic authentication. Use your Zendesk account **email** and **API token** (from **Admin Center** > **Apps and integrations** > **APIs** > **Zendesk API**). For API token authentication, the username must be in the form `your_email@example.com/token` and the password is your API token.
 
-## Available actions [zendesk-available-actions]
+## Connector actions [zendesk-connector-actions]
 
 | Action | Description |
 |--------|-------------|
@@ -40,7 +38,7 @@ Authentication
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [zendesk-api-credentials]
+## Get credentials [zendesk-api-credentials]
 
 1. Log in to your [Zendesk](https://www.zendesk.com/) account.
 2. Go to **Admin Center** > **Apps and integrations** > **APIs** > **Zendesk API**.

--- a/docs/reference/connectors-kibana/zoom-action-type.md
+++ b/docs/reference/connectors-kibana/zoom-action-type.md
@@ -20,11 +20,13 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 Zoom connectors have the following configuration properties:
 
 Zoom access token
-:   A Zoom Server-to-Server OAuth access token. Generate one through the Zoom Marketplace or API (refer to [Get API credentials](#zoom-api-credentials)). Tokens expire after 1 hour.
+:   A Zoom Server-to-Server OAuth access token. Generate one through the Zoom Marketplace or API (refer to [Get credentials](#zoom-api-credentials)). Tokens expire after 1 hour.
 
 ## Test connectors [zoom-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}. The test verifies connectivity by calling the `/users/me` endpoint and displaying the authenticated user's name.
+
+## Connector actions [zoom-connector-actions]
 
 The Zoom connector has the following actions:
 
@@ -84,7 +86,7 @@ Use *Who am I* to verify the connected user identity. Use *List user recordings*
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [zoom-api-credentials]
+## Get credentials [zoom-api-credentials]
 
 The Zoom connector supports two authentication methods: **OAuth Authorization Code** (recommended) and **Server-to-Server OAuth** (via Bearer token).
 


### PR DESCRIPTION
The connector reference pages had drifted into two generations with no shared skeleton: action catalogs were listed under Test connectors, the actions and credentials sections went by several different names, H1 headings and frontmatter were inconsistent, and some connectors that call external services had no networking section. I applied the standard page template from the issue across the connector pages, keeping every existing anchor so inbound links keep working, and updated docs/action-type-template.md so new pages start from the same skeleton. I left the action parameter content on the traditional alerting and case connectors in place, and kept the Configure sections that describe third party setup rather than credential retrieval, since the issue calls those out as needing separate treatment. Fixes #280455.

I pushed this to my fork first and the project's own CI workflows pass on the commit.
