### PR TITLE
[Security Solution][test-plan-generator] Enforce critical-workflows map consultation in self-review

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/output-formats.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/output-formats.md
@@ -80,6 +80,7 @@ Before saving the draft to `.agents/tmp/`, review every scenario in the test pla
 - [ ] No two scenarios test the same thing with different wording
 - [ ] No scenario tests something not described in the issue, sub-issues, linked PRs, or Figma designs
 - [ ] Scenarios are ordered by priority: P0 first, then P1, then P2
+- [ ] The owning team's critical-workflows map was consulted per [`critical-workflows.md`](critical-workflows.md) before finalizing priorities — either a matching map was loaded and its P0 / P1 tables informed the per-scenario priority assignments, or the [no-map fallback](critical-workflows.md#lookup-precedence) fired and Known Limitations contains the note `⚠️ No team critical-workflows map was applied — priority was derived from abstract impact rules only.` verbatim
 
 **Across the full test plan:**
 - [ ] All acceptance criteria listed in the Acceptance Criteria section are covered by at least one scenario


### PR DESCRIPTION
## Summary

Follow-up to [#280827](https://github.com/elastic/kibana/pull/280827) addressing a review comment from [@MadameSheema](https://github.com/MadameSheema) posted on [line 226 of `optional-scenarios.md`](https://github.com/elastic/kibana/pull/280827#discussion_r3664518811) shortly before that PR merged.

## The gap

`optional-scenarios.md#priority-levels` instructs the agent to consult the owning team's critical-workflows map before finalizing scenario priorities. The instruction is there, but nothing mechanically verifies:

1. That the consultation actually happened.
2. That the no-map fallback's verbatim `⚠️` note was written to *Known Limitations* when no map matched (per [`critical-workflows.md` line 43](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/critical-workflows.md#L43)).

This left a silent-drop mode where the agent could skip the map entirely with no downstream layer catching it.

## Change

Adds **one** item to the per-section self-review checklist in `references/output-formats.md`, next to the existing priority-ordering check:

```md
- [ ] The owning team's critical-workflows map was consulted per `critical-workflows.md` before finalizing priorities — either a matching map was loaded and its P0 / P1 tables informed the per-scenario priority assignments, or the no-map fallback fired and Known Limitations contains the note `⚠️ No team critical-workflows map was applied — priority was derived from abstract impact rules only.` verbatim
```

Placed in the **per-section self-review** layer (which already owns per-scenario / priority checks), **not** in `draft-coherence-review.md` (which is scoped to cross-section drift only, per [`SKILL.md` line 266](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/SKILL.md#L266)). Following Glo's guidance on the review thread — duplicating the rule across layers would recreate the two-sources-of-truth problem that motivated the earlier P1/P2 restructuring.

## Test plan

- [x] Internal Markdown links resolve (`critical-workflows.md` and its `#lookup-precedence` anchor both check out).
- [x] Change is one line added; no existing checklist item removed or reworded.
- [ ] Self-verification: the next `test-plan-generator` run will surface this checklist item in its per-section review.

---

Made with [Cursor](https://cursor.com).