### PR TITLE
[Security Solution][OneDiscover] make flyout tool headers readable at narrow widths

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/README.md
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/README.md
@@ -210,7 +210,7 @@ a "what happened" description onto an EBT event. Event types and schemas live in
 - `useOpenFlyout()` — the instrumented wrapper around `overlays.openSystemFlyout(flyoutProviders({...}))`. Handles
   Suspense fallback (`FlyoutLoading`), the `FlyoutSessionContextProvider`, and telemetry. All open methods go through
   it.
-- `useDefaultDocumentFlyoutProperties()` / `defaultToolsFlyoutProperties` — consistent size/width/padding options.
+- `useDefaultDocumentFlyoutProperties()` / `useDefaultToolsFlyoutProperties()` — consistent size/width/padding options.
   Spread these into your flyout properties.
 - `useTabs<T>()` — generic tab selection with localStorage persistence and optional tab-click telemetry. Priority:
   `initialTabId` → localStorage → `validTabIds[0]`.

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
@@ -38,7 +38,7 @@ jest.mock('../shared/components/flyout_provider', () => ({
 }));
 jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
   useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
-  defaultToolsFlyoutProperties: { size: 'm' },
+  useDefaultToolsFlyoutProperties: jest.fn(() => ({ minWidth: 384, size: 'm' })),
 }));
 
 const mockWriteOnOpen = jest.fn();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
