### PR TITLE
[CSP] Add media_src to CSP configuration

### DIFF
--- a/src/core/packages/http/server-internal/src/csp/config.ts
+++ b/src/core/packages/http/server-internal/src/csp/config.ts
@@ -78,6 +78,10 @@ const configSchema = schema.object(
       defaultValue: [],
       validate: getDirectiveValidator({ allowNone: false, allowNonce: false }),
     }),
+    media_src: schema.arrayOf(schema.string(), {
+      defaultValue: [],
+      validate: getDirectiveValidator({ allowNone: false, allowNonce: false }),
+    }),
     form_action: schema.arrayOf(schema.string(), {
       defaultValue: [],
       validate: getDirectiveValidator({ allowNone: false, allowNonce: false }),

--- a/src/core/packages/http/server-internal/src/csp/csp_directives.ts
+++ b/src/core/packages/http/server-internal/src/csp/csp_directives.ts
@@ -255,6 +255,9 @@ const parseConfigDirectives = (cspConfig: CspConfigType): CspConfigDirectives =>
   if (cspConfig.object_src?.length) {
     enforceDirectives.set('object-src', cspConfig.object_src);
   }
+  if (cspConfig.media_src?.length) {
+    enforceDirectives.set('media-src', cspConfig.media_src);
+  }
   if (cspConfig.form_action?.length) {
     enforceDirectives.set('form-action', cspConfig.form_action);
   }


### PR DESCRIPTION
## Summary

- Adds optional `media_src` config key to the CSP schema in `kibana.yml` under `csp:`
- Wires it to the `media-src` CSP directive in `parseConfigDirectives`

**Usage example:**
```yaml
csp:
  media_src:
    - 'https://media.example.com'
```

# Release Note
Added optional `media_src` config key to the CSP schema.



🤖 Generated with [Claude Code](https://claude.com/claude-code)