### PR TITLE
[Discover] POC: Allow sorting column order via drag and drop in the sidebar

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_grouped/field_list_grouped.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_grouped/field_list_grouped.tsx
@@ -55,6 +55,7 @@ export interface FieldListGroupedProps<T extends FieldListItem> {
   screenReaderDescriptionId?: string;
   localStorageKeyPrefix?: string; // Your app name: "discover", "lens", etc. If not provided, sections state would not be persisted.
   muteScreenReader?: boolean; // Changes aria-live from "polite" to "off" - it's useful when the numbers change due to something not directly related to the field list and we want to avoid announcing it.
+  reorderableGroupNames?: FieldsGroupNames[]; // Groups which support reordering their items via drag and drop
   'data-test-subj'?: string;
 }
 
@@ -67,6 +68,7 @@ function InnerFieldListGrouped<T extends FieldListItem = DataViewField>({
   screenReaderDescriptionId,
   muteScreenReader,
   localStorageKeyPrefix,
+  reorderableGroupNames,
   'data-test-subj': dataTestSubject = 'fieldListGrouped',
 }: FieldListGroupedProps<T>) {
   const styles = useMemoCss(componentStyles);
@@ -321,6 +323,7 @@ function InnerFieldListGrouped<T extends FieldListItem = DataViewField>({
                   paginatedFields={paginatedFields[key]}
                   groupIndex={index + 1}
                   groupName={key as FieldsGroupNames}
+                  isReorderable={reorderableGroupNames?.includes(key as FieldsGroupNames)}
                   onToggle={(open) => {
                     setAccordionState((s) => ({
                       ...s,

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_grouped/fields_accordion.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_grouped/fields_accordion.test.tsx
@@ -142,4 +142,19 @@ describe('UnifiedFieldList <FieldsAccordion />', () => {
       expect(screen.getByTestId('extra-action')).toBeVisible();
     });
   });
+
+  describe('when the group is reorderable', () => {
+    it('should wrap the field items in a reorder provider', () => {
+      setup({ isReorderable: true });
+
+      expect(screen.getByTestId('domDragDrop-reorderableGroup')).toBeInTheDocument();
+      expect(screen.getByText(dataView.fields[0].name)).toBeVisible();
+    });
+
+    it('should not render a reorder provider otherwise', () => {
+      setup({ isReorderable: false });
+
+      expect(screen.queryByTestId('domDragDrop-reorderableGroup')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_grouped/fields_accordion.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_grouped/fields_accordion.tsx
@@ -21,6 +21,7 @@ import {
 } from '@elastic/eui';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { type DataViewField } from '@kbn/data-views-plugin/common';
+import { ReorderProvider } from '@kbn/dom-drag-drop';
 import type { FieldsGroupNames } from '../../types';
 import { type FieldListItem, type RenderFieldItemParams } from '../../types';
 
@@ -44,6 +45,7 @@ export interface FieldsAccordionProps<T extends FieldListItem> {
   extraAction: React.ReactNode;
   showExistenceFetchError?: boolean;
   showExistenceFetchTimeout?: boolean;
+  isReorderable?: boolean;
 }
 
 function InnerFieldsAccordion<T extends FieldListItem = DataViewField>({
@@ -66,6 +68,7 @@ function InnerFieldsAccordion<T extends FieldListItem = DataViewField>({
   showExistenceFetchError,
   showExistenceFetchTimeout,
   extraAction,
+  isReorderable,
 }: FieldsAccordionProps<T>) {
   const styles = useMemoCss(componentStyles);
 
@@ -158,21 +161,24 @@ function InnerFieldsAccordion<T extends FieldListItem = DataViewField>({
         (!!fieldsCount ? (
           <>
             {extraAction}
-            <ul>
-              {paginatedFields &&
-                paginatedFields.map((field, index) => (
-                  <Fragment key={getFieldKey(field)}>
-                    {renderFieldItem({
-                      field,
-                      itemIndex: index,
-                      groupIndex,
-                      groupName,
-                      hideDetails,
-                      fieldSearchHighlight,
-                    })}
-                  </Fragment>
-                ))}
-            </ul>
+            {renderList(
+              <ul>
+                {paginatedFields &&
+                  paginatedFields.map((field, index) => (
+                    <Fragment key={getFieldKey(field)}>
+                      {renderFieldItem({
+                        field,
+                        itemIndex: index,
+                        groupIndex,
+                        groupName,
+                        hideDetails,
+                        fieldSearchHighlight,
+                      })}
+                    </Fragment>
+                  ))}
+              </ul>,
+              isReorderable
+            )}
           </>
         ) : (
           renderCallout()
@@ -180,6 +186,9 @@ function InnerFieldsAccordion<T extends FieldListItem = DataViewField>({
     </EuiAccordion>
   );
 }
+
+const renderList = (list: JSX.Element, isReorderable?: boolean): JSX.Element =>
+  isReorderable ? <ReorderProvider>{list}</ReorderProvider> : list;
 
 export const FieldsAccordion = React.memo(InnerFieldsAccordion) as typeof InnerFieldsAccordion;
 

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item.test.tsx
@@ -15,8 +15,9 @@ import { DataViewField } from '@kbn/data-views-plugin/public';
 import { EuiThemeProvider } from '@elastic/eui';
 import { getServicesMock } from '../../../__mocks__/services.mock';
 import { renderWithKibanaRenderContext } from '@kbn/test-jest-helpers';
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { stubDataView } from '@kbn/data-views-plugin/common/data_view.stub';
+import { ReorderProvider, RootDragDropProvider } from '@kbn/dom-drag-drop';
 import { UnifiedFieldListItem } from './field_list_item';
 
 jest.mock('../../services/field_stats', () => ({
@@ -101,6 +102,89 @@ const renderComponent = async ({
 
   return { field: finalField, props, user };
 };
+
+const renderReorderableList = ({
+  extraFieldWithoutGroup = false,
+}: {
+  extraFieldWithoutGroup?: boolean;
+} = {}) => {
+  const fields = ['bytes', 'extension', 'machine.os.raw'].map(
+    (name) =>
+      new DataViewField({
+        aggregatable: true,
+        esTypes: ['keyword'],
+        name,
+        searchable: true,
+        type: 'string',
+      })
+  );
+  const extraField = new DataViewField({
+    aggregatable: true,
+    esTypes: ['keyword'],
+    name: 'clientip',
+    searchable: true,
+    type: 'string',
+  });
+  const reorderableGroup = fields.map((field) => ({ id: field.name }));
+  const onReorderField = jest.fn();
+
+  const dataView = stubDataView;
+  dataView.toSpec = () => ({});
+
+  const stateService = createStateService({
+    options: {
+      originatingApp: 'test',
+    },
+  });
+
+  const commonProps: Omit<UnifiedFieldListItemProps, 'field' | 'itemIndex' | 'isSelected'> = {
+    dataView: stubDataView,
+    groupIndex: 1,
+    isEmpty: false,
+    onAddFieldToWorkspace: jest.fn(),
+    onRemoveFieldFromWorkspace: jest.fn(),
+    searchMode: 'documents',
+    services: getServicesMock(),
+    size: 'xs',
+    stateService,
+    workspaceSelectedFieldNames: fields.map((field) => field.name),
+  };
+
+  renderWithKibanaRenderContext(
+    <EuiThemeProvider>
+      <RootDragDropProvider>
+        <ReorderProvider>
+          {fields.map((field, itemIndex) => (
+            <UnifiedFieldListItem
+              key={field.name}
+              {...commonProps}
+              field={field}
+              itemIndex={itemIndex}
+              isSelected
+              reorderableGroup={reorderableGroup}
+              onReorderField={onReorderField}
+            />
+          ))}
+        </ReorderProvider>
+        {extraFieldWithoutGroup && (
+          <UnifiedFieldListItem
+            {...commonProps}
+            field={extraField}
+            itemIndex={0}
+            isSelected={false}
+          />
+        )}
+      </RootDragDropProvider>
+    </EuiThemeProvider>
+  );
+
+  return { fields, onReorderField };
+};
+
+const mockDataTransfer = () => ({
+  getData: jest.fn(() => ''),
+  setData: jest.fn(),
+});
 
 describe('UnifiedFieldListItem', () => {
   it('should allow selecting fields', async () => {
@@ -278,5 +362,80 @@ describe('UnifiedFieldListItem', () => {
     expect(
       screen.queryByRole('button', { name: 'Add "extension.keyword" field' })
     ).not.toBeInTheDocument();
+  });
+
+  describe('reordering', () => {
+    it('should invoke onReorderField when dropping a dragged field onto another field of the group', async () => {
+      const { onReorderField } = renderReorderableList();
+
+      // without an active drag, no reorder drop targets should be rendered
+      expect(
+        screen.queryByTestId('unifiedFieldListItemDnD-reorderTarget-extension')
+      ).not.toBeInTheDocument();
+
+      fireEvent.dragStart(screen.getByTestId('unifiedFieldListItemDnD-bytes'), {
+        dataTransfer: mockDataTransfer(),
+      });
+
+      // drop targets appear once a member of the group is being dragged
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('unifiedFieldListItemDnD-reorderTarget-machine.os.raw')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.drop(
+        within(screen.getByTestId('unifiedFieldListItemDnD-machine.os.raw')).getByTestId(
+          'domDragDrop-reorderableDropLayer'
+        ),
+        { dataTransfer: mockDataTransfer() }
+      );
+
+      expect(onReorderField).toHaveBeenCalledTimes(1);
+      expect(onReorderField).toHaveBeenCalledWith('bytes', 'machine.os.raw');
+    });
+
+    it('should not offer a reorder drop target on the dragged field itself', async () => {
+      renderReorderableList();
+
+      fireEvent.dragStart(screen.getByTestId('unifiedFieldListItemDnD-bytes'), {
+        dataTransfer: mockDataTransfer(),
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('unifiedFieldListItemDnD-reorderTarget-extension')
+        ).toBeInTheDocument();
+      });
+
+      // the dragged item itself must not render a drop layer to reorder onto
+      expect(
+        within(screen.getByTestId('unifiedFieldListItemDnD-bytes')).queryByTestId(
+          'domDragDrop-reorderableDropLayer'
+        )
+      ).not.toBeInTheDocument();
+      // while the other items of the group do
+      expect(screen.getAllByTestId('domDragDrop-reorderableDropLayer')).toHaveLength(2);
+    });
+
+    it('should not activate reorder drop targets when dragging a field from outside the group', async () => {
+      const { onReorderField } = renderReorderableList({ extraFieldWithoutGroup: true });
+
+      fireEvent.dragStart(screen.getByTestId('unifiedFieldListItemDnD-clientip'), {
+        dataTransfer: mockDataTransfer(),
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('unifiedFieldListItemDnD-clientip')).toHaveClass(
+          'domDraggable_active--copy'
+        );
+      });
+
+      expect(
+        screen.queryByTestId('unifiedFieldListItemDnD-reorderTarget-bytes')
+      ).not.toBeInTheDocument();
+      expect(screen.queryAllByTestId('domDragDrop-reorderableDropLayer')).toHaveLength(0);
+      expect(onReorderField).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item.tsx
@@ -417,7 +417,7 @@ function UnifiedFieldListItemComponent({
       isOpen={infoIsOpen}
       button={
         <Draggable
-          dragType="copy"
+          dragType={isReorderable ? 'move' : 'copy'}
           dragClassName="unifiedFieldListItemButton__dragging"
           order={order}
           value={value}

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item.tsx
@@ -12,7 +12,7 @@ import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { UiCounterMetricType } from '@kbn/analytics';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
-import { Draggable } from '@kbn/dom-drag-drop';
+import { Draggable, Droppable, useDragDropContext } from '@kbn/dom-drag-drop';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
 import type { Filter } from '@kbn/es-query';
 import { fieldSupportsBreakdown } from '@kbn/field-utils';
@@ -215,6 +215,15 @@ export interface UnifiedFieldListItemProps {
    * Optional stream name to fetch stream-specific field descriptions
    */
   streamNames?: string[];
+  /**
+   * Items of the same group ("Selected fields") which can be reordered via drag and drop.
+   * Enables reordering when it contains more than one item and `onReorderField` is provided.
+   */
+  reorderableGroup?: Array<{ id: string }>;
+  /**
+   * Callback to move the dragged field to the position of the target field within the workspace
+   */
+  onReorderField?: (sourceFieldName: string, targetFieldName: string) => void;
 }
 
 function UnifiedFieldListItemComponent({
@@ -241,8 +250,11 @@ function UnifiedFieldListItemComponent({
   size,
   additionalFilters,
   streamNames,
+  reorderableGroup,
+  onReorderField,
 }: UnifiedFieldListItemProps) {
   const [infoIsOpen, setOpen] = useState(false);
+  const [{ dragging }] = useDragDropContext();
 
   const isBreakdownSupported =
     searchMode === 'documents' ? fieldSupportsBreakdown(field) : isESQLFieldGroupable(field);
@@ -370,6 +382,35 @@ function UnifiedFieldListItemComponent({
   const order = useMemo(() => [0, groupIndex, itemIndex], [groupIndex, itemIndex]);
   const isDragDisabled =
     alwaysShowActionButton || stateService.creationOptions.disableFieldListItemDragAndDrop;
+  const isReorderable = Boolean(
+    onReorderField && reorderableGroup && reorderableGroup.length > 1 && !isDragDisabled
+  );
+  // only treat the items as drop targets while an item of the same group is being dragged
+  const isReorderDropTargetActive = Boolean(
+    isReorderable && dragging && reorderableGroup?.some((item) => item.id === dragging.id)
+  );
+  const dndDataTestSubjPrefix =
+    stateService.creationOptions.dataTestSubj?.fieldListItemDndDataTestSubjPrefix ??
+    'unifiedFieldListItemDnD';
+
+  const fieldItemButton = (
+    <FieldItemButton
+      fieldSearchHighlight={highlight}
+      isEmpty={isEmpty}
+      isActive={infoIsOpen}
+      withDragIcon={!isDragDisabled}
+      flush={alwaysShowActionButton ? 'both' : undefined}
+      shouldAlwaysShowAction={alwaysShowActionButton}
+      onClick={field.type !== '_source' ? togglePopover : undefined}
+      {...getCommonFieldItemButtonProps({
+        stateService,
+        field,
+        isSelected,
+        toggleDisplay,
+        size,
+      })}
+    />
+  );
 
   return (
     <FieldPopover
@@ -382,27 +423,24 @@ function UnifiedFieldListItemComponent({
           value={value}
           onDragStart={closePopover}
           isDisabled={isDragDisabled}
-          dataTestSubj={`${
-            stateService.creationOptions.dataTestSubj?.fieldListItemDndDataTestSubjPrefix ??
-            'unifiedFieldListItemDnD'
-          }-${field.name}`}
+          reorderableGroup={isReorderable ? reorderableGroup : undefined}
+          dataTestSubj={`${dndDataTestSubjPrefix}-${field.name}`}
         >
-          <FieldItemButton
-            fieldSearchHighlight={highlight}
-            isEmpty={isEmpty}
-            isActive={infoIsOpen}
-            withDragIcon={!isDragDisabled}
-            flush={alwaysShowActionButton ? 'both' : undefined}
-            shouldAlwaysShowAction={alwaysShowActionButton}
-            onClick={field.type !== '_source' ? togglePopover : undefined}
-            {...getCommonFieldItemButtonProps({
-              stateService,
-              field,
-              isSelected,
-              toggleDisplay,
-              size,
-            })}
-          />
+          {isReorderable && reorderableGroup && onReorderField ? (
+            <Droppable
+              order={order}
+              value={value}
+              isDisabled={!isReorderDropTargetActive}
+              dropTypes={dragging && dragging.id !== field.name ? ['reorder'] : []}
+              reorderableGroup={reorderableGroup}
+              onDrop={(source) => onReorderField(source.id, field.name)}
+              dataTestSubj={`${dndDataTestSubjPrefix}-reorderTarget-${field.name}`}
+            >
+              <div>{fieldItemButton}</div>
+            </Droppable>
+          ) : (
+            fieldItemButton
+          )}
         </Draggable>
       }
       closePopover={closePopover}

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar.tsx
@@ -35,6 +35,7 @@ import { useGroupedFields } from '../../hooks/use_grouped_fields';
 import { UnifiedFieldListItem, type UnifiedFieldListItemProps } from '../unified_field_list_item';
 import { SidebarToggleButton, type SidebarToggleButtonProps } from './sidebar_toggle_button';
 import {
+  getReorderTargetIndex,
   getSelectedFields,
   shouldShowField,
   type SelectedFieldsResult,
@@ -267,17 +268,32 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
 
   const onReorderSelectedField = useCallback(
     (sourceFieldName: string, targetFieldName: string) => {
-      if (!onMoveFieldInWorkspace || sourceFieldName === targetFieldName) {
+      if (!onMoveFieldInWorkspace) {
         return;
       }
-      const selectedFieldNames = selectedFieldsState.selectedFields.map((field) => field.name);
-      const targetIndex = selectedFieldNames.indexOf(targetFieldName);
-      if (targetIndex === -1 || !selectedFieldNames.includes(sourceFieldName)) {
-        return;
+      const targetIndex = getReorderTargetIndex({
+        selectedFieldNames: selectedFieldsState.selectedFields.map((field) => field.name),
+        sourceFieldName,
+        targetFieldName,
+      });
+      if (targetIndex > -1) {
+        // apply the new order to the local state right away, otherwise the dropped field
+        // would flicker back to its old position until the workspace state update
+        // (app state, URL sync) has completed its round trip back into this component
+        setSelectedFieldsState((prevState) => {
+          const selectedFields = [...prevState.selectedFields];
+          const sourceIndex = selectedFields.findIndex((field) => field.name === sourceFieldName);
+          if (sourceIndex === -1) {
+            return prevState;
+          }
+          const [movedField] = selectedFields.splice(sourceIndex, 1);
+          selectedFields.splice(targetIndex, 0, movedField);
+          return { ...prevState, selectedFields };
+        });
+        onMoveFieldInWorkspace(sourceFieldName, targetIndex);
       }
-      onMoveFieldInWorkspace(sourceFieldName, targetIndex);
     },
-    [onMoveFieldInWorkspace, selectedFieldsState.selectedFields]
+    [onMoveFieldInWorkspace, selectedFieldsState.selectedFields, setSelectedFieldsState]
   );
 
   useEffect(() => {

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar.tsx
@@ -82,6 +82,11 @@ export type UnifiedFieldListSidebarCustomizableProps = Pick<
    * Prop to pass additional field groups to the field list
    */
   additionalFieldGroups?: AdditionalFieldGroups;
+  /**
+   * Callback to move a selected field to another position within the workspace (table columns).
+   * When provided, the "Selected fields" section becomes reorderable via drag and drop.
+   */
+  onMoveFieldInWorkspace?: (fieldName: string, targetIndex: number) => void;
 };
 
 interface UnifiedFieldListSidebarInternalProps {
@@ -173,6 +178,7 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
   additionalFilters,
   additionalFieldGroups,
   streamNames,
+  onMoveFieldInWorkspace,
 }) => {
   const styles = useMemoCss(componentStyles);
 
@@ -241,6 +247,39 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
       additionalFieldGroups,
     });
 
+  // Reordering of the "Selected fields" section is only possible when all selected fields
+  // are visible, i.e. the list is not narrowed down by a field name search or type filter.
+  // Otherwise, the visible position of a field would not match its position in the workspace.
+  const selectedFieldsGroup = fieldListGroupedProps.fieldGroups[FieldsGroupNames.SelectedFields];
+  const isSelectedFieldsReorderable = Boolean(
+    onMoveFieldInWorkspace &&
+      selectedFieldsState.selectedFields.length > 1 &&
+      selectedFieldsGroup?.fields.length === selectedFieldsState.selectedFields.length
+  );
+
+  const reorderableSelectedFields = useMemo(
+    () =>
+      isSelectedFieldsReorderable
+        ? selectedFieldsState.selectedFields.map((field) => ({ id: field.name }))
+        : undefined,
+    [isSelectedFieldsReorderable, selectedFieldsState.selectedFields]
+  );
+
+  const onReorderSelectedField = useCallback(
+    (sourceFieldName: string, targetFieldName: string) => {
+      if (!onMoveFieldInWorkspace || sourceFieldName === targetFieldName) {
+        return;
+      }
+      const selectedFieldNames = selectedFieldsState.selectedFields.map((field) => field.name);
+      const targetIndex = selectedFieldNames.indexOf(targetFieldName);
+      if (targetIndex === -1 || !selectedFieldNames.includes(sourceFieldName)) {
+        return;
+      }
+      onMoveFieldInWorkspace(sourceFieldName, targetIndex);
+    },
+    [onMoveFieldInWorkspace, selectedFieldsState.selectedFields]
+  );
+
   useEffect(() => {
     if (
       searchMode !== 'documents' ||
@@ -262,7 +301,15 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
 
   const renderFieldItem: FieldListGroupedProps<DataViewField>['renderFieldItem'] = useCallback(
     ({ field, groupName, groupIndex, itemIndex, fieldSearchHighlight }) => (
-      <li key={`field${field.name}`} data-attr-field={field.name}>
+      <li
+        key={`field${field.name}`}
+        data-attr-field={field.name}
+        css={
+          groupName === FieldsGroupNames.SelectedFields && reorderableSelectedFields
+            ? styles.reorderableFieldItem
+            : undefined
+        }
+      >
         <UnifiedFieldListItem
           additionalFilters={additionalFilters}
           alwaysShowActionButton={alwaysShowActionButton}
@@ -290,6 +337,12 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
           trackUiMetric={trackUiMetric}
           workspaceSelectedFieldNames={workspaceSelectedFieldNames}
           streamNames={streamNames}
+          reorderableGroup={
+            groupName === FieldsGroupNames.SelectedFields ? reorderableSelectedFields : undefined
+          }
+          onReorderField={
+            groupName === FieldsGroupNames.SelectedFields ? onReorderSelectedField : undefined
+          }
         />
       </li>
     ),
@@ -312,6 +365,9 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
       selectedFieldsState.selectedFieldsMap,
       additionalFilters,
       streamNames,
+      reorderableSelectedFields,
+      onReorderSelectedField,
+      styles.reorderableFieldItem,
     ]
   );
 
@@ -415,6 +471,9 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
                 renderFieldItem={renderFieldItem}
                 localStorageKeyPrefix={stateService.creationOptions.localStorageKeyPrefix}
                 muteScreenReader={!isFieldNameSearchFocused}
+                reorderableGroupNames={
+                  isSelectedFieldsReorderable ? [FieldsGroupNames.SelectedFields] : undefined
+                }
               />
             ) : (
               <EuiFlexItem grow />
@@ -548,6 +607,10 @@ const componentStyles = {
   },
   sidebarGroup: css({
     height: '100%',
+  }),
+  // to properly contain the absolutely-positioned reorder drop target of an item
+  reorderableFieldItem: css({
+    position: 'relative',
   }),
   sidebarPrependedItem: ({ euiTheme }: UseEuiTheme) =>
     css({

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/group_fields.test.ts
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/group_fields.test.ts
@@ -9,7 +9,12 @@
 
 import { type DataViewField } from '@kbn/data-plugin/common';
 import { stubLogstashDataView as dataView } from '@kbn/data-views-plugin/common/data_view.stub';
-import { getSelectedFields, shouldShowField, INITIAL_SELECTED_FIELDS_RESULT } from './group_fields';
+import {
+  getReorderTargetIndex,
+  getSelectedFields,
+  shouldShowField,
+  INITIAL_SELECTED_FIELDS_RESULT,
+} from './group_fields';
 
 describe('group_fields', function () {
   it('should pick fields as unknown_selected if they are unknown', function () {
@@ -202,5 +207,81 @@ describe('group_fields', function () {
     expect(
       shouldShowField({ type: '_source', name: 'source' } as DataViewField, 'documents', true)
     ).toBe(false);
+  });
+
+  describe('getReorderTargetIndex', () => {
+    const selectedFieldNames = ['a', 'b', 'c', 'd'];
+
+    // mimics how the returned index is applied, e.g. by `onMoveColumn` of the unified data table
+    const moveField = (names: string[], sourceFieldName: string, targetIndex: number) => {
+      const nextNames = [...names];
+      nextNames.splice(nextNames.indexOf(sourceFieldName), 1);
+      nextNames.splice(targetIndex, 0, sourceFieldName);
+      return nextNames;
+    };
+
+    it('should place the dragged field right after the target when moving down', () => {
+      const targetIndex = getReorderTargetIndex({
+        selectedFieldNames,
+        sourceFieldName: 'a',
+        targetFieldName: 'c',
+      });
+      expect(targetIndex).toBe(2);
+      expect(moveField(selectedFieldNames, 'a', targetIndex)).toEqual(['b', 'c', 'a', 'd']);
+    });
+
+    it('should place the dragged field right before the target when moving up', () => {
+      const targetIndex = getReorderTargetIndex({
+        selectedFieldNames,
+        sourceFieldName: 'd',
+        targetFieldName: 'b',
+      });
+      expect(targetIndex).toBe(1);
+      expect(moveField(selectedFieldNames, 'd', targetIndex)).toEqual(['a', 'd', 'b', 'c']);
+    });
+
+    it('should support moving to the first and last position', () => {
+      const targetIndexFirst = getReorderTargetIndex({
+        selectedFieldNames,
+        sourceFieldName: 'c',
+        targetFieldName: 'a',
+      });
+      expect(targetIndexFirst).toBe(0);
+      expect(moveField(selectedFieldNames, 'c', targetIndexFirst)).toEqual(['c', 'a', 'b', 'd']);
+
+      const targetIndexLast = getReorderTargetIndex({
+        selectedFieldNames,
+        sourceFieldName: 'b',
+        targetFieldName: 'd',
+      });
+      expect(targetIndexLast).toBe(3);
+      expect(moveField(selectedFieldNames, 'b', targetIndexLast)).toEqual(['a', 'c', 'd', 'b']);
+    });
+
+    it('should return -1 when source and target are the same field', () => {
+      expect(
+        getReorderTargetIndex({ selectedFieldNames, sourceFieldName: 'b', targetFieldName: 'b' })
+      ).toBe(-1);
+    });
+
+    it('should return -1 when the source field is not selected', () => {
+      expect(
+        getReorderTargetIndex({
+          selectedFieldNames,
+          sourceFieldName: 'unknown',
+          targetFieldName: 'b',
+        })
+      ).toBe(-1);
+    });
+
+    it('should return -1 when the target field is not selected', () => {
+      expect(
+        getReorderTargetIndex({
+          selectedFieldNames,
+          sourceFieldName: 'b',
+          targetFieldName: 'unknown',
+        })
+      ).toBe(-1);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/group_fields.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/group_fields.tsx
@@ -46,6 +46,33 @@ export interface SelectedFieldsResult {
   selectedFieldsMap: Record<string, boolean>;
 }
 
+/**
+ * Resolves the target index for moving `sourceFieldName` to the position of `targetFieldName`
+ * when reordering the selected fields via drag and drop.
+ *
+ * The returned index refers to the position of the target field in the current (pre-move)
+ * order and is meant to be applied with a "remove source, then insert at index" move action
+ * (like `onMoveColumn` of the unified data table). This way the dragged field takes over the
+ * visual slot of the target field — right after it when moving down, right before it when
+ * moving up — which matches the drop preview shown by `@kbn/dom-drag-drop` in both directions.
+ *
+ * Returns `-1` when reordering is not possible for the given field names.
+ */
+export function getReorderTargetIndex({
+  selectedFieldNames,
+  sourceFieldName,
+  targetFieldName,
+}: {
+  selectedFieldNames: string[];
+  sourceFieldName: string;
+  targetFieldName: string;
+}): number {
+  if (sourceFieldName === targetFieldName || !selectedFieldNames.includes(sourceFieldName)) {
+    return -1;
+  }
+  return selectedFieldNames.indexOf(targetFieldName);
+}
+
 export function getSelectedFields({
   dataView,
   workspaceSelectedFieldNames,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -163,6 +163,7 @@ export function DiscoverLayout() {
     columns: currentColumns,
     onAddColumn,
     onRemoveColumn,
+    onMoveColumn,
   } = useColumns({
     capabilities,
     defaultOrder: uiSettings.get(SORT_DEFAULT_ORDER_SETTING),
@@ -417,6 +418,7 @@ export function DiscoverLayout() {
                 onChangeDataView={onChangeDataView}
                 onDataViewCreated={onDataViewCreated}
                 onFieldEdited={onFieldEdited}
+                onMoveField={onMoveColumn}
                 onRemoveField={onRemoveColumnWithTracking}
                 selectedDataView={dataView}
                 sidebarToggleState$={sidebarToggleState$}

--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -130,6 +130,13 @@ export interface DiscoverSidebarResponsiveProps {
    */
   onRemoveField: (fieldName: string) => void;
   /**
+   * Callback to move a field column to another position in the table,
+   * enables reordering the selected fields in the sidebar
+   * @param fieldName
+   * @param targetIndex
+   */
+  onMoveField?: (fieldName: string, targetIndex: number) => void;
+  /**
    * Currently selected data view
    */
   selectedDataView?: DataView;
@@ -187,6 +194,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
     onChangeDataView,
     onAddField,
     onRemoveField,
+    onMoveField,
     sidebarToggleState$,
     additionalFilters,
   } = props;
@@ -447,6 +455,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
             onAddFieldToWorkspace={onAddFieldToWorkspace}
             onAddFilter={onAddFilter}
             onFieldEdited={onFieldEdited}
+            onMoveFieldInWorkspace={onMoveField}
             onRemoveFieldFromWorkspace={onRemoveFieldFromWorkspace}
             prependInFlyout={prependDataViewPickerForMobile}
             ref={initializeUnifiedFieldListSidebarContainerApi}


### PR DESCRIPTION
## Summary

POC for #68270 (Addresses #68270 — does not close it).

Allows sorting the table column order in Discover by dragging fields within the "Selected fields" section of the sidebar, as requested in the issue. Reordering works with mouse drag and drop as well as keyboard (Enter to pick up, arrow up/down to move, Enter to drop, with screen reader announcements), reusing the existing `@kbn/dom-drag-drop` reorder support that Lens and the event annotation listing already use.

### How it works

**`@kbn/unified-field-list`** (opt-in via a new optional prop, other consumers — Security Timeline, SLO — are unaffected):

- `UnifiedFieldListSidebar` gets a new optional `onMoveFieldInWorkspace(fieldName, targetIndex)` prop. When provided, the "Selected fields" group becomes reorderable.
- `UnifiedFieldListItem` passes `reorderableGroup` to its existing `Draggable` and wraps the field button in a `Droppable` with `dropTypes={['reorder']}`. The drop targets only activate while a member of the selected group is being dragged, so dragging unselected fields (e.g. onto the table) is visually and behaviorally unchanged.
- `FieldsAccordion` wraps the group's list in a `ReorderProvider`, which drives the reorder translate animation.
- Reordering is automatically disabled while a field name search or type filter narrows the selected fields list, because the visible position would not match the column position, and when fewer than 2 fields are selected.

**Discover:**

- `discover_layout.tsx` passes the already-existing (and so far barely used) `onMoveColumn` action from `useColumns` through `DiscoverSidebarResponsive` into the sidebar. Column order changes therefore go through the same app state path as the data grid's own header-based column reordering (URL sync, saved search dirty state, etc.).

### What's intentionally out of scope (POC)

- Reordering while the field list is filtered (disabled instead)
- Adoption by other `UnifiedFieldListSidebar` consumers (Security Timeline)
- New unit/functional test coverage and telemetry for the reorder interaction

### Testing done

- Type checks for `kbn-unified-field-list` and `discover` pass, ESLint clean, existing `field_list_grouped` unit tests pass.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- The new `Droppable` wrapper mounts only during an active drag of a selected field; if any consumer relies on the exact DOM structure of field list items during drags, test subjects are preserved but wrapper elements change (`domDroppable` containers appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
