### PR TITLE
[CI] Mock getPrChangesCached in pull_request pipeline test

### DIFF
--- a/.buildkite/jest.config.js
+++ b/.buildkite/jest.config.js
@@ -8,12 +8,13 @@
  */
 
 const { createJsWithTsEsmPreset } = require('ts-jest');
+const { dirname } = require('node:path');
 
 const tsJestTransformCfg = createJsWithTsEsmPreset().transform;
 
 /** @type {import("jest").Config} **/
 module.exports = {
-  testEnvironment: 'node',
+  testEnvironment: require.resolve('jest-environment-node', { paths: [dirname(process.argv[1])] }),
   transform: {
     ...tsJestTransformCfg,
   },

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.test.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.test.ts
@@ -18,6 +18,7 @@ const mockFlushCancelOnGateFailureMetadata = jest.fn();
 const mockRunPreBuild = jest.fn();
 const mockGetEvalTriggerStep = jest.fn();
 const mockIsAutomatedVersionBumpPR = jest.fn();
+const mockGetPrChangesCached = jest.fn();
 
 jest.mock('#pipeline-utils', () => {
   const actual = jest.requireActual('#pipeline-utils');
@@ -30,6 +31,7 @@ jest.mock('#pipeline-utils', () => {
     getAgentImageConfig: mockGetAgentImageConfig,
     flushCancelOnGateFailureMetadata: mockFlushCancelOnGateFailureMetadata,
     isAutomatedVersionBumpPR: mockIsAutomatedVersionBumpPR,
+    getPrChangesCached: mockGetPrChangesCached,
   };
 });
 
@@ -81,6 +83,7 @@ describe('pull_request pipeline generation', () => {
     mockRunPreBuild.mockResolvedValue(undefined);
     mockGetEvalTriggerStep.mockReturnValue(null);
     mockIsAutomatedVersionBumpPR.mockResolvedValue(false);
+    mockGetPrChangesCached.mockResolvedValue([]);
   });
 
   afterEach(() => {


### PR DESCRIPTION
The call was introduced in #272841 without a corresponding test mock.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->