@@ -12,8 +12,8 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { cellActionRenderer } from '../shared/components/cell_actions';
 import {
-  defaultToolsFlyoutProperties,
   useDefaultDocumentFlyoutProperties,
+  useDefaultToolsFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
 import { useOpenFlyout } from '../shared/hooks/use_open_flyout';
 import type { FlyoutOrigin } from '../../common/lib/telemetry';
@@ -132,6 +132,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
   const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const defaultToolsFlyoutProperties = useDefaultToolsFlyoutProperties();
   const open = useOpenFlyout();
   const urlParamKey = urlParamKeyForHistoryKey(historyKey);
   const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
@@ -258,7 +259,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openAttackEntities = useCallback(
@@ -292,7 +293,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section.test.tsx
@@ -18,7 +18,6 @@ import { ResponseSectionContent } from './response_section_content';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
-import { defaultToolsFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 
 jest.mock('../../../../common/lib/kibana', () => ({
   useKibana: jest.fn(),
@@ -107,9 +106,13 @@ describe('<ResponseSection />', () => {
     expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        ...defaultToolsFlyoutProperties,
         historyKey: documentFlyoutHistoryKey,
+        minWidth: expect.any(Number),
+        ownFocus: false,
+        paddingSize: 'm',
+        resizable: true,
         session: 'start',
+        size: 'm',
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
@@ -38,7 +38,7 @@ jest.mock('../shared/components/flyout_provider', () => ({
 }));
 jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
   useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
-  defaultToolsFlyoutProperties: { size: 'm' },
+  useDefaultToolsFlyoutProperties: jest.fn(() => ({ minWidth: 384, size: 'm' })),
 }));
 
 const mockWriteOnOpen = jest.fn();
@@ -167,7 +167,7 @@ describe('useDocumentFlyoutApi', () => {
 
     expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
       'FLYOUT_CONTENT',
-      expect.objectContaining({ size: 'm', session: 'start' })
+      expect.objectContaining({ minWidth: 384, size: 'm', session: 'start' })
     );
     expect(mockReportEvent).toHaveBeenCalledWith(FlyoutV2EventTypes.FlyoutOpened, {
       surface: FLYOUT_SURFACE.TOOL,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -23,8 +23,8 @@ import type { OpenFlyoutLinkProps } from '../shared/components/open_flyout_link'
 import { OpenFlyoutLink } from '../shared/components/open_flyout_link';
 import { getColumns } from './tools/prevalence/utils/get_columns';
 import {
-  defaultToolsFlyoutProperties,
   useDefaultDocumentFlyoutProperties,
+  useDefaultToolsFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
 import { useOpenFlyout } from '../shared/hooks/use_open_flyout';
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
@@ -264,6 +264,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
   const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const defaultToolsFlyoutProperties = useDefaultToolsFlyoutProperties();
   const open = useOpenFlyout();
   const urlParamKey = urlParamKeyForHistoryKey(historyKey);
   const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
@@ -454,7 +455,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openSessionView = useCallback(
@@ -503,7 +504,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentEntities = useCallback(
@@ -538,7 +539,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentCorrelations = useCallback(
@@ -587,7 +588,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentResponse = useCallback(
@@ -617,7 +618,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentThreatIntelligence = useCallback(
@@ -651,7 +652,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentPrevalence = useCallback(
@@ -707,7 +708,15 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose, isInSecurityApp, renderFlyoutLink]
+    [
+      open,
+      defaultToolsFlyoutProperties,
+      historyKey,
+      writeOnOpen,
+      buildOnClose,
+      isInSecurityApp,
+      renderFlyoutLink,
+    ]
   );
 
   const openDocumentInvestigationGuide = useCallback(
@@ -741,7 +750,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentGraph = useCallback(
@@ -780,7 +789,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/alerts_insights/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/alerts_insights/index.test.tsx
@@ -81,6 +81,7 @@ jest.mock('../../../../shared/components/cell_actions', () => ({
 
 jest.mock('../../../../shared/hooks/use_default_flyout_properties', () => ({
   useDefaultDocumentFlyoutProperties: () => ({ size: 'm' }),
+  useDefaultToolsFlyoutProperties: () => ({ minWidth: 384, size: 'm' }),
 }));
 
 jest.mock('../../../../../common/hooks/is_in_security_app', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/risk_inputs/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/risk_inputs/index.test.tsx
@@ -76,6 +76,7 @@ jest.mock('../../../../shared/components/cell_actions', () => ({
 
 jest.mock('../../../../shared/hooks/use_default_flyout_properties', () => ({
   useDefaultDocumentFlyoutProperties: () => ({ size: 'm' }),
+  useDefaultToolsFlyoutProperties: () => ({ minWidth: 384, size: 'm' }),
 }));
 
 jest.mock('../../../../../common/hooks/is_in_security_app', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.test.tsx
@@ -42,7 +42,7 @@ jest.mock('../shared/components/flyout_provider', () => ({
 }));
 jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
   useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
-  defaultToolsFlyoutProperties: { size: 'm' },
+  useDefaultToolsFlyoutProperties: jest.fn(() => ({ minWidth: 384, size: 'm' })),
 }));
 
 const mockWriteOnOpen = jest.fn();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
@@ -16,8 +16,8 @@ import {
   FLYOUT_TYPE,
 } from '../../common/lib/telemetry';
 import {
-  defaultToolsFlyoutProperties,
   useDefaultDocumentFlyoutProperties,
+  useDefaultToolsFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
 import { useOpenFlyout } from '../shared/hooks/use_open_flyout';
 import {
@@ -216,6 +216,7 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
   const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const defaultToolsFlyoutProperties = useDefaultToolsFlyoutProperties();
   const open = useOpenFlyout();
   const urlParamKey = urlParamKeyForHistoryKey(historyKey);
   const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
@@ -249,7 +250,7 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       session: FLYOUT_SESSION_KIND.START,
       ...(title !== undefined ? { title } : {}),
     }),
-    [historyKey]
+    [defaultToolsFlyoutProperties, historyKey]
   );
 
   // Main entity flyouts.

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.test.tsx
@@ -40,7 +40,6 @@ jest.mock('../shared/components/flyout_provider', () => ({
 }));
 jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
   useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
-  defaultToolsFlyoutProperties: { size: 'm' },
 }));
 
 const mockOpenSystemFlyout = jest.fn();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/test_ids.ts
@@ -39,6 +39,7 @@ export const NOTES_LOADING_TEST_ID = `${PREFIX}HeaderNotesLoading` as const;
 
 export const TOOLS_FLYOUT_HEADER_TEST_ID = `${PREFIX}ToolsFlyoutHeader` as const;
 export const TOOLS_FLYOUT_HEADER_TITLE_TEST_ID = `${PREFIX}ToolsFlyoutHeaderTitle` as const;
+export const TOOLS_FLYOUT_HEADER_TIMESTAMP_TEST_ID = `${PREFIX}ToolsFlyoutHeaderTimestamp` as const;
 
 export const OPEN_FLYOUT_LINK_TEST_ID = `${PREFIX}OpenFlyoutLink` as const;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.test.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, renderHook, waitFor } from '@testing-library/react';
+import { useEuiTheme } from '@elastic/eui';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { ToolsFlyoutHeader } from './tools_flyout_header';
-import { TOOLS_FLYOUT_HEADER_TEST_ID } from './test_ids';
+import { TOOLS_FLYOUT_HEADER_TEST_ID, TOOLS_FLYOUT_HEADER_TIMESTAMP_TEST_ID } from './test_ids';
 
 jest.mock('./tools_flyout_title', () => ({
   ToolsFlyoutTitle: ({ label }: { label: string }) => (
@@ -41,6 +42,19 @@ describe('<ToolsFlyoutHeader />', () => {
     expect(getByText('Session view')).toBeInTheDocument();
   });
 
+  it('keeps both sides on the same row without breaking the tool title', () => {
+    const { getByTestId, getByText } = renderHeader(sourceProps);
+    const { result } = renderHook(() => useEuiTheme());
+
+    expect(getByTestId(TOOLS_FLYOUT_HEADER_TEST_ID)).toHaveStyle({ flexWrap: 'nowrap' });
+    expect(getByText('Correlations').closest('.euiTitle')).toHaveStyle({
+      whiteSpace: 'nowrap',
+    });
+    expect(getByTestId('mockToolsFlyoutTitle').parentElement).toHaveStyle({
+      minWidth: `${result.current.euiTheme.base * 8}px`,
+    });
+  });
+
   it('renders ToolsFlyoutTitle when onTitleClick, label and iconType are provided', () => {
     const { getByTestId } = renderHeader(sourceProps);
     expect(getByTestId('mockToolsFlyoutTitle')).toBeInTheDocument();
@@ -60,11 +74,25 @@ describe('<ToolsFlyoutHeader />', () => {
     expect(getByTestId('mockBadge')).toBeInTheDocument();
   });
 
-  it('renders timestamp when provided', () => {
+  it('truncates the timestamp and shows its full value in a tooltip', async () => {
     const { getByTestId } = renderHeader({
       ...sourceProps,
-      timestamp: <div data-test-subj="mockTimestamp" />,
+      timestamp: <div>{'Jul 28, 2026 @ 16:45:55.413'}</div>,
     });
-    expect(getByTestId('mockTimestamp')).toBeInTheDocument();
+
+    const timestamp = getByTestId(TOOLS_FLYOUT_HEADER_TIMESTAMP_TEST_ID);
+    expect(timestamp).toHaveStyle({
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    });
+    expect(timestamp).toHaveAttribute('tabindex', '0');
+
+    fireEvent.mouseOver(timestamp);
+    await waitFor(() => {
+      expect(document.querySelector('[role="tooltip"]')).toHaveTextContent(
+        'Jul 28, 2026 @ 16:45:55.413'
+      );
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.tsx
@@ -8,9 +8,9 @@
 import type { FC, ReactNode } from 'react';
 import React, { memo } from 'react';
 import type { IconType } from '@elastic/eui';
-import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiTitle, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { ToolsFlyoutTitle } from './tools_flyout_title';
-import { TOOLS_FLYOUT_HEADER_TEST_ID } from './test_ids';
+import { TOOLS_FLYOUT_HEADER_TEST_ID, TOOLS_FLYOUT_HEADER_TIMESTAMP_TEST_ID } from './test_ids';
 
 export interface ToolsFlyoutHeaderProps {
   /**
@@ -47,6 +47,7 @@ export interface ToolsFlyoutHeaderProps {
  */
 export const ToolsFlyoutHeader: FC<ToolsFlyoutHeaderProps> = memo(
   ({ title, onTitleClick, label, iconType, badge, timestamp }) => {
+    const { euiTheme } = useEuiTheme();
     const showSourceContext = !!onTitleClick && !!label && !!iconType;
 
     return (
@@ -55,19 +56,34 @@ export const ToolsFlyoutHeader: FC<ToolsFlyoutHeaderProps> = memo(
         alignItems="center"
         gutterSize="m"
         responsive={false}
+        css={{ flexWrap: 'nowrap' }}
         data-test-subj={TOOLS_FLYOUT_HEADER_TEST_ID}
       >
-        <EuiFlexItem grow={false}>
-          <EuiTitle size="xs">
+        <EuiFlexItem grow={false} css={{ flexShrink: 0 }}>
+          <EuiTitle size="xs" css={{ whiteSpace: 'nowrap' }}>
             <h4>{title}</h4>
           </EuiTitle>
         </EuiFlexItem>
         {showSourceContext && (
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup alignItems="flexEnd" direction="column" gutterSize="none">
-              <EuiFlexItem>
-                <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false} wrap={false}>
-                  <EuiFlexItem grow={false}>
+          <EuiFlexItem
+            grow={true}
+            css={{ marginInlineStart: 'auto', maxWidth: '100%', minWidth: 0 }}
+          >
+            <EuiFlexGroup
+              alignItems="flexEnd"
+              direction="column"
+              gutterSize="none"
+              css={{ minWidth: 0 }}
+            >
+              <EuiFlexItem css={{ maxWidth: '100%', minWidth: 0 }}>
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="xs"
+                  responsive={false}
+                  wrap={false}
+                  css={{ maxWidth: '100%', minWidth: 0 }}
+                >
+                  <EuiFlexItem css={{ minWidth: euiTheme.base * 8 }}>
                     <ToolsFlyoutTitle
                       onTitleClick={onTitleClick}
                       label={label}
@@ -77,7 +93,30 @@ export const ToolsFlyoutHeader: FC<ToolsFlyoutHeaderProps> = memo(
                   {badge && <EuiFlexItem grow={false}>{badge}</EuiFlexItem>}
                 </EuiFlexGroup>
               </EuiFlexItem>
-              {timestamp && <EuiFlexItem>{timestamp}</EuiFlexItem>}
+              {timestamp && (
+                <EuiFlexItem css={{ maxWidth: '100%', minWidth: 0 }}>
+                  <EuiToolTip content={timestamp}>
+                    <div
+                      css={{
+                        maxWidth: '100%',
+                        overflow: 'hidden',
+                        textAlign: 'right',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        '& > *': {
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        },
+                      }}
+                      data-test-subj={TOOLS_FLYOUT_HEADER_TIMESTAMP_TEST_ID}
+                      tabIndex={0}
+                    >
+                      {timestamp}
+                    </div>
+                  </EuiToolTip>
+                </EuiFlexItem>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
         )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.test.tsx
@@ -6,16 +6,21 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { ToolsFlyoutTitle } from './tools_flyout_title';
 import { TOOLS_FLYOUT_HEADER_TITLE_TEST_ID } from './test_ids';
 
 describe('<ToolsFlyoutTitle />', () => {
   it('renders the label', () => {
-    const { getByTestId } = render(
+    const { getByText, getByTestId } = render(
       <ToolsFlyoutTitle onTitleClick={jest.fn()} label="my-host" iconType="storage" />
     );
     expect(getByTestId(TOOLS_FLYOUT_HEADER_TITLE_TEST_ID)).toHaveTextContent('my-host');
+    expect(getByText('my-host')).toHaveStyle({
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    });
   });
 
   it('calls onTitleClick when clicked', () => {
@@ -25,5 +30,16 @@ describe('<ToolsFlyoutTitle />', () => {
     );
     fireEvent.click(getByTestId(TOOLS_FLYOUT_HEADER_TITLE_TEST_ID));
     expect(onTitleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the full label in a tooltip', async () => {
+    const { getByTestId } = render(
+      <ToolsFlyoutTitle onTitleClick={jest.fn()} label="my-host" iconType="storage" />
+    );
+
+    fireEvent.mouseOver(getByTestId(TOOLS_FLYOUT_HEADER_TITLE_TEST_ID));
+    await waitFor(() => {
+      expect(document.querySelector('[role="tooltip"]')).toHaveTextContent('my-host');
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.tsx
@@ -8,7 +8,7 @@
 import type { FC } from 'react';
 import React, { memo } from 'react';
 import type { IconType } from '@elastic/eui';
-import { EuiButtonEmpty, EuiIcon, useEuiTheme } from '@elastic/eui';
+import { EuiButtonEmpty, EuiIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { TOOLS_FLYOUT_HEADER_TITLE_TEST_ID } from './test_ids';
 
 export interface ToolsFlyoutTitleProps {
@@ -35,21 +35,34 @@ export const ToolsFlyoutTitle: FC<ToolsFlyoutTitleProps> = memo(
     const { euiTheme } = useEuiTheme();
 
     return (
-      <EuiButtonEmpty
-        onClick={onTitleClick}
-        iconType="expand"
-        size="xs"
-        flush="left"
-        data-test-subj={TOOLS_FLYOUT_HEADER_TITLE_TEST_ID}
-      >
-        <EuiIcon
-          type={iconType}
-          size="m"
-          aria-hidden={true}
-          css={{ marginRight: euiTheme.size.xs }}
-        />
-        {label}
-      </EuiButtonEmpty>
+      <EuiToolTip content={label}>
+        <EuiButtonEmpty
+          onClick={onTitleClick}
+          iconType="expand"
+          size="xs"
+          flush="left"
+          css={{ maxWidth: '100%', minWidth: 0 }}
+          data-test-subj={TOOLS_FLYOUT_HEADER_TITLE_TEST_ID}
+        >
+          <span css={{ alignItems: 'center', display: 'flex', maxWidth: '100%', minWidth: 0 }}>
+            <EuiIcon
+              type={iconType}
+              size="m"
+              aria-hidden={true}
+              css={{ flexShrink: 0, marginRight: euiTheme.size.xs }}
+            />
+            <span
+              css={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {label}
+            </span>
+          </span>
+        </EuiButtonEmpty>
+      </EuiToolTip>
     );
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_default_flyout_properties.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_default_flyout_properties.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useEuiTheme } from '@elastic/eui';
+import { useDefaultToolsFlyoutProperties } from './use_default_flyout_properties';
+
+describe('useDefaultToolsFlyoutProperties', () => {
+  it('sets a theme-aware minimum width', () => {
+    const { result } = renderHook(() => ({
+      properties: useDefaultToolsFlyoutProperties(),
+      theme: useEuiTheme().euiTheme,
+    }));
+
+    expect(result.current.properties).toEqual({
+      minWidth: result.current.theme.base * 24,
+      ownFocus: false,
+      paddingSize: 'm',
+      resizable: true,
+      size: 'm',
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_default_flyout_properties.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_default_flyout_properties.ts
@@ -30,11 +30,19 @@ export const useDefaultDocumentFlyoutProperties = (): OverlaySystemFlyoutOpenOpt
 };
 
 /**
- * Hook that returns the main properties used when opening a tools flyout, to ensure consistency.
+ * Hook that returns the properties used when opening a tools flyout, to ensure consistency.
  */
-export const defaultToolsFlyoutProperties: OverlaySystemFlyoutOpenOptions = {
-  ownFocus: false,
-  paddingSize: 'm',
-  resizable: true,
-  size: 'm',
+export const useDefaultToolsFlyoutProperties = (): OverlaySystemFlyoutOpenOptions => {
+  const { euiTheme } = useEuiTheme();
+
+  return useMemo(
+    () => ({
+      minWidth: euiTheme.base * 24,
+      ownFocus: false,
+      paddingSize: 'm',
+      resizable: true,
+      size: 'm',
+    }),
+    [euiTheme.base]
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.test.tsx
@@ -29,7 +29,7 @@ jest.mock('../components/flyout_provider', () => ({
   flyoutProviders: jest.fn(() => 'FLYOUT_CONTENT'),
 }));
 jest.mock('../hooks/use_default_flyout_properties', () => ({
-  defaultToolsFlyoutProperties: { size: 'm' },
+  useDefaultToolsFlyoutProperties: jest.fn(() => ({ minWidth: 384, size: 'm' })),
 }));
 
 const mockWriteOnOpen = jest.fn();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.tsx
@@ -9,7 +9,7 @@ import React, { lazy, useCallback, useMemo } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { FlyoutOrigin } from '../../../common/lib/telemetry';
 import { FLYOUT_SESSION_KIND, FLYOUT_SURFACE, FLYOUT_TOOL } from '../../../common/lib/telemetry';
-import { defaultToolsFlyoutProperties } from '../hooks/use_default_flyout_properties';
+import { useDefaultToolsFlyoutProperties } from '../hooks/use_default_flyout_properties';
 import { useOpenFlyout } from '../hooks/use_open_flyout';
 import { formatFlyoutTitle, NOTES_TITLE } from '../constants/flyout_titles';
 import { getDocumentTitle } from '../../document/main/utils/get_header_title';
@@ -49,6 +49,7 @@ export interface SharedToolsFlyoutApi {
  */
 export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
   const { historyKey } = useFlyoutSessionContext();
+  const defaultToolsFlyoutProperties = useDefaultToolsFlyoutProperties();
   const open = useOpenFlyout();
   const urlParamKey = urlParamKeyForHistoryKey(historyKey);
   const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
@@ -80,7 +81,7 @@ export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey, writeOnOpen, buildOnClose]
+    [open, defaultToolsFlyoutProperties, historyKey, writeOnOpen, buildOnClose]
   );
 
   return useMemo(() => ({ openNotes }), [openNotes]);

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
@@ -9,7 +9,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
-import { defaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { useDefaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 import { Footer } from '../../flyout_v2/document/main/footer';
 import { documentFlyoutHistoryKey } from '../../flyout_v2/shared/constants/flyout_history';
 import type { SecurityAppStore } from '../../common/store/types';
@@ -58,6 +58,7 @@ export const AlertFlyoutFooter = ({
   const [store, setStore] = useState<SecurityAppStore | null>(null);
   const isSecurityApp = useIsInSecurityApp();
   const historyKey = isSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultToolsFlyoutProperties = useDefaultToolsFlyoutProperties();
 
   const openNotesFlyout = useCallback(() => {
     if (!services || !store) {
@@ -87,7 +88,7 @@ export const AlertFlyoutFooter = ({
         origin: FLYOUT_ORIGIN.FOOTER_TAKE_ACTION,
       });
     }
-  }, [history, historyKey, hit, services, store]);
+  }, [defaultToolsFlyoutProperties, history, historyKey, hit, services, store]);
 
   useEffect(() => {
     let isCanceled = false;

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
@@ -13,7 +13,7 @@ import { useHistory } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { CellActionRenderer } from '../../flyout_v2/shared/components/cell_actions';
-import { defaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { useDefaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 import { RemoteDocumentCallout } from '../../flyout_v2/document/main/components/remote_document_callout';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
@@ -95,6 +95,7 @@ export const AlertFlyoutHeader = ({
   const [store, setStore] = useState<SecurityAppStore | null>(null);
   const isSecurityApp = useIsInSecurityApp();
   const historyKey = isSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultToolsFlyoutProperties = useDefaultToolsFlyoutProperties();
   const renderCellActions = useCallback<CellActionRenderer>(
     (props) => (
       <DiscoverCellActions
@@ -136,7 +137,7 @@ export const AlertFlyoutHeader = ({
         origin: FLYOUT_ORIGIN.FLYOUT_HEADER,
       });
     }
-  }, [history, historyKey, hit, services, store]);
+  }, [defaultToolsFlyoutProperties, history, historyKey, hit, services, store]);
 
   useEffect(() => {
     if (!services) {

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/attack_flyout_header_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/attack_flyout_header_component/index.tsx
@@ -9,7 +9,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
-import { defaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { useDefaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
 import { Header } from '../../flyout_v2/attack/main/header';
@@ -46,6 +46,7 @@ export const AttackFlyoutHeader = ({
   const [store, setStore] = useState<SecurityAppStore | null>(null);
   const isSecurityApp = useIsInSecurityApp();
   const historyKey = isSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultToolsFlyoutProperties = useDefaultToolsFlyoutProperties();
   const attackTitle = useMemo(() => getAttackTitleValue(hit), [hit]);
 
   const openNotesFlyout = useCallback(() => {
@@ -76,7 +77,7 @@ export const AttackFlyoutHeader = ({
         origin: FLYOUT_ORIGIN.FLYOUT_HEADER,
       });
     }
-  }, [attackTitle, history, historyKey, hit, services, store]);
+  }, [attackTitle, defaultToolsFlyoutProperties, history, historyKey, hit, services, store]);
 
   useEffect(() => {
     let isCanceled = false;


### PR DESCRIPTION
## Summary

- keep the Flyout V2 tool title and source context on one row at narrow widths
- truncate long source labels and timestamps while exposing their full values in accessible tooltips
- preserve a readable minimum width for the source link
- enforce a theme-aware 384 px minimum width across document, attack, entity, shared, and Discover-launched tool flyouts

Before:


https://github.com/user-attachments/assets/a265bd2b-8d47-4354-9a8f-62dbf19bb009



After:

https://github.com/user-attachments/assets/c6c78a70-6834-4ea5-9556-e528c1fb005b




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->