### PR TITLE
[9.3] chore: bump elastic-apm-node to 4.18.0 (#277387)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1302,7 +1302,7 @@
     "dom-to-image-more": "3.6.0",
     "dompurify": "3.4.11",
     "dotenv": "17.2.4",
-    "elastic-apm-node": "4.15.0",
+    "elastic-apm-node": "4.18.0",
     "email-addresses": "5.0.0",
     "eventsource-parser": "3.0.6",
     "execa": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10233,14 +10233,14 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz#02378d315fb648401a01ce6e119f6744f80bb1be"
   integrity sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==
 
-"@opentelemetry/core@1.30.1", "@opentelemetry/core@^1.1.0", "@opentelemetry/core@^1.11.0", "@opentelemetry/core@^1.25.1", "@opentelemetry/core@^1.26.0", "@opentelemetry/core@^1.30.1", "@opentelemetry/core@^1.8.0":
+"@opentelemetry/core@1.30.1", "@opentelemetry/core@^1.1.0", "@opentelemetry/core@^1.25.1", "@opentelemetry/core@^1.26.0", "@opentelemetry/core@^1.30.1", "@opentelemetry/core@^1.8.0":
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.30.1.tgz#a0b468bb396358df801881709ea38299fc30ab27"
   integrity sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==
   dependencies:
     "@opentelemetry/semantic-conventions" "1.28.0"
 
-"@opentelemetry/core@2.8.0":
+"@opentelemetry/core@2.8.0", "@opentelemetry/core@^2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.8.0.tgz#f6e86de3688bdb54a6ca8f4935363a5b588ae91c"
   integrity sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==
@@ -11263,7 +11263,7 @@
     "@opentelemetry/core" "1.30.1"
     "@opentelemetry/resources" "1.30.1"
 
-"@opentelemetry/sdk-metrics@1.30.1", "@opentelemetry/sdk-metrics@^1.12.0":
+"@opentelemetry/sdk-metrics@1.30.1":
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz#70e2bcd275b9df6e7e925e3fe53cfe71329b5fc8"
   integrity sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==
@@ -11271,7 +11271,7 @@
     "@opentelemetry/core" "1.30.1"
     "@opentelemetry/resources" "1.30.1"
 
-"@opentelemetry/sdk-metrics@2.8.0":
+"@opentelemetry/sdk-metrics@2.8.0", "@opentelemetry/sdk-metrics@^2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz#c3f908d9e7e02fb855673fcfd4b298ce279e61f1"
   integrity sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==
@@ -19897,15 +19897,15 @@ ejs@3.1.10:
   dependencies:
     jake "^10.8.5"
 
-elastic-apm-node@4.15.0, elastic-apm-node@^4.10.0:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-4.15.0.tgz#d98e9da2155eea019c2bf0a62e6129981604e79d"
-  integrity sha512-8N176AlRizpX+JcNP3xPPbl9HjiDG6PRTIY0XfY2SSmI7dAvxlYk/TFBcOXeGpoMTYCHZHNPUUL0ryvaMV7EGA==
+elastic-apm-node@4.18.0, elastic-apm-node@^4.10.0:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-4.18.0.tgz#239cbffb67a0e09331a0d39425e377428280d7f7"
+  integrity sha512-qOjG+Z1pu7mwQESw9XsCBUPKqsrc6uOr8CYl7LE8iQlscviEs7P/3NtKuA/Jn5mktEM7NAZcdG3n+TCZRGJxmA==
   dependencies:
     "@elastic/ecs-pino-format" "^1.5.0"
     "@opentelemetry/api" "^1.4.1"
-    "@opentelemetry/core" "^1.11.0"
-    "@opentelemetry/sdk-metrics" "^1.12.0"
+    "@opentelemetry/core" "^2.8.0"
+    "@opentelemetry/sdk-metrics" "^2.8.0"
     after-all-results "^2.0.0"
     agentkeepalive "^4.2.1"
     async-value-promise "^1.1.1"
@@ -19920,7 +19920,7 @@ elastic-apm-node@4.15.0, elastic-apm-node@^4.10.0:
     fast-safe-stringify "^2.0.7"
     fast-stream-to-buffer "^1.0.0"
     http-headers "^3.0.2"
-    import-in-the-middle "1.14.4"
+    import-in-the-middle "1.15.0"
     json-bigint "^1.0.0"
     lru-cache "10.2.0"
     measured-reporting "^1.51.1"
@@ -23111,10 +23111,10 @@ import-fresh@^3.2.1, import-fresh@^3.3.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@1.14.4, import-in-the-middle@^1.14.2, import-in-the-middle@^1.8.1:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz#5350cf8eba46e3b51cd3e507f5fe36a8faeb3684"
-  integrity sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==
+import-in-the-middle@1.15.0, import-in-the-middle@^1.14.2, import-in-the-middle@^1.8.1:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz#9e20827a322bbadaeb5e3bac49ea8f6d4685fdd8"
+  integrity sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==
   dependencies:
     acorn "^8.14.0"
     acorn-import-attributes "^1.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10240,14 +10240,14 @@
   dependencies:
     "@opentelemetry/semantic-conventions" "1.28.0"
 
-"@opentelemetry/core@2.8.0", "@opentelemetry/core@^2.8.0":
+"@opentelemetry/core@2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.8.0.tgz#f6e86de3688bdb54a6ca8f4935363a5b588ae91c"
   integrity sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==
   dependencies:
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/core@2.9.0", "@opentelemetry/core@2.x", "@opentelemetry/core@^2.0.0":
+"@opentelemetry/core@2.9.0", "@opentelemetry/core@2.x", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.8.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.9.0.tgz#49de86106f86255b471b2ff035ef1003a851b252"
   integrity sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==
@@ -11271,7 +11271,7 @@
     "@opentelemetry/core" "1.30.1"
     "@opentelemetry/resources" "1.30.1"
 
-"@opentelemetry/sdk-metrics@2.8.0", "@opentelemetry/sdk-metrics@^2.8.0":
+"@opentelemetry/sdk-metrics@2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz#c3f908d9e7e02fb855673fcfd4b298ce279e61f1"
   integrity sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==
@@ -11279,7 +11279,7 @@
     "@opentelemetry/core" "2.8.0"
     "@opentelemetry/resources" "2.8.0"
 
-"@opentelemetry/sdk-metrics@2.9.0":
+"@opentelemetry/sdk-metrics@2.9.0", "@opentelemetry/sdk-metrics@^2.8.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz#4339ac637b9dc99c597bafdefb0ba66ef7391a7c"
   integrity sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [chore: bump elastic-apm-node to 4.18.0 (#277387)](https://github.com/elastic/kibana/pull/277387)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gerard Soldevila","email":"gerard.soldevila@elastic.co"},"sourceCommit":{"committedDate":"2026-07-13T12:25:11Z","message":"chore: bump elastic-apm-node to 4.18.0 (#277387)\n\n## Summary\n\n- Bumps `elastic-apm-node` from `4.15.0` to `4.18.0`\n- `4.17.0` fixes IPv6 URL parsing errors (`Could not set destination\ncontext: Invalid URL`) reported in\n[sdh-apm#2043](https://github.com/elastic/sdh-apm/issues/2043)\n- `4.18.0` also updates OpenTelemetry 2.x dependencies\n([apm-agent-nodejs#5126](https://github.com/elastic/apm-agent-nodejs/pull/5126))\n\nRenovate has not opened this bump yet due to the 14-day\n`minimumReleaseAge` on the APM dependency group.\n\n## Test plan\n\n- [ ] CI green\n- [ ] Verify Kibana starts with default APM config\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"a89ab055e7b8532add6b8d90a9ec39b1122ef738","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:all-open","v9.5.0","v9.4.4","v9.6.0"],"title":"chore: bump elastic-apm-node to 4.18.0","number":277387,"url":"https://github.com/elastic/kibana/pull/277387","mergeCommit":{"message":"chore: bump elastic-apm-node to 4.18.0 (#277387)\n\n## Summary\n\n- Bumps `elastic-apm-node` from `4.15.0` to `4.18.0`\n- `4.17.0` fixes IPv6 URL parsing errors (`Could not set destination\ncontext: Invalid URL`) reported in\n[sdh-apm#2043](https://github.com/elastic/sdh-apm/issues/2043)\n- `4.18.0` also updates OpenTelemetry 2.x dependencies\n([apm-agent-nodejs#5126](https://github.com/elastic/apm-agent-nodejs/pull/5126))\n\nRenovate has not opened this bump yet due to the 14-day\n`minimumReleaseAge` on the APM dependency group.\n\n## Test plan\n\n- [ ] CI green\n- [ ] Verify Kibana starts with default APM config\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"a89ab055e7b8532add6b8d90a9ec39b1122ef738"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277758","number":277758,"state":"MERGED","mergeCommit":{"sha":"527900cc4ab3bc61b58e0b4a08988a74673ec1d9","message":"[9.5] chore: bump elastic-apm-node to 4.18.0 (#277387) (#277758)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [chore: bump elastic-apm-node to 4.18.0\n(#277387)](https://github.com/elastic/kibana/pull/277387)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Gerard Soldevila <gerard.soldevila@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277757","number":277757,"state":"MERGED","mergeCommit":{"sha":"9d83055bab60594745351ce5570e8721db4ba65a","message":"[9.4] chore: bump elastic-apm-node to 4.18.0 (#277387) (#277757)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [chore: bump elastic-apm-node to 4.18.0\n(#277387)](https://github.com/elastic/kibana/pull/277387)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Gerard Soldevila <gerard.soldevila@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277387","number":277387,"mergeCommit":{"message":"chore: bump elastic-apm-node to 4.18.0 (#277387)\n\n## Summary\n\n- Bumps `elastic-apm-node` from `4.15.0` to `4.18.0`\n- `4.17.0` fixes IPv6 URL parsing errors (`Could not set destination\ncontext: Invalid URL`) reported in\n[sdh-apm#2043](https://github.com/elastic/sdh-apm/issues/2043)\n- `4.18.0` also updates OpenTelemetry 2.x dependencies\n([apm-agent-nodejs#5126](https://github.com/elastic/apm-agent-nodejs/pull/5126))\n\nRenovate has not opened this bump yet due to the 14-day\n`minimumReleaseAge` on the APM dependency group.\n\n## Test plan\n\n- [ ] CI green\n- [ ] Verify Kibana starts with default APM config\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"a89ab055e7b8532add6b8d90a9ec39b1122ef738"}}]}] BACKPORT-->