### PR TITLE
[Synthetics] Add unit tests for private-location space handling

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/add_private_location.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/add_private_location.test.ts
@@ -7,7 +7,12 @@
 
 import type { AgentPolicy } from '@kbn/fleet-plugin/common';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
-import { getAgentPolicySpaceIds } from './add_private_location';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import { addPrivateLocationRoute, getAgentPolicySpaceIds } from './add_private_location';
+import { PrivateLocationRepository } from '../../../repositories/private_location_repository';
+
+jest.mock('./migrate_legacy_private_locations');
 
 const agentPolicy = (space_ids?: string[]) => ({ space_ids } as AgentPolicy);
 
@@ -28,5 +33,137 @@ describe('getAgentPolicySpaceIds', () => {
 
   it('returns the policy space ids when scoped to specific spaces', () => {
     expect(getAgentPolicySpaceIds(agentPolicy(['default', 'other']))).toEqual(['default', 'other']);
+  });
+});
+
+describe('addPrivateLocationRoute handler - space containment', () => {
+  const makeRouteContext = ({
+    policySpaceIds,
+    requestSpaces,
+    spaceId = 'naims',
+  }: {
+    policySpaceIds?: string[];
+    requestSpaces?: string[];
+    spaceId?: string;
+  }) => {
+    const response = httpServerMock.createResponseFactory();
+    const internalSOClient = {};
+    const agentPolicyService = {
+      get: jest.fn().mockResolvedValue({ id: 'ap', space_ids: policySpaceIds }),
+    };
+    const routeContext = {
+      server: {
+        logger: loggerMock.create(),
+        fleet: { agentPolicyService },
+        coreStart: {
+          savedObjects: { createInternalRepository: jest.fn().mockReturnValue(internalSOClient) },
+        },
+      },
+      request: { body: { label: 'loc', agentPolicyId: 'ap', spaces: requestSpaces } },
+      response,
+      spaceId,
+      savedObjectsClient: {},
+    } as any;
+    return { routeContext, response };
+  };
+
+  // Downstream of the containment check the handler runs migrate + duplicate
+  // validation + SO create; stub those so tests that pass containment don't
+  // touch Elasticsearch/Fleet internals.
+  const stubDownstream = () => {
+    jest
+      .spyOn(PrivateLocationRepository.prototype, 'validatePrivateLocation')
+      .mockResolvedValue(undefined);
+    return jest
+      .spyOn(PrivateLocationRepository.prototype, 'createPrivateLocation')
+      .mockResolvedValue({
+        attributes: { label: 'loc', id: 'x', agentPolicyId: 'ap' },
+        namespaces: [ALL_SPACES_ID],
+      } as any);
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('rejects when a space-scoped agent policy does not contain the requested space', async () => {
+    const { routeContext, response } = makeRouteContext({
+      policySpaceIds: ['other'],
+      requestSpaces: ['naims'],
+    });
+
+    await addPrivateLocationRoute().handler(routeContext);
+
+    expect(response.badRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          message: expect.stringContaining(
+            'must be fully contained within agent policy ap spaces [other]'
+          ),
+        }),
+      })
+    );
+  });
+
+  // The 9.4.4 fix (#277098): a non-space-aware policy has `space_ids: []`, which
+  // getAgentPolicySpaceIds now maps to all-spaces, so creation is no longer
+  // blocked (this was the exact `spaces []` customer regression on 9.4.0-9.4.3).
+  it('allows creation when the agent policy is non-space-aware (empty space_ids)', async () => {
+    const { routeContext, response } = makeRouteContext({
+      policySpaceIds: [],
+      requestSpaces: ['naims'],
+    });
+    const create = stubDownstream();
+
+    await addPrivateLocationRoute().handler(routeContext);
+
+    expect(response.badRequest).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalled();
+  });
+
+  it('allows creation when no specific space is requested (the "clear the Spaces field" behavior)', async () => {
+    const { routeContext, response } = makeRouteContext({
+      policySpaceIds: ['other'],
+      requestSpaces: undefined,
+    });
+    const create = stubDownstream();
+
+    await addPrivateLocationRoute().handler(routeContext);
+
+    expect(response.badRequest).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalled();
+  });
+
+  it('bypasses the containment check when the agent policy is all-spaces', async () => {
+    const { routeContext, response } = makeRouteContext({
+      policySpaceIds: [ALL_SPACES_ID],
+      requestSpaces: ['naims'],
+    });
+    stubDownstream();
+
+    await addPrivateLocationRoute().handler(routeContext);
+
+    expect(response.badRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('PrivateLocationRepository.getLocationSpaces', () => {
+  const repo = () =>
+    new PrivateLocationRepository({
+      server: { coreStart: { savedObjects: { createInternalRepository: jest.fn() } } },
+    } as any);
+
+  it('returns locationSpaces when provided', () => {
+    expect(
+      repo().getLocationSpaces({ locationSpaces: ['a', 'b'], agentPolicySpaces: ['default'] })
+    ).toEqual(['a', 'b']);
+  });
+
+  it('falls back to agentPolicySpaces when locationSpaces is empty', () => {
+    expect(
+      repo().getLocationSpaces({ locationSpaces: [], agentPolicySpaces: ['default'] })
+    ).toEqual(['default']);
+  });
+
+  it('falls back to agentPolicySpaces when locationSpaces is undefined', () => {
+    expect(repo().getLocationSpaces({ agentPolicySpaces: ['default'] })).toEqual(['default']);
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
+import type { AgentPolicy } from '@kbn/fleet-plugin/common';
+import type { NewPackagePolicyWithId } from '@kbn/fleet-plugin/server/services/package_policy';
+import { PackagePolicyService } from './package_policy_service';
+import type { SyntheticsServerSetup } from '../../types';
+
+// The space-scoped SO client is opaque here; we tag it with the namespace it was
+// scoped to so we can assert which space a package policy was written into.
+const makeServer = () => {
+  const asScopedToNamespace = jest.fn((space: string) => ({ __space: space }));
+  const getUnsafeInternalClient = jest.fn(() => ({ asScopedToNamespace }));
+  const fleetBulkCreate = jest.fn().mockResolvedValue({ created: [], failed: [] });
+  const getByIds = jest.fn();
+
+  const server = {
+    logger: loggerMock.create(),
+    fleet: {
+      packagePolicyService: { bulkCreate: fleetBulkCreate },
+      agentPolicyService: { getByIds },
+    },
+    coreStart: {
+      savedObjects: { getUnsafeInternalClient },
+      elasticsearch: { client: { asInternalUser: { __es: true } } },
+    },
+  } as unknown as SyntheticsServerSetup;
+
+  return { server, asScopedToNamespace, fleetBulkCreate, getByIds };
+};
+
+const policy = (overrides: Partial<NewPackagePolicyWithId> = {}): NewPackagePolicyWithId =>
+  ({ id: 'testId-policyId', policy_ids: ['policyId'], ...overrides } as NewPackagePolicyWithId);
+
+const agentPolicy = (spaceIds?: string[]): AgentPolicy =>
+  ({ id: 'policyId', space_ids: spaceIds } as AgentPolicy);
+
+describe('PackagePolicyService.getDefaultAndSpacePackagePolicies (via bulkCreate)', () => {
+  const clientPassedToFleet = (fleetBulkCreate: jest.Mock) => fleetBulkCreate.mock.calls[0][0];
+
+  it('writes the package policy to the DEFAULT space when the agent policy lives in default and the monitor is in another space', async () => {
+    const { server, getByIds, fleetBulkCreate } = makeServer();
+    getByIds.mockResolvedValue([agentPolicy(['default'])]);
+
+    await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy()],
+      spaceId: 'naims',
+    });
+
+    expect(fleetBulkCreate).toHaveBeenCalledTimes(1);
+    expect(clientPassedToFleet(fleetBulkCreate)).toEqual({ __space: DEFAULT_SPACE_ID });
+  });
+
+  it('writes the package policy to the monitor space when the agent policy is assigned to that space', async () => {
+    const { server, getByIds, fleetBulkCreate } = makeServer();
+    getByIds.mockResolvedValue([agentPolicy(['naims'])]);
+
+    await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy()],
+      spaceId: 'naims',
+    });
+
+    expect(clientPassedToFleet(fleetBulkCreate)).toEqual({ __space: 'naims' });
+  });
+
+  it('writes the package policy to the monitor space when the agent policy is all-spaces', async () => {
+    const { server, getByIds, fleetBulkCreate } = makeServer();
+    getByIds.mockResolvedValue([agentPolicy([ALL_SPACES_ID])]);
+
+    await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy()],
+      spaceId: 'naims',
+    });
+
+    expect(clientPassedToFleet(fleetBulkCreate)).toEqual({ __space: 'naims' });
+  });
+
+  it('falls back to the DEFAULT space when the agent policy cannot be found', async () => {
+    const { server, getByIds, fleetBulkCreate } = makeServer();
+    getByIds.mockResolvedValue([]);
+
+    await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy()],
+      spaceId: 'naims',
+    });
+
+    expect(clientPassedToFleet(fleetBulkCreate)).toEqual({ __space: DEFAULT_SPACE_ID });
+  });
+
+  it('short-circuits to the DEFAULT-space client without fetching agent policies when the monitor is in the default space', async () => {
+    const { server, getByIds, fleetBulkCreate } = makeServer();
+
+    await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy()],
+      spaceId: DEFAULT_SPACE_ID,
+    });
+
+    expect(getByIds).not.toHaveBeenCalled();
+    expect(clientPassedToFleet(fleetBulkCreate)).toEqual({ __space: DEFAULT_SPACE_ID });
+  });
+});


