### PR TITLE
[9.5] Fix Rules breadcrumbs in Stack Management (#280275)

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.test.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getAlertingSectionBreadcrumb } from './breadcrumb';
+import { getAlertingSectionBreadcrumb, getRulesBreadcrumbWithHref } from './breadcrumb';
 import { i18n } from '@kbn/i18n';
 import { routeToConnectors, routeToRules, routeToHome } from '../constants';
 
@@ -46,6 +46,17 @@ describe('getAlertingSectionBreadcrumb', () => {
       text: i18n.translate('xpack.triggersActionsUI.home.breadcrumbTitle', {
         defaultMessage: 'Rules',
       }),
+    });
+  });
+});
+
+describe('getRulesBreadcrumbWithHref', () => {
+  test('returns the rules route relative to the management app', () => {
+    expect(getRulesBreadcrumbWithHref()).toEqual({
+      text: i18n.translate('xpack.triggersActionsUI.rules.breadcrumbTitle', {
+        defaultMessage: 'Rules',
+      }),
+      href: routeToHome,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.ts
@@ -90,14 +90,8 @@ export const getAlertingSectionBreadcrumb = (
   }
 };
 
-export const getRulesBreadcrumbWithHref = (
-  getUrlForApp: (appId: string, options?: { path?: string }) => string
-) => {
-  const rulesBreadcrumb = getAlertingSectionBreadcrumb('rules', true);
-  const breadcrumbHref = getUrlForApp('rules', { path: '/' });
-
-  return {
-    ...rulesBreadcrumb,
-    href: breadcrumbHref,
-  };
-};
+export const getRulesBreadcrumbWithHref = () => ({
+  ...getAlertingSectionBreadcrumb('rules'),
+  // Management scopes breadcrumb hrefs to the mounted app.
+  href: routeToHome,
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
@@ -17,7 +17,6 @@ import {
   EuiPageSection,
   EuiCallOut,
   EuiSpacer,
-  EuiButton,
   EuiIcon,
   EuiLink,
   EuiIconTip,
@@ -111,7 +110,7 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
     notifications: { toasts },
     setBreadcrumbs,
   } = useKibana().services;
-  const { capabilities, getUrlForApp } = application;
+  const { capabilities } = application;
 
   const [rulesToDelete, setRulesToDelete] = useState<string[]>([]);
   const [rulesToUpdateAPIKey, setRulesToUpdateAPIKey] = useState<string[]>([]);
@@ -131,7 +130,7 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
 
   // Set breadcrumb and page title
   useEffect(() => {
-    const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref(getUrlForApp);
+    const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref();
     setBreadcrumbs([rulesBreadcrumbWithAppPath, { text: rule.name }]);
     chrome.docTitle.change(getCurrentDocTitle('rules'));
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -193,34 +192,33 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
             }
           ),
           text: toMountPoint(
-            <>
-              <p>
-                <FormattedMessage
-                  id="xpack.triggersActionsUI.sections.ruleDetails.scheduleIntervalToastMessage"
-                  defaultMessage="This rule has an interval set below the minimum configured interval. This may impact performance."
-                />
-              </p>
-              {hasEditButton && (
-                <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-                  <EuiFlexItem grow={false}>
-                    <EuiButton
-                      data-test-subj="ruleIntervalToastEditButton"
-                      onClick={() => {
-                        toasts.remove(configurationToast);
-                        onEditRuleClick();
-                      }}
-                    >
-                      <FormattedMessage
-                        id="xpack.triggersActionsUI.sections.ruleDetails.scheduleIntervalToastMessageButton"
-                        defaultMessage="Edit rule"
-                      />
-                    </EuiButton>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              )}
-            </>,
+            <p>
+              <FormattedMessage
+                id="xpack.triggersActionsUI.sections.ruleDetails.scheduleIntervalToastMessage"
+                defaultMessage="This rule has an interval set below the minimum configured interval. This may impact performance."
+              />
+            </p>,
             { i18n: i18nStart, theme, userProfile }
           ),
+          ...(hasEditButton
+            ? {
+                actionProps: {
+                  primary: {
+                    'data-test-subj': 'ruleIntervalToastEditButton',
+                    onClick: () => {
+                      toasts.remove(configurationToast);
+                      onEditRuleClick();
+                    },
+                    children: i18n.translate(
+                      'xpack.triggersActionsUI.sections.ruleDetails.scheduleIntervalToastMessageButton',
+                      {
+                        defaultMessage: 'Edit rule',
+                      }
+                    ),
+                  },
+                },
+              }
+            : {}),
         });
       }
     }

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details_route.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details_route.tsx
@@ -42,7 +42,6 @@ export const RuleDetailsRoute: React.FunctionComponent<RuleDetailsRouteProps> = 
     cps,
     notifications: { toasts },
     spaces: spacesApi,
-    application: { getUrlForApp },
     setBreadcrumbs,
   } = useKibana().services;
 
@@ -50,8 +49,8 @@ export const RuleDetailsRoute: React.FunctionComponent<RuleDetailsRouteProps> = 
 
   // sets a baseline breadcrumb regardless of the outcome of loading the rule
   useEffect(() => {
-    setBreadcrumbs([getRulesBreadcrumbWithHref(getUrlForApp)]);
-  }, [getUrlForApp, setBreadcrumbs]);
+    setBreadcrumbs([getRulesBreadcrumbWithHref()]);
+  }, [setBreadcrumbs]);
 
   const [rule, setRule] = useState<ResolvedRule | null>(null);
   const [ruleType, setRuleType] = useState<RuleType | null>(null);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_form/rule_form_route.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_form/rule_form_route.tsx
