### PR TITLE
[9.4] [Fleet] Fix agents left with outdated policies by version-specific agent policies

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -52,6 +52,7 @@ import type { UninstallTokenServiceInterface } from './security/uninstall_token_
 import { isSpaceAwarenessEnabled } from './spaces/helpers';
 import { scheduleDeployAgentPoliciesTask } from './agent_policies/deploy_agent_policies_task';
 import { createAgentPolicyWithPackages } from './agent_policy_create';
+import { reassignAgentsFromVersionSpecificPolicies } from './utils/version_specific_policies';
 import { agentlessAgentService } from './agents/agentless_agent';
 import { getPackageInfo } from './epm/packages';
 import { ensureInstalledPackage } from './epm/packages/install';
@@ -139,6 +140,13 @@ jest.mock('./agent_policies/deploy_agent_policies_task');
 jest.mock('./agent_policy_create');
 jest.mock('./epm/packages/install');
 jest.mock('./epm/packages');
+jest.mock('./utils/version_specific_policies', () => {
+  const actual = jest.requireActual('./utils/version_specific_policies');
+  return {
+    ...actual,
+    reassignAgentsFromVersionSpecificPolicies: jest.fn(),
+  };
+});
 
 const mockedAppContextService = appContextService as jest.Mocked<typeof appContextService>;
 mockedAppContextService.getSecuritySetup.mockImplementation(() => ({
@@ -2009,6 +2017,124 @@ describe('Agent policy', () => {
         'agent-policy',
         expect.objectContaining({ has_agent_version_conditions: false })
       );
+    });
+
+    it('reassigns agents back to the base policy when version conditions are removed', async () => {
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
+      mockedAppContextService.getExperimentalFeatures.mockReturnValue({
+        enableVersionSpecificPolicies: true,
+      } as any);
+      const soClient = getAgentPolicyCreateMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      // Existing policy still had version conditions...
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            attributes: { has_agent_version_conditions: true },
+            id: 'agent-policy',
+            type: 'mocked',
+            references: [],
+          },
+        ],
+      });
+      // ...but no package policy requires them anymore (global beforeEach returns []).
+      await agentPolicyService.update(soClient, esClient, 'agent-policy', {
+        name: 'updated',
+        namespace: 'default',
+      });
+
+      expect(reassignAgentsFromVersionSpecificPolicies).toHaveBeenCalledWith(
+        soClient,
+        esClient,
+        'agent-policy'
+      );
+    });
+
+    it('does not fail the update when reassigning agents from version-specific policies throws', async () => {
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
+      mockedAppContextService.getExperimentalFeatures.mockReturnValue({
+        enableVersionSpecificPolicies: true,
+      } as any);
+      (reassignAgentsFromVersionSpecificPolicies as jest.Mock).mockRejectedValueOnce(
+        new Error('transient ES failure')
+      );
+      const soClient = getAgentPolicyCreateMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            attributes: { has_agent_version_conditions: true },
+            id: 'agent-policy',
+            type: 'mocked',
+            references: [],
+          },
+        ],
+      });
+
+      await expect(
+        agentPolicyService.update(soClient, esClient, 'agent-policy', {
+          name: 'updated',
+          namespace: 'default',
+        })
+      ).resolves.not.toThrow();
+
+      expect(reassignAgentsFromVersionSpecificPolicies).toHaveBeenCalled();
+    });
+
+    it('does not reassign agents when version conditions were never present', async () => {
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
+      mockedAppContextService.getExperimentalFeatures.mockReturnValue({
+        enableVersionSpecificPolicies: true,
+      } as any);
+      const soClient = getAgentPolicyCreateMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            attributes: { has_agent_version_conditions: false },
+            id: 'agent-policy',
+            type: 'mocked',
+            references: [],
+          },
+        ],
+      });
+
+      await agentPolicyService.update(soClient, esClient, 'agent-policy', {
+        name: 'updated',
+        namespace: 'default',
+      });
+
+      expect(reassignAgentsFromVersionSpecificPolicies).not.toHaveBeenCalled();
+    });
+
+    it('does not reassign agents when the feature is disabled', async () => {
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
+      mockedAppContextService.getExperimentalFeatures.mockReturnValue({
+        enableVersionSpecificPolicies: false,
+      } as any);
+      const soClient = getAgentPolicyCreateMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            attributes: { has_agent_version_conditions: true },
+            id: 'agent-policy',
+            type: 'mocked',
+            references: [],
+          },
+        ],
+      });
+
+      await agentPolicyService.update(soClient, esClient, 'agent-policy', {
+        name: 'updated',
+        namespace: 'default',
+      });
+
+      expect(reassignAgentsFromVersionSpecificPolicies).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -176,6 +176,7 @@ import { getSpaceForAgentPolicy, getSpaceForAgentPolicySO } from './spaces/helpe
 import {
   getVersionSpecificPolicies,
   getAgentVersionsForVersionSpecificPolicies,
+  reassignAgentsFromVersionSpecificPolicies,
 } from './utils/version_specific_policies';
 import { scheduleReassignAgentsToVersionSpecificPoliciesTask } from './agent_policies/reassign_agents_to_version_specific_policies_task';
 
