### PR TITLE
[Security Solution] update useSelectedPatterns to take dataView instead of pageScope

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/pages/use_fetch_alert_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/pages/use_fetch_alert_data.ts
@@ -14,10 +14,12 @@ import { ALERTS_QUERY_NAMES } from '../../detections/containers/detection_engine
 import type { SignalHit } from '../../common/utils/alerts';
 import { buildAlertsQuery, formatAlertToEcsSignal } from '../../common/utils/alerts';
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 
 export const useFetchAlertData = (alertIds: string[]): [boolean, Record<string, unknown>] => {
   const { hasAlertsRead } = useAlertsPrivileges();
-  const selectedPatterns = useSelectedPatterns(PageScope.alerts);
+  const { dataView } = useDataView(PageScope.alerts);
+  const selectedPatterns = useSelectedPatterns(dataView);
 
   const alertsQuery = useMemo(() => buildAlertsQuery(alertIds), [alertIds]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -140,7 +140,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
   const { uiSettings, data } = useKibana().services;
 
   const { dataView, status } = useDataView(pageScope);
-  const selectedPatterns = useSelectedPatterns(pageScope);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const browserFields = useBrowserFields(dataView);
   const isLoadingIndexPattern = status !== 'ready';
   const dataViewId = dataView.id ?? null;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.tsx
@@ -28,6 +28,7 @@ import { useLocation } from 'react-router-dom';
 import { isString } from 'lodash/fp';
 import { PageScope } from '../../../data_view_manager/constants';
 import { useSelectedPatterns } from '../../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import type { InputsModelId } from '../../store/inputs/constants';
 import { NO_ALERT_INDEX } from '../../../../common/constants';
 import * as i18n from './translations';
@@ -130,7 +131,8 @@ export const ModalInspectQuery = ({
   const { pathname } = useLocation();
   const sourcererScope = inputId === 'timeline' ? PageScope.timeline : getScopeFromPath(pathname);
 
-  const selectedPatterns = useSelectedPatterns(sourcererScope);
+  const { dataView } = useDataView(sourcererScope);
+  const selectedPatterns = useSelectedPatterns(dataView);
 
   const modalTitleId = useGeneratedHtmlId();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
@@ -44,7 +44,7 @@ export const useInsightQuery = ({
   const { uiSettings } = useKibana().services;
   const esQueryConfig = useMemo(() => getEsQueryConfig(uiSettings), [uiSettings]);
   const { dataView } = useDataView(PageScope.timeline);
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const browserFields = useBrowserFields(dataView);
 
   const [hasError, setHasError] = useState(false);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
@@ -40,7 +40,7 @@ export const useLensAttributes = ({
 }: UseLensAttributesProps): LensAttributes | null => {
   const { euiTheme } = useEuiTheme();
   const { dataView } = useDataView(scopeId);
-  const dataViewSelectedPatterns = useSelectedPatterns(scopeId);
+  const dataViewSelectedPatterns = useSelectedPatterns(dataView);
   const indicesExist = !!dataView.matchedIndices?.length;
   const selectedPatterns = useMemo(() => {
     if (signalIndexName) {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/timeline/use_investigate_in_timeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/timeline/use_investigate_in_timeline.ts
@@ -9,6 +9,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux-v7';
 import type { Filter, Query } from '@kbn/es-query';
 import { useSelectedPatterns } from '../../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { PageScope } from '../../../data_view_manager/constants';
 import { useSelectDataView } from '../../../data_view_manager/hooks/use_select_data_view';
 import { useCreateTimeline } from '../../../timelines/hooks/use_create_timeline';
@@ -62,7 +63,8 @@ export const useInvestigateInTimeline = () => {
 
   const signalIndexName = useSelector(sourcererSelectors.signalIndexName);
   const defaultDataView = useSelector(sourcererSelectors.defaultDataView);
-  const timelineSelectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const { dataView } = useDataView(PageScope.timeline);
+  const timelineSelectedPatterns = useSelectedPatterns(dataView);
 
   const clearTimelineTemplate = useCreateTimeline({
     timelineId: TimelineId.active,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.test.ts
@@ -6,59 +6,33 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import { type DataView } from '@kbn/data-views-plugin/public';
 import { useSelectedPatterns } from './use_selected_patterns';
-import { useDataView } from './use_data_view';
-import type { PageScope } from '../constants';
-
-// Mock the useDataView hook
-jest.mock('./use_data_view');
 
 describe('useSelectedPatterns', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+  it('should return an array of patterns when the dataView returns an index pattern', () => {
+    const dataView = {
+      getIndexPattern: () => 'pattern1,pattern2,pattern3',
+    } as unknown as DataView;
 
-  it('should return an array of patterns when dataView returns an index pattern', () => {
-    // Setup
-    (useDataView as jest.Mock).mockReturnValue({
-      dataView: {
-        getIndexPattern: () => 'pattern1,pattern2,pattern3',
-      },
-    });
+    const { result } = renderHook(() => useSelectedPatterns(dataView));
 
-    // Execute
-    const { result } = renderHook(() => useSelectedPatterns('mockScope' as PageScope));
-
-    // Verify
     expect(result.current).toEqual(['pattern1', 'pattern2', 'pattern3']);
-    expect(useDataView).toHaveBeenCalledWith('mockScope');
   });
 
-  it('should return an empty array when dataView returns an empty pattern', () => {
-    // Setup
-    (useDataView as jest.Mock).mockReturnValue({
-      dataView: {
-        getIndexPattern: () => '',
-      },
-    });
+  it('should return an empty array when the dataView returns an empty pattern', () => {
+    const dataView = {
+      getIndexPattern: () => '',
+    } as unknown as DataView;
 
-    // Execute
-    const { result } = renderHook(() => useSelectedPatterns('mockScope' as PageScope));
+    const { result } = renderHook(() => useSelectedPatterns(dataView));
 
-    // Verify
     expect(result.current).toEqual([]);
   });
 
-  it('should return an empty array when dataView is falsy', () => {
-    // Setup
-    (useDataView as jest.Mock).mockReturnValue({
-      dataView: null,
-    });
+  it('should return an empty array when the dataView is falsy', () => {
+    const { result } = renderHook(() => useSelectedPatterns(null as unknown as DataView));
 
-    // Execute
-    const { result } = renderHook(() => useSelectedPatterns('mockScope' as PageScope));
-
-    // Verify
     expect(result.current).toEqual([]);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
@@ -6,13 +6,15 @@
  */
 
 import { useMemo } from 'react';
-import { PageScope } from '../constants';
-import { useDataView } from './use_data_view';
+import type { DataView } from '@kbn/data-views-plugin/public';
 
 const emptyArray: string[] = [];
 
-export const useSelectedPatterns = (scope: PageScope = PageScope.default): string[] => {
-  const { dataView } = useDataView(scope);
+/**
+ * Returns the list of index patterns for the provided dataView.
+ * The dataView should be retrieved once via the useDataView hook and passed in here.
+ */
+export const useSelectedPatterns = (dataView: DataView): string[] => {
   const indexPattern = dataView?.getIndexPattern?.() ?? '';
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
@@ -72,7 +72,7 @@ export const useAddBulkToTimelineAction = ({
 
   const { dataView } = useDataView(scopeId);
   const browserFields = useBrowserFields(dataView);
-  const selectedPatterns = useSelectedPatterns(scopeId);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const runtimeMappings = useMemo(
     () => dataView.getRuntimeMappings() as RunTimeMappings,
     [dataView]

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
@@ -55,9 +55,9 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
   const queryTimelineById = useQueryTimelineById();
   const [urlStateInitialized, setUrlStateInitialized] = useState(false);
 
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
   const { dataView } = useDataView(PageScope.timeline);
   const browserFields = useBrowserFields(dataView);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const selectDataView = useSelectDataView();
 
   const dataViewId = dataView?.id ?? '';

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
@@ -195,7 +195,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({
   );
 
   const { dataView, status } = useDataView(PageScope.explore);
-  const selectedPatterns = useSelectedPatterns(PageScope.explore);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const indicesExist = !!dataView.matchedIndices?.length;
 
   const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2);

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
@@ -100,7 +100,7 @@ const HostsComponent = () => {
   }, [globalFilters, severitySelection, tabName]);
 
   const { dataView, status } = useDataView(PageScope.explore);
-  const selectedPatterns = useSelectedPatterns(PageScope.explore);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const indicesExist = dataView.hasMatchedIndices();
 
   const [globalFilterQuery, kqlError] = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
@@ -103,7 +103,7 @@ const NetworkDetailsComponent: React.FC = () => {
   }, [detailName, dispatch]);
 
   const { dataView, status } = useDataView(PageScope.explore);
-  const selectedPatterns = useSelectedPatterns(PageScope.explore);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const indicesExist = dataView.hasMatchedIndices();
 
   const ip = decodeIpv6(detailName);

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
@@ -86,7 +86,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
     }, [tabName, globalFilters]);
 
     const { dataView, status } = useDataView(PageScope.explore);
-    const selectedPatterns = useSelectedPatterns(PageScope.explore);
+    const selectedPatterns = useSelectedPatterns(dataView);
     const indicesExist = dataView.hasMatchedIndices();
 
     const onSkipFocusBeforeEventsTable = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
@@ -194,7 +194,7 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
   );
 
   const { dataView, status } = useDataView(PageScope.explore);
-  const selectedPatterns = useSelectedPatterns(PageScope.explore);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const indicesExist = dataView.hasMatchedIndices();
 
   const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2);

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx
@@ -101,7 +101,7 @@ const UsersComponent = () => {
   }, [severitySelection, tabName, globalFilters]);
 
   const { dataView, status } = useDataView(PageScope.explore);
-  const selectedPatterns = useSelectedPatterns(PageScope.explore);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const indicesExist = dataView.hasMatchedIndices();
 
   const [globalFiltersQuery, kqlError] = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -79,9 +79,8 @@ export const AnalyzeGraph: FC = () => {
   const { from, to, shouldUpdate } = useTimelineDataFilters(isActiveTimeline(scopeId));
   const filters = useMemo(() => ({ from, to }), [from, to]);
 
-  const selectedPatterns = useSelectedPatterns(PageScope.analyzer);
-
   const { dataView, status } = useDataView(PageScope.analyzer);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const isLoading: boolean = useMemo(() => status === 'loading' || status === 'pristine', [status]);
   const isDataViewInvalid: boolean = useMemo(
     () => status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices()),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
@@ -76,6 +76,7 @@ import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useNavigateToUserDetails } from '../../../entity_details/user_right/hooks/use_navigate_to_user_details';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useSecurityDefaultPatterns } from '../../../../data_view_manager/hooks/use_security_default_patterns';
 import { useEntityFromStore } from '../../../entity_details/shared/hooks/use_entity_from_store';
 import { useObservedUser } from '../../../../flyout_v2/entity/user/main/hooks/use_observed_user';
@@ -158,7 +159,8 @@ export const UserDetails: React.FC<UserDetailsProps> = ({
   const EntityCellActions = isAttackDetails ? AttackDetailsCellActions : DocumentDetailsCellActions;
 
   const { to, from, deleteQuery, setQuery, isInitializing } = useGlobalTime();
-  const selectedPatterns = useSelectedPatterns();
+  const { dataView } = useDataView();
+  const selectedPatterns = useSelectedPatterns(dataView);
   const { indexPatterns: securityDefaultPatterns } = useSecurityDefaultPatterns();
 
   const dispatch = useDispatch();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/analyzer_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/analyzer_preview_container.test.tsx
@@ -212,7 +212,9 @@ describe('AnalyzerPreviewContainer', () => {
   it('should use the analyzer page scope hooks', () => {
     renderAnalyzerPreview();
 
-    expect(useSelectedPatterns).toHaveBeenCalledWith(PageScope.analyzer);
     expect(useDataView).toHaveBeenCalledWith(PageScope.analyzer);
+    expect(useSelectedPatterns).toHaveBeenCalledWith(
+      expect.objectContaining({ hasMatchedIndices: expect.any(Function) })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/analyzer_preview_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/analyzer_preview_container.tsx
@@ -77,8 +77,8 @@ export const AnalyzerPreviewContainer = memo(
       [disableNavigation, isEnabled]
     );
 
-    const selectedPatterns = useSelectedPatterns(PageScope.analyzer);
     const { dataView, status } = useDataView(PageScope.analyzer);
+    const selectedPatterns = useSelectedPatterns(dataView);
     const dataViewLoading = status === 'loading' || status === 'pristine';
     const dataViewError =
       status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/analyzer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/analyzer/index.tsx
@@ -14,6 +14,7 @@ import { DocumentToolsFlyoutHeader } from '../../../shared/components/document_t
 import { PREFIX } from '../../../../flyout/shared/test_ids';
 import { PageScope } from '../../../../data_view_manager/constants';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useTimelineDataFilters } from '../../../../timelines/containers/use_timeline_data_filters';
 import { Resolver } from '../../../../resolver/view';
 import { ANALYZER_TITLE } from '../../../shared/constants/flyout_titles';
@@ -48,7 +49,8 @@ export const AnalyzerGraph = memo(
     const { from, to, shouldUpdate } = useTimelineDataFilters(false);
     const filters = useMemo(() => ({ from, to }), [from, to]);
 
-    const selectedPatterns = useSelectedPatterns(PageScope.analyzer);
+    const { dataView } = useDataView(PageScope.analyzer);
+    const selectedPatterns = useSelectedPatterns(dataView);
 
     if (!eventId) {
       return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/main/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/main/content.tsx
@@ -77,7 +77,7 @@ export const Content: FC<ContentProps> = memo(({ ip, flowTarget }: ContentProps)
   } = useKibana();
 
   const { dataView, status } = useDataView();
-  const selectedPatterns = useSelectedPatterns();
+  const selectedPatterns = useSelectedPatterns(dataView);
   const indicesExist = !!dataView.matchedIndices?.length;
 
   const [filterQuery, kqlError] = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
@@ -19,6 +19,7 @@ import { DocumentDetailsRightPanelKey } from '../../flyout/document_details/shar
 import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
 import { DocumentEventTypes, FLYOUT_ORIGIN } from '../../common/lib/telemetry';
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 
 export const OPEN_FLYOUT_BUTTON = i18n.translate(
   'xpack.securitySolution.notes.openFlyoutButtonLabel',
@@ -48,7 +49,8 @@ export interface OpenFlyoutButtonIconProps {
  */
 export const OpenFlyoutButtonIcon = memo(
   ({ eventId, timelineId, iconType }: OpenFlyoutButtonIconProps) => {
-    const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+    const { dataView } = useDataView(PageScope.timeline);
+    const selectedPatterns = useSelectedPatterns(dataView);
 
     const { telemetry } = useKibana().services;
     const { openFlyout } = useExpandableFlyoutApi();

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/pages/data_quality.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/pages/data_quality.tsx
@@ -51,7 +51,7 @@ const DataQualityComponent: React.FC = () => {
   const [defaultNumberFormat] = useUiSetting$<string>(DEFAULT_NUMBER_FORMAT);
 
   const { dataView, status } = useDataView();
-  const selectedPatterns = useSelectedPatterns();
+  const selectedPatterns = useSelectedPatterns(dataView);
 
   const indicesExist = !!dataView?.matchedIndices?.length;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
@@ -58,7 +58,7 @@ const OverviewComponent = () => {
   const { from, deleteQuery, setQuery, to } = useGlobalTime();
 
   const { dataView, status } = useDataView();
-  const selectedPatterns = useSelectedPatterns();
+  const selectedPatterns = useSelectedPatterns(dataView);
   const indicesExist = !!dataView.matchedIndices?.length;
 
   // Keep-list: patterns from the data view with alert-backing indices stripped

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/hooks/use_ti_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/hooks/use_ti_data_view.ts
@@ -30,7 +30,7 @@ const indicatorNameField = {
 export const useTIDataView = (): SelectedDataView => {
   const { dataView, status } = useDataView();
   const browserFields = useBrowserFields(dataView);
-  const selectedPatterns = useSelectedPatterns();
+  const selectedPatterns = useSelectedPatterns(dataView);
 
   const tiBrowserFields = useMemo(() => {
     const { threat = { fields: {} } } = browserFields;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
@@ -158,7 +158,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
     );
 
     const { dataView } = useDataView(PageScope.timeline);
-    const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+    const selectedPatterns = useSelectedPatterns(dataView);
     const dataViewId = useMemo(() => dataView.id || '', [dataView.id]);
 
     const {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
@@ -19,6 +19,8 @@ import { NotePreviews } from '.';
 import { useDeleteNote } from './hooks/use_delete_note';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { withIndices } from '../../../../data_view_manager/hooks/__mocks__/use_data_view';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
 import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
@@ -31,6 +33,7 @@ const mockDispatch = jest.fn();
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../common/hooks/use_selector');
 jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
+jest.mock('../../../../data_view_manager/hooks/use_data_view');
 jest.mock('@kbn/expandable-flyout');
 jest.mock('../../../../flyout_v2/use_flyout_api');
 jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
@@ -74,6 +77,7 @@ describe('NotePreviews', () => {
       },
     });
     (useSelectedPatterns as jest.Mock).mockReturnValue(['test1', 'test2']);
+    jest.mocked(useDataView).mockReturnValue(withIndices(['test1', 'test2']));
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout: jest.fn() });
     flyoutApi = createFlyoutApiMock();
     jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
@@ -22,6 +22,7 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { userSelectedNotesForDeletion } from '../../../../notes';
 import { PageScope } from '../../../../data_view_manager/constants';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
@@ -54,7 +55,8 @@ const ToggleEventDetailsButtonComponent: React.FC<ToggleEventDetailsButtonProps>
   eventId,
   timelineId,
 }) => {
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const { dataView } = useDataView(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(dataView);
 
   const { telemetry } = useKibana().services;
   const { openFlyout } = useExpandableFlyoutApi();

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -101,8 +101,8 @@ const StatefulTimelineComponent: React.FC<Props> = ({
 
   const spaceId = useSpaceId();
 
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
   const { dataView, status } = useDataView(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const selectedDataViewId = useMemo(() => dataView.id ?? '', [dataView.id]);
 
   useEffect(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
@@ -36,7 +36,7 @@ interface KpiExpandedProps {
 export const TimelineKpisContainer = ({ timelineId }: KpiExpandedProps) => {
   const { dataView } = useDataView(PageScope.timeline);
   const browserFields = useBrowserFields(dataView);
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(dataView);
 
   const { uiSettings } = useKibana().services;
   const esQueryConfig = useMemo(() => getEsQueryConfig(uiSettings), [uiSettings]);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
@@ -60,7 +60,7 @@ export const EqlQueryBarTimeline = memo(({ timelineId }: { timelineId: string })
   const eqlOptions = useDeepEqualSelector((state) => getOptionsSelected(state, timelineId));
 
   const { dataView, status } = useDataView(PageScope.timeline);
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const indexPatternsLoading = useMemo(() => status !== 'ready', [status]);
 
   const initialState = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -90,7 +90,7 @@ export const EqlTabContentComponent: React.FC<Props> = ({
   const { setTimelineFullScreen, timelineFullScreen } = useTimelineFullScreen();
 
   const { dataView: experimentalDataView, status } = useDataView(PageScope.timeline);
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(experimentalDataView);
   const dataViewId = experimentalDataView.id ?? null;
   const dataViewLoading = useMemo(() => status !== 'ready', [status]);
   const runtimeMappings = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -86,8 +86,8 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   const enableNewFlyout = useIsNewFlyoutEnabled();
   const { openNotes } = useFlyoutApi();
 
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
   const { dataView } = useDataView(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const dataViewId = useMemo(() => dataView.id ?? '', [dataView.id]);
   const runtimeMappings = useMemo(
     () => dataView.getRuntimeMappings() as RunTimeMappings,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
@@ -92,7 +92,7 @@ export const TimelineQueryTabEventsCountComponent: React.FC<{ timelineId: string
   const dataViewLoading = useMemo(() => status !== 'ready', [status]);
   const browserFields = useBrowserFields(dataView);
   const dataViewId = dataView?.id || '';
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const runtimeMappings = useMemo(
     () => (dataView?.getRuntimeMappings() ?? {}) as RunTimeMappings,
     [dataView]

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -96,7 +96,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
 
   const { dataView, status: dataViewStatus } = useDataView(PageScope.timeline);
   const browserFields = useBrowserFields(dataView);
-  const selectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const selectedPatterns = useSelectedPatterns(dataView);
   const dataViewLoading = useMemo(() => dataViewStatus !== 'ready', [dataViewStatus]);
   const dataViewId = useMemo(() => dataView.id ?? '', [dataView.id]);
 


### PR DESCRIPTION
> [!NOTE]
> This PR is the third of a few aiming at improving performance around dataView information retrieval.

## Summary

This PR updates the `useSelectedPatterns` hook to take a `dataView` as prop instead of the `scope`, in order to avoid having to call `useDataView` inside. This allows less calls to the `useDataView` hook, which is most of the time (almost always) called alongside the `useSelectedPatterns` in the components we have.

> [!TIP]
> No behavior or UI changes should be introduced by this PR.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
