### PR TITLE
[Entity Analytics] Add comments clarifying generic entity extraction

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/entity_schema.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/entity_schema.ts
@@ -11,6 +11,10 @@ import { z } from '@kbn/zod/v4';
 export type EntityType = z.infer<typeof EntityType>;
 export const EntityType = z.enum(['user', 'host', 'service', 'generic']);
 
+// NOTE: 'generic' is intentionally excluded from customer-facing docs and EA feature support.
+// It is an internal type consumed only by Graph (entity flyout visualizations) and Asset Inventory,
+// both of which are tech preview. Do not add 'generic' to docs or new EA features without
+// explicit team alignment — it is only populated by the asset discovery integration today.
 export const ALL_ENTITY_TYPES = Object.values(EntityType.enum);
 
 const mappingSchema = z.any();

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/entity_schema.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/entity_schema.ts
@@ -11,10 +11,6 @@ import { z } from '@kbn/zod/v4';
 export type EntityType = z.infer<typeof EntityType>;
 export const EntityType = z.enum(['user', 'host', 'service', 'generic']);
 
-// NOTE: 'generic' is intentionally excluded from customer-facing docs and EA feature support.
-// It is an internal type consumed only by Graph (entity flyout visualizations) and Asset Inventory,
-// both of which are tech preview. Do not add 'generic' to docs or new EA features without
-// explicit team alignment — it is only populated by the asset discovery integration today.
 export const ALL_ENTITY_TYPES = Object.values(EntityType.enum);
 
 const mappingSchema = z.any();

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/generic.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/generic.ts
@@ -13,6 +13,10 @@ import {
   getEntityFieldsDescriptions,
 } from './common_fields';
 
+// Generic entities represent cloud and orchestrator resources (e.g. AWS ARNs, Azure Resource IDs,
+// GCP Resource Names, Kubernetes pods) sourced from CSP integrations that populate `entity.id`.
+// They are consumed by Graph (entity flyout visualizations) and Asset Inventory.
+// Customers without CSP integrations will not produce any generic entities.
 export const genericEntityDefinition = {
   type: 'generic',
   name: `Security 'generic' Entity Store Definition`,

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/generic.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/generic.ts
@@ -15,7 +15,7 @@ import {
 
 // Generic entities represent cloud and orchestrator resources (e.g. AWS ARNs, Azure Resource IDs,
 // GCP Resource Names, Kubernetes pods) sourced from CSP integrations that populate `entity.id`.
-// They are consumed by Graph (entity flyout visualizations) and Asset Inventory.
+// They are consumed by Graph (entity and event flyout visualizations) and Asset Inventory.
 // Customers without CSP integrations will not produce any generic entities.
 export const genericEntityDefinition = {
   type: 'generic',

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
@@ -21,7 +21,7 @@ export function registerTasks(
   isServerless: boolean
 ) {
   // ALL_ENTITY_TYPES includes 'generic' unconditionally. Generic entities are consumed by:
-  //   - Graph (entity flyout visualizations, Preview since 9.4, no feature flag)
+  //   - Graph (event and entity flyout visualizations, Preview since 9.4, no feature flag)
   //   - Asset Inventory (gated behind securitySolution:enableAssetInventory, tech preview)
   // Extraction is intentionally ungated because Graph has no feature flag to gate against.
   // Once both consumers reach GA, consider whether gating is still appropriate.

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
@@ -20,6 +20,11 @@ export function registerTasks(
   core: EntityStoreCoreSetup,
   isServerless: boolean
 ) {
+  // ALL_ENTITY_TYPES includes 'generic' unconditionally. Generic entities are consumed by:
+  //   - Graph (entity flyout visualizations, Preview since 9.4, no feature flag)
+  //   - Asset Inventory (gated behind securitySolution:enableAssetInventory, tech preview)
+  // Extraction is intentionally ungated because Graph has no feature flag to gate against.
+  // Once both consumers reach GA, consider whether gating is still appropriate.
   registerExtractEntityTasks({
     taskManager,
     logger,


### PR DESCRIPTION
 Generic entity extraction runs unconditionally but the intent and consumers are not yet documented, which can lead to some confusion. Add comments to `register_tasks`.ts and `generic.ts `to make this clear.

