### PR TITLE
[Connectors] Add Datadog connector

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
@@ -24,6 +24,7 @@ export * from './specs/notion/notion';
 export * from './specs/shodan/shodan';
 export * from './specs/urlvoid/urlvoid';
 export * from './specs/virustotal/virustotal';
+export * from './specs/datadog/datadog';
 export * from './specs/jina/jina_reader';
 export * from './specs/salesforce/salesforce';
 export * from './specs/servicenow_search/servicenow_search';

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
@@ -28,10 +28,7 @@ export const ConnectorIconsMap: Map<
   ],
   [
     '.datadog',
-    lazy(
-      () =>
-        import(/* webpackChunkName: "connectorIconDatadog" */ './specs/datadog/icon')
-    ),
+    lazy(() => import(/* webpackChunkName: "connectorIconDatadog" */ './specs/datadog/icon')),
   ],
   [
     '.alienvault-otx',

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
@@ -27,6 +27,13 @@ export const ConnectorIconsMap: Map<
     lazy(() => import(/* webpackChunkName: "connectorIconVirustotal" */ './specs/virustotal/icon')),
   ],
   [
+    '.datadog',
+    lazy(
+      () =>
+        import(/* webpackChunkName: "connectorIconDatadog" */ './specs/datadog/icon')
+    ),
+  ],
+  [
     '.alienvault-otx',
     lazy(
       () =>

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActionContext } from '../../connector_spec';
+import { DatadogConnector } from './datadog';
+import { DATADOG_WEBHOOK_PAYLOAD_TEMPLATE } from './types';
+
+describe('DatadogConnector', () => {
+  const mockClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const mockContext = {
+    client: mockClient,
+    log: {},
+    config: { site: 'datadoghq.com' },
+    secrets: {
+      authType: 'basic',
+      username: 'test-api-key',
+      password: 'test-app-key',
+    },
+  } as unknown as ActionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be discoverable via getConnectorSpec (all_specs wiring)', async () => {
+    const { getConnectorSpec } = await import('../../get_connector_spec');
+    expect(getConnectorSpec('.datadog')).toBeDefined();
+    expect(getConnectorSpec('.datadog')?.metadata.id).toBe('.datadog');
+  });
+
+  it('test validates API key then lists monitors', async () => {
+    mockClient.get.mockResolvedValueOnce({ data: { valid: true } }).mockResolvedValueOnce({
+      data: [{ id: 1, name: 'm' }],
+    });
+
+    const result = await DatadogConnector.test!.handler(mockContext);
+
+    expect(mockClient.get).toHaveBeenNthCalledWith(
+      1,
+      'https://api.datadoghq.com/api/v1/validate',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'DD-API-KEY': 'test-api-key',
+          'DD-APPLICATION-KEY': 'test-app-key',
+        }),
+      })
+    );
+    expect(mockClient.get).toHaveBeenNthCalledWith(
+      2,
+      'https://api.datadoghq.com/api/v1/monitor',
+      expect.objectContaining({ params: { page_size: 1 } })
+    );
+    expect(result).toEqual(
+      expect.objectContaining({ ok: true, site: 'datadoghq.com' })
+    );
+  });
+
+  it('registerWebhook posts payload template', async () => {
+    mockClient.post.mockResolvedValue({
+      data: { name: 'kibana-test', url: 'https://example.com/hook' },
+    });
+
+    const result = await DatadogConnector.actions.registerWebhook.handler(mockContext, {
+      name: 'kibana-test',
+      url: 'https://example.com/hook',
+      customAuthHeader: 'secret-token',
+    });
+
+    expect(mockClient.post).toHaveBeenCalledWith(
+      'https://api.datadoghq.com/api/v1/integration/webhooks/configuration/webhooks',
+      {
+        name: 'kibana-test',
+        url: 'https://example.com/hook',
+        payload: DATADOG_WEBHOOK_PAYLOAD_TEMPLATE,
+        custom_headers: JSON.stringify({ Authorization: 'Bearer secret-token' }),
+      },
+      expect.any(Object)
+    );
+    expect(result).toEqual(
+      expect.objectContaining({ name: 'kibana-test', url: 'https://example.com/hook' })
+    );
+  });
+
+  it('muteMonitor posts to mute endpoint', async () => {
+    mockClient.post.mockResolvedValue({
+      data: { id: 309422658, overall_state: 'Alert' },
+    });
+
+    const result = await DatadogConnector.actions.muteMonitor.handler(mockContext, {
+      monitorId: 309422658,
+      scope: 'host:web01',
+    });
+
+    expect(mockClient.post).toHaveBeenCalledWith(
+      'https://api.datadoghq.com/api/v1/monitor/309422658/mute',
+      { scope: 'host:web01' },
+      expect.any(Object)
+    );
+    expect(result).toEqual(
+      expect.objectContaining({ id: 309422658, overallState: 'Alert' })
+    );
+  });
+
+  it('listMonitors maps monitor summaries', async () => {
+    mockClient.get.mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          name: 'Payment Service Error Rate',
+          overall_state: 'Alert',
+          tags: ['env:demo'],
+          type: 'metric alert',
+        },
+      ],
+    });
+
+    const result = await DatadogConnector.actions.listMonitors.handler(mockContext, {
+      tags: 'env:demo',
+      groupStates: 'alert',
+    });
+
+    expect(mockClient.get).toHaveBeenCalledWith(
+      'https://api.datadoghq.com/api/v1/monitor',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          tags: 'env:demo',
+          group_states: 'alert',
+          page: 0,
+          page_size: 100,
+        }),
+      })
+    );
+    expect(result).toEqual({
+      count: 1,
+      monitors: [
+        {
+          id: 1,
+          name: 'Payment Service Error Rate',
+          overallState: 'Alert',
+          tags: ['env:demo'],
+          type: 'metric alert',
+        },
+      ],
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.test.ts
@@ -8,13 +8,13 @@
  */
 
 import type { ActionContext } from '../../connector_spec';
-import { DatadogConnector } from './datadog';
+import { DatadogConnector, getSite } from './datadog';
+import { DATADOG_SITES } from './types';
 
 describe('DatadogConnector', () => {
   const mockClient = {
     get: jest.fn(),
     post: jest.fn(),
-    delete: jest.fn(),
   };
 
   const mockContext = {
@@ -53,6 +53,21 @@ describe('DatadogConnector', () => {
     ]);
   });
 
+  describe('getSite', () => {
+    it('defaults to datadoghq.com when unset or unknown', () => {
+      expect(getSite({ ...mockContext, config: {} })).toBe('datadoghq.com');
+      expect(getSite({ ...mockContext, config: { site: 'app.datadoghq.com' } })).toBe(
+        'datadoghq.com'
+      );
+    });
+
+    it('accepts every known Datadog site', () => {
+      for (const site of DATADOG_SITES) {
+        expect(getSite({ ...mockContext, config: { site } })).toBe(site);
+      }
+    });
+  });
+
   it('test probes monitors with page_size 1', async () => {
     mockClient.get.mockResolvedValueOnce({
       data: [{ id: 1, name: 'm' }],
@@ -65,6 +80,21 @@ describe('DatadogConnector', () => {
       expect.objectContaining({ params: { page_size: 1 } })
     );
     expect(result).toEqual(expect.objectContaining({ ok: true, site: 'datadoghq.com' }));
+  });
+
+  it('uses api.<site> for non-US1 sites', async () => {
+    mockClient.get.mockResolvedValueOnce({ data: [] });
+    const euCtx = {
+      ...mockContext,
+      config: { site: 'datadoghq.eu' },
+    } as unknown as ActionContext;
+
+    await DatadogConnector.test!.handler(euCtx);
+
+    expect(mockClient.get).toHaveBeenCalledWith(
+      'https://api.datadoghq.eu/api/v1/monitor',
+      expect.any(Object)
+    );
   });
 
   it('muteMonitor posts to mute endpoint', async () => {
@@ -84,12 +114,29 @@ describe('DatadogConnector', () => {
     expect(result).toEqual(expect.objectContaining({ id: 309422658, overallState: 'Alert' }));
   });
 
-  it('unmuteMonitor posts to unmute endpoint', async () => {
+  it('unmuteMonitor posts scope when provided', async () => {
     mockClient.post.mockResolvedValue({
       data: { id: 309422658, overall_state: 'OK' },
     });
 
     const result = await DatadogConnector.actions.unmuteMonitor.handler(mockContext, {
+      monitorId: 309422658,
+      scope: 'host:web01',
+    });
+
+    expect(mockClient.post).toHaveBeenCalledWith(
+      'https://api.datadoghq.com/api/v1/monitor/309422658/unmute',
+      { scope: 'host:web01' }
+    );
+    expect(result).toEqual(expect.objectContaining({ id: 309422658, overallState: 'OK' }));
+  });
+
+  it('unmuteMonitor posts empty body when scope omitted', async () => {
+    mockClient.post.mockResolvedValue({
+      data: { id: 309422658, overall_state: 'OK' },
+    });
+
+    await DatadogConnector.actions.unmuteMonitor.handler(mockContext, {
       monitorId: 309422658,
     });
 
@@ -97,7 +144,6 @@ describe('DatadogConnector', () => {
       'https://api.datadoghq.com/api/v1/monitor/309422658/unmute',
       {}
     );
-    expect(result).toEqual(expect.objectContaining({ id: 309422658, overallState: 'OK' }));
   });
 
   it('getMonitor fetches with downtimes', async () => {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.test.ts
@@ -23,9 +23,8 @@ describe('DatadogConnector', () => {
     log: {},
     config: { site: 'datadoghq.com' },
     secrets: {
-      authType: 'basic',
-      username: 'test-api-key',
-      password: 'test-app-key',
+      authType: 'bearer',
+      token: 'ddsat_test-token',
     },
   } as unknown as ActionContext;
 
@@ -39,31 +38,25 @@ describe('DatadogConnector', () => {
     expect(getConnectorSpec('.datadog')?.metadata.id).toBe('.datadog');
   });
 
-  it('test validates API key then lists monitors', async () => {
-    mockClient.get.mockResolvedValueOnce({ data: { valid: true } }).mockResolvedValueOnce({
+  it('uses bearer auth (not basic / dual-header)', () => {
+    const types = DatadogConnector.auth?.types?.map((t) => t.type) ?? [];
+    expect(types).toEqual(['bearer']);
+    expect(types).not.toContain('basic');
+    expect(types).not.toContain('api_key_header');
+  });
+
+  it('test probes monitors with page_size 1', async () => {
+    mockClient.get.mockResolvedValueOnce({
       data: [{ id: 1, name: 'm' }],
     });
 
     const result = await DatadogConnector.test!.handler(mockContext);
 
-    expect(mockClient.get).toHaveBeenNthCalledWith(
-      1,
-      'https://api.datadoghq.com/api/v1/validate',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'DD-API-KEY': 'test-api-key',
-          'DD-APPLICATION-KEY': 'test-app-key',
-        }),
-      })
-    );
-    expect(mockClient.get).toHaveBeenNthCalledWith(
-      2,
+    expect(mockClient.get).toHaveBeenCalledWith(
       'https://api.datadoghq.com/api/v1/monitor',
       expect.objectContaining({ params: { page_size: 1 } })
     );
-    expect(result).toEqual(
-      expect.objectContaining({ ok: true, site: 'datadoghq.com' })
-    );
+    expect(result).toEqual(expect.objectContaining({ ok: true, site: 'datadoghq.com' }));
   });
 
   it('registerWebhook posts payload template', async () => {
@@ -84,8 +77,7 @@ describe('DatadogConnector', () => {
         url: 'https://example.com/hook',
         payload: DATADOG_WEBHOOK_PAYLOAD_TEMPLATE,
         custom_headers: JSON.stringify({ Authorization: 'Bearer secret-token' }),
-      },
-      expect.any(Object)
+      }
     );
     expect(result).toEqual(
       expect.objectContaining({ name: 'kibana-test', url: 'https://example.com/hook' })
@@ -104,12 +96,9 @@ describe('DatadogConnector', () => {
 
     expect(mockClient.post).toHaveBeenCalledWith(
       'https://api.datadoghq.com/api/v1/monitor/309422658/mute',
-      { scope: 'host:web01' },
-      expect.any(Object)
+      { scope: 'host:web01' }
     );
-    expect(result).toEqual(
-      expect.objectContaining({ id: 309422658, overallState: 'Alert' })
-    );
+    expect(result).toEqual(expect.objectContaining({ id: 309422658, overallState: 'Alert' }));
   });
 
   it('listMonitors maps monitor summaries', async () => {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.test.ts
@@ -9,7 +9,6 @@
 
 import type { ActionContext } from '../../connector_spec';
 import { DatadogConnector } from './datadog';
-import { DATADOG_WEBHOOK_PAYLOAD_TEMPLATE } from './types';
 
 describe('DatadogConnector', () => {
   const mockClient = {
@@ -45,6 +44,15 @@ describe('DatadogConnector', () => {
     expect(types).not.toContain('api_key_header');
   });
 
+  it('exposes monitor actions only (no webhook CRUD)', () => {
+    expect(Object.keys(DatadogConnector.actions).sort()).toEqual([
+      'getMonitor',
+      'listMonitors',
+      'muteMonitor',
+      'unmuteMonitor',
+    ]);
+  });
+
   it('test probes monitors with page_size 1', async () => {
     mockClient.get.mockResolvedValueOnce({
       data: [{ id: 1, name: 'm' }],
@@ -57,31 +65,6 @@ describe('DatadogConnector', () => {
       expect.objectContaining({ params: { page_size: 1 } })
     );
     expect(result).toEqual(expect.objectContaining({ ok: true, site: 'datadoghq.com' }));
-  });
-
-  it('registerWebhook posts payload template', async () => {
-    mockClient.post.mockResolvedValue({
-      data: { name: 'kibana-test', url: 'https://example.com/hook' },
-    });
-
-    const result = await DatadogConnector.actions.registerWebhook.handler(mockContext, {
-      name: 'kibana-test',
-      url: 'https://example.com/hook',
-      customAuthHeader: 'secret-token',
-    });
-
-    expect(mockClient.post).toHaveBeenCalledWith(
-      'https://api.datadoghq.com/api/v1/integration/webhooks/configuration/webhooks',
-      {
-        name: 'kibana-test',
-        url: 'https://example.com/hook',
-        payload: DATADOG_WEBHOOK_PAYLOAD_TEMPLATE,
-        custom_headers: JSON.stringify({ Authorization: 'Bearer secret-token' }),
-      }
-    );
-    expect(result).toEqual(
-      expect.objectContaining({ name: 'kibana-test', url: 'https://example.com/hook' })
-    );
   });
 
   it('muteMonitor posts to mute endpoint', async () => {
@@ -99,6 +82,53 @@ describe('DatadogConnector', () => {
       { scope: 'host:web01' }
     );
     expect(result).toEqual(expect.objectContaining({ id: 309422658, overallState: 'Alert' }));
+  });
+
+  it('unmuteMonitor posts to unmute endpoint', async () => {
+    mockClient.post.mockResolvedValue({
+      data: { id: 309422658, overall_state: 'OK' },
+    });
+
+    const result = await DatadogConnector.actions.unmuteMonitor.handler(mockContext, {
+      monitorId: 309422658,
+    });
+
+    expect(mockClient.post).toHaveBeenCalledWith(
+      'https://api.datadoghq.com/api/v1/monitor/309422658/unmute',
+      {}
+    );
+    expect(result).toEqual(expect.objectContaining({ id: 309422658, overallState: 'OK' }));
+  });
+
+  it('getMonitor fetches with downtimes', async () => {
+    mockClient.get.mockResolvedValue({
+      data: {
+        id: 42,
+        name: 'CPU high',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 80',
+        overall_state: 'Alert',
+        tags: ['env:demo'],
+        matching_downtimes: [],
+      },
+    });
+
+    const result = await DatadogConnector.actions.getMonitor.handler(mockContext, {
+      monitorId: 42,
+    });
+
+    expect(mockClient.get).toHaveBeenCalledWith(
+      'https://api.datadoghq.com/api/v1/monitor/42',
+      expect.objectContaining({ params: { with_downtimes: true } })
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 42,
+        name: 'CPU high',
+        overallState: 'Alert',
+        matchingDowntimes: [],
+      })
+    );
   });
 
   it('listMonitors maps monitor summaries', async () => {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
@@ -10,15 +10,16 @@
 /**
  * Datadog connector (`.datadog`)
  *
- * General Datadog integration for Workflows / Agent Builder / Alerting.
+ * General Datadog integration for Workflows / Agent Builder.
  * First action group covers monitors + webhook registration; additional
  * Datadog API domains (downtimes, events, hosts, metrics, incidents) should
  * be added as actions on this same connector — do not create `.datadog_*`
  * variants for each domain.
  *
- * Auth uses basic-auth fields relabeled as API Key + Application Key (both
- * encrypted). Handlers send DD-API-KEY / DD-APPLICATION-KEY headers; Datadog
- * ignores the unused HTTP Basic Authorization header.
+ * Auth: Datadog Personal Access Token (PAT) or Service Access Token (SAT)
+ * via native `bearer` (`Authorization: Bearer <token>`). Prefer SAT for
+ * automation (optional never-expire). Classic API key + application key
+ * dual-header auth is not supported.
  */
 
 import { i18n } from '@kbn/i18n';
@@ -40,12 +41,6 @@ import {
   type WebhookNameInput,
 } from './types';
 
-interface DatadogSecrets {
-  authType?: string;
-  username?: string;
-  password?: string;
-}
-
 interface DatadogConfig {
   site?: string;
 }
@@ -57,20 +52,6 @@ function getSite(ctx: ActionContext): string {
 
 function getBaseUrl(ctx: ActionContext): string {
   return `https://api.${getSite(ctx)}`;
-}
-
-function getDdHeaders(ctx: ActionContext): Record<string, string> {
-  const secrets = (ctx.secrets ?? {}) as DatadogSecrets;
-  const apiKey = secrets.username;
-  const applicationKey = secrets.password;
-  if (!apiKey || !applicationKey) {
-    throw new Error('Datadog API Key and Application Key are required');
-  }
-  return {
-    'DD-API-KEY': apiKey,
-    'DD-APPLICATION-KEY': applicationKey,
-    'Content-Type': 'application/json',
-  };
 }
 
 export const DatadogConnector: ConnectorSpec = {
@@ -94,35 +75,23 @@ export const DatadogConnector: ConnectorSpec = {
   auth: {
     types: [
       {
-        type: 'basic',
+        type: 'bearer',
+        defaults: {},
         overrides: {
-          label: i18n.translate('connectorSpecs.datadog.auth.label', {
-            defaultMessage: 'API Key + Application Key',
+          label: i18n.translate('connectorSpecs.datadog.auth.bearer.label', {
+            defaultMessage: 'Access token (PAT / SAT)',
           }),
           meta: {
-            username: {
-              label: i18n.translate('connectorSpecs.datadog.auth.apiKey.label', {
-                defaultMessage: 'API Key',
-              }),
-              helpText: i18n.translate('connectorSpecs.datadog.auth.apiKey.helpText', {
-                defaultMessage:
-                  'Datadog API key (DD-API-KEY). Organization Settings → API Keys.',
-              }),
-              placeholder: '••••••••',
+            token: {
               sensitive: true,
-            },
-            password: {
-              label: i18n.translate('connectorSpecs.datadog.auth.applicationKey.label', {
-                defaultMessage: 'Application Key',
+              label: i18n.translate('connectorSpecs.datadog.auth.bearer.token.label', {
+                defaultMessage: 'Access token',
               }),
-              helpText: i18n.translate(
-                'connectorSpecs.datadog.auth.applicationKey.helpText',
-                {
-                  defaultMessage:
-                    'Datadog application key (DD-APPLICATION-KEY). Organization Settings → Application Keys.',
-                }
-              ),
-              placeholder: '••••••••',
+              helpText: i18n.translate('connectorSpecs.datadog.auth.bearer.token.helpText', {
+                defaultMessage:
+                  'A Datadog Personal Access Token (ddpat_…) or Service Access Token (ddsat_…). Prefer a Service Access Token for automation (Organization Settings → Service Accounts). Classic API key + application key pairs are not supported.',
+              }),
+              placeholder: 'ddsat_… or ddpat_…',
             },
           },
         },
@@ -153,7 +122,9 @@ export const DatadogConnector: ConnectorSpec = {
   skill: [
     '## Datadog connector',
     '',
-    'General Datadog integration. Alerting actions use Monitors + Webhooks Integration APIs;',
+    'General Datadog integration. Auth with a Personal Access Token (PAT) or',
+    'Service Access Token (SAT) as Bearer — prefer SAT for automation.',
+    'Alerting actions use Monitors + Webhooks Integration APIs;',
     'additional domains (downtimes, events, hosts, metrics, incidents) belong on this same connector.',
     '',
     '### Alerting setup',
@@ -184,10 +155,10 @@ export const DatadogConnector: ConnectorSpec = {
             Authorization: `Bearer ${input.customAuthHeader}`,
           });
         }
+        // Bearer auth is applied by the auth type on ctx.client defaults.
         const response = await ctx.client.post(
           `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks`,
-          body,
-          { headers: getDdHeaders(ctx) }
+          body
         );
         return {
           name: response.data?.name ?? input.name,
@@ -205,8 +176,7 @@ export const DatadogConnector: ConnectorSpec = {
         const response = await ctx.client.get(
           `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks/${encodeURIComponent(
             input.name
-          )}`,
-          { headers: getDdHeaders(ctx) }
+          )}`
         );
         return response.data;
       },
@@ -220,8 +190,7 @@ export const DatadogConnector: ConnectorSpec = {
         await ctx.client.delete(
           `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks/${encodeURIComponent(
             input.name
-          )}`,
-          { headers: getDdHeaders(ctx) }
+          )}`
         );
         return { deleted: true, name: input.name };
       },
@@ -238,8 +207,7 @@ export const DatadogConnector: ConnectorSpec = {
         if (input.end !== undefined) body.end = input.end;
         const response = await ctx.client.post(
           `${getBaseUrl(ctx)}/api/v1/monitor/${input.monitorId}/mute`,
-          body,
-          { headers: getDdHeaders(ctx) }
+          body
         );
         return {
           id: response.data?.id ?? input.monitorId,
@@ -257,8 +225,7 @@ export const DatadogConnector: ConnectorSpec = {
       handler: async (ctx, input: UnmuteMonitorInput) => {
         const response = await ctx.client.post(
           `${getBaseUrl(ctx)}/api/v1/monitor/${input.monitorId}/unmute`,
-          {},
-          { headers: getDdHeaders(ctx) }
+          {}
         );
         return {
           id: response.data?.id ?? input.monitorId,
@@ -276,7 +243,6 @@ export const DatadogConnector: ConnectorSpec = {
         const response = await ctx.client.get(
           `${getBaseUrl(ctx)}/api/v1/monitor/${input.monitorId}`,
           {
-            headers: getDdHeaders(ctx),
             params: { with_downtimes: true },
           }
         );
@@ -300,7 +266,6 @@ export const DatadogConnector: ConnectorSpec = {
       input: ListMonitorsInputSchema,
       handler: async (ctx, input: ListMonitorsInput) => {
         const response = await ctx.client.get(`${getBaseUrl(ctx)}/api/v1/monitor`, {
-          headers: getDdHeaders(ctx),
           params: {
             name: input.name,
             tags: input.tags,
@@ -326,16 +291,12 @@ export const DatadogConnector: ConnectorSpec = {
 
   test: {
     description: i18n.translate('connectorSpecs.datadog.test.description', {
-      defaultMessage: 'Validates Datadog API Key and Application Key',
+      defaultMessage: 'Validates the Datadog access token (PAT or SAT)',
     }),
     handler: async (ctx) => {
-      const headers = getDdHeaders(ctx);
-      const base = getBaseUrl(ctx);
-      // Validate API key
-      await ctx.client.get(`${base}/api/v1/validate`, { headers });
-      // Validate application key (requires app key on monitor list)
-      await ctx.client.get(`${base}/api/v1/monitor`, {
-        headers,
+      // Bearer PATs/SATs are not API keys — /api/v1/validate is the wrong probe.
+      // A lightweight authenticated monitors list verifies token + scopes.
+      await ctx.client.get(`${getBaseUrl(ctx)}/api/v1/monitor`, {
         params: { page_size: 1 },
       });
       return {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
@@ -81,9 +81,14 @@ export const DatadogConnector: ConnectorSpec = {
       defaultMessage:
         'Manage Datadog monitors and webhooks; extensible for downtimes, events, hosts, metrics, and incidents',
     }),
+    // gold matches classic stack action peers (.pagerduty, .webhook) and
+    // threat-intel-ish specs (e.g. .virustotal); not a final packaging call.
     minimumLicense: 'gold',
     isTechnicalPreview: true,
-    supportedFeatureIds: ['workflows', 'agentBuilder', 'alerting'],
+    // Same surface as other kbn-connector-specs peers. Do not add 'alerting'
+    // until there is a real v1 rule-action params UI / default subAction —
+    // specs are Workflows / Agent Builder tools today, not rule actions.
+    supportedFeatureIds: ['workflows', 'agentBuilder'],
   },
 
   auth: {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
@@ -1,0 +1,343 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Datadog connector (`.datadog`)
+ *
+ * General Datadog integration for Workflows / Agent Builder / Alerting.
+ * First action group covers monitors + webhook registration; additional
+ * Datadog API domains (downtimes, events, hosts, metrics, incidents) should
+ * be added as actions on this same connector — do not create `.datadog_*`
+ * variants for each domain.
+ *
+ * Auth uses basic-auth fields relabeled as API Key + Application Key (both
+ * encrypted). Handlers send DD-API-KEY / DD-APPLICATION-KEY headers; Datadog
+ * ignores the unused HTTP Basic Authorization header.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { z, lazySchema } from '@kbn/zod/v4';
+import type { ActionContext, ConnectorSpec } from '../../connector_spec';
+import {
+  DATADOG_WEBHOOK_PAYLOAD_TEMPLATE,
+  GetMonitorInputSchema,
+  ListMonitorsInputSchema,
+  MuteMonitorInputSchema,
+  RegisterWebhookInputSchema,
+  UnmuteMonitorInputSchema,
+  WebhookNameInputSchema,
+  type GetMonitorInput,
+  type ListMonitorsInput,
+  type MuteMonitorInput,
+  type RegisterWebhookInput,
+  type UnmuteMonitorInput,
+  type WebhookNameInput,
+} from './types';
+
+interface DatadogSecrets {
+  authType?: string;
+  username?: string;
+  password?: string;
+}
+
+interface DatadogConfig {
+  site?: string;
+}
+
+function getSite(ctx: ActionContext): string {
+  const site = (ctx.config as DatadogConfig | undefined)?.site?.trim();
+  return site && site.length > 0 ? site : 'datadoghq.com';
+}
+
+function getBaseUrl(ctx: ActionContext): string {
+  return `https://api.${getSite(ctx)}`;
+}
+
+function getDdHeaders(ctx: ActionContext): Record<string, string> {
+  const secrets = (ctx.secrets ?? {}) as DatadogSecrets;
+  const apiKey = secrets.username;
+  const applicationKey = secrets.password;
+  if (!apiKey || !applicationKey) {
+    throw new Error('Datadog API Key and Application Key are required');
+  }
+  return {
+    'DD-API-KEY': apiKey,
+    'DD-APPLICATION-KEY': applicationKey,
+    'Content-Type': 'application/json',
+  };
+}
+
+export const DatadogConnector: ConnectorSpec = {
+  metadata: {
+    id: '.datadog',
+    displayName: 'Datadog',
+    description: i18n.translate('connectorSpecs.datadog.metadata.description', {
+      defaultMessage:
+        'Manage Datadog monitors and webhooks; extensible for downtimes, events, hosts, metrics, and incidents',
+    }),
+    minimumLicense: 'gold',
+    isTechnicalPreview: true,
+    supportedFeatureIds: ['workflows', 'agentBuilder', 'alerting'],
+  },
+
+  auth: {
+    types: [
+      {
+        type: 'basic',
+        overrides: {
+          label: i18n.translate('connectorSpecs.datadog.auth.label', {
+            defaultMessage: 'API Key + Application Key',
+          }),
+          meta: {
+            username: {
+              label: i18n.translate('connectorSpecs.datadog.auth.apiKey.label', {
+                defaultMessage: 'API Key',
+              }),
+              helpText: i18n.translate('connectorSpecs.datadog.auth.apiKey.helpText', {
+                defaultMessage:
+                  'Datadog API key (DD-API-KEY). Organization Settings → API Keys.',
+              }),
+              placeholder: '••••••••',
+              sensitive: true,
+            },
+            password: {
+              label: i18n.translate('connectorSpecs.datadog.auth.applicationKey.label', {
+                defaultMessage: 'Application Key',
+              }),
+              helpText: i18n.translate(
+                'connectorSpecs.datadog.auth.applicationKey.helpText',
+                {
+                  defaultMessage:
+                    'Datadog application key (DD-APPLICATION-KEY). Organization Settings → Application Keys.',
+                }
+              ),
+              placeholder: '••••••••',
+            },
+          },
+        },
+      },
+    ],
+  },
+
+  schema: lazySchema(() =>
+    z.object({
+      site: z
+        .string()
+        .default('datadoghq.com')
+        .describe('Datadog site hostname (e.g. datadoghq.com, datadoghq.eu)')
+        .meta({
+          widget: 'text',
+          label: i18n.translate('connectorSpecs.datadog.config.site.label', {
+            defaultMessage: 'Datadog site',
+          }),
+          helpText: i18n.translate('connectorSpecs.datadog.config.site.helpText', {
+            defaultMessage:
+              'Site hostname without scheme. US1: datadoghq.com, EU: datadoghq.eu, US3: us3.datadoghq.com',
+          }),
+          placeholder: 'datadoghq.com',
+        }),
+    })
+  ),
+
+  skill: [
+    '## Datadog connector',
+    '',
+    'General Datadog integration. Alerting actions use Monitors + Webhooks Integration APIs;',
+    'additional domains (downtimes, events, hosts, metrics, incidents) belong on this same connector.',
+    '',
+    '### Alerting setup',
+    '1. Call `registerWebhook` with a Kibana inbound URL (placeholder OK while inbound is WIP).',
+    '2. In Datadog, add `@webhook-{name}` to monitor notification messages.',
+    '3. Use `listMonitors` / `getMonitor` to find monitor IDs, then `muteMonitor` / `unmuteMonitor` for write-back.',
+    '',
+    '### Fingerprint notes (alerting)',
+    'Webhook payload includes monitor_id ($ALERT_ID) and groups ($ALERT_SCOPE) — Keep-aligned series identity.',
+  ].join('\n'),
+
+  actions: {
+    // --- Monitors & webhooks (alerting) ------------------------------------
+    registerWebhook: {
+      isTool: true,
+      description:
+        'Create a Datadog webhook integration that POSTs monitor notifications to a URL. ' +
+        'Returns the created webhook name. Monitors must mention @webhook-{name} to fire it.',
+      input: RegisterWebhookInputSchema,
+      handler: async (ctx, input: RegisterWebhookInput) => {
+        const body: Record<string, string> = {
+          name: input.name,
+          url: input.url,
+          payload: DATADOG_WEBHOOK_PAYLOAD_TEMPLATE,
+        };
+        if (input.customAuthHeader) {
+          body.custom_headers = JSON.stringify({
+            Authorization: `Bearer ${input.customAuthHeader}`,
+          });
+        }
+        const response = await ctx.client.post(
+          `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks`,
+          body,
+          { headers: getDdHeaders(ctx) }
+        );
+        return {
+          name: response.data?.name ?? input.name,
+          url: response.data?.url ?? input.url,
+          raw: response.data,
+        };
+      },
+    },
+
+    getWebhook: {
+      isTool: true,
+      description: 'Fetch a Datadog webhook integration by name to verify registration.',
+      input: WebhookNameInputSchema,
+      handler: async (ctx, input: WebhookNameInput) => {
+        const response = await ctx.client.get(
+          `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks/${encodeURIComponent(
+            input.name
+          )}`,
+          { headers: getDdHeaders(ctx) }
+        );
+        return response.data;
+      },
+    },
+
+    deleteWebhook: {
+      isTool: true,
+      description: 'Delete a Datadog webhook integration by name.',
+      input: WebhookNameInputSchema,
+      handler: async (ctx, input: WebhookNameInput) => {
+        await ctx.client.delete(
+          `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks/${encodeURIComponent(
+            input.name
+          )}`,
+          { headers: getDdHeaders(ctx) }
+        );
+        return { deleted: true, name: input.name };
+      },
+    },
+
+    muteMonitor: {
+      isTool: true,
+      description:
+        'Mute a Datadog monitor (optionally for a scope / until an end time). Use after listing monitors to get an ID.',
+      input: MuteMonitorInputSchema,
+      handler: async (ctx, input: MuteMonitorInput) => {
+        const body: Record<string, unknown> = {};
+        if (input.scope) body.scope = input.scope;
+        if (input.end !== undefined) body.end = input.end;
+        const response = await ctx.client.post(
+          `${getBaseUrl(ctx)}/api/v1/monitor/${input.monitorId}/mute`,
+          body,
+          { headers: getDdHeaders(ctx) }
+        );
+        return {
+          id: response.data?.id ?? input.monitorId,
+          overallState: response.data?.overall_state,
+          matchingDowntimes: response.data?.matching_downtimes,
+          raw: response.data,
+        };
+      },
+    },
+
+    unmuteMonitor: {
+      isTool: true,
+      description: 'Unmute a previously muted Datadog monitor.',
+      input: UnmuteMonitorInputSchema,
+      handler: async (ctx, input: UnmuteMonitorInput) => {
+        const response = await ctx.client.post(
+          `${getBaseUrl(ctx)}/api/v1/monitor/${input.monitorId}/unmute`,
+          {},
+          { headers: getDdHeaders(ctx) }
+        );
+        return {
+          id: response.data?.id ?? input.monitorId,
+          overallState: response.data?.overall_state,
+          raw: response.data,
+        };
+      },
+    },
+
+    getMonitor: {
+      isTool: true,
+      description: 'Get a Datadog monitor by ID, including matching downtimes.',
+      input: GetMonitorInputSchema,
+      handler: async (ctx, input: GetMonitorInput) => {
+        const response = await ctx.client.get(
+          `${getBaseUrl(ctx)}/api/v1/monitor/${input.monitorId}`,
+          {
+            headers: getDdHeaders(ctx),
+            params: { with_downtimes: true },
+          }
+        );
+        return {
+          id: response.data.id,
+          name: response.data.name,
+          type: response.data.type,
+          query: response.data.query,
+          overallState: response.data.overall_state,
+          tags: response.data.tags,
+          matchingDowntimes: response.data.matching_downtimes,
+          raw: response.data,
+        };
+      },
+    },
+
+    listMonitors: {
+      isTool: true,
+      description:
+        'List Datadog monitors with optional name/tags/state filters. Use to find IDs before mute/unmute.',
+      input: ListMonitorsInputSchema,
+      handler: async (ctx, input: ListMonitorsInput) => {
+        const response = await ctx.client.get(`${getBaseUrl(ctx)}/api/v1/monitor`, {
+          headers: getDdHeaders(ctx),
+          params: {
+            name: input.name,
+            tags: input.tags,
+            group_states: input.groupStates,
+            page: input.page ?? 0,
+            page_size: input.pageSize ?? 100,
+          },
+        });
+        const monitors = Array.isArray(response.data) ? response.data : [];
+        return {
+          count: monitors.length,
+          monitors: monitors.map((m: Record<string, unknown>) => ({
+            id: m.id,
+            name: m.name,
+            overallState: m.overall_state,
+            tags: m.tags,
+            type: m.type,
+          })),
+        };
+      },
+    },
+  },
+
+  test: {
+    description: i18n.translate('connectorSpecs.datadog.test.description', {
+      defaultMessage: 'Validates Datadog API Key and Application Key',
+    }),
+    handler: async (ctx) => {
+      const headers = getDdHeaders(ctx);
+      const base = getBaseUrl(ctx);
+      // Validate API key
+      await ctx.client.get(`${base}/api/v1/validate`, { headers });
+      // Validate application key (requires app key on monitor list)
+      await ctx.client.get(`${base}/api/v1/monitor`, {
+        headers,
+        params: { page_size: 1 },
+      });
+      return {
+        ok: true,
+        message: `Successfully connected to Datadog API (${getSite(ctx)})`,
+        site: getSite(ctx),
+      };
+    },
+  },
+};

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
@@ -290,6 +290,7 @@ export const DatadogConnector: ConnectorSpec = {
   },
 
   test: {
+    enabled: true,
     description: i18n.translate('connectorSpecs.datadog.test.description', {
       defaultMessage: 'Validates the Datadog access token (PAT or SAT)',
     }),

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
@@ -26,10 +26,12 @@ import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ActionContext, ConnectorSpec } from '../../connector_spec';
 import {
+  DATADOG_SITES,
   GetMonitorInputSchema,
   ListMonitorsInputSchema,
   MuteMonitorInputSchema,
   UnmuteMonitorInputSchema,
+  type DatadogSite,
   type GetMonitorInput,
   type ListMonitorsInput,
   type MuteMonitorInput,
@@ -37,12 +39,16 @@ import {
 } from './types';
 
 interface DatadogConfig {
-  site?: string;
+  site?: DatadogSite | string;
 }
 
-function getSite(ctx: ActionContext): string {
+/** Exported for unit tests — builds `https://api.${site}` from connector config. */
+export function getSite(ctx: ActionContext): DatadogSite {
   const site = (ctx.config as DatadogConfig | undefined)?.site?.trim();
-  return site && site.length > 0 ? site : 'datadoghq.com';
+  if (site && (DATADOG_SITES as readonly string[]).includes(site)) {
+    return site as DatadogSite;
+  }
+  return 'datadoghq.com';
 }
 
 function getBaseUrl(ctx: ActionContext): string {
@@ -97,19 +103,19 @@ export const DatadogConnector: ConnectorSpec = {
   schema: lazySchema(() =>
     z.object({
       site: z
-        .string()
+        .enum(DATADOG_SITES)
         .default('datadoghq.com')
-        .describe('Datadog site hostname (e.g. datadoghq.com, datadoghq.eu)')
+        .describe('Datadog site (API hostname suffix). US1: datadoghq.com, EU: datadoghq.eu')
         .meta({
-          widget: 'text',
+          // z.enum defaults to select in response-ops-form-generator; set explicitly for clarity.
+          widget: 'select',
           label: i18n.translate('connectorSpecs.datadog.config.site.label', {
             defaultMessage: 'Datadog site',
           }),
           helpText: i18n.translate('connectorSpecs.datadog.config.site.helpText', {
             defaultMessage:
-              'Site hostname without scheme. US1: datadoghq.com, EU: datadoghq.eu, US3: us3.datadoghq.com',
+              'Select your Datadog site. Values are API host suffixes (api.<site>) — not the app.* labels from Datadog’s docs.',
           }),
-          placeholder: 'datadoghq.com',
         }),
     })
   ),
@@ -154,12 +160,15 @@ export const DatadogConnector: ConnectorSpec = {
 
     unmuteMonitor: {
       isTool: true,
-      description: 'Unmute a previously muted Datadog monitor.',
+      description:
+        'Unmute a previously muted Datadog monitor. Pass the same scope used when muting (e.g. "host:web01"); omit scope to unmute the global * scope.',
       input: UnmuteMonitorInputSchema,
       handler: async (ctx, input: UnmuteMonitorInput) => {
+        const body: Record<string, unknown> = {};
+        if (input.scope) body.scope = input.scope;
         const response = await ctx.client.post(
           `${getBaseUrl(ctx)}/api/v1/monitor/${input.monitorId}/unmute`,
-          {}
+          body
         );
         return {
           id: response.data?.id ?? input.monitorId,

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/datadog.ts
@@ -11,10 +11,10 @@
  * Datadog connector (`.datadog`)
  *
  * General Datadog integration for Workflows / Agent Builder.
- * First action group covers monitors + webhook registration; additional
- * Datadog API domains (downtimes, events, hosts, metrics, incidents) should
- * be added as actions on this same connector — do not create `.datadog_*`
- * variants for each domain.
+ * First action group covers monitor discovery and mute/unmute write-back;
+ * additional Datadog API domains (webhooks, downtimes, events, hosts,
+ * metrics, incidents) should be added as actions on this same connector —
+ * do not create `.datadog_*` variants for each domain.
  *
  * Auth: Datadog Personal Access Token (PAT) or Service Access Token (SAT)
  * via native `bearer` (`Authorization: Bearer <token>`). Prefer SAT for
@@ -26,19 +26,14 @@ import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ActionContext, ConnectorSpec } from '../../connector_spec';
 import {
-  DATADOG_WEBHOOK_PAYLOAD_TEMPLATE,
   GetMonitorInputSchema,
   ListMonitorsInputSchema,
   MuteMonitorInputSchema,
-  RegisterWebhookInputSchema,
   UnmuteMonitorInputSchema,
-  WebhookNameInputSchema,
   type GetMonitorInput,
   type ListMonitorsInput,
   type MuteMonitorInput,
-  type RegisterWebhookInput,
   type UnmuteMonitorInput,
-  type WebhookNameInput,
 } from './types';
 
 interface DatadogConfig {
@@ -60,7 +55,7 @@ export const DatadogConnector: ConnectorSpec = {
     displayName: 'Datadog',
     description: i18n.translate('connectorSpecs.datadog.metadata.description', {
       defaultMessage:
-        'Manage Datadog monitors and webhooks; extensible for downtimes, events, hosts, metrics, and incidents',
+        'Manage Datadog monitors (list, get, mute, unmute); extensible for downtimes, events, hosts, metrics, and incidents',
     }),
     // gold matches classic stack action peers (.pagerduty, .webhook) and
     // threat-intel-ish specs (e.g. .virustotal); not a final packaging call.
@@ -124,78 +119,17 @@ export const DatadogConnector: ConnectorSpec = {
     '',
     'General Datadog integration. Auth with a Personal Access Token (PAT) or',
     'Service Access Token (SAT) as Bearer — prefer SAT for automation.',
-    'Alerting actions use Monitors + Webhooks Integration APIs;',
-    'additional domains (downtimes, events, hosts, metrics, incidents) belong on this same connector.',
+    'Current actions cover monitor discovery and mute/unmute write-back;',
+    'additional domains (webhooks, downtimes, events, hosts, metrics, incidents)',
+    'belong on this same connector.',
     '',
-    '### Alerting setup',
-    '1. Call `registerWebhook` with a Kibana inbound URL (placeholder OK while inbound is WIP).',
-    '2. In Datadog, add `@webhook-{name}` to monitor notification messages.',
-    '3. Use `listMonitors` / `getMonitor` to find monitor IDs, then `muteMonitor` / `unmuteMonitor` for write-back.',
-    '',
-    '### Fingerprint notes (alerting)',
-    'Webhook payload includes monitor_id ($ALERT_ID) and groups ($ALERT_SCOPE) — Keep-aligned series identity.',
+    '### Monitors',
+    '1. Use `listMonitors` / `getMonitor` to find monitor IDs.',
+    '2. Use `muteMonitor` / `unmuteMonitor` for write-back (silence).',
+    '3. For monitors currently alerting, filter with `groupStates: "alert"`.',
   ].join('\n'),
 
   actions: {
-    // --- Monitors & webhooks (alerting) ------------------------------------
-    registerWebhook: {
-      isTool: true,
-      description:
-        'Create a Datadog webhook integration that POSTs monitor notifications to a URL. ' +
-        'Returns the created webhook name. Monitors must mention @webhook-{name} to fire it.',
-      input: RegisterWebhookInputSchema,
-      handler: async (ctx, input: RegisterWebhookInput) => {
-        const body: Record<string, string> = {
-          name: input.name,
-          url: input.url,
-          payload: DATADOG_WEBHOOK_PAYLOAD_TEMPLATE,
-        };
-        if (input.customAuthHeader) {
-          body.custom_headers = JSON.stringify({
-            Authorization: `Bearer ${input.customAuthHeader}`,
-          });
-        }
-        // Bearer auth is applied by the auth type on ctx.client defaults.
-        const response = await ctx.client.post(
-          `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks`,
-          body
-        );
-        return {
-          name: response.data?.name ?? input.name,
-          url: response.data?.url ?? input.url,
-          raw: response.data,
-        };
-      },
-    },
-
-    getWebhook: {
-      isTool: true,
-      description: 'Fetch a Datadog webhook integration by name to verify registration.',
-      input: WebhookNameInputSchema,
-      handler: async (ctx, input: WebhookNameInput) => {
-        const response = await ctx.client.get(
-          `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks/${encodeURIComponent(
-            input.name
-          )}`
-        );
-        return response.data;
-      },
-    },
-
-    deleteWebhook: {
-      isTool: true,
-      description: 'Delete a Datadog webhook integration by name.',
-      input: WebhookNameInputSchema,
-      handler: async (ctx, input: WebhookNameInput) => {
-        await ctx.client.delete(
-          `${getBaseUrl(ctx)}/api/v1/integration/webhooks/configuration/webhooks/${encodeURIComponent(
-            input.name
-          )}`
-        );
-        return { deleted: true, name: input.name };
-      },
-    },
-
     muteMonitor: {
       isTool: true,
       description:

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/icon/index.tsx
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/icon/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiIcon } from '@elastic/eui';
+import type { ConnectorIconProps } from '../../../types';
+
+/** Placeholder brand mark until a Datadog asset is added. */
+export default (props: ConnectorIconProps) => {
+  return <EuiIcon type="logoObservability" {...props} />;
+};

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/types.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z, lazySchema } from '@kbn/zod/v4';
+
+export const RegisterWebhookInputSchema = lazySchema(() =>
+  z.object({
+    name: z
+      .string()
+      .min(1)
+      .describe(
+        'Webhook name in Datadog. Monitors notify it as @webhook-{name}. Example: "kibana-external-alerts"'
+      ),
+    url: z
+      .string()
+      .url()
+      .describe(
+        'Destination URL Datadog will POST to. For now a placeholder is fine (e.g. https://example.com/kibana/inbound/datadog).'
+      ),
+    customAuthHeader: z
+      .string()
+      .optional()
+      .describe(
+        'Optional Bearer token value sent as Authorization header on webhook POSTs. Leave empty to skip.'
+      ),
+  })
+);
+
+export const WebhookNameInputSchema = lazySchema(() =>
+  z.object({
+    name: z.string().min(1).describe('Datadog webhook integration name'),
+  })
+);
+
+export const MuteMonitorInputSchema = lazySchema(() =>
+  z.object({
+    monitorId: z
+      .number()
+      .int()
+      .positive()
+      .describe('Datadog monitor ID to mute. Example: 309422658'),
+    scope: z
+      .string()
+      .optional()
+      .describe('Optional scope to mute (e.g. "host:web01"). Omit to mute all scopes.'),
+    end: z
+      .number()
+      .int()
+      .optional()
+      .describe('Optional mute end time as Unix epoch seconds. Omit for indefinite mute.'),
+  })
+);
+
+export const UnmuteMonitorInputSchema = lazySchema(() =>
+  z.object({
+    monitorId: z.number().int().positive().describe('Datadog monitor ID to unmute'),
+  })
+);
+
+export const GetMonitorInputSchema = lazySchema(() =>
+  z.object({
+    monitorId: z.number().int().positive().describe('Datadog monitor ID'),
+  })
+);
+
+export const ListMonitorsInputSchema = lazySchema(() =>
+  z.object({
+    name: z.string().optional().describe('Filter monitors by name substring'),
+    tags: z
+      .string()
+      .optional()
+      .describe('Comma-separated tags filter, e.g. "env:demo,monitoring-tier:datadog"'),
+    groupStates: z
+      .string()
+      .optional()
+      .describe('Comma-separated group states, e.g. "alert,warn". Example: "alert"'),
+    page: z.number().int().min(0).optional().describe('Page number (0-based). Defaults to 0.'),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe('Results per page (1–1000). Defaults to 100.'),
+  })
+);
+
+export type RegisterWebhookInput = z.infer<typeof RegisterWebhookInputSchema>;
+export type WebhookNameInput = z.infer<typeof WebhookNameInputSchema>;
+export type MuteMonitorInput = z.infer<typeof MuteMonitorInputSchema>;
+export type UnmuteMonitorInput = z.infer<typeof UnmuteMonitorInputSchema>;
+export type GetMonitorInput = z.infer<typeof GetMonitorInputSchema>;
+export type ListMonitorsInput = z.infer<typeof ListMonitorsInputSchema>;
+
+/** Payload template registered on Datadog webhooks — Keep-aligned fingerprint fields. */
+export const DATADOG_WEBHOOK_PAYLOAD_TEMPLATE =
+  '{ "monitor_id": "$ALERT_ID", "groups": "$ALERT_SCOPE", "title": "$ALERT_TITLE", "transition": "$ALERT_TRANSITION", "priority": "$ALERT_PRIORITY", "tags": "$TAGS", "link": "$LINK", "date": "$DATE", "org_id": "$ORG_ID" }';

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/types.ts
@@ -9,35 +9,6 @@
 
 import { z, lazySchema } from '@kbn/zod/v4';
 
-export const RegisterWebhookInputSchema = lazySchema(() =>
-  z.object({
-    name: z
-      .string()
-      .min(1)
-      .describe(
-        'Webhook name in Datadog. Monitors notify it as @webhook-{name}. Example: "kibana-external-alerts"'
-      ),
-    url: z
-      .string()
-      .url()
-      .describe(
-        'Destination URL Datadog will POST to. For now a placeholder is fine (e.g. https://example.com/kibana/inbound/datadog).'
-      ),
-    customAuthHeader: z
-      .string()
-      .optional()
-      .describe(
-        'Optional Bearer token value sent as Authorization header on webhook POSTs. Leave empty to skip.'
-      ),
-  })
-);
-
-export const WebhookNameInputSchema = lazySchema(() =>
-  z.object({
-    name: z.string().min(1).describe('Datadog webhook integration name'),
-  })
-);
-
 export const MuteMonitorInputSchema = lazySchema(() =>
   z.object({
     monitorId: z
@@ -91,13 +62,7 @@ export const ListMonitorsInputSchema = lazySchema(() =>
   })
 );
 
-export type RegisterWebhookInput = z.infer<typeof RegisterWebhookInputSchema>;
-export type WebhookNameInput = z.infer<typeof WebhookNameInputSchema>;
 export type MuteMonitorInput = z.infer<typeof MuteMonitorInputSchema>;
 export type UnmuteMonitorInput = z.infer<typeof UnmuteMonitorInputSchema>;
 export type GetMonitorInput = z.infer<typeof GetMonitorInputSchema>;
 export type ListMonitorsInput = z.infer<typeof ListMonitorsInputSchema>;
-
-/** Payload template registered on Datadog webhooks — Keep-aligned fingerprint fields. */
-export const DATADOG_WEBHOOK_PAYLOAD_TEMPLATE =
-  '{ "monitor_id": "$ALERT_ID", "groups": "$ALERT_SCOPE", "title": "$ALERT_TITLE", "transition": "$ALERT_TRANSITION", "priority": "$ALERT_PRIORITY", "tags": "$TAGS", "link": "$LINK", "date": "$DATE", "org_id": "$ORG_ID" }';

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/datadog/types.ts
@@ -9,6 +9,25 @@
 
 import { z, lazySchema } from '@kbn/zod/v4';
 
+/**
+ * Hostname suffixes for `https://api.${site}`.
+ * Values match Datadog API hosts — not the `app.*` labels shown in their docs UI.
+ * @see https://docs.datadoghq.com/getting_started/site/
+ */
+export const DATADOG_SITES = [
+  'datadoghq.com', // US1
+  'us3.datadoghq.com', // US3
+  'us5.datadoghq.com', // US5
+  'datadoghq.eu', // EU
+  'ap1.datadoghq.com', // AP1
+  'ap2.datadoghq.com', // AP2
+  'uk1.datadoghq.com', // UK1
+  'ddog-gov.com', // US1-FED
+  'us2.ddog-gov.com', // US2-FED
+] as const;
+
+export type DatadogSite = (typeof DATADOG_SITES)[number];
+
 export const MuteMonitorInputSchema = lazySchema(() =>
   z.object({
     monitorId: z
@@ -31,6 +50,12 @@ export const MuteMonitorInputSchema = lazySchema(() =>
 export const UnmuteMonitorInputSchema = lazySchema(() =>
   z.object({
     monitorId: z.number().int().positive().describe('Datadog monitor ID to unmute'),
+    scope: z
+      .string()
+      .optional()
+      .describe(
+        'Optional scope to unmute (e.g. "host:web01"). Use the same scope that was muted. Omit to unmute the global * scope.'
+      ),
   })
 );
 


### PR DESCRIPTION
## Summary

Adds a general v2 **Datadog** connector (`.datadog`) for Workflows and Agent Builder.

This is intentionally **one connector**, not a Datadog-alerts-only type. Additional Datadog API domains should land as more actions on `.datadog`.

### Included now (outbound monitors)

- `listMonitors` / `getMonitor`
- `muteMonitor` / `unmuteMonitor`
- Connection `test`

Webhook registration (`registerWebhook` / get / delete) is **deferred** until Create Alert ingest is available — then it can land as a small follow-up on this same connector.

### Auth / config

**Bearer only — Datadog Personal Access Token (PAT) or Service Access Token (SAT).**

- Native connector-spec `bearer` → `Authorization: Bearer <token>`
- Prefer a **Service Access Token** (`ddsat_…`) for automation (Organization Settings → Service Accounts; optional never-expire TTL)
- PAT (`ddpat_…`) also works; PATs always expire (24h–1y), so they’re a weaker fit for long-lived connectors
- **Classic API key + application key dual-header auth is not supported**

Also:

- `site` config (default `datadoghq.com`)
- `minimumLicense: gold` — precedent from classic stack actions (`.pagerduty`, `.webhook`) and specs like `.virustotal`; not a final packaging call
- `supportedFeatureIds: ['workflows', 'agentBuilder']` only — not `alerting` (spec connectors have no v1 rule-action params UI)

### Planned follow-ons (same connector)

1. **Webhooks** — register / get / delete for Datadog → Kibana ingest
2. **Downtimes** — list / schedule / cancel (`/api/v2/downtime`)
3. **Hosts + events + metrics query** — enrichment / investigation
4. **Incidents** (optional)

Tracking: https://github.com/elastic/rna-program/issues/766

Supersedes closed draft #281599.

## Test plan

- [ ] `datadog.test.ts` passes
- [ ] Create connector type appears as **Datadog** (`.datadog`) in Stack Management → Connectors
- [ ] Auth form asks for a single access token (PAT/SAT), not API key + app key
- [ ] Test connection succeeds with a real SAT (preferred) or PAT that has monitors scopes
- [ ] `listMonitors` / `getMonitor` / mute / unmute work via `_execute` or harness
