### PR TITLE
[9.5] [Lens as code] Fix ad hoc data view resolution for XY annotation layers (#281079)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
@@ -59,6 +59,24 @@ function setSeriesType(attributes: LensAttributes, seriesType: 'bar' | 'line' | 
   };
 }
 
+type AnnotationApiLayer = Extract<XYConfigNoESQL['layers'][number], { type: 'annotations' }>;
+
+// Builds an XY API config whose annotation layer points at the given
+// data_source. Reuses annotationXY so every defaulted field is present and only
+// the annotation layer's data_source is swapped.
+function withAnnotationDataSource(
+  builder: LensConfigBuilder,
+  dataSource: AnnotationApiLayer['data_source']
+): XYConfigNoESQL {
+  const api = builder.toAPIFormat(annotationXY) as XYConfigNoESQL;
+  return {
+    ...api,
+    layers: api.layers.map((layer) =>
+      layer.type === 'annotations' ? { ...layer, data_source: dataSource } : layer
+    ),
+  };
+}
+
 describe('XY', () => {
   describe('state transform validation', () => {
     describe('Data only', () => {
@@ -311,33 +329,24 @@ describe('XY', () => {
         );
       });
 
-      // A query annotation layer can reference its own ad hoc data view (inline
-      // spec). It must round-trip as an `xy-visualization-layer-` reference (type
-      // index-pattern) pointing at the ad hoc data view id, matching Lens's own
-      // persistence, so the runtime resolves the correct data view instead of
-      // falling back to the data layers' one.
-      it('round-trips an ad hoc data view for a query annotation layer', () => {
+      // Regression test for https://github.com/elastic/kibana/issues/280977
+      //
+      // A query annotation layer that uses an inline (ad hoc) data view must
+      // round-trip through state and back:
+      //   - API -> state: the `xy-visualization-layer-<layerId>` reference lives in
+      //     `state.internalReferences` (not the top-level `references`) and points
+      //     at an ad hoc data view in `adHocDataViews`, matching Lens's own
+      //     persistence so the runtime resolves the correct data view.
+      //   - state -> API: the reference must be resolved from `internalReferences`
+      //     and the inline `data_view_spec` re-emitted, instead of throwing
+      //     "cannot find data view ID for annotation layer".
+      it('round-trips an inline (ad hoc) data view for a query annotation layer', () => {
         const builder = new LensConfigBuilder(undefined, true);
-        // annotationXY is a DSL chart with a query annotation layer; reuse it so
-        // every defaulted field is present, then point the annotation layer at its
-        // own ad hoc data view.
-        const api = builder.toAPIFormat(annotationXY) as XYConfigNoESQL;
-
-        const apiConfig: XYConfigNoESQL = {
-          ...api,
-          layers: api.layers.map((layer) =>
-            layer.type === 'annotations'
-              ? {
-                  ...layer,
-                  data_source: {
-                    type: AS_CODE_DATA_VIEW_SPEC_TYPE,
-                    index_pattern: 'annotations-*',
-                    time_field: '@timestamp',
-                  },
-                }
-              : layer
-          ),
-        };
+        const apiConfig = withAnnotationDataSource(builder, {
+          type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+          index_pattern: 'annotations-*',
+          time_field: '@timestamp',
+        });
 
         const lensState = builder.fromAPIFormat(apiConfig);
 
@@ -349,7 +358,8 @@ describe('XY', () => {
         );
         expect(annotationLayer).toBeDefined();
 
-        // Ad hoc data view references are stored in internalReferences.
+        // Ad hoc data view references are stored in internalReferences, pointing at
+        // an entry in adHocDataViews.
         const internalReferences = lensState.state.internalReferences ?? [];
         const annotationReference = internalReferences.find(
           (ref) => ref.name === `xy-visualization-layer-${annotationLayer?.layerId}`
@@ -357,10 +367,46 @@ describe('XY', () => {
         expect(annotationReference).toBeDefined();
         expect(annotationReference?.type).toBe('index-pattern');
 
-        // The reference must point at the ad hoc data view present in adHocDataViews.
         const adHocDataViews = lensState.state.adHocDataViews ?? {};
         expect(annotationReference?.id).toBeDefined();
         expect(Object.keys(adHocDataViews)).toContain(annotationReference?.id);
+
+        // Reading the state back to API must resolve the internalReferences entry
+        // and re-emit the inline data view spec.
+        const roundTripped = builder.toAPIFormat(lensState) as XYConfigNoESQL;
+        const roundTrippedAnnotationLayer = roundTripped.layers.find(
+          (layer) => layer.type === 'annotations'
+        );
+        expect(roundTrippedAnnotationLayer?.data_source).toEqual(
+          expect.objectContaining({
+            type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+            index_pattern: 'annotations-*',
+            time_field: '@timestamp',
+          })
+        );
+      });
+
+      // Guards the by-reference (persisted data view) branch through the full
+      // builder: a query annotation layer pointing at a persisted data view must
+      // round-trip API -> state -> API as a `data_view_reference`, preserving the
+      // referenced id rather than collapsing into an inline spec.
+      it('round-trips a persisted data view reference for a query annotation layer', () => {
+        const builder = new LensConfigBuilder(undefined, true);
+        const apiConfig = withAnnotationDataSource(builder, {
+          type: AS_CODE_DATA_VIEW_REFERENCE_TYPE,
+          ref_id: 'metrics-*',
+        });
+
+        const lensState = builder.fromAPIFormat(apiConfig);
+        const roundTripped = builder.toAPIFormat(lensState) as XYConfigNoESQL;
+        const annotationLayer = roundTripped.layers.find((layer) => layer.type === 'annotations');
+
+        expect(annotationLayer?.data_source).toEqual(
+          expect.objectContaining({
+            type: AS_CODE_DATA_VIEW_REFERENCE_TYPE,
+            ref_id: 'metrics-*',
+          })
+        );
       });
 
       for (const type of ['bar', 'line', 'area'] as const) {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
@@ -27,8 +27,6 @@ import {
   isPersistedLinkedByValueAnnotationsLayer,
   isRuntimeByReferenceAnnotationsLayer,
 } from '@kbn/lens-common';
-import { AS_CODE_DATA_VIEW_SPEC_TYPE } from '@kbn/as-code-data-views-schema';
-import { AS_CODE_DATA_VIEW_REFERENCE_TYPE } from '@kbn/as-code-data-views-schema';
 import type {
   AnnotationLayerByValueType,
   AnnotationLayerType,
@@ -40,7 +38,7 @@ import type {
   ReferenceLineLayerTypeNoESQL,
 } from '../../../schema/charts/xy';
 import { LENS_IGNORE_GLOBAL_FILTERS_DEFAULT_VALUE } from '../../../schema/constants';
-import type { DataSourceType } from '../../../schema/data_source';
+import type { DataSourceTypeNoESQL } from '../../../schema/data_source';
 import type { LensApiStaticValueOperation } from '../../../schema/metric_ops';
 import { isEsqlTableTypeDataSource } from '../../../utils';
 import {
@@ -59,12 +57,14 @@ import {
 } from '../../columns/utils';
 import {
   buildDataSourceState,
+  buildDataViewDataSource,
   generateApiLayer,
-  isDataViewSpec,
+  getXYAnnotationLayerReferenceName,
   isFormBasedLayer,
   isTextBasedLayer,
   nonNullable,
   operationFromColumn,
+  resolveDataViewId,
 } from '../../utils';
 import { stripUndefined } from '../utils';
 import { getYAccessorAxisModeMap, type ResolveAxisId } from './chart';
@@ -421,11 +421,6 @@ export function buildAPIReferenceLinesLayer(
   };
 }
 
-function findAnnotationDataView(layerId: string, references: SavedObjectReference[]) {
-  const ref = references.find((r) => r.name === `xy-visualization-layer-${layerId}`);
-  return ref?.id;
-}
-
 function getTextConfigurationForQueryAnnotation(
   annotation: XYByValueAnnotationLayerConfig['annotations'][number]
 ): Pick<
@@ -481,16 +476,17 @@ export function buildAPIAnnotationsLayer(
     };
   }
 
-  const indexPatternId =
-    'indexPatternId' in layer
-      ? layer.indexPatternId
-      : findAnnotationDataView(layer.layerId, references);
-
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const ignore_global_filters =
-    layer.ignoreGlobalFilters ?? LENS_IGNORE_GLOBAL_FILTERS_DEFAULT_VALUE;
-  const adHocDataView = adHocDataViews[layer.layerId];
-  const referencedDataView = findAnnotationDataView(layer.layerId, references);
+  // XY annotation layers resolve their data view exactly like data layers, except
+  // it is persisted under the `xy-visualization-layer-<layerId>` reference name
+  // (in top-level `references` when persisted, in `state.internalReferences` when
+  // ad hoc), or carried inline via `indexPatternId` on a runtime by-value layer.
+  const inlineDataViewId = 'indexPatternId' in layer ? layer.indexPatternId : undefined;
+  const dataViewId = resolveDataViewId(
+    references,
+    adhocReferences ?? [],
+    getXYAnnotationLayerReferenceName(layer.layerId),
+    inlineDataViewId
+  );
 
   // Only query annotations actually query an index, so the data view is only
   // meaningful for them. Manual point/range annotations are positioned purely by
@@ -499,31 +495,17 @@ export function buildAPIAnnotationsLayer(
   // is re-derived from the chart's data layers when converting back to state.
   const hasQueryAnnotation = layer.annotations.some(isQueryAnnotationConfig);
 
-  if (hasQueryAnnotation && !indexPatternId) {
+  if (hasQueryAnnotation && !dataViewId) {
     // A query annotation without a resolvable data view cannot be represented.
     throw new Error('XY visualization: cannot find data view ID for annotation layer.');
   }
 
-  const dataSource: Extract<
-    DataSourceType,
-    { type: typeof AS_CODE_DATA_VIEW_REFERENCE_TYPE | typeof AS_CODE_DATA_VIEW_SPEC_TYPE }
-  > | null =
-    !hasQueryAnnotation || !indexPatternId
-      ? null
-      : isDataViewSpec(adHocDataView) && adHocDataView?.id === indexPatternId
-      ? {
-          type: AS_CODE_DATA_VIEW_SPEC_TYPE,
-          index_pattern: indexPatternId,
-          time_field: adHocDataView.timeFieldName,
-        }
-      : {
-          type: AS_CODE_DATA_VIEW_REFERENCE_TYPE,
-          ref_id: referencedDataView ?? indexPatternId,
-        };
+  const dataSource: DataSourceTypeNoESQL | null =
+    !hasQueryAnnotation || !dataViewId ? null : buildDataViewDataSource(dataViewId, adHocDataViews);
   return {
     type: 'annotations',
     ...(dataSource ? { data_source: dataSource } : {}),
-    ignore_global_filters,
+    ignore_global_filters: layer.ignoreGlobalFilters ?? LENS_IGNORE_GLOBAL_FILTERS_DEFAULT_VALUE,
     events: layer.annotations.map((annotation) => {
       if (isQueryAnnotationConfig(annotation)) {
         return {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -65,11 +65,25 @@ export type DataSourceStateLayer =
   | PersistedIndexPatternLayer
   | TextBasedPersistedState['layers'][0];
 
+/**
+ * Reference name under which an XY by-value annotation layer persists its data
+ * view. Must match the name produced by the Lens XY persistence logic
+ * (`getLayerReferenceName` in x-pack/.../lens/public/visualizations/xy/persistence.ts),
+ * which lives in a plugin this shared package cannot import from.
+ */
+export function getXYAnnotationLayerReferenceName(layerId: string): string {
+  return `${LENS_XY_ANNOTATION_LAYER_SUFFIX}${layerId}`;
+}
+
+function getXYDataLayerReferenceName(layerId: string): string {
+  return `${LENS_LAYER_SUFFIX}${layerId}`;
+}
+
 function createDataViewReference(dataViewId: string, layerId: string): SavedObjectReference {
   return {
     type: INDEX_PATTERN_ID,
     id: dataViewId,
-    name: `${LENS_LAYER_SUFFIX}${layerId}`,
+    name: getXYDataLayerReferenceName(layerId),
   };
 }
 
@@ -80,7 +94,7 @@ function createAnnotationLayerDataViewReference(
   return {
     type: INDEX_PATTERN_ID,
     id: dataViewId,
-    name: `${LENS_XY_ANNOTATION_LAYER_SUFFIX}${layerId}`,
+    name: getXYAnnotationLayerReferenceName(layerId),
   };
 }
 
@@ -223,8 +237,72 @@ export function isDataViewSpec(spec: unknown): spec is DataViewSpec {
   return spec != null && typeof spec === 'object' && 'title' in spec;
 }
 
-function getReferenceCriteria(layerId: string) {
-  return (ref: SavedObjectReference) => ref.name === `${LENS_LAYER_SUFFIX}${layerId}`;
+export function isDataViewSpecWithTitle(spec: unknown): spec is DataViewSpec & { title: string } {
+  return isDataViewSpec(spec) && typeof spec.title === 'string' && spec.title.length > 0;
+}
+
+/**
+ * Builds the `data_view_spec` data source from an ad-hoc
+ * `DataViewSpec`. Shared by data layers and XY annotation layers so both emit an
+ * inline data view identically.
+ */
+export function buildDataViewSpecDataSource(
+  dataViewSpec: DataViewSpec & { title: string }
+): Extract<DataSourceType, { type: typeof AS_CODE_DATA_VIEW_SPEC_TYPE }> {
+  const fieldSettings = toApiFieldSettings(dataViewSpec);
+  return {
+    type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+    index_pattern: dataViewSpec.title,
+    time_field: dataViewSpec.timeFieldName,
+    ...(dataViewSpec.name ? { name: dataViewSpec.name } : {}),
+    ...(dataViewSpec.allowHidden !== undefined
+      ? { allow_hidden_indices: dataViewSpec.allowHidden }
+      : {}),
+    ...(fieldSettings ? { field_settings: fieldSettings } : {}),
+  };
+}
+
+/**
+ * Resolves the data view id for a NoESQL layer. The id is taken, in priority
+ * order, from an ad hoc reference (`state.internalReferences`), a persisted
+ * reference (top-level `references`), or the layer's own inline `indexPatternId`.
+ * Data layers and XY annotation layers persist their data view under different
+ * reference names, hence the `referenceName` parameter.
+ */
+export function resolveDataViewId(
+  references: SavedObjectReference[],
+  adhocReferences: SavedObjectReference[],
+  referenceName: string,
+  inlineDataViewId?: string
+): string | undefined {
+  const matchesName = (ref: SavedObjectReference) => ref.name === referenceName;
+  return (
+    adhocReferences.find(matchesName)?.id ?? references.find(matchesName)?.id ?? inlineDataViewId
+  );
+}
+
+/**
+ * Builds the NoESQL `data_source` for a resolved data view id: an inline
+ * `data_view_spec` when the id points at an ad hoc data view, otherwise a
+ * `data_view_reference`. Shared by data layers and XY annotation layers so both
+ * emit the data view identically.
+ *
+ * `dataViewId` must be a non-empty id: an empty `ref_id` is not a valid data
+ * source, so callers are responsible for resolving the id (or handling its
+ * absence) before calling this.
+ */
+export function buildDataViewDataSource(
+  dataViewId: string,
+  adHocDataViews: Record<string, unknown>
+): DataSourceTypeNoESQL {
+  const dataViewSpec = adHocDataViews[dataViewId];
+  if (isDataViewSpecWithTitle(dataViewSpec)) {
+    return buildDataViewSpecDataSource(dataViewSpec);
+  }
+  return {
+    type: AS_CODE_DATA_VIEW_REFERENCE_TYPE,
+    ref_id: dataViewId,
+  };
 }
 
 export function buildDataSourceStateNoESQL(
@@ -232,40 +310,20 @@ export function buildDataSourceStateNoESQL(
   layerId: string,
   adHocDataViews: Record<string, unknown>,
   references: SavedObjectReference[],
-  adhocReferences: SavedObjectReference[] = []
+  adhocReferences: SavedObjectReference[] = [],
+  referenceName: string = getXYDataLayerReferenceName(layerId)
 ): DataSourceTypeNoESQL {
-  const referenceCriteria = getReferenceCriteria(layerId);
-  const adhocReference = adhocReferences?.find(referenceCriteria);
-
-  if (adhocReference && adHocDataViews?.[adhocReference.id]) {
-    const dataViewSpec = adHocDataViews[adhocReference.id];
-    if (isDataViewSpec(dataViewSpec) && dataViewSpec.title) {
-      const fieldSettings = toApiFieldSettings(dataViewSpec);
-      return {
-        type: AS_CODE_DATA_VIEW_SPEC_TYPE,
-        index_pattern: dataViewSpec.title,
-        ...(dataViewSpec.name ? { name: dataViewSpec.name } : {}),
-        time_field: dataViewSpec.timeFieldName,
-        ...(dataViewSpec.allowHidden !== undefined
-          ? { allow_hidden_indices: dataViewSpec.allowHidden }
-          : {}),
-        ...(fieldSettings ? { field_settings: fieldSettings } : {}),
-      };
-    }
+  const inlineDataViewId = 'indexPatternId' in layer ? layer.indexPatternId : undefined;
+  const dataViewId = resolveDataViewId(
+    references,
+    adhocReferences,
+    referenceName,
+    inlineDataViewId
+  );
+  if (!dataViewId) {
+    throw new Error(`Cannot resolve the data view for layer "${layerId}".`);
   }
-
-  const reference = references?.find(referenceCriteria);
-  if (reference) {
-    return {
-      type: AS_CODE_DATA_VIEW_REFERENCE_TYPE,
-      ref_id: reference.id,
-    };
-  }
-
-  return {
-    type: AS_CODE_DATA_VIEW_REFERENCE_TYPE,
-    ref_id: 'indexPatternId' in layer ? layer.indexPatternId ?? '' : '',
-  };
+  return buildDataViewDataSource(dataViewId, adHocDataViews);
 }
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Lens as code] Fix ad hoc data view resolution for XY annotation layers (#281079)](https://github.com/elastic/kibana/pull/281079)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2026-07-28T16:28:20Z","message":"[Lens as code] Fix ad hoc data view resolution for XY annotation layers (#281079)\n\n### Summary\n\nfix #280977\n\nXY annotation layers that reference an ad hoc (inline) data view could\nnot round-trip through the Lens config builder. Converting such a chart\nfrom state back to API format threw `XY visualization: cannot find data\nview ID for annotation layer`, even though the state was perfectly\nvalid. This fixes that regression\n(https://github.com/elastic/kibana/issues/280977) and, along the way,\nunifies how NoESQL layers resolve their data view so data layers and\nannotation layers behave identically.\n\n### The problem\n\nWhen a query annotation layer uses an ad hoc data view, Lens persists\nthe `xy-visualization-layer-<layerId>` index-pattern reference in\n`state.internalReferences` (not the top-level `references`), and stores\nthe actual spec in `state.adHocDataViews`. The API transform for\nannotation layers, however, only looked at the top-level `references`\nand had its own bespoke logic (`findAnnotationDataView`) for deciding\nbetween an inline spec and a reference. Because it never consulted\n`internalReferences`, the ad hoc case resolved to nothing and the\ntransform threw. Data layers already handled this correctly in\n`buildDataSourceStateNoESQL`, so the two code paths had drifted apart\nand only one of them was right.\n\n### The fix\n\nData view resolution is now shared. A single `resolveDataViewId` looks\nup the id in priority order — ad hoc reference (`internalReferences`),\nthen persisted reference (`references`), then the layer's inline\n`indexPatternId` — and a single `buildDataViewDataSource` turns that id\ninto either an inline `data_view_spec` (when it points at an ad hoc data\nview) or a `data_view_reference`. Both the data-layer path and the\nannotation-layer path call these helpers, differing only in the\nreference name they resolve, which is why the annotation branch now\ncorrectly finds ad hoc data views and re-emits their inline spec.\n\n### Cleanup\n\nThe bespoke annotation resolution (`findAnnotationDataView`, the inline\nspec/reference branching, redundant lookups, and unused imports) is\nremoved in favor of the shared helpers. The reference-name strings are\nno longer duplicated string literals: `getXYDataLayerReferenceName` and\n`getXYAnnotationLayerReferenceName` centralize them and are documented\nto match Lens's own persistence naming, which lives in a plugin this\nshared package can't import from. `buildDataSourceStateNoESQL` also no\nlonger falls back to an invalid empty `ref_id: ''`; it fails loudly when\na layer's data view genuinely can't be resolved, which is the correct\nbehavior for a value that must be non-empty.\n\n### Test plan\n\n- [x] Existing XY transform tests pass.\n- [x] New regression test round-trips an inline (ad hoc) data view for a\nquery annotation layer (API -> state -> API).\n- [x] New test round-trips a persisted `data_view_reference` for a query\nannotation layer without collapsing it into an inline spec.\n\n\n## Release note\n\nFixed an issue where Visualizations with annotation layers backed by an\nad hoc data view could not be read back through the new Visualization\nAPI.","sha":"3c63e242e7d6b6130f3cc245d178f9b1ac73125a","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Visualizations","backport:version","v9.6.0","v9.4.5","v9.5.1"],"title":"[Lens as code] Fix ad hoc data view resolution for XY annotation layers","number":281079,"url":"https://github.com/elastic/kibana/pull/281079","mergeCommit":{"message":"[Lens as code] Fix ad hoc data view resolution for XY annotation layers (#281079)\n\n### Summary\n\nfix #280977\n\nXY annotation layers that reference an ad hoc (inline) data view could\nnot round-trip through the Lens config builder. Converting such a chart\nfrom state back to API format threw `XY visualization: cannot find data\nview ID for annotation layer`, even though the state was perfectly\nvalid. This fixes that regression\n(https://github.com/elastic/kibana/issues/280977) and, along the way,\nunifies how NoESQL layers resolve their data view so data layers and\nannotation layers behave identically.\n\n### The problem\n\nWhen a query annotation layer uses an ad hoc data view, Lens persists\nthe `xy-visualization-layer-<layerId>` index-pattern reference in\n`state.internalReferences` (not the top-level `references`), and stores\nthe actual spec in `state.adHocDataViews`. The API transform for\nannotation layers, however, only looked at the top-level `references`\nand had its own bespoke logic (`findAnnotationDataView`) for deciding\nbetween an inline spec and a reference. Because it never consulted\n`internalReferences`, the ad hoc case resolved to nothing and the\ntransform threw. Data layers already handled this correctly in\n`buildDataSourceStateNoESQL`, so the two code paths had drifted apart\nand only one of them was right.\n\n### The fix\n\nData view resolution is now shared. A single `resolveDataViewId` looks\nup the id in priority order — ad hoc reference (`internalReferences`),\nthen persisted reference (`references`), then the layer's inline\n`indexPatternId` — and a single `buildDataViewDataSource` turns that id\ninto either an inline `data_view_spec` (when it points at an ad hoc data\nview) or a `data_view_reference`. Both the data-layer path and the\nannotation-layer path call these helpers, differing only in the\nreference name they resolve, which is why the annotation branch now\ncorrectly finds ad hoc data views and re-emits their inline spec.\n\n### Cleanup\n\nThe bespoke annotation resolution (`findAnnotationDataView`, the inline\nspec/reference branching, redundant lookups, and unused imports) is\nremoved in favor of the shared helpers. The reference-name strings are\nno longer duplicated string literals: `getXYDataLayerReferenceName` and\n`getXYAnnotationLayerReferenceName` centralize them and are documented\nto match Lens's own persistence naming, which lives in a plugin this\nshared package can't import from. `buildDataSourceStateNoESQL` also no\nlonger falls back to an invalid empty `ref_id: ''`; it fails loudly when\na layer's data view genuinely can't be resolved, which is the correct\nbehavior for a value that must be non-empty.\n\n### Test plan\n\n- [x] Existing XY transform tests pass.\n- [x] New regression test round-trips an inline (ad hoc) data view for a\nquery annotation layer (API -> state -> API).\n- [x] New test round-trips a persisted `data_view_reference` for a query\nannotation layer without collapsing it into an inline spec.\n\n\n## Release note\n\nFixed an issue where Visualizations with annotation layers backed by an\nad hoc data view could not be read back through the new Visualization\nAPI.","sha":"3c63e242e7d6b6130f3cc245d178f9b1ac73125a"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281079","number":281079,"mergeCommit":{"message":"[Lens as code] Fix ad hoc data view resolution for XY annotation layers (#281079)\n\n### Summary\n\nfix #280977\n\nXY annotation layers that reference an ad hoc (inline) data view could\nnot round-trip through the Lens config builder. Converting such a chart\nfrom state back to API format threw `XY visualization: cannot find data\nview ID for annotation layer`, even though the state was perfectly\nvalid. This fixes that regression\n(https://github.com/elastic/kibana/issues/280977) and, along the way,\nunifies how NoESQL layers resolve their data view so data layers and\nannotation layers behave identically.\n\n### The problem\n\nWhen a query annotation layer uses an ad hoc data view, Lens persists\nthe `xy-visualization-layer-<layerId>` index-pattern reference in\n`state.internalReferences` (not the top-level `references`), and stores\nthe actual spec in `state.adHocDataViews`. The API transform for\nannotation layers, however, only looked at the top-level `references`\nand had its own bespoke logic (`findAnnotationDataView`) for deciding\nbetween an inline spec and a reference. Because it never consulted\n`internalReferences`, the ad hoc case resolved to nothing and the\ntransform threw. Data layers already handled this correctly in\n`buildDataSourceStateNoESQL`, so the two code paths had drifted apart\nand only one of them was right.\n\n### The fix\n\nData view resolution is now shared. A single `resolveDataViewId` looks\nup the id in priority order — ad hoc reference (`internalReferences`),\nthen persisted reference (`references`), then the layer's inline\n`indexPatternId` — and a single `buildDataViewDataSource` turns that id\ninto either an inline `data_view_spec` (when it points at an ad hoc data\nview) or a `data_view_reference`. Both the data-layer path and the\nannotation-layer path call these helpers, differing only in the\nreference name they resolve, which is why the annotation branch now\ncorrectly finds ad hoc data views and re-emits their inline spec.\n\n### Cleanup\n\nThe bespoke annotation resolution (`findAnnotationDataView`, the inline\nspec/reference branching, redundant lookups, and unused imports) is\nremoved in favor of the shared helpers. The reference-name strings are\nno longer duplicated string literals: `getXYDataLayerReferenceName` and\n`getXYAnnotationLayerReferenceName` centralize them and are documented\nto match Lens's own persistence naming, which lives in a plugin this\nshared package can't import from. `buildDataSourceStateNoESQL` also no\nlonger falls back to an invalid empty `ref_id: ''`; it fails loudly when\na layer's data view genuinely can't be resolved, which is the correct\nbehavior for a value that must be non-empty.\n\n### Test plan\n\n- [x] Existing XY transform tests pass.\n- [x] New regression test round-trips an inline (ad hoc) data view for a\nquery annotation layer (API -> state -> API).\n- [x] New test round-trips a persisted `data_view_reference` for a query\nannotation layer without collapsing it into an inline spec.\n\n\n## Release note\n\nFixed an issue where Visualizations with annotation layers backed by an\nad hoc data view could not be read back through the new Visualization\nAPI.","sha":"3c63e242e7d6b6130f3cc245d178f9b1ac73125a"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->