### PR TITLE
[Cases] - Minor UX fixes

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/components/field_definition_yaml_editor.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/components/field_definition_yaml_editor.tsx
@@ -85,7 +85,7 @@ const getDefinitionValidationErrors = (value: string): ValidationError[] => {
 export const FieldDefinitionYamlEditor: React.FC<FieldDefinitionYamlEditorProps> = ({
   value,
   onChange,
-  height = 200,
+  height = 300,
   'data-test-subj': dataTestSubj,
 }) => {
   const {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/debounced_template_text_field.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/debounced_template_text_field.tsx
@@ -18,6 +18,8 @@ interface DebouncedTemplateTextFieldProps {
   onChange: (value: string) => void;
   dataTestSubj: string;
   multiline?: boolean;
+  /** Commit each keystroke immediately instead of waiting for the debounce delay. */
+  commitOnChange?: boolean;
   isInvalid?: boolean;
   error?: ReactNode;
   helpText?: ReactNode;
@@ -34,6 +36,7 @@ export const DebouncedTemplateTextField: React.FC<DebouncedTemplateTextFieldProp
   onChange,
   dataTestSubj,
   multiline = false,
+  commitOnChange = false,
   isInvalid = false,
   error,
   helpText,
@@ -42,8 +45,12 @@ export const DebouncedTemplateTextField: React.FC<DebouncedTemplateTextFieldProp
 
   const sharedProps = {
     value: localValue,
-    onChange: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-      setValue(event.target.value),
+    onChange: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setValue(event.target.value);
+      if (commitOnChange) {
+        flush();
+      }
+    },
     onBlur: flush,
     isInvalid,
     fullWidth: true,

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/header_menu.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/header_menu.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getTemplateFormMenu } from './header_menu';
+import * as i18n from '../translations';
+
+const getMenu = ({
+  hasYamlValidationErrors = false,
+  metadataErrors = {},
+}: {
+  hasYamlValidationErrors?: boolean;
+  metadataErrors?: { name?: string; description?: string; tags?: string };
+} = {}) =>
+  getTemplateFormMenu({
+    hasChanges: false,
+    hasYamlValidationErrors,
+    metadataErrors,
+    isEdit: false,
+    isEnabled: true,
+    submitError: null,
+    onReset: jest.fn(),
+    onSave: jest.fn(),
+    onIsEnabledChange: jest.fn(),
+  });
+
+describe('getTemplateFormMenu', () => {
+  it.each([
+    [{ name: i18n.TEMPLATE_NAME_REQUIRED }, false, i18n.PROVIDE_TEMPLATE_NAME_IN_CONFIGURATION],
+    [{}, true, i18n.FIX_FIELDS_YAML_ERRORS],
+    [{ name: i18n.TEMPLATE_NAME_REQUIRED }, true, i18n.FIX_FIELDS_YAML_AND_TEMPLATE_NAME],
+    [{ tags: 'Tag is too long.' }, false, i18n.FIX_CONFIGURATION_ERRORS],
+  ])(
+    'disables saving and identifies where to fix validation errors',
+    (metadataErrors, hasYamlValidationErrors, expectedTooltipContent) => {
+      const menu = getMenu({ metadataErrors, hasYamlValidationErrors });
+
+      expect(menu.primaryActionItem.disableButton).toBe(true);
+      expect(menu.primaryActionItem.tooltipContent).toBe(expectedTooltipContent);
+    }
+  );
+
+  it('leaves saving enabled when YAML and Configuration are valid', () => {
+    const menu = getMenu();
+
+    expect(menu.primaryActionItem.disableButton).toBe(false);
+    expect(menu.primaryActionItem.tooltipContent).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/header_menu.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/header_menu.test.ts
@@ -37,16 +37,26 @@ describe('getTemplateFormMenu', () => {
     'disables saving and identifies where to fix validation errors',
     (metadataErrors, hasYamlValidationErrors, expectedTooltipContent) => {
       const menu = getMenu({ metadataErrors, hasYamlValidationErrors });
+      const { primaryActionItem } = menu;
 
-      expect(menu.primaryActionItem.disableButton).toBe(true);
-      expect(menu.primaryActionItem.tooltipContent).toBe(expectedTooltipContent);
+      if (primaryActionItem == null) {
+        throw new Error('Expected a primary template save action.');
+      }
+
+      expect(primaryActionItem.disableButton).toBe(true);
+      expect(primaryActionItem.tooltipContent).toBe(expectedTooltipContent);
     }
   );
 
   it('leaves saving enabled when YAML and Configuration are valid', () => {
     const menu = getMenu();
+    const { primaryActionItem } = menu;
 
-    expect(menu.primaryActionItem.disableButton).toBe(false);
-    expect(menu.primaryActionItem.tooltipContent).toBeUndefined();
+    if (primaryActionItem == null) {
+      throw new Error('Expected a primary template save action.');
+    }
+
+    expect(primaryActionItem.disableButton).toBe(false);
+    expect(primaryActionItem.tooltipContent).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/header_menu.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/header_menu.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AppHeaderBadge, AppHeaderMenu } from '@kbn/app-header';
+import type { TemplateMetadataErrors } from '../utils/template_metadata';
 import * as i18n from '../translations';
 import * as fieldLibraryI18n from '../../field_library/translations';
 
@@ -55,7 +56,8 @@ export const getTemplatesListMenu = ({
 
 interface GetTemplateFormMenuArgs {
   hasChanges: boolean;
-  hasValidationErrors: boolean;
+  hasYamlValidationErrors: boolean;
+  metadataErrors: TemplateMetadataErrors;
   isEdit: boolean;
   isLoading?: boolean;
   isSaving?: boolean;
@@ -65,6 +67,37 @@ interface GetTemplateFormMenuArgs {
   onSave: () => void;
   onIsEnabledChange: (isEnabled: boolean) => void;
 }
+
+const getValidationTooltipContent = (
+  hasYamlValidationErrors: boolean,
+  metadataErrors: TemplateMetadataErrors
+): string | undefined => {
+  const hasTemplateNameError = metadataErrors.name != null;
+  const hasOtherConfigurationErrors =
+    metadataErrors.description != null || metadataErrors.tags != null;
+
+  if (hasYamlValidationErrors && hasTemplateNameError) {
+    return i18n.FIX_FIELDS_YAML_AND_TEMPLATE_NAME;
+  }
+
+  if (hasYamlValidationErrors && hasOtherConfigurationErrors) {
+    return i18n.FIX_FIELDS_YAML_AND_CONFIGURATION_ERRORS;
+  }
+
+  if (hasYamlValidationErrors) {
+    return i18n.FIX_FIELDS_YAML_ERRORS;
+  }
+
+  if (hasTemplateNameError) {
+    return i18n.PROVIDE_TEMPLATE_NAME_IN_CONFIGURATION;
+  }
+
+  if (hasOtherConfigurationErrors) {
+    return i18n.FIX_CONFIGURATION_ERRORS;
+  }
+
+  return undefined;
+};
 
 export const getTemplateFormBadges = (hasChanges: boolean): AppHeaderBadge[] =>
   hasChanges
@@ -79,7 +112,8 @@ export const getTemplateFormBadges = (hasChanges: boolean): AppHeaderBadge[] =>
 
 export const getTemplateFormMenu = ({
   hasChanges,
-  hasValidationErrors,
+  hasYamlValidationErrors,
+  metadataErrors,
   isEdit,
   isLoading,
   isSaving,
@@ -89,10 +123,13 @@ export const getTemplateFormMenu = ({
   onSave,
   onIsEnabledChange,
 }: GetTemplateFormMenuArgs): AppHeaderMenu => {
-  const saveTooltipContent =
-    submitError ?? (hasValidationErrors ? i18n.FIX_VALIDATION_ERRORS : undefined);
+  const validationTooltipContent = getValidationTooltipContent(
+    hasYamlValidationErrors,
+    metadataErrors
+  );
+  const saveTooltipContent = submitError ?? validationTooltipContent;
   const isActionDisabled = Boolean(isLoading || isSaving);
-  const isSaveDisabled = isActionDisabled || hasValidationErrors;
+  const isSaveDisabled = isActionDisabled || validationTooltipContent != null;
 
   return {
     ...(hasChanges

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.test.tsx
@@ -100,6 +100,7 @@ const TestWrapper = ({
   isSaving = false,
   hasChanges = false,
   initialValue = baseEditorYaml,
+  initialMetadata = { name: 'Template metadata', description: '', tags: [] },
 }: {
   onCreate: (
     data: YamlEditorFormValues,
@@ -110,6 +111,7 @@ const TestWrapper = ({
   isSaving?: boolean;
   hasChanges?: boolean;
   initialValue?: string;
+  initialMetadata?: TemplateMetadata;
 }) => {
   const form = useForm<YamlEditorFormValues>({
     defaultValues: {
@@ -126,7 +128,7 @@ const TestWrapper = ({
       isSaving={isSaving}
       storageKey="test-storage-key"
       initialValue={initialValue}
-      initialMetadata={{ name: 'Template metadata', description: '', tags: [] }}
+      initialMetadata={initialMetadata}
     />
   );
 };
@@ -735,6 +737,17 @@ fields:
     });
 
     renderWithTestingProviders(<TestWrapper onCreate={mockOnCreate} />);
+
+    expect(screen.getByTestId('saveTemplateHeaderButton')).toBeDisabled();
+  });
+
+  it('disables save button when the template name is missing', () => {
+    renderWithTestingProviders(
+      <TestWrapper
+        onCreate={mockOnCreate}
+        initialMetadata={{ name: '', description: '', tags: [] }}
+      />
+    );
 
     expect(screen.getByTestId('saveTemplateHeaderButton')).toBeDisabled();
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.tsx
@@ -334,11 +334,9 @@ export const TemplateFormLayout: React.FC<TemplateFormLayoutProps> = ({
   );
   const isYamlDefinitionValid = yamlValidationResult.success;
 
-  // Only the YAML's structural validity gates the Save button. Template-details validity (e.g. the
-  // required name) is checked at submit time against the freshest metadata (see handleSave), so the
-  // button stays responsive while the debounced metadata fields settle rather than flickering
-  // disabled after every keystroke.
-  const hasValidationErrors = useMemo(() => !isYamlDefinitionValid, [isYamlDefinitionValid]);
+  // Both the YAML definition and Configuration metadata must be valid before the primary action is
+  // enabled. The menu tooltip identifies the exact place to fix when either (or both) is invalid.
+  const hasYamlValidationErrors = useMemo(() => !isYamlDefinitionValid, [isYamlDefinitionValid]);
 
   // Freshest YAML, updated synchronously on every edit so Save and each subsequent edit build on the
   // latest value even while the debounced persistence hook (and the render-panel forms) lag behind.
@@ -542,7 +540,8 @@ export const TemplateFormLayout: React.FC<TemplateFormLayoutProps> = ({
     () =>
       getTemplateFormMenu({
         hasChanges,
-        hasValidationErrors,
+        hasYamlValidationErrors,
+        metadataErrors,
         isEdit,
         isLoading,
         isSaving,
@@ -557,7 +556,8 @@ export const TemplateFormLayout: React.FC<TemplateFormLayoutProps> = ({
       handleResetClick,
       handleSave,
       hasChanges,
-      hasValidationErrors,
+      hasYamlValidationErrors,
+      metadataErrors,
       isEdit,
       isEnabled,
       isLoading,
@@ -630,7 +630,7 @@ export const TemplateFormLayout: React.FC<TemplateFormLayoutProps> = ({
             metadataErrors={metadataErrors}
             onMetadataChange={handleMetadataChange}
             formResetKey={formResetKey}
-            fieldsHaveErrors={hasValidationErrors}
+            fieldsHaveErrors={hasYamlValidationErrors}
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_metadata_form.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_metadata_form.test.tsx
@@ -53,13 +53,12 @@ describe('TemplateMetadataForm', () => {
     expect(screen.getByText('Template name is required.')).toBeInTheDocument();
   });
 
-  it('propagates a name edit (debounced, flushed on blur)', () => {
+  it('propagates a name edit immediately so the save action can update', () => {
     const onChange = jest.fn();
     renderWithTestingProviders(<TemplateMetadataForm {...defaultProps} onChange={onChange} />);
 
     const input = screen.getByTestId('templateMetadataNameInput');
     fireEvent.change(input, { target: { value: 'Renamed template' } });
-    fireEvent.blur(input);
 
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ name: 'Renamed template' }));
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_metadata_form.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_metadata_form.tsx
@@ -38,10 +38,9 @@ export const TemplateMetadataForm: React.FC<TemplateMetadataFormProps> = ({
     [metadata.tags]
   );
 
-  // name/description isolate their keystrokes in DebouncedTemplateTextField, so typing never
-  // re-renders this form, Monaco, or the tags combobox — only propagating on pause/blur. Tags change
-  // atomically, so they propagate immediately. (The required-name check does not gate the Save
-  // button; Save validates the freshest metadata at submit time — see template_form_layout.)
+  // The required name commits immediately so the header action accurately enables/disables while
+  // typing. Description keystrokes remain local until pause/blur, avoiding needless re-renders of
+  // this form, Monaco, and the tags combobox. Tags change atomically, so they propagate immediately.
   const handleNameChange = useCallback(
     (value: string) => onChange({ ...metadata, name: value }),
     [metadata, onChange]
@@ -126,6 +125,7 @@ export const TemplateMetadataForm: React.FC<TemplateMetadataFormProps> = ({
         label={i18n.TEMPLATE_NAME_LABEL}
         value={metadata.name}
         onChange={handleNameChange}
+        commitOnChange
         isInvalid={errors.name != null}
         error={errors.name}
         dataTestSubj="templateMetadataNameInput"

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/translations.ts
@@ -172,6 +172,33 @@ export const FIX_VALIDATION_ERRORS = i18n.translate('xpack.cases.templates.fixVa
   defaultMessage: 'Please fix validation errors before saving.',
 });
 
+export const FIX_FIELDS_YAML_ERRORS = i18n.translate('xpack.cases.templates.fixFieldsYamlErrors', {
+  defaultMessage: 'Please fix errors in the Fields YAML editor.',
+});
+
+export const PROVIDE_TEMPLATE_NAME_IN_CONFIGURATION = i18n.translate(
+  'xpack.cases.templates.provideTemplateNameInConfiguration',
+  { defaultMessage: 'Please provide a template name in the Configuration tab.' }
+);
+
+export const FIX_CONFIGURATION_ERRORS = i18n.translate(
+  'xpack.cases.templates.fixConfigurationErrors',
+  { defaultMessage: 'Please fix errors in the Configuration tab.' }
+);
+
+export const FIX_FIELDS_YAML_AND_TEMPLATE_NAME = i18n.translate(
+  'xpack.cases.templates.fixFieldsYamlAndTemplateName',
+  {
+    defaultMessage:
+      'Please fix errors in the Fields YAML editor and provide a template name in the Configuration tab.',
+  }
+);
+
+export const FIX_FIELDS_YAML_AND_CONFIGURATION_ERRORS = i18n.translate(
+  'xpack.cases.templates.fixFieldsYamlAndConfigurationErrors',
+  { defaultMessage: 'Please fix errors in the Fields YAML editor and Configuration tab.' }
+);
+
 export const UNSAVED_CHANGES = i18n.translate('xpack.cases.templates.unsavedChanges', {
   defaultMessage: 'Unsaved changes',
 });


### PR DESCRIPTION
## Summary

Two primary changes in this PR:

#### 1. Make sure the create/save button is disabled when a template doesn't have a name and we provide better error messaging:

<img width="501" height="925" alt="image" src="https://github.com/user-attachments/assets/543d0995-aacc-452e-8ddc-60abfe8dc2b4" />

#### 2. Increase the height of the field library editor slightly

<img width="856" height="897" alt="image" src="https://github.com/user-attachments/assets/45d6c9d4-d78e-4a51-a1ea-ee2c69c182c4" />


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->