### PR TITLE
[Synthetics] Populate context.viewInAppUrl for TLS certificate alerts

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/utils/get_synthetics_monitor_url.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/utils/get_synthetics_monitor_url.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getSyntheticsCertificatesRoute,
+  getSyntheticsErrorRouteFromMonitorId,
+} from './get_synthetics_monitor_url';
+
+describe('getSyntheticsErrorRouteFromMonitorId', () => {
+  it('builds a monitor error route with location id', () => {
+    expect(
+      getSyntheticsErrorRouteFromMonitorId({
+        configId: 'config-1',
+        stateId: 'state-1',
+        locationId: 'us-east',
+      })
+    ).toBe('/app/synthetics/monitor/config-1/errors/state-1?locationId=us-east');
+  });
+});
+
+describe('getSyntheticsCertificatesRoute', () => {
+  it('returns the certificates page when no filters are provided', () => {
+    expect(getSyntheticsCertificatesRoute({})).toBe('/app/synthetics/certificates');
+  });
+
+  it('pre-filters the certificates page by common name and issuer', () => {
+    expect(
+      getSyntheticsCertificatesRoute({
+        commonName: 'example.com',
+        issuer: 'Test CA',
+      })
+    ).toBe('/app/synthetics/certificates?search=example.com&issuers=%5B%22Test%20CA%22%5D');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/common/utils/get_synthetics_monitor_url.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/utils/get_synthetics_monitor_url.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 import { stringify } from 'querystring';
+import { CERTIFICATES_ROUTE, SYNTHETICS_APP_BASE_PATH } from '../constants/ui';
 
 const format = ({ pathname, query }: { pathname: string; query: Record<string, any> }): string => {
-  return `${pathname}?${stringify(query)}`;
+  const queryString = stringify(query);
+  return queryString ? `${pathname}?${queryString}` : pathname;
 };
 export const getSyntheticsErrorRouteFromMonitorId = ({
   configId,
@@ -24,3 +26,26 @@ export const getSyntheticsErrorRouteFromMonitorId = ({
       locationId,
     },
   });
+
+export const getSyntheticsCertificatesRoute = ({
+  commonName,
+  issuer,
+}: {
+  commonName?: string;
+  issuer?: string;
+}) => {
+  const query: Record<string, string> = {};
+
+  if (commonName) {
+    query.search = commonName;
+  }
+
+  if (issuer) {
+    query.issuers = JSON.stringify([issuer]);
+  }
+
+  return format({
+    pathname: `${SYNTHETICS_APP_BASE_PATH}${CERTIFICATES_ROUTE}`,
+    query,
+  });
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.ts
@@ -44,7 +44,10 @@ import type {
   SyntheticsMonitorStatusAlertState,
 } from '../../common/runtime_types/alert_rules/common';
 import { SyntheticsCommonStateCodec } from '../../common/runtime_types/alert_rules/common';
-import { getSyntheticsErrorRouteFromMonitorId } from '../../common/utils/get_synthetics_monitor_url';
+import {
+  getSyntheticsErrorRouteFromMonitorId,
+  getSyntheticsCertificatesRoute,
+} from '../../common/utils/get_synthetics_monitor_url';
 import { ALERT_DETAILS_URL, RECOVERY_REASON } from './action_variables';
 import type { MonitorStatusAlertDocument, MonitorSummaryStatusRule } from './status_rule/types';
 
@@ -137,6 +140,14 @@ export const getRelativeViewInAppUrl = ({
     locationId,
   });
 };
+
+export const getRelativeCertificatesViewInAppUrl = ({
+  commonName,
+  issuer,
+}: {
+  commonName?: string;
+  issuer?: string;
+}) => getSyntheticsCertificatesRoute({ commonName, issuer });
 
 /**
  * For ungrouped alerts, the alert ID is just the configId (no location suffix),

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/message_utils.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/message_utils.test.ts
@@ -6,7 +6,11 @@
  */
 
 import type { IBasePath } from '@kbn/core/server';
-import { getTLSCertAlertId, setTLSRecoveredAlertsContext } from './message_utils';
+import {
+  getTLSCertAlertId,
+  getTLSAlertContext,
+  setTLSRecoveredAlertsContext,
+} from './message_utils';
 import type { TLSLatestPing } from './tls_rule_executor';
 
 describe('getTLSCertAlertId', () => {
@@ -28,6 +32,65 @@ describe('getTLSCertAlertId', () => {
 
   it('returns undefined when neither a fingerprint nor a common name is available', () => {
     expect(getTLSCertAlertId({})).toBeUndefined();
+  });
+});
+
+describe('getTLSAlertContext', () => {
+  const basePath = {
+    publicBaseUrl: 'https://localhost:5601',
+  } as IBasePath;
+
+  const summary = {
+    summary: 'Certificate expires soon',
+    status: 'expiring',
+    sha256: 'cert-1-sha256',
+    commonName: 'cert-1',
+    issuer: 'test-issuer',
+    monitorName: 'test-monitor',
+    monitorId: '12345',
+    serviceName: 'test-service',
+    monitorType: 'HTTP',
+    locationId: 'us-east',
+    locationName: 'US East',
+    monitorUrl: 'https://example.com',
+    configId: '12345',
+    monitorTags: [],
+    lastErrorMessage: undefined,
+    lastErrorStack: undefined,
+    labels: {},
+    reason: 'Certificate expires soon',
+    hostName: 'host-1',
+    checkedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('sets alertDetailsUrl and viewInAppUrl alongside alert summary fields', async () => {
+    await expect(
+      getTLSAlertContext({
+        basePath,
+        spaceId: 'default',
+        summary,
+        alertUuid: 'alert-id',
+      })
+    ).resolves.toEqual({
+      alertDetailsUrl: 'https://localhost:5601/app/observability/alerts/alert-id',
+      viewInAppUrl:
+        'https://localhost:5601/app/synthetics/certificates?search=cert-1&issuers=%5B%22test-issuer%22%5D',
+      ...summary,
+    });
+  });
+
+  it('includes the space id in viewInAppUrl for non-default spaces', async () => {
+    await expect(
+      getTLSAlertContext({
+        basePath,
+        spaceId: 'team-a',
+        summary,
+        alertUuid: 'alert-id',
+      })
+    ).resolves.toMatchObject({
+      viewInAppUrl:
+        'https://localhost:5601/s/team-a/app/synthetics/certificates?search=cert-1&issuers=%5B%22test-issuer%22%5D',
+    });
   });
 });
 
@@ -98,6 +161,8 @@ describe('setTLSRecoveredAlertsContext', () => {
     expect(alertsClientMock.setAlertData).toBeCalledWith({
       context: {
         alertDetailsUrl: 'https://localhost:5601/app/observability/alerts/alert-id',
+        viewInAppUrl:
+          'https://localhost:5601/app/synthetics/certificates?search=cert-1&issuers=%5B%22test-issuer%22%5D',
         commonName: 'cert-1',
         configId: '12345',
         issuer: 'test-issuer',
@@ -161,6 +226,8 @@ describe('setTLSRecoveredAlertsContext', () => {
     expect(alertsClientMock.setAlertData).toBeCalledWith({
       context: {
         alertDetailsUrl: 'https://localhost:5601/app/observability/alerts/alert-id',
+        viewInAppUrl:
+          'https://localhost:5601/app/synthetics/certificates?search=cert-1&issuers=%5B%22test-issuer%22%5D',
         commonName: 'cert-1',
         configId: '12345',
         issuer: 'test-issuer',
@@ -210,6 +277,8 @@ describe('setTLSRecoveredAlertsContext', () => {
       id: 'alert-id',
       context: expect.objectContaining({
         alertDetailsUrl: 'https://localhost:5601/app/observability/alerts/alert-id',
+        viewInAppUrl:
+          'https://localhost:5601/app/synthetics/certificates?search=browser-cert-cn&issuers=%5B%22test-issuer%22%5D',
         commonName: 'browser-cert-cn',
         previousStatus: 'Certificate browser-cert-cn test-summary',
         newStatus: expect.stringContaining('browser-cert-cn'),

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/message_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/message_utils.ts
@@ -19,7 +19,12 @@ import type { ObservabilityUptimeAlert } from '@kbn/alerts-as-data-utils';
 import { ALERT_REASON, ALERT_UUID } from '@kbn/rule-data-utils';
 import type { MonitorSummaryTLSRule } from './types';
 import type { TLSLatestPing } from './tls_rule_executor';
-import { ALERT_DETAILS_URL } from '../action_variables';
+import { ALERT_DETAILS_URL, VIEW_IN_APP_URL } from '../action_variables';
+import {
+  generateAlertMessage,
+  getRelativeCertificatesViewInAppUrl,
+  getViewInAppUrl,
+} from '../common';
 import type { Cert } from '../../../common/runtime_types';
 import { tlsTranslations } from '../translations';
 import type { MonitorStatusActionGroup } from '../../../common/constants/synthetics_alerts';
@@ -40,7 +45,6 @@ import {
   SERVICE_NAME,
   URL_FULL,
 } from '../../../common/field_names';
-import { generateAlertMessage } from '../common';
 import { TlsTranslations } from '../../../common/rules/synthetics/translations';
 interface TLSContent {
   summary: string;
@@ -147,6 +151,48 @@ export const getCertSummary = (
   };
 };
 
+interface TlsCertIdentity {
+  commonName?: string;
+  issuer?: string;
+}
+
+const getTlsCertIdentity = (state: { commonName?: string; issuer?: string }): TlsCertIdentity => ({
+  commonName: state.commonName,
+  issuer: state.issuer,
+});
+
+const getTlsViewInAppUrl = (
+  basePath: IBasePath,
+  spaceId: string,
+  { commonName, issuer }: TlsCertIdentity
+) =>
+  getViewInAppUrl(basePath, spaceId, getRelativeCertificatesViewInAppUrl({ commonName, issuer }));
+
+const getTlsAlertUrlContext = async (
+  basePath: IBasePath,
+  spaceId: string,
+  alertUuid: string,
+  certIdentity: TlsCertIdentity
+) => ({
+  [ALERT_DETAILS_URL]: await getAlertDetailsUrl(basePath, spaceId, alertUuid),
+  [VIEW_IN_APP_URL]: getTlsViewInAppUrl(basePath, spaceId, certIdentity),
+});
+
+export const getTLSAlertContext = async ({
+  basePath,
+  spaceId,
+  summary,
+  alertUuid,
+}: {
+  basePath: IBasePath;
+  spaceId: string;
+  summary: CertSummary;
+  alertUuid: string;
+}) => ({
+  ...(await getTlsAlertUrlContext(basePath, spaceId, alertUuid, summary)),
+  ...summary,
+});
+
 export const getTLSAlertDocument = (cert: Cert, monitorSummary: CertSummary, uuid: string) => ({
   [CERT_COMMON_NAME]: cert.common_name,
   [CERT_ISSUER_NAME]: cert.issuer,
@@ -197,6 +243,7 @@ export const setTLSRecoveredAlertsContext = async ({
 
     const state = recoveredAlert.alert.getState();
     const alertUrl = await getAlertDetailsUrl(basePath, spaceId, alertUuid);
+    const certIdentity = getTlsCertIdentity(state);
 
     const configId = state.configId;
     const latestPing = latestPings.find((ping) => ping.config_id === configId);
@@ -228,6 +275,7 @@ export const setTLSRecoveredAlertsContext = async ({
           previousStatus,
           summary: newSummary,
           [ALERT_DETAILS_URL]: alertUrl,
+          [VIEW_IN_APP_URL]: getTlsViewInAppUrl(basePath, spaceId, certIdentity),
         },
       });
       continue;
@@ -263,6 +311,7 @@ export const setTLSRecoveredAlertsContext = async ({
       previousStatus,
       summary: newSummary,
       [ALERT_DETAILS_URL]: alertUrl,
+      [VIEW_IN_APP_URL]: getTlsViewInAppUrl(basePath, spaceId, certIdentity),
     };
     alertsClient.setAlertData({ id: recoveredAlertId, context });
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule.ts
@@ -19,15 +19,12 @@ import {
   tlsRuleParamsSchema,
   type TLSRuleParams,
 } from '@kbn/response-ops-rule-params/synthetics_tls';
-import {
-  getAlertDetailsUrl,
-  observabilityFeatureId,
-  observabilityPaths,
-} from '@kbn/observability-plugin/common';
+import { observabilityFeatureId, observabilityPaths } from '@kbn/observability-plugin/common';
 import type { ObservabilityUptimeAlert } from '@kbn/alerts-as-data-utils';
 import type { SyntheticsPluginsSetupDependencies, SyntheticsServerSetup } from '../../types';
 import {
   getCertSummary,
+  getTLSAlertContext,
   getTLSAlertDocument,
   getTLSCertAlertId,
   setTLSRecoveredAlertsContext,
@@ -36,7 +33,7 @@ import type { SyntheticsCommonState } from '../../../common/runtime_types/alert_
 import { TLSRuleExecutor } from './tls_rule_executor';
 import { TLS_CERTIFICATE } from '../../../common/constants/synthetics_alerts';
 import { SyntheticsRuleTypeAlertDefinition, updateState } from '../common';
-import { ALERT_DETAILS_URL, getActionVariables } from '../action_variables';
+import { getActionVariables } from '../action_variables';
 import type { SyntheticsMonitorClient } from '../../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 
 type TLSActionGroups = ActionGroupIdsOf<typeof TLS_CERTIFICATE>;
@@ -126,10 +123,12 @@ export const registerSyntheticsTLSCheckRule = (
 
         const payload = getTLSAlertDocument(cert, summary, uuid);
 
-        const context = {
-          [ALERT_DETAILS_URL]: await getAlertDetailsUrl(basePath, spaceId, uuid),
-          ...summary,
-        };
+        const context = await getTLSAlertContext({
+          basePath,
+          spaceId,
+          summary,
+          alertUuid: uuid,
+        });
 
         alertsClient.setAlertData({
           id: alertId,


### PR DESCRIPTION
Fixes #281563

The issue was reported on SDH.
The Synthetics TLS certificate rule (`xpack.synthetics.alerts.tls`) declared `context.viewInAppUrl` as an action variable, but the executor never set it — only `context.alertDetailsUrl` was populated. Connector templates using `{{context.viewInAppUrl}}` therefore rendered empty.

This change populates `context.viewInAppUrl` for both fired and recovered alerts. The URL deep-links to the Synthetics Certificates page, pre-filtered by the certificate's common name and issuer (matching how the Certificates page persists filters in the URL). Both `viewInAppUrl` and `alertDetailsUrl` remain distinct fields and respect `server.publicBaseUrl` and space ID via the existing `getViewInAppUrl` helper.

## Test plan

- [x] Unit test: `getTLSAlertContext` sets `viewInAppUrl` alongside `alertDetailsUrl` when an alert fires
- [x] Unit test: `viewInAppUrl` includes space ID for non-default spaces
- [x] Unit test: `setTLSRecoveredAlertsContext` sets `viewInAppUrl` for lightweight cert recovery paths
- [x] Unit test: `setTLSRecoveredAlertsContext` sets `viewInAppUrl` for browser cert recovery
- [x] Unit test: `getSyntheticsCertificatesRoute` builds the expected filtered certificates URL
- [ ] Manual: create a TLS rule, trigger a cert expiry alert, verify `{{context.viewInAppUrl}}` in a connector resolves to the filtered Certificates page
- [ ] Manual: verify behavior with and without `server.publicBaseUrl` configured
- [ ] Manual: verify recovery notifications include `viewInAppUrl`

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->