### PR DESCRIPTION
## Summary

Test-only PR. Adds unit coverage for how Synthetics private locations behave with Fleet space-awareness, locking in the 9.4.4 fix ([#277098](https://github.com/elastic/kibana/pull/277098)) and the space-routing of the backing integration policy.

- **`add_private_location` route handler / `getAgentPolicySpaceIds`**: a space-scoped agent policy rejects a location whose spaces aren't contained within it; a non-space-aware policy (`space_ids: []`) is treated as all-spaces and allowed (the 9.4.4 fix); the all-spaces (`*`) bypass; plus the `getLocationSpaces` fallback.
- **`getDefaultAndSpacePackagePolicies` routing**: the integration policy lands in the `default` space when the agent policy isn't in the monitor's space (so no orphaned integrations), with space-scoped, all-spaces, and missing-policy branches.

No runtime changes.

## Testing

```
node scripts/jest x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/add_private_location.test.ts x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
```

---

## Background: private-location creation in 9.4.x (space-aware vs non-space-aware)

The behavior these tests pin down was uncovered while diagnosing a customer report that private-location creation failed after upgrading to 9.4.x. The narrative below explains the root cause and the fix (shipped in 9.4.4, #277098) for reviewer context.

**Symptom:** After upgrading to 9.4.0–9.4.3, you can't create a private location. Saving fails with an error like *"Invalid spaces … must be fully contained within agent policy … spaces []."*

### Why this happens

Starting in 9.4.0, private locations became **space-aware**: a private location can only live in the same Kibana spaces as the Fleet agent policy that backs it.

Whether Fleet knows about spaces depends on a one-time **space-awareness migration**:

- On a **fresh** install, this is already done, so every agent policy belongs to at least the **Default** space.
- After an **upgrade** from an older version, the migration hasn't run yet, so your existing agent policies aren't associated with **any** space.

On 9.4.0–9.4.3, an agent policy that isn't associated with any space is treated as belonging to *no* spaces. So when you try to create a private location, Kibana decides the location's space isn't allowed by the policy and blocks it. In this state, creation is blocked in **every** space, including Default.

**9.4.4 fixes this:** an agent policy with no space association is now treated as "available everywhere," so private-location creation works again.

### Quick reference

| Version | Fleet space-awareness | Create in **Default** space | Create in **other** spaces |
|---|---|---|---|
| **9.4.0–9.4.3** | Not enabled (e.g. after upgrade) | ❌ Blocked (*"Invalid spaces…"*) | ❌ Blocked |
| **9.4.0–9.4.3** | Enabled | ✅ Works | ⚠️ Only if the agent policy is in that space |
| **9.4.4+** | Not enabled | ✅ Works | ✅ Works (create directly in any space) |
| **9.4.4+** | Enabled | ✅ Works | ⚠️ Share the location into the space (see below) |

*Versions earlier than 9.4.0 aren't affected — private locations weren't space-aware yet.*

> **Tip:** Not sure which row you're in? Run `GET kbn:/api/fleet/settings` — `use_space_awareness_migration_status: success` means space-awareness is enabled.

### How to fix it

Choose whichever fits your environment:

- **Upgrade to 9.4.4 (recommended).** This resolves the problem directly — no other changes needed. You can then create private locations in any space.
- **Enable Fleet space-awareness (if you can't upgrade yet).** Running the space-awareness migration associates your existing agent policies with the Default space, which lets private-location creation work again on your current version.

> **Don't clear the Spaces field to work around it.** On 9.4.0–9.4.3, creating a private location with an empty Spaces field doesn't help — it can make Kibana unresponsive. Use one of the two options above instead.

### Working with private locations across multiple spaces

Once creation works, you may want a private location to be usable in more than one space (for example, a shared location visible in several team spaces). How you do this depends on whether Fleet is space-aware.

#### If Fleet is space-aware

Your agent policies belong to specific spaces. To make a private location available in another space, you have two options:

**Option 1 — Add the space to the agent policy, then create the location there.**
This works when the agent policy's integration policies are **not** shared (each integration belongs to a single agent policy). In that case you can add the target space to the agent policy in Fleet and create the private location in that space normally.

> **Note:** If the agent policy uses **shared (reusable) integration policies** — an integration attached to more than one agent policy — Fleet **blocks** changing that policy's spaces (including *adding* one), with an error like *"Agent policies using reusable integration policies cannot be moved to a different space."* In that case, use Option 2.

**Option 2 — Share the private location into the space (recommended).**
Instead of touching the agent policy, share the **location** into the additional spaces. This always works — including when the agent policy uses reusable integration policies — and leaves the agent policy untouched:

```
POST kbn:/api/spaces/_update_objects_spaces
{
  "objects": [{ "type": "synthetics-private-location", "id": "<privateLocationId>" }],
  "spacesToAdd": ["<targetSpace>"],
  "spacesToRemove": []
}
```

#### If Fleet is not space-aware

A non-space-aware agent policy is treated as available everywhere, so you don't need to share anything. On 9.4.4 you can simply **create the private location directly in each space** you need, or create a single location that's available in **all** spaces. (On 9.4.0–9.4.3, create the location only after applying one of the fixes above.)
