### PR TITLE
[Entity Analytics] Mark GET /api/risk_score/history as added in 9.5.0

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -49849,6 +49849,7 @@ paths:
       summary: Get risk score history for an entity
       tags:
         - Security Entity Analytics API
+      x-state: Added in 9.5.0
       x-metaTags:
         - content: Kibana, Elastic Cloud Serverless
           name: product_name

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -53800,6 +53800,7 @@ paths:
       summary: Get risk score history for an entity
       tags:
         - Security Entity Analytics API
+      x-state: Added in 9.5.0
       x-metaTags:
         - content: Kibana
           name: product_name

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/risk_engine/risk_score_history_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/risk_engine/risk_score_history_route.schema.yaml
@@ -7,6 +7,7 @@ paths:
   /api/risk_score/history:
     get:
       x-labels: [ess, serverless]
+      x-state: Added in 9.5.0
       x-codegen-enabled: true
       operationId: GetRiskScoreHistory
       summary: Get risk score history for an entity

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1726,6 +1726,7 @@ paths:
       summary: Get risk score history for an entity
       tags:
         - Security Entity Analytics API
+      x-state: Added in 9.5.0
 components:
   schemas:
     AssetCriticalityBulkUploadErrorItem:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1726,6 +1726,7 @@ paths:
       summary: Get risk score history for an entity
       tags:
         - Security Entity Analytics API
+      x-state: Added in 9.5.0
 components:
   schemas:
     AssetCriticalityBulkUploadErrorItem:


### PR DESCRIPTION
## Summary

Adds availability metadata to the **Risk Score History** API (`GET /api/risk_score/history`) so the published API docs indicate the endpoint was introduced in **9.5.0**.

The operation is defined in a hand-written OpenAPI spec, so `x-state: Added in 9.5.0` is set directly on the operation (equivalent to `availability: { since: '9.5.0' }` on a code-first route, which the generator maps to the same `x-state`).

### Changes
- `risk_engine/risk_score_history_route.schema.yaml` — add `x-state: Added in 9.5.0` on the `get` operation.
- Regenerated bundled specs (`docs/openapi/ess` + `docs/openapi/serverless` entity analytics bundles).
- Regenerated merged output (`oas_docs/output/kibana.yaml` + `kibana.serverless.yaml`).

The generated files were updated to match the bundler/merge output (single `x-state` line per operation). CI (`yarn openapi:bundle:entity-analytics` and the OAS snapshot capture/merge) will confirm parity.

## Release notes
Marked `GET /api/risk_score/history` as available since 9.5.0 in the API documentation.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->