### PR TITLE
[Security Solution] remove unused code around hover actions

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/types.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/types.ts
@@ -80,7 +80,6 @@ export interface OsqueryTimelinesStart {
       dataProvider: unknown[];
       field: string;
       ownFocus: boolean;
-      showTooltip: boolean;
       startServices: { analytics: unknown; i18n: unknown; theme: unknown };
     }) => unknown;
   };

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.test.tsx
@@ -18,7 +18,6 @@ import AddToTimelineButton, {
 import type { DataProvider } from '../../../../common/types';
 import { IS_OPERATOR } from '../../../../common/types';
 import { TestProviders } from '../../../mock';
-import { PRESS } from '../../tooltip_with_keyboard_shortcut';
 import * as i18n from './translations';
 
 const coreStart = coreMock.createStart();
@@ -135,35 +134,6 @@ describe('add to timeline', () => {
     test('it has the expected aria label', () => {
       expect(getButton()).toHaveAttribute('aria-label', i18n.ADD_TO_TIMELINE);
     });
-  });
-
-  test('it renders the keyboard shortcut tooltip content when `showTooltip` is true', async () => {
-    render(
-      <TestProviders>
-        <AddToTimelineButton
-          field={field}
-          ownFocus={true}
-          showTooltip={true}
-          startServices={coreStart}
-        />
-      </TestProviders>
-    );
-
-    fireEvent.mouseOver(screen.getByRole('button'));
-
-    expect(await screen.findByText(PRESS)).toBeInTheDocument();
-  });
-
-  test('it does NOT render keyboard shortcut tooltip content when `showTooltip` is false (default)', () => {
-    render(
-      <TestProviders>
-        <AddToTimelineButton field={field} ownFocus={true} startServices={coreStart} />
-      </TestProviders>
-    );
-
-    fireEvent.mouseOver(screen.getByRole('button'));
-
-    expect(screen.queryByText(PRESS)).not.toBeInTheDocument();
   });
 
   describe('when the user clicks the button', () => {
@@ -309,7 +279,6 @@ describe('add to timeline', () => {
                 field={field}
                 keyboardEvent={keyboardEvent}
                 ownFocus={true}
-                showTooltip={true}
                 startServices={coreStart}
               />
             </TestProviders>
@@ -327,7 +296,6 @@ describe('add to timeline', () => {
                 field={field}
                 keyboardEvent={keyboardEvent}
                 ownFocus={true}
-                showTooltip={true}
                 startServices={coreStart}
               />
             </TestProviders>
@@ -346,7 +314,6 @@ describe('add to timeline', () => {
                 field={field}
                 keyboardEvent={keyboardEvent}
                 ownFocus={true}
-                showTooltip={true}
                 startServices={coreStart}
               />
             </TestProviders>
@@ -377,7 +344,6 @@ describe('add to timeline', () => {
                 field={field}
                 keyboardEvent={keyboardEvent}
                 ownFocus={true}
-                showTooltip={true}
                 startServices={coreStart}
               />
             </TestProviders>
@@ -395,7 +361,6 @@ describe('add to timeline', () => {
                 field={field}
                 keyboardEvent={keyboardEvent}
                 ownFocus={true}
-                showTooltip={true}
                 startServices={coreStart}
               />
             </TestProviders>
@@ -414,7 +379,6 @@ describe('add to timeline', () => {
                 field={field}
                 keyboardEvent={keyboardEvent}
                 ownFocus={true}
-                showTooltip={true}
                 startServices={coreStart}
               />
             </TestProviders>

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo } from 'react';
-import type { EuiContextMenuItem, EuiButtonEmpty } from '@elastic/eui';
+import type { EuiButtonEmpty, EuiContextMenuItem } from '@elastic/eui';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import type { DraggableId } from '@hello-pangea/dnd';
 import { isEmpty } from 'lodash';
@@ -18,8 +18,6 @@ import { TimelineId } from '../../../store/timeline';
 import { addProviderToTimeline } from '../../../store/timeline/actions';
 import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
 import type { DataProvider } from '../../../../common/types';
-import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
-import { getAdditionalScreenReaderOnlyContext } from '../utils';
 import { useAddToTimeline } from '../../../hooks/use_add_to_timeline';
 import type { HoverActionComponentProps } from './types';
 import { useAppToasts } from '../../../hooks/use_app_toasts';
@@ -78,8 +76,6 @@ const AddToTimelineButton: React.FC<AddToTimelineButtonProps> = React.memo(
     keyboardEvent,
     ownFocus,
     onClick,
-    showTooltip = false,
-    value,
     timelineType = 'default',
     startServices,
   }) => {
@@ -139,7 +135,7 @@ const AddToTimelineButton: React.FC<AddToTimelineButtonProps> = React.memo(
       }
     }, [handleStartDragToTimeline, keyboardEvent, ownFocus]);
 
-    const button = useMemo(
+    return useMemo(
       () =>
         Component ? (
           <Component
@@ -167,26 +163,6 @@ const AddToTimelineButton: React.FC<AddToTimelineButtonProps> = React.memo(
           </EuiToolTip>
         ),
       [Component, defaultFocusedButtonRef, handleStartDragToTimeline]
-    );
-
-    return showTooltip ? (
-      <EuiToolTip
-        content={
-          <TooltipWithKeyboardShortcut
-            additionalScreenReaderOnlyContext={getAdditionalScreenReaderOnlyContext({
-              field,
-              value,
-            })}
-            content={i18n.ADD_TO_TIMELINE}
-            shortcut={ADD_TO_TIMELINE_KEYBOARD_SHORTCUT}
-            showShortcut={ownFocus}
-          />
-        }
-      >
-        {button}
-      </EuiToolTip>
-    ) : (
-      button
     );
   }
 );

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/filter_for_value.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/filter_for_value.tsx
@@ -10,9 +10,8 @@ import { i18n } from '@kbn/i18n';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 
 import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
-import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
-import { createFilter, getAdditionalScreenReaderOnlyContext } from '../utils';
-import type { HoverActionComponentProps, FilterValueFnArgs } from './types';
+import { createFilter } from '../utils';
+import type { FilterValueFnArgs, HoverActionComponentProps } from './types';
 
 export const FILTER_FOR_VALUE = i18n.translate('xpack.timelines.hoverActions.filterIn', {
   defaultMessage: 'Filter for',
@@ -32,7 +31,6 @@ const FilterForValueButton: React.FC<FilterForValueProps> = React.memo(
     ownFocus,
     onClick,
     size,
-    showTooltip = false,
     value,
     dataViewId,
   }) => {
@@ -69,7 +67,7 @@ const FilterForValueButton: React.FC<FilterForValueProps> = React.memo(
       }
     }, [filterForValueFn, keyboardEvent, ownFocus]);
 
-    const button = useMemo(
+    return useMemo(
       () =>
         Component ? (
           <Component
@@ -98,26 +96,6 @@ const FilterForValueButton: React.FC<FilterForValueProps> = React.memo(
           </EuiToolTip>
         ),
       [Component, defaultFocusedButtonRef, filterForValueFn, size]
-    );
-
-    return showTooltip ? (
-      <EuiToolTip
-        content={
-          <TooltipWithKeyboardShortcut
-            additionalScreenReaderOnlyContext={getAdditionalScreenReaderOnlyContext({
-              field,
-              value,
-            })}
-            content={FILTER_FOR_VALUE}
-            shortcut={FILTER_FOR_VALUE_KEYBOARD_SHORTCUT}
-            showShortcut={ownFocus}
-          />
-        }
-      >
-        {button}
-      </EuiToolTip>
-    ) : (
-      button
     );
   }
 );

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/filter_out_value.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/filter_out_value.tsx
@@ -10,9 +10,8 @@ import { i18n } from '@kbn/i18n';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 
 import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
-import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
-import { createFilter, getAdditionalScreenReaderOnlyContext } from '../utils';
-import type { HoverActionComponentProps, FilterValueFnArgs } from './types';
+import { createFilter } from '../utils';
+import type { FilterValueFnArgs, HoverActionComponentProps } from './types';
 
 export const FILTER_OUT_VALUE = i18n.translate('xpack.timelines.hoverActions.filterOut', {
   defaultMessage: 'Filter out',
@@ -31,7 +30,6 @@ const FilterOutValueButton: React.FC<HoverActionComponentProps & FilterValueFnAr
     ownFocus,
     onClick,
     size,
-    showTooltip = false,
     value,
     dataViewId,
   }) => {
@@ -67,7 +65,7 @@ const FilterOutValueButton: React.FC<HoverActionComponentProps & FilterValueFnAr
       }
     }, [filterOutValueFn, keyboardEvent, ownFocus]);
 
-    const button = useMemo(
+    return useMemo(
       () =>
         Component ? (
           <Component
@@ -96,26 +94,6 @@ const FilterOutValueButton: React.FC<HoverActionComponentProps & FilterValueFnAr
           </EuiToolTip>
         ),
       [Component, defaultFocusedButtonRef, filterOutValueFn, size]
-    );
-
-    return showTooltip ? (
-      <EuiToolTip
-        content={
-          <TooltipWithKeyboardShortcut
-            additionalScreenReaderOnlyContext={getAdditionalScreenReaderOnlyContext({
-              field,
-              value,
-            })}
-            content={FILTER_OUT_VALUE}
-            shortcut={FILTER_OUT_VALUE_KEYBOARD_SHORTCUT}
-            showShortcut={ownFocus}
-          />
-        }
-      >
-        {button}
-      </EuiToolTip>
-    ) : (
-      button
     );
   }
 );

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/types.ts
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/types.ts
@@ -26,6 +26,5 @@ export interface HoverActionComponentProps {
   ownFocus: boolean;
   onClick?: () => void;
   size?: 'xs' | 's' | 'm';
-  showTooltip?: boolean;
   value?: string[] | string | null;
 }


### PR DESCRIPTION
## Summary

While reviewing the newest EUI [PR](https://github.com/elastic/kibana/pull/281406), I realized that we have a few props that are unused. This PR cleans these up so that we don't have to maintain them for no reason. The original code was written in 2021 and we have no usage today of these props, so we can safely assume they are not needed at all.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
