### PR TITLE
[9.5] [OAS] Fix Zod meta `availability` to `x-state` (#281156)

### DIFF
--- a/src/platform/packages/shared/kbn-router-to-openapispec/index.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/index.ts
@@ -12,4 +12,7 @@ export {
   type GenerateOpenApiDocumentOptionsFilters,
 } from './src/generate_oas';
 
-export type { OasMetaExtensions } from './src/oas_converter/zod/lib';
+// Writes the operation-level `x-state` string. Exported so @kbn/api-contracts can
+// round-trip it in a test: the contract checker's parseXState decodes exactly
+// what this produces, and that test fails loudly if the wording here ever drifts.
+export { getXState } from './src/util';

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/index.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/index.ts
@@ -67,7 +67,8 @@ export class OasConverter {
     const unwrapped = this.#unwrapSchema(schema);
     const { params, shared } = this.#getConverter(unwrapped).convertPathParameters(
       unwrapped,
-      pathParameters
+      pathParameters,
+      { env: this.#env, sharedSchemas: this.#sharedSchemas, onCollision: this.#onCollision }
     );
     this.#addComponents(shared);
     return params;
@@ -75,7 +76,11 @@ export class OasConverter {
 
   public convertQuery(schema: unknown) {
     const unwrapped = this.#unwrapSchema(schema);
-    const { query, shared } = this.#getConverter(unwrapped).convertQuery(unwrapped);
+    const { query, shared } = this.#getConverter(unwrapped).convertQuery(unwrapped, {
+      env: this.#env,
+      sharedSchemas: this.#sharedSchemas,
+      onCollision: this.#onCollision,
+    });
     this.#addComponents(shared);
     return query;
   }

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/index.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/index.ts
@@ -68,7 +68,7 @@ export class OasConverter {
     const { params, shared } = this.#getConverter(unwrapped).convertPathParameters(
       unwrapped,
       pathParameters,
-      { env: this.#env, sharedSchemas: this.#sharedSchemas, onCollision: this.#onCollision }
+      { env: this.#env, sharedSchemas: this.#sharedSchemas }
     );
     this.#addComponents(shared);
     return params;
@@ -79,7 +79,6 @@ export class OasConverter {
     const { query, shared } = this.#getConverter(unwrapped).convertQuery(unwrapped, {
       env: this.#env,
       sharedSchemas: this.#sharedSchemas,
-      onCollision: this.#onCollision,
     });
     this.#addComponents(shared);
     return query;

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.test.ts
@@ -329,6 +329,82 @@ describe('zod', () => {
       });
     });
 