@@ -328,6 +329,32 @@ class AgentPolicyService {
             spaceId: soClient.getCurrentNamespace(),
           },
         ]);
+      }
+    }
+
+    // If this policy no longer requires version-specific policies (e.g. the integration/input
+    // that required them was removed), reassign any agents still assigned to a variant policy back
+    // to the base policy and clean up the stale variant documents. Otherwise those agents stay on
+    // a variant policy that is never updated again and get stuck reporting an outdated policy.
+    // See https://github.com/elastic/kibana/issues/276294
+    if (
+      appContextService.getExperimentalFeatures().enableVersionSpecificPolicies &&
+      existingAgentPolicy.has_agent_version_conditions &&
+      options.hasAgentVersionConditions === false
+    ) {
+      logger.debug(
+        `Agent policy [${id}] no longer has agent version conditions, reassigning agents from version-specific policies back to the base policy`
+      );
+      // Swallow and log: the SO update, revision bump, and deploy have already committed above, so
+      // a transient failure here must not fail the whole update (a retry would also skip this
+      // branch, since has_agent_version_conditions is now false). The periodic sweep is the
+      // fallback that recovers any agents this inline pass misses.
+      try {
+        await reassignAgentsFromVersionSpecificPolicies(soClient, esClient, id);
+      } catch (error) {
+        logger.error(
+          `Failed to reassign agents from version-specific policies for agent policy [${id}]: ${error}`
+        );
       }
     }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/utils/version_specific_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/utils/version_specific_policies.test.ts
