### PR TITLE
[9.4] [Fleet] Add policy_base_id field to eliminate prefix/wildcard agent policy queries (B2) (#279716)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -27435,6 +27435,8 @@ paths:
                             type: string
                           maxItems: 10000
                           type: array
+                        policy_base_id:
+                          type: string
                         policy_id:
                           type: string
                         policy_revision:
@@ -28082,6 +28084,8 @@ paths:
                           type: string
                         maxItems: 10000
                         type: array
+                      policy_base_id:
+                        type: string
                       policy_id:
                         type: string
                       policy_revision:
@@ -28547,6 +28551,8 @@ paths:
                           type: string
                         maxItems: 10000
                         type: array
+                      policy_base_id:
+                        type: string
                       policy_id:
                         type: string
                       policy_revision:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -30163,6 +30163,8 @@ paths:
                             type: string
                           maxItems: 10000
                           type: array
+                        policy_base_id:
+                          type: string
                         policy_id:
                           type: string
                         policy_revision:
@@ -30810,6 +30812,8 @@ paths:
                           type: string
                         maxItems: 10000
                         type: array
+                      policy_base_id:
+                        type: string
                       policy_id:
                         type: string
                       policy_revision:
@@ -31275,6 +31279,8 @@ paths:
                           type: string
                         maxItems: 10000
                         type: array
+                      policy_base_id:
+                        type: string
                       policy_id:
                         type: string
                       policy_revision:

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -77,7 +77,7 @@ pageLoadAssetSize:
   files: 6037
   filesManagement: 5208
   fileUpload: 22957
-  fleet: 214000
+  fleet: 214010
   genAiSettings: 6400
   globalSearch: 6890
   globalSearchBar: 26122

--- a/x-pack/platform/plugins/shared/fleet/common/constants/mappings.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/mappings.ts
@@ -281,6 +281,9 @@ export const AGENT_MAPPINGS = {
     policy_id: {
       type: 'keyword',
     },
+    policy_base_id: {
+      type: 'keyword',
+    },
     policy_revision_idx: {
       type: 'integer',
     },

--- a/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.test.ts
@@ -15,6 +15,9 @@ import {
   buildVersionVariantsEsFilter,
   buildPolicyIdOrVariantsEsFilter,
   buildPolicyIdsOrVariantsEsFilter,
+  buildPolicyBaseIdWithFallbackEsFilter,
+  buildPolicyBaseIdsWithFallbackEsFilter,
+  buildPolicyBaseIdWithFallbackKuery,
 } from './version_specific_policies_utils';
 
 describe('removeVersionSuffixFromPolicyId', () => {
@@ -247,5 +250,100 @@ describe('buildPolicyIdsOrVariantsEsFilter', () => {
 
   it('should return match_none for an empty array instead of an empty terms clause', () => {
     expect(buildPolicyIdsOrVariantsEsFilter([])).toEqual({ match_none: {} });
+  });
+});
+
+describe('buildPolicyBaseIdWithFallbackKuery', () => {
+  it('should match migrated docs via policy_base_id term', () => {
+    expect(buildPolicyBaseIdWithFallbackKuery('my-policy')).toContain('policy_base_id:"my-policy"');
+  });
+
+  it('should include fallback branch for docs missing policy_base_id', () => {
+    expect(buildPolicyBaseIdWithFallbackKuery('my-policy')).toContain(
+      'policy_id:"my-policy" and not policy_base_id:*'
+    );
+  });
+
+  it('should use custom field names when provided', () => {
+    expect(
+      buildPolicyBaseIdWithFallbackKuery(
+        'my-policy',
+        'fleet-agents.policy_base_id',
+        'fleet-agents.policy_id'
+      )
+    ).toBe(
+      '(fleet-agents.policy_base_id:"my-policy" or (fleet-agents.policy_id:"my-policy" and not fleet-agents.policy_base_id:*))'
+    );
+  });
+
+  it('should escape quotes in the base id', () => {
+    expect(buildPolicyBaseIdWithFallbackKuery('my"policy')).toContain(
+      'policy_base_id:"my\\"policy"'
+    );
+  });
+});
+
+describe('buildPolicyBaseIdWithFallbackEsFilter', () => {
+  it('should match on policy_base_id for migrated docs', () => {
+    const filter = buildPolicyBaseIdWithFallbackEsFilter('my-policy');
+    expect(filter.bool.should[0]).toEqual({ term: { policy_base_id: 'my-policy' } });
+  });
+
+  it('should include a fallback branch for docs missing policy_base_id', () => {
+    const filter = buildPolicyBaseIdWithFallbackEsFilter('my-policy');
+    expect(filter.bool.should[1]).toEqual({
+      bool: {
+        filter: [{ term: { policy_id: 'my-policy' } }],
+        must_not: [{ exists: { field: 'policy_base_id' } }],
+      },
+    });
+  });
+
+  it('should use custom field names when provided', () => {
+    const filter = buildPolicyBaseIdWithFallbackEsFilter(
+      'my-policy',
+      'united.agent.policy_base_id',
+      'united.agent.policy_id'
+    );
+    expect(filter.bool.should[0]).toEqual({ term: { 'united.agent.policy_base_id': 'my-policy' } });
+    expect(filter.bool.should[1]).toEqual({
+      bool: {
+        filter: [{ term: { 'united.agent.policy_id': 'my-policy' } }],
+        must_not: [{ exists: { field: 'united.agent.policy_base_id' } }],
+      },
+    });
+  });
+
+  it('should require minimum_should_match: 1', () => {
+    const filter = buildPolicyBaseIdWithFallbackEsFilter('my-policy');
+    expect(filter.bool.minimum_should_match).toBe(1);
+  });
+});
+
+describe('buildPolicyBaseIdsWithFallbackEsFilter', () => {
+  it('should match on policy_base_id terms for migrated docs', () => {
+    const filter = buildPolicyBaseIdsWithFallbackEsFilter(['policy-a', 'policy-b']);
+    expect((filter as any).bool.should[0]).toEqual({
+      terms: { policy_base_id: ['policy-a', 'policy-b'] },
+    });
+  });
+
+  it('should include a fallback branch for docs missing policy_base_id', () => {
+    const filter = buildPolicyBaseIdsWithFallbackEsFilter(['policy-a', 'policy-b']);
+    expect((filter as any).bool.should[1]).toEqual({
+      bool: {
+        filter: [{ terms: { policy_id: ['policy-a', 'policy-b'] } }],
+        must_not: [{ exists: { field: 'policy_base_id' } }],
+      },
+    });
+  });
+
+  it('should de-duplicate repeated ids', () => {
+    const filter = buildPolicyBaseIdsWithFallbackEsFilter(['policy-a', 'policy-a']);
+    expect((filter as any).bool.should[0]).toEqual({ terms: { policy_base_id: ['policy-a'] } });
+  });
+
+  it('should return match_none for an empty array', () => {
+    expect(buildPolicyBaseIdsWithFallbackEsFilter([])).toEqual({ match_none: {} });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.ts
@@ -134,3 +134,78 @@ export function buildPolicyIdsOrVariantsEsFilter(
     },
   };
 }
+
+// TODO: Remove these two fallback helpers once all fleet-server versions in use populate
+// policy_base_id on agent enrolment. Until then, agents enrolled via an older fleet-server
+// during a mixed-version rollout will lack the field and must be matched via the legacy
+// policy_id exact-term path. No prefix is used so that the query remains compatible with
+// search.allow_expensive_queries:false; versioned policy_id values (e.g. policy-id#9.3)
+// without a policy_base_id can only arise in the narrow window of a mixed-version rollout,
+// and the startup backfill covers all pre-existing documents.
+
+/**
+ * KQL equivalent of {@link buildPolicyBaseIdWithFallbackEsFilter}: matches migrated documents via
+ * `policy_base_id:"id"` and un-migrated documents via `policy_id:"id" and not policy_base_id:*`.
+ * Use this when building a KQL string (e.g. for URL kuery params) instead of an ES DSL filter.
+ */
+export function buildPolicyBaseIdWithFallbackKuery(
+  baseId: string,
+  policyBaseIdField: string = 'policy_base_id',
+  policyIdField: string = DEFAULT_POLICY_ID_FIELD
+): string {
+  const escapedId = escapeQuotes(baseId);
+  return `(${policyBaseIdField}:"${escapedId}" or (${policyIdField}:"${escapedId}" and not ${policyBaseIdField}:*))`;
+}
+
+/**
+ * ES query DSL filter preferring `policy_base_id` for migrated documents, with a legacy
+ * `policy_id` exact-term fallback for documents that pre-date the `policy_base_id` field.
+ */
+export function buildPolicyBaseIdWithFallbackEsFilter(
+  baseId: string,
+  policyBaseIdField: string = 'policy_base_id',
+  policyIdField: string = DEFAULT_POLICY_ID_FIELD
+) {
+  return {
+    bool: {
+      should: [
+        { term: { [policyBaseIdField]: baseId } },
+        {
+          bool: {
+            filter: [{ term: { [policyIdField]: baseId } }],
+            must_not: [{ exists: { field: policyBaseIdField } }],
+          },
+        },
+      ],
+      minimum_should_match: 1,
+    },
+  };
+}
+
+/**
+ * Same as {@link buildPolicyBaseIdWithFallbackEsFilter}, for multiple base policy ids at once.
+ */
+export function buildPolicyBaseIdsWithFallbackEsFilter(
+  baseIds: string[],
+  policyBaseIdField: string = 'policy_base_id',
+  policyIdField: string = DEFAULT_POLICY_ID_FIELD
+) {
+  const uniqueIds = Array.from(new Set(baseIds));
+  if (uniqueIds.length === 0) {
+    return { match_none: {} };
+  }
+  return {
+    bool: {
+      should: [
+        { terms: { [policyBaseIdField]: uniqueIds } },
+        {
+          bool: {
+            filter: [{ terms: { [policyIdField]: uniqueIds } }],
+            must_not: [{ exists: { field: policyBaseIdField } }],
+          },
+        },
+      ],
+      minimum_should_match: 1,
+    },
+  };
+}

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/agent.ts
@@ -118,6 +118,7 @@ interface AgentBase {
   default_api_key?: string;
   default_api_key_id?: string;
   policy_id?: string;
+  policy_base_id?: string;
   policy_revision?: number | null;
   last_checkin?: string;
   last_checkin_status?: 'error' | 'online' | 'degraded' | 'updating' | 'starting' | 'disconnected';
@@ -330,6 +331,10 @@ export interface FleetServerAgent {
    * The policy ID for the Elastic Agent
    */
   policy_id?: string;
+  /**
+   * The base policy ID (policy_id without version suffix) for efficient querying.
+   */
+  policy_base_id?: string;
   /**
    * The current policy revision_idx for the Elastic Agent
    */

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/agent_policy.ts
@@ -321,6 +321,10 @@ export interface FleetServerPolicy {
    */
   policy_id: string;
   /**
+   * The base policy ID (policy_id without version suffix) for efficient querying.
+   */
+  policy_base_id?: string;
+  /**
    * The revision index of the policy
    */
   revision_idx: number;

--- a/x-pack/platform/plugins/shared/fleet/public/components/linked_agent_count.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/linked_agent_count.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { EuiLinkAnchorProps } from '@elastic/eui';
 import { EuiLink } from '@elastic/eui';
 
-import { buildPolicyIdOrVariantsKuery } from '../../common/services/version_specific_policies_utils';
+import { buildPolicyBaseIdWithFallbackKuery } from '../../common/services/version_specific_policies_utils';
 
 import { useLink } from '../hooks';
 import { AGENTS_PREFIX, UNPRIVILEGED_AGENT_KUERY, PRIVILEGED_AGENT_KUERY } from '../constants';
@@ -41,10 +41,12 @@ export const LinkedAgentCount = memo<
     <EuiLink
       {...otherEuiLinkProps}
       href={getHref('agent_list', {
-        // Same as server: exact parent policy or wildcard for version-specific (policy_id: id#*).
-        // encodeURIComponent below ensures # in kuery doesn't break the URL.
         kuery: encodeURIComponent(
-          `${buildPolicyIdOrVariantsKuery(agentPolicyId, `${AGENTS_PREFIX}.policy_id`)}${
+          `${buildPolicyBaseIdWithFallbackKuery(
+            agentPolicyId,
+            `${AGENTS_PREFIX}.policy_base_id`,
+            `${AGENTS_PREFIX}.policy_id`
+          )}${
             privilegeMode
               ? ` and ${
                   privilegeMode === 'unprivileged'

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -137,6 +137,7 @@ describe('fleet usage telemetry', () => {
           last_checkin: '2022-11-21T12:26:24Z',
           active: true,
           policy_id: 'policy1',
+          policy_base_id: 'policy1',
           local_metadata: {
             os: {
               name: 'Ubuntu',
@@ -175,6 +176,7 @@ describe('fleet usage telemetry', () => {
           last_checkin: '2022-11-21T12:27:24Z',
           active: true,
           policy_id: 'policy1',
+          policy_base_id: 'policy1',
           local_metadata: {
             os: {
               name: 'Ubuntu',
@@ -213,6 +215,7 @@ describe('fleet usage telemetry', () => {
           last_checkin: '2021-11-21T12:27:24Z',
           active: false,
           policy_id: 'policy1',
+          policy_base_id: 'policy1',
           local_metadata: {
             os: {
               name: 'Ubuntu',
@@ -243,6 +246,7 @@ describe('fleet usage telemetry', () => {
           last_checkin: new Date(Date.now() - 1000 * 60 * 6).toISOString(),
           active: true,
           policy_id: 'policy2',
+          policy_base_id: 'policy2',
           upgrade_details: {
             target_version: '8.11.0',
             state: 'UPG_ROLLBACK',
@@ -262,6 +266,7 @@ describe('fleet usage telemetry', () => {
           last_checkin: new Date(Date.now() - 1000 * 60 * 6).toISOString(),
           active: true,
           policy_id: 'policy3',
+          policy_base_id: 'policy3',
         },
       ],
       refresh: 'wait_for',

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/agent_policy_agent_count.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/agent_policy_agent_count.ts
@@ -9,7 +9,7 @@ import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 
 import { AGENTS_INDEX } from '../../../common';
-import { buildPolicyIdOrVariantsEsFilter } from '../../../common/services/version_specific_policies_utils';
+import { buildPolicyBaseIdWithFallbackEsFilter } from '../../../common/services/version_specific_policies_utils';
 
 /**
  * Given a list of Agent Policy IDs (parent policy ids), returns the count of active agents
@@ -27,7 +27,7 @@ export const getAgentCountForAgentPolicies = async (
 
   const filters: Record<string, QueryDslQueryContainer> = {};
   for (const policyId of agentPolicyIds) {
-    filters[policyId] = buildPolicyIdOrVariantsEsFilter(policyId);
+    filters[policyId] = buildPolicyBaseIdWithFallbackEsFilter(policyId);
   }
 
   const searchPromise = esClient.search<

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -40,7 +40,6 @@ import { AGENT_POLICY_INDEX, SO_SEARCH_LIMIT } from '../../common';
 import { agentPolicyService } from './agent_policy';
 import { agentPolicyUpdateEventHandler } from './agent_policy_update';
 
-import { getAgentsByKuery } from './agents';
 import { getPackagePolicySavedObjectType, packagePolicyService } from './package_policy';
 import { appContextService } from './app_context';
 import { outputService } from './output';
@@ -897,13 +896,7 @@ describe('Agent policy', () => {
         },
       ] as any);
       esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-
-      (getAgentsByKuery as jest.Mock).mockResolvedValue({
-        agents: [],
-        total: 0,
-        page: 1,
-        perPage: 10,
-      });
+      esClient.count.mockResolvedValue({ count: 0 } as any);
       mockedPackagePolicyService.create.mockReset();
     });
 
@@ -950,12 +943,7 @@ describe('Agent policy', () => {
     });
 
     it('should throw error if active agents are assigned to the policy', async () => {
-      (getAgentsByKuery as jest.Mock).mockResolvedValue({
-        agents: [],
-        total: 2,
-        page: 1,
-        perPage: 10,
-      });
+      esClient.count.mockResolvedValueOnce({ count: 2 } as any);
       await expect(agentPolicyService.delete(soClient, esClient, 'mocked')).rejects.toThrowError(
         'Cannot delete an agent policy that is assigned to any active or inactive agents'
       );

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -51,7 +51,7 @@ import {
 
 import {
   LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
-  AGENTS_PREFIX,
+  AGENTS_INDEX,
   FLEET_AGENT_POLICIES_SCHEMA_VERSION,
   PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE,
   SO_SEARCH_LIMIT,
@@ -128,7 +128,6 @@ import {
 import {
   hasVersionSuffix,
   removeVersionSuffixFromPolicyId,
-  buildPolicyIdOrVariantsKuery,
   buildPolicyIdOrVariantsEsFilter,
 } from '../../common/services/version_specific_policies_utils';
 
@@ -147,7 +146,8 @@ import {
 
 import { bulkInstallPackages, getPackageInfo } from './epm/packages';
 import { ensureInstalledPackage } from './epm/packages/install';
-import { getAgentsByKuery, unenrollForAgentPolicyId } from './agents';
+import { unenrollForAgentPolicyId } from './agents';
+import { getAgentCountForAgentPolicies } from './agent_policies/agent_policy_agent_count';
 import {
   buildCurrentRevisionFilter,
   getCompiledVersionsForAgentPolicy,
@@ -970,16 +970,11 @@ class AgentPolicyService {
               (await packagePolicyService.findAllForAgentPolicy(soClient, agentPolicy.id)) || [];
           }
           if (options.withAgentCount) {
-            const policyKuery = buildPolicyIdOrVariantsKuery(
-              agentPolicy.id,
-              `${AGENTS_PREFIX}.policy_id`
+            const counts = await getAgentCountForAgentPolicies(
+              appContextService.getInternalUserESClient(),
+              [agentPolicy.id]
             );
-            await getAgentsByKuery(appContextService.getInternalUserESClient(), soClient, {
-              showInactive: true,
-              perPage: 0,
-              page: 1,
-              kuery: policyKuery,
-            }).then(({ total }) => (agentPolicy.agents = total));
+            agentPolicy.agents = counts[agentPolicy.id] ?? 0;
           } else {
             agentPolicy.agents = 0;
           }
@@ -1646,14 +1641,16 @@ class AgentPolicyService {
       throw new HostedAgentPolicyRestrictionRelatedError(`Cannot delete hosted agent policy ${id}`);
     }
 
-    // Prevent deleting policy when assigned agents are inactive. Also matches agents on
-    // version-specific variants of this policy (e.g. `id#9.2`), which would otherwise be
-    // missed since their policy_id is not an exact match.
-    const { total } = await getAgentsByKuery(esClient, soClient, {
-      showInactive: true,
-      perPage: 0,
-      page: 1,
-      kuery: buildPolicyIdOrVariantsKuery(id, `${AGENTS_PREFIX}.policy_id`),
+    // Prevent deleting policy when assigned agents are inactive. active:true covers
+    // online, offline, and inactive agents; active:false is unenrolled.
+    const { count: total } = await esClient.count({
+      index: AGENTS_INDEX,
+      ignore_unavailable: true,
+      query: {
+        bool: {
+          filter: [{ term: { active: 'true' } }, buildPolicyIdOrVariantsEsFilter(id)],
+        },
+      },
     });
 
     if (total > 0 && !agentPolicy?.supports_agentless) {
@@ -1883,6 +1880,7 @@ class AgentPolicyService {
             namespaces: fullPolicy.namespaces,
             data: fullPolicy as unknown as FleetServerPolicy['data'],
             policy_id: fullPolicy.id,
+            policy_base_id: fullPolicy.id,
             default_fleet_server: policy.is_default_fleet_server === true,
           };
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.test.ts
@@ -862,16 +862,13 @@ describe('getAgentVersionsForAgentPolicyIds', () => {
         query: {
           bool: {
             filter: [
-              {
-                bool: {
-                  should: [
-                    { terms: { policy_id: ['policy-a', 'policy-b'] } },
-                    { prefix: { policy_id: 'policy-a#' } },
-                    { prefix: { policy_id: 'policy-b#' } },
-                  ],
-                  minimum_should_match: 1,
-                },
-              },
+              expect.objectContaining({
+                bool: expect.objectContaining({
+                  should: expect.arrayContaining([
+                    { terms: { policy_base_id: ['policy-a', 'policy-b'] } },
+                  ]),
+                }),
+              }),
             ],
           },
         },

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
@@ -21,8 +21,8 @@ import { ALL_SPACES_ID, SO_SEARCH_LIMIT } from '../../../common/constants';
 import { getSortConfig } from '../../../common';
 import { isAgentUpgradeAvailable } from '../../../common/services';
 import {
-  buildPolicyIdsOrVariantsEsFilter,
   removeVersionSuffixFromPolicyId,
+  buildPolicyBaseIdsWithFallbackEsFilter,
 } from '../../../common/services/version_specific_policies_utils';
 import { AGENTS_INDEX, LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE } from '../../constants';
 import {
@@ -685,9 +685,7 @@ export async function getAgentVersionsForAgentPolicyIds(
       >({
         query: {
           bool: {
-            // Also matches agents on version-specific variants of the given policies
-            // (e.g. `id#9.2`), which would otherwise be missed by an exact terms match.
-            filter: [buildPolicyIdsOrVariantsEsFilter(agentPolicyIds)],
+            filter: [buildPolicyBaseIdsWithFallbackEsFilter(agentPolicyIds)],
           },
         },
         index: AGENTS_INDEX,
@@ -695,9 +693,13 @@ export async function getAgentVersionsForAgentPolicyIds(
       })
     );
 
-    // Group by base policy id so version-specific variants roll up under their parent policy.
-    const groupedHits = groupBy(hits, (hit) =>
-      hit._source?.policy_id ? removeVersionSuffixFromPolicyId(hit._source.policy_id) : undefined
+    const groupedHits = groupBy(
+      hits,
+      (hit) =>
+        hit._source?.policy_base_id ??
+        (hit._source?.policy_id
+          ? removeVersionSuffixFromPolicyId(hit._source.policy_id)
+          : undefined)
     );
 
     for (const [policyId, policyHits] of Object.entries(groupedHits)) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/helpers.ts
@@ -73,6 +73,7 @@ export function searchHitToAgent(
     access_api_key_id: hit._source?.access_api_key_id,
     default_api_key_id: hit._source?.default_api_key_id,
     policy_id: hit._source?.policy_id,
+    policy_base_id: hit._source?.policy_base_id,
     last_checkin: hit._source?.last_checkin,
     last_checkin_status:
       hit._source?.last_checkin_status?.toLowerCase() as Agent['last_checkin_status'],

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.ts
@@ -19,6 +19,7 @@ import {
 import { SO_SEARCH_LIMIT } from '../../constants';
 import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
+import { removeVersionSuffixFromPolicyId } from '../../../common/services/version_specific_policies_utils';
 
 import {
   getAgentsById,
@@ -76,6 +77,7 @@ export async function reassignAgent(
 
   await updateAgent(esClient, agentId, {
     policy_id: newAgentPolicyId,
+    policy_base_id: removeVersionSuffixFromPolicyId(newAgentPolicyId),
     policy_revision: null,
     ...(newAgentPolicy?.space_ids ? { namespaces: newAgentPolicy.space_ids } : {}),
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign_action_runner.ts
@@ -14,6 +14,7 @@ import { AgentReassignmentError, HostedAgentPolicyRestrictionRelatedError } from
 import { appContextService } from '../app_context';
 
 import { agentPolicyService } from '../agent_policy';
+import { removeVersionSuffixFromPolicyId } from '../../../common/services/version_specific_policies_utils';
 
 import { ActionRunner } from './action_runner';
 
@@ -84,6 +85,7 @@ export async function reassignBatch(
       agentId: agent.id,
       data: {
         policy_id: options.newAgentPolicyId,
+        policy_base_id: removeVersionSuffixFromPolicyId(options.newAgentPolicyId),
         policy_revision: null,
         ...(newAgentPolicy?.space_ids ? { namespaces: newAgentPolicy.space_ids } : {}),
       },

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.test.ts
@@ -215,14 +215,9 @@ describe('getAgentStatusForAgentPolicy', () => {
           bool: expect.objectContaining({
             must: expect.arrayContaining([
               expect.objectContaining({
-                bool: {
-                  should: [
-                    { terms: { policy_id: agentPolicyIds } },
-                    { prefix: { policy_id: 'agentPolicyId1#' } },
-                    { prefix: { policy_id: 'agentPolicyId2#' } },
-                  ],
-                  minimum_should_match: 1,
-                },
+                bool: expect.objectContaining({
+                  should: expect.arrayContaining([{ terms: { policy_base_id: agentPolicyIds } }]),
+                }),
               }),
             ]),
           }),
@@ -265,13 +260,9 @@ describe('getAgentStatusForAgentPolicy', () => {
           bool: expect.objectContaining({
             must: expect.arrayContaining([
               expect.objectContaining({
-                bool: {
-                  should: [
-                    { term: { policy_id: 'agentPolicyId' } },
-                    { prefix: { policy_id: 'agentPolicyId#' } },
-                  ],
-                  minimum_should_match: 1,
-                },
+                bool: expect.objectContaining({
+                  should: expect.arrayContaining([{ term: { policy_base_id: 'agentPolicyId' } }]),
+                }),
               }),
             ]),
           }),

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
@@ -17,16 +17,17 @@ import type {
 
 import { ALL_SPACES_ID } from '../../../common/constants';
 import { agentStatusesToSummary } from '../../../common/services';
-import {
-  buildPolicyIdOrVariantsEsFilter,
-  buildPolicyIdsOrVariantsEsFilter,
-} from '../../../common/services/version_specific_policies_utils';
 import { AGENTS_INDEX } from '../../constants';
 import type { AgentStatus } from '../../types';
 import { FleetError, FleetUnauthorizedError } from '../../errors';
 import { appContextService } from '../app_context';
 import { isSpaceAwarenessEnabled } from '../spaces/helpers';
 import { retryTransientEsErrors } from '../epm/elasticsearch/retry';
+
+import {
+  buildPolicyBaseIdWithFallbackEsFilter,
+  buildPolicyBaseIdsWithFallbackEsFilter,
+} from '../../../common/services/version_specific_policies_utils';
 
 import { DEFAULT_NAMESPACES_FILTER } from '../spaces/agent_namespaces';
 
@@ -90,12 +91,10 @@ export async function getAgentStatusForAgentPolicy(
     );
     clauses.push(kueryAsElasticsearchQuery);
   }
-  // If agentPolicyIds is provided, we filter by those, otherwise we filter by deprecated agentPolicyId.
-  // Also matches agents on version-specific variants of the given policies (e.g. `id#9.2`).
   if (agentPolicyIds) {
-    clauses.push(buildPolicyIdsOrVariantsEsFilter(agentPolicyIds));
+    clauses.push(buildPolicyBaseIdsWithFallbackEsFilter(agentPolicyIds));
   } else if (agentPolicyId) {
-    clauses.push(buildPolicyIdOrVariantsEsFilter(agentPolicyId));
+    clauses.push(buildPolicyBaseIdWithFallbackEsFilter(agentPolicyId));
   }
 
   const query =

--- a/x-pack/platform/plugins/shared/fleet/server/services/backfill_policy_base_id.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/backfill_policy_base_id.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+import {
+  AGENT_POLICY_INDEX,
+  AGENTS_INDEX,
+  AGENT_POLICY_VERSION_SEPARATOR,
+} from '../../common/constants';
+
+import { appContextService } from '.';
+
+// Painless: strip version suffix from policy_id and store as policy_base_id.
+// Mirrors removeVersionSuffixFromPolicyId: only strips when the segment after the last
+// separator looks like a version (digits.digits). Painless regex is off by default so
+// we use a plain digit walk instead. Skips docs that already have policy_base_id (idempotent).
+const BACKFILL_SCRIPT = `
+  if (ctx._source.policy_id == null ||
+      (ctx._source.containsKey('policy_base_id') && ctx._source.policy_base_id != null)) {
+    ctx.op = 'noop';
+    return;
+  }
+  String pid = ctx._source.policy_id;
+  int sepIdx = pid.lastIndexOf(params.separator);
+  if (sepIdx >= 0) {
+    String suffix = pid.substring(sepIdx + 1);
+    int dotIdx = suffix.indexOf('.');
+    boolean isVersion = dotIdx > 0 && suffix.length() > dotIdx + 1;
+    if (isVersion) {
+      for (int i = 0; i < suffix.length(); i++) {
+        if (i != dotIdx && !Character.isDigit(suffix.charAt(i))) { isVersion = false; break; }
+      }
+    }
+    ctx._source.policy_base_id = isVersion ? pid.substring(0, sepIdx) : pid;
+  } else {
+    ctx._source.policy_base_id = pid;
+  }
+`.trim();
+
+async function runBackfill(esClient: ElasticsearchClient, index: string, label: string) {
+  const logger = appContextService.getLogger();
+  try {
+    const result = await esClient.updateByQuery({
+      index,
+      ignore_unavailable: true,
+      conflicts: 'proceed',
+      script: {
+        lang: 'painless',
+        source: BACKFILL_SCRIPT,
+        params: { separator: AGENT_POLICY_VERSION_SEPARATOR },
+      },
+      query: {
+        bool: {
+          must: [{ exists: { field: 'policy_id' } }],
+          must_not: [{ exists: { field: 'policy_base_id' } }],
+        },
+      },
+    });
+    logger.debug(
+      `Backfilled policy_base_id on ${result.updated ?? 0} ${label} documents (${
+        result.noops ?? 0
+      } noops)`
+    );
+  } catch (err) {
+    logger.warn(
+      `Failed to backfill policy_base_id on ${label}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    throw err;
+  }
+}
+
+export async function backfillPolicyBaseId(esClient: ElasticsearchClient) {
+  await Promise.all([
+    runBackfill(esClient, AGENTS_INDEX, 'fleet-agents'),
+    runBackfill(esClient, AGENT_POLICY_INDEX, 'fleet-policies'),
+  ]);
+}

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
@@ -60,6 +60,7 @@ import {
   getPreconfiguredDeleteUnenrolledAgentsSettingFromConfig,
 } from './preconfiguration/delete_unenrolled_agent_setting';
 import { backfillPackagePolicySupportsAgentless } from './backfill_agentless';
+import { backfillPolicyBaseId } from './backfill_policy_base_id';
 import { updateDeprecatedComponentTemplates } from './setup/update_deprecated_component_templates';
 import { createCCSIndexPatterns } from './setup/fleet_synced_integrations';
 import { ensureCorrectAgentlessSettingsIds } from './agentless_settings_ids';
@@ -299,6 +300,14 @@ async function createSetupSideEffects(
     ensureCorrectAgentlessSettingsIdsError = { error };
   }
 
+  let backfillPolicyBaseIdError;
+  try {
+    logger.debug('Backfilling policy_base_id on fleet-agents and fleet-policies');
+    await backfillPolicyBaseId(esClient);
+  } catch (error) {
+    backfillPolicyBaseIdError = { error };
+  }
+
   logger.debug('Update deprecated _source.mode in component templates');
   await updateDeprecatedComponentTemplates(esClient);
 
@@ -313,6 +322,7 @@ async function createSetupSideEffects(
       ? [backfillPackagePolicySupportsAgentlessError]
       : []),
     ...(ensureCorrectAgentlessSettingsIdsError ? [ensureCorrectAgentlessSettingsIdsError] : []),
+    ...(backfillPolicyBaseIdError ? [backfillPolicyBaseIdError] : []),
   ];
 
   logger.info('Scheduling async setup tasks');

--- a/x-pack/platform/plugins/shared/fleet/server/services/utils/version_specific_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/utils/version_specific_policies.test.ts
@@ -82,18 +82,21 @@ describe('getVersionSpecificPolicies', () => {
           ],
         },
         policy_id: 'policy1#9.3',
+        policy_base_id: 'policy1',
       },
       {
         data: {
           inputs: [],
         },
         policy_id: 'policy1#9.2',
+        policy_base_id: 'policy1',
       },
       {
         data: {
           inputs: [],
         },
         policy_id: 'policy1#8.9',
+        policy_base_id: 'policy1',
       },
     ]);
   });
@@ -126,12 +129,14 @@ describe('getVersionSpecificPolicies', () => {
           ],
         },
         policy_id: 'policy1#9.4',
+        policy_base_id: 'policy1',
       },
       {
         data: {
           inputs: [],
         },
         policy_id: 'policy1#9.1',
+        policy_base_id: 'policy1',
       },
     ]);
   });
@@ -151,6 +156,7 @@ describe('getVersionSpecificPolicies', () => {
           ],
         },
         policy_id: 'policy1#9.3',
+        policy_base_id: 'policy1',
       },
       {
         data: {
@@ -161,12 +167,14 @@ describe('getVersionSpecificPolicies', () => {
           ],
         },
         policy_id: 'policy1#9.2',
+        policy_base_id: 'policy1',
       },
       {
         data: {
           inputs: [],
         },
         policy_id: 'policy1#8.9',
+        policy_base_id: 'policy1',
       },
     ]);
   });
@@ -188,6 +196,7 @@ describe('getVersionSpecificPolicies', () => {
           ],
         },
         policy_id: 'policy1#9.4',
+        policy_base_id: 'policy1',
       },
       {
         data: {
@@ -198,6 +207,7 @@ describe('getVersionSpecificPolicies', () => {
           ],
         },
         policy_id: 'policy1#9.1',
+        policy_base_id: 'policy1',
       },
     ]);
   });
@@ -225,6 +235,7 @@ describe('getVersionSpecificPolicies', () => {
           ],
         },
         policy_id: 'policyBothConditions#9.3',
+        policy_base_id: 'policyBothConditions',
       },
       {
         data: {
@@ -235,12 +246,14 @@ describe('getVersionSpecificPolicies', () => {
           ],
         },
         policy_id: 'policyBothConditions#9.2',
+        policy_base_id: 'policyBothConditions',
       },
       {
         data: {
           inputs: [],
         },
         policy_id: 'policyBothConditions#8.9',
+        policy_base_id: 'policyBothConditions',
       },
     ]);
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/utils/version_specific_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/utils/version_specific_policies.ts
@@ -76,6 +76,7 @@ export async function getVersionSpecificPolicies(
     const versionSpecificPolicy: FleetServerPolicy = {
       ...fleetServerPolicy,
       policy_id: `${fullPolicy.id}${AGENT_POLICY_VERSION_SEPARATOR}${version}`,
+      policy_base_id: fullPolicy.id,
       data: {
         ...fleetServerPolicy.data,
         inputs: getInputsForVersion(updatedFullPolicy?.inputs ?? fullPolicy.inputs, version),

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent.ts
@@ -298,6 +298,7 @@ export const AgentResponseSchema = schema.object({
   default_api_key: schema.maybe(schema.string()),
   default_api_key_id: schema.maybe(schema.string()),
   policy_id: schema.maybe(schema.string()),
+  policy_base_id: schema.maybe(schema.string()),
   policy_revision: schema.maybe(schema.oneOf([schema.literal(null), schema.number()])),
   last_checkin: schema.maybe(schema.string()),
   last_checkin_status: schema.maybe(

--- a/x-pack/platform/plugins/shared/fleet/server/types/so_attributes.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/so_attributes.ts
@@ -101,6 +101,7 @@ export interface AgentSOAttributes {
   default_api_key?: string;
   default_api_key_id?: string;
   policy_id?: string;
+  policy_base_id?: string;
   policy_revision?: number | null;
   last_checkin?: string;
   last_checkin_status?: 'error' | 'online' | 'degraded' | 'updating' | 'disconnected';

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/index.js
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/index.js
@@ -17,6 +17,7 @@ export default function loadTests({ loadTestFile }) {
     loadTestFile(require.resolve('./agent_policy_outputs'));
     loadTestFile(require.resolve('./cleanup_agent_policy_revisions'));
     loadTestFile(require.resolve('./version_specific_policies'));
+    loadTestFile(require.resolve('./policy_base_id'));
     loadTestFile(require.resolve('./agent_policy_otel_routing'));
     loadTestFile(require.resolve('./agent_policy_otel_output'));
     loadTestFile(require.resolve('./agent_policy_otel_overrides'));

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/policy_base_id.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/policy_base_id.ts
@@ -1,0 +1,326 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { AGENTS_INDEX, AGENT_POLICY_INDEX } from '@kbn/fleet-plugin/common';
+import { skipIfNoDockerRegistry } from '../../helpers';
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const esArchiver = getService('esArchiver');
+  const fleetAndAgents = getService('fleetAndAgents');
+  const kibanaServer = getService('kibanaServer');
+
+  describe('fleet_policy_base_id', () => {
+    skipIfNoDockerRegistry(providerContext);
+
+    // ─── policy_base_id on .fleet-policies documents ──────────────────────────
+
+    describe('policy_base_id on .fleet-policies documents', () => {
+      let agentPolicyId: string;
+
+      before(async () => {
+        await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+        await kibanaServer.savedObjects.cleanStandardList();
+        await fleetAndAgents.setup();
+
+        const { body } = await supertest
+          .post('/api/fleet/agent_policies')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ name: 'policy_base_id doc test', namespace: 'default', force: true })
+          .expect(200);
+        agentPolicyId = body.item.id;
+      });
+
+      after(async () => {
+        await supertest
+          .post('/api/fleet/agent_policies/delete')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ agentPolicyId })
+          .expect(200);
+        await esArchiver.unload(
+          'x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server'
+        );
+      });
+
+      it('should set policy_base_id on .fleet-policies documents equal to base policy id', async () => {
+        const result = await es.search({
+          index: AGENT_POLICY_INDEX,
+          query: { term: { policy_id: agentPolicyId } },
+        });
+
+        expect(result.hits.hits.length).to.be.greaterThan(0);
+        for (const hit of result.hits.hits) {
+          const source = hit._source as any;
+          expect(source.policy_base_id).to.eql(agentPolicyId);
+        }
+      });
+
+      it('should set policy_base_id to the base id on versioned .fleet-policies documents', async () => {
+        const versionedId = `${agentPolicyId}#9.3`;
+
+        // Simulate a versioned policy doc as written by version_specific_policies.ts
+        await es.index({
+          index: AGENT_POLICY_INDEX,
+          document: {
+            policy_id: versionedId,
+            policy_base_id: agentPolicyId,
+            revision_idx: 1,
+            data: { inputs: [] },
+            default_fleet_server: false,
+          },
+          refresh: 'wait_for',
+        });
+
+        const result = await es.search({
+          index: AGENT_POLICY_INDEX,
+          query: { term: { policy_id: versionedId } },
+        });
+
+        expect(result.hits.hits.length).to.eql(1);
+        expect((result.hits.hits[0]._source as any).policy_base_id).to.eql(agentPolicyId);
+      });
+    });
+
+    // ─── agent count queries via policy_base_id ───────────────────────────────
+
+    describe('agent count queries via policy_base_id', () => {
+      let agentPolicyId: string;
+      const baseAgentId = `test-base-pbi-${Date.now()}`;
+      const versionedAgentId = `test-versioned-pbi-${Date.now()}`;
+
+      before(async () => {
+        await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+        await kibanaServer.savedObjects.cleanStandardList();
+        await fleetAndAgents.setup();
+
+        const { body } = await supertest
+          .post('/api/fleet/agent_policies')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ name: 'policy_base_id count test', namespace: 'default', force: true })
+          .expect(200);
+        agentPolicyId = body.item.id;
+
+        // Agent on the base policy_id, with policy_base_id set
+        await es.index({
+          index: AGENTS_INDEX,
+          id: baseAgentId,
+          document: {
+            active: true,
+            policy_id: agentPolicyId,
+            policy_base_id: agentPolicyId,
+            last_checkin: new Date().toISOString(),
+            last_checkin_status: 'online',
+            type: 'PERMANENT',
+            agent: { version: '9.0.0' },
+          },
+          refresh: 'wait_for',
+        });
+
+        // Agent on a versioned policy_id, but correct policy_base_id
+        await es.index({
+          index: AGENTS_INDEX,
+          id: versionedAgentId,
+          document: {
+            active: true,
+            policy_id: `${agentPolicyId}#9.3`,
+            policy_base_id: agentPolicyId,
+            last_checkin: new Date().toISOString(),
+            last_checkin_status: 'online',
+            type: 'PERMANENT',
+            agent: { version: '9.3.0' },
+          },
+          refresh: 'wait_for',
+        });
+      });
+
+      after(async () => {
+        await es.delete({ index: AGENTS_INDEX, id: baseAgentId, refresh: true }).catch(() => {});
+        await es
+          .delete({ index: AGENTS_INDEX, id: versionedAgentId, refresh: true })
+          .catch(() => {});
+        await supertest
+          .post('/api/fleet/agent_policies/delete')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ agentPolicyId })
+          .expect(200);
+        await esArchiver.unload(
+          'x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server'
+        );
+      });
+
+      it('should count agents on base and versioned policies via policy_base_id when fetching policy', async () => {
+        const { body } = await supertest
+          .get(`/api/fleet/agent_policies/${agentPolicyId}`)
+          .expect(200);
+        expect(body.item.agents).to.eql(2);
+      });
+
+      it('should count agents via policy_base_id when listing policies with withAgentCount', async () => {
+        const { body } = await supertest
+          .get('/api/fleet/agent_policies?withAgentCount=true&perPage=100')
+          .expect(200);
+        const policy = body.items.find((p: any) => p.id === agentPolicyId);
+        expect(policy).to.be.ok();
+        expect(policy.agents).to.eql(2);
+      });
+    });
+
+    // ─── fallback for agents without policy_base_id ───────────────────────────
+
+    describe('fallback for agents without policy_base_id (old fleet-server)', () => {
+      let agentPolicyId: string;
+      const legacyAgentId = `test-legacy-pbi-${Date.now()}`;
+
+      before(async () => {
+        await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+        await kibanaServer.savedObjects.cleanStandardList();
+        await fleetAndAgents.setup();
+
+        const { body } = await supertest
+          .post('/api/fleet/agent_policies')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ name: 'policy_base_id fallback test', namespace: 'default', force: true })
+          .expect(200);
+        agentPolicyId = body.item.id;
+
+        // Agent enrolled via old fleet-server: has policy_id but no policy_base_id
+        await es.index({
+          index: AGENTS_INDEX,
+          id: legacyAgentId,
+          document: {
+            active: true,
+            policy_id: agentPolicyId,
+            // policy_base_id intentionally absent
+            last_checkin: new Date().toISOString(),
+            last_checkin_status: 'online',
+            type: 'PERMANENT',
+            agent: { version: '9.0.0' },
+          },
+          refresh: 'wait_for',
+        });
+      });
+
+      after(async () => {
+        await es.delete({ index: AGENTS_INDEX, id: legacyAgentId, refresh: true }).catch(() => {});
+        await supertest
+          .post('/api/fleet/agent_policies/delete')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ agentPolicyId })
+          .expect(200);
+        await esArchiver.unload(
+          'x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server'
+        );
+      });
+
+      it('should count agents without policy_base_id via policy_id fallback', async () => {
+        const { body } = await supertest
+          .get(`/api/fleet/agent_policies/${agentPolicyId}`)
+          .expect(200);
+        expect(body.item.agents).to.eql(1);
+      });
+    });
+
+    // ─── backfill on Fleet setup ───────────────────────────────────────────────
+
+    describe('policy_base_id backfill on Fleet setup', () => {
+      const agentId = `test-backfill-pbi-${Date.now()}`;
+      const versionedAgentId = `test-backfill-versioned-pbi-${Date.now()}`;
+      const hashNonVersionAgentId = `test-backfill-hash-pbi-${Date.now()}`;
+
+      before(async () => {
+        await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+        await fleetAndAgents.setup();
+
+        // Insert agents without policy_base_id to simulate old fleet-server enrollment
+        await es.index({
+          index: AGENTS_INDEX,
+          id: agentId,
+          document: {
+            active: true,
+            policy_id: 'backfill-test-policy',
+            last_checkin: new Date().toISOString(),
+            type: 'PERMANENT',
+            agent: { version: '9.0.0' },
+          },
+          refresh: 'wait_for',
+        });
+
+        await es.index({
+          index: AGENTS_INDEX,
+          id: versionedAgentId,
+          document: {
+            active: true,
+            policy_id: 'backfill-test-policy#9.3',
+            last_checkin: new Date().toISOString(),
+            type: 'PERMANENT',
+            agent: { version: '9.3.0' },
+          },
+          refresh: 'wait_for',
+        });
+
+        // Agent whose policy_id contains '#' but NOT a version suffix (e.g. 'foo#bar').
+        // policy_base_id should equal the full policy_id, not just the part before '#'.
+        await es.index({
+          index: AGENTS_INDEX,
+          id: hashNonVersionAgentId,
+          document: {
+            active: true,
+            policy_id: 'backfill-test-policy#notaversion',
+            last_checkin: new Date().toISOString(),
+            type: 'PERMANENT',
+            agent: { version: '9.0.0' },
+          },
+          refresh: 'wait_for',
+        });
+
+        // Trigger Fleet setup to run the self-limiting backfill
+        await supertest.post('/api/fleet/setup').set('kbn-xsrf', 'xxxx').expect(200);
+      });
+
+      after(async () => {
+        await es.delete({ index: AGENTS_INDEX, id: agentId, refresh: true }).catch(() => {});
+        await es
+          .delete({ index: AGENTS_INDEX, id: versionedAgentId, refresh: true })
+          .catch(() => {});
+        await es
+          .delete({ index: AGENTS_INDEX, id: hashNonVersionAgentId, refresh: true })
+          .catch(() => {});
+        await esArchiver.unload(
+          'x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server'
+        );
+      });
+
+      it('should populate policy_base_id on agents missing the field after setup', async () => {
+        const agent = await es.get({ index: AGENTS_INDEX, id: agentId });
+        expect((agent._source as any).policy_base_id).to.eql('backfill-test-policy');
+      });
+
+      it('should strip version suffix when populating policy_base_id', async () => {
+        const agent = await es.get({ index: AGENTS_INDEX, id: versionedAgentId });
+        expect((agent._source as any).policy_base_id).to.eql('backfill-test-policy');
+      });
+
+      it('should not strip # segments that are not a version suffix', async () => {
+        const agent = await es.get({ index: AGENTS_INDEX, id: hashNonVersionAgentId });
+        expect((agent._source as any).policy_base_id).to.eql('backfill-test-policy#notaversion');
+      });
+
+      it('should not backfill agents that already have policy_base_id on subsequent setup calls', async () => {
+        // Run setup again — self-limiting query should process 0 docs
+        await supertest.post('/api/fleet/setup').set('kbn-xsrf', 'xxxx').expect(200);
+
+        // Agents should still have correct policy_base_id (unchanged)
+        const agent = await es.get({ index: AGENTS_INDEX, id: agentId });
+        expect((agent._source as any).policy_base_id).to.eql('backfill-test-policy');
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/helpers.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/helpers.ts
@@ -17,6 +17,7 @@ import {
   AGENTS_INDEX,
   type FleetServerAgent,
 } from '@kbn/fleet-plugin/common';
+import { removeVersionSuffixFromPolicyId } from '@kbn/fleet-plugin/common/services';
 import { ENROLLMENT_API_KEYS_INDEX } from '@kbn/fleet-plugin/common/constants';
 import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 
@@ -145,6 +146,7 @@ export async function createFleetAgent(
         access_api_key_id: 'api-key-3',
         active: true,
         policy_id: agentPolicyId,
+        policy_base_id: removeVersionSuffixFromPolicyId(agentPolicyId),
         policy_revision_idx: 1,
         last_checkin_status: 'online',
         type: 'PERMANENT',

--- a/x-pack/platform/test/fleet_api_integration/helpers.ts
+++ b/x-pack/platform/test/fleet_api_integration/helpers.ts
@@ -7,7 +7,10 @@
 
 import * as uuid from 'uuid';
 import type { ToolingLog } from '@kbn/tooling-log';
-import { agentPolicyRouteService } from '@kbn/fleet-plugin/common/services';
+import {
+  agentPolicyRouteService,
+  removeVersionSuffixFromPolicyId,
+} from '@kbn/fleet-plugin/common/services';
 import { GLOBAL_SETTINGS_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common/constants';
 import type {
   AgentPolicy,
@@ -124,6 +127,7 @@ export async function generateAgent(
       enrolled_at: new Date().toISOString(),
       last_checkin: new Date().toISOString(),
       policy_id: policyId,
+      policy_base_id: removeVersionSuffixFromPolicyId(policyId),
       policy_revision: 1,
       agent: {
         id,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[Fleet] Add policy_base_id field to eliminate prefix/wildcard agent policy queries (B2) (#279716)](https://github.com/elastic/kibana/pull/279716)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":279716,"url":"https://github.com/elastic/kibana/pull/279716","title":"[Fleet] Add policy_base_id field to eliminate prefix/wildcard agent policy queries (B2)"},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"sourceCommit":{"sha":"83bf19763c00e563edd02e6ffcb9282e8be5d522"}}] BACKPORT-->