### PR TITLE
[9.4] [APM] De-flake latest_agent_versions API test by asserting route contract (#275440)

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/agent_explorer/latest_agent_versions.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/agent_explorer/latest_agent_versions.spec.ts
@@ -10,8 +10,6 @@ import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider
 
 export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
   const apmApiClient = getService('apmApi');
-  const retry = getService('retry');
-  const nodeAgentName = 'nodejs';
   const unlistedAgentName = 'unlistedAgent';
 
   async function callApi() {
@@ -20,35 +18,30 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     });
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/264146
-  describe.skip('Agent latest versions when configuration is defined', () => {
-    it('returns a version when agent is listed in the file', async () => {
-      await retry.tryForTime(120000, async () => {
-        const { status, body } = await callApi();
-        expect(status).to.be(200);
-        if (body.error) {
-          throw new Error(`Latest agent versions fetch failed: ${JSON.stringify(body.error)}`);
-        }
-        const agents = body.data;
-        const nodeAgent = agents[nodeAgentName] as ElasticApmAgentLatestVersion;
-        expect(nodeAgent?.latest_version).not.to.be(undefined);
-      });
+  // The latest agent versions are fetched live from an external service
+  // (`xpack.apm.latestAgentVersionsUrl`). This deployment-agnostic suite runs on
+  // Cloud lanes too and cannot override that URL, so the assertions below verify
+  // only the route contract (always 200 with a well-formed `data` object) and
+  // never the externally sourced version content, which is covered by the
+  // `fetch_agents_latest_version` unit test. Asserting on the external payload
+  // here made the test flaky whenever the upstream service was briefly degraded.
+  // See https://github.com/elastic/kibana/issues/264146
+  describe('Agent latest versions when configuration is defined', () => {
+    it('returns a well-formed response', async () => {
+      const { status, body } = await callApi();
+      expect(status).to.be(200);
+      expect(body.data).to.be.an('object');
     });
 
-    it('returns undefined when agent is not listed in the file', async () => {
-      await retry.tryForTime(120000, async () => {
-        const { status, body } = await callApi();
-        expect(status).to.be(200);
-        if (body.error) {
-          throw new Error(`Latest agent versions fetch failed: ${JSON.stringify(body.error)}`);
-        }
+    it('does not return a version for an agent that is not listed', async () => {
+      const { status, body } = await callApi();
+      expect(status).to.be(200);
 
-        const agents = body.data;
+      const agents = body.data;
 
-        // @ts-ignore
-        const unlistedAgent = agents[unlistedAgentName] as ElasticApmAgentLatestVersion;
-        expect(unlistedAgent?.latest_version).to.be(undefined);
-      });
+      // @ts-ignore
+      const unlistedAgent = agents[unlistedAgentName] as ElasticApmAgentLatestVersion;
+      expect(unlistedAgent?.latest_version).to.be(undefined);
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[APM] De-flake latest_agent_versions API test by asserting route contract (#275440)](https://github.com/elastic/kibana/pull/275440)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":275440,"url":"https://github.com/elastic/kibana/pull/275440","title":"[APM] De-flake latest_agent_versions API test by asserting route contract"},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"sourceCommit":{"sha":"682c05c3fac2305395e0932bed405f51418d6ff7"}}] BACKPORT-->