### PR TITLE
[POC] [Alerting v2] Add episode Agent Builder attachment and Add to chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "@kbn/alerting-rule-utils": "link:x-pack/platform/packages/shared/alerting-rule-utils",
     "@kbn/alerting-state-types": "link:x-pack/platform/packages/private/kbn-alerting-state-types",
     "@kbn/alerting-types": "link:src/platform/packages/shared/kbn-alerting-types",
+    "@kbn/alerting-v2-common-queries": "link:x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries",
     "@kbn/alerting-v2-constants": "link:x-pack/platform/packages/shared/response-ops/alerting-v2-constants",
     "@kbn/alerting-v2-episodes-ui": "link:x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui",
     "@kbn/alerting-v2-plugin": "link:x-pack/platform/plugins/shared/alerting_v2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -117,6 +117,8 @@
       "@kbn/alerting-state-types/*": ["./x-pack/platform/packages/private/kbn-alerting-state-types/*"],
       "@kbn/alerting-types": ["./src/platform/packages/shared/kbn-alerting-types"],
       "@kbn/alerting-types/*": ["./src/platform/packages/shared/kbn-alerting-types/*"],
+      "@kbn/alerting-v2-common-queries": ["./x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries"],
+      "@kbn/alerting-v2-common-queries/*": ["./x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/*"],
       "@kbn/alerting-v2-constants": ["./x-pack/platform/packages/shared/response-ops/alerting-v2-constants"],
       "@kbn/alerting-v2-constants/*": ["./x-pack/platform/packages/shared/response-ops/alerting-v2-constants/*"],
       "@kbn/alerting-v2-episodes-ui": ["./x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui"],

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -272,6 +272,7 @@ export const AGENT_BUILDER_BUILTIN_ATTACHMENTS = [
   // Platform – Alerting v2
   'rule',
   'action_policy',
+  'episode',
 
   // Security Solution
   'security.alert',

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/constants.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-export const ALERT_EVENTS_DATA_STREAM = '.rule-events';
-export const ALERT_ACTIONS_DATA_STREAM = '.alert-actions';
-export const TIME_FIELD = '@timestamp';
+export {
+  ALERT_EVENTS_DATA_STREAM,
+  ALERT_ACTIONS_DATA_STREAM,
+  DEFAULT_TIME_FIELD as TIME_FIELD,
+} from '@kbn/alerting-v2-constants';
 
 export const EPISODES_LIST_PAGE_SIZE = 1000;
 export const HISTOGRAM_EPISODE_LIMIT = 10_000;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/constants.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ALERT_EVENTS_DATA_STREAM = '.rule-events';
+export const ALERT_ACTIONS_DATA_STREAM = '.alert-actions';
+export const TIME_FIELD = '@timestamp';
+
+export const EPISODES_LIST_PAGE_SIZE = 1000;
+export const HISTOGRAM_EPISODE_LIMIT = 10_000;
+export const RELATED_EPISODES_LIMIT = 5;
+export const DEFAULT_ACTIONS_HISTORY_PAGE_SIZE = 25;
+export const TAG_OPTIONS_LIMIT = 500;
+export const TAG_SUGGESTIONS_LIMIT = 20;
+export const DEFAULT_FLAPPING_LOOKBACK = 10;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_actions_history_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_actions_history_query.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ALERT_ACTIONS_DATA_STREAM, DEFAULT_ACTIONS_HISTORY_PAGE_SIZE } from './constants';
+
+export interface BuildEpisodeActionsHistoryQueryOptions {
+  before?: string;
+  limit?: number;
+}
+
+export const buildEpisodeActionsHistoryQuery = (
+  spaceId: string,
+  episodeId: string,
+  groupHash: string,
+  { before, limit = DEFAULT_ACTIONS_HISTORY_PAGE_SIZE }: BuildEpisodeActionsHistoryQueryOptions = {}
+): ComposerQuery => {
+  const query = esql
+    .from([ALERT_ACTIONS_DATA_STREAM], ['_id'])
+    .where`space_id == ${spaceId}`
+    .where`episode_id == ${episodeId} OR (group_hash == ${groupHash} AND episode_id IS NULL)`
+    .where`action_type IN ("ack", "unack", "snooze", "unsnooze", "deactivate", "activate", "tag", "assign")`;
+
+  if (before) {
+    query.where`@timestamp <= ${before}`;
+  }
+
+  return query
+    .sort(['@timestamp', 'DESC'])
+    .limit(limit)
+    .keep(
+      '_id',
+      '@timestamp',
+      'action_type',
+      'actor',
+      'episode_id',
+      'group_hash',
+      'tags',
+      'assignee_uid',
+      'expiry',
+      'reason'
+    );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_actions_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_actions_query.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ALERT_ACTIONS_DATA_STREAM } from './constants';
+
+export const buildEpisodeActionsQuery = (
+  spaceId: string,
+  episodeIds: string[]
+): ComposerQuery => {
+  const episodeIdLiterals = episodeIds.map((id) => esql.str(id));
+
+  return esql.from(ALERT_ACTIONS_DATA_STREAM)
+    .where`space_id == ${spaceId}`
+    .where`episode_id IN (${episodeIdLiterals})`
+    .where`action_type IN ("ack", "unack", "assign")`
+    .pipe`EVAL
+      ack_action = CASE(action_type IN ("ack", "unack"), action_type, null),
+      assignee_value = CASE(action_type == "assign", assignee_uid, null),
+      ack_actor = CASE(action_type == "ack", actor, null)`
+    .pipe`STATS
+      last_ack_action = LAST(ack_action, @timestamp),
+      last_assignee_uid = LAST(assignee_value, @timestamp),
+      last_ack_actor = LAST(ack_actor, @timestamp)
+      BY episode_id, rule_id, group_hash`
+    .keep('episode_id', 'rule_id', 'group_hash', 'last_ack_action', 'last_assignee_uid', 'last_ack_actor');
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_event_data_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_event_data_query.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ALERT_EVENTS_DATA_STREAM } from './constants';
+
+export const buildEpisodeEventDataQuery = (spaceId: string, episodeId: string): ComposerQuery => {
+  return esql.from([ALERT_EVENTS_DATA_STREAM], ['_source'])
+    .where`space_id == ${spaceId}`
+    .where`type == "alert"`
+    .where`episode.id == ${episodeId}`
+    .pipe`EVAL extracted_data = JSON_EXTRACT(_source, "data")`
+    .pipe`INLINE STATS
+      last_data = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}",
+      last_data_timestamp = MAX(@timestamp) WHERE extracted_data != "{}",
+      last_event_timestamp = MAX(@timestamp)
+      BY \`episode.id\``;
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_events_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_events_query.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ALERT_EVENTS_DATA_STREAM, TIME_FIELD } from './constants';
+
+export const ALERT_EPISODE_EVENT_FIELDS = [
+  '@timestamp',
+  'episode.id',
+  'episode.status',
+  'rule.id',
+  'group_hash',
+  'severity',
+  'data',
+] as const;
+
+export const buildEpisodeEventsQuery = (spaceId: string, episodeId: string): ComposerQuery => {
+  return esql.from([ALERT_EVENTS_DATA_STREAM], ['_source'])
+    .where`space_id == ${spaceId}`
+    .where`type == "alert"`
+    .where`episode.id == ${episodeId}`
+    .pipe`EVAL data = JSON_EXTRACT(_source, "$.data")`
+    .sort([TIME_FIELD, 'ASC'])
+    .keep(...ALERT_EPISODE_EVENT_FIELDS);
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_flapping_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_flapping_query.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ALERT_EVENTS_DATA_STREAM, TIME_FIELD, DEFAULT_FLAPPING_LOOKBACK } from './constants';
+
+export const buildEpisodeFlappingQuery = (
+  spaceId: string,
+  episodeId: string,
+  limit: number = DEFAULT_FLAPPING_LOOKBACK
+): ComposerQuery => {
+  return esql.from([ALERT_EVENTS_DATA_STREAM])
+    .where`space_id == ${spaceId}`
+    .where`type == "alert"`
+    .where`episode.id == ${episodeId}`
+    .sort([TIME_FIELD, 'DESC'])
+    .keep('episode.status')
+    .limit(limit);
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_query.ts
@@ -6,11 +6,9 @@
  */
 
 import type { ComposerQuery } from '@elastic/esql';
-import { buildEpisodeQuery as buildEpisodeQueryCommon } from '@kbn/alerting-v2-common-queries';
+import { ALERT_EPISODE_FIELDS, buildEpisodesBaseQuery } from './episodes_query';
 
-/**
- * Builds an ES|QL query that returns the single aggregated row for one episode,
- * reusing the same aggregation pipeline as the list query.
- */
 export const buildEpisodeQuery = (spaceId: string, episodeId: string): ComposerQuery =>
-  buildEpisodeQueryCommon(spaceId, episodeId);
+  buildEpisodesBaseQuery(spaceId).where`episode.id == ${episodeId}`.pipe`LIMIT 1`.keep(
+    ...ALERT_EPISODE_FIELDS
+  );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_tag_options_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_tag_options_query.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ALERT_ACTIONS_DATA_STREAM, TAG_OPTIONS_LIMIT } from './constants';
+
+export const buildEpisodeTagOptionsQuery = (spaceId: string): ComposerQuery => {
+  return esql.from(ALERT_ACTIONS_DATA_STREAM)
+    .where`space_id == ${spaceId}`
+    .where`action_type == "tag"`
+    .where`tags IS NOT NULL`
+    .pipe`MV_EXPAND tags`
+    .pipe`STATS BY tags`
+    .sort(['tags', 'ASC'])
+    .pipe`LIMIT ${TAG_OPTIONS_LIMIT}`;
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_trend_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episode_trend_query.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { Builder, LeafPrinter, esql } from '@elastic/esql';
+import { ALERT_EVENTS_DATA_STREAM, TIME_FIELD } from './constants';
+
+const metricColumn = (label: string): string =>
+  LeafPrinter.column(Builder.expression.column(label));
+
+const dataSelector = (label: string): string =>
+  LeafPrinter.string({ valueUnquoted: `data['${label.replace(/['\\]/g, '\\$&')}']` });
+
+export const buildEpisodeTrendQuery = (
+  spaceId: string,
+  episodeId: string,
+  metricLabels: string[]
+): ComposerQuery => {
+  let query = esql.from([ALERT_EVENTS_DATA_STREAM], ['_source'])
+    .where`space_id == ${spaceId}`
+    .where`type == "alert"`
+    .where`episode.id == ${episodeId}`;
+
+  metricLabels.forEach((label) => {
+    query = query.pipe(
+      `EVAL ${metricColumn(label)} = JSON_EXTRACT(_source, ${dataSelector(label)})`
+    );
+  });
+
+  return query.sort([TIME_FIELD, 'ASC']).keep('@timestamp', 'episode.status', ...metricLabels);
+};
+
+export const parseEpisodeTrendRows = (
+  rawRows: Array<Record<string, unknown>>,
+  metricLabels: string[]
+): Array<{ '@timestamp': string; 'episode.status': string; metrics: Record<string, number | null> }> =>
+  rawRows.map((row) => ({
+    '@timestamp': row['@timestamp'] as string,
+    'episode.status': row['episode.status'] as string,
+    metrics: Object.fromEntries(
+      metricLabels.map((label) => {
+        const val = row[label];
+        const num = typeof val === 'number' ? val : typeof val === 'string' ? Number(val) : NaN;
+        return [label, Number.isFinite(num) ? num : null];
+      })
+    ),
+  }));

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episodes_query.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { escapeStringValue } from '@kbn/esql-utils';
+import { ALERT_EPISODE_STATUS, type AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
+import {
+  ALERT_EVENTS_DATA_STREAM,
+  ALERT_ACTIONS_DATA_STREAM,
+  HISTOGRAM_EPISODE_LIMIT,
+} from './constants';
+
+export const ALERT_EPISODE_FIELDS = [
+  '@timestamp',
+  'episode.id',
+  'episode.status',
+  'rule.id',
+  'group_hash',
+  'first_timestamp',
+  'last_timestamp',
+  'duration',
+  'triggered_at',
+  'last_ack_action',
+  'last_assignee_uid',
+  'last_snooze_action',
+  'snooze_expiry',
+  'last_tags',
+  'episode_data',
+  'severity',
+  'space_id',
+] as const;
+
+export interface EpisodesFilterState {
+  status?: string[] | null;
+  ruleId?: string | null;
+  groupHash?: string | null;
+  groupingValues?: Record<string, string | null> | null;
+  queryString?: string | null;
+  tags?: string[] | null;
+  severity?: string[] | null;
+  assigneeUid?: string;
+}
+
+export interface EpisodesSortState {
+  sortField: string;
+  sortDirection: 'asc' | 'desc';
+}
+
+const EPISODE_SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'] as const;
+const EPISODE_SEVERITY_CHART_VALUE: Record<string, number> = {
+  info: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+const EPISODE_SEVERITY_FILTER_NONE = '__no_severity__';
+const EPISODE_WITHOUT_SEVERITY_SORT_VALUE = -1;
+
+const addGroupHashActionStats = (query: ComposerQuery) => {
+  query
+    .pipe`INLINE STATS last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze"),
+                       snooze_expiry      = LAST(expiry, @timestamp)      WHERE action_type == "snooze",
+                       last_tags          = LAST(tags, @timestamp)        WHERE action_type == "tag"
+          BY group_hash`;
+};
+
+const addEpisodeIdActionStats = (query: ComposerQuery) => {
+  query
+    .pipe`EVAL episode_id = COALESCE(\`episode.id\`, episode_id)`
+    .pipe`INLINE STATS last_ack_action      = LAST(action_type,  @timestamp) WHERE action_type IN ("ack", "unack"),
+                       last_assignee_uid    = LAST(assignee_uid, @timestamp) WHERE action_type == "assign"
+          BY episode_id`;
+};
+
+export const addEpisodeAggregation = (query: ComposerQuery) => {
+  query
+    .pipe`EVAL extracted_data = JSON_EXTRACT(_source, "data")`
+    .pipe`INLINE STATS first_timestamp = MIN(@timestamp), last_timestamp = MAX(@timestamp), triggered_at = MIN(@timestamp) WHERE \`episode.status\` == "active", episode_data = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}", severity = LAST(severity, @timestamp) WHERE status == "breached" AND severity IS NOT NULL BY episode.id`
+    .pipe`EVAL duration = DATE_DIFF("ms", first_timestamp, last_timestamp)`
+    .pipe`WHERE @timestamp == last_timestamp`;
+};
+
+export const buildEpisodesBaseQuery = (spaceId: string, search?: string): ComposerQuery => {
+  const query = esql.from([ALERT_EVENTS_DATA_STREAM, ALERT_ACTIONS_DATA_STREAM], ['_source'])
+    .where`space_id == ${spaceId}`;
+
+  const trimmedSearch = search?.trim();
+  if (trimmedSearch) {
+    query.pipe(
+      `WHERE ((type == "alert" AND QSTR(${escapeStringValue(
+        trimmedSearch
+      )})) OR (action_type IN ("snooze", "unsnooze", "tag", "ack", "unack", "assign")))`
+    );
+  } else {
+    query.where`type == "alert" OR action_type IN ("snooze", "unsnooze", "tag", "ack", "unack", "assign")`;
+  }
+
+  addGroupHashActionStats(query);
+  addEpisodeIdActionStats(query);
+  query.where`type == "alert"`;
+  addEpisodeAggregation(query);
+
+  return query;
+};
+
+const addTagsFilter = (query: ComposerQuery, tags: string[]) => {
+  const trimmed = tags.map((t) => t.trim()).filter(Boolean);
+  if (trimmed.length === 0) return;
+  if (trimmed.length === 1) {
+    query.where`MV_CONTAINS(last_tags, ${trimmed[0]})`;
+    return;
+  }
+  const clause = trimmed.map((t) => `MV_CONTAINS(last_tags, ${escapeStringValue(t)})`).join(' OR ');
+  query.pipe(`WHERE (${clause})`);
+};
+
+const addStatusFilter = (query: ComposerQuery, statuses: string[]) => {
+  const validStatuses = statuses.filter((status): status is AlertEpisodeStatus =>
+    (Object.values(ALERT_EPISODE_STATUS) as string[]).includes(status)
+  );
+  if (!validStatuses.length) return;
+  if (validStatuses.length === 1) {
+    query.where`\`episode.status\` == ${validStatuses[0]}`;
+    return;
+  }
+  const inList = validStatuses.map((status) => escapeStringValue(status)).join(', ');
+  query.pipe(`WHERE \`episode.status\` IN (${inList})`);
+};
+
+const isSupportedEpisodeSeverity = (severity: string | undefined | null): severity is string => {
+  if (!severity || typeof severity !== 'string') return false;
+  return (EPISODE_SEVERITIES as readonly string[]).includes(severity.toLowerCase());
+};
+
+const normalizeEpisodeSeverity = (severity: string): string => severity.toLowerCase();
+
+const addSeverityFilter = (query: ComposerQuery, severities: string[]) => {
+  const severityValues = severities
+    .filter((s) => s !== EPISODE_SEVERITY_FILTER_NONE)
+    .filter(isSupportedEpisodeSeverity)
+    .map(normalizeEpisodeSeverity);
+  const includeNoSeverity = severities.includes(EPISODE_SEVERITY_FILTER_NONE);
+
+  const parts: string[] = [];
+  if (severityValues.length) {
+    const inList = severityValues.map((s) => escapeStringValue(s)).join(', ');
+    parts.push(`severity IN (${inList})`);
+  }
+  if (includeNoSeverity) {
+    parts.push('severity IS NULL');
+  }
+  if (!parts.length) return;
+  query.pipe(`WHERE ${parts.join(' OR ')}`);
+};
+
+export const applyFilterState = (query: ComposerQuery, filterState: EpisodesFilterState): void => {
+  if (filterState.status?.length) {
+    addStatusFilter(query, filterState.status);
+  }
+  if (filterState.ruleId) {
+    query.where`rule.id == ${filterState.ruleId}`;
+  }
+  if (filterState.groupHash) {
+    query.where`group_hash == ${filterState.groupHash}`;
+  }
+  if (filterState.tags?.length) {
+    addTagsFilter(query, filterState.tags);
+  }
+  if (filterState.severity?.length) {
+    addSeverityFilter(query, filterState.severity);
+  }
+  if (filterState.assigneeUid) {
+    query.where`last_assignee_uid == ${filterState.assigneeUid}`;
+  }
+};
+
+const ALLOWLISTED_SORT_FIELDS = new Set([
+  '@timestamp',
+  'episode.id',
+  'episode.status',
+  'rule.id',
+  'duration',
+]);
+
+const SEVERITY_SORT_FIELD = '_severity_sort';
+
+const sanitizeSortField = (field: string) =>
+  ALLOWLISTED_SORT_FIELDS.has(field) ? field : '@timestamp';
+
+const buildSeveritySortEval = (): string => {
+  const cases = EPISODE_SEVERITIES.map(
+    (severity) => `severity == "${severity}", ${EPISODE_SEVERITY_CHART_VALUE[severity]}`
+  ).join(', ');
+  return `EVAL ${SEVERITY_SORT_FIELD} = CASE(${cases}, ${EPISODE_WITHOUT_SEVERITY_SORT_VALUE})`;
+};
+
+const resolveSortField = (sortField: string): string =>
+  sortField === 'severity' ? SEVERITY_SORT_FIELD : sanitizeSortField(sortField);
+
+export const buildEpisodesQuery = (
+  spaceId: string,
+  sortState: EpisodesSortState = { sortField: '@timestamp', sortDirection: 'desc' },
+  filterState?: EpisodesFilterState,
+  pageSizeVariable?: string
+): ComposerQuery => {
+  const sortDir = sortState.sortDirection.toUpperCase() as 'ASC' | 'DESC';
+
+  const query = buildEpisodesBaseQuery(spaceId, filterState?.queryString?.trim());
+
+  if (filterState) {
+    applyFilterState(query, filterState);
+  }
+
+  if (sortState.sortField === 'severity') {
+    query.pipe(buildSeveritySortEval());
+  }
+
+  const sortField = resolveSortField(sortState.sortField);
+  query.sort([sortField, sortDir]);
+
+  if (pageSizeVariable) {
+    const pageSizeParam = esql.par(undefined, pageSizeVariable);
+    query.pipe`LIMIT ${pageSizeParam}`;
+  }
+
+  return query.keep(...ALERT_EPISODE_FIELDS);
+};
+
+export const buildEpisodesKpisQuery = (
+  spaceId: string,
+  currentUserUid?: string,
+  filterState?: EpisodesFilterState
+): ComposerQuery => {
+  const query = buildEpisodesBaseQuery(spaceId, filterState?.queryString?.trim());
+
+  if (filterState) {
+    applyFilterState(query, filterState);
+  }
+
+  query
+    .pipe`EVAL _active_rule_id = CASE(\`episode.status\` == "active", \`rule.id\`, null)`;
+
+  if (currentUserUid) {
+    query.pipe(
+      `EVAL _assigned_to_me = CASE(last_assignee_uid == ${escapeStringValue(currentUserUid)}, 1, 0)`
+    );
+  } else {
+    query.pipe`EVAL _assigned_to_me = 0`;
+  }
+
+  query
+    .pipe`EVAL _is_unassigned  = CASE(last_assignee_uid IS NULL, 1, 0)`
+    .pipe`EVAL _is_acked       = CASE(last_ack_action == "ack", 1, 0)`
+    .pipe`EVAL _is_snoozed     = CASE(last_snooze_action == "snooze" AND (snooze_expiry IS NULL OR TO_DATETIME(snooze_expiry) > NOW()), 1, 0)`
+    .pipe`STATS
+      alerts_count   = COUNT(*),
+      firing_rules   = COUNT_DISTINCT(_active_rule_id),
+      assigned_to_me = SUM(_assigned_to_me),
+      unassigned     = SUM(_is_unassigned),
+      acknowledged   = SUM(_is_acked),
+      snoozed        = SUM(_is_snoozed)`;
+
+  return query;
+};
+
+export const buildEpisodesHistogramQuery = (
+  spaceId: string,
+  filterState?: EpisodesFilterState,
+  breakdownField?: string
+): ComposerQuery => {
+  const query = buildEpisodesBaseQuery(spaceId, filterState?.queryString?.trim());
+
+  if (filterState) {
+    applyFilterState(query, filterState);
+  }
+
+  const keepFields = [
+    ...new Set(
+      ['first_timestamp', 'last_timestamp', 'episode.status', breakdownField].filter(
+        (f): f is string => Boolean(f)
+      )
+    ),
+  ];
+
+  return query.keep(...(keepFields as [string, ...string[]])).limit(HISTOGRAM_EPISODE_LIMIT);
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/episodes_query.ts
@@ -37,8 +37,10 @@ export const ALERT_EPISODE_FIELDS = [
 
 export interface EpisodesFilterState {
   status?: string[] | null;
-  ruleId?: string | null;
-  groupHash?: string | null;
+  /** Filter by one or more rule IDs (OR). */
+  ruleIds?: string[] | null;
+  /** Filter by one or more group hashes (OR). */
+  groupHashes?: string[] | null;
   groupingValues?: Record<string, string | null> | null;
   queryString?: string | null;
   tags?: string[] | null;
@@ -163,12 +165,23 @@ export const applyFilterState = (query: ComposerQuery, filterState: EpisodesFilt
   if (filterState.status?.length) {
     addStatusFilter(query, filterState.status);
   }
-  if (filterState.ruleId) {
-    query.where`rule.id == ${filterState.ruleId}`;
+
+  const ruleIds = filterState.ruleIds?.filter(Boolean) ?? [];
+  if (ruleIds.length === 1) {
+    query.where`rule.id == ${ruleIds[0]}`;
+  } else if (ruleIds.length > 1) {
+    const inList = ruleIds.map((id) => escapeStringValue(id)).join(', ');
+    query.pipe(`WHERE \`rule.id\` IN (${inList})`);
   }
-  if (filterState.groupHash) {
-    query.where`group_hash == ${filterState.groupHash}`;
+
+  const groupHashes = filterState.groupHashes?.filter(Boolean) ?? [];
+  if (groupHashes.length === 1) {
+    query.where`group_hash == ${groupHashes[0]}`;
+  } else if (groupHashes.length > 1) {
+    const inList = groupHashes.map((hash) => escapeStringValue(hash)).join(', ');
+    query.pipe(`WHERE group_hash IN (${inList})`);
   }
+
   if (filterState.tags?.length) {
     addTagsFilter(query, filterState.tags);
   }
@@ -186,6 +199,8 @@ const ALLOWLISTED_SORT_FIELDS = new Set([
   'episode.status',
   'rule.id',
   'duration',
+  'first_timestamp',
+  'last_timestamp',
 ]);
 
 const SEVERITY_SORT_FIELD = '_severity_sort';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/group_actions_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/group_actions_query.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ALERT_ACTIONS_DATA_STREAM } from './constants';
+
+export const buildGroupActionsQuery = (spaceId: string, groupHashes: string[]): ComposerQuery => {
+  const groupHashLiterals = groupHashes.map((h) => esql.str(h));
+
+  return esql.from(ALERT_ACTIONS_DATA_STREAM)
+    .where`space_id == ${spaceId}`
+    .where`group_hash IN (${groupHashLiterals})`
+    .where`action_type IN ("deactivate", "activate", "snooze", "unsnooze", "tag")`
+    .pipe`STATS
+        tags = LAST(tags, @timestamp) WHERE action_type IN ("tag"),
+        last_deactivate_action = LAST(action_type, @timestamp) WHERE action_type IN ("deactivate", "activate"),
+        last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze"),
+        snooze_expiry = LAST(expiry, @timestamp) WHERE action_type IN ("snooze"),
+        last_snooze_actor = LAST(actor, @timestamp) WHERE action_type == "snooze",
+        last_deactivate_actor = LAST(actor, @timestamp) WHERE action_type == "deactivate"
+      BY group_hash, rule_id`
+    .keep('group_hash', 'rule_id', 'last_deactivate_action', 'last_snooze_action', 'snooze_expiry', 'tags', 'last_snooze_actor', 'last_deactivate_actor');
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/index.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  ALERT_EVENTS_DATA_STREAM,
+  ALERT_ACTIONS_DATA_STREAM,
+  TIME_FIELD,
+  EPISODES_LIST_PAGE_SIZE,
+  HISTOGRAM_EPISODE_LIMIT,
+  RELATED_EPISODES_LIMIT,
+  DEFAULT_ACTIONS_HISTORY_PAGE_SIZE,
+  TAG_OPTIONS_LIMIT,
+  TAG_SUGGESTIONS_LIMIT,
+  DEFAULT_FLAPPING_LOOKBACK,
+} from './constants';
+
+export {
+  ALERT_EPISODE_FIELDS,
+  buildEpisodesBaseQuery,
+  buildEpisodesQuery,
+  buildEpisodesKpisQuery,
+  buildEpisodesHistogramQuery,
+  addEpisodeAggregation,
+  applyFilterState,
+} from './episodes_query';
+export type { EpisodesFilterState, EpisodesSortState } from './episodes_query';
+
+export { buildEpisodeQuery } from './episode_query';
+
+export { buildEpisodeEventsQuery, ALERT_EPISODE_EVENT_FIELDS } from './episode_events_query';
+
+export { buildEpisodeEventDataQuery } from './episode_event_data_query';
+
+export { buildEpisodeActionsQuery } from './episode_actions_query';
+
+export {
+  buildEpisodeActionsHistoryQuery,
+} from './episode_actions_history_query';
+export type { BuildEpisodeActionsHistoryQueryOptions } from './episode_actions_history_query';
+
+export { buildEpisodeFlappingQuery } from './episode_flapping_query';
+
+export { buildEpisodeTrendQuery, parseEpisodeTrendRows } from './episode_trend_query';
+
+export { buildEpisodeTagOptionsQuery } from './episode_tag_options_query';
+
+export { buildGroupActionsQuery } from './group_actions_query';
+
+export {
+  buildRelatedSameRuleQuery,
+  buildRelatedOtherGroupsQuery,
+  buildRelatedSameGroupQuery,
+  buildRelatedBaseQuery,
+  finishRelatedEpisodesQuery,
+  RELATED_EPISODE_FIELDS,
+} from './related_episodes_query';
+
+export { buildTagSuggestionsQuery } from './tag_suggestions_query';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/related_episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/related_episodes_query.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ALERT_EVENTS_DATA_STREAM, TIME_FIELD, RELATED_EPISODES_LIMIT } from './constants';
+import { addEpisodeAggregation } from './episodes_query';
+
+export const RELATED_EPISODE_FIELDS = [
+  '@timestamp',
+  'episode.id',
+  'episode.status',
+  'rule.id',
+  'group_hash',
+  'first_timestamp',
+  'last_timestamp',
+  'duration',
+  'episode_data',
+  'severity',
+] as const;
+
+export const buildRelatedBaseQuery = (
+  spaceId: string,
+  ruleId: string,
+  excludeEpisodeId: string
+): ComposerQuery => {
+  return esql.from([ALERT_EVENTS_DATA_STREAM], ['_source']).where`space_id == ${spaceId}`
+    .where`type == "alert"`.where`rule.id == ${ruleId} AND episode.id != ${excludeEpisodeId}`;
+};
+
+export const finishRelatedEpisodesQuery = (
+  query: ComposerQuery,
+  limit: number = RELATED_EPISODES_LIMIT
+): ComposerQuery => {
+  addEpisodeAggregation(query);
+
+  return query
+    .sort([TIME_FIELD, 'DESC'])
+    .limit(limit)
+    .keep(...RELATED_EPISODE_FIELDS);
+};
+
+export const buildRelatedSameRuleQuery = (
+  spaceId: string,
+  ruleId: string,
+  excludeEpisodeId: string,
+  limit?: number
+): ComposerQuery => {
+  return finishRelatedEpisodesQuery(
+    buildRelatedBaseQuery(spaceId, ruleId, excludeEpisodeId),
+    limit
+  );
+};
+
+export const buildRelatedOtherGroupsQuery = (
+  spaceId: string,
+  ruleId: string,
+  groupHash: string,
+  excludeEpisodeId: string,
+  limit?: number
+): ComposerQuery => {
+  const query = buildRelatedBaseQuery(spaceId, ruleId, excludeEpisodeId);
+  query.where`group_hash != ${groupHash}`;
+  return finishRelatedEpisodesQuery(query, limit);
+};
+
+export const buildRelatedSameGroupQuery = (
+  spaceId: string,
+  ruleId: string,
+  groupHash: string,
+  excludeEpisodeId: string,
+  limit?: number
+): ComposerQuery => {
+  const query = buildRelatedBaseQuery(spaceId, ruleId, excludeEpisodeId);
+  query.where`group_hash == ${groupHash}`;
+  return finishRelatedEpisodesQuery(query, limit);
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/tag_suggestions_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/episodes/tag_suggestions_query.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { escapeStringValue } from '@kbn/esql-utils';
+import { ALERT_ACTIONS_DATA_STREAM, TAG_SUGGESTIONS_LIMIT } from './constants';
+
+export const buildTagSuggestionsQuery = (spaceId: string): string =>
+  `FROM ${ALERT_ACTIONS_DATA_STREAM}
+| WHERE space_id == ${escapeStringValue(spaceId)} AND action_type == "tag" AND episode_id IS NOT NULL
+| STATS last_tags = LAST(tags, @timestamp) BY episode_id
+| MV_EXPAND last_tags
+| STATS cnt = COUNT(*) BY last_tags
+| SORT cnt DESC, last_tags ASC
+| LIMIT ${TAG_SUGGESTIONS_LIMIT}
+| RENAME last_tags AS tags
+| KEEP tags`;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/index.ts
@@ -5,9 +5,4 @@
  * 2.0.
  */
 
-import { buildTagSuggestionsQuery } from '@kbn/alerting-v2-common-queries';
-
-export const ALERT_ACTION_TAG_SUGGESTIONS_LIMIT = 20;
-
-export const buildAlertActionTagSuggestionsQuery = (spaceId: string): string =>
-  buildTagSuggestionsQuery(spaceId);
+export * from './episodes';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/kibana.jsonc
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/kibana.jsonc
@@ -1,0 +1,7 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/alerting-v2-common-queries",
+  "owner": "@elastic/rna-project-team",
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/package.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@kbn/alerting-v2-common-queries",
+  "description": "Shared ES|QL query builders for alerting v2 episodes.",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0",
+  "sideEffects": false
+}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/tsconfig.json
@@ -10,6 +10,7 @@
     "target/**/*"
   ],
   "kbn_references": [
+    "@kbn/alerting-v2-constants",
     "@kbn/alerting-v2-schemas",
     "@kbn/esql-utils"
   ]

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types"
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/alerting-v2-schemas",
+    "@kbn/esql-utils"
+  ]
+}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-constants/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-constants/index.ts
@@ -8,6 +8,13 @@
 export * from './src';
 
 export const DEFAULT_TIME_FIELD = '@timestamp';
+export const ALERT_EVENTS_DATA_STREAM = '.rule-events';
+export const ALERT_ACTIONS_DATA_STREAM = '.alert-actions';
+
+export const ALERTING_V2_SECTION_ID = 'alertingV2';
+export const ALERTING_V2_RULES_APP_ID = 'rules';
+export const ALERTING_V2_EPISODES_APP_ID = 'episodes';
+
 export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rules' as const;
 export const ALERTING_V2_ALERT_API_PATH = '/api/alerting/v2/alerts' as const;
 export const ALERTING_V2_ACTION_POLICY_API_PATH = '/api/alerting/v2/action_policies' as const;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/apis/fetch_rules_by_ids.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/apis/fetch_rules_by_ids.test.ts
@@ -7,7 +7,7 @@
 
 import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
-import { ALERT_EPISODES_LIST_PAGE_SIZE } from '../constants';
+import { EPISODES_LIST_PAGE_SIZE } from '../constants';
 import { fetchRulesByIds } from './fetch_rules_by_ids';
 
 const mockHttp = httpServiceMock.createStartContract();
@@ -19,7 +19,7 @@ describe('fetchRulesByIds', () => {
       items: [],
       total: 0,
       page: 1,
-      perPage: ALERT_EPISODES_LIST_PAGE_SIZE,
+      perPage: EPISODES_LIST_PAGE_SIZE,
     });
   });
 
@@ -34,15 +34,15 @@ describe('fetchRulesByIds', () => {
     expect(mockHttp.get).toHaveBeenCalledWith(ALERTING_V2_RULE_API_PATH, {
       query: {
         filter: '(id: "rule-a" OR id: "rule-b")',
-        perPage: ALERT_EPISODES_LIST_PAGE_SIZE,
+        perPage: EPISODES_LIST_PAGE_SIZE,
         page: 1,
       },
     });
   });
 
-  it('caps ids at ALERT_EPISODES_LIST_PAGE_SIZE', async () => {
+  it('caps ids at EPISODES_LIST_PAGE_SIZE', async () => {
     const ids = Array.from(
-      { length: ALERT_EPISODES_LIST_PAGE_SIZE + 1 },
+      { length: EPISODES_LIST_PAGE_SIZE + 1 },
       (_, index) => `rule-${index}`
     );
 
@@ -51,8 +51,8 @@ describe('fetchRulesByIds', () => {
     expect(mockHttp.get).toHaveBeenCalledTimes(1);
     expect(mockHttp.get).toHaveBeenCalledWith(ALERTING_V2_RULE_API_PATH, {
       query: {
-        filter: expect.not.stringContaining(`rule-${ALERT_EPISODES_LIST_PAGE_SIZE}`),
-        perPage: ALERT_EPISODES_LIST_PAGE_SIZE,
+        filter: expect.not.stringContaining(`rule-${EPISODES_LIST_PAGE_SIZE}`),
+        perPage: EPISODES_LIST_PAGE_SIZE,
         page: 1,
       },
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/apis/fetch_rules_by_ids.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/apis/fetch_rules_by_ids.ts
@@ -10,7 +10,7 @@ import { nodeBuilder, nodeTypes, toKqlExpression } from '@kbn/es-query';
 import type { HttpStart } from '@kbn/core-http-browser';
 import type { FindRulesResponse, RuleResponse } from '@kbn/alerting-v2-schemas';
 import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
-import { ALERT_EPISODES_LIST_PAGE_SIZE } from '../constants';
+import { EPISODES_LIST_PAGE_SIZE } from '../constants';
 
 export interface FetchRulesByIdsParams {
   http: HttpStart;
@@ -30,7 +30,7 @@ export const fetchRulesByIds = async ({
   http,
   ids,
 }: FetchRulesByIdsParams): Promise<RuleResponse[]> => {
-  const idsToFetch = take(ids, ALERT_EPISODES_LIST_PAGE_SIZE);
+  const idsToFetch = take(ids, EPISODES_LIST_PAGE_SIZE);
   if (idsToFetch.length === 0) {
     return [];
   }
@@ -38,7 +38,7 @@ export const fetchRulesByIds = async ({
   const response = await http.get<FindRulesResponse>(ALERTING_V2_RULE_API_PATH, {
     query: {
       filter: buildRuleIdsFilter(idsToFetch),
-      perPage: ALERT_EPISODES_LIST_PAGE_SIZE,
+      perPage: EPISODES_LIST_PAGE_SIZE,
       page: 1,
     },
   });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/related/group_subsection.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/related/group_subsection.tsx
@@ -22,7 +22,7 @@ import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { css } from '@emotion/react';
 import { getRuleIdFromRuleState, type RuleState } from '../../../types/rule_state';
-import { RELATED_ALERT_EPISODES_PAGE_SIZE } from '../../../constants';
+import { RELATED_EPISODES_LIMIT } from '../../../constants';
 import { useFetchEpisodeActions } from '../../../hooks/use_fetch_episode_actions';
 import { useFetchGroupActions } from '../../../hooks/use_fetch_group_actions';
 import { useFetchSameGroupEpisodesQuery } from '../../../hooks/use_fetch_same_group_episodes_query';
@@ -75,7 +75,7 @@ export function RelatedEpisodesGroupSubsection({
     useFetchSameGroupEpisodesQuery({
       ruleId,
       excludeEpisodeId: currentEpisodeId,
-      pageSize: RELATED_ALERT_EPISODES_PAGE_SIZE,
+      pageSize: RELATED_EPISODES_LIMIT,
       groupHash,
       services: { expressions, spaces },
       toastDanger,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/related/rule_subsection.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/related/rule_subsection.tsx
@@ -22,7 +22,7 @@ import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { css } from '@emotion/react';
 import { getRuleIdFromRuleState, type RuleState } from '../../../types/rule_state';
-import { RELATED_ALERT_EPISODES_PAGE_SIZE } from '../../../constants';
+import { RELATED_EPISODES_LIMIT } from '../../../constants';
 import { useFetchEpisodeActions } from '../../../hooks/use_fetch_episode_actions';
 import { useFetchGroupActions } from '../../../hooks/use_fetch_group_actions';
 import { useFetchSameRuleEpisodesQuery } from '../../../hooks/use_fetch_same_rule_episodes_query';
@@ -75,7 +75,7 @@ export function RelatedEpisodesRuleSubsection({
     useFetchSameRuleEpisodesQuery({
       ruleId,
       excludeEpisodeId: currentEpisodeId,
-      pageSize: RELATED_ALERT_EPISODES_PAGE_SIZE,
+      pageSize: RELATED_EPISODES_LIMIT,
       currentGroupHash,
       services: { expressions, spaces },
       toastDanger,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/constants.ts
@@ -7,10 +7,13 @@
 
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import { i18n } from '@kbn/i18n';
+export {
+  ALERT_EVENTS_DATA_STREAM,
+  ALERT_ACTIONS_DATA_STREAM,
+  HISTOGRAM_EPISODE_LIMIT,
+} from '@kbn/alerting-v2-common-queries';
 
 export const EMPTY_VALUE = '—';
-export const ALERT_EVENTS_DATA_STREAM = '.rule-events';
-export const ALERT_ACTIONS_DATA_STREAM = '.alert-actions';
 export const LAST_EPISODE_TIMESTAMP_ESQL_VARIABLE = 'lastEpisodeTimestamp';
 export const PAGE_SIZE_ESQL_VARIABLE = 'pageSize';
 export const RELATED_ALERT_EPISODES_PAGE_SIZE = 5;
@@ -51,7 +54,6 @@ export const HISTOGRAM_BREAKDOWN_COLUMNS: DatatableColumn[] = [
     meta: { type: 'string' },
   },
 ];
-export const HISTOGRAM_EPISODE_LIMIT = 10_000;
 export const DEFAULT_DATE_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
 export const FLYOUT_FOOTER_OFFSET = 80;
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/constants.ts
@@ -10,8 +10,12 @@ import { i18n } from '@kbn/i18n';
 export {
   ALERT_EVENTS_DATA_STREAM,
   ALERT_ACTIONS_DATA_STREAM,
-  HISTOGRAM_EPISODE_LIMIT,
-} from '@kbn/alerting-v2-common-queries';
+  DEFAULT_TIME_FIELD as TIME_FIELD,
+  ALERTING_V2_SECTION_ID,
+  ALERTING_V2_RULES_APP_ID,
+  ALERTING_V2_EPISODES_APP_ID,
+} from '@kbn/alerting-v2-constants';
+export { HISTOGRAM_EPISODE_LIMIT } from '@kbn/alerting-v2-common-queries';
 
 export const EMPTY_VALUE = '—';
 export const LAST_EPISODE_TIMESTAMP_ESQL_VARIABLE = 'lastEpisodeTimestamp';
@@ -20,7 +24,6 @@ export const RELATED_ALERT_EPISODES_PAGE_SIZE = 5;
 /** Max episodes returned per list page (ESQL LIMIT) and max unique rules resolved in one batch. */
 export const ALERT_EPISODES_LIST_PAGE_SIZE = 1000;
 export const QUERY_STALE_TIME = 30_000;
-export const TIME_FIELD = '@timestamp';
 /**
  * Fields produced by buildEpisodesHistogramQuery that are valid as breakdown dimensions.
  * Passed as esqlColumns to UnifiedBreakdownFieldSelector to restrict the picker to only
@@ -56,10 +59,6 @@ export const HISTOGRAM_BREAKDOWN_COLUMNS: DatatableColumn[] = [
 ];
 export const DEFAULT_DATE_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
 export const FLYOUT_FOOTER_OFFSET = 80;
-
-const ALERTING_V2_SECTION_ID = 'alertingV2';
-const ALERTING_V2_RULES_APP_ID = 'rules';
-const ALERTING_V2_EPISODES_APP_ID = 'episodes';
 
 // Ideally, these should be computed using the `paths` factory of the alerting-v2-plugin, which
 // shouldn't be imported in this package. Marking this for future improvement.

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/constants.ts
@@ -7,7 +7,7 @@
 
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import { i18n } from '@kbn/i18n';
-export {
+import {
   ALERT_EVENTS_DATA_STREAM,
   ALERT_ACTIONS_DATA_STREAM,
   DEFAULT_TIME_FIELD as TIME_FIELD,
@@ -15,6 +15,14 @@ export {
   ALERTING_V2_RULES_APP_ID,
   ALERTING_V2_EPISODES_APP_ID,
 } from '@kbn/alerting-v2-constants';
+export {
+  ALERT_EVENTS_DATA_STREAM,
+  ALERT_ACTIONS_DATA_STREAM,
+  TIME_FIELD,
+  ALERTING_V2_SECTION_ID,
+  ALERTING_V2_RULES_APP_ID,
+  ALERTING_V2_EPISODES_APP_ID,
+};
 export {
   HISTOGRAM_EPISODE_LIMIT,
   EPISODES_LIST_PAGE_SIZE,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/constants.ts
@@ -15,14 +15,15 @@ export {
   ALERTING_V2_RULES_APP_ID,
   ALERTING_V2_EPISODES_APP_ID,
 } from '@kbn/alerting-v2-constants';
-export { HISTOGRAM_EPISODE_LIMIT } from '@kbn/alerting-v2-common-queries';
+export {
+  HISTOGRAM_EPISODE_LIMIT,
+  EPISODES_LIST_PAGE_SIZE,
+  RELATED_EPISODES_LIMIT,
+} from '@kbn/alerting-v2-common-queries';
 
 export const EMPTY_VALUE = '—';
 export const LAST_EPISODE_TIMESTAMP_ESQL_VARIABLE = 'lastEpisodeTimestamp';
 export const PAGE_SIZE_ESQL_VARIABLE = 'pageSize';
-export const RELATED_ALERT_EPISODES_PAGE_SIZE = 5;
-/** Max episodes returned per list page (ESQL LIMIT) and max unique rules resolved in one batch. */
-export const ALERT_EPISODES_LIST_PAGE_SIZE = 1000;
 export const QUERY_STALE_TIME = 30_000;
 /**
  * Fields produced by buildEpisodesHistogramQuery that are valid as breakdown dimensions.

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/alert_action_tag_suggestions_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/alert_action_tag_suggestions_query.ts
@@ -7,7 +7,7 @@
 
 import { buildTagSuggestionsQuery } from '@kbn/alerting-v2-common-queries';
 
-export const ALERT_ACTION_TAG_SUGGESTIONS_LIMIT = 20;
+export { TAG_SUGGESTIONS_LIMIT } from '@kbn/alerting-v2-common-queries';
 
 export const buildAlertActionTagSuggestionsQuery = (spaceId: string): string =>
   buildTagSuggestionsQuery(spaceId);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_actions_history_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_actions_history_query.ts
@@ -5,8 +5,11 @@
  * 2.0.
  */
 
-import { esql } from '@elastic/esql';
-import { ALERT_ACTIONS_DATA_STREAM } from '../constants';
+import {
+  buildEpisodeActionsHistoryQuery as buildEpisodeActionsHistoryQueryCommon,
+  DEFAULT_ACTIONS_HISTORY_PAGE_SIZE,
+} from '@kbn/alerting-v2-common-queries';
+import type { BuildEpisodeActionsHistoryQueryOptions as BuildEpisodeActionsHistoryQueryOptionsCommon } from '@kbn/alerting-v2-common-queries';
 
 export interface EpisodeActionHistoryEntry {
   _id: string;
@@ -21,52 +24,17 @@ export interface EpisodeActionHistoryEntry {
   reason: string | null;
 }
 
-export const DEFAULT_ACTIONS_HISTORY_PAGE_SIZE = 25;
+export { DEFAULT_ACTIONS_HISTORY_PAGE_SIZE };
 
-export interface BuildEpisodeActionsHistoryQueryOptions {
-  /** Keyset cursor: only return records at or before this timestamp (exclusive on refetch, see hook dedup). */
-  before?: string;
-  /** Page size. Defaults to {@link DEFAULT_ACTIONS_HISTORY_PAGE_SIZE}. */
-  limit?: number;
-}
+export type BuildEpisodeActionsHistoryQueryOptions = BuildEpisodeActionsHistoryQueryOptionsCommon;
 
 /**
  * Returns individual action records for an episode (both episode-level and group-level),
- * sorted newest-first, one keyset page at a time. Non-aggregating counterpart to
- * buildEpisodeActionsQuery. `_id` is projected via `METADATA _id` so callers can dedup records
- * that straddle a page boundary (the `before` cursor is inclusive to avoid dropping same-timestamp
- * records split across pages).
+ * sorted newest-first, one keyset page at a time.
  */
 export const buildEpisodeActionsHistoryQuery = (
   spaceId: string,
   episodeId: string,
   groupHash: string,
-  { before, limit = DEFAULT_ACTIONS_HISTORY_PAGE_SIZE }: BuildEpisodeActionsHistoryQueryOptions = {}
-) => {
-  // prettier-ignore
-  const query = esql
-    .from([ALERT_ACTIONS_DATA_STREAM], ['_id'])
-    .where`space_id == ${spaceId}`
-    .where`episode_id == ${episodeId} OR (group_hash == ${groupHash} AND episode_id IS NULL)`
-    .where`action_type IN ("ack", "unack", "snooze", "unsnooze", "deactivate", "activate", "tag", "assign")`;
-
-  if (before) {
-    query.where`@timestamp <= ${before}`;
-  }
-
-  return query
-    .sort(['@timestamp', 'DESC'])
-    .limit(limit)
-    .keep(
-      '_id',
-      '@timestamp',
-      'action_type',
-      'actor',
-      'episode_id',
-      'group_hash',
-      'tags',
-      'assignee_uid',
-      'expiry',
-      'reason'
-    );
-};
+  options?: BuildEpisodeActionsHistoryQueryOptions
+) => buildEpisodeActionsHistoryQueryCommon(spaceId, episodeId, groupHash, options);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_actions_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_actions_query.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { esql } from '@elastic/esql';
-import { ALERT_ACTIONS_DATA_STREAM } from '../constants';
+import { buildEpisodeActionsQuery as buildEpisodeActionsQueryCommon } from '@kbn/alerting-v2-common-queries';
 
 export interface AlertEpisodeAction {
   episode_id: string;
@@ -17,22 +16,5 @@ export interface AlertEpisodeAction {
   last_ack_actor: string | null;
 }
 
-export const buildEpisodeActionsQuery = (spaceId: string, episodeIds: string[]) => {
-  const episodeIdLiterals = episodeIds.map((id) => esql.str(id));
-
-  // prettier-ignore
-  return esql.from(ALERT_ACTIONS_DATA_STREAM)
-    .where`space_id == ${spaceId}`
-    .where`episode_id IN (${episodeIdLiterals})`
-    .where`action_type IN ("ack", "unack", "assign")`
-    .pipe`EVAL
-      ack_action = CASE(action_type IN ("ack", "unack"), action_type, null),
-      assignee_value = CASE(action_type == "assign", assignee_uid, null),
-      ack_actor = CASE(action_type == "ack", actor, null)`
-    .pipe`STATS
-      last_ack_action = LAST(ack_action, @timestamp),
-      last_assignee_uid = LAST(assignee_value, @timestamp),
-      last_ack_actor = LAST(ack_actor, @timestamp)
-      BY episode_id, rule_id, group_hash`
-    .keep('episode_id', 'rule_id', 'group_hash', 'last_ack_action', 'last_assignee_uid', 'last_ack_actor');
-};
+export const buildEpisodeActionsQuery = (spaceId: string, episodeIds: string[]) =>
+  buildEpisodeActionsQueryCommon(spaceId, episodeIds);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_event_data_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_event_data_query.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { esql } from '@elastic/esql';
-import { ALERT_EVENTS_DATA_STREAM } from '../constants';
+import { buildEpisodeEventDataQuery as buildEpisodeEventDataQueryCommon } from '@kbn/alerting-v2-common-queries';
 
 export interface EpisodeEventDataRow {
   'episode.id': string;
@@ -19,24 +18,6 @@ export interface EpisodeEventDataRow {
  * ES|QL query that extracts the alert `data` object from the latest non-empty
  * `.rule-events` document for the given episode, alongside the timestamp of
  * that data event and the timestamp of the most recent event overall.
- *
- * Uses `METADATA _source` so `JSON_EXTRACT` can access the full document source.
- * `INLINE STATS LAST(...) WHERE extracted_data != "{}"` skips status-only events
- * (e.g. inactive/recovered) whose `data` field is empty, returning the last event
- * that carried actual alert evaluation data. `last_event_timestamp` (no WHERE)
- * lets callers detect when the displayed data is stale relative to the latest
- * event (e.g. after recovery).
  */
-export const buildEpisodeEventDataQuery = (spaceId: string, episodeId: string) => {
-  // prettier-ignore
-  return esql.from([ALERT_EVENTS_DATA_STREAM], ['_source'])
-    .where`space_id == ${spaceId}`
-    .where`type == "alert"`
-    .where`episode.id == ${episodeId}`
-    .pipe`EVAL extracted_data = JSON_EXTRACT(_source, "data")`
-    .pipe`INLINE STATS
-      last_data = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}",
-      last_data_timestamp = MAX(@timestamp) WHERE extracted_data != "{}",
-      last_event_timestamp = MAX(@timestamp)
-      BY \`episode.id\``;
-};
+export const buildEpisodeEventDataQuery = (spaceId: string, episodeId: string) =>
+  buildEpisodeEventDataQueryCommon(spaceId, episodeId);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_events_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_events_query.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { esql } from '@elastic/esql';
 import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
-import { ALERT_EVENTS_DATA_STREAM, TIME_FIELD } from '../constants';
+import { buildEpisodeEventsQuery as buildEpisodeEventsQueryCommon } from '@kbn/alerting-v2-common-queries';
 
 export interface EpisodeEventRow {
   '@timestamp': string;
@@ -19,26 +18,8 @@ export interface EpisodeEventRow {
   data?: string | Record<string, unknown> | null;
 }
 
-const ALERT_EPISODE_EVENT_FIELDS = [
-  '@timestamp',
-  'episode.id',
-  'episode.status',
-  'rule.id',
-  'group_hash',
-  'severity',
-  'data',
-] as const;
-
 /**
  * ES|QL query returning all events for a single alert episode, oldest first.
  */
-export const buildEpisodeEventsEsqlQuery = (spaceId: string, episodeId: string) => {
-  // prettier-ignore
-  return esql.from([ALERT_EVENTS_DATA_STREAM], ['_source'])
-    .where`space_id == ${spaceId}`
-    .where`type == "alert"`
-    .where`episode.id == ${episodeId}`
-    .pipe`EVAL data = JSON_EXTRACT(_source, "$.data")`
-    .sort([TIME_FIELD, 'ASC'])
-    .keep(...ALERT_EPISODE_EVENT_FIELDS);
-};
+export const buildEpisodeEventsEsqlQuery = (spaceId: string, episodeId: string) =>
+  buildEpisodeEventsQueryCommon(spaceId, episodeId);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_flapping_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_flapping_query.ts
@@ -5,38 +5,20 @@
  * 2.0.
  */
 
-import { esql } from '@elastic/esql';
 import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
-import { ALERT_EVENTS_DATA_STREAM, TIME_FIELD } from '../constants';
+import { buildEpisodeFlappingQuery as buildEpisodeFlappingQueryCommon } from '@kbn/alerting-v2-common-queries';
 import { DEFAULT_EPISODE_FLAPPING_SETTINGS } from '../utils/is_episode_flapping';
 
 export interface EpisodeFlappingRow {
   'episode.status': AlertEpisodeStatus;
 }
 
-const ALERT_EPISODE_FLAPPING_FIELDS = ['episode.status'] as const;
-
 /**
  * ES|QL query returning the most recent `limit` rule-event statuses for a single
  * episode, newest first. Callers reverse the rows to restore chronological order.
- *
- * Unlike the shared oldest-first {@link buildEpisodeEventsEsqlQuery}, this sorts
- * `@timestamp` DESC with an explicit LIMIT so the flapping look-back always
- * reflects the genuinely latest events. Reusing the unbounded ascending query
- * would hit ES|QL's implicit `LIMIT 1000` and return the oldest 1000 rows for
- * long-running episodes, making the "most recent" look-back window stale.
  */
 export const buildEpisodeFlappingEsqlQuery = (
   spaceId: string,
   episodeId: string,
   limit: number = DEFAULT_EPISODE_FLAPPING_SETTINGS.lookBackWindow
-) => {
-  // prettier-ignore
-  return esql.from([ALERT_EVENTS_DATA_STREAM])
-    .where`space_id == ${spaceId}`
-    .where`type == "alert"`
-    .where`episode.id == ${episodeId}`
-    .sort([TIME_FIELD, 'DESC'])
-    .keep(...ALERT_EPISODE_FLAPPING_FIELDS)
-    .limit(limit);
-};
+) => buildEpisodeFlappingQueryCommon(spaceId, episodeId, limit);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_tag_options_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_tag_options_query.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { esql } from '@elastic/esql';
-import { ALERT_ACTIONS_DATA_STREAM } from '../constants';
+import { buildEpisodeTagOptionsQuery as buildEpisodeTagOptionsQueryCommon } from '@kbn/alerting-v2-common-queries';
 
 export interface EpisodeTagOptionRow {
   tags: string;
@@ -15,12 +14,5 @@ export interface EpisodeTagOptionRow {
 /**
  * Distinct tag values from tag actions in the selected time range (via kibana_context).
  */
-export const buildEpisodeTagOptionsQuery = (spaceId: string) => {
-  // prettier-ignore
-  return esql.from(ALERT_ACTIONS_DATA_STREAM).where`space_id == ${spaceId}`.where`action_type == "tag"`
-    .where`tags IS NOT NULL`
-    .pipe`MV_EXPAND tags`
-    .pipe`STATS BY tags`
-    .sort(['tags', 'ASC'])
-    .pipe`LIMIT 500`;
-};
+export const buildEpisodeTagOptionsQuery = (spaceId: string) =>
+  buildEpisodeTagOptionsQueryCommon(spaceId);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_trend_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episode_trend_query.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import { Builder, LeafPrinter, esql } from '@elastic/esql';
 import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
-import { ALERT_EVENTS_DATA_STREAM, TIME_FIELD } from '../constants';
+import {
+  buildEpisodeTrendQuery as buildEpisodeTrendQueryCommon,
+  parseEpisodeTrendRows as parseEpisodeTrendRowsCommon,
+} from '@kbn/alerting-v2-common-queries';
 
 export interface EpisodeTrendRow {
   '@timestamp': string;
@@ -20,69 +22,22 @@ export interface EpisodeTrendRow {
 }
 
 /**
- * Escaped ES|QL identifier for the column holding a metric label's values. The column
- * is named after the label itself, so the query reads as `EVAL count = ...` rather than
- * an opaque positional name; `LeafPrinter` backtick-escapes labels with special characters.
- */
-const metricColumn = (label: string): string =>
-  LeafPrinter.column(Builder.expression.column(label));
-
-/**
- * `JSON_EXTRACT` string-literal selector reading `<label>` out of the event's flattened
- * `data` object. Bracket notation (`data['count']`) reads the label as a single key, so
- * labels containing dots or other special characters work; `'` and `\` are escaped.
- */
-const dataSelector = (label: string): string =>
-  LeafPrinter.string({ valueUnquoted: `data['${label.replace(/['\\]/g, '\\$&')}']` });
-
-const toNumberOrNull = (value: unknown): number | null => {
-  const num = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
-  return Number.isFinite(num) ? num : null;
-};
-
-/**
  * ES|QL query returning every `.rule-events` event for an episode (oldest first),
  * carrying the lifecycle status and, for each requested metric label, the value the
- * rule evaluated for that execution. Unlike a re-aggregation of the source index,
- * these are the exact values the rule evaluated, at the timestamps it evaluated them
- * — and they are already scoped to the episode's group via `episode.id`.
- *
- * `METADATA _source` lets `JSON_EXTRACT` read the flattened `data` field. Rather than
- * shipping the whole `data` row, we project only the charted metrics — one column per
- * requested label, named after it — so the response carries just the values the trend
- * chart plots.
+ * rule evaluated for that execution.
  */
 export const buildEpisodeTrendQuery = (
   spaceId: string,
   episodeId: string,
   metricLabels: string[]
-) => {
-  // prettier-ignore
-  let query = esql.from([ALERT_EVENTS_DATA_STREAM], ['_source'])
-    .where`space_id == ${spaceId}`
-    .where`type == "alert"`
-    .where`episode.id == ${episodeId}`;
-
-  metricLabels.forEach((label) => {
-    query = query.pipe(
-      `EVAL ${metricColumn(label)} = JSON_EXTRACT(_source, ${dataSelector(label)})`
-    );
-  });
-
-  return query.sort([TIME_FIELD, 'ASC']).keep('@timestamp', 'episode.status', ...metricLabels);
-};
+) => buildEpisodeTrendQueryCommon(spaceId, episodeId, metricLabels);
 
 /**
  * Maps the raw ES|QL rows back into {@link EpisodeTrendRow}s, keying each event's values
- * by the metric label that produced them and coercing the extracted values to numbers
- * (`JSON_EXTRACT` returns keywords).
+ * by the metric label that produced them and coercing the extracted values to numbers.
  */
 export const parseEpisodeTrendRows = (
   rawRows: Array<Record<string, unknown>>,
   metricLabels: string[]
 ): EpisodeTrendRow[] =>
-  rawRows.map((row) => ({
-    '@timestamp': row['@timestamp'] as string,
-    'episode.status': row['episode.status'] as AlertEpisodeStatus,
-    metrics: Object.fromEntries(metricLabels.map((label) => [label, toNumberOrNull(row[label])])),
-  }));
+  parseEpisodeTrendRowsCommon(rawRows, metricLabels) as EpisodeTrendRow[];

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.test.ts
@@ -164,33 +164,55 @@ describe('buildEpisodesQuery', () => {
     expect(queryString).not.toContain('`episode.status` IN');
   });
 
-  it('should apply ruleId filter', () => {
+  it('should apply ruleIds filter', () => {
     const query = buildEpisodesQuery(
       SPACE_ID,
       { sortField: '@timestamp', sortDirection: 'desc' },
-      { ruleId: 'rule-123' }
+      { ruleIds: ['rule-123'] }
     );
     const queryString = query.print('basic');
 
     expect(queryString).toContain('WHERE rule.id == "rule-123"');
   });
 
-  it('should apply groupHash filter', () => {
+  it('should apply multiple ruleIds with IN', () => {
     const query = buildEpisodesQuery(
       SPACE_ID,
       { sortField: '@timestamp', sortDirection: 'desc' },
-      { groupHash: 'abc123' }
+      { ruleIds: ['rule-1', 'rule-2'] }
+    );
+    const queryString = query.print('basic');
+
+    expect(queryString).toContain('WHERE `rule.id` IN ("rule-1", "rule-2")');
+  });
+
+  it('should apply groupHashes filter', () => {
+    const query = buildEpisodesQuery(
+      SPACE_ID,
+      { sortField: '@timestamp', sortDirection: 'desc' },
+      { groupHashes: ['abc123'] }
     );
     const queryString = query.print('basic');
 
     expect(queryString).toContain('WHERE group_hash == "abc123"');
   });
 
-  it('should not apply groupHash filter when null', () => {
+  it('should apply multiple groupHashes with IN', () => {
     const query = buildEpisodesQuery(
       SPACE_ID,
       { sortField: '@timestamp', sortDirection: 'desc' },
-      { groupHash: null }
+      { groupHashes: ['abc123', 'def456'] }
+    );
+    const queryString = query.print('basic');
+
+    expect(queryString).toContain('WHERE group_hash IN ("abc123", "def456")');
+  });
+
+  it('should not apply groupHashes filter when null', () => {
+    const query = buildEpisodesQuery(
+      SPACE_ID,
+      { sortField: '@timestamp', sortDirection: 'desc' },
+      { groupHashes: null }
     );
     const queryString = query.print('basic');
 
@@ -202,7 +224,7 @@ describe('buildEpisodesQuery', () => {
       SPACE_ID,
       { sortField: '@timestamp', sortDirection: 'desc' },
       {
-        groupHash: 'abc123',
+        groupHashes: ['abc123'],
         groupingValues: { 'host.name': 'web-01', 'service.name': 'checkout' },
       }
     );
@@ -232,7 +254,7 @@ describe('buildEpisodesQuery', () => {
       {
         queryString: 'alert.name: "test"',
         status: ['active'],
-        ruleId: 'rule-123',
+        ruleIds: ['rule-123'],
       }
     );
     const queryString = query.print('basic');
@@ -339,8 +361,8 @@ describe('buildEpisodesQuery', () => {
       {
         queryString: null,
         status: null,
-        ruleId: undefined,
-        groupHash: null,
+        ruleIds: undefined,
+        groupHashes: null,
         tags: null,
         severity: null,
       }
@@ -405,7 +427,7 @@ describe('buildEpisodesQuery', () => {
     const query = buildEpisodesQuery(
       SPACE_ID,
       { sortField: '@timestamp', sortDirection: 'desc' },
-      { assigneeUid: 'user-123', status: ['active'], ruleId: 'rule-456' }
+      { assigneeUid: 'user-123', status: ['active'], ruleIds: ['rule-456'] }
     );
     const queryString = query.print('basic');
 
@@ -502,8 +524,8 @@ describe('buildEpisodesKpisQuery', () => {
     expect(output).toMatch(/\| WHERE `episode\.status` == "active"/);
   });
 
-  it('applies ruleId filter when provided', () => {
-    const output = buildEpisodesKpisQuery(SPACE, UID, { ruleId: 'rule-xyz' });
+  it('applies ruleIds filter when provided', () => {
+    const output = buildEpisodesKpisQuery(SPACE, UID, { ruleIds: ['rule-xyz'] });
     expect(output).toContain('WHERE rule.id == "rule-xyz"');
   });
 });
@@ -536,8 +558,8 @@ describe('buildEpisodesHistogramQuery', () => {
     expect(output).toMatch(/\| WHERE `episode\.status` == "active"/);
   });
 
-  it('includes the ruleId filter when filterState.ruleId is provided', () => {
-    const output = buildEpisodesHistogramQuery('default', { ruleId: 'rule-abc' }).print('basic');
+  it('includes the ruleIds filter when filterState.ruleIds is provided', () => {
+    const output = buildEpisodesHistogramQuery('default', { ruleIds: ['rule-abc'] }).print('basic');
     expect(output).toContain('rule-abc');
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.ts
@@ -150,11 +150,19 @@ const applyFilterState = (query: ComposerQuery, filterState: EpisodesFilterState
   if (filterState.status?.length) {
     addStatusFilter(query, filterState.status);
   }
-  if (filterState.ruleId) {
-    query.where`rule.id == ${filterState.ruleId}`;
+  const ruleIds = filterState.ruleIds?.filter(Boolean) ?? [];
+  if (ruleIds.length === 1) {
+    query.where`rule.id == ${ruleIds[0]}`;
+  } else if (ruleIds.length > 1) {
+    const inList = ruleIds.map((id) => escapeStringValue(id)).join(', ');
+    query.pipe(`WHERE \`rule.id\` IN (${inList})`);
   }
-  if (filterState.groupHash) {
-    query.where`group_hash == ${filterState.groupHash}`;
+  const groupHashes = filterState.groupHashes?.filter(Boolean) ?? [];
+  if (groupHashes.length === 1) {
+    query.where`group_hash == ${groupHashes[0]}`;
+  } else if (groupHashes.length > 1) {
+    const inList = groupHashes.map((hash) => escapeStringValue(hash)).join(', ');
+    query.pipe(`WHERE group_hash IN (${inList})`);
   }
   if (filterState.tags?.length) {
     addTagsFilter(query, filterState.tags);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.ts
@@ -7,14 +7,19 @@
 
 import type { ComposerQuery } from '@elastic/esql';
 import { esql } from '@elastic/esql';
-import { escapeStringValue } from '@kbn/esql-utils/src/utils/append_to_query/utils';
+import { escapeStringValue } from '@kbn/esql-utils';
 import { ALERT_EPISODE_STATUS, type AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
 import {
-  ALERT_EVENTS_DATA_STREAM,
-  ALERT_ACTIONS_DATA_STREAM,
-  PAGE_SIZE_ESQL_VARIABLE,
+  buildEpisodesBaseQuery as buildEpisodesBaseQueryCommon,
+  addEpisodeAggregation as addEpisodeAggregationCommon,
+  ALERT_EPISODE_FIELDS as ALERT_EPISODE_FIELDS_COMMON,
   HISTOGRAM_EPISODE_LIMIT,
-} from '../constants';
+} from '@kbn/alerting-v2-common-queries';
+import type {
+  EpisodesFilterState as EpisodesFilterStateCommon,
+  EpisodesSortState as EpisodesSortStateCommon,
+} from '@kbn/alerting-v2-common-queries';
+import { PAGE_SIZE_ESQL_VARIABLE } from '../constants';
 import {
   EPISODE_SEVERITIES,
   EPISODE_SEVERITY_CHART_VALUE,
@@ -22,6 +27,9 @@ import {
   isSupportedEpisodeSeverity,
   normalizeEpisodeSeverity,
 } from '../components/severity/severity_utils';
+
+export type EpisodesFilterState = EpisodesFilterStateCommon;
+export type EpisodesSortState = EpisodesSortStateCommon;
 
 export interface AlertEpisode {
   '@timestamp': string;
@@ -52,53 +60,11 @@ export interface AlertEpisodeEsqlRow extends Omit<AlertEpisode, 'last_tags'> {
   last_tags?: string | string[] | null;
 }
 
-export const ALERT_EPISODE_FIELDS = [
-  '@timestamp',
-  'episode.id',
-  'episode.status',
-  'rule.id',
-  'group_hash',
-  'first_timestamp',
-  'last_timestamp',
-  'duration',
-  'triggered_at',
-  'last_ack_action',
-  'last_assignee_uid',
-  'last_snooze_action',
-  'snooze_expiry',
-  'last_tags',
-  'episode_data',
-  'severity',
-] as const;
+export const ALERT_EPISODE_FIELDS = ALERT_EPISODE_FIELDS_COMMON;
 
-export interface EpisodesFilterState {
-  /** Status values (OR). Empty/undefined shows all statuses. */
-  status?: string[] | null;
-  /** Rule ID or null */
-  ruleId?: string | null;
-  /** Group hash — narrows to a single per-rule series (used for deep-links from rule details). */
-  groupHash?: string | null;
-  /**
-   * Display-only companion to `groupHash`. When a deep-link carries the
-   * resolved grouping field values (e.g. `{ "host.name": "web-01" }`), the
-   * destination chip can render `host=web-01` without re-running the DSL
-   * lookup. Does NOT affect the query — `buildEpisodesQuery` ignores it.
-   */
-  groupingValues?: Record<string, string | null> | null;
-  /** Query string for full-text search */
-  queryString?: string | null;
-  /** Tag values — episodes matching any selected tag (OR) */
-  tags?: string[] | null;
-  /** Severity values (OR). Includes EPISODE_SEVERITY_FILTER_NONE for episodes without severity. */
-  severity?: string[] | null;
-  /** Assignee UID — episodes whose last assignee matches this user profile UID */
-  assigneeUid?: string;
-}
+export const addEpisodeAggregation = addEpisodeAggregationCommon;
 
-export interface EpisodesSortState {
-  sortField: string;
-  sortDirection: 'asc' | 'desc';
-}
+export const buildEpisodesBaseQuery = buildEpisodesBaseQueryCommon;
 
 const ALLOWLISTED_SORT_FIELDS = new Set([
   '@timestamp',
@@ -129,40 +95,6 @@ const resolveSortField = (sortField: string): string => {
   }
 
   return sanitizeSortField(sortField);
-};
-
-export const addEpisodeAggregation = (query: ComposerQuery) => {
-  /* This will be simplified when the `$.alerting-episodes` ES|QL view works.
-   * Matches `buildEpisodeEventDataQuery` and `buildRelatedEpisodesQuery`.
-   */
-
-  // prettier-ignore
-  query
-    .pipe`EVAL extracted_data = JSON_EXTRACT(_source, "data")`
-    .pipe`INLINE STATS first_timestamp = MIN(@timestamp), last_timestamp = MAX(@timestamp), triggered_at = MIN(@timestamp) WHERE \`episode.status\` == "active", episode_data = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}", severity = LAST(severity, @timestamp) WHERE status == "breached" AND severity IS NOT NULL BY episode.id`
-    .pipe`EVAL duration = DATE_DIFF("ms", first_timestamp, last_timestamp)`
-    .pipe`WHERE @timestamp == last_timestamp`;
-};
-
-const addGroupHashActionStats = (query: ComposerQuery) => {
-  // prettier-ignore
-  query
-    .pipe`INLINE STATS last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze"),
-                       snooze_expiry      = LAST(expiry, @timestamp)      WHERE action_type == "snooze",
-                       last_tags          = LAST(tags, @timestamp)        WHERE action_type == "tag"
-          BY group_hash`;
-};
-
-const addEpisodeIdActionStats = (query: ComposerQuery) => {
-  // `.rule-events` documents carry the nested `episode.id`, while `.alert-actions`
-  // documents carry a flat `episode_id` — unify them so INLINE STATS groups both
-  // sides under the same key.
-  // prettier-ignore
-  query
-    .pipe`EVAL episode_id = COALESCE(\`episode.id\`, episode_id)`
-    .pipe`INLINE STATS last_ack_action      = LAST(action_type,  @timestamp) WHERE action_type IN ("ack", "unack"),
-                       last_assignee_uid    = LAST(assignee_uid, @timestamp) WHERE action_type == "assign"
-          BY episode_id`;
 };
 
 const addTagsFilter = (query: ComposerQuery, tags: string[]) => {
@@ -236,39 +168,6 @@ const applyFilterState = (query: ComposerQuery, filterState: EpisodesFilterState
 };
 
 /**
- * Builds an ES|QL query that aggregates episode data from `.rule-events` and
- * `.alert-actions` (last tags per group_hash, last ack / assignee per
- * episode) and narrows to alert episode rows.
- *
- * `episode.status` comes straight from `.rule-events`. User-initiated
- * `deactivate` / `activate` actions also write a synthetic `.rule-events`
- * doc, so the column is always current — the UI does **not** derive an
- * `effective_status` by joining `.alert-actions` audit rows back in.
- */
-export const buildEpisodesBaseQuery = (spaceId: string, search?: string): ComposerQuery => {
-  const query = esql.from([ALERT_EVENTS_DATA_STREAM, ALERT_ACTIONS_DATA_STREAM], ['_source'])
-    .where`space_id == ${spaceId}`;
-
-  const trimmedSearch = search?.trim();
-  if (trimmedSearch) {
-    query.pipe(
-      `WHERE ((type == "alert" AND QSTR(${escapeStringValue(
-        trimmedSearch
-      )})) OR (action_type IN ("snooze", "unsnooze", "tag", "ack", "unack", "assign")))`
-    );
-  } else {
-    query.where`type == "alert" OR action_type IN ("snooze", "unsnooze", "tag", "ack", "unack", "assign")`;
-  }
-
-  addGroupHashActionStats(query);
-  addEpisodeIdActionStats(query);
-  query.where`type == "alert"`;
-  addEpisodeAggregation(query);
-
-  return query;
-};
-
-/**
  * Builds an ES|QL query for episodes request with sorting and filtering.
  *
  * Joins `.rule-events` and `.alert-actions` so that per-group action state
@@ -318,9 +217,6 @@ export const buildEpisodesKpisQuery = (
     applyFilterState(query, filterState);
   }
 
-  // Indicator columns — null for distinct count, 1/0 for sum-based counts.
-  // When there's no current user (anonymous/proxy-authenticated), nothing can be
-  // "assigned to me", so the indicator is always 0.
   // prettier-ignore
   query
     .pipe`EVAL _active_rule_id = CASE(\`episode.status\` == "active", \`rule.id\`, null)`

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/group_actions_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/group_actions_query.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { esql } from '@elastic/esql';
-import { ALERT_ACTIONS_DATA_STREAM } from '../constants';
+import { buildGroupActionsQuery as buildGroupActionsQueryCommon } from '@kbn/alerting-v2-common-queries';
 
 export interface GroupActionRow {
   group_hash: string;
@@ -19,20 +18,5 @@ export interface GroupActionRow {
   last_deactivate_actor: string | null;
 }
 
-export const buildGroupActionsQuery = (spaceId: string, groupHashes: string[]) => {
-  const groupHashLiterals = groupHashes.map((h) => esql.str(h));
-  // prettier-ignore
-  return esql.from(ALERT_ACTIONS_DATA_STREAM)
-    .where`space_id == ${spaceId}`
-    .where`group_hash IN (${groupHashLiterals})`
-    .where`action_type IN ("deactivate", "activate", "snooze", "unsnooze", "tag")`
-    .pipe`STATS
-        tags = LAST(tags, @timestamp) WHERE action_type IN ("tag"),
-        last_deactivate_action = LAST(action_type, @timestamp) WHERE action_type IN ("deactivate", "activate"),
-        last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze"),
-        snooze_expiry = LAST(expiry, @timestamp) WHERE action_type IN ("snooze"),
-        last_snooze_actor = LAST(actor, @timestamp) WHERE action_type == "snooze",
-        last_deactivate_actor = LAST(actor, @timestamp) WHERE action_type == "deactivate"
-      BY group_hash, rule_id`
-    .keep('group_hash', 'rule_id', 'last_deactivate_action', 'last_snooze_action', 'snooze_expiry', 'tags', 'last_snooze_actor', 'last_deactivate_actor');
-};
+export const buildGroupActionsQuery = (spaceId: string, groupHashes: string[]) =>
+  buildGroupActionsQueryCommon(spaceId, groupHashes);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/related_episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/related_episodes_query.ts
@@ -5,45 +5,20 @@
  * 2.0.
  */
 
-import { esql } from '@elastic/esql';
 import type { ComposerQuery } from '@elastic/esql';
-import { ALERT_EVENTS_DATA_STREAM, TIME_FIELD } from '../constants';
-import { addEpisodeAggregation } from './episodes_query';
+import {
+  buildRelatedBaseQuery as buildRelatedBaseQueryCommon,
+  finishRelatedEpisodesQuery as finishRelatedEpisodesQueryCommon,
+  RELATED_EPISODE_FIELDS as RELATED_EPISODE_FIELDS_COMMON,
+} from '@kbn/alerting-v2-common-queries';
 
-// Subset of `ALERT_EPISODE_FIELDS` actually populated by this query. The action
-// `last_*` columns are excluded because we only read from `.rule-events` here
-// and don't run the action INLINE STATS — keeping them caused a runtime error.
-export const RELATED_EPISODE_FIELDS = [
-  '@timestamp',
-  'episode.id',
-  'episode.status',
-  'rule.id',
-  'group_hash',
-  'first_timestamp',
-  'last_timestamp',
-  'duration',
-  'episode_data',
-  'severity',
-] as const;
+export const RELATED_EPISODE_FIELDS = RELATED_EPISODE_FIELDS_COMMON;
 
-const RELATED_EPISODE_LIMIT = 5;
-
-export const finishRelatedEpisodesQuery = (query: ComposerQuery) => {
-  addEpisodeAggregation(query);
-
-  return query
-    .sort([TIME_FIELD, 'DESC'])
-    .limit(RELATED_EPISODE_LIMIT)
-    .keep(...RELATED_EPISODE_FIELDS);
-};
+export const finishRelatedEpisodesQuery = (query: ComposerQuery) =>
+  finishRelatedEpisodesQueryCommon(query);
 
 export const buildRelatedBaseQuery = (
   spaceId: string,
   ruleId: string,
   excludeEpisodeId: string
-) => {
-  // Because addEpisodeAggregation uses JSON_EXTRACT(_source, "data"),
-  // _source must be included here.
-  return esql.from([ALERT_EVENTS_DATA_STREAM], ['_source']).where`space_id == ${spaceId}`
-    .where`type == "alert"`.where`rule.id == ${ruleId} AND episode.id != ${excludeEpisodeId}`;
-};
+) => buildRelatedBaseQueryCommon(spaceId, ruleId, excludeEpisodeId);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/tsconfig.json
@@ -8,6 +8,7 @@
   "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/alerting-v2-schemas",
+    "@kbn/alerting-v2-common-queries",
     "@kbn/datemath",
     "@kbn/core",
     "@kbn/core-application-browser",

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/episode_data_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/episode_data_schema.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { episodeDataSchema } from './episode_data_schema';
+
+const baseEpisode = {
+  episode_id: 'ep-1',
+  episode_status: 'inactive' as const,
+  rule_id: 'rule-1',
+  group_hash: 'group-1',
+  first_timestamp: '2026-07-29T14:41:46.565Z',
+  last_timestamp: '2026-07-29T14:42:46.565Z',
+  duration: 60000,
+  space_id: 'default',
+};
+
+describe('episodeDataSchema', () => {
+  it('accepts a minimal episode without optional fields', () => {
+    expect(episodeDataSchema.parse(baseEpisode)).toEqual(baseEpisode);
+  });
+
+  it('accepts null for ES|QL-absent optional fields', () => {
+    expect(
+      episodeDataSchema.parse({
+        ...baseEpisode,
+        triggered_at: null,
+        severity: null,
+        episode_data: null,
+        last_ack_action: null,
+        last_assignee_uid: null,
+        last_snooze_action: null,
+        snooze_expiry: null,
+      })
+    ).toEqual({
+      ...baseEpisode,
+      triggered_at: null,
+      severity: null,
+      episode_data: null,
+      last_ack_action: null,
+      last_assignee_uid: null,
+      last_snooze_action: null,
+      snooze_expiry: null,
+    });
+  });
+
+  it('stringifies object episode_data from JSON_EXTRACT', () => {
+    expect(
+      episodeDataSchema.parse({
+        ...baseEpisode,
+        episode_data: { count: '1487' },
+      })
+    ).toEqual({
+      ...baseEpisode,
+      episode_data: '{"count":"1487"}',
+    });
+  });
+
+  it('preserves string episode_data', () => {
+    expect(
+      episodeDataSchema.parse({
+        ...baseEpisode,
+        episode_data: '{"host.name":"h1"}',
+      }).episode_data
+    ).toBe('{"host.name":"h1"}');
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/episode_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/episode_data_schema.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ALERT_EPISODE_STATUS } from './alert_action_schema';
+
+export const EPISODE_ATTACHMENT_TYPE = 'episode' as const;
+
+/**
+ * ES|QL `JSON_EXTRACT` may return an object for `episode_data`; normalize to a
+ * JSON string so attachment consumers can treat it uniformly.
+ */
+const episodeDataPayloadSchema = z.preprocess((value) => {
+  if (value == null) {
+    return value;
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return value;
+}, z.string().nullish());
+
+/**
+ * Episode rows from ES|QL use `null` for absent optional fields (not
+ * `undefined`), so these must be `.nullish()` rather than `.optional()`.
+ */
+export const episodeDataSchema = z.object({
+  episode_id: z.string().min(1),
+  episode_status: z.enum([
+    ALERT_EPISODE_STATUS.INACTIVE,
+    ALERT_EPISODE_STATUS.PENDING,
+    ALERT_EPISODE_STATUS.ACTIVE,
+    ALERT_EPISODE_STATUS.RECOVERING,
+  ]),
+  rule_id: z.string().min(1),
+  group_hash: z.string().min(1),
+  first_timestamp: z.string().min(1),
+  last_timestamp: z.string().min(1),
+  duration: z.number(),
+  triggered_at: z.string().nullish(),
+  severity: z.string().nullish(),
+  episode_data: episodeDataPayloadSchema,
+  last_ack_action: z.enum(['ack', 'unack']).nullish(),
+  last_assignee_uid: z.string().nullish(),
+  last_snooze_action: z.enum(['snooze', 'unsnooze']).nullish(),
+  snooze_expiry: z.string().nullish(),
+  space_id: z.string().min(1),
+});
+
+export type EpisodeData = z.infer<typeof episodeDataSchema>;
+
+/** Attachment payload is the same shape as {@link EpisodeData}. */
+export type EpisodeAttachmentData = EpisodeData;
+
+export const episodeAttachmentDataSchema = episodeDataSchema;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/index.ts
@@ -21,6 +21,7 @@ export * from './action_policy_data_schema';
 export * from './action_policy_response_schema';
 export * from './action_policy_attachment_schema';
 export * from './alert_action_schema';
+export * from './episode_data_schema';
 export * from './bulk_operation_schema';
 export * from './policy_execution_history_schema';
 export * from './rule_execution_history_schema';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/episode_attachment_definition.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/episode_attachment_definition.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { AttachmentUIDefinition } from '@kbn/agent-builder-browser/attachments';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import { EPISODE_ATTACHMENT_TYPE, type EpisodeAttachmentData } from '@kbn/alerting-v2-schemas';
+import { EpisodeInlineContent } from './episode_inline_content';
+
+export type EpisodeAttachment = Attachment<typeof EPISODE_ATTACHMENT_TYPE, EpisodeAttachmentData>;
+
+export const createEpisodeAttachmentDefinition =
+  (): AttachmentUIDefinition<EpisodeAttachment> => ({
+    getLabel: (attachment) =>
+      `Episode ${attachment.data.episode_id.slice(0, 8)} (${attachment.data.episode_status})`,
+    getIcon: () => 'alert',
+
+    renderInlineContent: (props) => <EpisodeInlineContent {...props} />,
+  });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/episode_inline_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/episode_inline_content.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import type { AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
+import { i18n } from '@kbn/i18n';
+import type { EpisodeAttachment } from './episode_attachment_definition';
+
+const STATUS_COLORS: Record<string, string> = {
+  active: 'danger',
+  pending: 'warning',
+  recovering: 'primary',
+  inactive: 'default',
+};
+
+const formatDuration = (ms: number): string => {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+};
+
+export const EpisodeInlineContent: React.FC<AttachmentRenderProps<EpisodeAttachment>> = ({
+  attachment,
+}) => {
+  const { data } = attachment;
+  const statusColor = STATUS_COLORS[data.episode_status] ?? 'default';
+
+  return (
+    <EuiPanel paddingSize="s" hasShadow={false} hasBorder>
+      <EuiFlexGroup direction="column" gutterSize="xs">
+        <EuiFlexItem>
+          <EuiFlexGroup alignItems="center" gutterSize="s" wrap>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color={statusColor}>{data.episode_status}</EuiBadge>
+            </EuiFlexItem>
+            {data.severity && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow">{data.severity}</EuiBadge>
+              </EuiFlexItem>
+            )}
+            {data.last_ack_action === 'ack' && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow">
+                  {i18n.translate('xpack.alertingV2.episodeAttachment.acknowledged', {
+                    defaultMessage: 'Acknowledged',
+                  })}
+                </EuiBadge>
+              </EuiFlexItem>
+            )}
+            {data.last_snooze_action === 'snooze' && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow">
+                  {i18n.translate('xpack.alertingV2.episodeAttachment.snoozed', {
+                    defaultMessage: 'Snoozed',
+                  })}
+                </EuiBadge>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('xpack.alertingV2.episodeAttachment.duration', {
+              defaultMessage: 'Duration: {duration}',
+              values: { duration: formatDuration(data.duration) },
+            })}
+          </EuiText>
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('xpack.alertingV2.episodeAttachment.ruleId', {
+              defaultMessage: 'Rule: {ruleId}',
+              values: { ruleId: data.rule_id },
+            })}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/get_episode_attachment.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/get_episode_attachment.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AlertEpisode } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import { EPISODE_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
+import { getEpisodeAttachment, getEpisodeAttachmentData } from './get_episode_attachment';
+
+const mockEpisode = {
+  '@timestamp': '2026-05-08T08:00:00.000Z',
+  'episode.id': 'ep-1',
+  'episode.status': 'active' as const,
+  'rule.id': 'rule-1',
+  group_hash: 'group-1',
+  first_timestamp: '2026-05-08T08:00:00.000Z',
+  last_timestamp: '2026-05-08T08:05:00.000Z',
+  triggered_at: '2026-05-08T08:00:00.000Z',
+  duration: 300000,
+  severity: 'high',
+  episode_data: '{"host.name":"h1"}',
+  last_ack_action: 'ack' as const,
+  last_assignee_uid: 'u-1',
+  last_snooze_action: 'snooze' as const,
+  snooze_expiry: '2026-05-08T09:00:00.000Z',
+} as AlertEpisode;
+
+describe('getEpisodeAttachment', () => {
+  it('maps AlertEpisode fields into EpisodeAttachmentData', () => {
+    expect(getEpisodeAttachmentData(mockEpisode, 'default')).toEqual({
+      episode_id: 'ep-1',
+      episode_status: 'active',
+      rule_id: 'rule-1',
+      group_hash: 'group-1',
+      first_timestamp: '2026-05-08T08:00:00.000Z',
+      last_timestamp: '2026-05-08T08:05:00.000Z',
+      duration: 300000,
+      triggered_at: '2026-05-08T08:00:00.000Z',
+      severity: 'high',
+      episode_data: '{"host.name":"h1"}',
+      last_ack_action: 'ack',
+      last_assignee_uid: 'u-1',
+      last_snooze_action: 'snooze',
+      snooze_expiry: '2026-05-08T09:00:00.000Z',
+      space_id: 'default',
+    });
+  });
+
+  it('builds an AttachmentInput with type, origin, and stable id', () => {
+    expect(getEpisodeAttachment(mockEpisode, 'space-a')).toEqual({
+      id: `${EPISODE_ATTACHMENT_TYPE}:ep-1`,
+      type: EPISODE_ATTACHMENT_TYPE,
+      origin: 'ep-1',
+      data: getEpisodeAttachmentData(mockEpisode, 'space-a'),
+    });
+  });
+
+  it('stringifies object episode_data from ES|QL JSON_EXTRACT', () => {
+    const episodeWithObjectData = {
+      ...mockEpisode,
+      episode_data: { count: '1487' },
+    } as unknown as AlertEpisode;
+
+    expect(getEpisodeAttachmentData(episodeWithObjectData, 'default').episode_data).toBe(
+      '{"count":"1487"}'
+    );
+  });
+
+  it('omits null optional fields from ES|QL', () => {
+    const episodeWithNulls = {
+      ...mockEpisode,
+      triggered_at: null,
+      severity: null,
+      episode_data: null,
+      last_ack_action: null,
+      last_assignee_uid: null,
+      last_snooze_action: null,
+      snooze_expiry: null,
+    } as unknown as AlertEpisode;
+
+    expect(getEpisodeAttachmentData(episodeWithNulls, 'default')).toEqual({
+      episode_id: 'ep-1',
+      episode_status: 'active',
+      rule_id: 'rule-1',
+      group_hash: 'group-1',
+      first_timestamp: '2026-05-08T08:00:00.000Z',
+      last_timestamp: '2026-05-08T08:05:00.000Z',
+      duration: 300000,
+      space_id: 'default',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/get_episode_attachment.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/get_episode_attachment.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import {
+  EPISODE_ATTACHMENT_TYPE,
+  type EpisodeAttachmentData,
+} from '@kbn/alerting-v2-schemas';
+import type { AlertEpisode } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+
+const normalizeEpisodeData = (
+  value: AlertEpisode['episode_data'] | Record<string, unknown> | undefined
+): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return value;
+};
+
+/** Drop ES|QL `null`s so JSON payloads omit the key (Zod `.optional()` rejects null). */
+const omitNull = <T>(value: T | null | undefined): T | undefined =>
+  value == null ? undefined : value;
+
+export const getEpisodeAttachmentData = (
+  episode: AlertEpisode,
+  spaceId: string
+): EpisodeAttachmentData => ({
+  episode_id: episode['episode.id'],
+  episode_status: episode['episode.status'],
+  rule_id: episode['rule.id'],
+  group_hash: episode.group_hash,
+  first_timestamp: episode.first_timestamp,
+  last_timestamp: episode.last_timestamp,
+  duration: episode.duration,
+  triggered_at: omitNull(episode.triggered_at),
+  severity: omitNull(episode.severity),
+  // ES|QL JSON_EXTRACT may return an object; coerce to a JSON string for the schema.
+  episode_data: normalizeEpisodeData(episode.episode_data),
+  last_ack_action: omitNull(episode.last_ack_action),
+  last_assignee_uid: omitNull(episode.last_assignee_uid),
+  last_snooze_action: omitNull(episode.last_snooze_action),
+  snooze_expiry: omitNull(episode.snooze_expiry),
+  space_id: spaceId,
+});
+
+export const getEpisodeAttachment = (
+  episode: AlertEpisode,
+  spaceId: string
+): AttachmentInput<typeof EPISODE_ATTACHMENT_TYPE, EpisodeAttachmentData> => ({
+  id: `${EPISODE_ATTACHMENT_TYPE}:${episode['episode.id']}`,
+  type: EPISODE_ATTACHMENT_TYPE,
+  origin: episode['episode.id'],
+  data: getEpisodeAttachmentData(episode, spaceId),
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/use_add_episode_to_chat.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/use_add_episode_to_chat.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { PluginStart } from '@kbn/core-di';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
+import type { AlertEpisode } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import { getEpisodeAttachment } from './get_episode_attachment';
+
+export interface UseAddEpisodeToChatResult {
+  addToChat: () => void;
+  isAddToChatAvailable: boolean;
+}
+
+/**
+ * Opens Agent Builder chat with the given episode attached (Cases-style button pattern).
+ * Does not auto-send a prompt — the user drives the conversation.
+ */
+export const useAddEpisodeToChat = (
+  episode: AlertEpisode | undefined
+): UseAddEpisodeToChatResult => {
+  const application = useService(CoreStart('application'));
+  const agentBuilder = useService(PluginStart('agentBuilder'), {
+    optional: true,
+  }) as AgentBuilderPluginStart | undefined;
+  const spaces = useService(PluginStart('spaces')) as SpacesPluginStart;
+
+  const hasAgentBuilderCapability = application.capabilities.agentBuilder?.show === true;
+  const isAddToChatAvailable =
+    Boolean(episode) && hasAgentBuilderCapability && Boolean(agentBuilder?.openChat);
+
+  const addToChat = useCallback(() => {
+    if (!isAddToChatAvailable || !agentBuilder?.openChat || !episode) {
+      return;
+    }
+
+    void spaces.getActiveSpace().then((space) => {
+      agentBuilder.openChat({
+        autoSendInitialMessage: false,
+        newConversation: true,
+        attachments: [getEpisodeAttachment(episode, space.id)],
+      });
+    });
+  }, [agentBuilder, episode, isAddToChatAvailable, spaces]);
+
+  return useMemo(
+    () => ({
+      addToChat,
+      isAddToChatAvailable,
+    }),
+    [addToChat, isAddToChatAvailable]
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/alert_timeline/alert_timeline_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/alert_timeline/alert_timeline_section.tsx
@@ -105,7 +105,7 @@ export const AlertTimelineSection: React.FC = () => {
     () =>
       http.basePath.prepend(
         paths.alertEpisodesListHref({
-          filters: { ruleId: rule.id, status: 'all' },
+          filters: { ruleIds: [rule.id], status: 'all' },
           timeRange: {
             from: new Date(windowStartMs).toISOString(),
             to: new Date(windowEndMs).toISOString(),

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.test.ts
@@ -26,27 +26,27 @@ describe('paths.alertEpisodesListHref', () => {
     );
   });
 
-  it('encodes ruleId into _a.episodesList', () => {
-    const url = paths.alertEpisodesListHref({ filters: { ruleId: 'rule-1' } });
-    expect(decodeAppState(url)).toMatchObject({ ruleId: 'rule-1' });
+  it('encodes ruleIds into _a.episodesList', () => {
+    const url = paths.alertEpisodesListHref({ filters: { ruleIds: ['rule-1'] } });
+    expect(decodeAppState(url)).toMatchObject({ ruleIds: ['rule-1'] });
   });
 
-  it('encodes groupHash and groupingValues into _a.episodesList', () => {
+  it('encodes groupHashes and groupingValues into _a.episodesList', () => {
     const url = paths.alertEpisodesListHref({
       filters: {
-        groupHash: 'abc123',
+        groupHashes: ['abc123'],
         groupingValues: { 'host.name': 'web-01', region: null },
       },
     });
     expect(decodeAppState(url)).toMatchObject({
-      groupHash: 'abc123',
+      groupHashes: ['abc123'],
       groupingValues: { 'host.name': 'web-01', region: null },
     });
   });
 
   it('encodes timeRange as timeFrom/timeTo inside _a.episodesList, not in _g', () => {
     const url = paths.alertEpisodesListHref({
-      filters: { ruleId: 'r1' },
+      filters: { ruleIds: ['r1'] },
       timeRange: { from: 'now-7d', to: 'now' },
     });
     expect(decodeAppState(url)).toMatchObject({ timeFrom: 'now-7d', timeTo: 'now' });
@@ -55,7 +55,7 @@ describe('paths.alertEpisodesListHref', () => {
 
   it('omits empty groupingValues objects', () => {
     const url = paths.alertEpisodesListHref({
-      filters: { ruleId: 'r1', groupingValues: {} },
+      filters: { ruleIds: ['r1'], groupingValues: {} },
     });
     const state = decodeAppState(url) as Record<string, unknown>;
     expect(state).not.toHaveProperty('groupingValues');
@@ -64,16 +64,16 @@ describe('paths.alertEpisodesListHref', () => {
   it('encodes all fields together', () => {
     const url = paths.alertEpisodesListHref({
       filters: {
-        ruleId: 'r1',
-        groupHash: 'gh1',
+        ruleIds: ['r1'],
+        groupHashes: ['gh1'],
         status: 'active',
         groupingValues: { env: 'prod' },
       },
       timeRange: { from: '2024-01-01T00:00:00.000Z', to: '2024-01-07T00:00:00.000Z' },
     });
     expect(decodeAppState(url)).toEqual({
-      ruleId: 'r1',
-      groupHash: 'gh1',
+      ruleIds: ['r1'],
+      groupHashes: ['gh1'],
       status: 'active',
       groupingValues: { env: 'prod' },
       timeFrom: '2024-01-01T00:00:00.000Z',

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
@@ -44,11 +44,11 @@ export {
 export interface AlertEpisodesListLinkOptions {
   /** Pre-applied filters carried via the rison-encoded `_a` query param. */
   filters?: {
-    ruleId?: string;
-    groupHash?: string;
+    ruleIds?: string[];
+    groupHashes?: string[];
     status?: string;
     /**
-     * Display-only companion to `groupHash`. When the source surface (e.g.
+     * Display-only companion to `groupHashes`. When the source surface (e.g.
      * the rule details heatmap) has already resolved grouping field values,
      * passing them through avoids a second lookup at the destination.
      */
@@ -77,7 +77,7 @@ export const paths = {
    * filters and time range via `_a.episodesList.*`.
    *
    * Shape MUST match what `readEpisodesListAppStateFromUrlStorage` reads:
-   * flat fields inside `_a.episodesList` (`ruleId`, `groupHash`,
+   * flat fields inside `_a.episodesList` (`ruleIds`, `groupHashes`,
    * `groupingValues`, `timeFrom`, `timeTo`). Time is NOT put in `_g` —
    * the episodes list reads time from `_a.episodesList.{timeFrom,timeTo}`
    * so that no Kibana global-time sync fires on mount and pushes a spurious
@@ -89,8 +89,8 @@ export const paths = {
     const { filters, timeRange } = opts;
     const episodesList = Object.fromEntries(
       Object.entries({
-        ruleId: filters?.ruleId,
-        groupHash: filters?.groupHash,
+        ruleIds: filters?.ruleIds?.length ? filters.ruleIds : undefined,
+        groupHashes: filters?.groupHashes?.length ? filters.groupHashes : undefined,
         status: filters?.status,
         groupingValues:
           filters?.groupingValues && Object.keys(filters.groupingValues).length > 0

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -23,6 +23,7 @@ import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 import { WorkflowApi } from '@kbn/workflows-ui';
 import { ALERTING_V2_ENABLED_SETTING_ID } from '@kbn/alerting-v2-constants';
+import { EPISODE_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import {
   ALERTING_V2_SECTION_ID,
   ALERTING_V2_RULES_APP_ID,
@@ -223,6 +224,15 @@ export const module = new ContainerModule(({ bind }) => {
             );
           }
         );
+        import(
+          /* webpackChunkName: "alerting_v2_episode_attachment" */
+          './agent_builder/attachments/episode_attachment_definition'
+        ).then(({ createEpisodeAttachmentDefinition }) => {
+          agentBuilder.attachments.addAttachmentType(
+            EPISODE_ATTACHMENT_TYPE,
+            createEpisodeAttachmentDefinition()
+          );
+        });
       }
     });
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.test.tsx
@@ -449,7 +449,7 @@ describe('episode count + reset filters toolbar', () => {
     await waitFor(() => expect(capturedFilterBarOnFilterChange).toBeDefined());
 
     await act(async () => {
-      capturedFilterBarOnFilterChange!({ ...DEFAULT_EPISODES_LIST_FILTER, ruleId: 'rule-1' });
+      capturedFilterBarOnFilterChange!({ ...DEFAULT_EPISODES_LIST_FILTER, ruleIds: ['rule-1'] });
     });
 
     const button = await screen.findByTestId('episodesFilterBar-resetFilters');

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
@@ -39,7 +39,7 @@ import { useQueryClient } from '@kbn/react-query';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useService } from '@kbn/core-di-browser';
 import { useFetchAlertingEpisodesQuery } from '@kbn/alerting-v2-episodes-ui/hooks/use_fetch_alerting_episodes_query';
-import { ALERT_EPISODES_LIST_PAGE_SIZE } from '@kbn/alerting-v2-episodes-ui/constants';
+import { EPISODES_LIST_PAGE_SIZE } from '@kbn/alerting-v2-episodes-ui/constants';
 import { useInvalidateEpisodeQueries } from '@kbn/alerting-v2-episodes-ui/hooks/use_invalidate_episode_queries';
 import { useAlertingRulesCache } from '@kbn/alerting-v2-episodes-ui/hooks/use_alerting_rules_cache';
 import { useAlertingRuleSourceDataViews } from '@kbn/alerting-v2-episodes-ui/hooks/use_alerting_rule_source_data_views';
@@ -174,7 +174,7 @@ export const AlertEpisodesListPage = () => {
     dataView,
     isLoading,
   } = useFetchAlertingEpisodesQuery({
-    pageSize: ALERT_EPISODES_LIST_PAGE_SIZE,
+    pageSize: EPISODES_LIST_PAGE_SIZE,
     services,
     filterState,
     sortState,
@@ -503,11 +503,11 @@ export const AlertEpisodesListPage = () => {
                     customGridColumnsConfiguration={CUSTOM_GRID_COLUMNS_CONFIGURATION}
                     externalCustomRenderers={externalCustomRenderers}
                     rows={rows}
-                    totalHits={!episodesData?.length ? 0 : ALERT_EPISODES_LIST_PAGE_SIZE + 1}
+                    totalHits={!episodesData?.length ? 0 : EPISODES_LIST_PAGE_SIZE + 1}
                     loadingState={isLoading ? DataLoadingState.loading : DataLoadingState.loaded}
                     isPaginationEnabled
                     paginationMode="singlePage"
-                    sampleSizeState={ALERT_EPISODES_LIST_PAGE_SIZE}
+                    sampleSizeState={EPISODES_LIST_PAGE_SIZE}
                     isSortEnabled
                     sort={sort}
                     onSort={onSort}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_filter_bar.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_filter_bar.tsx
@@ -91,7 +91,7 @@ export const EpisodesFilterBar = ({
 
   const onRuleChange = useCallback(
     (ruleId: string | undefined) => {
-      onFilterChange((prev) => ({ ...prev, ruleId }));
+      onFilterChange((prev) => ({ ...prev, ruleIds: ruleId ? [ruleId] : undefined }));
     },
     [onFilterChange]
   );
@@ -149,7 +149,7 @@ export const EpisodesFilterBar = ({
               />
 
               <AlertEpisodesRuleFilter
-                selectedRuleId={filterState.ruleId}
+                selectedRuleId={filterState.ruleIds?.[0]}
                 onRuleChange={onRuleChange}
                 ruleOptions={ruleOptions}
                 data-test-subj="episodesFilterBar-rule"

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/hooks/use_episodes_list_url_state.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/hooks/use_episodes_list_url_state.test.tsx
@@ -42,7 +42,7 @@ describe('useEpisodesListUrlState', () => {
 
     expect(result.current.filterState).toEqual({
       status: ['active'],
-      ruleId: 'rule-123',
+      ruleIds: ['rule-123'],
     });
   });
 
@@ -56,12 +56,12 @@ describe('useEpisodesListUrlState', () => {
     const { result } = renderHook(() => useEpisodesListUrlState(timefilter), { wrapper });
 
     await act(async () => {
-      result.current.setFilterState({ status: ['recovering'], ruleId: 'r9' });
+      result.current.setFilterState({ status: ['recovering'], ruleIds: ['r9'] });
     });
 
-    expect(result.current.filterState).toEqual({ status: ['recovering'], ruleId: 'r9' });
+    expect(result.current.filterState).toEqual({ status: ['recovering'], ruleIds: ['r9'] });
     expect(history.location.search).toBe(
-      '?_a=(episodesList:(ruleId:r9,status:!(recovering),timeFrom:now-15m,timeTo:now))'
+      '?_a=(episodesList:(ruleIds:!(r9),status:!(recovering),timeFrom:now-15m,timeTo:now))'
     );
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.test.ts
@@ -39,7 +39,7 @@ describe('episodes_list_url_state', () => {
     it('reads filter + time fields as expected from _a.episodesList', async () => {
       const storage = await createKbnTestUrlStorage({
         status: ['active', 'pending'],
-        ruleId: 'r1',
+        ruleIds: ['r1'],
         queryString: '  host  ',
         tags: ['a', 'b'],
         severity: ['high', '__no_severity__'],
@@ -51,7 +51,7 @@ describe('episodes_list_url_state', () => {
       expect(readEpisodesListAppStateFromUrlStorage(storage)).toEqual({
         filterState: {
           status: ['active', 'pending'],
-          ruleId: 'r1',
+          ruleIds: ['r1'],
           queryString: 'host',
           tags: ['a', 'b'],
           severity: ['high', '__no_severity__'],
@@ -90,6 +90,15 @@ describe('episodes_list_url_state', () => {
       ]);
     });
 
+    it('maps a legacy single-string ruleId to ruleIds array', async () => {
+      const storage = await createKbnTestUrlStorage({
+        ruleId: 'legacy-rule',
+      });
+      expect(readEpisodesListAppStateFromUrlStorage(storage).filterState.ruleIds).toEqual([
+        'legacy-rule',
+      ]);
+    });
+
     it('defaults status to active when _a is missing', async () => {
       const storage = await createKbnTestUrlStorage();
       expect(readEpisodesListAppStateFromUrlStorage(storage)).toEqual({
@@ -97,15 +106,24 @@ describe('episodes_list_url_state', () => {
       });
     });
 
-    it('reads groupHash and groupingValues from the URL blob', async () => {
+    it('reads groupHashes and groupingValues from the URL blob', async () => {
       const storage = await createKbnTestUrlStorage({
-        groupHash: 'abc123',
+        groupHashes: ['abc123'],
         groupingValues: { 'host.name': 'web-01', region: null },
       });
       expect(readEpisodesListAppStateFromUrlStorage(storage).filterState).toMatchObject({
-        groupHash: 'abc123',
+        groupHashes: ['abc123'],
         groupingValues: { 'host.name': 'web-01', region: null },
       });
+    });
+
+    it('maps a legacy single-string groupHash to groupHashes array', async () => {
+      const storage = await createKbnTestUrlStorage({
+        groupHash: 'legacy-hash',
+      });
+      expect(readEpisodesListAppStateFromUrlStorage(storage).filterState.groupHashes).toEqual([
+        'legacy-hash',
+      ]);
     });
 
     it('ignores groupingValues when it is not a plain object', async () => {
@@ -195,14 +213,14 @@ describe('episodes_list_url_state', () => {
       ]);
     });
 
-    it('round-trips groupHash and groupingValues', async () => {
+    it('round-trips groupHashes and groupingValues', async () => {
       const storage = await createKbnTestUrlStorage();
 
       await writeEpisodesListAppStateToUrlStorage(
         storage,
         {
           status: ['active'],
-          groupHash: 'xyz',
+          groupHashes: ['xyz'],
           groupingValues: { 'host.name': 'web-01', region: null },
         },
         DEFAULT_EPISODES_LIST_TIME_RANGE
@@ -210,7 +228,7 @@ describe('episodes_list_url_state', () => {
 
       expect(storage.get('_a')).toEqual({
         [EPISODES_LIST_APP_STATE_KEY]: {
-          groupHash: 'xyz',
+          groupHashes: ['xyz'],
           groupingValues: { 'host.name': 'web-01', region: null },
         },
       });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.ts
@@ -51,11 +51,17 @@ function decodeFilterFields(o: Record<string, unknown>): EpisodesFilterState {
     // Back-compat with bookmarks/deep-links created before status became multi-select.
     result.status = [o.status];
   }
-  if (isNonEmptyString(o.ruleId)) {
-    result.ruleId = o.ruleId;
+  if (isStringArray(o.ruleIds)) {
+    result.ruleIds = [...o.ruleIds];
+  } else if (isNonEmptyString(o.ruleId)) {
+    // Back-compat with bookmarks/deep-links created before ruleId became ruleIds.
+    result.ruleIds = [o.ruleId];
   }
-  if (isNonEmptyString(o.groupHash)) {
-    result.groupHash = o.groupHash;
+  if (isStringArray(o.groupHashes)) {
+    result.groupHashes = [...o.groupHashes];
+  } else if (isNonEmptyString(o.groupHash)) {
+    // Back-compat with bookmarks/deep-links created before groupHash became groupHashes.
+    result.groupHashes = [o.groupHash];
   }
   if (isGroupingValues(o.groupingValues)) {
     result.groupingValues = o.groupingValues;
@@ -104,11 +110,11 @@ function encodeFilterFields(state: EpisodesFilterState): Record<string, unknown>
   } else if (!isSameStatusSet(st, DEFAULT_EPISODES_LIST_FILTER.status ?? [])) {
     result.status = [...st];
   }
-  if (isNonEmptyString(state.ruleId)) {
-    result.ruleId = state.ruleId;
+  if (isStringArray(state.ruleIds)) {
+    result.ruleIds = [...state.ruleIds];
   }
-  if (isNonEmptyString(state.groupHash)) {
-    result.groupHash = state.groupHash;
+  if (isStringArray(state.groupHashes)) {
+    result.groupHashes = [...state.groupHashes];
   }
   if (isGroupingValues(state.groupingValues)) {
     result.groupingValues = { ...state.groupingValues };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.test.tsx
@@ -113,6 +113,14 @@ jest.mock('../../hooks/use_breadcrumbs', () => ({
   useBreadcrumbs: jest.fn(),
 }));
 
+jest.mock('../../agent_builder/use_add_episode_to_chat', () => ({
+  useAddEpisodeToChat: jest.fn(() => ({
+    addToChat: jest.fn(),
+    isAddToChatAvailable: false,
+  })),
+}));
+
+
 const mockUseParams = jest.mocked(useParams);
 const mockUseFetchEpisodeQuery = jest.mocked(useFetchEpisodeQuery);
 const mockUseFetchEpisodeActions = jest.mocked(useFetchEpisodeActions);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.tsx
@@ -57,6 +57,7 @@ import {
 } from '../../utils/filter_episode_actions_by_privilege';
 import { UserCapabilities } from '../../services/user_capabilities';
 import { getEpisodeHeaderBadges } from './utils/get_episode_header_badges';
+import { useAddEpisodeToChat } from '../../agent_builder/use_add_episode_to_chat';
 import { getEpisodeHeaderMenu } from './utils/get_episode_header_menu';
 import {
   getEpisodeHeaderTabs,
@@ -224,14 +225,17 @@ export function EpisodeDetailsPage() {
     [episode, episodeAction, groupAction, isFlapping]
   );
 
+  const { addToChat, isAddToChatAvailable } = useAddEpisodeToChat(episode);
+
   const headerMenu = useMemo(
     () =>
       getEpisodeHeaderMenu({
         actions: applicableActions,
         episode,
         onSuccess: invalidateEpisodeQueries,
+        onAddToChat: isAddToChatAvailable ? addToChat : undefined,
       }),
-    [applicableActions, episode, invalidateEpisodeQueries]
+    [addToChat, applicableActions, episode, invalidateEpisodeQueries, isAddToChatAvailable]
   );
 
   const episodesListHref = services.http.basePath.prepend(paths.alertEpisodesList);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/translations.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/translations.ts
@@ -293,3 +293,8 @@ export const RULE_STATUS_DISABLED = i18n.translate(
 export const RUNBOOK_EMPTY = i18n.translate('xpack.alertingV2.episodeDetails.runbookEmpty', {
   defaultMessage: 'No runbook has been added to this rule.',
 });
+
+/** --- Header actions --- */
+export const ADD_TO_CHAT = i18n.translate('xpack.alertingV2.agentBuilder.addToChatButtonLabel', {
+  defaultMessage: 'Add to chat',
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/utils/get_episode_header_menu.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/utils/get_episode_header_menu.test.ts
@@ -158,4 +158,39 @@ describe('getEpisodeHeaderMenu', () => {
       onSuccess,
     });
   });
+
+  it('prepends Add to chat when onAddToChat is provided', async () => {
+    const onAddToChat = jest.fn();
+    const actions = [createAction({ id: 'ALERTING_V2_ACK_EPISODE', order: 10 })];
+
+    const menu = getEpisodeHeaderMenu({
+      actions,
+      episode: mockEpisode,
+      onSuccess: jest.fn(),
+      onAddToChat,
+    });
+
+    expect(menu.items?.[0]).toMatchObject({
+      id: 'ALERTING_V2_ADD_EPISODE_TO_CHAT',
+      label: 'Add to chat',
+      iconType: 'productAgent',
+      order: 0,
+      testId: 'episodeActionsBar-primary-ALERTING_V2_ADD_EPISODE_TO_CHAT',
+    });
+    expect(menu.items?.[0]).not.toHaveProperty('overflow');
+
+    await menu.items?.[0]?.run?.();
+    expect(onAddToChat).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits Add to chat when onAddToChat is not provided', () => {
+    const menu = getEpisodeHeaderMenu({
+      actions: [createAction({ id: 'ALERTING_V2_ACK_EPISODE', order: 10 })],
+      episode: mockEpisode,
+      onSuccess: jest.fn(),
+    });
+
+    expect(menu.items?.some((item) => item.id === 'ALERTING_V2_ADD_EPISODE_TO_CHAT')).toBe(false);
+  });
+
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/utils/get_episode_header_menu.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/utils/get_episode_header_menu.ts
@@ -8,11 +8,14 @@
 import type { AppHeaderMenu } from '@kbn/app-header';
 import type { EpisodeAction } from '@kbn/alerting-v2-episodes-ui/actions';
 import type { AlertEpisode } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import { ADD_TO_CHAT } from '../translations';
 
 export interface EpisodeHeaderMenuArgs {
   actions: EpisodeAction[];
   episode: AlertEpisode | undefined;
   onSuccess: () => void;
+  /** When set, shows an "Add to chat" action in the header. */
+  onAddToChat?: () => void;
 }
 
 const SECONDARY_ACTION_IDS = new Set([
@@ -26,10 +29,13 @@ const SECONDARY_ACTION_IDS = new Set([
 // the header (after the overflow trigger) instead of among the ordered items.
 const PRIMARY_ACTION_ITEM_ID = 'ALERTING_V2_OPEN_EPISODE_IN_DISCOVER';
 
+const ADD_TO_CHAT_ACTION_ID = 'ALERTING_V2_ADD_EPISODE_TO_CHAT';
+
 export const getEpisodeHeaderMenu = ({
   actions,
   episode,
   onSuccess,
+  onAddToChat,
 }: EpisodeHeaderMenuArgs): AppHeaderMenu => {
   const runAction = (action: EpisodeAction) => () =>
     action.execute({
@@ -39,24 +45,41 @@ export const getEpisodeHeaderMenu = ({
 
   const primaryAction = actions.find((action) => action.id === PRIMARY_ACTION_ITEM_ID);
 
-  return {
-    items: actions
-      .filter((action) => action.id !== PRIMARY_ACTION_ITEM_ID)
-      .map((action) => {
-        const isSecondary = SECONDARY_ACTION_IDS.has(action.id);
+  const actionItems = actions
+    .filter((action) => action.id !== PRIMARY_ACTION_ITEM_ID)
+    .map((action) => {
+      const isSecondary = SECONDARY_ACTION_IDS.has(action.id);
 
-        return {
-          id: action.id,
-          label: action.displayName,
-          iconType: action.iconType,
-          run: runAction(action),
-          testId: isSecondary
-            ? `episodeActionsBar-overflow-${action.id}`
-            : `episodeActionsBar-primary-${action.id}`,
-          order: action.order,
-          overflow: isSecondary,
-        };
-      }),
+      return {
+        id: action.id,
+        label: action.displayName,
+        iconType: action.iconType,
+        run: runAction(action),
+        testId: isSecondary
+          ? `episodeActionsBar-overflow-${action.id}`
+          : `episodeActionsBar-primary-${action.id}`,
+        order: action.order,
+        overflow: isSecondary,
+      };
+    });
+
+  return {
+    items: [
+      ...(onAddToChat
+        ? [
+            {
+              id: ADD_TO_CHAT_ACTION_ID,
+              label: ADD_TO_CHAT,
+              iconType: 'productAgent' as const,
+              run: onAddToChat,
+              testId: 'episodeActionsBar-primary-ALERTING_V2_ADD_EPISODE_TO_CHAT',
+              // Appear before other primary header actions.
+              order: 0,
+            },
+          ]
+        : []),
+      ...actionItems,
+    ],
     ...(primaryAction
       ? {
           primaryActionItem: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AttachmentResolveContext,
+  AttachmentTypeDefinition,
+} from '@kbn/agent-builder-server/attachments';
+import { getLatestVersion, type VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import type { Logger } from '@kbn/core/server';
+import {
+  EPISODE_ATTACHMENT_TYPE,
+  episodeAttachmentDataSchema,
+  type EpisodeAttachmentData,
+} from '@kbn/alerting-v2-schemas';
+import type { EpisodesClientContract } from '../../lib/episodes_client';
+
+interface CreateEpisodeAttachmentTypeOptions {
+  logger: Logger;
+  getEpisodesClient: (context: AttachmentResolveContext) => EpisodesClientContract;
+}
+
+const formatDuration = (ms: number): string => {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+};
+
+export const formatEpisodeAsText = (data: EpisodeAttachmentData): string => {
+  const lines = [
+    `Alert Episode "${data.episode_id}"`,
+    `Status: ${data.episode_status}`,
+    `Rule ID: ${data.rule_id}`,
+    `Group Hash: ${data.group_hash}`,
+    `Duration: ${formatDuration(data.duration)}`,
+    `First seen: ${data.first_timestamp}`,
+    `Last seen: ${data.last_timestamp}`,
+  ];
+
+  if (data.triggered_at) {
+    lines.push(`Triggered at: ${data.triggered_at}`);
+  }
+  if (data.severity) {
+    lines.push(`Severity: ${data.severity}`);
+  }
+  if (data.last_ack_action) {
+    lines.push(`Acknowledged: ${data.last_ack_action === 'ack' ? 'yes' : 'no'}`);
+  }
+  if (data.last_assignee_uid) {
+    lines.push(`Assignee: ${data.last_assignee_uid}`);
+  }
+  if (data.last_snooze_action === 'snooze') {
+    lines.push(`Snoozed${data.snooze_expiry ? ` until ${data.snooze_expiry}` : ''}`);
+  }
+
+  return lines.join('\n');
+};
+
+export const createEpisodeAttachmentType = ({
+  logger,
+  getEpisodesClient,
+}: CreateEpisodeAttachmentTypeOptions): AttachmentTypeDefinition<
+  typeof EPISODE_ATTACHMENT_TYPE,
+  EpisodeAttachmentData
+> => {
+  const fetchEpisode = async (
+    episodeId: string,
+    context: AttachmentResolveContext
+  ): Promise<EpisodeAttachmentData | undefined> => {
+    const episodesClient = getEpisodesClient(context);
+    return episodesClient.get(episodeId);
+  };
+
+  return {
+    id: EPISODE_ATTACHMENT_TYPE,
+    isReadonly: true,
+
+    validate: (input) => {
+      const result = episodeAttachmentDataSchema.safeParse(input);
+      if (result.success) {
+        return { valid: true, data: result.data };
+      }
+      return { valid: false, error: result.error.message };
+    },
+
+    resolve: async (origin, context): Promise<EpisodeAttachmentData | undefined> => {
+      try {
+        return await fetchEpisode(origin, context);
+      } catch (error) {
+        logger.warn(`Failed to resolve episode attachment for origin "${origin}": ${error}`);
+        return undefined;
+      }
+    },
+
+    isStale: async (
+      attachment: VersionedAttachment<typeof EPISODE_ATTACHMENT_TYPE, EpisodeAttachmentData>,
+      context
+    ): Promise<boolean> => {
+      if (!attachment.origin) {
+        return false;
+      }
+
+      const latestVersion = getLatestVersion(attachment);
+      if (!latestVersion) {
+        return false;
+      }
+
+      try {
+        const latestEpisode = await fetchEpisode(attachment.origin, context);
+        return (
+          !latestEpisode ||
+          latestVersion.data.last_timestamp !== latestEpisode.last_timestamp ||
+          latestVersion.data.episode_status !== latestEpisode.episode_status
+        );
+      } catch (error) {
+        logger.warn(
+          `Failed to check staleness for episode attachment "${attachment.origin}": ${error}`
+        );
+        return false;
+      }
+    },
+
+    format: (attachment) => ({
+      getRepresentation: () => ({
+        type: 'text',
+        value: formatEpisodeAsText(attachment.data),
+      }),
+    }),
+
+    getAgentDescription: () =>
+      'An episode attachment represents an alert episode — a lifecycle of a single alert series (group) within a rule, from first breach through recovery. Rendering inline shows a card with status, optional severity / acknowledged / snoozed badges, duration, and rule ID. When an episode attachment is present and you discuss it, emit `<render_attachment id="..." />` using that attachment\'s id (and optional version); without it the user only sees a short text label under "Added".',
+
+    getTools: () => [],
+  };
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/episodes_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/episodes_client.ts
@@ -1,0 +1,454 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsqlQueryRequest } from '@elastic/elasticsearch/lib/api/types';
+import { inject, injectable } from 'inversify';
+import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
+import {
+  buildEpisodeQuery,
+  buildEpisodeEventsQuery,
+  buildEpisodeEventDataQuery,
+  buildEpisodeActionsQuery,
+  buildEpisodeActionsHistoryQuery,
+  buildEpisodeFlappingQuery,
+  buildEpisodeTrendQuery,
+  buildEpisodeTagOptionsQuery,
+  buildGroupActionsQuery,
+  buildTagSuggestionsQuery,
+  buildRelatedSameRuleQuery,
+  buildRelatedOtherGroupsQuery,
+  buildRelatedSameGroupQuery,
+  ALERT_EVENTS_DATA_STREAM,
+  ALERT_ACTIONS_DATA_STREAM,
+} from '@kbn/alerting-v2-common-queries';
+import type { AlertEventType } from '../../resources/datastreams/alert_events';
+import type { QueryServiceContract } from '../services/query_service/query_service';
+import { QueryServiceScopedToken } from '../services/query_service/tokens';
+import { RequestSpaceIdToken } from '../services/spaces_service/tokens';
+import type {
+  EpisodesClientContract,
+  EpisodeData,
+  FindEpisodesParams,
+  FindEpisodesResult,
+  EpisodeKpis,
+  GetKpisParams,
+  EpisodeEventRow,
+  EpisodeEventDataRow,
+  EpisodeActionState,
+  EpisodeActionHistoryEntry,
+  GetActionsHistoryParams,
+  GroupActionState,
+  GetRelatedEpisodesParams,
+  RelatedEpisode,
+  EpisodeTrendRow,
+  GetTrendParams,
+  EpisodeFlappingStatus,
+} from './types';
+
+const EPISODE_LOOKBACK_DAYS = 30;
+
+const defaultTimeRange = (): { gte: string } => ({
+  gte: new Date(Date.now() - EPISODE_LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString(),
+});
+
+const buildTimestampFilter = (timeRange: { gte: string; lte?: string }) => ({
+  range: {
+    '@timestamp': {
+      gte: timeRange.gte,
+      ...(timeRange.lte ? { lte: timeRange.lte } : {}),
+    },
+  },
+});
+
+interface RawEpisodeRow {
+  'episode.id': string;
+  'episode.status': string;
+  'rule.id': string;
+  group_hash: string;
+  first_timestamp: string;
+  last_timestamp: string;
+  duration: number;
+  triggered_at?: string;
+  severity?: string | null;
+  episode_data?: string | null;
+  last_ack_action?: string;
+  last_assignee_uid?: string | null;
+  last_snooze_action?: string;
+  snooze_expiry?: string;
+  space_id: string;
+}
+
+const toEpisodeData = (row: RawEpisodeRow): EpisodeData => ({
+  episode_id: row['episode.id'],
+  episode_status: row['episode.status'] as EpisodeData['episode_status'],
+  rule_id: row['rule.id'],
+  group_hash: row.group_hash,
+  first_timestamp: row.first_timestamp,
+  last_timestamp: row.last_timestamp,
+  duration: row.duration,
+  triggered_at: row.triggered_at,
+  severity: row.severity,
+  episode_data: row.episode_data,
+  last_ack_action: row.last_ack_action as EpisodeData['last_ack_action'],
+  last_assignee_uid: row.last_assignee_uid,
+  last_snooze_action: row.last_snooze_action as EpisodeData['last_snooze_action'],
+  snooze_expiry: row.snooze_expiry,
+  space_id: row.space_id,
+});
+
+@injectable()
+export class EpisodesClient implements EpisodesClientContract {
+  constructor(
+    @inject(QueryServiceScopedToken) private readonly queryService: QueryServiceContract,
+    @inject(RequestSpaceIdToken) private readonly spaceId: string
+  ) {}
+
+  public async find(params: FindEpisodesParams): Promise<FindEpisodesResult> {
+    const {
+      filters = {},
+      timeRange,
+      page = 1,
+      perPage = 10,
+      sortBy = 'last_timestamp',
+      sortOrder = 'desc',
+    } = params;
+
+    const alertEventType: AlertEventType = 'alert';
+
+    const whereClauses: string[] = [];
+    const queryParams: unknown[] = [];
+
+    if (filters.status?.length) {
+      const placeholders = filters.status.map(() => '?').join(', ');
+      whereClauses.push(`episode.status IN (${placeholders})`);
+      queryParams.push(...filters.status);
+    }
+    if (filters.rule_ids?.length) {
+      const placeholders = filters.rule_ids.map(() => '?').join(', ');
+      whereClauses.push(`rule.id IN (${placeholders})`);
+      queryParams.push(...filters.rule_ids);
+    }
+    if (filters.severity?.length) {
+      const placeholders = filters.severity.map(() => '?').join(', ');
+      whereClauses.push(`severity IN (${placeholders})`);
+      queryParams.push(...filters.severity);
+    }
+    if (filters.group_hashes?.length) {
+      const placeholders = filters.group_hashes.map(() => '?').join(', ');
+      whereClauses.push(`group_hash IN (${placeholders})`);
+      queryParams.push(...filters.group_hashes);
+    }
+
+    const postAggWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(' AND ')}` : '';
+
+    const queryString = `FROM ${ALERT_EVENTS_DATA_STREAM},${ALERT_ACTIONS_DATA_STREAM} METADATA _source
+    | WHERE (type == "alert" OR action_type IN ("snooze", "unsnooze", "ack", "unack", "assign")) AND space_id == ?
+    | INLINE STATS
+        last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze"),
+        snooze_expiry      = LAST(expiry, @timestamp)      WHERE action_type == "snooze"
+      BY group_hash
+    | EVAL episode_id = COALESCE(episode.id, episode_id)
+    | INLINE STATS
+        last_ack_action    = LAST(action_type, @timestamp) WHERE action_type IN ("ack", "unack"),
+        last_assignee_uid  = LAST(assignee_uid, @timestamp) WHERE action_type == "assign"
+      BY episode_id
+    | WHERE type == ?
+    | EVAL extracted_data = JSON_EXTRACT(_source, "data")
+    | DROP _source
+    | INLINE STATS
+        first_timestamp = MIN(@timestamp),
+        last_timestamp  = MAX(@timestamp),
+        triggered_at    = MIN(@timestamp) WHERE episode.status == "active",
+        episode_data    = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}",
+        severity        = LAST(severity, @timestamp) WHERE status == "breached" AND severity IS NOT NULL
+      BY episode.id
+    | EVAL duration = DATE_DIFF("ms", first_timestamp, last_timestamp)
+    | WHERE @timestamp == last_timestamp ${postAggWhere}
+    | KEEP episode.id, episode.status, rule.id, group_hash, first_timestamp, last_timestamp,
+           duration, triggered_at, severity, episode_data, last_ack_action, last_assignee_uid,
+           last_snooze_action, snooze_expiry, space_id
+    | SORT ${sortBy} ${sortOrder.toUpperCase()}
+    | LIMIT ${(page - 1) * perPage + perPage}`;
+
+    const response = await this.queryService.executeQuery({
+      query: queryString,
+      params: [this.spaceId, alertEventType, ...queryParams],
+      filter: buildTimestampFilter(timeRange),
+    });
+
+    const allRows = this.toRows<RawEpisodeRow>(response);
+    const offset = (page - 1) * perPage;
+    const pageRows = allRows.slice(offset, offset + perPage);
+
+    return {
+      episodes: pageRows.map(toEpisodeData),
+      total: allRows.length >= (page - 1) * perPage + perPage ? -1 : allRows.length,
+    };
+  }
+
+  public async get(episodeId: string): Promise<EpisodeData | undefined> {
+    const query = buildEpisodeQuery(this.spaceId, episodeId);
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+      filter: buildTimestampFilter(defaultTimeRange()),
+    });
+
+    const rows = this.toRows<RawEpisodeRow>(response);
+    return rows.length > 0 ? toEpisodeData(rows[0]) : undefined;
+  }
+
+  public async getKpis(params: GetKpisParams): Promise<EpisodeKpis> {
+    const { currentUserUid, filters = {}, timeRange } = params;
+    const alertEventType: AlertEventType = 'alert';
+
+    const whereClauses: string[] = [];
+    const queryParams: unknown[] = [];
+
+    if (filters.status?.length) {
+      const placeholders = filters.status.map(() => '?').join(', ');
+      whereClauses.push(`episode.status IN (${placeholders})`);
+      queryParams.push(...filters.status);
+    }
+    if (filters.rule_ids?.length) {
+      const placeholders = filters.rule_ids.map(() => '?').join(', ');
+      whereClauses.push(`rule.id IN (${placeholders})`);
+      queryParams.push(...filters.rule_ids);
+    }
+
+    const postAggWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(' AND ')}` : '';
+
+    const assignedToMeEval = currentUserUid
+      ? `EVAL _assigned_to_me = CASE(last_assignee_uid == ?, 1, 0)`
+      : `EVAL _assigned_to_me = 0`;
+    const assignedParams = currentUserUid ? [currentUserUid] : [];
+
+    const queryString = `FROM ${ALERT_EVENTS_DATA_STREAM},${ALERT_ACTIONS_DATA_STREAM} METADATA _source
+    | WHERE (type == "alert" OR action_type IN ("snooze", "unsnooze", "ack", "unack", "assign")) AND space_id == ?
+    | INLINE STATS
+        last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze"),
+        snooze_expiry      = LAST(expiry, @timestamp)      WHERE action_type == "snooze"
+      BY group_hash
+    | EVAL episode_id = COALESCE(episode.id, episode_id)
+    | INLINE STATS
+        last_ack_action    = LAST(action_type, @timestamp) WHERE action_type IN ("ack", "unack"),
+        last_assignee_uid  = LAST(assignee_uid, @timestamp) WHERE action_type == "assign"
+      BY episode_id
+    | WHERE type == ?
+    | EVAL extracted_data = JSON_EXTRACT(_source, "data")
+    | DROP _source
+    | INLINE STATS
+        first_timestamp = MIN(@timestamp),
+        last_timestamp  = MAX(@timestamp),
+        triggered_at    = MIN(@timestamp) WHERE episode.status == "active",
+        episode_data    = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}",
+        severity        = LAST(severity, @timestamp) WHERE status == "breached" AND severity IS NOT NULL
+      BY episode.id
+    | EVAL duration = DATE_DIFF("ms", first_timestamp, last_timestamp)
+    | WHERE @timestamp == last_timestamp ${postAggWhere}
+    | EVAL _active_rule_id = CASE(episode.status == "active", rule.id, null)
+    | ${assignedToMeEval}
+    | EVAL _is_unassigned  = CASE(last_assignee_uid IS NULL, 1, 0)
+    | EVAL _is_acked       = CASE(last_ack_action == "ack", 1, 0)
+    | EVAL _is_snoozed     = CASE(last_snooze_action == "snooze" AND (snooze_expiry IS NULL OR TO_DATETIME(snooze_expiry) > NOW()), 1, 0)
+    | STATS
+      alerts_count   = COUNT(*),
+      firing_rules   = COUNT_DISTINCT(_active_rule_id),
+      assigned_to_me = SUM(_assigned_to_me),
+      unassigned     = SUM(_is_unassigned),
+      acknowledged   = SUM(_is_acked),
+      snoozed        = SUM(_is_snoozed)`;
+
+    const response = await this.queryService.executeQuery({
+      query: queryString,
+      params: [this.spaceId, alertEventType, ...queryParams, ...assignedParams],
+      filter: buildTimestampFilter(timeRange),
+    });
+
+    const rows = this.toRows<EpisodeKpis>(response);
+    return rows[0] ?? { alerts_count: 0, firing_rules: 0, assigned_to_me: 0, unassigned: 0, acknowledged: 0, snoozed: 0 };
+  }
+
+  public async getEvents(
+    episodeId: string,
+    timeRange: { gte: string; lte?: string }
+  ): Promise<EpisodeEventRow[]> {
+    const query = buildEpisodeEventsQuery(this.spaceId, episodeId);
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+      filter: buildTimestampFilter(timeRange),
+    });
+
+    return this.toRows<EpisodeEventRow>(response);
+  }
+
+  public async getEventData(
+    episodeId: string,
+    timeRange: { gte: string; lte?: string }
+  ): Promise<EpisodeEventDataRow | undefined> {
+    const query = buildEpisodeEventDataQuery(this.spaceId, episodeId);
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+      filter: buildTimestampFilter(timeRange),
+    });
+
+    const rows = this.toRows<EpisodeEventDataRow>(response);
+    return rows[0];
+  }
+
+  public async getActions(episodeIds: string[]): Promise<EpisodeActionState[]> {
+    if (episodeIds.length === 0) return [];
+
+    const query = buildEpisodeActionsQuery(this.spaceId, episodeIds);
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+    });
+
+    return this.toRows<EpisodeActionState>(response);
+  }
+
+  public async getActionsHistory(params: GetActionsHistoryParams): Promise<EpisodeActionHistoryEntry[]> {
+    const { episodeId, groupHash, before, limit } = params;
+
+    const query = buildEpisodeActionsHistoryQuery(this.spaceId, episodeId, groupHash, {
+      before,
+      limit,
+    });
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+    });
+
+    return this.toRows<EpisodeActionHistoryEntry>(response);
+  }
+
+  public async getGroupActions(groupHashes: string[]): Promise<GroupActionState[]> {
+    if (groupHashes.length === 0) return [];
+
+    const query = buildGroupActionsQuery(this.spaceId, groupHashes);
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+    });
+
+    return this.toRows<GroupActionState>(response);
+  }
+
+  public async getRelatedEpisodes(params: GetRelatedEpisodesParams): Promise<RelatedEpisode[]> {
+    const { ruleId, excludeEpisodeId, groupHash, excludeGroupHash, limit, timeRange } = params;
+
+    let query;
+    if (groupHash && excludeGroupHash) {
+      query = buildRelatedOtherGroupsQuery(this.spaceId, ruleId, groupHash, excludeEpisodeId, limit);
+    } else if (groupHash && !excludeGroupHash) {
+      query = buildRelatedSameGroupQuery(this.spaceId, ruleId, groupHash, excludeEpisodeId, limit);
+    } else {
+      query = buildRelatedSameRuleQuery(this.spaceId, ruleId, excludeEpisodeId, limit);
+    }
+
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+      filter: buildTimestampFilter(timeRange),
+    });
+
+    return this.toRows<RelatedEpisode>(response);
+  }
+
+  public async getTrend(params: GetTrendParams): Promise<EpisodeTrendRow[]> {
+    const { episodeId, metricLabels, timeRange } = params;
+
+    const query = buildEpisodeTrendQuery(this.spaceId, episodeId, metricLabels);
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+      filter: buildTimestampFilter(timeRange),
+    });
+
+    const rawRows = this.toRows<Record<string, unknown>>(response);
+    return rawRows.map((row) => ({
+      '@timestamp': row['@timestamp'] as string,
+      'episode.status': row['episode.status'] as AlertEpisodeStatus,
+      metrics: Object.fromEntries(
+        metricLabels.map((label) => {
+          const val = row[label];
+          const num = typeof val === 'number' ? val : typeof val === 'string' ? Number(val) : NaN;
+          return [label, Number.isFinite(num) ? num : null];
+        })
+      ),
+    }));
+  }
+
+  public async getFlappingStatuses(
+    episodeId: string,
+    limit: number = 10
+  ): Promise<EpisodeFlappingStatus[]> {
+    const query = buildEpisodeFlappingQuery(this.spaceId, episodeId, limit);
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+    });
+
+    return this.toRows<EpisodeFlappingStatus>(response);
+  }
+
+  public async getTagOptions(timeRange: { gte: string; lte?: string }): Promise<string[]> {
+    const query = buildEpisodeTagOptionsQuery(this.spaceId);
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+
+    const response = await this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+      filter: buildTimestampFilter(timeRange),
+    });
+
+    return this.toRows<{ tags: string }>(response).map((r) => r.tags);
+  }
+
+  public async getTagSuggestions(): Promise<string[]> {
+    const queryString = buildTagSuggestionsQuery(this.spaceId);
+
+    const response = await this.queryService.executeQuery({
+      query: queryString,
+    });
+
+    return this.toRows<{ tags: string }>(response).map((r) => r.tags);
+  }
+
+  private toRows<T>(response: { columns: Array<{ name: string }>; values: unknown[][] }): T[] {
+    const columnNames = response.columns.map((c) => c.name);
+    return response.values.map((valueRow) => {
+      const row: Record<string, unknown> = {};
+      for (let i = 0; i < columnNames.length; i++) {
+        const value = valueRow[i];
+        row[columnNames[i]] = typeof value === 'bigint' ? Number(value) : value;
+      }
+      return row as T;
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/episodes_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/episodes_client.ts
@@ -8,7 +8,7 @@
 import type { EsqlQueryRequest } from '@elastic/elasticsearch/lib/api/types';
 import type { ComposerQuery } from '@elastic/esql';
 import { inject, injectable } from 'inversify';
-import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
+import type { AlertEpisodeStatus, EpisodeData } from '@kbn/alerting-v2-schemas';
 import {
   buildEpisodeQuery,
   buildEpisodeEventsQuery,
@@ -32,7 +32,6 @@ import { QueryServiceScopedToken } from '../services/query_service/tokens';
 import { RequestSpaceIdToken } from '../services/spaces_service/tokens';
 import type {
   EpisodesClientContract,
-  EpisodeData,
   FindEpisodesParams,
   FindEpisodesResult,
   FindEpisodesFilters,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/episodes_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/episodes_client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EsqlQueryRequest } from '@elastic/elasticsearch/lib/api/types';
+import type { ComposerQuery } from '@elastic/esql';
 import { inject, injectable } from 'inversify';
 import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
 import {
@@ -22,10 +23,10 @@ import {
   buildRelatedSameRuleQuery,
   buildRelatedOtherGroupsQuery,
   buildRelatedSameGroupQuery,
-  ALERT_EVENTS_DATA_STREAM,
-  ALERT_ACTIONS_DATA_STREAM,
+  buildEpisodesQuery,
+  buildEpisodesKpisQuery,
+  type EpisodesFilterState,
 } from '@kbn/alerting-v2-common-queries';
-import type { AlertEventType } from '../../resources/datastreams/alert_events';
 import type { QueryServiceContract } from '../services/query_service/query_service';
 import { QueryServiceScopedToken } from '../services/query_service/tokens';
 import { RequestSpaceIdToken } from '../services/spaces_service/tokens';
@@ -34,6 +35,7 @@ import type {
   EpisodeData,
   FindEpisodesParams,
   FindEpisodesResult,
+  FindEpisodesFilters,
   EpisodeKpis,
   GetKpisParams,
   EpisodeEventRow,
@@ -62,6 +64,13 @@ const buildTimestampFilter = (timeRange: { gte: string; lte?: string }) => ({
       ...(timeRange.lte ? { lte: timeRange.lte } : {}),
     },
   },
+});
+
+const toFilterState = (filters: FindEpisodesFilters = {}): EpisodesFilterState => ({
+  status: filters.status,
+  ruleIds: filters.rule_ids,
+  groupHashes: filters.group_hashes,
+  severity: filters.severity,
 });
 
 interface RawEpisodeRow {
@@ -117,69 +126,13 @@ export class EpisodesClient implements EpisodesClientContract {
       sortOrder = 'desc',
     } = params;
 
-    const alertEventType: AlertEventType = 'alert';
+    const query = buildEpisodesQuery(
+      this.spaceId,
+      { sortField: sortBy, sortDirection: sortOrder },
+      toFilterState(filters)
+    ).limit((page - 1) * perPage + perPage);
 
-    const whereClauses: string[] = [];
-    const queryParams: unknown[] = [];
-
-    if (filters.status?.length) {
-      const placeholders = filters.status.map(() => '?').join(', ');
-      whereClauses.push(`episode.status IN (${placeholders})`);
-      queryParams.push(...filters.status);
-    }
-    if (filters.rule_ids?.length) {
-      const placeholders = filters.rule_ids.map(() => '?').join(', ');
-      whereClauses.push(`rule.id IN (${placeholders})`);
-      queryParams.push(...filters.rule_ids);
-    }
-    if (filters.severity?.length) {
-      const placeholders = filters.severity.map(() => '?').join(', ');
-      whereClauses.push(`severity IN (${placeholders})`);
-      queryParams.push(...filters.severity);
-    }
-    if (filters.group_hashes?.length) {
-      const placeholders = filters.group_hashes.map(() => '?').join(', ');
-      whereClauses.push(`group_hash IN (${placeholders})`);
-      queryParams.push(...filters.group_hashes);
-    }
-
-    const postAggWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(' AND ')}` : '';
-
-    const queryString = `FROM ${ALERT_EVENTS_DATA_STREAM},${ALERT_ACTIONS_DATA_STREAM} METADATA _source
-    | WHERE (type == "alert" OR action_type IN ("snooze", "unsnooze", "ack", "unack", "assign")) AND space_id == ?
-    | INLINE STATS
-        last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze"),
-        snooze_expiry      = LAST(expiry, @timestamp)      WHERE action_type == "snooze"
-      BY group_hash
-    | EVAL episode_id = COALESCE(episode.id, episode_id)
-    | INLINE STATS
-        last_ack_action    = LAST(action_type, @timestamp) WHERE action_type IN ("ack", "unack"),
-        last_assignee_uid  = LAST(assignee_uid, @timestamp) WHERE action_type == "assign"
-      BY episode_id
-    | WHERE type == ?
-    | EVAL extracted_data = JSON_EXTRACT(_source, "data")
-    | DROP _source
-    | INLINE STATS
-        first_timestamp = MIN(@timestamp),
-        last_timestamp  = MAX(@timestamp),
-        triggered_at    = MIN(@timestamp) WHERE episode.status == "active",
-        episode_data    = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}",
-        severity        = LAST(severity, @timestamp) WHERE status == "breached" AND severity IS NOT NULL
-      BY episode.id
-    | EVAL duration = DATE_DIFF("ms", first_timestamp, last_timestamp)
-    | WHERE @timestamp == last_timestamp ${postAggWhere}
-    | KEEP episode.id, episode.status, rule.id, group_hash, first_timestamp, last_timestamp,
-           duration, triggered_at, severity, episode_data, last_ack_action, last_assignee_uid,
-           last_snooze_action, snooze_expiry, space_id
-    | SORT ${sortBy} ${sortOrder.toUpperCase()}
-    | LIMIT ${(page - 1) * perPage + perPage}`;
-
-    const response = await this.queryService.executeQuery({
-      query: queryString,
-      params: [this.spaceId, alertEventType, ...queryParams],
-      filter: buildTimestampFilter(timeRange),
-    });
-
+    const response = await this.executeComposerQuery(query, buildTimestampFilter(timeRange));
     const allRows = this.toRows<RawEpisodeRow>(response);
     const offset = (page - 1) * perPage;
     const pageRows = allRows.slice(offset, offset + perPage);
@@ -191,14 +144,10 @@ export class EpisodesClient implements EpisodesClientContract {
   }
 
   public async get(episodeId: string): Promise<EpisodeData | undefined> {
-    const query = buildEpisodeQuery(this.spaceId, episodeId);
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-      filter: buildTimestampFilter(defaultTimeRange()),
-    });
+    const response = await this.executeComposerQuery(
+      buildEpisodeQuery(this.spaceId, episodeId),
+      buildTimestampFilter(defaultTimeRange())
+    );
 
     const rows = this.toRows<RawEpisodeRow>(response);
     return rows.length > 0 ? toEpisodeData(rows[0]) : undefined;
@@ -206,88 +155,33 @@ export class EpisodesClient implements EpisodesClientContract {
 
   public async getKpis(params: GetKpisParams): Promise<EpisodeKpis> {
     const { currentUserUid, filters = {}, timeRange } = params;
-    const alertEventType: AlertEventType = 'alert';
 
-    const whereClauses: string[] = [];
-    const queryParams: unknown[] = [];
-
-    if (filters.status?.length) {
-      const placeholders = filters.status.map(() => '?').join(', ');
-      whereClauses.push(`episode.status IN (${placeholders})`);
-      queryParams.push(...filters.status);
-    }
-    if (filters.rule_ids?.length) {
-      const placeholders = filters.rule_ids.map(() => '?').join(', ');
-      whereClauses.push(`rule.id IN (${placeholders})`);
-      queryParams.push(...filters.rule_ids);
-    }
-
-    const postAggWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(' AND ')}` : '';
-
-    const assignedToMeEval = currentUserUid
-      ? `EVAL _assigned_to_me = CASE(last_assignee_uid == ?, 1, 0)`
-      : `EVAL _assigned_to_me = 0`;
-    const assignedParams = currentUserUid ? [currentUserUid] : [];
-
-    const queryString = `FROM ${ALERT_EVENTS_DATA_STREAM},${ALERT_ACTIONS_DATA_STREAM} METADATA _source
-    | WHERE (type == "alert" OR action_type IN ("snooze", "unsnooze", "ack", "unack", "assign")) AND space_id == ?
-    | INLINE STATS
-        last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze"),
-        snooze_expiry      = LAST(expiry, @timestamp)      WHERE action_type == "snooze"
-      BY group_hash
-    | EVAL episode_id = COALESCE(episode.id, episode_id)
-    | INLINE STATS
-        last_ack_action    = LAST(action_type, @timestamp) WHERE action_type IN ("ack", "unack"),
-        last_assignee_uid  = LAST(assignee_uid, @timestamp) WHERE action_type == "assign"
-      BY episode_id
-    | WHERE type == ?
-    | EVAL extracted_data = JSON_EXTRACT(_source, "data")
-    | DROP _source
-    | INLINE STATS
-        first_timestamp = MIN(@timestamp),
-        last_timestamp  = MAX(@timestamp),
-        triggered_at    = MIN(@timestamp) WHERE episode.status == "active",
-        episode_data    = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}",
-        severity        = LAST(severity, @timestamp) WHERE status == "breached" AND severity IS NOT NULL
-      BY episode.id
-    | EVAL duration = DATE_DIFF("ms", first_timestamp, last_timestamp)
-    | WHERE @timestamp == last_timestamp ${postAggWhere}
-    | EVAL _active_rule_id = CASE(episode.status == "active", rule.id, null)
-    | ${assignedToMeEval}
-    | EVAL _is_unassigned  = CASE(last_assignee_uid IS NULL, 1, 0)
-    | EVAL _is_acked       = CASE(last_ack_action == "ack", 1, 0)
-    | EVAL _is_snoozed     = CASE(last_snooze_action == "snooze" AND (snooze_expiry IS NULL OR TO_DATETIME(snooze_expiry) > NOW()), 1, 0)
-    | STATS
-      alerts_count   = COUNT(*),
-      firing_rules   = COUNT_DISTINCT(_active_rule_id),
-      assigned_to_me = SUM(_assigned_to_me),
-      unassigned     = SUM(_is_unassigned),
-      acknowledged   = SUM(_is_acked),
-      snoozed        = SUM(_is_snoozed)`;
-
-    const response = await this.queryService.executeQuery({
-      query: queryString,
-      params: [this.spaceId, alertEventType, ...queryParams, ...assignedParams],
-      filter: buildTimestampFilter(timeRange),
-    });
+    const response = await this.executeComposerQuery(
+      buildEpisodesKpisQuery(this.spaceId, currentUserUid, toFilterState(filters)),
+      buildTimestampFilter(timeRange)
+    );
 
     const rows = this.toRows<EpisodeKpis>(response);
-    return rows[0] ?? { alerts_count: 0, firing_rules: 0, assigned_to_me: 0, unassigned: 0, acknowledged: 0, snoozed: 0 };
+    return (
+      rows[0] ?? {
+        alerts_count: 0,
+        firing_rules: 0,
+        assigned_to_me: 0,
+        unassigned: 0,
+        acknowledged: 0,
+        snoozed: 0,
+      }
+    );
   }
 
   public async getEvents(
     episodeId: string,
     timeRange: { gte: string; lte?: string }
   ): Promise<EpisodeEventRow[]> {
-    const query = buildEpisodeEventsQuery(this.spaceId, episodeId);
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-      filter: buildTimestampFilter(timeRange),
-    });
-
+    const response = await this.executeComposerQuery(
+      buildEpisodeEventsQuery(this.spaceId, episodeId),
+      buildTimestampFilter(timeRange)
+    );
     return this.toRows<EpisodeEventRow>(response);
   }
 
@@ -295,15 +189,10 @@ export class EpisodesClient implements EpisodesClientContract {
     episodeId: string,
     timeRange: { gte: string; lte?: string }
   ): Promise<EpisodeEventDataRow | undefined> {
-    const query = buildEpisodeEventDataQuery(this.spaceId, episodeId);
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-      filter: buildTimestampFilter(timeRange),
-    });
-
+    const response = await this.executeComposerQuery(
+      buildEpisodeEventDataQuery(this.spaceId, episodeId),
+      buildTimestampFilter(timeRange)
+    );
     const rows = this.toRows<EpisodeEventDataRow>(response);
     return rows[0];
   }
@@ -311,45 +200,30 @@ export class EpisodesClient implements EpisodesClientContract {
   public async getActions(episodeIds: string[]): Promise<EpisodeActionState[]> {
     if (episodeIds.length === 0) return [];
 
-    const query = buildEpisodeActionsQuery(this.spaceId, episodeIds);
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-    });
-
+    const response = await this.executeComposerQuery(
+      buildEpisodeActionsQuery(this.spaceId, episodeIds)
+    );
     return this.toRows<EpisodeActionState>(response);
   }
 
   public async getActionsHistory(params: GetActionsHistoryParams): Promise<EpisodeActionHistoryEntry[]> {
     const { episodeId, groupHash, before, limit } = params;
 
-    const query = buildEpisodeActionsHistoryQuery(this.spaceId, episodeId, groupHash, {
-      before,
-      limit,
-    });
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-    });
-
+    const response = await this.executeComposerQuery(
+      buildEpisodeActionsHistoryQuery(this.spaceId, episodeId, groupHash, {
+        before,
+        limit,
+      })
+    );
     return this.toRows<EpisodeActionHistoryEntry>(response);
   }
 
   public async getGroupActions(groupHashes: string[]): Promise<GroupActionState[]> {
     if (groupHashes.length === 0) return [];
 
-    const query = buildGroupActionsQuery(this.spaceId, groupHashes);
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-    });
-
+    const response = await this.executeComposerQuery(
+      buildGroupActionsQuery(this.spaceId, groupHashes)
+    );
     return this.toRows<GroupActionState>(response);
   }
 
@@ -365,28 +239,17 @@ export class EpisodesClient implements EpisodesClientContract {
       query = buildRelatedSameRuleQuery(this.spaceId, ruleId, excludeEpisodeId, limit);
     }
 
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-      filter: buildTimestampFilter(timeRange),
-    });
-
+    const response = await this.executeComposerQuery(query, buildTimestampFilter(timeRange));
     return this.toRows<RelatedEpisode>(response);
   }
 
   public async getTrend(params: GetTrendParams): Promise<EpisodeTrendRow[]> {
     const { episodeId, metricLabels, timeRange } = params;
 
-    const query = buildEpisodeTrendQuery(this.spaceId, episodeId, metricLabels);
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-      filter: buildTimestampFilter(timeRange),
-    });
+    const response = await this.executeComposerQuery(
+      buildEpisodeTrendQuery(this.spaceId, episodeId, metricLabels),
+      buildTimestampFilter(timeRange)
+    );
 
     const rawRows = this.toRows<Record<string, unknown>>(response);
     return rawRows.map((row) => ({
@@ -406,38 +269,38 @@ export class EpisodesClient implements EpisodesClientContract {
     episodeId: string,
     limit: number = 10
   ): Promise<EpisodeFlappingStatus[]> {
-    const query = buildEpisodeFlappingQuery(this.spaceId, episodeId, limit);
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
-
-    const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-    });
-
+    const response = await this.executeComposerQuery(
+      buildEpisodeFlappingQuery(this.spaceId, episodeId, limit)
+    );
     return this.toRows<EpisodeFlappingStatus>(response);
   }
 
   public async getTagOptions(timeRange: { gte: string; lte?: string }): Promise<string[]> {
-    const query = buildEpisodeTagOptionsQuery(this.spaceId);
-    const request = query.toRequest();
-    const { filter: _composerFilter, ...esqlRequest } = request;
+    const response = await this.executeComposerQuery(
+      buildEpisodeTagOptionsQuery(this.spaceId),
+      buildTimestampFilter(timeRange)
+    );
+    return this.toRows<{ tags: string }>(response).map((r) => r.tags);
+  }
 
+  public async getTagSuggestions(): Promise<string[]> {
     const response = await this.queryService.executeQuery({
-      query: (esqlRequest as unknown as EsqlQueryRequest).query,
-      filter: buildTimestampFilter(timeRange),
+      query: buildTagSuggestionsQuery(this.spaceId),
     });
 
     return this.toRows<{ tags: string }>(response).map((r) => r.tags);
   }
 
-  public async getTagSuggestions(): Promise<string[]> {
-    const queryString = buildTagSuggestionsQuery(this.spaceId);
-
-    const response = await this.queryService.executeQuery({
-      query: queryString,
+  private async executeComposerQuery(
+    query: ComposerQuery,
+    filter?: ReturnType<typeof buildTimestampFilter>
+  ) {
+    const request = query.toRequest();
+    const { filter: _composerFilter, ...esqlRequest } = request;
+    return this.queryService.executeQuery({
+      query: (esqlRequest as unknown as EsqlQueryRequest).query,
+      ...(filter ? { filter } : {}),
     });
-
-    return this.toRows<{ tags: string }>(response).map((r) => r.tags);
   }
 
   private toRows<T>(response: { columns: Array<{ name: string }>; values: unknown[][] }): T[] {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/index.ts
@@ -9,7 +9,6 @@ export { EpisodesClient } from './episodes_client';
 export { EpisodesClientToken } from './tokens';
 export type {
   EpisodesClientContract,
-  EpisodeData,
   FindEpisodesParams,
   FindEpisodesResult,
   FindEpisodesFilters,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { EpisodesClient } from './episodes_client';
+export { EpisodesClientToken } from './tokens';
+export type {
+  EpisodesClientContract,
+  EpisodeData,
+  FindEpisodesParams,
+  FindEpisodesResult,
+  FindEpisodesFilters,
+  EpisodeKpis,
+  GetKpisParams,
+  EpisodeEventRow,
+  EpisodeEventDataRow,
+  EpisodeActionState,
+  EpisodeActionHistoryEntry,
+  GetActionsHistoryParams,
+  GroupActionState,
+  GetRelatedEpisodesParams,
+  RelatedEpisode,
+  EpisodeTrendRow,
+  GetTrendParams,
+  EpisodeFlappingStatus,
+} from './types';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/tokens.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/tokens.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { buildTagSuggestionsQuery } from '@kbn/alerting-v2-common-queries';
+import { createToken } from '@kbn/core-di';
+import type { EpisodesClientContract } from './types';
 
-export const ALERT_ACTION_TAG_SUGGESTIONS_LIMIT = 20;
-
-export const buildAlertActionTagSuggestionsQuery = (spaceId: string): string =>
-  buildTagSuggestionsQuery(spaceId);
+export const EpisodesClientToken = createToken<EpisodesClientContract>(
+  'alerting_v2.EpisodesClient'
+);

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/types.ts
@@ -5,27 +5,9 @@
  * 2.0.
  */
 
-import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
+import type { AlertEpisodeStatus, EpisodeData } from '@kbn/alerting-v2-schemas';
 
-export type EpisodeStatus = 'inactive' | 'pending' | 'active' | 'recovering';
-
-export interface EpisodeData {
-  episode_id: string;
-  episode_status: EpisodeStatus;
-  rule_id: string;
-  group_hash: string;
-  first_timestamp: string;
-  last_timestamp: string;
-  duration: number;
-  triggered_at?: string;
-  severity?: string | null;
-  episode_data?: string | null;
-  last_ack_action?: 'ack' | 'unack';
-  last_assignee_uid?: string | null;
-  last_snooze_action?: 'snooze' | 'unsnooze';
-  snooze_expiry?: string;
-  space_id: string;
-}
+export type EpisodeStatus = AlertEpisodeStatus;
 
 export interface FindEpisodesFilters {
   status?: EpisodeStatus[];

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/episodes_client/types.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
+
+export type EpisodeStatus = 'inactive' | 'pending' | 'active' | 'recovering';
+
+export interface EpisodeData {
+  episode_id: string;
+  episode_status: EpisodeStatus;
+  rule_id: string;
+  group_hash: string;
+  first_timestamp: string;
+  last_timestamp: string;
+  duration: number;
+  triggered_at?: string;
+  severity?: string | null;
+  episode_data?: string | null;
+  last_ack_action?: 'ack' | 'unack';
+  last_assignee_uid?: string | null;
+  last_snooze_action?: 'snooze' | 'unsnooze';
+  snooze_expiry?: string;
+  space_id: string;
+}
+
+export interface FindEpisodesFilters {
+  status?: EpisodeStatus[];
+  rule_ids?: string[];
+  severity?: string[];
+  group_hashes?: string[];
+}
+
+export interface FindEpisodesParams {
+  filters?: FindEpisodesFilters;
+  timeRange: { gte: string; lte?: string };
+  page?: number;
+  perPage?: number;
+  sortBy?: 'last_timestamp' | 'first_timestamp' | 'duration';
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface FindEpisodesResult {
+  episodes: EpisodeData[];
+  total: number;
+}
+
+export interface EpisodeKpis {
+  alerts_count: number;
+  firing_rules: number;
+  assigned_to_me: number;
+  unassigned: number;
+  acknowledged: number;
+  snoozed: number;
+}
+
+export interface GetKpisParams {
+  currentUserUid?: string;
+  filters?: FindEpisodesFilters;
+  timeRange: { gte: string; lte?: string };
+}
+
+export interface EpisodeEventRow {
+  '@timestamp': string;
+  'episode.id': string;
+  'episode.status': AlertEpisodeStatus;
+  'rule.id': string;
+  group_hash: string;
+  severity?: string | null;
+  data?: string | Record<string, unknown> | null;
+}
+
+export interface EpisodeEventDataRow {
+  'episode.id': string;
+  last_data: string | null;
+  last_data_timestamp: string | null;
+  last_event_timestamp: string | null;
+}
+
+export interface EpisodeActionState {
+  episode_id: string;
+  rule_id: string | null;
+  group_hash: string | null;
+  last_ack_action: string | null;
+  last_assignee_uid: string | null;
+  last_ack_actor: string | null;
+}
+
+export interface EpisodeActionHistoryEntry {
+  _id: string;
+  '@timestamp': string;
+  action_type: string;
+  actor: string | null;
+  episode_id: string | null;
+  group_hash: string | null;
+  tags: string[] | null;
+  assignee_uid: string | null;
+  expiry: string | null;
+  reason: string | null;
+}
+
+export interface GetActionsHistoryParams {
+  episodeId: string;
+  groupHash: string;
+  before?: string;
+  limit?: number;
+}
+
+export interface GroupActionState {
+  group_hash: string;
+  rule_id: string | null;
+  last_deactivate_action: string | null;
+  last_snooze_action: string | null;
+  snooze_expiry: string | null;
+  tags: string | string[] | null;
+  last_snooze_actor: string | null;
+  last_deactivate_actor: string | null;
+}
+
+export interface GetRelatedEpisodesParams {
+  ruleId: string;
+  excludeEpisodeId: string;
+  groupHash?: string;
+  excludeGroupHash?: boolean;
+  limit?: number;
+  timeRange: { gte: string; lte?: string };
+}
+
+export interface RelatedEpisode {
+  '@timestamp': string;
+  'episode.id': string;
+  'episode.status': AlertEpisodeStatus;
+  'rule.id': string;
+  group_hash: string;
+  first_timestamp: string;
+  last_timestamp: string;
+  duration: number;
+  episode_data?: string | null;
+  severity?: string | null;
+}
+
+export interface EpisodeTrendRow {
+  '@timestamp': string;
+  'episode.status': AlertEpisodeStatus;
+  metrics: Record<string, number | null>;
+}
+
+export interface GetTrendParams {
+  episodeId: string;
+  metricLabels: string[];
+  timeRange: { gte: string; lte?: string };
+}
+
+export interface EpisodeFlappingStatus {
+  'episode.status': AlertEpisodeStatus;
+}
+
+export interface EpisodesClientContract {
+  find(params: FindEpisodesParams): Promise<FindEpisodesResult>;
+  get(episodeId: string): Promise<EpisodeData | undefined>;
+  getKpis(params: GetKpisParams): Promise<EpisodeKpis>;
+  getEvents(episodeId: string, timeRange: { gte: string; lte?: string }): Promise<EpisodeEventRow[]>;
+  getEventData(episodeId: string, timeRange: { gte: string; lte?: string }): Promise<EpisodeEventDataRow | undefined>;
+  getActions(episodeIds: string[]): Promise<EpisodeActionState[]>;
+  getActionsHistory(params: GetActionsHistoryParams): Promise<EpisodeActionHistoryEntry[]>;
+  getGroupActions(groupHashes: string[]): Promise<GroupActionState[]>;
+  getRelatedEpisodes(params: GetRelatedEpisodesParams): Promise<RelatedEpisode[]>;
+  getTrend(params: GetTrendParams): Promise<EpisodeTrendRow[]>;
+  getFlappingStatuses(episodeId: string, limit?: number): Promise<EpisodeFlappingStatus[]>;
+  getTagOptions(timeRange: { gte: string; lte?: string }): Promise<string[]>;
+  getTagSuggestions(): Promise<string[]>;
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -11,6 +11,7 @@ import { CoreStart } from '@kbn/core-di-server';
 import { ALERTING_V2_ENABLED_SETTING_ID } from '@kbn/alerting-v2-constants';
 import type { Container, ContainerModuleLoadOptions } from 'inversify';
 import { createActionPolicyAttachmentType } from '../agent_builder/attachments/action_policy_attachment_type';
+import { createEpisodeAttachmentType } from '../agent_builder/attachments/episode_attachment_type';
 import { createRuleAttachmentType } from '../agent_builder/attachments/rule_attachment_type';
 import { resolveRequestScoped } from '../agent_builder/resolve_request_scoped';
 import { registerSkills } from '../agent_builder/skills/register_skills';
@@ -20,6 +21,7 @@ import { createRuleSmlType } from '../agent_builder/sml/rule_sml_type';
 import { AttachmentTypeToken } from '../agent_builder/tokens';
 import { ActionPolicyClient } from '../lib/action_policy_client';
 import { WorkflowsManagementApiToken } from '../lib/dispatcher/steps/dispatch_step_tokens';
+import { EpisodesClient } from '../lib/episodes_client';
 import { RulesClient } from '../lib/rules_client';
 import { ACTION_POLICY_SAVED_OBJECT_TYPE, RULE_SAVED_OBJECT_TYPE } from '../saved_objects';
 import { SettingsServiceToken } from '../lib/services/settings_service/tokens';
@@ -64,6 +66,15 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
         logger,
         getActionPolicyClient: (context) =>
           resolveRequestScoped(injection, context.request, ActionPolicyClient),
+      }) as AttachmentTypeDefinition,
+    [Logger, CoreStart('injection')]
+  );
+  bind(AttachmentTypeToken).toResolvedValue(
+    (logger, injection) =>
+      createEpisodeAttachmentType({
+        logger,
+        getEpisodesClient: (context) =>
+          resolveRequestScoped(injection, context.request, EpisodesClient),
       }) as AttachmentTypeDefinition,
     [Logger, CoreStart('injection')]
   );

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -12,6 +12,7 @@ import { CoreStart, Request, SavedObjectsClientFactory } from '@kbn/core-di-serv
 import type { ContainerModuleLoadOptions } from 'inversify';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '@kbn/maintenance-windows-plugin/common';
 import { AlertActionsClient } from '../lib/alert_actions_client';
+import { EpisodesClient } from '../lib/episodes_client';
 import { DirectorService } from '../lib/director/director';
 import { BasicTransitionStrategy } from '../lib/director/strategies/basic_strategy';
 import { CountTimeframeStrategy } from '../lib/director/strategies/count_timeframe_strategy';
@@ -26,6 +27,7 @@ import {
   ExecutionHistoryClient,
   ExecutionHistoryClientToken,
 } from '../lib/execution_history_client';
+import { EpisodesClientToken } from '../lib/episodes_client';
 import { RulesClient } from '../lib/rules_client';
 import { RequestSpaceIdToken } from '../lib/services/spaces_service/tokens';
 import { ApiKeyService } from '../lib/services/api_key_service/api_key_service';
@@ -95,6 +97,8 @@ import type { AlertingServerSetupDependencies, AlertingServerStartDependencies }
 
 export function bindServices({ bind }: ContainerModuleLoadOptions) {
   bind(AlertActionsClient).toSelf().inRequestScope();
+  bind(EpisodesClient).toSelf().inRequestScope();
+  bind(EpisodesClientToken).toService(EpisodesClient);
   bind(RulesClient).toSelf().inRequestScope();
   bind(RequestSpaceIdToken)
     .toDynamicValue(({ get }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
@@ -41,6 +41,7 @@
     "@kbn/core-elasticsearch-client-server-mocks",
     "@kbn/es-errors",
     "@kbn/alerting-v2-schemas",
+    "@kbn/alerting-v2-common-queries",
     "@kbn/alerting-v2-rule-form",
     "@kbn/data-views-plugin",
     "@kbn/zod",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4734,6 +4734,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/alerting-v2-common-queries@link:x-pack/platform/packages/shared/response-ops/alerting-v2-common-queries":
+  version "0.0.0"
+  uid ""
+
 "@kbn/alerting-v2-constants@link:x-pack/platform/packages/shared/response-ops/alerting-v2-constants":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary
- Adds an Alerting v2 **episode** attachment type for Agent Builder (schema, server type, UI definition/inline card, allow list registration).
- Adds an **Add to chat** action on the episode details header that opens Agent Builder with the episode attached.
- Hardens episode attachment validation for real ES|QL payloads (`null` optional action fields; object-shaped `episode_data` from `JSON_EXTRACT`).
- Guides the agent to emit `<render_attachment>` so the episode inline card can appear in chat responses.

## Test plan
- [ ] Open an alert episode details page with Agent Builder enabled and capability available
- [ ] Confirm **Add to chat** appears in the header and opens a new conversation with an episode attachment pill
- [ ] Send a prompt about the episode and confirm converse succeeds (no attachment validation Bad Request)
- [ ] Confirm the agent can render the episode inline card via `<render_attachment>`
- [ ] Confirm unit tests for episode schema, attachment mapping, and header menu pass


Made with [Cursor](https://cursor.com)