### PR TITLE
Remove object-path-immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1522,7 +1522,6 @@
     "nodemailer": "8.0.7",
     "normalize-path": "3.0.0",
     "object-hash": "3.0.0",
-    "object-path-immutable": "4.1.2",
     "oniguruma-to-es": "4.3.4",
     "openai": "4.104.0",
     "openpgp": "5.11.3",

--- a/renovate.json
+++ b/renovate.json
@@ -1517,7 +1517,7 @@
     },
     {
       "groupName": "kibana-presentation misc canvas dependencies",
-      "matchDepNames": ["object-path-immutable", "safe-squel"],
+      "matchDepNames": ["safe-squel"],
       "reviewers": ["team:kibana-presentation"],
       "matchBaseBranches": ["main"],
       "addLabels": ["Team:Presentation"],

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/axis_config/extended_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/axis_config/extended_template.tsx
@@ -8,8 +8,8 @@
 import type { ChangeEvent } from 'react';
 import React, { Fragment, PureComponent } from 'react';
 import { EuiSelect, EuiFormRow, EuiSpacer, EuiText } from '@elastic/eui';
-import { set } from 'object-path-immutable';
 import { get } from 'lodash';
+import { set } from '../../../../common/lib/object_path_immutable';
 import type { ExpressionAstExpression } from '../../../../types';
 import { ArgumentStrings } from '../../../../i18n/ui';
 

--- a/x-pack/platform/plugins/private/canvas/common/lib/object_path_immutable.test.ts
+++ b/x-pack/platform/plugins/private/canvas/common/lib/object_path_immutable.test.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * These test cases are adapted from the upstream `object-path-immutable` test
+ * suite (MIT licensed, Copyright (c) 2015 Mario Casciaro), covering the subset
+ * of functionality that Canvas vendors in `object_path_immutable.ts`
+ * (`set`, `del`, `assign`, `push`, `insert`). They lock in the exact path
+ * semantics, structural sharing and immutability guarantees of the original.
+ */
+
+import { set, del, assign, push, insert } from './object_path_immutable';
+
+describe('object_path_immutable', () => {
+  describe('set', () => {
+    it('should set a deep key without modifying the original object', () => {
+      const obj = { a: { b: 1 }, c: { d: 2 } };
+
+      const newObj = set(obj, 'a.b', 3);
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(obj.a).toEqual({ b: 1 });
+      // this should be the same
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a.b).toBe(3);
+    });
+
+    it('should set a deep array', () => {
+      const obj = { a: { b: [1, 2, 3] }, c: { d: 2 } };
+
+      const newObj = set(obj, 'a.b.1', 4);
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(newObj.a.b).not.toBe(obj.a.b);
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a.b).toEqual([1, 4, 3]);
+    });
+
+    it('should create intermediate objects and array', () => {
+      const obj = { a: {}, c: { d: 2 } };
+
+      const newObj: any = set(obj, 'a.b.1.f', 'a');
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(obj.a).toEqual({});
+      expect(newObj.a).toEqual({ b: [undefined, { f: 'a' }] });
+    });
+
+    it('should return the input value if passed an empty path', () => {
+      const obj = {};
+
+      expect(set(obj, '', 'yo')).toBe('yo');
+    });
+
+    it('should set at a numeric path', () => {
+      expect(set([], 0, 'yo')).toEqual(['yo']);
+    });
+
+    it('[security] should not override an object prototype', () => {
+      set({}, '__proto__.injected', 'yo');
+      expect(({} as Record<string, unknown>).injected).toBeUndefined();
+    });
+
+    it('[security] should not assign into an object prototype', () => {
+      set({}, 'test', { __proto__: { injected: true } });
+      expect(({} as Record<string, unknown>).injected).toBeUndefined();
+    });
+  });
+
+  describe('insert', () => {
+    it('should insert value into existing array without modifying the object', () => {
+      const obj = { a: ['a'], c: {} };
+
+      const newObj = insert(obj, 'a', 'b', 0);
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a).toEqual(['b', 'a']);
+    });
+
+    it('should create intermediary array', () => {
+      const obj = { a: [], c: {} };
+
+      const newObj: any = insert(obj, 'a.0.1', 'b');
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a).toEqual([[undefined, ['b']]]);
+    });
+
+    it('should insert in another index', () => {
+      const obj = { a: 'b', b: { c: [], d: ['a', 'b'], e: [{}, { f: 'g' }], f: 'i' } };
+
+      const newObj = insert(obj, 'b.d', 'asdf', 1);
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.b.d).toEqual(['a', 'asdf', 'b']);
+    });
+
+    it('should handle sparse array', () => {
+      const obj: any = { a: 'b', b: { c: [], d: ['a', 'b'], e: [{}, { f: 'g' }], f: 'i' } };
+      obj.b.d = new Array(4);
+      obj.b.d[0] = 'a';
+      obj.b.d[1] = 'b';
+
+      const newObj: any = insert(obj, 'b.d', 'asdf', 3);
+      expect(newObj).not.toBe(obj);
+      expect(newObj.b.d[0]).toEqual('a');
+      expect(newObj.b.d[1]).toEqual('b');
+      expect(newObj.b.d[2]).toBeUndefined();
+      expect(newObj.b.d[3]).toEqual('asdf');
+      expect(newObj.b.d[4]).toBeUndefined();
+      expect(newObj.b.d.length).toEqual(5);
+    });
+
+    it('should throw if asked to insert into something other than an array', () => {
+      expect(() => {
+        insert({ foo: 'bar' }, 'foo', 'baz');
+      }).toThrow();
+    });
+
+    it('should return an array with an undefined value if passed an empty path and empty value and src is not an array', () => {
+      const obj = {};
+
+      expect(insert(obj, '')).toEqual([undefined]);
+    });
+
+    it('should insert the value in src if passed an empty path', () => {
+      const obj = ['a', 'b', 'c'];
+
+      expect(insert(obj, '', 'd', 1)).toEqual(['a', 'd', 'b', 'c']);
+    });
+
+    it('should insert at a numeric path', () => {
+      expect(insert([[23, 42]], 0, 'yo', 1)).toEqual([[23, 'yo', 42]]);
+    });
+  });
+
+  describe('push', () => {
+    it('should push values without modifying the object', () => {
+      const obj = { a: ['a'], c: {} };
+
+      const newObj = push(obj, 'a', 'b');
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a).toEqual(['a', 'b']);
+    });
+
+    it('should create intermediate objects/arrays', () => {
+      const obj = { a: [], c: {} };
+
+      const newObj: any = push(obj, 'a.0.1', 'b');
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a).toEqual([[undefined, ['b']]]);
+    });
+
+    it('should push into the cloned original object if passed an empty path', () => {
+      const obj = ['yoo'];
+
+      expect(push(obj, '', 'yo')).toEqual(['yoo', 'yo']);
+    });
+
+    it('returns new array if passed an empty path and src is not an array', () => {
+      const obj = {};
+
+      expect(push(obj, '', 'yo')).toEqual(['yo']);
+    });
+
+    it('should push at a numeric path', () => {
+      expect(push([[]], 0, 'yo')).toEqual([['yo']]);
+    });
+  });
+
+  describe('del', () => {
+    it('should delete deep values without modifying the object', () => {
+      const obj = { a: { d: 1, f: 2 }, c: {} };
+
+      const newObj = del(obj, 'a.d');
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a).toEqual({ f: 2 });
+    });
+
+    it('should delete deep values in array without modifying the object', () => {
+      const obj = { a: ['a'], c: {} };
+
+      const newObj = del(obj, 'a.0');
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a).toEqual([]);
+    });
+
+    it('should return undefined if passed an empty path', () => {
+      const obj = {};
+
+      expect(del(obj, '')).toBeUndefined();
+    });
+
+    it('should del at a numeric path', () => {
+      expect(del([23, 'yo', 42], 1)).toEqual([23, 42]);
+    });
+
+    it('should delete falsy value', () => {
+      expect(del(['', false], 1)).toEqual(['']);
+    });
+  });
+
+  describe('assign', () => {
+    it('should assign an object without modifying the original object', () => {
+      const obj = { a: { b: 1 }, c: { d: 2 } };
+
+      const newObj = assign(obj, 'a', { b: 3 });
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(obj.a).toEqual({ b: 1 });
+      expect(newObj.c).toBe(obj.c);
+
+      expect(newObj.a.b).toBe(3);
+    });
+
+    it('should keep existing fields that are not overwritten', () => {
+      const obj = { a: { b: 1 } };
+
+      const newObj: any = assign(obj, 'a', { c: 2 });
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(obj.a).toEqual({ b: 1 });
+      expect(newObj.a).toEqual({ b: 1, c: 2 });
+    });
+
+    it('should create intermediate objects', () => {
+      const obj = { a: {}, c: { d: 2 } };
+
+      const newObj: any = assign(obj, 'a.b', { f: 'a' });
+
+      expect(newObj).not.toBe(obj);
+      expect(newObj.a).not.toBe(obj.a);
+      expect(obj.a).toEqual({});
+      expect(newObj.a).toEqual({ b: { f: 'a' } });
+    });
+
+    it('should return the original object if passed an empty path and an empty value to assign', () => {
+      const obj = {};
+
+      expect(assign(obj, '', {})).toBe(obj);
+    });
+
+    it('should assign at a numeric path', () => {
+      expect(assign([{ foo: 'bar' }], 0, { foo: 'baz', fiz: 'biz' })).toEqual([
+        { foo: 'baz', fiz: 'biz' },
+      ]);
+    });
+
+    it('does not assign inherited properties', () => {
+      const base = { fiz: 'biz' };
+      const source: any = Object.create(base);
+      source.frob = 'nard';
+
+      const obj = { foo: {} };
+
+      expect(assign(obj, 'foo', source)).toEqual({ foo: { frob: 'nard' } });
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/canvas/common/lib/object_path_immutable.ts
+++ b/x-pack/platform/plugins/private/canvas/common/lib/object_path_immutable.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * A self-contained reimplementation of the subset of `object-path-immutable`
+ * (`set`, `del`, `assign`, `push`, `insert`) that Canvas relies on. The path
+ * semantics are intentionally identical to the upstream package (MIT licensed):
+ * string paths are split on `.`, numeric segments are treated as array indices,
+ * and intermediate objects/arrays are created as needed. Every operation returns
+ * a new object with structural sharing and never mutates its input.
+ */
+
+export type PathSegment = string | number;
+export type Path = PathSegment | PathSegment[];
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+const isNumber = (value: unknown): value is number => typeof value === 'number';
+const isString = (value: unknown): value is string => typeof value === 'string';
+const isArray = Array.isArray;
+
+const isEmpty = (value: any): boolean => {
+  if (isNumber(value)) {
+    return false;
+  }
+  if (!value) {
+    return true;
+  }
+  if (isArray(value) && value.length === 0) {
+    return true;
+  } else if (!isString(value)) {
+    for (const key in value) {
+      if (hasOwnProperty.call(value, key)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+};
+
+const assignToObj = (target: any, source: any): any => {
+  for (const key in source) {
+    if (hasOwnProperty.call(source, key)) {
+      target[key] = source[key];
+    }
+  }
+  return target;
+};
+
+// Numeric string keys are interpreted as array indices (e.g. `pages.0.style`).
+const getKey = (key: string): PathSegment => {
+  const intKey = parseInt(key, 10);
+  if (intKey.toString() === key) {
+    return intKey;
+  }
+  return key;
+};
+
+const clone = (obj: any, createIfEmpty?: boolean, assumeArray?: boolean): any => {
+  if (obj == null) {
+    if (createIfEmpty) {
+      return assumeArray ? [] : {};
+    }
+    return obj;
+  } else if (isArray(obj)) {
+    return obj.slice();
+  }
+  return assignToObj({}, obj);
+};
+
+type ChangeCallback = (clonedObj: any, finalPath: PathSegment) => any;
+
+const changeImmutable = (dest: any, src: any, path: Path, changeCallback: ChangeCallback): any => {
+  if (isNumber(path)) {
+    path = [path];
+  }
+  if (isEmpty(path)) {
+    return src;
+  }
+  if (isString(path)) {
+    return changeImmutable(dest, src, path.split('.').map(getKey), changeCallback);
+  }
+
+  const segments = path as PathSegment[];
+  const currentPath = segments[0];
+
+  if (!dest || dest === src) {
+    dest = clone(src, true, isNumber(currentPath));
+  }
+
+  if (segments.length === 1) {
+    return changeCallback(dest, currentPath);
+  }
+
+  if (src != null) {
+    src = src[currentPath];
+  }
+
+  dest[currentPath] = changeImmutable(dest[currentPath], src, segments.slice(1), changeCallback);
+
+  return dest;
+};
+
+export function set<T extends object>(src: T, path: Path, value: any): T {
+  if (isEmpty(path)) {
+    return value;
+  }
+  return changeImmutable(null, src, path, (clonedObj, finalPath) => {
+    clonedObj[finalPath] = value;
+    return clonedObj;
+  });
+}
+
+export function del<T extends object>(src: T, path: Path): T {
+  if (isEmpty(path)) {
+    return undefined as unknown as T;
+  }
+  return changeImmutable(null, src, path, (clonedObj, finalPath) => {
+    if (isArray(clonedObj)) {
+      if (clonedObj[finalPath] !== undefined) {
+        clonedObj.splice(finalPath as number, 1);
+      }
+    } else if (hasOwnProperty.call(clonedObj, finalPath)) {
+      delete clonedObj[finalPath];
+    }
+    return clonedObj;
+  });
+}
+
+export function assign<T extends object>(src: T, path: Path, source: object): T {
+  if (isEmpty(path)) {
+    if (isEmpty(source)) {
+      return src;
+    }
+    return assignToObj(clone(src), source);
+  }
+  return changeImmutable(null, src, path, (clonedObj, finalPath) => {
+    const normalizedSource = Object(source);
+    const target = clone(clonedObj[finalPath], true);
+    assignToObj(target, normalizedSource);
+    clonedObj[finalPath] = target;
+    return clonedObj;
+  });
+}
+
+export function push<T extends object>(src: T, path: Path, ...values: any[]): T {
+  if (isEmpty(path)) {
+    return (!isArray(src) ? values : (src as any[]).concat(values)) as unknown as T;
+  }
+  return changeImmutable(null, src, path, (clonedObj, finalPath) => {
+    if (!isArray(clonedObj[finalPath])) {
+      clonedObj[finalPath] = values;
+    } else {
+      clonedObj[finalPath] = clonedObj[finalPath].concat(values);
+    }
+    return clonedObj;
+  });
+}
+
+export function insert<T extends object>(src: T, path: Path, value?: any, at?: number): T {
+  const index = Math.trunc(Number(at)) || 0;
+  if (isEmpty(path)) {
+    if (!isArray(src)) {
+      return [value] as unknown as T;
+    }
+    const firstPart = (src as any[]).slice(0, index);
+    firstPart.push(value);
+    return firstPart.concat((src as any[]).slice(index)) as unknown as T;
+  }
+  return changeImmutable(null, src, path, (clonedObj, finalPath) => {
+    let arr = clonedObj[finalPath];
+    if (!isArray(arr)) {
+      if (arr != null && typeof arr !== 'undefined') {
+        throw new Error(`Expected ${String(path)} to be an array. Instead got ${typeof arr}`);
+      }
+      arr = [];
+    }
+    const firstPart = arr.slice(0, index);
+    firstPart.push(value);
+    clonedObj[finalPath] = firstPart.concat(arr.slice(index));
+    return clonedObj;
+  });
+}

--- a/x-pack/platform/plugins/private/canvas/common/lib/object_path_immutable.ts
+++ b/x-pack/platform/plugins/private/canvas/common/lib/object_path_immutable.ts
@@ -106,7 +106,7 @@ const changeImmutable = (dest: any, src: any, path: Path, changeCallback: Change
   return dest;
 };
 
-export function set<T extends object>(src: T, path: Path, value: any): T {
+export function set<T = object>(src: T, path: Path, value: any): T {
   if (isEmpty(path)) {
     return value;
   }
@@ -116,14 +116,15 @@ export function set<T extends object>(src: T, path: Path, value: any): T {
   });
 }
 
-export function del<T extends object>(src: T, path: Path): T {
+export function del<T = object>(src: T, path: Path): T {
   if (isEmpty(path)) {
     return undefined as unknown as T;
   }
   return changeImmutable(null, src, path, (clonedObj, finalPath) => {
     if (isArray(clonedObj)) {
-      if (clonedObj[finalPath] !== undefined) {
-        clonedObj.splice(finalPath as number, 1);
+      const index = finalPath as number;
+      if (clonedObj[index] !== undefined) {
+        clonedObj.splice(index, 1);
       }
     } else if (hasOwnProperty.call(clonedObj, finalPath)) {
       delete clonedObj[finalPath];
@@ -132,7 +133,7 @@ export function del<T extends object>(src: T, path: Path): T {
   });
 }
 
-export function assign<T extends object>(src: T, path: Path, source: object): T {
+export function assign<T = object>(src: T, path: Path, source: any): T {
   if (isEmpty(path)) {
     if (isEmpty(source)) {
       return src;
@@ -148,7 +149,7 @@ export function assign<T extends object>(src: T, path: Path, source: object): T 
   });
 }
 
-export function push<T extends object>(src: T, path: Path, ...values: any[]): T {
+export function push<T = object>(src: T, path: Path, ...values: any[]): T {
   if (isEmpty(path)) {
     return (!isArray(src) ? values : (src as any[]).concat(values)) as unknown as T;
   }
@@ -162,7 +163,7 @@ export function push<T extends object>(src: T, path: Path, ...values: any[]): T 
   });
 }
 
-export function insert<T extends object>(src: T, path: Path, value?: any, at?: number): T {
+export function insert<T = object>(src: T, path: Path, value?: any, at?: number): T {
   const index = Math.trunc(Number(at)) || 0;
   if (isEmpty(path)) {
     if (!isArray(src)) {

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/index.ts
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/index.ts
@@ -7,8 +7,8 @@
 
 import type { ComponentType } from 'react';
 import { withHandlers } from 'react-recompose';
-import { set } from 'object-path-immutable';
 import { get } from 'lodash';
+import { set } from '../../../../common/lib/object_path_immutable';
 import { templateFromReactComponent } from '../../../lib/template_from_react_component';
 import type { Arguments as SimpleArguments } from './simple_template';
 import { SimpleTemplate } from './simple_template';

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/extended_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/extended_template.tsx
@@ -8,8 +8,8 @@
 import type { FunctionComponent, ChangeEvent } from 'react';
 import React, { Fragment } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect, EuiSpacer } from '@elastic/eui';
-import { set, del } from 'object-path-immutable';
 import { get } from 'lodash';
+import { set, del } from '../../../../common/lib/object_path_immutable';
 import type { ResolvedArgProps, ResolvedLabels } from '../../arg';
 import type { ExpressionAstExpression } from '../../../../types';
 import { ArgTypesStrings } from '../../../../i18n';

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/simple_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/simple_template.tsx
@@ -15,8 +15,8 @@ import {
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
-import { set, del } from 'object-path-immutable';
 import { get } from 'lodash';
+import { set, del } from '../../../../common/lib/object_path_immutable';
 import type { ResolvedArgProps, ResolvedLabels } from '../../arg';
 import { ColorPickerPopover } from '../../../components/color_picker_popover';
 import { TooltipIcon, IconType } from '../../../components/tooltip_icon';

--- a/x-pack/platform/plugins/private/canvas/public/lib/sync_filter_expression.ts
+++ b/x-pack/platform/plugins/private/canvas/public/lib/sync_filter_expression.ts
@@ -6,8 +6,8 @@
  */
 
 import { fromExpression } from '@kbn/interpreter';
-import { set, del } from 'object-path-immutable';
 import { get } from 'lodash';
+import { set, del } from '../../common/lib/object_path_immutable';
 
 export function syncFilterExpression(
   config: Record<string, any>,

--- a/x-pack/platform/plugins/private/canvas/public/state/actions/elements.js
+++ b/x-pack/platform/plugins/private/canvas/public/state/actions/elements.js
@@ -6,9 +6,9 @@
  */
 
 import { createAction } from 'redux-actions';
-import { set, del } from 'object-path-immutable';
 import { get, pick, cloneDeep, without, last } from 'lodash';
 import { toExpression, safeElementFromExpression } from '@kbn/interpreter';
+import { set, del } from '../../../common/lib/object_path_immutable';
 import { createThunk } from '../../lib/create_thunk';
 import { isGroupId } from '../../lib/workpad';
 import {

--- a/x-pack/platform/plugins/private/canvas/public/state/reducers/assets.js
+++ b/x-pack/platform/plugins/private/canvas/public/state/reducers/assets.js
@@ -6,8 +6,8 @@
  */
 
 import { handleActions, combineActions } from 'redux-actions';
-import { set, assign, del } from 'object-path-immutable';
 import { get } from 'lodash';
+import { set, assign, del } from '../../../common/lib/object_path_immutable';
 import { setAssetValue, removeAsset, setAssets, resetAssets, setAsset } from '../actions/assets';
 
 export const assetsReducer = handleActions(

--- a/x-pack/platform/plugins/private/canvas/public/state/reducers/elements.js
+++ b/x-pack/platform/plugins/private/canvas/public/state/reducers/elements.js
@@ -6,8 +6,8 @@
  */
 
 import { handleActions } from 'redux-actions';
-import { assign, push, del, set } from 'object-path-immutable';
 import { get } from 'lodash';
+import { assign, push, del, set } from '../../../common/lib/object_path_immutable';
 
 const getLocation = (type) => (type === 'group' ? 'groups' : 'elements');
 const firstOccurrence = (element, index, array) => array.indexOf(element) === index;

--- a/x-pack/platform/plugins/private/canvas/public/state/reducers/pages.js
+++ b/x-pack/platform/plugins/private/canvas/public/state/reducers/pages.js
@@ -6,7 +6,7 @@
  */
 
 import { handleActions } from 'redux-actions';
-import { set, del, insert } from 'object-path-immutable';
+import { set, del, insert } from '../../../common/lib/object_path_immutable';
 import { cloneSubgraphs } from '../../lib/clone_subgraphs';
 import { getId } from '../../lib/get_id';
 import { getDefaultPage } from '../defaults';

--- a/x-pack/platform/plugins/private/canvas/public/state/reducers/resolved_args.js
+++ b/x-pack/platform/plugins/private/canvas/public/state/reducers/resolved_args.js
@@ -6,8 +6,8 @@
  */
 
 import { handleActions } from 'redux-actions';
-import { set, del } from 'object-path-immutable';
 import { get } from 'lodash';
+import { set, del } from '../../../common/lib/object_path_immutable';
 import { prepend } from '../../lib/modify_path';
 import * as actions from '../actions/resolved_args';
 

--- a/x-pack/platform/plugins/private/canvas/public/state/reducers/transient.js
+++ b/x-pack/platform/plugins/private/canvas/public/state/reducers/transient.js
@@ -6,7 +6,7 @@
  */
 
 import { handleActions } from 'redux-actions';
-import { set, del } from 'object-path-immutable';
+import { set, del } from '../../../common/lib/object_path_immutable';
 
 export const transientReducer = handleActions(
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28458,19 +28458,6 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-path-immutable@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/object-path-immutable/-/object-path-immutable-4.1.2.tgz#d78e3587f03c9a41f83dd6465cfef5a9eb390bb4"
-  integrity sha512-Bfrox46OegMkQXL872EzEjofMyBxk/2hgiy99NkCkYFegn6Dm9FvV2jY2Tnp9qLj2QL0TLii12CuPpzonkjJrA==
-  dependencies:
-    is-plain-object "^5.0.0"
-    object-path "^0.11.8"
-
-object-path@^0.11.8:
-  version "0.11.8"
-  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.8.tgz#ed002c02bbdd0070b78a27455e8ae01fc14d4742"
-  integrity sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==
-
 object.assign@^4.1.0, object.assign@^4.1.4, object.assign@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.5.tgz#3a833f9ab7fdb80fc9e8d2300c803d216d8fdbb0"


### PR DESCRIPTION
## Summary

Removes `object-path-immutable` in favor of first-party implementation. The only usage was within Canvas, and it was only using a subset of the dependency.