### PR TITLE
Prevent implicit Codex invocation for opt-in skills

### DIFF
--- a/.agents/skills/accessibility/agents/openai.yaml
+++ b/.agents/skills/accessibility/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/codeql/agents/openai.yaml
+++ b/.agents/skills/codeql/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/debug-oas/agents/openai.yaml
+++ b/.agents/skills/debug-oas/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/enzyme-to-rtl/agents/openai.yaml
+++ b/.agents/skills/enzyme-to-rtl/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/evals-create-suite/agents/openai.yaml
+++ b/.agents/skills/evals-create-suite/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/evals-write-spec/agents/openai.yaml
+++ b/.agents/skills/evals-write-spec/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/fix-package-docs/agents/openai.yaml
+++ b/.agents/skills/fix-package-docs/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/flaky-test-investigator/agents/openai.yaml
+++ b/.agents/skills/flaky-test-investigator/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/gh-create-issue/agents/openai.yaml
+++ b/.agents/skills/gh-create-issue/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/gh-enhance-issue/agents/openai.yaml
+++ b/.agents/skills/gh-enhance-issue/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/improve-oas/agents/openai.yaml
+++ b/.agents/skills/improve-oas/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/kbn-ui-package/agents/openai.yaml
+++ b/.agents/skills/kbn-ui-package/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/optimize-bundle-size/agents/openai.yaml
+++ b/.agents/skills/optimize-bundle-size/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/validate-oas/agents/openai.yaml
+++ b/.agents/skills/validate-oas/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
Codex does not support disable-model-invocation in SKILL.md frontmatter, so affected skills otherwise remain eligible for implicit invocation.