### PR TITLE
[kbn-evals] Fix on-demand evals Buildkite pipeline link

### DIFF
--- a/.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml
+++ b/.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml
@@ -5,7 +5,7 @@ metadata:
   name: bk-kibana-evals-on-demand
   description: 'Runs a single @kbn/evals suite and model on demand'
   links:
-    - url: 'https://buildkite.com/elastic/kibana-evals-on-demand'
+    - url: 'https://buildkite.com/elastic/kibana-evals-on-demand-llm-evals'
       title: Pipeline link
 spec:
   type: buildkite-pipeline

--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -6,7 +6,7 @@ Offline evaluation framework for LLM-based workflows in Kibana. Requires the `ev
 
 - **Local** - `node scripts/evals start` (interactive CLI, see [CLI.md](./CLI.md) for the full command reference)
 - **CI on PRs** - GitHub labels (`evals:<suite-id>`, `models:<model-group>`)
-- **On-demand** - [Buildkite pipeline](https://buildkite.com/elastic/kibana-evals-on-demand)
+- **On-demand** - [Buildkite pipeline](https://buildkite.com/elastic/kibana-evals-on-demand-llm-evals)
 - **UI** - the "New experiment" form on the Experiments tab runs experiments server-side via Kibana Workflows, no CLI required (see [From the UI](../../../plugins/shared/evals/README.md#from-the-ui))
 - **Agent Builder** - the `eval-experiment-authoring` skill composes, previews, saves, and runs experiments from a chat (see [From Agent Builder](../../../plugins/shared/evals/README.md#from-agent-builder))
 - **Workflow YAML** - a version-controlled experiment workflow file, run via Workflows Management (see [From YAML](../../../plugins/shared/evals/README.md#from-yaml))
@@ -219,7 +219,7 @@ results and triage.
 
 Run a suite on any branch without a PR:
 
-1. Open [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand)
+1. Open [kibana-evals-on-demand-llm-evals](https://buildkite.com/elastic/kibana-evals-on-demand-llm-evals)
 2. Click **New build**, select branch/commit
 3. Add environment variables:
 


### PR DESCRIPTION
## Summary

Fixes a stale link in the `@kbn/evals` README for the on-demand pipeline.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
