### PR TITLE
[Security Solution] update useBrowserFields to take dataView instead of pageScope

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
@@ -20,7 +20,7 @@ export const TopValuesPopover = React.memo(() => {
   const { pathname } = useLocation();
   const scope = getScopeFromPath(pathname);
   const { dataView } = useDataView(scope);
-  const browserFields = useBrowserFields(scope);
+  const browserFields = useBrowserFields(dataView);
 
   const {
     services: { topValuesPopover },

--- a/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
@@ -27,6 +27,7 @@ import { TopValuesPopover } from '../components/top_values_popover/top_values_po
 import { useInitDataViewManager } from '../../data_view_manager/hooks/use_init_data_view_manager';
 import { useRestoreDataViewManagerStateFromURL } from '../../data_view_manager/hooks/use_sync_url_state';
 import { useBrowserFields } from '../../data_view_manager/hooks/use_browser_fields';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { useFlyoutV2RestoreFromUrl } from '../../flyout_v2/shared/url_state/use_flyout_v2_restore';
 import {
   FLYOUT_V2_URL_PARAM,
@@ -41,7 +42,8 @@ interface HomePageProps {
 
 const HomePageComponent: React.FC<HomePageProps> = ({ children }) => {
   const { pathname } = useLocation();
-  const browserFields = useBrowserFields(getScopeFromPath(pathname));
+  const { dataView } = useDataView(getScopeFromPath(pathname));
+  const browserFields = useBrowserFields(dataView);
 
   useRestoreDataViewManagerStateFromURL(useInitDataViewManager(), getScopeFromPath(pathname));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ease/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ease/table.tsx
@@ -12,7 +12,6 @@ import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
 import { useBrowserFields } from '../../../../../../../data_view_manager/hooks/use_browser_fields';
-import { PageScope } from '../../../../../../../data_view_manager/constants';
 import type { AdditionalTableContext } from '../../../../../../../detections/components/alert_summary/table/table';
 import {
   ACTION_COLUMN_WIDTH,
@@ -101,7 +100,7 @@ export const Table = memo(({ dataView, id, packages, query }: TableProps) => {
   const bulkAddToChatConfig = useBulkAddToChatConfig('bulk_alerts_attack_discovery');
   const maybeBulkAddToChatConfig = isAgentBuilderEnabled ? bulkAddToChatConfig : undefined;
 
-  const browserFields = useBrowserFields(PageScope.alerts);
+  const browserFields = useBrowserFields(dataView);
 
   const additionalContext: AdditionalTableContext = useMemo(
     () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ease/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ease/table.tsx
@@ -20,7 +20,6 @@ import { useAgentBuilderAvailability } from '../../../agent_builder/hooks/use_ag
 import { ActionsCell } from '../../../detections/components/alert_summary/table/actions_cell';
 import { CellValue } from '../../../detections/components/alert_summary/table/render_cell';
 import { useBrowserFields } from '../../../data_view_manager/hooks/use_browser_fields';
-import { PageScope } from '../../../data_view_manager/constants';
 import type { AdditionalTableContext } from '../../../detections/components/alert_summary/table/table';
 import {
   ACTION_COLUMN_WIDTH,
@@ -104,7 +103,7 @@ export const Table = memo(({ dataView, id, onLoaded, packages, query }: TablePro
     ]
   );
 
-  const browserFields = useBrowserFields(PageScope.alerts);
+  const browserFields = useBrowserFields(dataView);
 
   const { isAgentBuilderEnabled } = useAgentBuilderAvailability();
   const bulkAddToChatConfig = useBulkAddToChatConfig('bulk_alerts_cases');

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -141,7 +141,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
 
   const { dataView, status } = useDataView(pageScope);
   const selectedPatterns = useSelectedPatterns(pageScope);
-  const browserFields = useBrowserFields(pageScope);
+  const browserFields = useBrowserFields(dataView);
   const isLoadingIndexPattern = status !== 'ready';
   const dataViewId = dataView.id ?? null;
   const selectedDataViewId = dataView.id;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
@@ -45,7 +45,7 @@ export const useInsightQuery = ({
   const esQueryConfig = useMemo(() => getEsQueryConfig(uiSettings), [uiSettings]);
   const { dataView } = useDataView(PageScope.timeline);
   const selectedPatterns = useSelectedPatterns(PageScope.timeline);
-  const browserFields = useBrowserFields(PageScope.timeline);
+  const browserFields = useBrowserFields(dataView);
 
   const [hasError, setHasError] = useState(false);
   const combinedQueries = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
@@ -6,49 +6,33 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { TestProviders } from '../../common/mock';
-import { useBrowserFields } from './use_browser_fields';
-import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../constants';
-import { useDataView } from './use_data_view';
 import { DataView } from '@kbn/data-views-plugin/common';
-import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
+import { useBrowserFields } from './use_browser_fields';
+import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID } from '../constants';
 
-jest.mock('../../common/hooks/use_experimental_features');
-
-jest.mock('./use_data_view', () => ({
-  useDataView: jest.fn(),
-}));
-
-describe('useBrowserFields', () => {
-  beforeAll(() => {
-    jest.mocked(useDataView).mockReturnValue({
-      dataView: new DataView({
-        spec: {
-          id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
-          title: 'security-solution-data-view',
-          fields: {
-            '@timestamp': {
-              name: '@timestamp',
-              type: 'date',
-              esTypes: ['date'],
-              aggregatable: true,
-              searchable: true,
-              scripted: false,
-            },
-          },
+const buildDataView = () =>
+  new DataView({
+    spec: {
+      id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
+      title: 'security-solution-data-view',
+      fields: {
+        '@timestamp': {
+          name: '@timestamp',
+          type: 'date',
+          esTypes: ['date'],
+          aggregatable: true,
+          searchable: true,
+          scripted: false,
         },
-        // @ts-expect-error: DataView constructor expects more, but this is enough for our test
-        fieldFormats: { getDefaultInstance: () => ({}) },
-      }),
-      status: 'ready',
-    });
+      },
+    },
+    // @ts-expect-error: DataView constructor expects more, but this is enough for our test
+    fieldFormats: { getDefaultInstance: () => ({}) },
   });
 
-  it('should call the useDataView hook and return browser fields map', () => {
-    jest.mocked(useIsExperimentalFeatureEnabled).mockReturnValue(true);
-    const wrapper = renderHook(() => useBrowserFields(PageScope.default), {
-      wrapper: TestProviders,
-    });
+describe('useBrowserFields', () => {
+  it('should return browser fields map built from the provided dataView', () => {
+    const wrapper = renderHook(() => useBrowserFields(buildDataView()));
 
     expect(wrapper.result.current).toMatchInlineSnapshot(`
       Object {
@@ -69,5 +53,11 @@ describe('useBrowserFields', () => {
         },
       }
     `);
+  });
+
+  it('should return empty browser fields when no dataView is provided', () => {
+    const wrapper = renderHook(() => useBrowserFields(undefined as unknown as DataView));
+
+    expect(wrapper.result.current).toEqual({});
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
@@ -7,20 +7,21 @@
 
 import { useMemo } from 'react';
 import type { BrowserFields } from '@kbn/timelines-plugin/common';
-import { PageScope } from '../constants';
-import { useDataView } from './use_data_view';
+import type { DataView } from '@kbn/data-views-plugin/public';
 import { buildBrowserFields } from '../utils/build_browser_fields';
 
 const emptyFields = {} as BrowserFields;
 
-export const useBrowserFields = (scope: PageScope = PageScope.default): BrowserFields => {
-  const { dataView } = useDataView(scope);
-
+/**
+ * Returns the BrowserFields map for the provided dataView.
+ * The dataView should be retrieved once via the useDataView hook and passed in here.
+ */
+export const useBrowserFields = (dataView: DataView): BrowserFields => {
   return useMemo(() => {
     if (!dataView?.id) {
       return emptyFields;
     }
 
-    return buildBrowserFields(dataView?.fields);
+    return buildBrowserFields(dataView.fields);
   }, [dataView]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
@@ -27,7 +27,6 @@ import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import styled from '@emotion/styled';
 import { RELATED_INTEGRATION } from '../../../constants';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
-import { PageScope } from '../../../../data_view_manager/constants';
 import { useAdditionalBulkActions } from '../../../hooks/alert_summary/use_additional_bulk_actions';
 import { APP_ID, CASES_FEATURE_ID } from '../../../../../common';
 import { ActionsCell } from './actions_cell';
@@ -194,7 +193,7 @@ export const Table = memo(({ dataView, groupingFilters, packages }: TableProps) 
     [globalFilters, groupingFilters, timeRangeFilter]
   );
 
-  const browserFields = useBrowserFields(PageScope.alerts);
+  const browserFields = useBrowserFields(dataView);
 
   const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuerySelector(), []);
   const globalQuery = useDeepEqualSelector(getGlobalQuerySelector);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
@@ -20,6 +20,9 @@ jest.mock('react-router-dom', () => {
   return { ...actual, useLocation: jest.fn().mockReturnValue({ pathname: '' }) };
 });
 jest.mock('../../../../data_view_manager/hooks/use_browser_fields');
+jest.mock('../../../../data_view_manager/hooks/use_data_view', () => ({
+  useDataView: jest.fn(() => ({ dataView: {}, status: 'ready' })),
+}));
 
 describe('getAggregatableFields', () => {
   test('getAggregatableFields when useLensCompatibleFields = false', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.ts
@@ -18,6 +18,7 @@ import { getScopeFromPath } from '../../../../sourcerer/containers/sourcerer_pat
 import { getAllFieldsByName } from '../../../../common/containers/source';
 import { isLensSupportedType } from '../../../../common/utils/lens';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 
 export interface UseInspectButtonParams extends Pick<GlobalTimeArgs, 'setQuery' | 'deleteQuery'> {
   response: string;
@@ -101,7 +102,8 @@ export const useStackByFields = (useLensCompatibleFields?: boolean) => {
   const { addError } = useAppToasts();
   const pageScope = getScopeFromPath(pathname);
 
-  const browserFields = useBrowserFields(pageScope);
+  const { dataView } = useDataView(pageScope);
+  const browserFields = useBrowserFields(dataView);
 
   return useCallback(() => {
     try {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -157,7 +157,7 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
     services: { uiSettings },
   } = useKibana();
   const { dataView } = useDataView(pageScope);
-  const browserFields = useBrowserFields(pageScope);
+  const browserFields = useBrowserFields(dataView);
 
   const getGlobalQuery = useCallback(
     (customFilters: Filter[]) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -188,7 +188,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services' | 'isMutedAlerts
     onRuleChange,
   });
   const { dataView } = useDataView(pageScope);
-  const browserFields = useBrowserFields(pageScope);
+  const browserFields = useBrowserFields(dataView);
   const runtimeMappings = useMemo(() => dataView.getRuntimeMappings(), [dataView]);
 
   const license = useLicense();

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
@@ -71,7 +71,7 @@ export const useAddBulkToTimelineAction = ({
   } = useUserPrivileges();
 
   const { dataView } = useDataView(scopeId);
-  const browserFields = useBrowserFields(scopeId);
+  const browserFields = useBrowserFields(dataView);
   const selectedPatterns = useSelectedPatterns(scopeId);
   const runtimeMappings = useMemo(
     () => dataView.getRuntimeMappings() as RunTimeMappings,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/use_filtered_related_alert_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/use_filtered_related_alert_ids.ts
@@ -61,7 +61,7 @@ export const useFilteredRelatedAlertIds = ({
   const globalQuery = useDeepEqualSelector(getGlobalQuerySelector);
 
   const { dataView } = useDataView(PageScope.attacks);
-  const browserFields = useBrowserFields(PageScope.attacks);
+  const browserFields = useBrowserFields(dataView);
   const timeRangeFilter = useMemo(() => buildTimeRangeFilter(from, to), [from, to]);
 
   const query = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/cell_value_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/cell_value_context.tsx
@@ -17,6 +17,7 @@ import { getAllFieldsByName } from '../../../common/containers/source';
 import type { AlertColumnHeaders } from './columns';
 import { eventRenderedViewColumns, getColumns } from './columns';
 import { useBrowserFields } from '../../../data_view_manager/hooks/use_browser_fields';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 
 interface AlertTableCellContextProps {
   browserFields: BrowserFields;
@@ -35,7 +36,8 @@ export const AlertTableCellContextProvider = ({
   sourcererScope: PageScope;
   children: React.ReactNode;
 }) => {
-  const browserFields = useBrowserFields(sourcererScope);
+  const { dataView } = useDataView(sourcererScope);
+  const browserFields = useBrowserFields(dataView);
   const browserFieldsByName = useMemo(() => getAllFieldsByName(browserFields), [browserFields]);
   const license = useLicense();
   const gridColumns = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
@@ -56,8 +56,8 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
   const [urlStateInitialized, setUrlStateInitialized] = useState(false);
 
   const selectedPatterns = useSelectedPatterns(PageScope.timeline);
-  const browserFields = useBrowserFields(PageScope.timeline);
   const { dataView } = useDataView(PageScope.timeline);
+  const browserFields = useBrowserFields(dataView);
   const selectDataView = useSelectDataView();
 
   const dataViewId = dataView?.id ?? '';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_attack_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_attack_details.ts
@@ -74,7 +74,7 @@ export const useAttackDetails = ({
   // https://github.com/elastic/kibana/issues/244205
   const pageScope = PageScope.attacks;
   const { dataView } = useDataView(pageScope);
-  const browserFields = useBrowserFields(pageScope);
+  const browserFields = useBrowserFields(dataView);
 
   const runtimeMappings = dataView?.getRuntimeMappings() as RunTimeMappings;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
@@ -98,7 +98,7 @@ export const useEventDetails = ({
     pageName === SecurityPageName.detections ? PageScope.alerts : PageScope.default;
 
   const { dataView } = useDataView(sourcererScope);
-  const browserFields = useBrowserFields(sourcererScope);
+  const browserFields = useBrowserFields(dataView);
   const runtimeMappings = dataView?.getRuntimeMappings() as RunTimeMappings;
 
   const [loading, dataFormattedForFieldBrowser, searchHit, dataAsNestedObject, refetchFlyoutData] =

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/table_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/table_tab.test.tsx
@@ -19,6 +19,10 @@ jest.mock('../../../../data_view_manager/hooks/use_browser_fields', () => ({
   useBrowserFields: () => ({}),
 }));
 
+jest.mock('../../../../data_view_manager/hooks/use_data_view', () => ({
+  useDataView: () => ({ dataView: {}, status: 'ready' }),
+}));
+
 jest.mock('../../../document/main/utils/get_timeline_events_details_from_record', () => ({
   getTimelineEventsDetailsFromRecord: () => [],
 }));

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/table_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/table_tab.tsx
@@ -16,6 +16,7 @@ import { getTableTabItems } from '../utils/table_tab_items';
 import { getAllFieldsByName } from '../../../../common/containers/source';
 import { getTimelineEventsDetailsFromRecord } from '../../../document/main/utils/get_timeline_events_details_from_record';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { PageScope } from '../../../../data_view_manager/constants';
 import type { CellActionRenderer } from '../../../shared/components/cell_actions';
 
@@ -71,7 +72,8 @@ export const TableTab = memo(({ hit, renderCellActions }: TableTabProps) => {
     [hit]
   );
 
-  const browserFields = useBrowserFields(PageScope.attacks);
+  const { dataView } = useDataView(PageScope.attacks);
+  const browserFields = useBrowserFields(dataView);
 
   const onTableChange = useCallback(
     ({ page: { index } }: { page: { index: number } }) => setPagination({ pageIndex: index }),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/tabs/table_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/tabs/table_tab.test.tsx
@@ -45,6 +45,10 @@ jest.mock('../../../../data_view_manager/hooks/use_browser_fields', () => ({
   useBrowserFields: () => ({}),
 }));
 
+jest.mock('../../../../data_view_manager/hooks/use_data_view', () => ({
+  useDataView: () => ({ dataView: {}, status: 'ready' }),
+}));
+
 jest.mock('../../../../detection_engine/rule_management/logic/use_rule_with_fallback', () => ({
   useRuleWithFallback: () => ({ rule: undefined }),
 }));

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/tabs/table_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/tabs/table_tab.tsx
@@ -38,6 +38,7 @@ import { useHighlightedFields } from '../hooks/use_highlighted_fields';
 import { getTimelineEventsDetailsFromRecord } from '../utils/get_timeline_events_details_from_record';
 import { useRuleWithFallback } from '../../../../detection_engine/rule_management/logic/use_rule_with_fallback';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import type { CellActionRenderer } from '../../../shared/components/cell_actions';
 import type { OpenFlyoutLinkRenderer } from '../../../shared/components/open_flyout_link';
 import { EventKind } from '../constants/event_kinds';
@@ -162,7 +163,8 @@ export const TableTab = memo(
       [hit]
     );
 
-    const browserFields = useBrowserFields(getSourcererScopeId(scopeId));
+    const { dataView } = useDataView(getSourcererScopeId(scopeId));
+    const browserFields = useBrowserFields(dataView);
 
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/hooks/use_ti_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/hooks/use_ti_data_view.ts
@@ -29,7 +29,7 @@ const indicatorNameField = {
 
 export const useTIDataView = (): SelectedDataView => {
   const { dataView, status } = useDataView();
-  const browserFields = useBrowserFields();
+  const browserFields = useBrowserFields(dataView);
   const selectedPatterns = useSelectedPatterns();
 
   const tiBrowserFields = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -73,7 +73,7 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
     const dispatch = useDispatch();
 
     const { dataView } = useDataView(PageScope.timeline);
-    const browserFields = useBrowserFields(PageScope.timeline);
+    const browserFields = useBrowserFields(dataView);
 
     const { cases, uiSettings } = useKibana().services;
     const esQueryConfig = useMemo(() => getEsQueryConfig(uiSettings), [uiSettings]);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
@@ -13,6 +13,7 @@ import { IS_DRAGGING_CLASS_NAME } from '@kbn/securitysolution-t-grid';
 import { EuiFlexGroup, EuiFlexItem, EuiSuperSelect, EuiToolTip } from '@elastic/eui';
 import { PageScope } from '../../../../data_view_manager/constants';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { DroppableWrapper } from '../../../../common/components/drag_and_drop/droppable_wrapper';
 import { droppableTimelineProvidersPrefix } from '../../../../common/components/drag_and_drop/helpers';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
@@ -103,7 +104,8 @@ const CustomTooltipDiv = styled.div`
 export const DataProviders = React.memo<Props>(({ timelineId }) => {
   const dispatch = useDispatch();
 
-  const browserFields = useBrowserFields(PageScope.timeline);
+  const { dataView } = useDataView(PageScope.timeline);
+  const browserFields = useBrowserFields(dataView);
 
   const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
@@ -34,8 +34,8 @@ interface KpiExpandedProps {
 }
 
 export const TimelineKpisContainer = ({ timelineId }: KpiExpandedProps) => {
-  const browserFields = useBrowserFields(PageScope.timeline);
   const { dataView } = useDataView(PageScope.timeline);
+  const browserFields = useBrowserFields(dataView);
   const selectedPatterns = useSelectedPatterns(PageScope.timeline);
 
   const { uiSettings } = useKibana().services;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
@@ -110,7 +110,7 @@ export const QueryBarTimeline = memo<QueryBarTimelineComponentProps>(
       toStr != null ? toStr : new Date(to).toISOString()
     );
     const { dataView } = useDataView(PageScope.timeline);
-    const browserFields = useBrowserFields(PageScope.timeline);
+    const browserFields = useBrowserFields(dataView);
 
     const [savedQuery, setSavedQuery] = useState<SavedQuery | undefined>(undefined);
     const [filterQueryConverted, setFilterQueryConverted] = useState<Query>({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
@@ -90,7 +90,7 @@ export const TimelineQueryTabEventsCountComponent: React.FC<{ timelineId: string
   const dispatch = useDispatch();
   const { dataView, status } = useDataView(PageScope.timeline);
   const dataViewLoading = useMemo(() => status !== 'ready', [status]);
-  const browserFields = useBrowserFields(PageScope.timeline);
+  const browserFields = useBrowserFields(dataView);
   const dataViewId = dataView?.id || '';
   const selectedPatterns = useSelectedPatterns(PageScope.timeline);
   const runtimeMappings = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -95,7 +95,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const dispatch = useDispatch();
 
   const { dataView, status: dataViewStatus } = useDataView(PageScope.timeline);
-  const browserFields = useBrowserFields(PageScope.timeline);
+  const browserFields = useBrowserFields(dataView);
   const selectedPatterns = useSelectedPatterns(PageScope.timeline);
   const dataViewLoading = useMemo(() => dataViewStatus !== 'ready', [dataViewStatus]);
   const dataViewId = useMemo(() => dataView.id ?? '', [dataView.id]);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.tsx
@@ -8,13 +8,15 @@
 import { useMemo } from 'react';
 import { PageScope } from '../../../../../data_view_manager/constants';
 import { useBrowserFields } from '../../../../../data_view_manager/hooks/use_browser_fields';
+import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { requiredFieldsForActions } from '../../../../../detections/components/alerts_table/default_config';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
 import type { ColumnHeaderOptions } from '../../../../../../common/types';
 import { memoizedGetTimelineColumnHeaders } from './utils';
 
 export const useTimelineColumns = (columns: ColumnHeaderOptions[]) => {
-  const browserFields = useBrowserFields(PageScope.timeline);
+  const { dataView } = useDataView(PageScope.timeline);
+  const browserFields = useBrowserFields(dataView);
 
   const localColumns = useMemo(() => columns ?? defaultUdtHeaders, [columns]);
 


### PR DESCRIPTION
> [!NOTE]
> This PR is the second of a few aiming at improving performance around dataView information retrieval.

## Summary

This PR updates the `useBrowserFields` hook to take a `dataView` as prop instead of the `scope`, in order to avoid having to call `useDataView` inside. This allows less calls to the `useDataView` hook, which is most of the time (almost always) called alongside the `useBrowserFields` in the components we have.

> [!TIP]
> No behavior or UI changes should be introduced by this PR.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
