### PR TITLE
[Cases] Assignee fields population

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../constants';
 import { FieldSchema, isRefField } from './fields';
 import { CaseConnectorWithoutNameSchema } from '../../domain_zod/connector/v1';
-import { CaseAssigneesSchema } from '../../domain_zod/user/v1';
+import { CaseUserProfilesSchema } from '../../domain_zod/user/v1';
 
 /** Template tag: non-empty and length-bounded, mirroring the client-side metadata validation. */
 const TemplateTagSchema = z.string().min(1).max(MAX_TEMPLATE_TAG_LENGTH);
@@ -164,7 +164,7 @@ export const ParsedTemplateDefinitionSchema = z.object({
   tags: z.array(z.string()).optional(),
   severity: z.enum(['low', 'medium', 'high', 'critical']).nullable().optional(),
   category: z.string().nullable().optional(),
-  assignees: CaseAssigneesSchema.optional(),
+  assignees: CaseUserProfilesSchema.optional(),
   /**
    * Default connector pre-selected when creating a case from this template (`name` resolved from
    * `id` at create time). A first-class case concept, separate from the `fields` system.

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user/v1.ts
@@ -47,8 +47,21 @@ export const CaseUserProfileRt = rt.strict({
 
 export type CaseUserProfile = rt.TypeOf<typeof CaseUserProfileRt>;
 
+export const CaseAssigneeRt = rt.exact(
+  rt.intersection([
+    rt.type({ uid: rt.string }),
+    rt.partial({
+      username: rt.union([rt.string, rt.null]),
+      full_name: rt.union([rt.string, rt.null]),
+      email: rt.union([rt.string, rt.null]),
+    }),
+  ])
+);
+
+export type CaseAssignee = rt.TypeOf<typeof CaseAssigneeRt>;
+
 /**
  * Assignees
  */
-export const CaseAssigneesRt = rt.array(CaseUserProfileRt);
+export const CaseAssigneesRt = rt.array(CaseAssigneeRt);
 export type CaseAssignees = rt.TypeOf<typeof CaseAssigneesRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain_zod/user/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain_zod/user/v1.ts
@@ -40,6 +40,13 @@ export const CaseUserProfileSchema = z.object({
 
 export type CaseUserProfile = z.infer<typeof CaseUserProfileSchema>;
 
+/**
+ * UID-only assignees for caller-supplied input (templates, imports). Identity
+ * fields are server-derived, so they must not be expressible on the input side.
+ */
+export const CaseUserProfilesSchema = z.array(CaseUserProfileSchema);
+export type CaseUserProfiles = z.infer<typeof CaseUserProfilesSchema>;
+
 export const CaseAssigneeSchema = z.object({
   uid: z.string(),
   username: z.string().nullable().optional(),

--- a/x-pack/platform/plugins/shared/cases/common/types/domain_zod/user/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain_zod/user/v1.ts
@@ -40,8 +40,17 @@ export const CaseUserProfileSchema = z.object({
 
 export type CaseUserProfile = z.infer<typeof CaseUserProfileSchema>;
 
+export const CaseAssigneeSchema = z.object({
+  uid: z.string(),
+  username: z.string().nullable().optional(),
+  full_name: z.string().nullable().optional(),
+  email: z.string().nullable().optional(),
+});
+
+export type CaseAssignee = z.infer<typeof CaseAssigneeSchema>;
+
 /**
  * Assignees
  */
-export const CaseAssigneesSchema = z.array(CaseUserProfileSchema);
+export const CaseAssigneesSchema = z.array(CaseAssigneeSchema);
 export type CaseAssignees = z.infer<typeof CaseAssigneesSchema>;

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_parse_yaml.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_parse_yaml.ts
@@ -11,7 +11,7 @@ import { FieldSchema } from '../../../../common/types/domain/template/fields';
 import { TemplateSettingsSchema } from '../../../../common/types/domain/template/v1';
 import { CaseSeveritySchema } from '../../../../common/types/domain_zod/case/v1';
 import { CaseConnectorWithoutNameSchema } from '../../../../common/types/domain_zod/connector/v1';
-import { CaseAssigneesSchema } from '../../../../common/types/domain_zod/user/v1';
+import { CaseUserProfilesSchema } from '../../../../common/types/domain_zod/user/v1';
 import { MAX_TEMPLATES_PER_FILE, MAX_TOTAL_IMPORT_TEMPLATES } from '../constants';
 import { checkTemplateExists } from '../utils';
 import type { ValidatedFile } from './use_validate_yaml';
@@ -49,7 +49,7 @@ const ImportedTemplateSchema = z
     // Legacy top-level import shape support.
     severity: CaseSeveritySchema.optional(),
     category: z.string().nullable().optional(),
-    assignees: CaseAssigneesSchema.optional(),
+    assignees: CaseUserProfilesSchema.optional(),
     connector: CaseConnectorWithoutNameSchema.optional(),
     settings: TemplateSettingsSchema.optional(),
     author: z.string().optional(),
@@ -80,7 +80,7 @@ export interface ParsedTemplateEntry {
     tags?: string[];
     severity?: z.infer<typeof CaseSeveritySchema>;
     category?: string | null;
-    assignees?: z.infer<typeof CaseAssigneesSchema>;
+    assignees?: z.infer<typeof CaseUserProfilesSchema>;
   };
   severity?: z.infer<typeof CaseSeveritySchema>;
   category?: string | null;

--- a/x-pack/platform/plugins/shared/cases/server/agent_builder/skills/cases_analytics_skill.ts
+++ b/x-pack/platform/plugins/shared/cases/server/agent_builder/skills/cases_analytics_skill.ts
@@ -57,7 +57,7 @@ The indices are named \`.cases\` / \`.cases-activity\` / \`.cases-attachments\` 
 
 | Index | Grain | Key fields |
 |-------|-------|-----------|
-| \`.cases\` | one doc per case (lookup-mode) | \`case.id\`, \`case.status\`, \`case.severity\`, \`case.owner\`, \`case.created_at\`, \`case.closed_at\`, \`case.in_progress_at\`, \`case.time_to_acknowledge\`, \`case.time_to_investigate\`, \`case.time_to_resolve\`, \`case.duration\`, \`case.total_alerts\`, \`case.total_comments\`, \`case.tags\`, \`case.category\`, \`case.assignees.uid\`, \`case.observables.observable-type-<x>\`, \`case.extended_fields\` |
+| \`.cases\` | one doc per case (lookup-mode) | \`case.id\`, \`case.status\`, \`case.severity\`, \`case.owner\`, \`case.created_at\`, \`case.closed_at\`, \`case.in_progress_at\`, \`case.time_to_acknowledge\`, \`case.time_to_investigate\`, \`case.time_to_resolve\`, \`case.duration\`, \`case.total_alerts\`, \`case.total_comments\`, \`case.tags\`, \`case.category\`, \`case.assignees.uid\`, \`case.assignees.username\`, \`case.assignees.full_name\`, \`case.assignees.email\`, \`case.observables.observable-type-<x>\`, \`case.extended_fields\` |
 | \`.cases-activity\` | one doc per user action | \`case.id\`, \`action.type\`, \`action.verb\`, \`action.status_new\`, \`action.severity_new\`, \`action.assignees_changed\`, \`action.tags_changed\`, \`action.connector_id_new\`, \`action.attachment_reference_id\`, \`actor.*\`, \`@timestamp\` |
 | \`.cases-attachments\` | one doc per comment/attachment | \`case.id\`, \`attachment.type\`, \`attachment.comment\`, \`attachment.alert.rule.id\`, \`attachment.alert.rule.name\`, \`attachment.alert.indices\`, \`attachment.event.indices\`, \`attachment.attachment_id\`, \`created_at\` |
 
@@ -113,9 +113,11 @@ FROM .cases
 
 \`FIELD_EXTRACT\` is a **Technical Preview** function. It reads numeric and keyword sub-keys from the flattened \`case.extended_fields\`, but blank/unset custom fields are common, so **always report how many docs had the field populated** (\`COUNT(<extracted>)\`) alongside the metric. When precision matters or FIELD_EXTRACT returns nothing, fall back to the \`Case Analytics\` data view (see "KQL / the Case Analytics data view"), whose typed runtime field \`case.<name>_as_<type>\` reads the same values.
 
-## Resolving user UIDs to names
+## Resolving assignee UIDs to names
 
-Assignees are stored as **profile UIDs only** — \`case.assignees.uid\` (and \`action.assignees_changed\` on the activity stream). No tool resolves them and there is no user directory index to join. But every \`.cases-activity\` row carries the **acting** user's identity (\`actor.profile_uid\` + \`actor.full_name\` + \`actor.username\`), so you can build a best-effort UID→name directory from the activity stream and use it to label UIDs:
+Assignees carry identity inline on \`.cases\`: \`case.assignees.username\`, \`case.assignees.full_name\` and \`case.assignees.email\` alongside \`case.assignees.uid\`. **Prefer these fields** — label assignees with \`case.assignees.full_name\` (fall back to \`username\`, then \`uid\`), no join or helper query needed.
+
+These fields are **forward-only**: they are populated when the case was created/updated after the identity rollout and the profile resolved. Legacy cases, unresolved UIDs, and deployments where population is still disabled leave them \`null\` — for those, and for \`action.assignees_changed\` on the activity stream (still UID-only), fall back to the activity-derived UID→name directory below.
 
 \`\`\`esql
 FROM .cases-activity
@@ -126,14 +128,14 @@ FROM .cases-activity
 | KEEP uid, actor.full_name, actor.username
 \`\`\`
 
-Run this as a helper query, then map the UIDs in your result (e.g. \`case.assignees.uid\`) to names. Key points:
+Run this as a helper query, then map any UIDs left unresolved by the inline fields to names. Key points:
 - **Best-effort coverage** — the directory only knows users who have *performed* a case action. A user who was assigned but never acted won't appear; show their UID and say the display name isn't available rather than guessing.
 - **Renamed users** — a user whose name/username changed may appear on more than one row; the most recent (top, by \`latest\`) is current.
 - **DLS-scoped** — you only see actors in the owners/spaces you can read, so the directory is naturally limited to authorized names.
 - **Not a \`LOOKUP JOIN\`** — \`.cases-activity\` is a fact index (not lookup-mode), so it can't be a join target. Build the directory table first, then annotate in a second step.
 - **Reporters need no resolution** — \`case.created_by\` / \`case.updated_by\` / \`case.closed_by\` already carry \`username\` / \`full_name\` / \`email\`.
 
-For a dashboard (where the two-step annotate isn't available), surface the same directory query as its own table/Lens panel so it acts as a UID→name key alongside the UID-keyed charts.
+For a dashboard, prefer the inline \`case.assignees.full_name\`; where UIDs remain (legacy docs, \`action.assignees_changed\`), surface the directory query as its own table/Lens panel so it acts as a UID→name key alongside the UID-keyed charts.
 
 ## Building visualizations
 
@@ -200,7 +202,7 @@ FROM .cases
 | STATS open_cases = COUNT(*) BY case.assignees.uid
 | SORT open_cases DESC
 \`\`\`
-Note: \`case.assignees.uid\` is a profile UID. Label it with the activity-derived UID→name directory (helper below) — best-effort, covering users who've performed an action; otherwise show the UID. Reporters (\`case.created_by\` / \`case.updated_by\` / \`case.closed_by\`) already carry \`username\` / \`full_name\` / \`email\`.
+Note: prefer the inline identity fields for labels — group/label by \`case.assignees.full_name\` (fall back to \`case.assignees.username\`, then \`case.assignees.uid\`). These are forward-only, so for legacy docs / unresolved UIDs (and for \`action.assignees_changed\`) fall back to the activity-derived UID→name directory (helper below) — best-effort, covering users who've performed an action; otherwise show the UID. Reporters (\`case.created_by\` / \`case.updated_by\` / \`case.closed_by\`) already carry \`username\` / \`full_name\` / \`email\`.
 
 ## User UID → name directory (helper for labeling assignee UIDs)
 \`\`\`esql
@@ -211,7 +213,7 @@ FROM .cases-activity
 | RENAME actor.profile_uid AS uid
 | KEEP uid, actor.full_name, actor.username
 \`\`\`
-Best-effort: only users who have performed an action appear. Use it to label \`case.assignees.uid\` / \`action.assignees_changed\`; fall back to the UID when absent (a renamed user's most recent row, by \`latest\`, is current). \`.cases-activity\` is a fact index, so this is a build-then-annotate step, not a \`LOOKUP JOIN\`.`,
+Best-effort: only users who have performed an action appear. Prefer the inline \`case.assignees.{full_name,username}\` fields first; use this directory only for UIDs they leave \`null\` (legacy/unresolved docs) and for \`action.assignees_changed\`, falling back to the UID when still absent (a renamed user's most recent row, by \`latest\`, is current). \`.cases-activity\` is a fact index, so this is a build-then-annotate step, not a \`LOOKUP JOIN\`.`,
     },
     {
       relativePath: './analytics',

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/ensure_indices/case.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/ensure_indices/case.test.ts
@@ -56,15 +56,20 @@ describe('ensureCaseIndex', () => {
     expect(call.settings['index.auto_expand_replicas']).toBe('0-1');
   });
 
-  it('skips creation and logs debug when the index already exists', async () => {
+  it('applies an additive mapping sync (no create) when the index already exists', async () => {
     const { esClient, logger } = buildDeps();
     (esClient.indices.exists as unknown as jest.Mock).mockResolvedValue(true);
+    (esClient.indices.putMapping as unknown as jest.Mock).mockResolvedValue({});
 
     await ensureCaseIndex({ esClient, logger });
 
     expect(esClient.indices.create).not.toHaveBeenCalled();
+    expect(esClient.indices.putMapping).toHaveBeenCalledTimes(1);
+    const call = (esClient.indices.putMapping as unknown as jest.Mock).mock.calls[0][0];
+    expect(call.index).toBe(CASE_INDEX_NAME);
+    expect(call.properties).toBeDefined();
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('already exists; skipping bootstrap')
+      expect.stringContaining('applied additive mapping sync')
     );
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/ensure_indices/case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/ensure_indices/case.ts
@@ -10,9 +10,12 @@ import { CASE_INDEX_NAME } from '../constants';
 import { CASE_INDEX_MAPPING } from '../mappings/case';
 
 /**
- * Idempotently creates `.cases` if it doesn't already exist. Safe to call
- * from multiple Kibana nodes concurrently — the second caller hits an
- * `already_exists` exception and short-circuits.
+ * Idempotently creates `.cases` if it doesn't already exist, or applies an
+ * additive mapping sync when it does (new CASE_INDEX_MAPPING fields must reach
+ * already-created indices before writers emit them; the strict mapping rejects
+ * unmapped fields otherwise). Safe to call from multiple Kibana nodes
+ * concurrently — the create loser hits an `already_exists` exception and
+ * short-circuits; the putMapping is idempotent for already-present fields.
  *
  * Settings:
  *   - `index.hidden: true` — not surfaced by default in `_cat/indices`
@@ -54,7 +57,18 @@ export async function ensureCaseIndex({
   try {
     const exists = await esClient.indices.exists({ index: CASE_INDEX_NAME });
     if (exists) {
-      logger.debug(`${CASE_INDEX_NAME} already exists; skipping bootstrap`);
+      // `indices.create` only runs on first bootstrap, so fields later added to
+      // CASE_INDEX_MAPPING never reach an already-created `.cases`. The index is
+      // `dynamic: 'strict'`, so a doc carrying an unmapped field is rejected
+      // with `mapper_parsing_exception` (silently swallowed by the writer).
+      // Apply an additive, idempotent mapping sync so new fields exist before
+      // any writer emits them.
+      await esClient.indices.putMapping({
+        index: CASE_INDEX_NAME,
+        properties: CASE_INDEX_MAPPING.properties,
+        dynamic_templates: CASE_INDEX_MAPPING.dynamic_templates,
+      });
+      logger.debug(`${CASE_INDEX_NAME} already exists; applied additive mapping sync`);
       return;
     }
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/case.ts
@@ -101,6 +101,9 @@ export const CASE_INDEX_MAPPING: MappingTypeMapping = {
         assignees: {
           properties: {
             uid: { type: 'keyword' },
+            username: { type: 'keyword' },
+            full_name: { type: 'keyword' },
+            email: { type: 'keyword' },
           },
         },
         created_at: { type: 'date' },

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/schema_drift.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/schema_drift.test.ts
@@ -72,7 +72,7 @@ const buildFullAttributes = (): {
   description: 'A description',
   tags: ['tag1'],
   category: 'malware',
-  assignees: [{ uid: 'u-1' }],
+  assignees: [{ uid: 'u-1', username: 'u1', full_name: 'User One', email: 'u1@e.com' }],
   severity: CasePersistedSeverity.HIGH,
   status: CasePersistedStatus.CLOSED,
   created_at: '2026-05-01T00:00:00.000Z',

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.test.ts
@@ -27,7 +27,10 @@ const fullCaseSO = (
       description: 'A description',
       tags: ['tag1', 'tag2'],
       category: 'malware',
-      assignees: [{ uid: 'u-1' }, { uid: 'u-2' }],
+      assignees: [
+        { uid: 'u-1', username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+        { uid: 'u-2' },
+      ],
       severity: CasePersistedSeverity.HIGH,
       status: CasePersistedStatus.IN_PROGRESS,
       created_at: '2026-05-01T00:00:00.000Z',
@@ -81,6 +84,14 @@ describe('buildCaseDoc', () => {
     const so = fullCaseSO();
     const doc = buildCaseDoc({ ...so, namespaces: ['security-1'] });
     expect(doc.space_id).toBe('security-1');
+  });
+
+  it('passes assignee identity fields through to the analytics doc', () => {
+    const doc = buildCaseDoc(fullCaseSO());
+    expect(doc.case.assignees).toEqual([
+      { uid: 'u-1', username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+      { uid: 'u-2' },
+    ]);
   });
 
   it('emits owner at the document root (DLS field) and mirrors it under case.*', () => {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.ts
@@ -68,7 +68,12 @@ export interface CaseAnalyticsDoc {
     category?: string | null;
     status: CaseStatusString;
     severity: CaseSeverityString;
-    assignees?: Array<{ uid: string }>;
+    assignees?: Array<{
+      uid: string;
+      username?: string | null;
+      full_name?: string | null;
+      email?: string | null;
+    }>;
     created_at: string;
     updated_at?: string | null;
     closed_at?: string | null;

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_create.test.ts
@@ -86,6 +86,69 @@ describe('bulkCreate', () => {
     });
   });
 
+  describe('assignee identity population', () => {
+    const clientArgs = createCasesClientMockArgs();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      clientArgs.config = { ...clientArgs.config, assigneeIdentity: { enabled: true } };
+      clientArgs.services.caseService.bulkCreateCases.mockResolvedValue({
+        saved_objects: [caseSO],
+      });
+    });
+
+    it('resolves every uid across all cases in a single bulkGet and populates identity', async () => {
+      clientArgs.securityStartPlugin.userProfiles.bulkGet.mockResolvedValue([
+        {
+          uid: '1',
+          enabled: true,
+          data: {},
+          user: { username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+        },
+        {
+          uid: '2',
+          enabled: true,
+          data: {},
+          user: { username: 'u2', full_name: 'User Two', email: 'u2@e.com' },
+        },
+      ] as never);
+
+      await bulkCreate(
+        {
+          cases: [
+            getCases({ assignees: [{ uid: '1' }] })[0],
+            getCases({ assignees: [{ uid: '2' }] })[0],
+          ],
+        },
+        clientArgs,
+        casesClientMock
+      );
+
+      expect(clientArgs.securityStartPlugin.userProfiles.bulkGet).toHaveBeenCalledTimes(1);
+      const { cases } = clientArgs.services.caseService.bulkCreateCases.mock.calls[0][0];
+      expect(cases[0].assignees).toEqual([
+        { uid: '1', username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+      ]);
+      expect(cases[1].assignees).toEqual([
+        { uid: '2', username: 'u2', full_name: 'User Two', email: 'u2@e.com' },
+      ]);
+    });
+
+    it('does not resolve profiles when the flag is disabled', async () => {
+      clientArgs.config = { ...clientArgs.config, assigneeIdentity: { enabled: false } };
+
+      await bulkCreate(
+        { cases: getCases({ assignees: [{ uid: '1' }] }) },
+        clientArgs,
+        casesClientMock
+      );
+
+      expect(clientArgs.securityStartPlugin.userProfiles.bulkGet).not.toHaveBeenCalled();
+      const { cases } = clientArgs.services.caseService.bulkCreateCases.mock.calls[0][0];
+      expect(cases[0].assignees).toEqual([{ uid: '1' }]);
+    });
+  });
+
   describe('execution', () => {
     const createdAtDate = new Date('2023-11-05');
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_create.ts
@@ -26,7 +26,7 @@ import type {
 } from '../../../common/types/api';
 import { BulkCreateCasesResponseRt, BulkCreateCasesRequestRt } from '../../../common/types/api';
 import { validateCustomFields } from './validators';
-import { normalizeCreateCaseRequest } from './utils';
+import { applyProfilesToAssignees, getUserProfilesSafe, normalizeCreateCaseRequest } from './utils';
 import { ensureTemplateVersionIsPinned } from './expand_template_defaults';
 import type { BulkCreateCasesArgs } from '../../services/cases/types';
 import type { NotifyAssigneesArgs } from '../../services/notifications/types';
@@ -93,6 +93,22 @@ export const bulkCreate = async (
           templatesEnabled: clientArgs.config.templates.enabled,
         })
       );
+    }
+
+    // Server-derived assignee identity, gated by feature flag `assigneeIdentity`
+    if (clientArgs.config.assigneeIdentity.enabled) {
+      const allUids = new Set(
+        bulkCreateRequest.flatMap((theCase) => theCase.assignees?.map(({ uid }) => uid) ?? [])
+      );
+      const profiles = await getUserProfilesSafe(clientArgs.securityStartPlugin, allUids, logger);
+
+      if (profiles) {
+        for (const theCase of bulkCreateRequest) {
+          if (theCase.assignees && theCase.assignees.length > 0) {
+            theCase.assignees = applyProfilesToAssignees(theCase.assignees, profiles);
+          }
+        }
+      }
     }
 
     const bulkCreateResponse = await caseService.bulkCreateCases({
@@ -295,7 +311,8 @@ const createBulkCreateUserActionsRequest = ({
     owner: theCase.attributes.owner,
     description: theCase.attributes.description,
     severity: theCase.attributes.severity ?? CaseSeverity.LOW,
-    assignees: theCase.attributes.assignees ?? [],
+    // Keep the user action uid-only
+    assignees: theCase.attributes.assignees?.map(({ uid }) => ({ uid })) ?? [],
     category: theCase.attributes.category ?? null,
     customFields: theCase.attributes.customFields ?? [],
   };

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
@@ -91,6 +91,66 @@ describe('update', () => {
       const patchArgs = clientArgs.services.caseService.patchCases.mock.calls[0][0];
       expect(patchArgs.cases[0].updatedAttributes.assignees).toEqual([{ uid: '1' }]);
     });
+
+    it('notifies only newly added assignees, not retained legacy uid-only ones', async () => {
+      // Pre-rollout case: the retained assignee is stored uid-only, so enrichment must not make it
+      // look newly added (notification selection compares by uid, not object identity).
+      clientArgs.services.caseService.getCases.mockResolvedValue({
+        saved_objects: [
+          {
+            ...mockCases[0],
+            attributes: { ...mockCases[0].attributes, assignees: [{ uid: 'legacy' }] },
+          },
+        ],
+      });
+      clientArgs.securityStartPlugin.userProfiles.bulkGet.mockResolvedValue([
+        {
+          uid: 'legacy',
+          enabled: true,
+          data: {},
+          user: { username: 'leg', full_name: 'Legacy', email: 'l@e.com' },
+        },
+        {
+          uid: '1',
+          enabled: true,
+          data: {},
+          user: { username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+        },
+      ] as never);
+      clientArgs.services.caseService.patchCases.mockResolvedValue({
+        saved_objects: [
+          {
+            ...mockCases[0],
+            attributes: {
+              assignees: [
+                { uid: 'legacy', username: 'leg', full_name: 'Legacy', email: 'l@e.com' },
+                { uid: '1', username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+              ],
+            },
+          },
+        ],
+      });
+
+      await bulkUpdate(
+        {
+          cases: [
+            {
+              id: mockCases[0].id,
+              version: mockCases[0].version ?? '',
+              assignees: [{ uid: 'legacy' }, { uid: '1' }],
+            },
+          ],
+        },
+        clientArgs,
+        casesClientMock
+      );
+
+      expect(clientArgs.services.notificationService.bulkNotifyAssignees).toHaveBeenCalledTimes(1);
+      const notified = clientArgs.services.notificationService.bulkNotifyAssignees.mock.calls[0][0];
+      expect(notified[0].assignees).toEqual([
+        { uid: '1', username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+      ]);
+    });
   });
 
   describe('Assignees', () => {

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
@@ -38,6 +38,61 @@ describe('update', () => {
   const casesClientMock = createCasesClientMock();
   casesClientMock.configure.get = jest.fn().mockResolvedValue([]);
 
+  describe('assignee identity population', () => {
+    const clientArgs = createCasesClientMockArgs();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      clientArgs.config = { ...clientArgs.config, assigneeIdentity: { enabled: true } };
+      clientArgs.services.caseService.getCases.mockResolvedValue({ saved_objects: mockCases });
+      clientArgs.services.caseService.getAllCaseComments.mockResolvedValue({
+        saved_objects: [],
+        total: 0,
+        per_page: 10,
+        page: 1,
+      });
+      clientArgs.services.caseService.patchCases.mockResolvedValue({
+        saved_objects: [{ ...mockCases[0], attributes: { assignees: cases.cases[0].assignees } }],
+      });
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
+      clientArgs.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({
+        [mockCases[0].id]: 0,
+        [mockCases[1].id]: 0,
+      });
+    });
+
+    it('populates assignee identity on the patch payload when enabled', async () => {
+      clientArgs.securityStartPlugin.userProfiles.bulkGet.mockResolvedValue([
+        {
+          uid: '1',
+          enabled: true,
+          data: {},
+          user: { username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+        },
+      ] as never);
+
+      await bulkUpdate(cases, clientArgs, casesClientMock);
+
+      expect(clientArgs.securityStartPlugin.userProfiles.bulkGet).toHaveBeenCalledTimes(1);
+      const patchArgs = clientArgs.services.caseService.patchCases.mock.calls[0][0];
+      expect(patchArgs.cases[0].updatedAttributes.assignees).toEqual([
+        { uid: '1', username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+      ]);
+    });
+
+    it('does not resolve profiles when the flag is disabled', async () => {
+      clientArgs.config = { ...clientArgs.config, assigneeIdentity: { enabled: false } };
+
+      await bulkUpdate(cases, clientArgs, casesClientMock);
+
+      expect(clientArgs.securityStartPlugin.userProfiles.bulkGet).not.toHaveBeenCalled();
+      const patchArgs = clientArgs.services.caseService.patchCases.mock.calls[0][0];
+      expect(patchArgs.cases[0].updatedAttributes.assignees).toEqual([{ uid: '1' }]);
+    });
+  });
+
   describe('Assignees', () => {
     const clientArgs = createCasesClientMockArgs();
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
@@ -47,13 +47,7 @@ import {
   isAlertAttachmentType,
   UNIFIED_ALERT_TYPES_ARRAY,
 } from '../../../common/utils/attachments';
-import {
-  arraysDifference,
-  getCaseToUpdate,
-  buildFilter,
-  combineFilters,
-  NodeBuilderOperators,
-} from '../utils';
+import { getCaseToUpdate, buildFilter, combineFilters, NodeBuilderOperators } from '../utils';
 import {
   applyProfilesToAssignees,
   dedupAssignees,
@@ -1086,16 +1080,18 @@ const getCasesAndAssigneesToNotifyForAssignment = (
       return acc;
     }
 
-    const alreadyAssignedToCase = originalCaseSO.attributes.assignees;
-    const comparedAssignees = arraysDifference(
-      alreadyAssignedToCase,
-      updatedCase.attributes.assignees ?? []
+    // Compare by uid, not object identity: server-derived identity fields make an enriched
+    // assignee unequal to the legacy uid-only record, so a deep diff would flag every retained
+    // assignee on a pre-rollout case as newly added and re-notify them.
+    const alreadyAssignedUids = new Set(originalCaseSO.attributes.assignees.map(({ uid }) => uid));
+    const addedAssignees = (updatedCase.attributes.assignees ?? []).filter(
+      ({ uid }) => !alreadyAssignedUids.has(uid)
     );
 
-    if (comparedAssignees && comparedAssignees.addedItems.length > 0) {
+    if (addedAssignees.length > 0) {
       const theCase = mergeOriginalSOWithUpdatedSO(originalCaseSO, updatedCase);
 
-      const assigneesWithoutCurrentUser = comparedAssignees.addedItems.filter(
+      const assigneesWithoutCurrentUser = addedAssignees.filter(
         (assignee) => assignee.uid !== user.profile_uid
       );
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
@@ -55,6 +55,7 @@ import {
   NodeBuilderOperators,
 } from '../utils';
 import {
+  applyProfilesToAssignees,
   dedupAssignees,
   fillMissingCustomFields,
   getCloseReasonIfValid,
@@ -62,6 +63,7 @@ import {
   getDurationForUpdate,
   getInProgressInfoForUpdate,
   getTimingMetricsForUpdate,
+  getUserProfilesSafe,
 } from './utils';
 import { LICENSING_CASE_ASSIGNMENT_FEATURE } from '../../common/constants';
 import type { LicensingService } from '../../services/licensing';
@@ -732,6 +734,28 @@ export const bulkUpdate = async (
 
     await throwIfMaxUserActionsReached({ userActionsDict, userActionService });
     notifyPlatinumUsage(licensingService, casesToUpdate);
+
+    // Server-derived assignee identity, gated by feature flag `assigneeIdentity`
+    if (clientArgs.config.assigneeIdentity.enabled) {
+      const allUids = new Set(
+        patchCasesPayload.cases.flatMap(
+          ({ updatedAttributes }) => updatedAttributes.assignees?.map(({ uid }) => uid) ?? []
+        )
+      );
+
+      if (allUids.size > 0) {
+        const profiles = await getUserProfilesSafe(clientArgs.securityStartPlugin, allUids, logger);
+
+        if (profiles) {
+          for (const patchCase of patchCasesPayload.cases) {
+            const { assignees } = patchCase.updatedAttributes;
+            if (assignees && assignees.length > 0) {
+              patchCase.updatedAttributes.assignees = applyProfilesToAssignees(assignees, profiles);
+            }
+          }
+        }
+      }
+    }
 
     const updatedCases = await patchCases({ caseService, patchCasesPayload });
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
@@ -220,7 +220,7 @@ describe('create', () => {
       );
     });
 
-    it('fills null identity for uids without a resolvable profile', async () => {
+    it('keeps assignees uid-only for uids without a resolvable profile', async () => {
       clientArgs.securityStartPlugin.userProfiles.bulkGet.mockResolvedValue([] as never);
 
       await create({ ...theCase, assignees: [{ uid: '1' }] }, clientArgs, casesClientMock);
@@ -228,7 +228,7 @@ describe('create', () => {
       expect(clientArgs.services.caseService.createCase).toHaveBeenCalledWith(
         expect.objectContaining({
           attributes: expect.objectContaining({
-            assignees: [{ uid: '1', username: null, full_name: null, email: null }],
+            assignees: [{ uid: '1' }],
           }),
         })
       );

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
@@ -190,6 +190,80 @@ describe('create', () => {
     });
   });
 
+  describe('assignee identity population', () => {
+    const clientArgs = createCasesClientMockArgs();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      clientArgs.services.caseService.createCase.mockResolvedValue(caseSO);
+      clientArgs.config = { ...clientArgs.config, assigneeIdentity: { enabled: true } };
+    });
+
+    it('populates assignee identity from user profiles when enabled', async () => {
+      clientArgs.securityStartPlugin.userProfiles.bulkGet.mockResolvedValue([
+        {
+          uid: '1',
+          enabled: true,
+          data: {},
+          user: { username: 'u1', full_name: 'User One', email: 'u1@e.com' },
+        },
+      ] as never);
+
+      await create({ ...theCase, assignees: [{ uid: '1' }] }, clientArgs, casesClientMock);
+
+      expect(clientArgs.services.caseService.createCase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            assignees: [{ uid: '1', username: 'u1', full_name: 'User One', email: 'u1@e.com' }],
+          }),
+        })
+      );
+    });
+
+    it('fills null identity for uids without a resolvable profile', async () => {
+      clientArgs.securityStartPlugin.userProfiles.bulkGet.mockResolvedValue([] as never);
+
+      await create({ ...theCase, assignees: [{ uid: '1' }] }, clientArgs, casesClientMock);
+
+      expect(clientArgs.services.caseService.createCase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            assignees: [{ uid: '1', username: null, full_name: null, email: null }],
+          }),
+        })
+      );
+    });
+
+    it('does not resolve profiles when the flag is disabled', async () => {
+      clientArgs.config = { ...clientArgs.config, assigneeIdentity: { enabled: false } };
+
+      await create({ ...theCase, assignees: [{ uid: '1' }] }, clientArgs, casesClientMock);
+
+      expect(clientArgs.securityStartPlugin.userProfiles.bulkGet).not.toHaveBeenCalled();
+      expect(clientArgs.services.caseService.createCase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({ assignees: [{ uid: '1' }] }),
+        })
+      );
+    });
+
+    it('is non-fatal: stores assignees uid-only when profile resolution fails', async () => {
+      (clientArgs.securityStartPlugin.userProfiles.bulkGet as jest.Mock).mockRejectedValue(
+        new Error('profiles service down')
+      );
+
+      await expect(
+        create({ ...theCase, assignees: [{ uid: '1' }] }, clientArgs, casesClientMock)
+      ).resolves.not.toThrow();
+
+      expect(clientArgs.services.caseService.createCase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({ assignees: [{ uid: '1' }] }),
+        })
+      );
+    });
+  });
+
   describe('Attributes', () => {
     const clientArgs = createCasesClientMockArgs();
     clientArgs.services.caseService.createCase.mockResolvedValue(caseSO);

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
@@ -27,7 +27,7 @@ import {
 } from './validators';
 import type { CreateUserAction, CommonUserActionArgs } from '../../services/user_actions/types';
 import { emptyCaseAssigneesSanitizer } from './sanitizers';
-import { normalizeCreateCaseRequest } from './utils';
+import { normalizeCreateCaseRequest, populateAssigneesIdentity } from './utils';
 import { mergeCustomFieldsIntoExtendedFields } from '../../../common/utils/template_fields';
 import {
   applyTemplateDefaultsToCreateRequest,
@@ -189,11 +189,26 @@ export const create = async (
         undefined; // return type includes null when input is null; CasePostRequest.extended_fields is never null
     }
 
+    const attributes = transformNewCase({
+      user,
+      newCase: normalizedCase,
+    });
+
+    // Server-derived assignee identity: resolve profile uids to username /
+    // full_name / email so downstream consumers (e.g. cases-as-data analytics)
+    // can read human-readable assignees. Gated until the MV10 mapping is rolled
+    // out fleet-wide (off by default on serverless).
+    if (clientArgs.config.assigneeIdentity.enabled) {
+      attributes.assignees =
+        (await populateAssigneesIdentity(
+          clientArgs.securityStartPlugin,
+          logger,
+          attributes.assignees
+        )) ?? [];
+    }
+
     const newCase = await caseService.createCase({
-      attributes: transformNewCase({
-        user,
-        newCase: normalizedCase,
-      }),
+      attributes,
       id: savedObjectID,
       refresh: false,
     });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
@@ -8,6 +8,7 @@
 import { isEmpty, uniqBy } from 'lodash';
 import type { UserProfile } from '@kbn/security-plugin/common';
 import type { IBasePath } from '@kbn/core-http-browser';
+import type { Logger } from '@kbn/logging';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { v4 } from 'uuid';
@@ -622,6 +623,72 @@ export const getUserProfiles = async (
     acc.set(profile.uid, profile);
     return acc;
   }, new Map());
+};
+
+/**
+ * Best-effort `getUserProfiles`: resolves profiles for `uids`, returning
+ * `undefined` (not throwing) if the user-profiles service fails. A transient
+ * `bulkGet` failure must not block case create/update — callers fall back to
+ * storing assignees uid-only, and the read path still resolves identity live.
+ */
+export const getUserProfilesSafe = async (
+  securityStartPlugin: SecurityPluginStart,
+  uids: Set<string>,
+  logger: Logger
+): Promise<Map<string, UserProfileWithAvatar> | undefined> => {
+  try {
+    return await getUserProfiles(securityStartPlugin, uids);
+  } catch (error) {
+    logger.warn(
+      `Failed to resolve assignee user profiles; storing assignees without identity: ${error}`
+    );
+    return undefined;
+  }
+};
+
+/**
+ * Maps resolved user profiles onto assignees, populating `username`,
+ * `full_name` and `email`. Uids without a resolvable profile keep `null`
+ * identity. Pure — the profiles are fetched once by the caller so a bulk
+ * operation can share a single `bulkGet`.
+ */
+export const applyProfilesToAssignees = (
+  assignees: CaseAssignees,
+  profiles: Map<string, UserProfileWithAvatar>
+): CaseAssignees =>
+  assignees.map(({ uid }) => {
+    const profile = profiles.get(uid);
+
+    return {
+      uid,
+      username: profile?.user.username ?? null,
+      full_name: profile?.user.full_name ?? null,
+      email: profile?.user.email ?? null,
+    };
+  });
+
+/**
+ * Resolves each assignee's `uid` to its identity via the user-profiles service
+ * and returns the assignees with those fields populated. The caller gates
+ * invocation on the `assigneeIdentity` config flag. Non-fatal: on a profile
+ * lookup failure the original (uid-only) assignees are returned unchanged.
+ */
+export const populateAssigneesIdentity = async (
+  securityStartPlugin: SecurityPluginStart,
+  logger: Logger,
+  assignees?: CaseAssignees
+): Promise<CaseAssignees | undefined> => {
+  if (assignees == null || assignees.length === 0) {
+    return assignees;
+  }
+
+  const profiles = await getUserProfilesSafe(
+    securityStartPlugin,
+    new Set(assignees.map(({ uid }) => uid)),
+    logger
+  );
+
+  return profiles ? applyProfilesToAssignees(assignees, profiles) : assignees;
 };
 
 export const fillMissingCustomFields = ({

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
@@ -648,9 +648,9 @@ export const getUserProfilesSafe = async (
 
 /**
  * Maps resolved user profiles onto assignees, populating `username`,
- * `full_name` and `email`. Uids without a resolvable profile keep `null`
- * identity. Pure — the profiles are fetched once by the caller so a bulk
- * operation can share a single `bulkGet`.
+ * `full_name` and `email`. Uids without a resolvable profile stay uid-only.
+ * Pure — the profiles are fetched once by the caller so a bulk operation can
+ * share a single `bulkGet`.
  */
 export const applyProfilesToAssignees = (
   assignees: CaseAssignees,
@@ -659,11 +659,15 @@ export const applyProfilesToAssignees = (
   assignees.map(({ uid }) => {
     const profile = profiles.get(uid);
 
+    if (!profile) {
+      return { uid };
+    }
+
     return {
       uid,
-      username: profile?.user.username ?? null,
-      full_name: profile?.user.full_name ?? null,
-      email: profile?.user.email ?? null,
+      username: profile.user.username ?? null,
+      full_name: profile.user.full_name ?? null,
+      email: profile.user.email ?? null,
     };
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/client/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/mocks.ts
@@ -291,7 +291,12 @@ export const createCasesClientMockArgs = () => {
     ),
     savedObjectsSerializer: createSavedObjectsSerializerMock(),
     fileService: createFileServiceMock(),
-    config: ConfigSchema.validate({}),
+    // Assignee-identity population is opt-in per test; keep it off by default so
+    // the broad create/update suites keep asserting uid-only assignees.
+    config: {
+      ...ConfigSchema.validate({}),
+      assigneeIdentity: { enabled: false },
+    },
     casesEventBus: createCasesEventBusMock(),
     request: httpServerMock.createKibanaRequest(),
   };

--- a/x-pack/platform/plugins/shared/cases/server/common/types/user.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/types/user.ts
@@ -14,4 +14,7 @@ export interface User {
 
 export interface UserProfile {
   uid: string;
+  username?: string | null;
+  full_name?: string | null;
+  email?: string | null;
 }

--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -24,6 +24,9 @@ describe('config validation', () => {
             "resetPageDelayMs": 0,
             "resetTaskTimeoutMinutes": 60,
           },
+          "assigneeIdentity": Object {
+            "enabled": true,
+          },
           "attachments": Object {
             "enabled": true,
           },

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -14,6 +14,16 @@ import {
 } from '../common/constants/incremental_id';
 
 export const ConfigSchema = schema.object({
+  /**
+   * Gates server-side population of assignee identity fields (`username`,
+   * `full_name`, `email`) on the cases saved object at write time.
+   */
+  assigneeIdentity: schema.object({
+    enabled: offeringBasedSchema({
+      serverless: schema.boolean({ defaultValue: false }),
+      traditional: schema.boolean({ defaultValue: true }),
+    }),
+  }),
   analytics: schema.object({
     index: schema.object({
       enabled: offeringBasedSchema({

--- a/x-pack/platform/plugins/shared/cases/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/mocks.ts
@@ -778,6 +778,7 @@ export const mockCasesContract = (): CasesServerStart => ({
   getUnifiedAttachmentTypeRegistry: jest.fn(),
   config: {
     enabled: true,
+    assigneeIdentity: { enabled: true },
     stack: {
       enabled: true,
     },

--- a/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
@@ -31,6 +31,7 @@ import type { CasesServerSetupDependencies, CasesServerStartDependencies } from 
 function getConfig(overrides: Partial<ConfigType> = {}): ConfigType {
   return {
     enabled: true,
+    assigneeIdentity: { enabled: true },
     markdownPlugins: { lens: true },
     files: { maxSize: 1, allowedMimeTypes: ALLOWED_MIME_TYPES },
     stack: { enabled: true },
@@ -182,6 +183,9 @@ describe('Cases Plugin', () => {
               "reconciliationIntervalMinutes": 30,
               "resetPageDelayMs": 0,
               "resetTaskTimeoutMinutes": 60,
+            },
+            "assigneeIdentity": Object {
+              "enabled": true,
             },
             "attachments": Object {
               "enabled": true,

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/cases/assignees.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/cases/assignees.ts
@@ -77,6 +77,34 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(retrievedProfiles[0]).to.eql(profile[0]);
       });
 
+      it('populates the assignee identity fields from the resolved profile', async () => {
+        const profile = await suggestUserProfiles({
+          supertest: supertestWithoutAuth,
+          req: {
+            name: 'delete',
+            owners: ['securitySolutionFixture'],
+            size: 1,
+          },
+          auth: { user: superUser, space: 'space1' },
+        });
+
+        const postedCase = await createCase(
+          supertest,
+          getPostCaseRequest({
+            assignees: [{ uid: profile[0].uid }],
+          })
+        );
+
+        expect(postedCase.assignees).to.eql([
+          {
+            uid: profile[0].uid,
+            username: profile[0].user.username,
+            full_name: profile[0].user.full_name ?? null,
+            email: profile[0].user.email ?? null,
+          },
+        ]);
+      });
+
       it('assigns multiple users to a case and retrieves their profiles', async () => {
         const profiles = await suggestUserProfiles({
           supertest: supertestWithoutAuth,


### PR DESCRIPTION
## Summary

Dependency: https://github.com/elastic/kibana/pull/281357 to be merged first

Follow-up to the MV10 mapping PR ([#281357](https://github.com/elastic/kibana/pull/281357)), This PR populates the new `assignees[]` identity fields (`username`, `full_name`, `email`) on the case saved object at write time, and mirrors them into the cases-as-data v2 analytics index.

Identity is **server-derived**: on create / bulk-create / update the assignee `uid`s are resolved via `security.userProfiles.bulkGet` and stored alongside `uid`. API callers still send `uid` only, and the activity log stays `uid`-only.

Population is gated by a new `xpack.cases.assigneeIdentity.enabled` setting: **on by default for traditional**, **off for serverless** 

### Notes

- **Forward-only**: existing cases are not backfilled 
- **Non-fatal**: a failed profile lookup logs a warning and stores assignees `uid`-only 
- **Cases-as-data v2**: the `.cases` mapping gains the identity fields, `ensureCaseIndex` applies an additive `putMapping` so already-created (strict) indices accept them, and the doc builder emits them.

Example dashboard
<img width="1198" height="560" alt="image" src="https://github.com/user-attachments/assets/144a6918-07f5-4fca-a5da-82d36033b7b8" />

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Assisted by Claude

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->