### PR TITLE
Add margin around telemetry callout

### DIFF
--- a/src/core/packages/overlays/browser-internal/src/banners/banners_list.test.tsx
+++ b/src/core/packages/overlays/browser-internal/src/banners/banners_list.test.tsx
@@ -43,7 +43,7 @@ describe('BannersList', () => {
       </Wrapper>
     );
     expect(container.innerHTML).toMatchInlineSnapshot(
-      `"<div class=\\"kbnGlobalBannerList\\"><div data-test-priority=\\"0\\" data-test-subj=\\"global-banner-item\\" class=\\"css-1y3glo5\\"><h1>Hello!</h1></div></div>"`
+      `"<div class=\\"kbnGlobalBannerList\\"><div data-test-priority=\\"0\\" data-test-subj=\\"global-banner-item\\" class=\\"css-1dneiex\\"><h1>Hello!</h1></div></div>"`
     );
   });
 
@@ -92,7 +92,7 @@ describe('BannersList', () => {
 
     // Two new banners should be rendered
     expect(container.innerHTML).toMatchInlineSnapshot(
-      `"<div class=\\"kbnGlobalBannerList\\"><div data-test-priority=\\"1\\" data-test-subj=\\"global-banner-item\\" class=\\"css-1y3glo5\\"><h1>First Banner!</h1></div><div data-test-priority=\\"0\\" data-test-subj=\\"global-banner-item\\" class=\\"css-1y3glo5\\"><h1>Second banner!</h1></div></div>"`
+      `"<div class=\\"kbnGlobalBannerList\\"><div data-test-priority=\\"1\\" data-test-subj=\\"global-banner-item\\" class=\\"css-1dneiex\\"><h1>First Banner!</h1></div><div data-test-priority=\\"0\\" data-test-subj=\\"global-banner-item\\" class=\\"css-1dneiex\\"><h1>Second banner!</h1></div></div>"`
     );
     // Original banner should be unmounted
     expect(unmount).toHaveBeenCalled();

--- a/src/core/packages/overlays/browser-internal/src/banners/banners_list.tsx
+++ b/src/core/packages/overlays/browser-internal/src/banners/banners_list.tsx
@@ -51,7 +51,8 @@ const BannerItem: React.FunctionComponent<{ banner: OverlayBanner }> = ({ banner
     <div
       data-test-priority={banner.priority}
       css={({ euiTheme }) => ({
-        '& + &': { marginTop: euiTheme.size.s },
+        margin: euiTheme.size.s,
+        '& + &': { marginTop: 0 },
       })}
       ref={element}
       data-test-subj="global-banner-item"


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/278581

## Summary

EUI callouts were redesigned and now have a border. In places where callouts sit flush to their container, this results in border+border result.

#### Before
<img width="3012" height="540" alt="CleanShot 2026-07-28 at 11 41 39@2x" src="https://github.com/user-attachments/assets/8ca4efe0-06df-4fbc-a7d2-e67d6d3ec287" />

<img width="2434" height="422" alt="CleanShot 2026-07-28 at 11 47 07@2x" src="https://github.com/user-attachments/assets/1a10ba20-b090-4b5e-8d1b-8ac9291a78d1" />


#### After
<img width="1794" height="714" alt="CleanShot 2026-07-29 at 07 56 52@2x" src="https://github.com/user-attachments/assets/2b54aa54-cdc0-45e3-aa4a-c813209365e4" />

<img width="1928" height="600" alt="CleanShot 2026-07-29 at 07 56 15@2x" src="https://github.com/user-attachments/assets/ddf158d6-97f4-4d2b-9710-2c47cf6f0bc7" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



