### PR TITLE
[Obs AI Assistant] Fix unhandled RxJS error crashing Kibana on non-streaming chat/complete

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
@@ -1713,6 +1713,36 @@ describe('Observability AI Assistant client', () => {
       );
     });
   });
+  describe('when completing a conversation in non-streaming mode', () => {
+    describe('when the conversation is not found', () => {
+      it('rejects getConversation() without hanging or throwing an uncaughtException', async () => {
+        client = createClient();
+
+        inferenceClientMock.chatComplete.mockImplementation(
+          () =>
+            new Observable((subscriber) => {
+              llmSimulator = createLlmSimulator(subscriber);
+            })
+        );
+
+        const { getConversation } = client.complete({
+          connectorId: 'foo',
+          messages: [user('Hello')],
+          functionClient: functionClientMock,
+          signal: new AbortController().signal,
+          conversationId: 'does-not-exist',
+          persist: true,
+        });
+
+        await expect(getConversation()).rejects.toThrow('Conversation not found');
+
+        expect(loggerMock.error).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'Conversation not found' })
+        );
+      });
+    });
+  });
+
   describe('when duplicating a conversation', () => {
     beforeEach(async () => {
       client = createClient();

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -227,9 +227,11 @@ export class ObservabilityAIAssistantClient {
       const isConversationUpdate = persist && !!predefinedConversationId;
       const conversationId = persist ? predefinedConversationId || v4() : undefined;
       let resolveConversationRequest: (value: ConversationCreateRequest | undefined) => void;
+      let rejectConversationRequest: (err: Error) => void;
       const conversationRequestPromise = new Promise<ConversationCreateRequest | undefined>(
-        (resolve) => {
+        (resolve, reject) => {
           resolveConversationRequest = resolve;
+          rejectConversationRequest = reject;
         }
       );
 
@@ -484,7 +486,9 @@ export class ObservabilityAIAssistantClient {
       return {
         response$,
         getConversation: async () => {
-          const subscription = response$.subscribe();
+          const subscription = response$.subscribe({
+            error: (err) => rejectConversationRequest(err),
+          });
 
           try {
             const response = await conversationRequestPromise;


### PR DESCRIPTION
## Summary
Fixes a denial-of-service bug in the Observability AI Assistant where a single non-streaming `chat/complete` request could crash the entire Kibana Node.js process.

## Problem

The `POST /internal/observability_ai_assistant/chat/complete` endpoint supports two response modes controlled by the `isStream` flag. In the non-streaming path (`isStream: false`), the handler drives the chat pipeline by subscribing to an
internal RxJS observable with no error handler. When the pipeline errors (e.g. a missing conversation, an LLM connector failure, a permissions error), RxJS routes the unhandled error through a detached `setTimeout` macrotask, which
Node.js receives as an `uncaughtException`, terminating the entire process and denying service to every user until Kibana restarts.

## Root cause
Two gaps in the non-streaming path of `getConversation()`:
1. The `response$` subscription had no error handler, turning pipeline errors into unhandled RxJS errors → `uncaughtException` → process exit.
2. The internal conversation promise had no reject path, so an erroring observable never settled it → infinite hang.

## Fix
- Add a reject callback to the conversation promise so it can settle on error.
- Add an error handler to the subscription that rejects the promise, propagating the error up to the route handler, which returns a proper HTTP error response.

The error continues to be logged by the existing `catchError` in the pipeline, no additional logging needed.

## Before / After

**Before**
```sh
[ERROR][plugins.observabilityAIAssistant.service] Error: Conversation not found
[WARN ][environment] Detected an uncaughtException: Error: Conversation not found
...
ChatCompletionError: Conversation not found
Node.js v24.18.0
 server crashed  with status code 1
```

**After**
```sh
[ERROR][plugins.observabilityAIAssistant.service] Error: Conversation not found
```
Kibana stays running and the client receives an HTTP error response immediately.

## How to test

1. Start Kibana with a valid connector configured.
2. Send a non-streaming `chat/complete` request with a `conversationId` that does not exist.
3. Confirm Kibana is still running and the request returned an error response rather than hanging or crashing the server.




<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->