### PR TITLE
[Security Solution] remove defaultDataView and signalIndexName old sourcerer selectors

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
@@ -9,13 +9,11 @@ import type { FC, PropsWithChildren } from 'react';
 import React, { useCallback } from 'react';
 import { EuiButton, EuiButtonEmpty, EuiToolTip } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
-import { useDispatch, useSelector } from 'react-redux-v7';
+import { useDispatch } from 'react-redux-v7';
 import { css } from '@emotion/react';
 import { useAssistantContext } from '@kbn/elastic-assistant';
 import { PageScope } from '../../data_view_manager/constants';
 import { extractTimelineCapabilities } from '../../common/utils/timeline_capabilities';
-import { sourcererSelectors } from '../../common/store';
-import { sourcererActions } from '../../common/store/actions';
 import { inputsActions } from '../../common/store/inputs';
 import { InputsModelId } from '../../common/store/inputs/constants';
 import type { TimeRange } from '../../common/store/inputs/model';
@@ -38,6 +36,9 @@ import { useShowTimeline } from '../../common/utils/timeline/use_show_timeline';
 import { useDiscoverState } from '../../timelines/components/timeline/tabs/esql/use_discover_state';
 import { useKibana } from '../../common/lib/kibana';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
+import { useSignalIndexName } from '../../data_view_manager/hooks/use_signal_index_name';
+import { useSecurityDefaultPatterns } from '../../data_view_manager/hooks/use_security_default_patterns';
+import { useSelectDataView } from '../../data_view_manager/hooks/use_select_data_view';
 
 export interface SendToTimelineButtonProps {
   asEmptyButton: boolean;
@@ -70,8 +71,9 @@ export const SendToTimelineButton: FC<PropsWithChildren<SendToTimelineButtonProp
     application: { capabilities },
   } = useKibana().services;
   const { read: hasAccessToTimeline } = extractTimelineCapabilities(capabilities);