+    test.each([
+      [
+        'schema > optional > meta',
+        z
+          .string()
+          .optional()
+          .meta({ openapi: { availability: { stability: 'stable', since: '9.5.0' } } }),
+      ],
+      [
+        'schema > meta > optional',
+        z
+          .string()
+          .meta({ openapi: { availability: { stability: 'stable', since: '9.5.0' } } })
+          .optional(),
+      ],
+      [
+        'schema > default > meta',
+        z
+          .string()
+          .default('foo')
+          .meta({ openapi: { availability: { stability: 'stable', since: '9.5.0' } } }),
+      ],
+      [
+        'schema > meta > default',
+        z
+          .string()
+          .meta({ openapi: { availability: { stability: 'stable', since: '9.5.0' } } })
+          .default('foo'),
+      ],
+      [
+        'schema > default > optional > meta',
+        z
+          .string()
+          .default('foo')
+          .optional()
+          .meta({ openapi: { availability: { stability: 'stable', since: '9.5.0' } } }),
+      ],
+      [
+        'schema > meta > default > optional',
+        z
+          .string()
+          .meta({ openapi: { availability: { stability: 'stable', since: '9.5.0' } } })
+          .default('foo')
+          .optional(),
+      ],
+    ])('applies openapi availability x-state regardless of modifier order (%s)', (_name, tags) => {
+      const result = convertQuery(z.object({ tags }));
+      expect(result.query.at(0)?.schema).toHaveProperty(
+        'x-state',
+        'Generally available; added in 9.5.0'
+      );
+    });
+
+    test('omits availability since from query param x-state in serverless mode', () => {
+      const result = convertQuery(
+        z.object({
+          tags: z
+            .string()
+            .optional()
+            .meta({ openapi: { availability: { stability: 'stable', since: '9.5.0' } } }),
+        }),
+        { env: { serverless: true } }
+      );
+      expect(result.query).toEqual([
+        {
+          in: 'query',
+          name: 'tags',
+          required: false,
+          schema: {
+            type: 'string',
+            'x-state': 'Generally available',
+          },
+        },
+      ]);
+    });
+
     test('handles transform schemas (like dateFromString)', () => {
       const dateFromString = z.string().transform((input) => new Date(input));
       const schema = z.object({ from: dateFromString, to: dateFromString });

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.ts
@@ -8,6 +8,7 @@
  */
 
 import { z, isZod } from '@kbn/zod';
+import type { OasMetaExtensions } from '@kbn/zod';
 import { isPassThroughAny } from '@kbn/zod-helpers/v4';
 import type { OpenAPIV3 } from 'openapi-types';
 
@@ -64,17 +65,23 @@ const unwrapZodOptionalDefault = (
   defaultValue: unknown;
   isOptional: boolean;
   innerType: z.ZodTypeAny;
+  outerOpenApiMeta: OasMetaExtensions | undefined;
 } => {
   let description: z.ZodTypeAny['description'];
   let defaultValue: unknown;
   let isOptional = false;
   let innerType = type;
+  // Collect `openapi` meta declared on the wrapper(s) so that extensions like
+  // `availability` (→ `x-state`) are applied regardless of whether `.meta()`
+  // was chained before or after `.optional()` / `.default()`. Outer-most wins.
+  let outerOpenApiMeta: OasMetaExtensions | undefined;
 
   while (true) {
     const defType = getDefType(innerType);
     if (defType === 'optional') {
       isOptional = true;
       description = !description ? (innerType as any).description : description;
+      outerOpenApiMeta = outerOpenApiMeta ?? getZodMeta(innerType).openapi;
       innerType = (innerType as any)._zod.def.innerType;
     } else if (defType === 'default') {
       defaultValue = (innerType as any)._zod.def.defaultValue;
@@ -82,13 +89,14 @@ const unwrapZodOptionalDefault = (
         defaultValue = (defaultValue as () => unknown)();
       }
       description = !description ? (innerType as any).description : description;
+      outerOpenApiMeta = outerOpenApiMeta ?? getZodMeta(innerType).openapi;
       innerType = (innerType as any)._zod.def.innerType;
     } else {
       break;
     }
   }
 
-  return { description, defaultValue, isOptional, innerType };
+  return { description, defaultValue, isOptional, innerType, outerOpenApiMeta };
 };
 
 /**
@@ -206,7 +214,8 @@ const instanceofZodTypeLikeString = (_type: z.ZodTypeAny, allowMixedUnion: boole
 const convertObjectMembersToParameterObjects = (
   shape: z.ZodRawShape,
   isPathParameter = false,
-  knownParameters: KnownParameters = {}
+  knownParameters: KnownParameters = {},
+  env?: ConvertOptions['env']
 ): OpenAPIV3.ParameterObject[] => {
   return Object.entries(shape).map(([shapeKey, subShape]) => {
     const typeWithoutLazy = unwrapZodLazy(subShape as z.ZodTypeAny);
@@ -215,6 +224,7 @@ const convertObjectMembersToParameterObjects = (
       isOptional,
       defaultValue,
       innerType: typeWithoutOptionalDefault,
+      outerOpenApiMeta,
     } = unwrapZodOptionalDefault(typeWithoutLazy);
 
     // Except for path parameters, OpenAPI supports mixed unions with `anyOf` e.g. for query parameters
@@ -228,10 +238,19 @@ const convertObjectMembersToParameterObjects = (
 
     const {
       schema: { description: schemaDescription, ...openApiSchemaObject },
-    } = convert(typeWithoutOptionalDefault);
+    } = convert(typeWithoutOptionalDefault, { env });
 
     if (typeof defaultValue !== 'undefined') {
       openApiSchemaObject.default = defaultValue;
+    }
+
+    // Merge OAS extensions declared on the outer `.optional()` / `.default()`
+    // wrappers (e.g. `openapi.availability` → `x-state`) so modifier order does
+    // not matter. Applied before `collapseArrayUnion` so the extensions survive
+    // the union collapse (which spreads the remaining top-level keys).
+    const outerExtensions = normalizeRawOasMetaExtensions(outerOpenApiMeta, env);
+    if (outerExtensions) {
+      Object.assign(openApiSchemaObject, outerExtensions);
     }
 
     const finalSchema = !isPathParameter
@@ -257,13 +276,18 @@ const getPassThroughShape = (knownParameters: KnownParameters, isPathParameter =
   return passThroughShape as z.ZodRawShape;
 };
 
-export const convertQuery = (schema: unknown) => {
+export const convertQuery = (schema: unknown, opts: ConvertOptions = {}) => {
   assertInstanceOfZodType(schema);
   const unwrappedSchema = unwrapZodType(schema, true);
 
   if (isPassThroughAny(unwrappedSchema)) {
     return {
-      query: convertObjectMembersToParameterObjects(getPassThroughShape({}, false), true),
+      query: convertObjectMembersToParameterObjects(
+        getPassThroughShape({}, false),
+        true,
+        undefined,
+        opts.env
+      ),
       shared: {},
     };
   }
@@ -272,12 +296,21 @@ export const convertQuery = (schema: unknown) => {
     throw createError('Query schema must be an _object_ schema validator!');
   }
   return {
-    query: convertObjectMembersToParameterObjects(unwrappedSchema.shape, false),
+    query: convertObjectMembersToParameterObjects(
+      unwrappedSchema.shape,
+      false,
+      undefined,
+      opts.env
+    ),
     shared: {},
   };
 };
 
-export const convertPathParameters = (schema: unknown, knownParameters: KnownParameters) => {
+export const convertPathParameters = (
+  schema: unknown,
+  knownParameters: KnownParameters,
+  opts: ConvertOptions = {}
+) => {
   assertInstanceOfZodType(schema);
   const unwrappedSchema = unwrapZodType(schema, true);
   const paramKeys = Object.keys(knownParameters);
@@ -291,7 +324,9 @@ export const convertPathParameters = (schema: unknown, knownParameters: KnownPar
     return {
       params: convertObjectMembersToParameterObjects(
         getPassThroughShape(knownParameters, true),
-        true
+        true,
+        undefined,
+        opts.env
       ),
       shared: {},
     };
@@ -303,7 +338,12 @@ export const convertPathParameters = (schema: unknown, knownParameters: KnownPar
   const schemaKeys = Object.keys(unwrappedSchema.shape);
   validatePathParameters(paramKeys, schemaKeys);
   return {
-    params: convertObjectMembersToParameterObjects(unwrappedSchema.shape, true),
+    params: convertObjectMembersToParameterObjects(
+      unwrappedSchema.shape,
+      true,
+      undefined,
+      opts.env
+    ),
     shared: {},
   };
 };
@@ -396,34 +436,6 @@ const zodV4OasComponentRegistry = new WeakMap<object, string>();
 
 const OAS_EXTENSIONS_MARKER = 'x-kbn-oas-extensions';
 
-/**
- * Register a Zod schema so that the OAS converter emits it as a named
- * component (`$ref: '#/components/schemas/<name>'`) instead of inlining it.
- *
- * These fields are merged verbatim into the generated OAS component schema,
- * filling the gap where Zod/JSON Schema cannot express OAS-native concepts.
- *
- * Example:
- * ```ts
- * export const StreamDefinition = z.union([...]).meta({
- *   id: 'StreamDefinition',
- *   openapi: {
- *     discriminator: {
- *       propertyName: 'type',
- *       mapping: { wired: '#/components/schemas/WiredStreamDefinition' },
- *     },
- *   },
- * });
- * ```
- */
-export interface OasMetaExtensions {
-  discriminator?: OpenAPIV3.DiscriminatorObject;
-  availability?: {
-    stability?: 'experimental' | 'stable' | 'tech_preview';
-    since?: string;
-  };
-}
-
 type NormalizedOasMetaExtensions = Omit<OasMetaExtensions, 'availability'> & {
   'x-state'?: string;
 };
@@ -450,6 +462,28 @@ const getZodMeta = (schema: z.ZodType): ZodSchemaMeta =>
 const getStableComponentName = (schema: z.ZodType): string | undefined =>
   zodV4OasComponentRegistry.get(schema as object) ?? getZodMeta(schema).id;
 
+/**
+ * Normalize a raw `openapi` meta object (as supplied via `.meta({ openapi })`)
+ * into the OAS extensions we emit. Notably converts `availability` into the
+ * `x-state` string. This is intentionally schema-agnostic so it can be reused
+ * for metadata that lives on outer wrappers (e.g. `.optional()` / `.default()`)
+ * where we only have the raw meta, not a convertible schema node.
+ */
+function normalizeRawOasMetaExtensions(
+  meta: OasMetaExtensions | undefined,
+  env: ConvertOptions['env']
+): NormalizedOasMetaExtensions | undefined {
+  if (!meta) return undefined;
+  const { availability, ...rest } = meta;
+  const xState = getXState(availability, env ?? { serverless: false });
+  const extensions: NormalizedOasMetaExtensions = {
+    ...rest,
+    ...(xState !== undefined ? { 'x-state': xState } : {}),
+  };
+
+  return Object.keys(extensions).length > 0 ? extensions : undefined;
+}
+
 function normalizeOasMetaExtensions(
   schema: z.ZodType,
   env: ConvertOptions['env']
@@ -457,12 +491,10 @@ function normalizeOasMetaExtensions(
   const { openapi: meta } = getZodMeta(schema);
   const autoDisc = meta?.discriminator ? null : buildAutoDiscriminator(schema);
   const autoDiscriminator = autoDisc?.discriminator;
-  const { availability, ...rest } = meta ?? {};
-  const xState = getXState(availability, env ?? { serverless: false });
+  const base = normalizeRawOasMetaExtensions(meta, env);
   const extensions = {
-    ...rest,
+    ...(base ?? {}),
     ...(autoDiscriminator ? { discriminator: autoDiscriminator } : {}),
-    ...(xState !== undefined ? { 'x-state': xState } : {}),
   };
 
   return Object.keys(extensions).length > 0 ? extensions : undefined;

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/type.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/type.ts
@@ -23,13 +23,17 @@ export interface ConvertOptions {
 export interface OpenAPIConverter {
   convertPathParameters(
     schema: unknown,
-    knownPathParameters: KnownParameters
+    knownPathParameters: KnownParameters,
+    opts?: ConvertOptions
   ): {
     params: OpenAPIV3.ParameterObject[];
     shared: { [key: string]: OpenAPIV3.SchemaObject };
   };
 
-  convertQuery(schema: unknown): {
+  convertQuery(
+    schema: unknown,
+    opts?: ConvertOptions
+  ): {
     query: OpenAPIV3.ParameterObject[];
     shared: { [key: string]: OpenAPIV3.SchemaObject };
   };

--- a/src/platform/packages/shared/kbn-zod/v4/index.ts
+++ b/src/platform/packages/shared/kbn-zod/v4/index.ts
@@ -7,6 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+// Side-effect import so the `GlobalMeta` augmentation (adding the typed
+// `openapi` field to `.meta()`) is included wherever `@kbn/zod` is imported.
+import './openapi';
+
 export * from 'zod/v4';
 export { isZod } from './util';
 export { lazySchema, setLazySchemaDisabled } from './lazy_schema';
+export type { OasMetaExtensions, OasMetaAvailability } from './openapi';

--- a/src/platform/packages/shared/kbn-zod/v4/openapi.ts
+++ b/src/platform/packages/shared/kbn-zod/v4/openapi.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// OpenAPI-specific metadata that can be attached to a Zod schema via `.meta({ openapi: { ... } })`.
+// These concepts cannot be expressed with plain Zod / JSON Schema, so they are
+// carried on the schema's global-registry metadata and merged into the OpenAPI
+// (OAS) document by `@kbn/router-to-openapispec`.
+
+/**
+ * OpenAPI discriminator. Structurally mirrors `OpenAPIV3.DiscriminatorObject`
+ * from `openapi-types` (kept local so `@kbn/zod` stays dependency-free).
+ */
+export interface DiscriminatorObject {
+  /** Name of the property in the payload that holds the discriminating value. */
+  propertyName: string;
+  /**
+   * Optional map of discriminating values to the schema (usually a
+   * `#/components/schemas/...` reference) that should be used for that value.
+   */
+  mapping?: { [key: string]: string };
+}
+
+/**
+ * API lifecycle information. The OAS generator maps this to an `x-state`
+ * extension on the corresponding schema (or named component).
+ */
+export interface OasMetaAvailability {
+  /**
+   * Lifecycle stage of the API surface. Determines the leading `x-state` text:
+   *
+   * - `stable` → Generally available
+   * - `tech_preview` → Technical Preview
+   * - `experimental` → Experimental
+   */
+  stability?: 'experimental' | 'stable' | 'tech_preview';
+  /**
+   * Version in which this feature became available (e.g. `'9.4.0'`).
+   * Appended to `x-state` output. Omitted in serverless output.
+   */
+  since?: string;
+}
+
+/**
+ * Register a Zod schema so that the OAS converter emits it as a named
+ * component (`$ref: '#/components/schemas/<name>'`) instead of inlining it.
+ *
+ * These fields are merged verbatim into the generated OAS component schema,
+ * filling the gap where Zod/JSON Schema cannot express OAS-native concepts.
+ *
+ */
+export interface OasMetaExtensions {
+  /**
+   * OAS discriminator for `z.union` schemas. Emitted verbatim as the
+   * `discriminator` keyword on the generated schema.
+   *
+   * @example
+   * ```ts
+   * export const StreamDefinition = z.union([...]).meta({
+   *   id: 'StreamDefinition',
+   *   openapi: {
+   *     discriminator: {
+   *       propertyName: 'type',
+   *       mapping: { wired: '#/components/schemas/WiredStreamDefinition' },
+   *     },
+   *   },
+   * });
+   * ```
+   */
+  discriminator?: DiscriminatorObject;
+  /**
+   * API lifecycle info. Mapped by the generator to an `x-state` extension on
+   * the corresponding schema (or named component).
+   *
+   * @example
+   * z.string().meta({
+   *   openapi: { availability: { stability: 'stable', since: '9.4.0' } },
+   * });
+   */
+  availability?: OasMetaAvailability;
+}
+
+declare module 'zod/v4/core' {
+  interface GlobalMeta {
+    /**
+     * OpenAPI-specific metadata consumed by `@kbn/router-to-openapispec` when
+     * generating the OAS document. Ignored by Zod's runtime validation.
+     */
+    openapi?: OasMetaExtensions;
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[OAS] Fix Zod meta `availability` to `x-state` (#281156)](https://github.com/elastic/kibana/pull/281156)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2026-07-29T21:09:49Z","message":"[OAS] Fix Zod meta `availability` to `x-state` (#281156)\n\n## Summary\n\nFix usage of `openapi.availability` when used on `.optional` or\n`.default` wrapper.\n\n```ts\nconst mySchema1 = z.string()\n  .optional() // this no longer blocks availability context\n  .meta({ openapi: { availability: { stability: 'stable', since: '9.6.0' } } });\n  \nconst mySchema2 = z.string()\n  .default('foo') // this no longer blocks availability context\n  .meta({ openapi: { availability: { stability: 'stable', since: '9.6.0' } } });\n```\n\nAlso adds global type support for custom `.meta({ openapi })`.\n\nFixes #281140\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1af96922d4be25932c3edbb9845f1f9ab9bd85af","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.6.0","v9.5.1"],"title":"[OAS] Fix Zod meta `availability` to `x-state`","number":281156,"url":"https://github.com/elastic/kibana/pull/281156","mergeCommit":{"message":"[OAS] Fix Zod meta `availability` to `x-state` (#281156)\n\n## Summary\n\nFix usage of `openapi.availability` when used on `.optional` or\n`.default` wrapper.\n\n```ts\nconst mySchema1 = z.string()\n  .optional() // this no longer blocks availability context\n  .meta({ openapi: { availability: { stability: 'stable', since: '9.6.0' } } });\n  \nconst mySchema2 = z.string()\n  .default('foo') // this no longer blocks availability context\n  .meta({ openapi: { availability: { stability: 'stable', since: '9.6.0' } } });\n```\n\nAlso adds global type support for custom `.meta({ openapi })`.\n\nFixes #281140\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1af96922d4be25932c3edbb9845f1f9ab9bd85af"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281156","number":281156,"mergeCommit":{"message":"[OAS] Fix Zod meta `availability` to `x-state` (#281156)\n\n## Summary\n\nFix usage of `openapi.availability` when used on `.optional` or\n`.default` wrapper.\n\n```ts\nconst mySchema1 = z.string()\n  .optional() // this no longer blocks availability context\n  .meta({ openapi: { availability: { stability: 'stable', since: '9.6.0' } } });\n  \nconst mySchema2 = z.string()\n  .default('foo') // this no longer blocks availability context\n  .meta({ openapi: { availability: { stability: 'stable', since: '9.6.0' } } });\n```\n\nAlso adds global type support for custom `.meta({ openapi })`.\n\nFixes #281140\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1af96922d4be25932c3edbb9845f1f9ab9bd85af"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->