### PR TITLE
Amend Serverless changelog bundle

### DIFF
--- a/docs/releases/cloud-serverless/kibana-2026-07-21.amend-1.yaml
+++ b/docs/releases/cloud-serverless/kibana-2026-07-21.amend-1.yaml
@@ -1,0 +1,10 @@
+products:
+- product: cloud-serverless
+  target: 2026-07-21
+  lifecycle: preview
+  repo: kibana
+  owner: elastic
+exclude-entries:
+- file:
+    name: 277615.yaml
+    checksum: 68cd2f628f05e929177ec439447faa375b1c2139


### PR DESCRIPTION
Removes outdated entries from published Elastic Cloud Serverless changelog bundles using immutable amendment sidecars.

## Review manifest

The generated amendment files contain only filenames and checksums. The sections below resolve each exclusion against its parent bundle so the removed titles can be reviewed directly. Source YAML links point to this PR branch.

<details>
<summary><strong>July 21, 2026</strong> — 1 exclusion</summary>

[Amendment YAML](https://github.com/elastic/kibana/blob/remove-serverless-esql-data-federation/docs/releases/cloud-serverless/kibana-2026-07-21.amend-1.yaml) · [Parent bundle](https://github.com/elastic/kibana/blob/main/docs/releases/cloud-serverless/kibana-2026-07-21.yaml)

| Entry YAML | Removed changelog title | Source PR |
|---|---|---|
| [`277615.yaml`](https://github.com/elastic/kibana/blob/remove-serverless-esql-data-federation/docs/changelog/277615.yaml) | Fix query sandbox rejecting ES\|QL data federation datasets | [#277615](https://github.com/elastic/kibana/pull/277615) |

</details>


## Validation

- 1 exclusion from 1 release bundle.
- Generated with docs-builder 1.30.0 using `changelog bundle-amend --remove`.
- Every amendment dry run completed with zero errors and zero warnings.
- Effective bundles were rendered with their amendments applied.
- All targeted entry IDs were absent from the rendered output.
- Source changelog YAML files are unchanged; only the Cloud Serverless bundle output is amended.