@@ -9,6 +9,8 @@ jest.mock('../agents', () => ({
   getAvailableVersions: jest
     .fn()
     .mockResolvedValue(['9.3.0', '9.1.0', '8.6.0', '8.9.0', '8.8.0', '7.17.0']),
+  getAgentsByKuery: jest.fn(),
+  reassignAgents: jest.fn(),
 }));
 
 jest.mock('../app_context', () => ({
@@ -16,6 +18,7 @@ jest.mock('../app_context', () => ({
     getKibanaVersion: () => '9.3.0',
     getLogger: () => ({
       debug: jest.fn(),
+      info: jest.fn(),
     }),
   },
 }));
@@ -44,9 +47,14 @@ jest.mock('../agent_policy', () => ({
   },
 }));
 
+import * as AgentService from '../agents';
+
 import {
+  buildVariantAgentsKuery,
+  deleteVersionSpecificFleetServerPolicies,
   getAgentVersionsForVersionSpecificPolicies,
   getVersionSpecificPolicies,
+  reassignAgentsFromVersionSpecificPolicies,
 } from './version_specific_policies';
 
 describe('getAgentVersionsForVersionSpecificPolicies', () => {
@@ -71,6 +79,7 @@ describe('getVersionSpecificPolicies', () => {
     expect(policies).toEqual([
       {
         data: {
+          id: 'policy1#9.3',
           inputs: [
             {
               meta: {
@@ -86,6 +95,7 @@ describe('getVersionSpecificPolicies', () => {
       },
       {
         data: {
+          id: 'policy1#9.2',
           inputs: [],
         },
         policy_id: 'policy1#9.2',
@@ -93,6 +103,7 @@ describe('getVersionSpecificPolicies', () => {
       },
       {
         data: {
+          id: 'policy1#8.9',
           inputs: [],
         },
         policy_id: 'policy1#8.9',
@@ -118,6 +129,7 @@ describe('getVersionSpecificPolicies', () => {
     expect(policies).toEqual([
       {
         data: {
+          id: 'policy1#9.4',
           inputs: [
             {
               meta: {
@@ -133,6 +145,7 @@ describe('getVersionSpecificPolicies', () => {
       },
       {
         data: {
+          id: 'policy1#9.1',
           inputs: [],
         },
         policy_id: 'policy1#9.1',
@@ -149,6 +162,7 @@ describe('getVersionSpecificPolicies', () => {
     expect(policies).toEqual([
       {
         data: {
+          id: 'policy1#9.3',
           inputs: [
             {
               type: 'cel',
@@ -160,6 +174,7 @@ describe('getVersionSpecificPolicies', () => {
       },
       {
         data: {
+          id: 'policy1#9.2',
           inputs: [
             {
               type: 'cel',
@@ -171,6 +186,7 @@ describe('getVersionSpecificPolicies', () => {
       },
       {
         data: {
+          id: 'policy1#8.9',
           inputs: [],
         },
         policy_id: 'policy1#8.9',
@@ -189,6 +205,7 @@ describe('getVersionSpecificPolicies', () => {
     expect(policies).toEqual([
       {
         data: {
+          id: 'policy1#9.4',
           inputs: [
             {
               type: 'cel',
@@ -200,6 +217,7 @@ describe('getVersionSpecificPolicies', () => {
       },
       {
         data: {
+          id: 'policy1#9.1',
           inputs: [
             {
               type: 'cel',
@@ -225,6 +243,7 @@ describe('getVersionSpecificPolicies', () => {
     expect(policies).toEqual([
       {
         data: {
+          id: 'policyBothConditions#9.3',
           inputs: [
             {
               meta: { package: { agentVersion: '>=9.3.0' } },
@@ -239,6 +258,7 @@ describe('getVersionSpecificPolicies', () => {
       },
       {
         data: {
+          id: 'policyBothConditions#9.2',
           inputs: [
             {
               type: 'cel',
@@ -250,11 +270,94 @@ describe('getVersionSpecificPolicies', () => {
       },
       {
         data: {
+          id: 'policyBothConditions#8.9',
           inputs: [],
         },
         policy_id: 'policyBothConditions#8.9',
         policy_base_id: 'policyBothConditions',
       },
     ]);
+  });
+});
+
+describe('reassignAgentsFromVersionSpecificPolicies', () => {
+  const soClient = {} as any;
+  const esClient = { deleteByQuery: jest.fn() } as any;
+  const getAgentsByKueryMock = AgentService.getAgentsByKuery as jest.Mock;
+  const reassignAgentsMock = AgentService.reassignAgents as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    esClient.deleteByQuery.mockResolvedValue({});
+  });
+
+  const variantKuery = 'policy_base_id:"policy1" and not policy_id:"policy1"';
+
+  it('reassigns agents on variant policies back to the base policy', async () => {
+    getAgentsByKueryMock.mockResolvedValue({ total: 3 });
+
+    await reassignAgentsFromVersionSpecificPolicies(soClient, esClient, 'policy1');
+
+    expect(getAgentsByKueryMock).toHaveBeenCalledWith(esClient, soClient, {
+      kuery: variantKuery,
+      showInactive: false,
+      perPage: 0,
+    });
+    expect(reassignAgentsMock).toHaveBeenCalledWith(
+      soClient,
+      esClient,
+      { kuery: variantKuery, showInactive: false },
+      'policy1'
+    );
+  });
+
+  it('does not reassign when there are no agents on variant policies', async () => {
+    getAgentsByKueryMock.mockResolvedValue({ total: 0 });
+
+    await reassignAgentsFromVersionSpecificPolicies(soClient, esClient, 'policy1');
+
+    expect(reassignAgentsMock).not.toHaveBeenCalled();
+  });
+
+  it('does not delete variant documents (deletion is owned by the periodic sweep)', async () => {
+    getAgentsByKueryMock.mockResolvedValue({ total: 3 });
+
+    await reassignAgentsFromVersionSpecificPolicies(soClient, esClient, 'policy1');
+
+    expect(esClient.deleteByQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteVersionSpecificFleetServerPolicies', () => {
+  const esClient = { deleteByQuery: jest.fn() } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    esClient.deleteByQuery.mockResolvedValue({});
+  });
+
+  it('deletes only the variant documents via policy_base_id (excluding the base) without forcing a refresh', async () => {
+    await deleteVersionSpecificFleetServerPolicies(esClient, 'policy1');
+
+    expect(esClient.deleteByQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: '.fleet-policies',
+        query: {
+          bool: {
+            filter: [{ term: { policy_base_id: 'policy1' } }],
+            must_not: [{ term: { policy_id: 'policy1' } }],
+          },
+        },
+        refresh: false,
+      })
+    );
+  });
+});
+
+describe('buildVariantAgentsKuery', () => {
+  it('matches variant assignments via policy_base_id and excludes the base policy (no wildcard)', () => {
+    const kuery = buildVariantAgentsKuery('policy1');
+    expect(kuery).toBe('policy_base_id:"policy1" and not policy_id:"policy1"');
+    expect(kuery).not.toContain('*');
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/utils/version_specific_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/utils/version_specific_policies.ts
@@ -7,14 +7,35 @@
 
 import { coerce, satisfies } from 'semver';
 
-import type { SavedObjectsClientContract } from '@kbn/core/server';
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import { escapeQuotes } from '@kbn/es-query';
 
 import { appContextService } from '../app_context';
 import * as AgentService from '../agents';
 import type { FleetServerPolicy, FullAgentPolicy, FullAgentPolicyInput } from '../../types';
 import { agentPolicyService } from '../agent_policy';
 import type { PackageInfo, PackagePolicyAssetsMap } from '../../../common/types';
-import { AGENT_POLICY_VERSION_SEPARATOR } from '../../../common/constants';
+import { AGENT_POLICY_INDEX, AGENT_POLICY_VERSION_SEPARATOR } from '../../../common/constants';
+
+/** Field on `.fleet-agents` / `.fleet-policies` holding the canonical (suffix-stripped) policy id. */
+const POLICY_BASE_ID_FIELD = 'policy_base_id';
+
+/**
+ * KQL matching agents assigned to a version-specific variant of the given base policy — but NOT the
+ * base policy itself. Term-based on `policy_base_id` (no wildcard/prefix), so it stays compatible
+ * with `search.allow_expensive_queries: false`.
+ *
+ * Mixed-version rollout note: an agent enrolled by a downlevel fleet-server after the last Kibana
+ * startup backfill will have a versioned `policy_id` (e.g. `policy1#9.4`) but no `policy_base_id`
+ * field. Such agents are NOT matched by this kuery. The orphan sweep may therefore delete the
+ * variant `.fleet-policies` document before that agent is reassigned, leaving it pointing to a
+ * missing policy until the next Kibana restart re-runs the startup backfill and recovers it. The
+ * window is bounded by the time between the mixed-version enrollment and the next restart.
+ */
+export function buildVariantAgentsKuery(parentPolicyId: string): string {
+  const escapedId = escapeQuotes(parentPolicyId);
+  return `${POLICY_BASE_ID_FIELD}:"${escapedId}" and not policy_id:"${escapedId}"`;
+}
 
 export async function getAgentVersionsForVersionSpecificPolicies(): Promise<string[]> {
   const commonVersions = [];
@@ -73,12 +94,18 @@ export async function getVersionSpecificPolicies(
         agentVersion: version,
       });
     }
+    const versionedPolicyId = `${fullPolicy.id}${AGENT_POLICY_VERSION_SEPARATOR}${version}`;
     const versionSpecificPolicy: FleetServerPolicy = {
       ...fleetServerPolicy,
-      policy_id: `${fullPolicy.id}${AGENT_POLICY_VERSION_SEPARATOR}${version}`,
+      policy_id: versionedPolicyId,
       policy_base_id: fullPolicy.id,
       data: {
         ...fleetServerPolicy.data,
+        // The agent reports the policy id from `data.id` on checkin, so it must carry the
+        // version suffix too. Otherwise the agent reports the base id, fleet-server sees a
+        // mismatch against the versioned `agent.policy_id`, and the agent churns on
+        // POLICY_CHANGE actions every checkin. See https://github.com/elastic/kibana/issues/276294
+        id: versionedPolicyId,
         inputs: getInputsForVersion(updatedFullPolicy?.inputs ?? fullPolicy.inputs, version),
       },
     };
@@ -86,6 +113,74 @@ export async function getVersionSpecificPolicies(
   }
 
   return fleetServerPolicies;
+}
+
+/**
+ * Reassign any agents still on a version-specific variant policy (`<parentId>#<version>`) of a
+ * parent that no longer requires them back to the base policy, so they keep syncing.
+ *
+ * Without this, removing the integration/input that required version-specific policies leaves
+ * agents assigned to a variant policy that is never updated again, so they get stuck reporting an
+ * outdated policy. See https://github.com/elastic/kibana/issues/276294
+ *
+ * This is the inline fast path invoked from the agent policy update, and is scoped to the caller's
+ * space via `soClient`. It intentionally does NOT delete the variant `.fleet-policies` documents:
+ * deletion is global (across spaces) and owned by the periodic sweep, which first reassigns agents
+ * across every space. Deleting here would strand agents in other spaces that still reference the
+ * variant document until the next sweep run.
+ */
+export async function reassignAgentsFromVersionSpecificPolicies(
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  parentPolicyId: string
+): Promise<void> {
+  const logger = appContextService.getLogger();
+  const variantKuery = buildVariantAgentsKuery(parentPolicyId);
+
+  const { total } = await AgentService.getAgentsByKuery(esClient, soClient, {
+    kuery: variantKuery,
+    showInactive: false,
+    perPage: 0,
+  });
+  if (total === 0) {
+    return;
+  }
+  logger.info(
+    `Reassigning ${total} agents from version-specific policies of ${parentPolicyId} back to the base policy`
+  );
+  await AgentService.reassignAgents(
+    soClient,
+    esClient,
+    { kuery: variantKuery, showInactive: false },
+    parentPolicyId
+  );
+}
+
+/**
+ * Delete the version-specific (`<parentId>#<version>`) documents for a parent agent policy from
+ * the `.fleet-policies` index. Used when a policy no longer requires version-specific policies so
+ * the now-stale variant documents don't linger.
+ */
+export async function deleteVersionSpecificFleetServerPolicies(
+  esClient: ElasticsearchClient,
+  parentPolicyId: string
+): Promise<void> {
+  await esClient.deleteByQuery({
+    index: AGENT_POLICY_INDEX,
+    ignore_unavailable: true,
+    // Match only the variant documents: `policy_base_id` is the base id for both the base and its
+    // variants, so exclude the base document by `must_not policy_id: parentPolicyId`. Term-based
+    // (no `prefix`), so it works with `search.allow_expensive_queries: false`. Every `.fleet-policies`
+    // document carries `policy_base_id` (written on deploy and backfilled at startup).
+    query: {
+      bool: {
+        filter: [{ term: { [POLICY_BASE_ID_FIELD]: parentPolicyId } }],
+        must_not: [{ term: { policy_id: parentPolicyId } }],
+      },
+    },
+    // Cleanup only; no reader needs the deletion visible synchronously, so avoid forcing a refresh.
+    refresh: false,
+  });
 }
 
 export function hasAgentVersionConditionInInputTemplate(

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.test.ts
@@ -15,10 +15,16 @@ import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
 import { createAppContextStartContractMock } from '../mocks';
 import { agentPolicyService, appContextService, packagePolicyService } from '../services';
 import { fetchAllAgentsByKuery, getAgentsByKuery } from '../services/agents';
+import { reassignAgents } from '../services/agents/reassign';
 import { getPackageInfo } from '../services/epm/packages';
 import { getAgentTemplateAssetsMap } from '../services/epm/packages/get';
-import { hasAgentVersionConditionInInputTemplate } from '../services/utils/version_specific_policies';
+import {
+  deleteVersionSpecificFleetServerPolicies,
+  hasAgentVersionConditionInInputTemplate,
+} from '../services/utils/version_specific_policies';
 import type { Agent, AgentPolicy, PackagePolicy } from '../types';
+
+import { AGENT_POLICY_INDEX } from '../../common/constants';
 
 import {
   VersionSpecificPolicyAssignmentTask,
@@ -28,6 +34,7 @@ import {
 
 jest.mock('../services');
 jest.mock('../services/agents');
+jest.mock('../services/agents/reassign');
 jest.mock('../services/epm/packages');
 jest.mock('../services/epm/packages/get');
 jest.mock('../services/utils/version_specific_policies');
@@ -59,6 +66,11 @@ const mockedGetAgentTemplateAssetsMap = getAgentTemplateAssetsMap as jest.Mocked
 const mockedHasAgentVersionConditionInInputTemplate =
   hasAgentVersionConditionInInputTemplate as jest.MockedFunction<
     typeof hasAgentVersionConditionInInputTemplate
+  >;
+const mockedReassignAgents = reassignAgents as jest.MockedFunction<typeof reassignAgents>;
+const mockedDeleteVersionSpecificFleetServerPolicies =
+  deleteVersionSpecificFleetServerPolicies as jest.MockedFunction<
+    typeof deleteVersionSpecificFleetServerPolicies
   >;
 
 const getMockAgentPolicyFetchAllAgentPolicies = (items: AgentPolicy[]) =>
@@ -126,6 +138,20 @@ describe('VersionSpecificPolicyAssignmentTask', () => {
     const mockTaskManagerStart = tmStartMock();
     await mockTask.start({ taskManager: mockTaskManagerStart });
     return mockTask.runTask(taskInstance, mockCore, new AbortController());
+  };
+
+  // Configure the .fleet-policies terms aggregation the orphan sweep reads in its first pass.
+  const mockVariantPoliciesInIndex = async (variantPolicyIds: string[]) => {
+    const [coreStart] = await mockCore.getStartServices();
+    const esClient = coreStart.elasticsearch.client.asInternalUser as any;
+    esClient.search.mockResolvedValue({
+      aggregations: {
+        variant_policies: {
+          buckets: variantPolicyIds.map((key) => ({ key })),
+          sum_other_doc_count: 0,
+        },
+      },
+    });
   };
 
   describe('Task lifecycle', () => {
@@ -212,10 +238,13 @@ describe('VersionSpecificPolicyAssignmentTask', () => {
 
     it('Should do nothing if no agent policies have version conditions', async () => {
       mockAgentPolicyService.fetchAllAgentPolicies = getMockAgentPolicyFetchAllAgentPolicies([]);
+      // Orphan sweep runs afterwards; no version-specific policies exist in .fleet-policies.
+      await mockVariantPoliciesInIndex([]);
 
       await runTask();
 
-      expect(mockedGetAgentsByKuery).not.toHaveBeenCalled();
+      expect(mockAgentPolicyService.deployPolicies).not.toHaveBeenCalled();
+      expect(mockedReassignAgents).not.toHaveBeenCalled();
     });
 
     it('Should process agent policies with version conditions', async () => {
@@ -579,6 +608,167 @@ describe('VersionSpecificPolicyAssignmentTask', () => {
         ['policy-1'],
         undefined,
         { agentVersions: ['8.18'] }
+      );
+    });
+  });
+
+  describe('Orphaned version-specific policy sweep', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(appContextService, 'getExperimentalFeatures')
+        .mockReturnValue({ enableVersionSpecificPolicies: true } as any);
+      jest
+        .spyOn(appContextService, 'getInternalUserSOClientWithoutSpaceExtension')
+        .mockReturnValue({} as any);
+      // No agent policies with version conditions, so the main processing is a no-op and only the
+      // orphan sweep runs.
+      mockAgentPolicyService.fetchAllAgentPolicies = getMockAgentPolicyFetchAllAgentPolicies([]);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('reassigns orphaned agents and deletes stale variant docs when the parent no longer has version conditions', async () => {
+      await mockVariantPoliciesInIndex(['policy-1#9.4', 'policy-1#9.3']);
+      mockAgentPolicyService.getByIds = jest
+        .fn()
+        .mockResolvedValue([{ id: 'policy-1', has_agent_version_conditions: false }]);
+      const variantAgents = [
+        { id: 'agent-1', policy_id: 'policy-1#9.4' },
+        { id: 'agent-2', policy_id: 'policy-1#9.3' },
+      ] as Agent[];
+      mockedFetchAllAgentsByKuery.mockResolvedValue(getMockFetchAllAgentsByKuery(variantAgents));
+      // Post-reassignment count check: all agents moved successfully.
+      mockedGetAgentsByKuery.mockResolvedValueOnce({ total: 0, agents: [], page: 1, perPage: 0 });
+
+      await runTask();
+
+      expect(mockAgentPolicyService.getByIds).toHaveBeenCalledWith(
+        expect.anything(),
+        [{ id: 'policy-1', spaceId: '*' }],
+        expect.objectContaining({ ignoreMissing: true })
+      );
+      // Inactive agents must be included, otherwise their variant doc is deleted below while they
+      // still reference it (https://github.com/elastic/kibana/pull/280250 review).
+      expect(mockedFetchAllAgentsByKuery).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ showInactive: true })
+      );
+      expect(mockedReassignAgents).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        { agentIds: ['agent-1', 'agent-2'], showInactive: true },
+        'policy-1'
+      );
+      expect(mockedDeleteVersionSpecificFleetServerPolicies).toHaveBeenCalledWith(
+        expect.anything(),
+        'policy-1'
+      );
+    });
+
+    it('skips variant doc deletion and retries on next run when bulk reassignment partially fails', async () => {
+      // Simulate: reassignAgents returns { actionId } without throwing even though one agent's
+      // _update failed (bulkUpdateAgents silently collects per-agent errors). The post-reassignment
+      // count check sees 1 remaining agent and must skip deleteVersionSpecificFleetServerPolicies
+      // so the next sweep run can retry rather than stranding the agent on a missing policy.
+      await mockVariantPoliciesInIndex(['policy-1#9.4']);
+      mockAgentPolicyService.getByIds = jest
+        .fn()
+        .mockResolvedValue([{ id: 'policy-1', has_agent_version_conditions: false }]);
+      mockedFetchAllAgentsByKuery.mockResolvedValue(
+        getMockFetchAllAgentsByKuery([{ id: 'agent-1', policy_id: 'policy-1#9.4' }] as Agent[])
+      );
+      // Post-reassignment count: 1 agent still on variant (bulk update failed silently).
+      mockedGetAgentsByKuery.mockResolvedValueOnce({ total: 1, agents: [], page: 1, perPage: 0 });
+
+      await runTask();
+
+      expect(mockedReassignAgents).toHaveBeenCalled();
+      // Must NOT delete variant docs — the stranded agent must be recoverable on the next run.
+      expect(mockedDeleteVersionSpecificFleetServerPolicies).not.toHaveBeenCalled();
+    });
+
+    it('does not reassign when the parent policy still has version conditions', async () => {
+      await mockVariantPoliciesInIndex(['policy-1#9.4']);
+      mockAgentPolicyService.getByIds = jest
+        .fn()
+        .mockResolvedValue([{ id: 'policy-1', has_agent_version_conditions: true }]);
+
+      await runTask();
+
+      expect(mockedFetchAllAgentsByKuery).not.toHaveBeenCalled();
+      expect(mockedReassignAgents).not.toHaveBeenCalled();
+      expect(mockedDeleteVersionSpecificFleetServerPolicies).not.toHaveBeenCalled();
+    });
+
+    it('does not reassign when the parent policy no longer exists', async () => {
+      await mockVariantPoliciesInIndex(['policy-1#9.4']);
+      // getByIds with ignoreMissing filters out deleted policies.
+      mockAgentPolicyService.getByIds = jest.fn().mockResolvedValue([]);
+
+      await runTask();
+
+      expect(mockedReassignAgents).not.toHaveBeenCalled();
+      expect(mockedDeleteVersionSpecificFleetServerPolicies).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no version-specific policies exist', async () => {
+      await mockVariantPoliciesInIndex([]);
+      mockAgentPolicyService.getByIds = jest.fn();
+
+      await runTask();
+
+      expect(mockAgentPolicyService.getByIds).not.toHaveBeenCalled();
+      expect(mockedReassignAgents).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-versioned policy ids when scanning .fleet-policies', async () => {
+      // The whole-index aggregation returns base ids too; only variant ids should be acted on.
+      await mockVariantPoliciesInIndex(['policy-1', 'policy-2']);
+      mockAgentPolicyService.getByIds = jest.fn();
+
+      await runTask();
+
+      expect(mockAgentPolicyService.getByIds).not.toHaveBeenCalled();
+      expect(mockedReassignAgents).not.toHaveBeenCalled();
+    });
+
+    it('queries .fleet-policies with the correct aggregation shape', async () => {
+      const [coreStart] = await mockCore.getStartServices();
+      const esClient = coreStart.elasticsearch.client.asInternalUser as any;
+      await mockVariantPoliciesInIndex([]);
+
+      await runTask();
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: AGENT_POLICY_INDEX,
+          size: 0,
+          aggs: expect.objectContaining({
+            variant_policies: expect.objectContaining({
+              terms: expect.objectContaining({ field: 'policy_id' }),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('deletes variant docs even when the orphaned parent currently has no assigned agents', async () => {
+      await mockVariantPoliciesInIndex(['policy-1#9.4']);
+      mockAgentPolicyService.getByIds = jest
+        .fn()
+        .mockResolvedValue([{ id: 'policy-1', has_agent_version_conditions: false }]);
+      // No agents remain on the variant policies (e.g. already reassigned by the inline path).
+      mockedFetchAllAgentsByKuery.mockResolvedValue(getMockFetchAllAgentsByKuery([]));
+
+      await runTask();
+
+      expect(mockedReassignAgents).not.toHaveBeenCalled();
+      expect(mockedDeleteVersionSpecificFleetServerPolicies).toHaveBeenCalledWith(
+        expect.anything(),
+        'policy-1'
       );
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.ts
@@ -28,14 +28,18 @@ import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../constants';
 import { agentPolicyService, appContextService, packagePolicyService } from '../services';
 import { getPackageInfo } from '../services/epm/packages';
 import { getAgentTemplateAssetsMap } from '../services/epm/packages/get';
-import { hasAgentVersionConditionInInputTemplate } from '../services/utils/version_specific_policies';
+import {
+  buildVariantAgentsKuery,
+  deleteVersionSpecificFleetServerPolicies,
+  hasAgentVersionConditionInInputTemplate,
+} from '../services/utils/version_specific_policies';
 import { fetchAllAgentsByKuery, getAgentsByKuery } from '../services/agents';
 import { reassignAgents } from '../services/agents/reassign';
 import {
   splitVersionSuffixFromPolicyId,
   buildVersionVariantsKueryFragment,
 } from '../../common/services/version_specific_policies_utils';
-import { AGENT_POLICY_VERSION_SEPARATOR } from '../../common/constants';
+import { AGENT_POLICY_INDEX, AGENT_POLICY_VERSION_SEPARATOR } from '../../common/constants';
 
 import { throwIfAborted } from './utils';
 
@@ -50,6 +54,9 @@ const AGENTS_BATCHSIZE = 1000;
 const MAX_CONCURRENT_REASSIGNMENTS = 5;
 // Time window to look for recently upgraded agents
 const RECENTLY_UPGRADED_WINDOW_MINUTES = 30;
+// Upper bound on the number of distinct version-specific policy ids we inspect for orphaned agents
+// in a single run. Far above any realistic deployment; a safety valve against unbounded aggregations.
+const MAX_VERSION_SPECIFIC_POLICY_BUCKETS = 10000;
 
 interface VersionSpecificPolicyAssignmentTaskConfig {
   taskInterval?: string;
@@ -175,6 +182,11 @@ export class VersionSpecificPolicyAssignmentTask {
 
     try {
       await this.processAgentPoliciesWithVersionConditions(esClient, soClient, abortController);
+      await this.reassignAgentsFromOrphanedVersionSpecificPolicies(
+        esClient,
+        soClient,
+        abortController
+      );
       this.endRun('success');
     } catch (err) {
       if (err instanceof errors.RequestAbortedError) {
@@ -525,6 +537,166 @@ export class VersionSpecificPolicyAssignmentTask {
     } catch (error) {
       this.logger.error(
         `[VersionSpecificPolicyAssignmentTask] Error reassigning agents to ${targetPolicyId}: ${error}`
+      );
+    }
+  }
+
+  /**
+   * Orphan sweep: find version-specific (variant) policies whose parent policy no longer requires
+   * them (e.g. the integration/input that required them was removed), reassign any agents still on
+   * those variants back to the base policy so they keep syncing, and delete the stale variant
+   * documents.
+   *
+   * This complements the reassignment done inline when the agent policy is updated: it is the
+   * cross-space source of truth that recovers agents the inline path can't (agents in a different
+   * space than the request, or updates that predate the inline fix) and removes the variant
+   * documents once no agent references them. See https://github.com/elastic/kibana/issues/276294
+   */
+  private async reassignAgentsFromOrphanedVersionSpecificPolicies(
+    esClient: ElasticsearchClient,
+    soClient: SavedObjectsClientContract,
+    abortController: AbortController
+  ) {
+    // Cheap first pass: enumerate the distinct policy ids present in `.fleet-policies` via a terms
+    // aggregation (not gated by `search.allow_expensive_queries`). That index is far smaller than
+    // `.fleet-agents` (one set of documents per policy, not per agent), so we drive the sweep off it
+    // rather than scanning agents; working from the documents also means stale variants are cleaned
+    // up even once every agent has already moved off them. The version suffix is filtered in memory
+    // below, which keeps the aggregation to a single field and yields exactly the base ids that have
+    // variant documents.
+    const policiesResponse = await esClient.search<
+      unknown,
+      { variant_policies: { buckets: Array<{ key: string }>; sum_other_doc_count: number } }
+    >({
+      index: AGENT_POLICY_INDEX,
+      ignore_unavailable: true,
+      size: 0,
+      aggs: {
+        // Named 'variant_policies' for intent. The field is 'policy_id' (not 'policy_base_id')
+        // because we need every doc in the index — base and variant alike. Version-suffixed ids
+        // are then filtered in memory below to derive the set of parent ids with variant docs.
+        variant_policies: {
+          terms: { field: 'policy_id', size: MAX_VERSION_SPECIFIC_POLICY_BUCKETS },
+        },
+      },
+    });
+
+    const variantPoliciesAgg = policiesResponse.aggregations?.variant_policies;
+    const buckets = variantPoliciesAgg?.buckets ?? [];
+    if (buckets.length === 0) {
+      return;
+    }
+    if (variantPoliciesAgg?.sum_other_doc_count) {
+      this.logger.warn(
+        `[VersionSpecificPolicyAssignmentTask] More than ${MAX_VERSION_SPECIFIC_POLICY_BUCKETS} policies in .fleet-policies; some version-specific policies will be checked for orphaned assignments on a later run`
+      );
+    }
+
+    // Keep only version-specific variant ids (e.g. `policy1#9.4`) and collapse them down to their
+    // distinct parent policy ids.
+    const basePolicyIds = [
+      ...new Set(
+        buckets
+          .map((bucket) => splitVersionSuffixFromPolicyId(bucket.key))
+          .filter(({ version }) => version !== null)
+          .map(({ baseId }) => baseId)
+      ),
+    ];
+    if (basePolicyIds.length === 0) {
+      return;
+    }
+
+    // A variant is only orphaned if its parent policy still exists but no longer has version
+    // conditions. Parents that still have conditions are healthy; parents that no longer exist are
+    // handled by the agent policy deletion flow (which unenrolls agents and removes documents).
+    const parentPolicies = await agentPolicyService.getByIds(
+      soClient,
+      basePolicyIds.map((id) => ({ id, spaceId: '*' })),
+      { fields: ['id', 'has_agent_version_conditions'], ignoreMissing: true }
+    );
+    const orphanedParentPolicyIds = parentPolicies
+      .filter((policy) => !policy.has_agent_version_conditions)
+      .map((policy) => policy.id);
+
+    if (orphanedParentPolicyIds.length === 0) {
+      return;
+    }
+
+    this.logger.debug(
+      `[VersionSpecificPolicyAssignmentTask] Found ${orphanedParentPolicyIds.length} agent policies with orphaned version-specific assignments to clean up`
+    );
+
+    for (const parentPolicyId of orphanedParentPolicyIds) {
+      throwIfAborted(abortController);
+      await this.reassignOrphanedAgentsToBasePolicy(
+        esClient,
+        soClient,
+        parentPolicyId,
+        abortController
+      );
+    }
+  }
+
+  /**
+   * Reassign every agent still on a variant policy of the given parent back to the base policy
+   * (across all spaces, by agent id), then delete the now-stale variant `.fleet-policies` documents.
+   */
+  private async reassignOrphanedAgentsToBasePolicy(
+    esClient: ElasticsearchClient,
+    soClient: SavedObjectsClientContract,
+    parentPolicyId: string,
+    abortController: AbortController
+  ) {
+    try {
+      const variantAgentsKuery = buildVariantAgentsKuery(parentPolicyId);
+
+      const agentIds: string[] = [];
+      // Include inactive agents: reassignment is a metadata update on `.fleet-agents` that is valid
+      // regardless of active status. Skipping them would delete the variant documents below while an
+      // inactive agent still references one, leaving it stuck on a missing policy when it reactivates.
+      const agentsFetcher = await fetchAllAgentsByKuery(esClient, soClient, {
+        kuery: variantAgentsKuery,
+        perPage: AGENTS_BATCHSIZE,
+        showInactive: true,
+      });
+      for await (const agentsBatch of agentsFetcher) {
+        throwIfAborted(abortController);
+        for (const agent of agentsBatch) {
+          agentIds.push(agent.id);
+        }
+      }
+
+      if (agentIds.length > 0) {
+        this.logger.info(
+          `[VersionSpecificPolicyAssignmentTask] Reassigning ${agentIds.length} orphaned agents from version-specific policies of ${parentPolicyId} back to the base policy`
+        );
+        // Reassign by agent id (not kuery) so agents in every space are covered — the task runs
+        // with a space-agnostic saved objects client.
+        await reassignAgents(soClient, esClient, { agentIds, showInactive: true }, parentPolicyId);
+
+        // bulkUpdateAgents collects per-agent ES errors without throwing, so reassignAgents
+        // returns { actionId } even if some updates silently failed (e.g. retry_on_conflict
+        // exhausted under heavy check-in churn). Re-check the count before deleting variant docs:
+        // if any agents remain on the variant, skip deletion so the next sweep run can retry.
+        const { total: remaining } = await getAgentsByKuery(esClient, soClient, {
+          kuery: variantAgentsKuery,
+          showInactive: true,
+          perPage: 0,
+        });
+        if (remaining > 0) {
+          this.logger.warn(
+            `[VersionSpecificPolicyAssignmentTask] ${remaining} agent(s) still on variant policies of ${parentPolicyId} after reassignment (bulk update may have partially failed); skipping variant doc deletion so the next sweep run can retry`
+          );
+          return;
+        }
+      }
+
+      // All agents have been moved off the variant policies (or there were none to move).
+      // Safe to remove the now-stale variant documents.
+      await deleteVersionSpecificFleetServerPolicies(esClient, parentPolicyId);
+    } catch (error) {
+      this.logger.error(
+        `[VersionSpecificPolicyAssignmentTask] Error reassigning orphaned agents from version-specific policies of ${parentPolicyId}: ${error}`
       );
     }
   }


### PR DESCRIPTION
## Summary

Backport of #280250 to 9.4.

**Fix: post-reassignment count gate prevents variant doc deletion when bulk update silently fails.**

`bulkUpdateAgents` collects per-agent ES errors without throwing, so `reassignAgents` returns `{ actionId }` even if some updates silently failed. After reassignment, re-check agent count via `getAgentsByKuery`; skip `deleteVersionSpecificFleetServerPolicies` if any agents remain. The next task run will retry.

Also adds:
- Comment on the `policy_id` aggregation field explaining why the field name differs from the bucket name `variant_policies`
- Agg-shape test verifying the correct ES query structure
- Test for the partial-failure skip path

## Test plan

- [ ] Jest tests pass: `node scripts/jest x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.test.ts --no-coverage`
- [ ] Manual: verify orphaned agents are reassigned and variant docs deleted on next run after a clean reassignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)