### PR TITLE
[9.3] [Entity Store] Enforce privileges on apply_dataview_indices route

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
@@ -11,6 +11,10 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 import type { ApplyEntityEngineDataviewIndicesResponse } from '../../../../../common/api/entity_analytics/entity_store/engine/apply_dataview_indices.gen';
 import { API_VERSIONS, APP_ID } from '../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import {
+  getAllMissingPrivileges,
+  getMissingPrivilegesErrorMessage,
+} from '../../../../../common/entity_analytics/privileges';
 import type { ITelemetryEventsSender } from '../../../telemetry/sender';
 import { ENTITY_STORE_API_CALL_EVENT } from '../../../telemetry/event_based/events';
 
@@ -46,9 +50,23 @@ export const applyDataViewIndicesEntityEngineRoute = (
 
         try {
           const secSol = await context.securitySolution;
-          const { errors, successes } = await secSol
-            .getEntityStoreDataClient()
-            .applyDataViewIndices();
+          const entityStoreClient = secSol.getEntityStoreDataClient();
+
+          // Applying data view indices reconfigures and regenerates the entity discovery
+          // resources (transforms, ingest pipelines) and mints an API key, so it requires the
+          // same Elasticsearch privileges as initializing the entity store. The Kibana feature
+          // privilege alone does not gate this, so enforce the init privileges explicitly.
+          const privileges = await entityStoreClient.getEntityStoreInitPrivileges([]);
+          if (!privileges.has_all_required) {
+            return siemResponse.error({
+              statusCode: 403,
+              body: `User does not have the required privileges to apply data view indices to the entity store\n${getMissingPrivilegesErrorMessage(
+                getAllMissingPrivileges(privileges)
+              )}`,
+            });
+          }
+
+          const { errors, successes } = await entityStoreClient.applyDataViewIndices();
 
           const errorMessages = errors.map((e) => e.message);
 


### PR DESCRIPTION
## Summary

The `POST /api/entity_store/engines/apply_dataview_indices` route (Entity Store
v1) reconfigures the entity discovery resources and mints an Elasticsearch API
key, but it was gated only by the Kibana feature privileges (`securitySolution`,
`securitySolution-entity-analytics`) and never checked the caller's
Elasticsearch privileges. The sibling entity engine `init` route does perform
that check.

This adds the same `getEntityStoreInitPrivileges` check used by `init` and
returns `403` with the missing-privilege detail before doing any work. A user
without the entity store management privileges (ES cluster `manage_*`, index
`manage`, and the saved-object create privileges) can no longer trigger the
route or its API key generation.

## Context

- Entity Store v1 is removed on `main` and `9.5`, so there is no upstream PR to
  backport from; this is a direct fix on the supported release lines that still
  ship the route (`9.3`, `8.19`, and separately `9.4`).

## Testing

- Manual: as a user with only the Security Solution read feature privilege and
  no ES cluster/index manage privileges, the route now returns `403` instead of
  `200` + API key creation. A user with the entity store management privileges
  is unaffected.