@@ -12,7 +12,7 @@ import { AlertConsumers, getRulesAppDetailsRoute } from '@kbn/rule-data-utils';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { ProjectRoutingAccess, useRouteBasedCpsPickerAccess } from '@kbn/cps-utils';
 import { useKibana } from '../../../common/lib/kibana';
-import { getAlertingSectionBreadcrumb } from '../../lib/breadcrumb';
+import { getAlertingSectionBreadcrumb, getRulesBreadcrumbWithHref } from '../../lib/breadcrumb';
 import { getCurrentDocTitle } from '../../lib/doc_title';
 import { RuleTemplateError } from './components/rule_template_error';
 import { CenterJustifiedSpinner } from '../../components/center_justified_spinner';
@@ -37,7 +37,6 @@ export const RuleFormRoute = () => {
     setBreadcrumbs,
     ...startServices
   } = useKibana().services;
-  const { getUrlForApp } = application;
 
   const location = useLocation<{ returnApp?: string; returnPath?: string }>();
   const history = useHistory();
@@ -70,13 +69,7 @@ export const RuleFormRoute = () => {
 
   // Set breadcrumb and page title
   useEffect(() => {
-    const rulesBreadcrumb = getAlertingSectionBreadcrumb('rules', true);
-    const breadcrumbHref = getUrlForApp('rules', { path: '/' });
-
-    const rulesBreadcrumbWithAppPath = {
-      ...rulesBreadcrumb,
-      href: breadcrumbHref,
-    };
+    const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref();
 
     if (id) {
       setBreadcrumbs([rulesBreadcrumbWithAppPath, getAlertingSectionBreadcrumb('editRule')]);
@@ -87,7 +80,7 @@ export const RuleFormRoute = () => {
       chrome.docTitle.change(getCurrentDocTitle('createRule'));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ruleTypeId, templateId, id, getUrlForApp]);
+  }, [ruleTypeId, templateId, id]);
 
   if (isLoadingRuleTemplate) {
     return <CenterJustifiedSpinner />;

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
@@ -36,7 +36,7 @@ const RulesPage = () => {
   const location = useLocation();
   const {
     chrome: { docTitle },
-    application: { getUrlForApp, isAppRegistered },
+    application: { isAppRegistered },
     http,
     notifications: { toasts },
     ruleTypeRegistry,
@@ -156,14 +156,14 @@ const RulesPage = () => {
   useEffect(() => {
     if (setBreadcrumbs) {
       if (currentSection === 'logs') {
-        const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref(getUrlForApp);
+        const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref();
         setBreadcrumbs([rulesBreadcrumbWithAppPath, getAlertingSectionBreadcrumb('logs')]);
       } else {
         setBreadcrumbs([getAlertingSectionBreadcrumb('rules')]);
       }
     }
     docTitle.change(getCurrentDocTitle('rules'));
-  }, [docTitle, setBreadcrumbs, currentSection, getUrlForApp, isAppRegistered]);
+  }, [docTitle, setBreadcrumbs, currentSection, isAppRegistered]);
 
   return (
     <>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix Rules breadcrumbs in Stack Management (#280275)](https://github.com/elastic/kibana/pull/280275)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Melissa Alvarez","email":"melissa.alvarez@elastic.co"},"sourceCommit":{"committedDate":"2026-07-24T14:39:13Z","message":"Fix Rules breadcrumbs in Stack Management (#280275)\n\n## Summary\n\nFixes Rules breadcrumbs after the page moved into Stack Management\n(https://github.com/elastic/kibana/pull/269568).\n\nBreadcrumb links now use the local Rules route so Stack Management can\nhandle navigation correctly, avoiding duplicated URLs and ensuring the\nRules list loads immediately when navigating back from rule details or\nforms.\n\nBefore:\n\nhttps://github.com/user-attachments/assets/97e5b68b-827f-426d-bf25-e247ccd6377e\n\nAfter:\n\nhttps://github.com/user-attachments/assets/eedb741a-d339-4ea9-82d9-fa0d5b9ea8d1\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f1586bde263e25a49040ce3fe50ba65f83cce4fe","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.6.0","v9.5.1"],"title":"Fix Rules breadcrumbs in Stack Management","number":280275,"url":"https://github.com/elastic/kibana/pull/280275","mergeCommit":{"message":"Fix Rules breadcrumbs in Stack Management (#280275)\n\n## Summary\n\nFixes Rules breadcrumbs after the page moved into Stack Management\n(https://github.com/elastic/kibana/pull/269568).\n\nBreadcrumb links now use the local Rules route so Stack Management can\nhandle navigation correctly, avoiding duplicated URLs and ensuring the\nRules list loads immediately when navigating back from rule details or\nforms.\n\nBefore:\n\nhttps://github.com/user-attachments/assets/97e5b68b-827f-426d-bf25-e247ccd6377e\n\nAfter:\n\nhttps://github.com/user-attachments/assets/eedb741a-d339-4ea9-82d9-fa0d5b9ea8d1\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f1586bde263e25a49040ce3fe50ba65f83cce4fe"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280275","number":280275,"mergeCommit":{"message":"Fix Rules breadcrumbs in Stack Management (#280275)\n\n## Summary\n\nFixes Rules breadcrumbs after the page moved into Stack Management\n(https://github.com/elastic/kibana/pull/269568).\n\nBreadcrumb links now use the local Rules route so Stack Management can\nhandle navigation correctly, avoiding duplicated URLs and ensuring the\nRules list loads immediately when navigating back from rule details or\nforms.\n\nBefore:\n\nhttps://github.com/user-attachments/assets/97e5b68b-827f-426d-bf25-e247ccd6377e\n\nAfter:\n\nhttps://github.com/user-attachments/assets/eedb741a-d339-4ea9-82d9-fa0d5b9ea8d1\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f1586bde263e25a49040ce3fe50ba65f83cce4fe"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->