### PR TITLE
[9.4] [Lens as code] Fix XY annotation layers dataview references (#275372)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.ts
@@ -957,7 +957,13 @@ const annotationManualRange = schema.object(
 const annotationLayerByValueSchema = schema.object(
   {
     ...ignoringGlobalFiltersSchemaRaw,
-    ...dataSourceSchema,
+    // A by-value annotation layer does not require its own data source: manual
+    // point-in-time/range annotations carry no field references and the Lens XY
+    // renderer resolves the data view by falling back to the chart's data layers.
+    // When omitted, the data view is re-derived from the sibling data layers when
+    // converting back to Lens state. See
+    // x-pack/.../lens/public/visualizations/xy/persistence.ts.
+    data_source: schema.maybe(dataSourceSchema.data_source),
     type: schema.literal('annotations'),
     events: schema.arrayOf(
       schema.oneOf([annotationQuery, annotationManualEvent, annotationManualRange]),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { XYVisualizationState } from '@kbn/lens-common';
-import type { XYConfig } from '../../schema/charts/xy';
+import type { XYConfig, XYConfigNoESQL } from '../../schema/charts/xy';
 import { AUTO_COLOR, DEFAULT_CATEGORICAL_COLOR_MAPPING } from '../../schema/color';
 import { LensConfigBuilder } from '../../config_builder';
 import type { LensAttributes } from '../../types';
@@ -220,6 +220,202 @@ describe('XY', () => {
         expect(matchingRef).toBeDefined();
         expect(matchingRef?.id).toBe('my-runtime-annotation-group-id');
         expect(matchingRef?.type).toBe('event-annotation-group');
+      });
+
+      // Regression test for https://github.com/elastic/kibana/issues/268821
+      // A by-value annotation layer must round-trip its data view reference under
+      // the `xy-visualization-layer-` name, matching the layer id in the rebuilt
+      // visualization state. If the reference is emitted with the generic
+      // `indexpattern-datasource-layer-` prefix, the runtime cannot resolve the
+      // annotation layer's data view and the panel fails to render.
+      it('preserves resolvable data view references for a by-value annotation layer after an API round trip', () => {
+        const builder = new LensConfigBuilder(undefined, true);
+        const api = builder.toAPIFormat(annotationXY);
+        const lensState = builder.fromAPIFormat(api);
+
+        const referenceNames = new Set(lensState.references.map((ref) => ref.name));
+
+        const visualizationLayers = (
+          lensState.state.visualization as { layers: Array<Record<string, unknown>> }
+        ).layers;
+        for (const layer of visualizationLayers) {
+          if (layer.layerType === 'annotations' && layer.persistanceType !== 'byReference') {
+            expect(referenceNames.has(`xy-visualization-layer-${layer.layerId}`)).toBe(true);
+          }
+        }
+
+        const formBasedLayerIds = Object.keys(
+          lensState.state.datasourceStates.formBased?.layers ?? {}
+        );
+        for (const layerId of formBasedLayerIds) {
+          expect(referenceNames.has(`indexpattern-datasource-layer-${layerId}`)).toBe(true);
+        }
+      });
+
+      // Regression test for https://github.com/elastic/kibana/issues/268821
+      // A by-value annotation layer made of manual (point/range) annotations does
+      // not query an index, so the data view is not useful for it. Even when the
+      // state still carries a `xy-visualization-layer-<layerId>` reference (e.g.
+      // sample data / older saved objects), `toAPIFormat` should NOT emit a
+      // `data_source` for a manual-only layer, and the round trip back to state
+      // produces a persisted by-value layer (no `indexPatternId`) that relies on
+      // the Lens XY runtime fallback.
+      it('omits data_source for a manual-only annotation layer and persists it for the runtime fallback', () => {
+        const manualAnnotationXY: LensAttributes = {
+          ...annotationXY,
+          state: {
+            ...annotationXY.state,
+            visualization: {
+              ...(annotationXY.state.visualization as XYVisualizationState),
+              layers: (annotationXY.state.visualization as XYVisualizationState).layers.map(
+                (layer) =>
+                  layer.layerType === 'annotations'
+                    ? {
+                        ...layer,
+                        annotations: [
+                          {
+                            type: 'manual',
+                            id: 'manual_event_0',
+                            label: 'Event',
+                            key: {
+                              type: 'point_in_time',
+                              timestamp: '2016-02-09T10:30:00.000Z',
+                            },
+                          },
+                        ],
+                      }
+                    : layer
+              ),
+            },
+          },
+        } as LensAttributes;
+
+        const builder = new LensConfigBuilder(undefined, true);
+
+        expect(() => builder.toAPIFormat(manualAnnotationXY)).not.toThrow();
+
+        const api = builder.toAPIFormat(manualAnnotationXY) as XYConfig;
+        const annotationLayer = api.layers.find((layer) => layer.type === 'annotations');
+
+        // Manual-only annotation layer: no data view is emitted on the API layer,
+        // even though the source state still has the `xy-visualization-layer-` ref.
+        expect(annotationLayer).toBeDefined();
+        expect(annotationLayer?.data_source).toBeUndefined();
+
+        // Round trip back to state must produce a persisted by-value annotation
+        // layer (no `indexPatternId`, no own reference). The Lens XY runtime then
+        // injects the data view via the first-index-pattern fallback.
+        const lensState = builder.fromAPIFormat(api);
+        const referenceNames = new Set(lensState.references.map((ref) => ref.name));
+
+        const visualizationLayers = (
+          lensState.state.visualization as { layers: Array<Record<string, unknown>> }
+        ).layers;
+        const rebuiltAnnotationLayer = visualizationLayers.find(
+          (layer) => layer.layerType === 'annotations'
+        );
+
+        expect(rebuiltAnnotationLayer).toBeDefined();
+        expect(rebuiltAnnotationLayer).not.toHaveProperty('indexPatternId');
+        expect(rebuiltAnnotationLayer?.persistanceType).toBe('byValue');
+        expect(
+          referenceNames.has(`xy-visualization-layer-${rebuiltAnnotationLayer?.layerId}`)
+        ).toBe(false);
+      });
+
+      // A query annotation genuinely queries an index, so `toAPIFormat` must emit
+      // its `data_source` (and `fromAPIFormat` must round-trip the reference).
+      it('emits data_source for a query annotation layer', () => {
+        const builder = new LensConfigBuilder(undefined, true);
+        const api = builder.toAPIFormat(annotationXY) as XYConfig;
+        const annotationLayer = api.layers.find((layer) => layer.type === 'annotations');
+
+        expect(annotationLayer?.data_source).toEqual(
+          expect.objectContaining({
+            type: AS_CODE_DATA_VIEW_REFERENCE_TYPE,
+            ref_id: 'metrics-*',
+          })
+        );
+      });
+
+      // The inbound direction must reject a query annotation layer that arrives
+      // without a data_source, since a query event cannot be represented without
+      // an index to query.
+      it('throws when a query annotation layer is missing its data_source', () => {
+        const builder = new LensConfigBuilder(undefined, true);
+        // annotationXY is a DSL chart, so narrow to the concrete (non-ES|QL)
+        // config to keep the spread within a single union member.
+        const api = builder.toAPIFormat(annotationXY) as XYConfigNoESQL;
+
+        // Strip data_source from the annotation layer to simulate a query
+        // annotation arriving without an index to query. data_source is optional
+        // in the schema, so the resulting config is still a valid XYConfig.
+        const apiWithoutAnnotationDataSource: XYConfigNoESQL = {
+          ...api,
+          layers: api.layers.map((layer) => {
+            if (layer.type !== 'annotations') {
+              return layer;
+            }
+            const { data_source: _, ...rest } = layer;
+            return rest;
+          }),
+        };
+
+        expect(() => builder.fromAPIFormat(apiWithoutAnnotationDataSource)).toThrow(
+          'A data source is required for annotation layers with query events'
+        );
+      });
+
+      // A query annotation layer can reference its own ad hoc data view (inline
+      // spec). It must round-trip as an `xy-visualization-layer-` reference (type
+      // index-pattern) pointing at the ad hoc data view id, matching Lens's own
+      // persistence, so the runtime resolves the correct data view instead of
+      // falling back to the data layers' one.
+      it('round-trips an ad hoc data view for a query annotation layer', () => {
+        const builder = new LensConfigBuilder(undefined, true);
+        // annotationXY is a DSL chart with a query annotation layer; reuse it so
+        // every defaulted field is present, then point the annotation layer at its
+        // own ad hoc data view.
+        const api = builder.toAPIFormat(annotationXY) as XYConfigNoESQL;
+
+        const apiConfig: XYConfigNoESQL = {
+          ...api,
+          layers: api.layers.map((layer) =>
+            layer.type === 'annotations'
+              ? {
+                  ...layer,
+                  data_source: {
+                    type: AS_CODE_DATA_VIEW_SPEC_TYPE,
+                    index_pattern: 'annotations-*',
+                    time_field: '@timestamp',
+                  },
+                }
+              : layer
+          ),
+        };
+
+        const lensState = builder.fromAPIFormat(apiConfig);
+
+        const visualizationLayers = (
+          lensState.state.visualization as { layers: Array<Record<string, unknown>> }
+        ).layers;
+        const annotationLayer = visualizationLayers.find(
+          (layer) => layer.layerType === 'annotations'
+        );
+        expect(annotationLayer).toBeDefined();
+
+        // Ad hoc data view references are stored in internalReferences.
+        const internalReferences = lensState.state.internalReferences ?? [];
+        const annotationReference = internalReferences.find(
+          (ref) => ref.name === `xy-visualization-layer-${annotationLayer?.layerId}`
+        );
+        expect(annotationReference).toBeDefined();
+        expect(annotationReference?.type).toBe('index-pattern');
+
+        // The reference must point at the ad hoc data view present in adHocDataViews.
+        const adHocDataViews = lensState.state.adHocDataViews ?? {};
+        expect(annotationReference?.id).toBeDefined();
+        expect(Object.keys(adHocDataViews)).toContain(annotationReference?.id);
       });
     });
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy.ts
@@ -19,7 +19,7 @@ import type { LensAttributes } from '../../types';
 import { buildDatasourceStates, buildReferences, getAdhocDataviews } from '../utils';
 import { buildVisualizationAPI, buildVisualizationState } from './xy/chart';
 import { buildFormBasedXYLayer, getValueColumns } from './xy/state_layers';
-import { LENS_LAYER_SUFFIX } from '../constants';
+import { getIdForLayer, isAPIAnnotationLayer } from './xy/helpers';
 
 type XYLens = Extract<TypedLensSerializedState['attributes'], { visualizationType: 'lnsXY' }>;
 type XYLensState = Omit<XYLens['state'], 'filters' | 'query'>;
@@ -37,7 +37,26 @@ export function fromAPItoLensState(config: XYConfig): XYLensWithoutQueryAndFilte
     getValueColumns
   );
 
-  const { adHocDataViews, internalReferences } = getAdhocDataviews(usedDataviews);
+  // By-value annotation layers persist their data view under the
+  // `xy-visualization-layer-` reference name (regular and ad hoc alike), matching
+  // Lens's own persistence logic so the XY runtime can resolve it. A manual-only
+  // layer carries no data view at all and emits no such reference; the runtime
+  // then falls back to the first index-pattern reference at load time (see
+  // x-pack/.../lens/public/visualizations/xy/persistence.ts).
+  const annotationLayerIds = new Set(
+    config.layers
+      .map((layer, index) =>
+        isAPIAnnotationLayer(layer) && !('group_id' in layer)
+          ? getIdForLayer(layer, index)
+          : undefined
+      )
+      .filter((id): id is string => id != null)
+  );
+
+  const { adHocDataViews, internalReferences } = getAdhocDataviews(
+    usedDataviews,
+    annotationLayerIds
+  );
 
   const regularDataViews = Object.entries(usedDataviews).filter(
     (v): v is [string, { id: string; type: 'dataView' }] => v[1].type === 'dataView'
@@ -46,23 +65,14 @@ export function fromAPItoLensState(config: XYConfig): XYLensWithoutQueryAndFilte
   const regularDataViewsMap = Object.fromEntries(
     regularDataViews.map(([key, { id }]) => [key, id])
   );
-  // merge both internal references and regularDataViews into a single map { layerId => dataViewId }
-  const dataViewLayerToIdMap: Record<string, string> = Object.fromEntries([
-    ...Object.entries(regularDataViewsMap).map(([layerId, dataViewId]) => [layerId, dataViewId]),
-    ...internalReferences.map((ref) => [ref.name.replace(LENS_LAYER_SUFFIX, ''), ref.id]),
-  ]);
 
   const annotationGroupReferences: SavedObjectReference[] = [];
 
-  const visualizationState = buildVisualizationState(
-    config,
-    dataViewLayerToIdMap,
-    annotationGroupReferences
-  );
+  const visualizationState = buildVisualizationState(config, annotationGroupReferences);
 
   const references = [
     ...annotationGroupReferences,
-    ...(regularDataViews.length ? buildReferences(regularDataViewsMap) : []),
+    ...buildReferences(regularDataViewsMap, annotationLayerIds),
   ];
 
   return {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
@@ -486,18 +486,31 @@ export function buildAPIAnnotationsLayer(
       ? layer.indexPatternId
       : findAnnotationDataView(layer.layerId, references);
 
-  if (!indexPatternId) {
-    // shouldn't happen unless data is corrupt
-    throw new Error('XY visualization: cannot find data view ID for annotation layer.');
-  }
-
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const ignore_global_filters =
     layer.ignoreGlobalFilters ?? LENS_IGNORE_GLOBAL_FILTERS_DEFAULT_VALUE;
   const adHocDataView = adHocDataViews[layer.layerId];
   const referencedDataView = findAnnotationDataView(layer.layerId, references);
-  const dataSource = (
-    isDataViewSpec(adHocDataView) && adHocDataView?.id === indexPatternId
+
+  // Only query annotations actually query an index, so the data view is only
+  // meaningful for them. Manual point/range annotations are positioned purely by
+  // timestamp and don't need a data view: we omit `data_source` for those layers
+  // so the API output isn't polluted with an unused data view, and the data view
+  // is re-derived from the chart's data layers when converting back to state.
+  const hasQueryAnnotation = layer.annotations.some(isQueryAnnotationConfig);
+
+  if (hasQueryAnnotation && !indexPatternId) {
+    // A query annotation without a resolvable data view cannot be represented.
+    throw new Error('XY visualization: cannot find data view ID for annotation layer.');
+  }
+
+  const dataSource: Extract<
+    DataSourceType,
+    { type: typeof AS_CODE_DATA_VIEW_REFERENCE_TYPE | typeof AS_CODE_DATA_VIEW_SPEC_TYPE }
+  > | null =
+    !hasQueryAnnotation || !indexPatternId
+      ? null
+      : isDataViewSpec(adHocDataView) && adHocDataView?.id === indexPatternId
       ? {
           type: AS_CODE_DATA_VIEW_SPEC_TYPE,
           index_pattern: indexPatternId,
@@ -506,14 +519,10 @@ export function buildAPIAnnotationsLayer(
       : {
           type: AS_CODE_DATA_VIEW_REFERENCE_TYPE,
           ref_id: referencedDataView ?? indexPatternId,
-        }
-  ) satisfies Extract<
-    DataSourceType,
-    { type: typeof AS_CODE_DATA_VIEW_REFERENCE_TYPE | typeof AS_CODE_DATA_VIEW_SPEC_TYPE }
-  >;
+        };
   return {
     type: 'annotations',
-    data_source: dataSource,
+    ...(dataSource ? { data_source: dataSource } : {}),
     ignore_global_filters,
     events: layer.annotations.map((annotation) => {
       if (isQueryAnnotationConfig(annotation)) {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/chart.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/chart.ts
@@ -14,7 +14,7 @@ import type { XYConfig, XYConfigNoESQL, XYConfigESQL, XYLayer } from '../../../s
 import type { DataSourceStateLayer } from '../../utils';
 import { convertLegendToAPIFormat, convertLegendToStateFormat } from './legend';
 import { buildXYLayer } from './state_layers';
-import { getIdForLayer, isAPIesqlXYLayer, isLensStateDataLayer } from './helpers';
+import { isAPIesqlXYLayer, isLensStateDataLayer } from './helpers';
 import { nonNullable, isFormBasedLayer, isTextBasedLayer } from '../../utils';
 import { getReversibleMappings, getScaleTypeFromColumnType } from '../utils';
 import {
@@ -168,23 +168,12 @@ function getLayerPresence(dataLayers: XYDataLayerConfig[]): LayerPresence {
   };
 }
 
-type LayerToDataView = Record<string, string>;
-
 export function buildVisualizationState(
   config: XYConfig,
-  usedDataViews: LayerToDataView,
   annotationGroupReferences: SavedObjectReference[]
 ): XYPersistedState {
   const layers = config.layers
-    .map((layer, index) =>
-      buildXYLayer(
-        config,
-        layer,
-        index,
-        usedDataViews[getIdForLayer(layer, index)],
-        annotationGroupReferences
-      )
-    )
+    .map((layer, index) => buildXYLayer(config, layer, index, annotationGroupReferences))
     .filter(nonNullable);
   return {
     preferredSeriesType: layers.filter(isLensStateDataLayer)[0]?.seriesType ?? 'bar_stacked',

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/helpers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/helpers.ts
@@ -67,7 +67,11 @@ export function isAPIXYLayer(layer: unknown): layer is XYLayer {
 }
 
 export function isAPIesqlXYLayer(layer: XYLayer): layer is LayerTypeESQL {
-  return 'data_source' in layer && isEsqlTableTypeDataSource(layer.data_source);
+  return (
+    'data_source' in layer &&
+    layer.data_source != null &&
+    isEsqlTableTypeDataSource(layer.data_source)
+  );
 }
 
 export function isLensStateDataLayer(

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
@@ -9,9 +9,9 @@
 
 import type {
   SeriesType,
-  XYAnnotationLayerConfig,
   XYDataLayerConfig,
   XYPersistedByReferenceAnnotationLayerConfig,
+  XYPersistedByValueAnnotationLayerConfig,
   XYPersistedLayerConfig,
   XYReferenceLineLayerConfig,
   YConfig,
@@ -115,13 +115,17 @@ function buildDataLayer(config: XYConfig, layer: DataLayerType, i: number): XYDa
 
 function buildByValueAnnotationLayer(
   layer: AnnotationLayerByValueType,
-  i: number,
-  dataViewId: string
-): XYAnnotationLayerConfig {
+  i: number
+): XYPersistedByValueAnnotationLayerConfig {
+  // Emit a persisted by-value annotation layer (no `indexPatternId` by design). The Lens
+  // XY runtime injects the data view at load time from the
+  // `xy-visualization-layer-<layerId>` reference, falling back to the first
+  // index-pattern reference when the layer has no dedicated data view.
+  // See x-pack/.../lens/public/visualizations/xy/persistence.ts.
   return {
     layerType: 'annotations',
+    persistanceType: 'byValue',
     layerId: getIdForLayer(layer, i),
-    indexPatternId: dataViewId,
     ignoreGlobalFilters: layer.ignore_global_filters,
     annotations: layer.events.map((annotation, index) => {
       if (annotation.type === 'range') {
@@ -222,7 +226,6 @@ export function buildXYLayer(
   config: XYConfig,
   layer: unknown,
   i: number,
-  dataViewId: string,
   annotationGroupReferences: SavedObjectReference[]
 ): XYPersistedLayerConfig | undefined {
   if (!isAPIXYLayer(layer)) {
@@ -251,7 +254,7 @@ export function buildXYLayer(
     }
 
     // by-value annotation layer
-    return buildByValueAnnotationLayer(layer, i, dataViewId);
+    return buildByValueAnnotationLayer(layer, i);
   }
   if (isAPIReferenceLineLayer(layer)) {
     return buildReferenceLineLayer(layer, i);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/constants.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/constants.ts
@@ -8,5 +8,13 @@
  */
 
 export const LENS_LAYER_SUFFIX = `indexpattern-datasource-layer-`;
+/**
+ * Reference name prefix used by the XY visualization for the data view of a
+ * by-value annotation layer. This must match the prefix produced by the Lens
+ * XY persistence logic (`xy-visualization-layer-<layerId>`); otherwise the
+ * runtime cannot resolve the annotation layer's data view and the panel fails
+ * to render. See x-pack/.../lens/public/visualizations/xy/persistence.ts.
+ */
+export const LENS_XY_ANNOTATION_LAYER_SUFFIX = `xy-visualization-layer-`;
 export const LENS_DEFAULT_TIME_FIELD = '@timestamp';
 export const INDEX_PATTERN_ID = 'index-pattern';

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -13,7 +13,6 @@ import {
   getDataSourceIndex,
   getAdHocDataViewSpec,
   addLayerColumn,
-  getDefaultReferences,
   operationFromColumn,
   buildDataSourceState,
   isSingleLayer,
@@ -51,6 +50,30 @@ test('build references correctly builds references', () => {
       Object {
         "id": "test-dataview",
         "name": "indexpattern-datasource-layer-layer2",
+        "type": "index-pattern",
+      },
+    ]
+  `);
+});
+
+test('build references uses the xy annotation prefix for annotation layer ids', () => {
+  const results = buildReferences(
+    {
+      layer1: dataView,
+      annotations_1: dataView,
+    },
+    new Set(['annotations_1'])
+  );
+  expect(results).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "id": "test-dataview",
+        "name": "indexpattern-datasource-layer-layer1",
+        "type": "index-pattern",
+      },
+      Object {
+        "id": "test-dataview",
+        "name": "xy-visualization-layer-annotations_1",
         "type": "index-pattern",
       },
     ]
@@ -327,21 +350,6 @@ describe('buildDatasourceStates', () => {
           },
         },
       }
-    `);
-  });
-});
-
-describe('getDefaultReferences', () => {
-  test('generates correct references for index and layer id', () => {
-    const result = getDefaultReferences('my-index', 'layer_1');
-    expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "id": "my-index",
-          "name": "indexpattern-datasource-layer-layer_1",
-          "type": "index-pattern",
-        },
-      ]
     `);
   });
 });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -39,7 +39,12 @@ import { toApiFieldSettings, fromApiFieldSettings } from './columns/field_settin
 import { getMetricApiColumnFromLensState } from './columns/metric';
 import type { AnyLensStateColumn, APIAdHocDataView, APIDataView } from './columns/types';
 import { isLensStateBucketColumnType } from './columns/utils';
-import { LENS_LAYER_SUFFIX, LENS_DEFAULT_TIME_FIELD, INDEX_PATTERN_ID } from './constants';
+import {
+  LENS_LAYER_SUFFIX,
+  LENS_XY_ANNOTATION_LAYER_SUFFIX,
+  LENS_DEFAULT_TIME_FIELD,
+  INDEX_PATTERN_ID,
+} from './constants';
 import {
   LENS_SAMPLING_DEFAULT_VALUE,
   LENS_IGNORE_GLOBAL_FILTERS_DEFAULT_VALUE,
@@ -60,20 +65,24 @@ export type DataSourceStateLayer =
   | PersistedIndexPatternLayer
   | TextBasedPersistedState['layers'][0];
 
-export function createDataViewReference(index: string, layerId: string): SavedObjectReference {
+function createDataViewReference(dataViewId: string, layerId: string): SavedObjectReference {
   return {
     type: INDEX_PATTERN_ID,
-    id: index,
+    id: dataViewId,
     name: `${LENS_LAYER_SUFFIX}${layerId}`,
   };
 }
 
-export const getDefaultReferences = (
-  index: string,
-  dataLayerId: string
-): SavedObjectReference[] => {
-  return [createDataViewReference(index, dataLayerId)];
-};
+function createAnnotationLayerDataViewReference(
+  dataViewId: string,
+  layerId: string
+): SavedObjectReference {
+  return {
+    type: INDEX_PATTERN_ID,
+    id: dataViewId,
+    name: `${LENS_XY_ANNOTATION_LAYER_SUFFIX}${layerId}`,
+  };
+}
 
 // Need to dance a bit to satisfy TypeScript
 function convertToTypedLayerColumns(layer: Omit<FormBasedLayer, 'indexPatternId'>): {
@@ -161,7 +170,10 @@ export function getAdHocDataViewSpec(dataView: APIAdHocDataView) {
   };
 }
 
-export const getAdhocDataviews = (dataviews: Record<string, APIDataView | APIAdHocDataView>) => {
+export const getAdhocDataviews = (
+  dataviews: Record<string, APIDataView | APIAdHocDataView>,
+  annotationLayerIds: ReadonlySet<string> = new Set()
+) => {
   // filter out ad hoc dataViews only
   const adHocDataViewsFiltered = Object.entries(dataviews).filter(
     ([_layerId, dataViewEntry]) => dataViewEntry.type === 'adHocDataView'
@@ -186,7 +198,14 @@ export const getAdhocDataviews = (dataviews: Record<string, APIDataView | APIAdH
   for (const [baseSpec, { layerIds, id }] of Array.from(internalReferencesMap.entries())) {
     adHocDataViews[id] = getAdHocDataViewSpec(baseSpec);
     for (const layerId of layerIds) {
-      internalReferences.push(createDataViewReference(id, layerId));
+      // XY annotation layers reference their data view (ad hoc included) under the
+      // `xy-visualization-layer-` name, matching Lens's own persistence logic, so
+      // the runtime can resolve it. Other layers use the default datasource name.
+      internalReferences.push(
+        annotationLayerIds.has(layerId)
+          ? createAnnotationLayerDataViewReference(id, layerId)
+          : createDataViewReference(id, layerId)
+      );
     }
   }
 
@@ -268,15 +287,27 @@ export function buildDataSourceState(
   return buildDataSourceStateNoESQL(layer, layerId, adHocDataViews, references, adhocReferences);
 }
 
-// builds Lens State references from list of dataviews
-export function buildReferences(dataviews: Record<string, string>): SavedObjectReference[] {
-  const references: SavedObjectReference[][] = [];
-  for (const layerid in dataviews) {
-    if (dataviews[layerid]) {
-      references.push(getDefaultReferences(dataviews[layerid], layerid));
-    }
-  }
-  return references.flat(2);
+/**
+ * Builds Lens State data view references from a `{ layerId => dataViewId }` map.
+ *
+ * Most layers persist their data view under the `indexpattern-datasource-layer-`
+ * reference name. By-value XY annotation layers are the exception: their data
+ * view must be persisted under the `xy-visualization-layer-` name so the XY
+ * runtime can resolve it (otherwise it falls back to the first index-pattern
+ * reference and the panel fails to render). Pass those layer ids via
+ * `annotationLayerIds` so they get the correct prefix.
+ * See x-pack/.../lens/public/visualizations/xy/persistence.ts and
+ * https://github.com/elastic/kibana/issues/268821.
+ */
+export function buildReferences(
+  dataviews: Record<string, string>,
+  annotationLayerIds: ReadonlySet<string> = new Set()
+): SavedObjectReference[] {
+  return Object.entries(dataviews).map(([layerId, dataViewId]) =>
+    annotationLayerIds.has(layerId)
+      ? createAnnotationLayerDataViewReference(dataViewId, layerId)
+      : createDataViewReference(dataViewId, layerId)
+  );
 }
 
 export function isSingleLayer(
@@ -404,6 +435,22 @@ export const buildDatasourceStates = (
     if (!dataSource) {
       if ('type' in layer && layer.type === 'annotation_group' && 'group_id' in layer) {
         // by-ref annotation layers don't require a data_source
+        continue;
+      }
+      if ('type' in layer && layer.type === 'annotations') {
+        // Query annotations actually query an index, so they require a data
+        // source. Manual point/range annotations are positioned purely by
+        // timestamp and may omit their data_source: they share the data view of
+        // the chart's data layers, which the Lens XY runtime resolves at load
+        // time. Either way an annotation layer produces no datasource state, so
+        // there's nothing to build here.
+        const hasQueryEvent =
+          'events' in layer &&
+          Array.isArray(layer.events) &&
+          layer.events.some((event) => event?.type === 'query');
+        if (hasQueryEvent) {
+          throw Error('A data source is required for annotation layers with query events');
+        }
         continue;
       }
       throw Error('DataSource must be defined');

--- a/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.test.ts
@@ -37,6 +37,35 @@ describe('getTransformOut', () => {
     }
   );
 
+  // Regression test for https://github.com/elastic/kibana/issues/268821
+  // When a dashboard is copied to another space, SO import remaps the panel's
+  // index-pattern references to the new space's data view ids. The apiFormat
+  // output must reflect the remapped ids (taken from `panelReferences`), not the
+  // chart's original embedded references; otherwise the copied panel points at
+  // the wrong-space data view and fails to render.
+  it('uses remapped panel references for the apiFormat data view id', () => {
+    const builder = new LensConfigBuilder(undefined, true);
+    const transformOut = getTransformOut(builder, transformDrilldownsOut, true);
+
+    const originalReference = simpleMetricAttributes.references[0];
+    const remappedDataViewId = 'remapped-data-view-id';
+
+    const storedState: LensByValueSerializedState = {
+      title: 'Metric',
+      attributes: {
+        ...simpleMetricAttributes,
+      },
+      references: [],
+    };
+
+    const result = transformOut(storedState, [
+      // Same reference name, remapped id (as produced by copy-to-space).
+      { ...originalReference, id: remappedDataViewId },
+    ]) as { data_source?: { type: string; ref_id?: string } };
+
+    expect(result.data_source).toEqual(expect.objectContaining({ ref_id: remappedDataViewId }));
+  });
+
   // When the panel has no title (key absent or `undefined`), fall back to the attributes
   // title so legacy by-value panels keep their title through the apiFormat round-trip.
   // See https://github.com/elastic/kibana/issues/268821

--- a/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.ts
@@ -64,7 +64,16 @@ export const getTransformOut = (
       return injectedState as LensByValueTransformOutResult;
     }
 
-    const chartType = builder.getType(migratedAttributes);
+    // Use the reference-injected attributes (not `migratedAttributes`) so the
+    // resolved/remapped panel references win over the chart's embedded ones.
+    // When a dashboard is copied to another space, SO import remaps the panel
+    // `index-pattern` references; `toAPIFormat` reads data view ids from the
+    // attributes' references, so it must see the remapped ids. Otherwise the
+    // panel keeps the original (wrong-space) data view id and fails to render.
+    // See https://github.com/elastic/kibana/issues/268821.
+    const injectedAttributes = injectedState.attributes ?? migratedAttributes;
+
+    const chartType = builder.getType(injectedAttributes);
     // should be filtered out my unmapped panel check
     if (!builder.isSupported(chartType)) {
       throw new Error(`Lens "${chartType}" chart type is not supported`);
@@ -75,8 +84,8 @@ export const getTransformOut = (
       description: attributesDescription,
       ...apiConfig
     } = builder.toAPIFormat({
-      ...migratedAttributes,
-      visualizationType: migratedAttributes.visualizationType ?? LENS_UNKNOWN_VIS,
+      ...injectedAttributes,
+      visualizationType: injectedAttributes.visualizationType ?? LENS_UNKNOWN_VIS,
     });
 
     // For by-value panels the panel-level title/description take precedence and the

--- a/x-pack/platform/plugins/shared/lens/public/user_messages_ids.ts
+++ b/x-pack/platform/plugins/shared/lens/public/user_messages_ids.ts
@@ -63,6 +63,7 @@ export const STATIC_VALUE_NOT_VALID_NUMBER = 'static_value_not_valid_number';
 
 /** Annotations require a time based chart to work. Add a date histogram. */
 export const ANNOTATION_MISSING_DATE_HISTOGRAM = 'annotation_missing_date_histogram';
+export const ANNOTATION_DATAVIEW_NOT_FOUND = 'annotation_dataview_not_found';
 export const ANNOTATION_MISSING_TIME_FIELD = 'annotation_missing_time_field';
 export const ANNOTATION_MISSING_TOOLTIP_FIELD = 'annotation_missing_tooltip_field';
 export const ANNOTATION_TIME_FIELD_NOT_FOUND = 'annotation_time_field_not_found_in_dataview';

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/state_helpers.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/state_helpers.tsx
@@ -37,6 +37,7 @@ import {
   isByReferenceAnnotationsLayer,
 } from './visualization_helpers';
 import {
+  ANNOTATION_DATAVIEW_NOT_FOUND,
   ANNOTATION_INVALID_FILTER_QUERY,
   ANNOTATION_MISSING_TIME_FIELD,
   ANNOTATION_MISSING_TOOLTIP_FIELD,
@@ -257,6 +258,23 @@ export function getAnnotationLayerErrors(
   const layerDataView = dataViews.indexPatterns[layer.indexPatternId];
 
   const invalidMessages: UserMessage[] = [];
+
+  // The annotation layer's data view can be missing (e.g. the referenced
+  // index-pattern saved object does not exist in the current space). Surface a
+  // clean error instead of dereferencing an undefined data view below.
+  if (!layerDataView) {
+    return [
+      createAnnotationErrorMessage(
+        ANNOTATION_DATAVIEW_NOT_FOUND,
+        i18n.translate('xpack.lens.xyChart.annotationError.dataViewNotFound', {
+          defaultMessage: 'Data view {dataView} not found',
+          values: { dataView: layer.indexPatternId },
+        }),
+        annotation.id,
+        annotation.label
+      ),
+    ];
+  }
 
   if (annotation.timeField == null || annotation.timeField === '') {
     invalidMessages.push(

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.test.tsx
@@ -3411,6 +3411,29 @@ describe('xy_visualization', () => {
             })
           );
         });
+        it('should return a data view not found error instead of throwing when the annotation data view is missing', () => {
+          // Regression test for https://github.com/elastic/kibana/issues/268821:
+          // when the annotation layer references an index-pattern that does not
+          // exist in the current space, getUserMessages must not throw.
+          const xyState = createStateWithAnnotationProps({});
+          const annotationLayer = xyState.layers.find(
+            (layer) => layer.layerType === layerTypes.ANNOTATIONS
+          )!;
+          // Point the annotation layer at a data view that is not loaded.
+          (annotationLayer as { indexPatternId: string }).indexPatternId = 'missing-data-view';
+
+          let errors: ReturnType<typeof getErrorMessages>;
+          expect(() => {
+            errors = getErrorMessages(xyVisualization, xyState, getFrameMock());
+          }).not.toThrow();
+          expect(errors!).toHaveLength(1);
+          expect(errors![0]).toEqual(
+            expect.objectContaining({
+              shortMessage: 'Data view missing-data-view not found',
+            })
+          );
+        });
+
         it('should return error if current annotation contains non existent field as textField', () => {
           const xyState = createStateWithAnnotationProps({
             textField: 'non-existent',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens as code] Fix XY annotation layers dataview references (#275372)](https://github.com/elastic/kibana/pull/275372)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2026-07-02T10:55:41Z","message":"[Lens as code] Fix XY annotation layers dataview references (#275372)\n\n## Summary\n\nFixes Lens panels failing to render (and dashboard panels being dropped)\nwhen the `lens.apiFormat` feature flag is enabled, primarily around how\nXY annotation layers handle data view references. Closes #268825.\n\nThe work breaks down into three areas:\n\n### 1. Respect remapped panel references on `transformOut`\nWhen `lens.apiFormat` is enabled, the API conversion bypassed\ndashboard-level `panelReferences`, so copied dashboards (with remapped\ndata view IDs across spaces) emitted stale references. `getTransformOut`\nnow converts the **injected** attributes (with remapped references\napplied) instead of the original migrated attributes.\n\n### 2. Make `data_source` optional for XY annotation layers\nManual (point/range) annotations don't need a data view — only query\nannotations do. Previously the state→API transform threw `cannot find\ndata view ID for annotation layer` whenever an annotation layer had no\nexplicit data view.\n\n- `data_source` is now `schema.maybe(...)` for by-value annotation\nlayers (OAS bundles updated accordingly).\n- **State → API**: manual-only annotation layers omit `data_source`;\nquery annotation layers still require a resolvable data view (throws\notherwise).\n- **API → state**: the config builder now emits a **persisted** by-value\nannotation layer (no inline `indexPatternId`), letting the Lens XY\nruntime (`persistence.ts`) inject the data view from the\n`xy-visualization-layer-` reference with its existing\nfirst-index-pattern fallback. This removes duplicated fallback logic\nfrom the config builder.\n- **Inbound validation**: a by-value annotation layer arriving without\n`data_source` but containing query events is rejected, keeping API↔state\nsymmetric.\n- Fixed a pre-existing bug where a query annotation pointing at its own\n**ad hoc** data view emitted the internal reference under the wrong name\n(`indexpattern-datasource-layer-` instead of `xy-visualization-layer-`),\ncausing the runtime to fall back to the wrong data view.\n`getAdhocDataviews` now uses the annotation reference name for\nannotation layers, matching Lens's own persistence.\n\n### 3. Graceful error on missing annotation data view\nAdded a defensive null check in `getAnnotationLayerErrors` plus a new\n`ANNOTATION_DATAVIEW_NOT_FOUND` user message, so a missing/deleted\nannotation data view surfaces a clear message instead of crashing with\n`Cannot read properties of undefined (reading 'getFieldByName')`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f4bb234b323f564a5041d3266f6043c307535db6","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","backport:skip","v9.5.0"],"title":"[Lens as code] Fix XY annotation layers dataview references","number":275372,"url":"https://github.com/elastic/kibana/pull/275372","mergeCommit":{"message":"[Lens as code] Fix XY annotation layers dataview references (#275372)\n\n## Summary\n\nFixes Lens panels failing to render (and dashboard panels being dropped)\nwhen the `lens.apiFormat` feature flag is enabled, primarily around how\nXY annotation layers handle data view references. Closes #268825.\n\nThe work breaks down into three areas:\n\n### 1. Respect remapped panel references on `transformOut`\nWhen `lens.apiFormat` is enabled, the API conversion bypassed\ndashboard-level `panelReferences`, so copied dashboards (with remapped\ndata view IDs across spaces) emitted stale references. `getTransformOut`\nnow converts the **injected** attributes (with remapped references\napplied) instead of the original migrated attributes.\n\n### 2. Make `data_source` optional for XY annotation layers\nManual (point/range) annotations don't need a data view — only query\nannotations do. Previously the state→API transform threw `cannot find\ndata view ID for annotation layer` whenever an annotation layer had no\nexplicit data view.\n\n- `data_source` is now `schema.maybe(...)` for by-value annotation\nlayers (OAS bundles updated accordingly).\n- **State → API**: manual-only annotation layers omit `data_source`;\nquery annotation layers still require a resolvable data view (throws\notherwise).\n- **API → state**: the config builder now emits a **persisted** by-value\nannotation layer (no inline `indexPatternId`), letting the Lens XY\nruntime (`persistence.ts`) inject the data view from the\n`xy-visualization-layer-` reference with its existing\nfirst-index-pattern fallback. This removes duplicated fallback logic\nfrom the config builder.\n- **Inbound validation**: a by-value annotation layer arriving without\n`data_source` but containing query events is rejected, keeping API↔state\nsymmetric.\n- Fixed a pre-existing bug where a query annotation pointing at its own\n**ad hoc** data view emitted the internal reference under the wrong name\n(`indexpattern-datasource-layer-` instead of `xy-visualization-layer-`),\ncausing the runtime to fall back to the wrong data view.\n`getAdhocDataviews` now uses the annotation reference name for\nannotation layers, matching Lens's own persistence.\n\n### 3. Graceful error on missing annotation data view\nAdded a defensive null check in `getAnnotationLayerErrors` plus a new\n`ANNOTATION_DATAVIEW_NOT_FOUND` user message, so a missing/deleted\nannotation data view surfaces a clear message instead of crashing with\n`Cannot read properties of undefined (reading 'getFieldByName')`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f4bb234b323f564a5041d3266f6043c307535db6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275372","number":275372,"mergeCommit":{"message":"[Lens as code] Fix XY annotation layers dataview references (#275372)\n\n## Summary\n\nFixes Lens panels failing to render (and dashboard panels being dropped)\nwhen the `lens.apiFormat` feature flag is enabled, primarily around how\nXY annotation layers handle data view references. Closes #268825.\n\nThe work breaks down into three areas:\n\n### 1. Respect remapped panel references on `transformOut`\nWhen `lens.apiFormat` is enabled, the API conversion bypassed\ndashboard-level `panelReferences`, so copied dashboards (with remapped\ndata view IDs across spaces) emitted stale references. `getTransformOut`\nnow converts the **injected** attributes (with remapped references\napplied) instead of the original migrated attributes.\n\n### 2. Make `data_source` optional for XY annotation layers\nManual (point/range) annotations don't need a data view — only query\nannotations do. Previously the state→API transform threw `cannot find\ndata view ID for annotation layer` whenever an annotation layer had no\nexplicit data view.\n\n- `data_source` is now `schema.maybe(...)` for by-value annotation\nlayers (OAS bundles updated accordingly).\n- **State → API**: manual-only annotation layers omit `data_source`;\nquery annotation layers still require a resolvable data view (throws\notherwise).\n- **API → state**: the config builder now emits a **persisted** by-value\nannotation layer (no inline `indexPatternId`), letting the Lens XY\nruntime (`persistence.ts`) inject the data view from the\n`xy-visualization-layer-` reference with its existing\nfirst-index-pattern fallback. This removes duplicated fallback logic\nfrom the config builder.\n- **Inbound validation**: a by-value annotation layer arriving without\n`data_source` but containing query events is rejected, keeping API↔state\nsymmetric.\n- Fixed a pre-existing bug where a query annotation pointing at its own\n**ad hoc** data view emitted the internal reference under the wrong name\n(`indexpattern-datasource-layer-` instead of `xy-visualization-layer-`),\ncausing the runtime to fall back to the wrong data view.\n`getAdhocDataviews` now uses the annotation reference name for\nannotation layers, matching Lens's own persistence.\n\n### 3. Graceful error on missing annotation data view\nAdded a defensive null check in `getAnnotationLayerErrors` plus a new\n`ANNOTATION_DATAVIEW_NOT_FOUND` user message, so a missing/deleted\nannotation data view surfaces a clear message instead of crashing with\n`Cannot read properties of undefined (reading 'getFieldByName')`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f4bb234b323f564a5041d3266f6043c307535db6"}}]}] BACKPORT-->