### PR TITLE
fix(ci): skip bundle size limits paths absent from the target branch

### DIFF
--- a/.github/scripts/bundle_size_limits_comment.js
+++ b/.github/scripts/bundle_size_limits_comment.js
@@ -15,13 +15,18 @@ const LIMITS_PATHS = [
 ];
 
 const getContent = async ({ github, context }, ref, path) => {
-  const { data } = await github.rest.repos.getContent({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    path,
-    ref,
-  });
-  return Buffer.from(data.content, 'base64').toString('utf8');
+  try {
+    const { data } = await github.rest.repos.getContent({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      path,
+      ref,
+    });
+    return Buffer.from(data.content, 'base64').toString('utf8');
+  } catch (err) {
+    if (err.status === 404) return null;
+    throw err;
+  }
 };
 
 const parseYaml = (content) => {
@@ -42,6 +47,8 @@ module.exports = async ({ github, context }) => {
       getContent({ github, context }, pr.base.sha, path),
       getContent({ github, context }, pr.head.sha, path),
     ]);
+
+    if (baseContent === null || headContent === null) continue;
 
     const baseMap = parseYaml(baseContent);
     const headMap = parseYaml(headContent);


### PR DESCRIPTION
## Summary

The `bundle-size-limits-comment` workflow runs from `main` via `pull_request_target`, but fetches `limits.yml` at the PR's `base.sha` and `head.sha`. For backport PRs targeting older branches (e.g. `9.4`) that only have `packages/kbn-optimizer/limits.yml` (not `packages/kbn-rspack-optimizer/limits.yml`), the GitHub API returns 404 and the uncaught error fails the workflow.

**Root cause:** `getContent` propagates 404s; the `for` loop doesn't skip absent paths.

**Fix:** catch HTTP 404 in `getContent` (return `null`) and `continue` if either base or head content is absent for a given path.

Fixes [#281441](https://github.com/elastic/kibana/pull/281441) (`[9.4]` backport failing on `bundle-size-limits-comment`).

## Test plan

- [ ] Re-run `bundle-size-limits-comment` on a PR targeting `9.4` — should pass without error
- [ ] PRs targeting `main` that touch `kbn-rspack-optimizer/limits.yml` still get comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)