### PR TITLE
[9.5] [Fleet] Hide var_group options unsupported by the scoped policy template (#281509)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/hooks.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/hooks.tsx
@@ -81,6 +81,12 @@ interface UseVarGroupSelectionsParams {
    * If not provided, only var_group_selections will be included in updates.
    */
   packagePolicy?: NewPackagePolicy;
+  /**
+   * Optional: options to hide per var group (e.g. options unsupported by the
+   * policy template the form is scoped to). Hidden options are excluded when
+   * computing default selections.
+   */
+  hideInVarGroupOptions?: Record<string, string[]>;
 }
 
 /**
@@ -94,22 +100,27 @@ export function useVarGroupSelections({
   isAgentlessEnabled,
   onSelectionsChange,
   packagePolicy,
+  hideInVarGroupOptions,
 }: UseVarGroupSelectionsParams) {
   // Derive current selections from saved or compute defaults
   const selections = useMemo((): VarGroupSelection => {
     if (savedSelections) return savedSelections;
-    return computeDefaultVarGroupSelections(varGroups, isAgentlessEnabled);
-  }, [savedSelections, varGroups, isAgentlessEnabled]);
+    return computeDefaultVarGroupSelections(varGroups, isAgentlessEnabled, hideInVarGroupOptions);
+  }, [savedSelections, varGroups, isAgentlessEnabled, hideInVarGroupOptions]);
 
   // Initialize with defaults on mount if not already set
   useEffect(() => {
     if (varGroups && varGroups.length > 0 && !savedSelections) {
-      const defaults = computeDefaultVarGroupSelections(varGroups, isAgentlessEnabled);
+      const defaults = computeDefaultVarGroupSelections(
+        varGroups,
+        isAgentlessEnabled,
+        hideInVarGroupOptions
+      );
       if (Object.keys(defaults).length > 0) {
         onSelectionsChange({ var_group_selections: defaults });
       }
     }
-  }, [varGroups, isAgentlessEnabled, savedSelections, onSelectionsChange]);
+  }, [varGroups, isAgentlessEnabled, savedSelections, onSelectionsChange, hideInVarGroupOptions]);
 
   // Handle selection change with policy effects computation
   const handleSelectionChange = useCallback(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
@@ -87,6 +87,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
   onNamespaceCustomizationEnabledChange?: (enabled: boolean, isInit?: boolean) => void;
   onIlmPolicyChange?: (ilmPolicy: string | undefined, isInit?: boolean) => void;
   packagePolicyId?: string;
+  hideInVarGroupOptions?: Record<string, string[]>;
 }> = memo(
   ({
     namespacePlaceholder,
@@ -102,6 +103,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
     onNamespaceCustomizationEnabledChange,
     onIlmPolicyChange,
     packagePolicyId,
+    hideInVarGroupOptions,
   }) => {
     const { docLinks, cloud } = useStartServices();
     const { enableVarGroups } = ExperimentalFeaturesService.get();
@@ -125,6 +127,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
         isAgentlessEnabled: isAgentlessSelected,
         onSelectionsChange: updatePackagePolicy,
         packagePolicy,
+        hideInVarGroupOptions,
       });
 
     const {
@@ -379,6 +382,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                   onSelectionChange={handleVarGroupSelectionChange}
                   isAgentlessEnabled={isAgentlessSelected}
                   disabled={isEditPage && isCloudConnectorSelected}
+                  hideInVarGroupOptions={hideInVarGroupOptions}
                 />
               </EuiFlexItem>
             ))}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/index.ts
@@ -19,6 +19,7 @@ export {
   isVarRequiredByVarGroup,
   isVarInSelectedVarGroupOption,
   getSelectedOption,
+  getHiddenVarGroupOptionsForPolicyTemplate,
   isInputCompatibleWithVarGroupSelections,
   isInputVisibleForVarGroupSelections,
 } from './var_group_helpers';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/var_group_helpers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/var_group_helpers.test.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PackageInfo } from '../../../../types';
+
+import { getHiddenVarGroupOptionsForPolicyTemplate } from './var_group_helpers';
+
+describe('getHiddenVarGroupOptionsForPolicyTemplate', () => {
+  const agentlessDeploymentModes = {
+    default: { enabled: true },
+    agentless: { enabled: true },
+  };
+
+  const buildPackageInfo = (policyTemplates: unknown[]): PackageInfo =>
+    ({
+      name: 'aws',
+      version: '7.0.0',
+      var_groups: [
+        {
+          name: 'credential_type',
+          title: 'Setup Access',
+          options: [
+            { name: 'identity_federation', title: 'Identity Federation', vars: [] },
+            { name: 'direct_access_key', title: 'Direct Access Keys', vars: [] },
+          ],
+        },
+      ],
+      policy_templates: policyTemplates,
+    } as unknown as PackageInfo);
+
+  it('hides an option when every input of the policy template hides it', () => {
+    const packageInfo = buildPackageInfo([
+      {
+        name: 'rds',
+        deployment_modes: agentlessDeploymentModes,
+        inputs: [
+          {
+            type: 'aws/metrics',
+            hide_in_var_group_options: { credential_type: ['identity_federation'] },
+          },
+        ],
+      },
+    ]);
+
+    expect(getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 'rds', true)).toEqual({
+      credential_type: ['identity_federation'],
+    });
+  });
+
+  it('does not hide an option when at least one available input supports it', () => {
+    const packageInfo = buildPackageInfo([
+      {
+        name: 'guardduty',
+        deployment_modes: agentlessDeploymentModes,
+        inputs: [
+          { type: 'httpjson' },
+          {
+            type: 'aws/metrics',
+            hide_in_var_group_options: { credential_type: ['identity_federation'] },
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 'guardduty', true)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when no input of the policy template hides any option', () => {
+    const packageInfo = buildPackageInfo([
+      {
+        name: 'cloudtrail',
+        inputs: [{ type: 'httpjson' }, { type: 'aws-cloudwatch' }],
+      },
+    ]);
+
+    expect(
+      getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 'cloudtrail', false)
+    ).toBeUndefined();
+  });
+
+  it('ignores inputs that are not available in agentless mode (blocklisted input types)', () => {
+    // Mirrors the AWS `s3` template: the aws-s3 logs input supports identity federation
+    // but cannot run agentless (AGENTLESS_DISABLED_INPUTS), so only metrics remains and
+    // identity_federation must be hidden.
+    const packageInfo = buildPackageInfo([
+      {
+        name: 's3',
+        deployment_modes: agentlessDeploymentModes,
+        inputs: [
+          { type: 'aws-s3' },
+          {
+            type: 'aws/metrics',
+            hide_in_var_group_options: { credential_type: ['identity_federation'] },
+          },
+        ],
+      },
+    ]);
+
+    expect(getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 's3', true)).toEqual({
+      credential_type: ['identity_federation'],
+    });
+  });
+
+  it('does not hide an option in default mode when a blocklisted-for-agentless input supports it', () => {
+    const packageInfo = buildPackageInfo([
+      {
+        name: 's3',
+        deployment_modes: agentlessDeploymentModes,
+        inputs: [
+          { type: 'aws-s3' },
+          {
+            type: 'aws/metrics',
+            hide_in_var_group_options: { credential_type: ['identity_federation'] },
+          },
+        ],
+      },
+    ]);
+
+    expect(getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 's3', false)).toBeUndefined();
+  });
+
+  it('honors input-level deployment_modes overriding the agentless blocklist', () => {
+    const packageInfo = buildPackageInfo([
+      {
+        name: 's3',
+        deployment_modes: agentlessDeploymentModes,
+        inputs: [
+          { type: 'aws-s3', deployment_modes: ['default', 'agentless'] },
+          {
+            type: 'aws/metrics',
+            hide_in_var_group_options: { credential_type: ['identity_federation'] },
+          },
+        ],
+      },
+    ]);
+
+    expect(getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 's3', true)).toBeUndefined();
+  });
+
+  it('handles multiple var groups and multiple hidden options', () => {
+    const packageInfo = {
+      name: 'test',
+      version: '1.0.0',
+      var_groups: [
+        {
+          name: 'credential_type',
+          title: 'Setup Access',
+          options: [
+            { name: 'identity_federation', title: 'Identity Federation', vars: [] },
+            { name: 'direct_access_key', title: 'Direct Access Keys', vars: [] },
+          ],
+        },
+        {
+          name: 'collection_mode',
+          title: 'Collection Mode',
+          options: [
+            { name: 'push', title: 'Push', vars: [] },
+            { name: 'pull', title: 'Pull', vars: [] },
+          ],
+        },
+      ],
+      policy_templates: [
+        {
+          name: 'template_a',
+          inputs: [
+            {
+              type: 'logs',
+              hide_in_var_group_options: {
+                credential_type: ['identity_federation', 'direct_access_key'],
+                collection_mode: ['push'],
+              },
+            },
+            {
+              type: 'metrics',
+              hide_in_var_group_options: {
+                credential_type: ['identity_federation', 'direct_access_key'],
+              },
+            },
+          ],
+        },
+      ],
+    } as unknown as PackageInfo;
+
+    expect(getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 'template_a', false)).toEqual({
+      credential_type: ['identity_federation', 'direct_access_key'],
+    });
+  });
+
+  it('returns undefined when the package has no var_groups', () => {
+    const packageInfo = {
+      name: 'test',
+      version: '1.0.0',
+      policy_templates: [{ name: 'rds', inputs: [{ type: 'aws/metrics' }] }],
+    } as unknown as PackageInfo;
+
+    expect(getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 'rds', false)).toBeUndefined();
+  });
+
+  it('returns undefined when no policy template name is provided', () => {
+    const packageInfo = buildPackageInfo([
+      {
+        name: 'rds',
+        inputs: [
+          {
+            type: 'aws/metrics',
+            hide_in_var_group_options: { credential_type: ['identity_federation'] },
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, undefined, false)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the policy template is not found', () => {
+    const packageInfo = buildPackageInfo([
+      {
+        name: 'rds',
+        inputs: [
+          {
+            type: 'aws/metrics',
+            hide_in_var_group_options: { credential_type: ['identity_federation'] },
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 'unknown', false)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when packageInfo is undefined', () => {
+    expect(getHiddenVarGroupOptionsForPolicyTemplate(undefined, 'rds', false)).toBeUndefined();
+  });
+
+  it('returns undefined when the policy template has no inputs', () => {
+    const packageInfo = buildPackageInfo([{ name: 'empty_template', inputs: [] }]);
+
+    expect(
+      getHiddenVarGroupOptionsForPolicyTemplate(packageInfo, 'empty_template', false)
+    ).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/var_group_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/var_group_helpers.ts
@@ -9,6 +9,7 @@ import {
   doesPackageHaveIntegrations,
   getNormalizedInputs,
 } from '../../../../../../../common/services';
+import { isInputAllowedForDeploymentMode } from '../../../../../../../common/services/agentless_policy_helper';
 import type {
   PackageInfo,
   RegistryInput,
@@ -86,6 +87,59 @@ export function isInputVisibleForVarGroupSelections(
   }
 
   return isInputCompatibleWithVarGroupSelections(registryInput, varGroupSelections);
+}
+
+/**
+ * Compute the var_group options to hide when the package policy form is scoped to a
+ * single policy template (integration). An option is hidden when every input of that
+ * policy template available in the selected deployment mode declares it in
+ * `hide_in_var_group_options`, since selecting it would leave the integration without
+ * any usable inputs.
+ */
+export function getHiddenVarGroupOptionsForPolicyTemplate(
+  packageInfo: PackageInfo | undefined,
+  policyTemplateName: string | undefined,
+  isAgentlessEnabled: boolean
+): Record<string, string[]> | undefined {
+  if (!packageInfo?.var_groups?.length || !policyTemplateName) {
+    return undefined;
+  }
+
+  const policyTemplate = packageInfo.policy_templates?.find(
+    (template) => template.name === policyTemplateName
+  );
+  if (!policyTemplate) {
+    return undefined;
+  }
+
+  const deploymentMode = isAgentlessEnabled ? 'agentless' : 'default';
+  const inputs = getNormalizedInputs(policyTemplate).filter((input) =>
+    isInputAllowedForDeploymentMode(
+      { type: input.type, policy_template: policyTemplateName },
+      deploymentMode,
+      packageInfo
+    )
+  );
+  if (!inputs.length) {
+    return undefined;
+  }
+
+  const hiddenOptions: Record<string, string[]> = {};
+  for (const varGroup of packageInfo.var_groups) {
+    const hiddenOptionNames = varGroup.options
+      .filter((option) =>
+        inputs.every((input) =>
+          input.hide_in_var_group_options?.[varGroup.name]?.includes(option.name)
+        )
+      )
+      .map((option) => option.name);
+
+    if (hiddenOptionNames.length > 0) {
+      hiddenOptions[varGroup.name] = hiddenOptionNames;
+    }
+  }
+
+  return Object.keys(hiddenOptions).length > 0 ? hiddenOptions : undefined;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -80,6 +80,7 @@ import {
 
 import {
   computeDefaultVarGroupSelections,
+  getHiddenVarGroupOptionsForPolicyTemplate,
   type VarGroupSelection,
 } from '../services/var_group_helpers';
 import { applyNamespaceCustomizationChange } from '../services/apply_namespace_customization';
@@ -269,12 +270,23 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   const { enableVarGroups } = ExperimentalFeaturesService.get();
   const varGroups =
     enableVarGroups && packageInfo?.var_groups ? packageInfo?.var_groups : undefined;
+  // Options unsupported by the policy template the page is scoped to (e.g. opened
+  // from the integrations browse page) are hidden from selectors and defaults
+  const hiddenVarGroupOptions = useMemo(
+    () =>
+      getHiddenVarGroupOptionsForPolicyTemplate(
+        packageInfo,
+        integrationToEnable,
+        isAgentlessSelected
+      ),
+    [packageInfo, integrationToEnable, isAgentlessSelected]
+  );
   const varGroupSelections = useMemo((): VarGroupSelection => {
     if (packagePolicy.var_group_selections) {
       return packagePolicy.var_group_selections;
     }
-    return computeDefaultVarGroupSelections(varGroups, isAgentlessSelected);
-  }, [packagePolicy.var_group_selections, varGroups, isAgentlessSelected]);
+    return computeDefaultVarGroupSelections(varGroups, isAgentlessSelected, hiddenVarGroupOptions);
+  }, [packagePolicy.var_group_selections, varGroups, isAgentlessSelected, hiddenVarGroupOptions]);
 
   const updateNewAgentPolicy = useCallback(
     (updatedFields: Partial<NewAgentPolicy>) => {
@@ -630,6 +642,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
             onIlmPolicyChange={(ilmPolicy) => {
               ilmPolicyRef.current = ilmPolicy;
             }}
+            hideInVarGroupOptions={hiddenVarGroupOptions}
           />
 
           {/* Show SetupTechnologySelector for all agentless integrations, including extension views, if agentless is default display as a separate step  */}
@@ -685,6 +698,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       isAgentlessSelected,
       handleExtensionViewOnChange,
       varGroupSelections,
+      hiddenVarGroupOptions,
       setupTechnologySelector,
       useCheckableCardsForSetupTechnologySelector,
       createDatasetTemplates,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Fleet] Hide var_group options unsupported by the scoped policy template (#281509)](https://github.com/elastic/kibana/pull/281509)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sean Rathier","email":"sean.rathier@gmail.com"},"sourceCommit":{"committedDate":"2026-07-29T18:12:51Z","message":"[Fleet] Hide var_group options unsupported by the scoped policy template (#281509)","sha":"32e0791072dbd589f9136af3c1b7408788002cc8","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","backport:skip","Team:Fleet","Team:Cloud Security","ci:project-deploy-security","ci:project-redeploy","v9.6.0","v9.5.1"],"title":"[Fleet] Hide var_group options unsupported by the scoped policy template","number":281509,"url":"https://github.com/elastic/kibana/pull/281509","mergeCommit":{"message":"[Fleet] Hide var_group options unsupported by the scoped policy template (#281509)","sha":"32e0791072dbd589f9136af3c1b7408788002cc8"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281509","number":281509,"mergeCommit":{"message":"[Fleet] Hide var_group options unsupported by the scoped policy template (#281509)","sha":"32e0791072dbd589f9136af3c1b7408788002cc8"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->