-  const signalIndexName = useSelector(sourcererSelectors.signalIndexName);
-  const defaultDataView = useSelector(sourcererSelectors.defaultDataView);
+  const signalIndexName = useSignalIndexName();
+  const { id: defaultDataViewId } = useSecurityDefaultPatterns();
+  const setSelectedDataView = useSelectDataView();
 
   const configureAndOpenTimeline = useCallback(async () => {
     // Hide the assistant overlay so timeline can be seen (noop if using assistant in timeline)
@@ -231,13 +233,11 @@ export const SendToTimelineButton: FC<PropsWithChildren<SendToTimelineButtonProp
       // Only show detection alerts
       // (This is required so the timeline event count matches the prevalence count)
       if (!keepDataView) {
-        dispatch(
-          sourcererActions.setSelectedDataView({
-            id: PageScope.timeline,
-            selectedDataViewId: defaultDataView.id,
-            selectedPatterns: [signalIndexName || ''],
-          })
-        );
+        setSelectedDataView({
+          scope: PageScope.timeline,
+          id: defaultDataViewId,
+          fallbackPatterns: [signalIndexName || ''],
+        });
       }
       // Unlock the time range from the global time range
       dispatch(inputsActions.removeLinkTo([InputsModelId.timeline, InputsModelId.global]));
@@ -250,7 +250,8 @@ export const SendToTimelineButton: FC<PropsWithChildren<SendToTimelineButtonProp
     dispatch,
     discoverStateContainer,
     timelineDataViewId,
-    defaultDataView.id,
+    defaultDataViewId,
+    setSelectedDataView,
     signalIndexName,
     setDiscoverAppState,
     defaultDiscoverAppState,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/timeline/use_investigate_in_timeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/timeline/use_investigate_in_timeline.ts
@@ -6,16 +6,17 @@
  */
 
 import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux-v7';
+import { useDispatch } from 'react-redux-v7';
 import type { Filter, Query } from '@kbn/es-query';
 import { useSelectedPatterns } from '../../../data_view_manager/hooks/use_selected_patterns';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { PageScope } from '../../../data_view_manager/constants';
 import { useSelectDataView } from '../../../data_view_manager/hooks/use_select_data_view';
+import { useSignalIndexName } from '../../../data_view_manager/hooks/use_signal_index_name';
+import { useSecurityDefaultPatterns } from '../../../data_view_manager/hooks/use_security_default_patterns';
 import { useCreateTimeline } from '../../../timelines/hooks/use_create_timeline';
 import { applyKqlFilterQuery, setFilters, updateProviders } from '../../../timelines/store/actions';
 import type { DataProvider } from '../../../../common/types';
-import { sourcererSelectors } from '../../store';
 import { inputsActions } from '../../store/inputs';
 import { InputsModelId } from '../../store/inputs/constants';
 import type { TimeRange } from '../../store/inputs/model';
@@ -61,8 +62,8 @@ interface InvestigateInTimelineArgs {
 export const useInvestigateInTimeline = () => {
   const dispatch = useDispatch();
 
-  const signalIndexName = useSelector(sourcererSelectors.signalIndexName);
-  const defaultDataView = useSelector(sourcererSelectors.defaultDataView);
+  const signalIndexName = useSignalIndexName();
+  const { id: defaultDataViewId } = useSecurityDefaultPatterns();
   const { dataView } = useDataView(PageScope.timeline);
   const timelineSelectedPatterns = useSelectedPatterns(dataView);
 
@@ -146,7 +147,7 @@ export const useInvestigateInTimeline = () => {
         } else if (!keepDataView) {
           setSelectedDataView({
             scope: PageScope.timeline,
-            id: defaultDataView.id,
+            id: defaultDataViewId,
             fallbackPatterns: [signalIndexName || ''],
           });
         }
@@ -159,7 +160,7 @@ export const useInvestigateInTimeline = () => {
       clearTimelineDefault,
       dispatch,
       setSelectedDataView,
-      defaultDataView.id,
+      defaultDataViewId,
       signalIndexName,
       timelineSelectedPatterns,
     ]

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/user_info/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/user_info/index.test.tsx
@@ -14,7 +14,6 @@ import { useKibana } from '../../../common/lib/kibana';
 import * as api from '../../containers/detection_engine/alerts/api';
 import { TestProviders } from '../../../common/mock/test_providers';
 import { UserPrivilegesProvider } from '../../../common/components/user_privileges/user_privileges_context';
-import { sourcererSelectors } from '../../../common/store';
 import { SECURITY_FEATURE_ID } from '../../../../common';
 
 jest.mock('../../../common/lib/kibana');
@@ -34,8 +33,6 @@ describe('useUserInfo', () => {
         },
       },
     });
-
-    jest.spyOn(sourcererSelectors, 'signalIndexName').mockReturnValue(null);
   });
   it('returns default state', async () => {
     const { result } = renderHook(() => useUserInfo(), {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_signal_index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_signal_index.test.tsx
@@ -10,7 +10,6 @@ import { useSignalIndex } from './use_signal_index';
 import * as api from './api';
 import { useAppToastsMock } from '../../../../common/hooks/use_app_toasts.mock';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
-import { sourcererSelectors } from '../../../../common/store';
 import {
   signalIndexNameSelector,
   signalIndexOutdatedSelector,
@@ -29,7 +28,6 @@ describe('useSignalIndex', () => {
     jest.clearAllMocks();
     appToastsMock = useAppToastsMock.create();
     (useAppToasts as jest.Mock).mockReturnValue(appToastsMock);
-    jest.spyOn(sourcererSelectors, 'signalIndexName').mockReturnValue(null);
   });
 
   test('init', async () => {
@@ -153,9 +151,6 @@ describe('useSignalIndex', () => {
 
   test('should not make API calls when signal index already stored in sourcerer', async () => {
     const spyOnGetSignalIndex = jest.spyOn(api, 'getSignalIndex');
-    jest
-      .spyOn(sourcererSelectors, 'signalIndexName')
-      .mockReturnValue('mock-signal-index-from-sourcerer');
     jest.mocked(signalIndexOutdatedSelector).mockReturnValue(false);
     jest.mocked(signalIndexNameSelector).mockReturnValue('mock-signal-index-from-sourcerer');
 

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.test.ts
@@ -7,7 +7,6 @@
 
 import { renderHook } from '@testing-library/react';
 
-import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { updateProviders } from '../../../../timelines/store/actions';
 import { useNavigateToTimeline } from './use_navigate_to_timeline';
 import * as mock from './mock_data';
@@ -16,11 +15,12 @@ jest.mock('../../../../timelines/hooks/use_create_timeline', () => ({
   useCreateTimeline: () => jest.fn(),
 }));
 
-jest.mock('../../../../common/hooks/use_selector');
-(useDeepEqualSelector as jest.Mock).mockImplementation(() => ({
-  defaultDataView: {
-    id: 'someId',
-  },
+jest.mock('../../../../data_view_manager/hooks/use_signal_index_name', () => ({
+  useSignalIndexName: () => 'mock-signal-index',
+}));
+
+jest.mock('../../../../data_view_manager/hooks/use_security_default_patterns', () => ({
+  useSecurityDefaultPatterns: () => ({ id: 'someId', indexPatterns: [] }),
 }));
 
 const mockDispatch = jest.fn();

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.tsx
@@ -6,10 +6,12 @@
  */
 
 import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux-v7';
+import { useDispatch } from 'react-redux-v7';
 import { v4 as uuidv4 } from 'uuid';
 import { PageScope } from '../../../../data_view_manager/constants';
-import { sourcererActions } from '../../../../sourcerer/store';
+import { useSignalIndexName } from '../../../../data_view_manager/hooks/use_signal_index_name';
+import { useSecurityDefaultPatterns } from '../../../../data_view_manager/hooks/use_security_default_patterns';
+import { useSelectDataView } from '../../../../data_view_manager/hooks/use_select_data_view';
 import {
   getDataProvider,
   getDataProviderAnd,
@@ -19,7 +21,6 @@ import { TimelineId } from '../../../../../common/types/timeline';
 import { TimelineTypeEnum } from '../../../../../common/api/timeline';
 import { useCreateTimeline } from '../../../../timelines/hooks/use_create_timeline';
 import { updateProviders } from '../../../../timelines/store/actions';
-import { sourcererSelectors } from '../../../../common/store';
 import type { TimeRange } from '../../../../common/store/inputs/model';
 
 export interface Filter {
@@ -31,8 +32,9 @@ export interface Filter {
 export const useNavigateToTimeline = () => {
   const dispatch = useDispatch();
 
-  const signalIndexName = useSelector(sourcererSelectors.signalIndexName);
-  const defaultDataView = useSelector(sourcererSelectors.defaultDataView);
+  const signalIndexName = useSignalIndexName();
+  const { id: defaultDataViewId } = useSecurityDefaultPatterns();
+  const setSelectedDataView = useSelectDataView();
 
   const clearTimeline = useCreateTimeline({
     timelineId: TimelineId.active,
@@ -51,15 +53,13 @@ export const useNavigateToTimeline = () => {
         })
       );
 
-      dispatch(
-        sourcererActions.setSelectedDataView({
-          id: PageScope.timeline,
-          selectedDataViewId: defaultDataView.id,
-          selectedPatterns: [signalIndexName || ''],
-        })
-      );
+      setSelectedDataView({
+        scope: PageScope.timeline,
+        id: defaultDataViewId,
+        fallbackPatterns: [signalIndexName || ''],
+      });
     },
-    [clearTimeline, defaultDataView.id, dispatch, signalIndexName]
+    [clearTimeline, defaultDataViewId, dispatch, setSelectedDataView, signalIndexName]
   );
 
   /** *

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/selectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/selectors.ts
@@ -48,23 +48,3 @@ export const sourcererScopeMissingPatterns = createSelector(
     },
   }
 );
-
-export const defaultDataView = createSelector(
-  selectSourcerer,
-  (sourcerer) => sourcerer.defaultDataView,
-  {
-    memoizeOptions: {
-      maxSize: SOURCERER_SCOPE_MAX_SIZE,
-    },
-  }
-);
-
-export const signalIndexName = createSelector(
-  selectSourcerer,
-  (sourcerer) => sourcerer.signalIndexName,
-  {
-    memoizeOptions: {
-      maxSize: SOURCERER_SCOPE_MAX_SIZE,
-    },
-  }
-);


### PR DESCRIPTION
> [!NOTE]
> This PR is the first of a few aiming at removing all dependencies on the legacy `sourcerer` code. We officially switched to using the `data_view_manager` code [a couple of months ago](https://github.com/elastic/kibana/pull/238549).

## Summary

This PR migrates the last three consumers of the legacy `sourcerer` store's `signalIndexName` and `defaultDataView` selectors over to the `data_view_manager` hooks, then removes the now-dead selectors.

### Code changes

- migrate the three remaining consumers off `sourcererSelectors` to use `useSignalIndexName()` and `useSecurityDefaultPatterns()`
- remove the dead `signalIndexName` and `defaultDataView` selectors

> [!TIP]
> This PR does not introduce any visual or functional change. The behavior is preserved via the equivalent `data_view_manager` hooks.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
