### PR TITLE
Introduce priority in Kibana templates, SML template assigns priority

### DIFF
--- a/src/platform/packages/shared/kbn-storage-adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/index.ts
@@ -47,6 +47,15 @@ interface StorageSettingsBase {
 
 export interface IndexStorageSettings extends StorageSettingsBase {
   name: string;
+  /**
+   * Optional index-template priority. When multiple index templates match a
+   * backing index name, Elasticsearch selects the one with the highest
+   * priority (not the most specific pattern). Set this when a more-specific
+   * pattern must win over a broader, higher-priority template — e.g. an
+   * ES-managed base template that would otherwise create the index without
+   * this adapter's alias.
+   */
+  priority?: number;
 }
 
 export type StorageSettings = IndexStorageSettings;

--- a/src/platform/packages/shared/kbn-storage-adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/index.ts
@@ -47,14 +47,6 @@ interface StorageSettingsBase {
 
 export interface IndexStorageSettings extends StorageSettingsBase {
   name: string;
-  /**
-   * Optional index-template priority. When multiple index templates match a
-   * backing index name, Elasticsearch selects the one with the highest
-   * priority (not the most specific pattern). Set this when a more-specific
-   * pattern must win over a broader, higher-priority template — e.g. an
-   * ES-managed base template that would otherwise create the index without
-   * this adapter's alias.
-   */
   priority?: number;
 }
 

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
@@ -242,6 +242,35 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
     );
   });
 
+  it('forwards priority to the index template when set', async () => {
+    const adapter = new StorageIndexAdapter(
+      esClient,
+      loggerMock,
+      { ...storageSettings, priority: 600 },
+      { isServerless: true }
+    );
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ priority: 600 })
+    );
+  });
+
+  it('omits priority from the index template when unset', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings, {
+      isServerless: true,
+    });
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ priority: expect.anything() })
+    );
+  });
+
   it('omits index template settings when isServerless option is true', async () => {
     const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings, {
       isServerless: true,

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -249,6 +249,7 @@ export class StorageIndexAdapter<
           allow_auto_create: false,
           index_patterns: getIndexPattern(this.storage.name),
           _meta: { version },
+          ...(this.storage.priority !== undefined ? { priority: this.storage.priority } : {}),
           template: {
             ...(includeSettings ? { settings: StorageIndexAdapter.INDEX_SETTINGS } : {}),
             mappings,

--- a/x-pack/platform/plugins/shared/agent_builder_sml/server/services/sml/sml_storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_sml/server/services/sml/sml_storage.ts
@@ -88,11 +88,7 @@ const smlStorageSchemaProperties = {
 export const storageSettings = {
   name: smlIndexName,
   /**
-   * The SML backing index name (`ai-index-idx-sml-data-*`) also matches ES's
-   * `ai-index-idx` template (priority 500), which has no alias block. ES picks
-   * the highest-priority matching template regardless of pattern specificity,
-   * so this template must outrank it to ensure the write alias is created.
-   * See https://github.com/elastic/search-team/issues/15534.
+   * Ensure the SML backing index name has a higher priority than built-in AI index templates.
    */
   priority: 600,
   schema: {

--- a/x-pack/platform/plugins/shared/agent_builder_sml/server/services/sml/sml_storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_sml/server/services/sml/sml_storage.ts
@@ -87,6 +87,14 @@ const smlStorageSchemaProperties = {
 
 export const storageSettings = {
   name: smlIndexName,
+  /**
+   * The SML backing index name (`ai-index-idx-sml-data-*`) also matches ES's
+   * `ai-index-idx` template (priority 500), which has no alias block. ES picks
+   * the highest-priority matching template regardless of pattern specificity,
+   * so this template must outrank it to ensure the write alias is created.
+   * See https://github.com/elastic/search-team/issues/15534.
+   */
+  priority: 600,
   schema: {
     properties: smlStorageSchemaProperties,
   },


### PR DESCRIPTION
Introduces an optional template priority in the KBN storage adapter, which Agent Builder's SML index uses to temporarily override built in AI Index component templates defined within Elasticsearch.