### PR TITLE
[maps] Fix stuck loading state after state reset

### DIFF
--- a/x-pack/platform/plugins/shared/maps/common/descriptor_types/layer_descriptor_types.ts
+++ b/x-pack/platform/plugins/shared/maps/common/descriptor_types/layer_descriptor_types.ts
@@ -53,7 +53,7 @@ export type TileError = {
   error?: ErrorCause;
 };
 
-interface RuntimeLayerState {
+export interface RuntimeLayerState {
   __dataRequests?: DataRequestDescriptor[];
   __isPreviewLayer?: boolean;
   __trackedLayerDescriptor?:

--- a/x-pack/platform/plugins/shared/maps/common/index.ts
+++ b/x-pack/platform/plugins/shared/maps/common/index.ts
@@ -36,6 +36,7 @@ export type {
   EMSFileSourceDescriptor,
   ESTermSourceDescriptor,
   LayerDescriptor,
+  RuntimeLayerState,
   TooltipFeature,
   TooltipFeatureAction,
   VectorLayerDescriptor,

--- a/x-pack/platform/plugins/shared/maps/public/actions/get_runtime_state.test.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/get_runtime_state.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LAYER_TYPE } from '../../common';
+import type { LayerDescriptor, RuntimeLayerState } from '../../common/descriptor_types';
+import { getRuntimeState } from './get_runtime_state';
+
+describe('getRuntimeState', () => {
+  test('should only return runtime state', () => {
+    const persistentLayerState: LayerDescriptor = {
+      id: 'layer1',
+      label: 'label for layer 1',
+      type: LAYER_TYPE.LAYER_GROUP,
+      visible: true,
+    };
+    const layer: LayerDescriptor & Required<RuntimeLayerState> = {
+      ...persistentLayerState,
+      __dataRequests: [],
+      __isPreviewLayer: false,
+      __trackedLayerDescriptor: persistentLayerState,
+      __areTilesLoaded: false,
+      __tileMetaFeatures: [],
+      __tileErrors: [],
+    };
+    expect(getRuntimeState(layer)).toMatchInlineSnapshot(`
+      Object {
+        "__areTilesLoaded": false,
+        "__dataRequests": Array [],
+        "__isPreviewLayer": false,
+        "__tileErrors": Array [],
+        "__tileMetaFeatures": Array [],
+        "__trackedLayerDescriptor": Object {
+          "id": "layer1",
+          "label": "label for layer 1",
+          "type": "LAYER_GROUP",
+          "visible": true,
+        },
+      }
+    `);
+  });
+});

--- a/x-pack/platform/plugins/shared/maps/public/actions/get_runtime_state.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/get_runtime_state.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LayerDescriptor, RuntimeLayerState } from '../../common/descriptor_types';
+
+export function getRuntimeState(layerDescriptor: LayerDescriptor): RuntimeLayerState {
+  const runtimeState: RuntimeLayerState = {};
+  for (const key in layerDescriptor) {
+    if (key.startsWith('__')) {
+      // @ts-ignore
+      runtimeState[key] = layerDescriptor[key];
+    }
+  }
+  return runtimeState;
+}

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.test.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.test.ts
@@ -5,9 +5,13 @@
  * 2.0.
  */
 
-import { addLayer } from './layer_actions';
+import { addLayer, removeLayer, replaceLayerList } from './layer_actions';
 import type { LayerDescriptor } from '../../common/descriptor_types';
 import { LICENSED_FEATURES } from '../licensed_features';
+import { createMapStore } from '../reducers/store';
+import { mapReady } from './map_actions';
+import { LAYER_TYPE, SOURCE_TYPES } from '../../common';
+import { UPDATE_LAYER_PROP } from './map_action_constants';
 
 jest.mock('../kibana_services', () => {
   return {
@@ -21,6 +25,13 @@ jest.mock('../kibana_services', () => {
         },
       };
     },
+    getShowMapsInspectorAdapter() {
+      return false;
+    },
+    getTimeFilter: () => ({
+      getTime: () => ({ from: 'now-15m', to: 'now' }),
+      getRefreshInterval: () => undefined,
+    }),
   };
 });
 
