### PR TITLE
Bump brace-expansion to 5.0.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17847,9 +17847,9 @@ brace-expansion@^2.0.1, brace-expansion@^2.0.2:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2, brace-expansion@^5.0.5:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Summary

Bumps `brace-expansion` from 5.0.7 to 5.0.8.

`brace-expansion` is a transitive dependency (pulled in via `minimatch@10.x`); 5.0.8 satisfies the existing `^5.0.2` / `^5.0.5` ranges, so this is a lockfile-only change with no `package.json` edit. Routine dependency maintenance.

## Release note

`release_note:skip`


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->