### PR TITLE
[Entity Store] Require read privileges on excluded index patterns

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
@@ -286,6 +286,46 @@ describe('AssetManagerClient', () => {
         expect.arrayContaining(['manage', 'view_index_metadata'])
       );
     });
+
+    it('requires source privileges on excluded index patterns as literal names', async () => {
+      getLocalIndexPatternsMock.mockResolvedValue(['logs-*']);
+
+      await getPrivilegesClient.getPrivileges(
+        {} as KibanaRequest,
+        [],
+        ['restricted-*', '-already-negated-*']
+      );
+
+      const [calledWith] = checkPrivilegesWithRequestMock.mock.calls[0];
+      const { index } = calledWith.elasticsearch;
+
+      // Excluded patterns are checked for read/view_index_metadata, with any leading `-` dropped
+      // so `_has_privileges` receives a literal index name.
+      expect(index['restricted-*']).toEqual(
+        expect.arrayContaining(['read', 'view_index_metadata'])
+      );
+      expect(index['already-negated-*']).toEqual(
+        expect.arrayContaining(['read', 'view_index_metadata'])
+      );
+      expect(Object.keys(index)).not.toContain('-already-negated-*');
+    });
+
+    it('skips remote excluded index patterns', async () => {
+      getLocalIndexPatternsMock.mockResolvedValue(['logs-*']);
+
+      await getPrivilegesClient.getPrivileges(
+        {} as KibanaRequest,
+        [],
+        ['remote_cluster:restricted-*']
+      );
+
+      const [calledWith] = checkPrivilegesWithRequestMock.mock.calls[0];
+
+      // Remote patterns are not privilege-checked here, mirroring the source-pattern handling.
+      expect(Object.keys(calledWith.elasticsearch.index)).not.toContain(
+        'remote_cluster:restricted-*'
+      );
+    });
   });
 
   describe('uninstall', () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -14,6 +14,7 @@ import type {
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { CheckPrivilegesResponse } from '@kbn/security-plugin-types-server';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { EntityType } from '../../../common';
 import {
@@ -350,7 +351,8 @@ export class AssetManagerClient {
 
   public async getPrivileges(
     request: KibanaRequest,
-    additionalIndexPatterns: string[] = []
+    additionalIndexPatterns: string[] = [],
+    excludedIndexPatterns: string[] = []
   ): Promise<CheckPrivilegesResponse> {
     const checkPrivileges = this.security.authz.checkPrivilegesDynamicallyWithRequest(request);
 
@@ -382,6 +384,16 @@ export class AssetManagerClient {
 
     sourceIndexPatterns
       .filter((idx) => !idx.startsWith('-'))
+      .forEach((idx) => unionPrivileges(idx, ENTITY_STORE_SOURCE_INDICES_PRIVILEGES));
+
+    // A caller may only exclude source indices they can actually read. Requiring the same
+    // source privileges on excluded patterns stops an under-privileged user from suppressing
+    // extraction coverage on indices they have no access to. Remote patterns are not checked
+    // here (mirroring the source-pattern handling above), and any leading `-` is dropped since
+    // `_has_privileges` treats it as a literal index name.
+    excludedIndexPatterns
+      .map((idx) => (idx.startsWith('-') ? idx.slice(1) : idx))
+      .filter((idx) => idx.length > 0 && !isNonLocalIndexName(idx))
       .forEach((idx) => unionPrivileges(idx, ENTITY_STORE_SOURCE_INDICES_PRIVILEGES));
 
     return checkPrivileges({

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/install/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/install/index.ts
@@ -60,7 +60,8 @@ export function registerInstall(router: EntityStorePluginRouter) {
           assetManager,
           req,
           res,
-          logExtraction?.additionalIndexPatterns
+          logExtraction?.additionalIndexPatterns,
+          logExtraction?.excludedIndexPatterns
         );
         if (forbidden) return forbidden;
         const { engines } = await assetManager.getStatus();

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/update.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/update.ts
@@ -60,7 +60,8 @@ export function registerUpdate(router: EntityStorePluginRouter) {
           assetManager,
           req,
           res,
-          req.body.logExtraction?.additionalIndexPatterns
+          req.body.logExtraction?.additionalIndexPatterns,
+          req.body.logExtraction?.excludedIndexPatterns
         );
         if (forbidden) return forbidden;
 

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_entity_store_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_entity_store_privileges.ts
@@ -34,9 +34,14 @@ export async function enforceEntityStorePrivileges(
   assetManager: AssetManagerClient,
   req: KibanaRequest,
   res: KibanaResponseFactory,
-  additionalIndexPatterns?: string[]
+  additionalIndexPatterns?: string[],
+  excludedIndexPatterns?: string[]
 ): Promise<IKibanaResponse | null> {
-  const privileges = await assetManager.getPrivileges(req, additionalIndexPatterns);
+  const privileges = await assetManager.getPrivileges(
+    req,
+    additionalIndexPatterns,
+    excludedIndexPatterns
+  );
   if (!privileges.hasAllRequested) {
     return res.forbidden({
       body: {

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_store_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_store_privileges.spec.ts
@@ -258,4 +258,58 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
       });
     }
   );
+
+  // --- excluded index patterns (must also be readable by the caller) ---
+
+  apiTest(
+    'install - Should fail when user lacks permissions for excluded index patterns',
+    async ({ apiClient, esClient, requestAuth }) => {
+      const restrictedIndex = 'restricted-test-logs';
+      additionalIndicesToCleanup = [restrictedIndex];
+
+      await esClient.indices.create({ index: restrictedIndex });
+
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(getRoleWithAllPrivileges());
+
+      const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: { logExtraction: { excludedIndexPatterns: [restrictedIndex] } },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_elasticsearch_privileges: {
+          cluster: [],
+          index: [{ index: restrictedIndex, privileges: ENTITY_STORE_SOURCE_INDICES_PRIVILEGES }],
+        },
+      });
+    }
+  );
+
+  apiTest(
+    'update - Should fail when user lacks permissions for excluded index patterns',
+    async ({ apiClient, esClient, requestAuth }) => {
+      const restrictedIndex = 'restricted-test-logs';
+      additionalIndicesToCleanup = [restrictedIndex];
+
+      await esClient.indices.create({ index: restrictedIndex });
+
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(getRoleWithAllPrivileges());
+
+      const response = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+        headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: { logExtraction: { excludedIndexPatterns: [restrictedIndex] } },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_elasticsearch_privileges: {
+          cluster: [],
+          index: [{ index: restrictedIndex, privileges: ENTITY_STORE_SOURCE_INDICES_PRIVILEGES }],
+        },
+      });
+    }
+  );
 });


### PR DESCRIPTION
## Summary

The Entity Store install and update APIs validate the caller's Elasticsearch
privileges on `additionalIndexPatterns` (via the shared
`enforceEntityStorePrivileges` / `AssetManagerClient.getPrivileges` check), but
they do not apply any check to `excludedIndexPatterns`. This lets a caller
reconfigure which source indices are excluded from extraction without holding
any access to those indices.

This change extends the same check to `excludedIndexPatterns`: a caller must
hold `read` + `view_index_metadata` on any local index patterns they exclude,
keeping source-pattern reconfiguration consistent across both lists.

## Changes

- `AssetManagerClient.getPrivileges` accepts `excludedIndexPatterns` and unions
  the source-index privileges over them (local patterns only, mirroring the
  existing source-pattern handling; a leading `-` is stripped so
  `_has_privileges` receives a literal index name).
- `enforceEntityStorePrivileges` forwards `excludedIndexPatterns` to
  `getPrivileges`.
- The install and update route handlers pass
  `logExtraction?.excludedIndexPatterns` into the check.
- Unit tests for the excluded-pattern handling (including remote-pattern skip)
  and Scout API scenarios for install + update.

## Notes

- Remote (`cluster:index`) patterns are intentionally not privilege-checked
  here, matching how source patterns are already handled.