@@ -62,6 +73,101 @@ describe('layer_actions', () => {
       expect(notifyLicensedFeatureUsageMock).toHaveBeenCalledWith(
         LICENSED_FEATURES.GEO_SHAPE_AGGS_GEO_TILE
       );
+    });
+  });
+
+  describe('replaceLayerList', () => {
+    let store = createMapStore();
+
+    const ORIGINAL_LAYER_LIST = [
+      {
+        id: 'layer0',
+        sourceDescriptor: {
+          id: 'world_countries',
+          type: SOURCE_TYPES.EMS_FILE,
+        },
+        type: LAYER_TYPE.GEOJSON_VECTOR,
+      },
+      {
+        id: 'layer1',
+        sourceDescriptor: {
+          id: 'australia_states',
+          type: SOURCE_TYPES.EMS_FILE,
+        },
+        type: LAYER_TYPE.GEOJSON_VECTOR,
+      },
+      {
+        id: 'layer2',
+        sourceDescriptor: {
+          id: 'canada_provinces',
+          type: SOURCE_TYPES.EMS_FILE,
+        },
+        type: LAYER_TYPE.GEOJSON_VECTOR,
+      },
+      {
+        id: 'layer3',
+        sourceDescriptor: {
+          id: 'usa_states',
+          type: SOURCE_TYPES.EMS_FILE,
+        },
+        type: LAYER_TYPE.GEOJSON_VECTOR,
+      },
+    ] as LayerDescriptor[];
+    const ORIGINAL_LAYER_IDS = ORIGINAL_LAYER_LIST.map(({ id }) => id);
+
+    function getLayerIds() {
+      return store.getState().map.layerList.map(({ id }) => id);
+    }
+
+    beforeEach(() => {
+      store = createMapStore();
+      store.dispatch<any>(replaceLayerList(ORIGINAL_LAYER_LIST));
+      store.dispatch<any>(mapReady());
+    });
+
+    it('should restore deleted layers in correct order', async () => {
+      store.dispatch<any>(removeLayer('layer2'));
+      expect(getLayerIds()).toEqual(['layer0', 'layer1', 'layer3']);
+      store.dispatch<any>(replaceLayerList(ORIGINAL_LAYER_LIST));
+      expect(getLayerIds()).toEqual(ORIGINAL_LAYER_IDS);
+    });
+
+    it('should remove new layers', async () => {
+      store.dispatch<any>(
+        addLayer({
+          id: 'layer4',
+          sourceDescriptor: {
+            id: 'uk_subdivisions',
+            type: SOURCE_TYPES.EMS_FILE,
+          },
+          type: LAYER_TYPE.GEOJSON_VECTOR,
+        })
+      );
+      expect(getLayerIds()).toEqual([...ORIGINAL_LAYER_IDS, 'layer4']);
+      store.dispatch<any>(replaceLayerList(ORIGINAL_LAYER_LIST));
+      expect(getLayerIds()).toEqual(ORIGINAL_LAYER_IDS);
+    });
+
+    it('should retain runtime state for existing layers', async () => {
+      store.dispatch({
+        type: UPDATE_LAYER_PROP,
+        id: 'layer0',
+        propName: '__dataRequests',
+        newValue: [],
+      });
+      expect('__dataRequests' in store.getState().map.layerList[0]).toBe(true);
+      store.dispatch<any>(replaceLayerList(ORIGINAL_LAYER_LIST));
+      expect(store.getState().map.layerList[0]).toMatchInlineSnapshot(`
+        Object {
+          "__dataRequests": Array [],
+          "id": "layer0",
+          "sourceDescriptor": Object {
+            "id": "world_countries",
+            "type": "EMS_FILE",
+          },
+          "type": "GEOJSON_VECTOR",
+        }
+      `);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -158,10 +158,10 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
     // reset ordering
     const unorderedNewLayerList = getLayerListRaw(getState());
     const newOrder = [];
-    for (let i = 0; i < unorderedNewLayerList.length; i++) {
-      const newIndex = newLayerList.findIndex(({ id }) => id === unorderedNewLayerList[i].id);
-      if (newIndex !== -1) {
-        newOrder.push(newIndex);
+    for (let i = 0; i < newLayerList.length; i++) {
+      const index = unorderedNewLayerList.findIndex(({ id }) => id === newLayerList[i].id);
+      if (index !== -1) {
+        newOrder.push(index);
       }
     }
     dispatch(updateLayerOrder(newOrder));

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -50,6 +50,7 @@ import type {
   JoinDescriptor,
   LayerDescriptor,
   LayerGroupDescriptor,
+  RuntimeLayerState,
   StyleDescriptor,
   TileError,
   TileMetaFeature,
@@ -113,46 +114,26 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
     dispatch: ThunkDispatch<MapStoreState, void, AnyAction>,
     getState: () => MapStoreState
   ) => {
+    const runtimeLayers: Record<string, RuntimeLayerState> = {};
     const isMapReady = getMapReady(getState());
     if (!isMapReady) {
       dispatch({
         type: CLEAR_WAITING_FOR_MAP_READY_LAYER_LIST,
       });
-
-      newLayerList.forEach((layerDescriptor) => {
-        dispatch(addLayer(layerDescriptor));
+    } else {
+      getLayerListRaw(getState()).forEach((layerDescriptor) => {
+        runtimeLayers[layerDescriptor.id] = getRuntimeState(layerDescriptor);
+        dispatch(removeLayerFromLayerList(layerDescriptor.id));
       });
-      return;
     }
 
-    const newLayerIds = newLayerList.map(({ id }) => id);
-
-    const currentLayers: Record<string, LayerDescriptor> = {};
-    getLayerListRaw(getState()).forEach((layerDescriptor) => {
-      currentLayers[layerDescriptor.id] = layerDescriptor;
-
-      // Remove layers that no longer exist
-      if (!newLayerIds.includes(layerDescriptor.id)) {
-        dispatch(removeLayerFromLayerList(layerDescriptor.id));
-      }
-    });
-
-    newLayerList.forEach((newLayerDescriptor) => {
-      const currentLayerDescriptor = currentLayers[newLayerDescriptor.id];
-      // Add layers that do not currently exist
-      if (!currentLayerDescriptor) {
-        dispatch(addLayer(newLayerDescriptor));
-        return;
-      }
-
-      // Reset layer with new state + current runtime
+    newLayerList.forEach((layerDescriptor) => {
       dispatch(
-        updateLayerDescriptor({
-          ...newLayerDescriptor,
-          ...getRuntimeState(currentLayerDescriptor),
+        addLayer({
+          ...layerDescriptor,
+          ...runtimeLayers[layerDescriptor.id],
         })
       );
-      dispatch(syncDataForLayerId(newLayerDescriptor.id, false));
     });
   };
 }

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -50,7 +50,6 @@ import type {
   JoinDescriptor,
   LayerDescriptor,
   LayerGroupDescriptor,
-  RuntimeLayerState,
   StyleDescriptor,
   TileError,
   TileMetaFeature,
@@ -114,26 +113,46 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
     dispatch: ThunkDispatch<MapStoreState, void, AnyAction>,
     getState: () => MapStoreState
   ) => {
-    const runtimeLayers: Record<string, RuntimeLayerState> = {};
     const isMapReady = getMapReady(getState());
     if (!isMapReady) {
       dispatch({
         type: CLEAR_WAITING_FOR_MAP_READY_LAYER_LIST,
       });
-    } else {
-      getLayerListRaw(getState()).forEach((layerDescriptor) => {
-        runtimeLayers[layerDescriptor.id] = getRuntimeState(layerDescriptor);
-        dispatch(removeLayerFromLayerList(layerDescriptor.id));
+
+      newLayerList.forEach((layerDescriptor) => {
+        dispatch(addLayer(layerDescriptor));
       });
+      return;
     }
 
-    newLayerList.forEach((layerDescriptor) => {
+    const newLayerIds = newLayerList.map(({ id }) => id);
+
+    const currentLayers: Record<string, LayerDescriptor> = {};
+    getLayerListRaw(getState()).forEach((layerDescriptor) => {
+      currentLayers[layerDescriptor.id] = layerDescriptor;
+
+      // Remove layers that no longer exist
+      if (!newLayerIds.includes(layerDescriptor.id)) {
+        dispatch(removeLayerFromLayerList(layerDescriptor.id));
+      }
+    });
+
+    newLayerList.forEach((newLayerDescriptor) => {
+      const currentLayerDescriptor = currentLayers[newLayerDescriptor.id];
+      // Add layers that do not currently exist
+      if (!currentLayerDescriptor) {
+        dispatch(addLayer(newLayerDescriptor));
+        return;
+      }
+
+      // Reset layer with new state + current runtime
       dispatch(
-        addLayer({
-          ...layerDescriptor,
-          ...runtimeLayers[layerDescriptor.id],
+        updateLayerDescriptor({
+          ...newLayerDescriptor,
+          ...getRuntimeState(currentLayerDescriptor),
         })
       );
+      dispatch(syncDataForLayerId(newLayerDescriptor.id, false));
     });
   };
 }

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -156,10 +156,10 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
     });
 
     // reset ordering
-    const unorderedNewLayerList = getLayerListRaw(getState());
+    const replacedLayerList = getLayerListRaw(getState());
     const newOrder = [];
     for (let i = 0; i < newLayerList.length; i++) {
-      const index = unorderedNewLayerList.findIndex(({ id }) => id === newLayerList[i].id);
+      const index = replacedLayerList.findIndex(({ id }) => id === newLayerList[i].id);
       if (index !== -1) {
         newOrder.push(index);
       }

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -70,6 +70,7 @@ import type { IVectorSource } from '../classes/sources/vector_source';
 import { getDrawMode, getOpenTOCDetails } from '../selectors/ui_selectors';
 import { isLayerGroup, LayerGroup } from '../classes/layers/layer_group';
 import { isSpatialJoin } from '../classes/joins/is_spatial_join';
+import { getRuntimeState } from './get_runtime_state';
 
 export function trackCurrentLayerState(layerId: string) {
   return {
@@ -117,14 +118,41 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
       dispatch({
         type: CLEAR_WAITING_FOR_MAP_READY_LAYER_LIST,
       });
-    } else {
-      getLayerListRaw(getState()).forEach(({ id }) => {
-        dispatch(removeLayerFromLayerList(id));
+
+      newLayerList.forEach((layerDescriptor) => {
+        dispatch(addLayer(layerDescriptor));
       });
+      return;
     }
 
-    newLayerList.forEach((layerDescriptor) => {
-      dispatch(addLayer(layerDescriptor));
+    const newLayerIds = newLayerList.map(({ id }) => id);
+
+    const currentLayers: Record<string, LayerDescriptor> = {};
+    getLayerListRaw(getState()).forEach((layerDescriptor) => {
+      currentLayers[layerDescriptor.id] = layerDescriptor;
+
+      // Remove layers that no longer exist
+      if (!newLayerIds.includes(layerDescriptor.id)) {
+        dispatch(removeLayerFromLayerList(layerDescriptor.id));
+      }
+    });
+
+    newLayerList.forEach((newLayerDescriptor) => {
+      const currentLayerDescriptor = currentLayers[newLayerDescriptor.id];
+      // Add layers that do not currently exist
+      if (!currentLayerDescriptor) {
+        dispatch(addLayer(newLayerDescriptor));
+        return;
+      }
+
+      // Reset layer with new state + current runtime
+      dispatch(
+        updateLayerDescriptor({
+          ...newLayerDescriptor,
+          ...getRuntimeState(currentLayerDescriptor),
+        })
+      );
+      dispatch(syncDataForLayerId(newLayerDescriptor.id, false));
     });
   };
 }

--- a/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/layer_actions.ts
@@ -154,6 +154,17 @@ export function replaceLayerList(newLayerList: LayerDescriptor[]) {
       );
       dispatch(syncDataForLayerId(newLayerDescriptor.id, false));
     });
+
+    // reset ordering
+    const unorderedNewLayerList = getLayerListRaw(getState());
+    const newOrder = [];
+    for (let i = 0; i < unorderedNewLayerList.length; i++) {
+      const newIndex = newLayerList.findIndex(({ id }) => id === unorderedNewLayerList[i].id);
+      if (newIndex !== -1) {
+        newOrder.push(newIndex);
+      }
+    }
+    dispatch(updateLayerOrder(newOrder));
   };
 }
 

--- a/x-pack/platform/plugins/shared/maps/public/classes/util/can_skip_fetch.ts
+++ b/x-pack/platform/plugins/shared/maps/public/classes/util/can_skip_fetch.ts
@@ -19,7 +19,7 @@ export function updateDueToExtent(prevMeta: DataRequestMeta = {}, nextMeta: Data
   const { buffer: previousBuffer } = prevMeta;
   const { buffer: newBuffer } = nextMeta;
 
-  if (!previousBuffer || !previousBuffer || !newBuffer) {
+  if (!previousBuffer || !newBuffer) {
     return SOURCE_UPDATE_REQUIRED;
   }
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/281351

Resolves issue of stuck loading state after reset by merging layer state with existing runtime state. Sync data uses layer state and runtime state to determine if layer data needs to be re-fetched.

### Test instructions for stuck layer loading state
* Install sample web logs
* Open sample web logs dashboard
* Change time range to "last 24 hours"
* Click saved secondary button and select "reset"
* Verify map loading indicator goes away after map loads

### Test instructions for layer reset
* Create new dashboard
* add by value map with some layers
* save dashboard
* edit by value map with logs of things
* click "Save and return"
* reset dashboard. Verify map goes back to original map as expected.

