### PR TITLE
[UIAM OAuth] Pass serverless project ID to listOAuthConnections

### DIFF
--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -139,15 +139,17 @@ export interface UiamOAuthType {
   ): Promise<UiamOAuthClientResponse | null>;
 
   /**
-   * Lists OAuth connections, optionally filtered by client ID and/or connection ID.
+   * Lists OAuth connections, optionally filtered by client ID, connection ID and/or project ID.
    * @param request The Kibana request containing the authorization header.
    * @param clientId Optional client ID filter.
    * @param connectionId Optional connection ID filter.
+   * @param projectId Optional project ID filter.
    */
   listConnections(
     request: KibanaRequest,
     clientId?: string,
-    connectionId?: string
+    connectionId?: string,
+    projectId?: string
   ): Promise<{ connections: UiamOAuthConnectionResponse[] } | null>;
 
   /**

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
@@ -265,7 +265,29 @@ describe('UiamOAuth', () => {
       expect(mockUiam.listOAuthConnections).toHaveBeenCalledWith(
         'essu_access_token',
         'c1',
-        'conn1'
+        'conn1',
+        undefined
+      );
+    });
+
+    it('forwards project_id filter to UIAM service', async () => {
+      const mockResponse = { connections: [] };
+      mockUiam.listOAuthConnections.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.listConnections(
+        request,
+        undefined,
+        undefined,
+        'my-project-id'
+      );
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.listOAuthConnections).toHaveBeenCalledWith(
+        'essu_access_token',
+        undefined,
+        undefined,
+        'my-project-id'
       );
     });
   });

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
@@ -142,7 +142,8 @@ export class UiamOAuth implements UiamOAuthType {
   async listConnections(
     request: KibanaRequest,
     clientId?: string,
-    connectionId?: string
+    connectionId?: string,
+    projectId?: string
   ): Promise<{ connections: UiamOAuthConnectionResponse[] } | null> {
     if (!this.license.isEnabled()) {
       this.logger.debug(
@@ -155,7 +156,12 @@ export class UiamOAuth implements UiamOAuthType {
     this.logger.debug('Attempting to list OAuth connections');
 
     try {
-      const result = await this.uiam.listOAuthConnections(accessToken, clientId, connectionId);
+      const result = await this.uiam.listOAuthConnections(
+        accessToken,
+        clientId,
+        connectionId,
+        projectId
+      );
       this.logger.debug('OAuth connections listed successfully');
       return result;
     } catch (e) {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.test.ts
@@ -29,6 +29,8 @@ describe('Get OAuth Connection route', () => {
     });
   }
 
+  const PROJECT_ID = 'test-project-id';
+
   let routeHandler: RequestHandler<any, any, any, any>;
   let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
   let oauthMock: jest.Mocked<UiamOAuthType>;
@@ -37,6 +39,7 @@ describe('Get OAuth Connection route', () => {
     oauthMock = authc.oauth as jest.Mocked<UiamOAuthType>;
     const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
     mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
+    mockRouteDefinitionParams.serverlessProjectId = PROJECT_ID;
 
     defineGetOAuthConnectionRoute(mockRouteDefinitionParams);
 
@@ -77,7 +80,12 @@ describe('Get OAuth Connection route', () => {
 
     expect(response.status).toBe(200);
     expect(response.payload).toEqual(mockConnection);
-    expect(oauthMock.listConnections).toHaveBeenCalledWith(expect.anything(), 'client-1', 'conn-1');
+    expect(oauthMock.listConnections).toHaveBeenCalledWith(
+      expect.anything(),
+      'client-1',
+      'conn-1',
+      PROJECT_ID
+    );
   });
 
   it('returns 404 when connection is not found', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.ts
@@ -15,6 +15,7 @@ import { createLicensedRouteHandler } from '../licensed_route_handler';
 export function defineGetOAuthConnectionRoute({
   router,
   getAuthenticationService,
+  serverlessProjectId,
 }: RouteDefinitionParams) {
   router.get(
     {
@@ -48,7 +49,8 @@ export function defineGetOAuthConnectionRoute({
         const result = await oauth.listConnections(
           request,
           request.params.client_id,
-          request.params.connection_id
+          request.params.connection_id,
+          serverlessProjectId
         );
         if (!result) {
           return response.notFound({

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -29,6 +29,8 @@ describe('List OAuth Connections route', () => {
     });
   }
 
+  const PROJECT_ID = 'test-project-id';
+
   let routeHandler: RequestHandler<any, any, any, any>;
   let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
   let oauthMock: jest.Mocked<UiamOAuthType>;
@@ -37,6 +39,7 @@ describe('List OAuth Connections route', () => {
     oauthMock = authc.oauth as jest.Mocked<UiamOAuthType>;
     const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
     mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
+    mockRouteDefinitionParams.serverlessProjectId = PROJECT_ID;
 
     defineListOAuthConnectionsRoute(mockRouteDefinitionParams);
 
@@ -66,6 +69,23 @@ describe('List OAuth Connections route', () => {
 
     expect(response.status).toBe(200);
     expect(response.payload).toEqual(mockResponse);
+  });
+
+  it('forwards serverless project id as project_id filter to oauth service', async () => {
+    oauthMock.listConnections.mockResolvedValue({ connections: [] });
+
+    await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(oauthMock.listConnections).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      undefined,
+      PROJECT_ID
+    );
   });
 
   it('passes through the client_name from the connection response', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
@@ -17,6 +17,7 @@ export function defineListOAuthConnectionsRoute({
   router,
   logger,
   getAuthenticationService,
+  serverlessProjectId,
 }: RouteDefinitionParams) {
   router.get(
     {
@@ -54,7 +55,8 @@ export function defineListOAuthConnectionsRoute({
         const result = await oauth.listConnections(
           request,
           request.query.client_id,
-          request.query.connection_id
+          request.query.connection_id,
+          serverlessProjectId
         );
         if (!result) {
           return response.notFound({

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -1287,11 +1287,34 @@ describe('UiamService', () => {
         json: async () => ({ connections: [] }),
       });
 
-      await uiamService.listOAuthConnections('access-token', 'cid', 'conn-id');
+      await uiamService.listOAuthConnections('access-token', 'cid', 'conn-id', 'my-project-id');
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://uiam.service/uiam/api/v1/oauth/connections?client_id=cid&connection_id=conn-id',
+        'https://uiam.service/uiam/api/v1/oauth/connections?client_id=cid&connection_id=conn-id&project_id=my-project-id',
+        {
+          method: 'GET',
+          headers: {
+            'User-Agent': 'Kibana/9.0.0',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer access-token',
+          },
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('includes project_id query parameter when provided', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ connections: [] }),
+      });
+
+      await uiamService.listOAuthConnections('access-token', undefined, undefined, 'my-project-id');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/connections?project_id=my-project-id',
         {
           method: 'GET',
           headers: {

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -258,11 +258,13 @@ export interface UiamServicePublic {
    * @param accessToken UIAM session access token.
    * @param clientId Optional client ID filter.
    * @param connectionId Optional connection ID filter.
+   * @param projectId Optional project ID filter.
    */
   listOAuthConnections(
     accessToken: string,
     clientId?: string,
-    connectionId?: string
+    connectionId?: string,
+    projectId?: string
   ): Promise<OAuthConnectionsResponse>;
 
   /**
@@ -752,7 +754,8 @@ export class UiamService implements UiamServicePublic {
   async listOAuthConnections(
     accessToken: string,
     clientId?: string,
-    connectionId?: string
+    connectionId?: string,
+    projectId?: string
   ): Promise<OAuthConnectionsResponse> {
     try {
       this.#logger.debug('Attempting to list OAuth connections.');
@@ -763,6 +766,9 @@ export class UiamService implements UiamServicePublic {
       }
       if (connectionId) {
         url.searchParams.set('connection_id', connectionId);
+      }
+      if (projectId) {
+        url.searchParams.set('project_id', projectId);
       }
 
       const response = await UiamService.#parseUiamResponse(


### PR DESCRIPTION
## Summary

Forwards the serverless project ID as the `project_id` filter on the UIAM `listOAuthConnections` call.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


