### PR TITLE
[9.4] [Fleet] Pass existing expiration field in POST /enrollment_api_keys to security APIs (#281324)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -72660,6 +72660,9 @@ components:
           type: string
         created_at:
           type: string
+        expire_at:
+          description: The expiration date of the enrollment token as an ISO 8601 date string. Absent when the token never expires.
+          type: string
         hidden:
           type: boolean
         id:
@@ -90417,6 +90420,8 @@ components:
       additionalProperties: false
       properties:
         expiration:
+          description: The expiration time for the enrollment token, expressed as a duration (for example, 30d, 24h, 90m). By default, enrollment tokens never expire.
+          maxLength: 20
           type: string
         name:
           type: string

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -83819,6 +83819,9 @@ components:
           type: string
         created_at:
           type: string
+        expire_at:
+          description: The expiration date of the enrollment token as an ISO 8601 date string. Absent when the token never expires.
+          type: string
         hidden:
           type: boolean
         id:
@@ -101576,6 +101579,8 @@ components:
       additionalProperties: false
       properties:
         expiration:
+          description: The expiration time for the enrollment token, expressed as a duration (for example, 30d, 24h, 90m). By default, enrollment tokens never expire.
+          maxLength: 20
           type: string
         name:
           type: string

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -77,7 +77,7 @@ pageLoadAssetSize:
   files: 6037
   filesManagement: 5208
   fileUpload: 22957
-  fleet: 214235
+  fleet: 214611
   genAiSettings: 6400
   globalSearch: 6890
   globalSearchBar: 26122

--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -7,6 +7,7 @@
 
 export * from './routes';
 export { validateFleetSavedObjectId } from './validate_fleet_id';
+export { isValidDuration, isValidEnrollmentKeyExpiration } from './validate_duration';
 export * as AgentStatusKueryHelper from './agent_status';
 export * from './package_helpers';
 export {

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_duration.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_duration.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const DURATION_REGEX = /^\d+(ms|s|m|h)$/;
+
+export const isValidDuration = (value: string): boolean => DURATION_REGEX.test(value);
+
+// Valid time units for ES Security API enrollment key expiration: days, hours, minutes, seconds.
+// Requires a positive (non-zero) integer so callers can't create an already-expired token.
+export const ES_ENROLLMENT_KEY_DURATION_REGEX = /^[1-9]\d*(d|h|m|s)$/;
+
+// Maximum values per unit derived from ES TimeValue ceiling: Long.MAX_VALUE nanoseconds ≈ 106,751 days
+const ES_ENROLLMENT_KEY_MAX_BY_UNIT: Record<string, number> = {
+  d: 106751,
+  h: 2562024,
+  m: 153721440,
+  s: 9223286400,
+};
+
+export const isValidEnrollmentKeyExpiration = (value: string): boolean => {
+  if (!ES_ENROLLMENT_KEY_DURATION_REGEX.test(value)) return false;
+  const unit = value[value.length - 1];
+  const amount = parseInt(value.slice(0, -1), 10);
+  return amount <= ES_ENROLLMENT_KEY_MAX_BY_UNIT[unit];
+};

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/enrollment_api_key.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/enrollment_api_key.ts
@@ -14,6 +14,7 @@ export interface EnrollmentAPIKey {
   active: boolean;
   policy_id?: string;
   created_at: string;
+  expire_at?: string;
   hidden?: boolean;
 }
 

--- a/x-pack/platform/plugins/shared/fleet/public/components/new_enrollment_key_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/new_enrollment_key_modal.test.tsx
@@ -6,12 +6,14 @@
  */
 
 import React from 'react';
-import { act } from '@testing-library/react';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 
 import { createFleetTestRendererMock } from '../mock';
 import type { AgentPolicy } from '../types';
 
 import { NewEnrollmentTokenModal } from './new_enrollment_key_modal';
+
+const mockSendCreateEnrollmentAPIKey = jest.fn().mockResolvedValue({ data: { item: {} } });
 
 jest.mock('../hooks', () => ({
   ...jest.requireActual('../hooks'),
@@ -23,7 +25,7 @@ jest.mock('../hooks', () => ({
       },
     },
   }),
-  sendCreateEnrollmentAPIKey: jest.fn().mockResolvedValue({ data: { item: {} } }),
+  sendCreateEnrollmentAPIKey: (...args: unknown[]) => mockSendCreateEnrollmentAPIKey(...args),
 }));
 
 const MOCK_POLICIES = [
@@ -56,6 +58,124 @@ describe('NewEnrollmentTokenModal', () => {
     // Managed and agentless policies should never appear
     expect(results.queryByText('Managed Policy')).toBeNull();
     expect(results.queryByText('Agentless Policy')).toBeNull();
+  });
+
+  it('renders the expiration field', () => {
+    const testRenderer = createFleetTestRendererMock();
+    const results = testRenderer.render(
+      <NewEnrollmentTokenModal agentPolicies={MOCK_POLICIES} onClose={jest.fn()} />
+    );
+    expect(results.getByTestId('createEnrollmentTokenExpirationField')).toBeInTheDocument();
+  });
+
+  it.each([
+    'notaduration',
+    '7D',
+    '-1d',
+    '1.5d',
+    '7',
+    '7 d',
+    '7days',
+    '7w',
+    '500ms',
+    '100micros',
+    '50nanos',
+    '0d',
+  ])('shows a validation error for invalid expiration "%s"', async (invalidValue) => {
+    const testRenderer = createFleetTestRendererMock();
+    const results = testRenderer.render(
+      <NewEnrollmentTokenModal agentPolicies={MOCK_POLICIES} onClose={jest.fn()} />
+    );
+
+    const expirationField = results.getByTestId('createEnrollmentTokenExpirationField');
+    await act(async () => {
+      fireEvent.change(expirationField, { target: { value: invalidValue } });
+    });
+
+    // Submit to trigger validation
+    await act(async () => {
+      // EuiConfirmModal renders the title and the confirm button with the same text; pick the button
+      const confirmButtons = results.getAllByText('Create enrollment token');
+      confirmButtons[confirmButtons.length - 1].click();
+    });
+
+    await waitFor(() => {
+      expect(
+        results.getByText('Expiration must be a valid duration (for example, 30d, 24h, 90m, 60s)')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it.each(['7d', '24h', '30m', '60s'])('accepts valid expiration "%s"', async (validValue) => {
+    mockSendCreateEnrollmentAPIKey.mockResolvedValue({ data: { item: {} } });
+    const testRenderer = createFleetTestRendererMock();
+    const results = testRenderer.render(
+      <NewEnrollmentTokenModal agentPolicies={MOCK_POLICIES} onClose={jest.fn()} />
+    );
+
+    const expirationField = results.getByTestId('createEnrollmentTokenExpirationField');
+    await act(async () => {
+      fireEvent.change(expirationField, { target: { value: validValue } });
+    });
+
+    await act(async () => {
+      const confirmButtons = results.getAllByText('Create enrollment token');
+      confirmButtons[confirmButtons.length - 1].click();
+    });
+
+    await waitFor(() => {
+      expect(mockSendCreateEnrollmentAPIKey).toHaveBeenCalledWith(
+        expect.objectContaining({ expiration: validValue })
+      );
+    });
+    expect(
+      results.queryByText('Expiration must be a valid duration (for example, 30d, 24h, 90m, 60s)')
+    ).toBeNull();
+  });
+
+  it('includes expiration in the API call when a valid duration is provided', async () => {
+    mockSendCreateEnrollmentAPIKey.mockResolvedValue({ data: { item: {} } });
+    const testRenderer = createFleetTestRendererMock();
+    const results = testRenderer.render(
+      <NewEnrollmentTokenModal agentPolicies={MOCK_POLICIES} onClose={jest.fn()} />
+    );
+
+    const expirationField = results.getByTestId('createEnrollmentTokenExpirationField');
+    await act(async () => {
+      fireEvent.change(expirationField, { target: { value: '30d' } });
+    });
+
+    await act(async () => {
+      // EuiConfirmModal renders the title and the confirm button with the same text; pick the button
+      const confirmButtons = results.getAllByText('Create enrollment token');
+      confirmButtons[confirmButtons.length - 1].click();
+    });
+
+    await waitFor(() => {
+      expect(mockSendCreateEnrollmentAPIKey).toHaveBeenCalledWith(
+        expect.objectContaining({ expiration: '30d' })
+      );
+    });
+  });
+
+  it('does not include expiration in the API call when left empty', async () => {
+    mockSendCreateEnrollmentAPIKey.mockResolvedValue({ data: { item: {} } });
+    const testRenderer = createFleetTestRendererMock();
+    const results = testRenderer.render(
+      <NewEnrollmentTokenModal agentPolicies={MOCK_POLICIES} onClose={jest.fn()} />
+    );
+
+    await act(async () => {
+      // EuiConfirmModal renders the title and the confirm button with the same text; pick the button
+      const confirmButtons = results.getAllByText('Create enrollment token');
+      confirmButtons[confirmButtons.length - 1].click();
+    });
+
+    await waitFor(() => {
+      expect(mockSendCreateEnrollmentAPIKey).toHaveBeenCalledWith(
+        expect.not.objectContaining({ expiration: expect.anything() })
+      );
+    });
   });
 
   it('renders with no options when all policies are managed or agentless', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/components/new_enrollment_key_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/new_enrollment_key_modal.tsx
@@ -18,12 +18,23 @@ import {
 
 import type { AgentPolicy, EnrollmentAPIKey } from '../types';
 import { useInput, useStartServices, sendCreateEnrollmentAPIKey } from '../hooks';
+import { isValidEnrollmentKeyExpiration } from '../../common/services';
 
 function validatePolicyId(value: string) {
   if (value === '') {
     return [
       i18n.translate('xpack.fleet.newEnrollmentKeyForm.policyIdRequireErrorMessage', {
         defaultMessage: 'Policy is required',
+      }),
+    ];
+  }
+}
+
+function validateExpiration(value: string) {
+  if (value !== '' && !isValidEnrollmentKeyExpiration(value)) {
+    return [
+      i18n.translate('xpack.fleet.newEnrollmentKeyForm.expirationInvalidErrorMessage', {
+        defaultMessage: 'Expiration must be a valid duration (for example, 30d, 24h, 90m, 60s)',
       }),
     ];
   }
@@ -36,11 +47,12 @@ function useCreateApiKeyForm(
 ) {
   const [isLoading, setIsLoading] = useState(false);
   const apiKeyNameInput = useInput('');
+  const expirationInput = useInput('', validateExpiration);
   const policyIdInput = useInput(policyIdDefaultValue, validatePolicyId);
 
-  const onSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-    if (!policyIdInput.validate() || !apiKeyNameInput.validate()) {
+  const onSubmit = async (event?: React.FormEvent) => {
+    event?.preventDefault();
+    if (!policyIdInput.validate() || !apiKeyNameInput.validate() || !expirationInput.validate()) {
       return;
     }
     setIsLoading(true);
@@ -48,6 +60,7 @@ function useCreateApiKeyForm(
       const res = await sendCreateEnrollmentAPIKey({
         name: apiKeyNameInput.value,
         policy_id: policyIdInput.value,
+        ...(expirationInput.value ? { expiration: expirationInput.value } : {}),
       });
 
       if (res.error) {
@@ -55,6 +68,7 @@ function useCreateApiKeyForm(
       }
       policyIdInput.clear();
       apiKeyNameInput.clear();
+      expirationInput.clear();
       setIsLoading(false);
       if (res.data?.item) {
         onSuccess(res.data.item);
@@ -70,6 +84,7 @@ function useCreateApiKeyForm(
     onSubmit,
     policyIdInput,
     apiKeyNameInput,
+    expirationInput,
   };
 }
 
@@ -131,6 +146,27 @@ export const NewEnrollmentTokenModal: React.FunctionComponent<Props> = ({
               defaultMessage: 'Enter a token name',
             })}
             {...form.apiKeyNameInput.props}
+          />
+        </EuiFormRow>
+
+        <EuiFormRow
+          label={i18n.translate('xpack.fleet.newEnrollmentKey.expirationLabel', {
+            defaultMessage: 'Expiration',
+          })}
+          helpText={i18n.translate('xpack.fleet.newEnrollmentKey.expirationHelpText', {
+            defaultMessage:
+              'Optional. How long until the token expires (for example, 30d, 24h, 90m). Leave empty for a token that never expires.',
+          })}
+          {...form.expirationInput.formRowProps}
+        >
+          <EuiFieldText
+            data-test-subj="createEnrollmentTokenExpirationField"
+            name="expiration"
+            autoComplete="off"
+            placeholder={i18n.translate('xpack.fleet.newEnrollmentKey.expirationPlaceholder', {
+              defaultMessage: 'For example, 30d',
+            })}
+            {...form.expirationInput.props}
           />
         </EuiFormRow>
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/api_keys/enrollment_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/api_keys/enrollment_api_key.test.ts
@@ -151,6 +151,107 @@ describe('enrollment api keys', () => {
         })
       );
     });
+
+    it('should pass expiration to the Security API and persist expire_at when expiration is provided', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      // The Security API returns expiration as epoch-ms
+      const expirationEpochMs = new Date('2030-01-01T00:00:00.000Z').getTime();
+
+      esClient.create.mockResolvedValue({
+        _id: 'test-enrollment-api-key-id',
+      } as any);
+
+      esClient.security.createApiKey.mockResolvedValue({
+        api_key: 'test-api-key-value',
+        id: 'test-api-key-id',
+        expiration: expirationEpochMs,
+      } as any);
+
+      mockedAgentPolicyService.get.mockResolvedValue({
+        id: 'test-agent-policy',
+      } as any);
+
+      const result = await generateEnrollmentAPIKey(soClient, esClient, {
+        name: 'test-api-key',
+        expiration: '7d',
+        agentPolicyId: 'test-agent-policy',
+        forceRecreate: true,
+      });
+
+      expect(esClient.security.createApiKey).toHaveBeenCalledWith(
+        expect.objectContaining({ expiration: '7d' })
+      );
+
+      expect(esClient.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            expire_at: new Date(expirationEpochMs).toISOString(),
+          }),
+        })
+      );
+
+      expect(result.expire_at).toBe(new Date(expirationEpochMs).toISOString());
+    });
+
+    it('should not pass expiration to the Security API when expiration is not provided', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      esClient.create.mockResolvedValue({
+        _id: 'test-enrollment-api-key-id',
+      } as any);
+
+      esClient.security.createApiKey.mockResolvedValue({
+        api_key: 'test-api-key-value',
+        id: 'test-api-key-id',
+      } as any);
+
+      mockedAgentPolicyService.get.mockResolvedValue({
+        id: 'test-agent-policy',
+      } as any);
+
+      const result = await generateEnrollmentAPIKey(soClient, esClient, {
+        name: 'test-api-key',
+        agentPolicyId: 'test-agent-policy',
+        forceRecreate: true,
+      });
+
+      expect(esClient.security.createApiKey).toHaveBeenCalledWith(
+        expect.not.objectContaining({ expiration: expect.anything() })
+      );
+
+      expect(result.expire_at).toBeUndefined();
+    });
+
+    it('should throw FleetError for an invalid expiration format', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      await expect(
+        generateEnrollmentAPIKey(soClient, esClient, {
+          name: 'test-api-key',
+          agentPolicyId: 'test-agent-policy',
+          expiration: 'notaduration',
+        })
+      ).rejects.toThrow(
+        'Invalid expiration value "notaduration". Must be a positive duration (for example'
+      );
+    });
+
+    it('should throw FleetError for an expiration value exceeding the ES maximum', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      await expect(
+        generateEnrollmentAPIKey(soClient, esClient, {
+          name: 'test-api-key',
+          agentPolicyId: 'test-agent-policy',
+          expiration: '106752d',
+        })
+      ).rejects.toThrow('Invalid expiration value "106752d"');
+    });
   });
 
   describe('deleteEnrollmentApiKey', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/api_keys/enrollment_api_key.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/api_keys/enrollment_api_key.ts
@@ -16,6 +16,7 @@ import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import type { ESSearchResponse as SearchResponse } from '@kbn/es-types';
 
 import { ALL_SPACES_ID } from '../../../common/constants';
+import { isValidEnrollmentKeyExpiration } from '../../../common/services';
 import type { EnrollmentAPIKey, FleetServerEnrollmentAPIKey } from '../../types';
 import { FleetError, EnrollmentKeyNameExistsError, EnrollmentKeyNotFoundError } from '../../errors';
 import { ENROLLMENT_API_KEYS_INDEX } from '../../constants';
@@ -217,6 +218,11 @@ export async function generateEnrollmentAPIKey(
     forceRecreate?: boolean;
   }
 ): Promise<EnrollmentAPIKey> {
+  if (data.expiration !== undefined && !isValidEnrollmentKeyExpiration(data.expiration)) {
+    throw new FleetError(
+      `Invalid expiration value "${data.expiration}". Must be a positive duration (for example, 30d, 24h, 90m, 60s) not exceeding 106751d.`
+    );
+  }
   const id = uuidv4();
   const { name: providedKeyName, forceRecreate, agentPolicyId } = data;
   const logger = appContextService.getLogger();
@@ -272,6 +278,7 @@ export async function generateEnrollmentAPIKey(
   const key = await esClient.security
     .createApiKey({
       name,
+      ...(data.expiration ? { expiration: data.expiration } : {}),
       metadata: {
         managed_by: 'fleet',
         managed: true,
@@ -307,6 +314,9 @@ export async function generateEnrollmentAPIKey(
 
   const apiKey = Buffer.from(`${key.id}:${key.api_key}`).toString('base64');
 
+  // key.expiration is epoch-ms returned by the Security API; convert to ISO for the date-typed field
+  const expireAt = key.expiration ? new Date(key.expiration).toISOString() : undefined;
+
   const body = {
     active: true,
     api_key_id: key.id,
@@ -316,6 +326,7 @@ export async function generateEnrollmentAPIKey(
     namespaces: agentPolicy?.space_ids,
     created_at: new Date().toISOString(),
     hidden: agentPolicy?.supports_agentless || agentPolicy?.is_managed,
+    ...(expireAt ? { expire_at: expireAt } : {}),
   };
 
   const res = await esClient.create({
@@ -333,6 +344,7 @@ export async function generateEnrollmentAPIKey(
     active: body.active,
     policy_id: body.policy_id,
     created_at: body.created_at,
+    ...(expireAt ? { expire_at: expireAt } : {}),
   };
 
   return enrollmentAPIKey;
@@ -434,5 +446,6 @@ function esDocToEnrollmentApiKey(doc: {
     created_at: doc._source.created_at as string,
     active: doc._source.active || false,
     hidden: doc._source.hidden || false,
+    ...(doc._source.expire_at ? { expire_at: doc._source.expire_at } : {}),
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/enrollment_api_key.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/enrollment_api_key.ts
@@ -33,6 +33,14 @@ export const EnrollmentAPIKeySchema = schema.object(
       })
     ),
     created_at: schema.string(),
+    expire_at: schema.maybe(
+      schema.string({
+        meta: {
+          description:
+            'The expiration date of the enrollment token as an ISO 8601 date string. Absent when the token never expires.',
+        },
+      })
+    ),
     hidden: schema.maybe(schema.boolean()),
   },
   { meta: { id: 'enrollment_api_key' } }

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/enrollment_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/enrollment_api_key.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PostEnrollmentAPIKeyRequestSchema } from './enrollment_api_key';
+
+describe('PostEnrollmentAPIKeyRequestSchema', () => {
+  const validate = (expiration: unknown) =>
+    PostEnrollmentAPIKeyRequestSchema.body.validate({
+      policy_id: 'test-policy',
+      expiration,
+    });
+
+  describe('expiration field validation', () => {
+    const validDurations = [
+      '1d',
+      '7d',
+      '30d',
+      '24h',
+      '60m',
+      '90s',
+      '106751d',
+      '2562024h',
+      '153721440m',
+      '9223286400s',
+    ];
+
+    validDurations.forEach((value) => {
+      it(`accepts valid duration "${value}"`, () => {
+        expect(() => validate(value)).not.toThrow();
+      });
+    });
+
+    it('accepts missing expiration (field is optional)', () => {
+      expect(() =>
+        PostEnrollmentAPIKeyRequestSchema.body.validate({ policy_id: 'test-policy' })
+      ).not.toThrow();
+    });
+
+    const invalidDurations = [
+      ['7D', 'uppercase unit'],
+      ['7', 'bare integer without unit'],
+      ['d', 'unit without integer'],
+      ['7 d', 'space between number and unit'],
+      ['notaduration', 'arbitrary string'],
+      ['-1d', 'negative value'],
+      ['1.5d', 'decimal value'],
+      ['7days', 'full unit word'],
+      ['7w', 'unsupported unit (weeks)'],
+      ['500ms', 'unsupported unit (ms)'],
+      ['100micros', 'unsupported unit (micros)'],
+      ['50nanos', 'unsupported unit (nanos)'],
+      ['0d', 'zero value (already-expired token)'],
+      ['0h', 'zero hours'],
+      ['106752d', 'exceeds ES max days (106751)'],
+      ['9223286401s', 'exceeds ES max seconds (9223286400)'],
+    ];
+
+    invalidDurations.forEach(([value, description]) => {
+      it(`rejects invalid duration: ${description} ("${value}")`, () => {
+        expect(() => validate(value)).toThrow('Expiration must be a valid duration (for example');
+      });
+    });
+
+    it('rejects values exceeding maxLength of 20 characters', () => {
+      expect(() => validate('1'.repeat(20) + 'd')).toThrow();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/enrollment_api_key.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/enrollment_api_key.ts
@@ -10,6 +10,7 @@ import { schema } from '@kbn/config-schema';
 import { ENROLLMENT_API_KEY_MAPPINGS } from '../../constants';
 
 import { FLEET_ENROLLMENT_API_PREFIX } from '../../../common/constants';
+import { isValidEnrollmentKeyExpiration } from '../../../common/services';
 
 import { validateKuery } from '../../routes/utils/filter_utils';
 import { EnrollmentAPIKeySchema } from '../models';
@@ -67,7 +68,20 @@ export const PostEnrollmentAPIKeyRequestSchema = {
     {
       name: schema.maybe(schema.string()),
       policy_id: schema.string(),
-      expiration: schema.maybe(schema.string()),
+      expiration: schema.maybe(
+        schema.string({
+          maxLength: 20,
+          meta: {
+            description:
+              'The expiration time for the enrollment token, expressed as a duration (for example, 30d, 24h, 90m). By default, enrollment tokens never expire.',
+          },
+          validate: (value) => {
+            if (!isValidEnrollmentKeyExpiration(value)) {
+              return 'Expiration must be a valid duration (for example, 30d, 24h, 90m, 60s)';
+            }
+          },
+        })
+      ),
     },
     { meta: { id: 'new_enrollment_api_key' } }
   ),

--- a/x-pack/platform/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
@@ -312,6 +312,44 @@ export default function (providerContext: FtrProviderContext) {
           },
         });
       });
+
+      it('should pass expiration to the ES ApiKey and populate expire_at on the response', async () => {
+        const { body: apiResponse } = await supertest
+          .post(`/api/fleet/enrollment_api_keys`)
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            policy_id: 'policy1',
+            expiration: '30d',
+          })
+          .expect(200);
+
+        expect(apiResponse.item).to.have.property('expire_at');
+        expect(apiResponse.item.expire_at).to.be.a('string');
+
+        // Confirm the underlying ES API key also has an expiration set
+        const apiKeyRes = await es.security.getApiKey({
+          id: apiResponse.item.api_key_id,
+        });
+        expect(apiKeyRes.api_keys[0]).to.have.property('expiration');
+        expect(apiKeyRes.api_keys[0].expiration).to.be.a('number');
+
+        // The stored expire_at should match the ES expiration (epoch-ms → ISO)
+        const expectedExpireAt = new Date(apiKeyRes.api_keys[0].expiration as number).toISOString();
+        expect(apiResponse.item.expire_at).to.eql(expectedExpireAt);
+      });
+
+      it('should return 400 for an invalid expiration format', async () => {
+        const { body: apiResponse } = await supertest
+          .post(`/api/fleet/enrollment_api_keys`)
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            policy_id: 'policy1',
+            expiration: 'notaduration',
+          })
+          .expect(400);
+
+        expect(apiResponse.message).to.contain('Expiration must be a valid duration (for example');
+      });
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Fleet] Pass existing expiration field in POST /enrollment_api_keys to security APIs (#281324)](https://github.com/elastic/kibana/pull/281324)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-30T08:05:25Z","message":"[Fleet] Pass existing expiration field in POST /enrollment_api_keys to security APIs (#281324)\n\nFixes #191575.\n\n## Summary\n\nThe `POST /enrollment_api_keys` endpoint has accepted an optional\n`expiration` parameter for long time, but the value was silently dropped\nbefore reaching ES, meaning enrollment tokens always had no expiration\nregardless of what was passed.\n\n- The value is now validated against the Elasticsearch duration format\n(e.g. `7d`, `24h`, `30m`) and invalid values are rejected with a 400.\n- Valid durations are forwarded to the ES Security API when creating the\nAPI key.\n- The resolved expiry date (returned by ES as epoch-ms) is stored as\n`expire_at` in the enrollment token index document and returned in the\nAPI response, including on GET list and GET single endpoints.\n- A new optional **Expiration** field is added to the \"Create enrollment\ntoken\" modal in the Fleet UI, with client-side format validation.\n\nThe `expire_at` field and its index mapping already existed but were\nnever populated, so no migration is needed.\n\n\n## Testing\n\n### Prerequisites\n- Kibana + Elasticsearch running locally\n- A valid Fleet agent policy ID (visible in Fleet → Agent policies, or\nuse the default)\n\n\n### 1. Expiration is applied end-to-end\n\nCreate an enrollment token with a 2-day expiration via the Kibana Dev\nTools console:\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\",\n  \"expiration\": \"2d\"\n}\n```\n\nExpected: response includes `expire_at` set to ~2 days from now.\n\nConfirm in Elasticsearch using the `api_key_id` from the response:\n\n```\nGET _security/api_key?id=<api_key_id>&owner=false\n```\n\nExpected: `expiration` field is set in the returned key, and `new\nDate(expiration).toISOString()` matches the `expire_at` in the Fleet\nresponse.\n\n### 2. Invalid duration returns 400\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\",\n  \"expiration\": \"notaduration\"\n}\n```\n\nExpected: **400** with `expiration must be a valid duration`. Also test\n`\"7D\"` (uppercase), `\"7\"` (no unit), `\"1.5d\"` (decimal), `\"500ms\"` (ms\nnot supported).\n\n### 3. No expiration works as before\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\"\n}\n```\n\nExpected: **200**, no `expire_at` field in response, ES key has no\n`expiration`.\n\n### 4. UI — new Expiration field in the modal\n\n1. Open Fleet → **Enrollment tokens** → **Create enrollment token**\n2. An optional **Expiration** field is visible between \"Token name\" and\n\"Policy\"\n3. Enter `notaduration` → clicking \"Create enrollment token\" shows an\ninline validation error\n4. Enter `30d` → token creates successfully, response includes\n`expire_at`\n5. Leave empty → token creates with no expiration\n\n<img width=\"508\" height=\"489\" alt=\"Screenshot 2026-07-28 at 17 51 20\"\nsrc=\"https://github.com/user-attachments/assets/cd9322fb-f84f-489f-a223-1e10821226c4\"\n/>\n<img width=\"502\" height=\"518\" alt=\"Screenshot 2026-07-28 at 17 51 33\"\nsrc=\"https://github.com/user-attachments/assets/87e43ace-0a5b-43d3-8771-6db2923401d8\"\n/>\n\n\n\n### 5. GET endpoints return `expire_at`\n\nAfter creating a token with expiration, verify both list and single-key\nresponses include `expire_at`:\n\n```\nGET kbn:/api/fleet/enrollment_api_keys\nGET kbn:/api/fleet/enrollment_api_keys/<key-id>\n```\n\nTokens created without expiration should not have the `expire_at` field.\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Non-breaking additive change**: the `expiration` field was already\naccepted by the schema and already existed in the index mapping —\nexisting clients sending no `expiration` are unaffected.\n- **New `expire_at` field in API response**: clients that do strict\nresponse shape validation could be affected. The field is optional and\nonly present when expiration was set.\n- No data loss risk: the fix only adds a write path that was previously\nmissing.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"26a72e6696bedabaa798be181702da137618cafd","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.3.0","v9.4.0","v9.5.0","v9.6.0"],"title":"[Fleet] Pass existing expiration field in POST /enrollment_api_keys to security APIs","number":281324,"url":"https://github.com/elastic/kibana/pull/281324","mergeCommit":{"message":"[Fleet] Pass existing expiration field in POST /enrollment_api_keys to security APIs (#281324)\n\nFixes #191575.\n\n## Summary\n\nThe `POST /enrollment_api_keys` endpoint has accepted an optional\n`expiration` parameter for long time, but the value was silently dropped\nbefore reaching ES, meaning enrollment tokens always had no expiration\nregardless of what was passed.\n\n- The value is now validated against the Elasticsearch duration format\n(e.g. `7d`, `24h`, `30m`) and invalid values are rejected with a 400.\n- Valid durations are forwarded to the ES Security API when creating the\nAPI key.\n- The resolved expiry date (returned by ES as epoch-ms) is stored as\n`expire_at` in the enrollment token index document and returned in the\nAPI response, including on GET list and GET single endpoints.\n- A new optional **Expiration** field is added to the \"Create enrollment\ntoken\" modal in the Fleet UI, with client-side format validation.\n\nThe `expire_at` field and its index mapping already existed but were\nnever populated, so no migration is needed.\n\n\n## Testing\n\n### Prerequisites\n- Kibana + Elasticsearch running locally\n- A valid Fleet agent policy ID (visible in Fleet → Agent policies, or\nuse the default)\n\n\n### 1. Expiration is applied end-to-end\n\nCreate an enrollment token with a 2-day expiration via the Kibana Dev\nTools console:\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\",\n  \"expiration\": \"2d\"\n}\n```\n\nExpected: response includes `expire_at` set to ~2 days from now.\n\nConfirm in Elasticsearch using the `api_key_id` from the response:\n\n```\nGET _security/api_key?id=<api_key_id>&owner=false\n```\n\nExpected: `expiration` field is set in the returned key, and `new\nDate(expiration).toISOString()` matches the `expire_at` in the Fleet\nresponse.\n\n### 2. Invalid duration returns 400\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\",\n  \"expiration\": \"notaduration\"\n}\n```\n\nExpected: **400** with `expiration must be a valid duration`. Also test\n`\"7D\"` (uppercase), `\"7\"` (no unit), `\"1.5d\"` (decimal), `\"500ms\"` (ms\nnot supported).\n\n### 3. No expiration works as before\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\"\n}\n```\n\nExpected: **200**, no `expire_at` field in response, ES key has no\n`expiration`.\n\n### 4. UI — new Expiration field in the modal\n\n1. Open Fleet → **Enrollment tokens** → **Create enrollment token**\n2. An optional **Expiration** field is visible between \"Token name\" and\n\"Policy\"\n3. Enter `notaduration` → clicking \"Create enrollment token\" shows an\ninline validation error\n4. Enter `30d` → token creates successfully, response includes\n`expire_at`\n5. Leave empty → token creates with no expiration\n\n<img width=\"508\" height=\"489\" alt=\"Screenshot 2026-07-28 at 17 51 20\"\nsrc=\"https://github.com/user-attachments/assets/cd9322fb-f84f-489f-a223-1e10821226c4\"\n/>\n<img width=\"502\" height=\"518\" alt=\"Screenshot 2026-07-28 at 17 51 33\"\nsrc=\"https://github.com/user-attachments/assets/87e43ace-0a5b-43d3-8771-6db2923401d8\"\n/>\n\n\n\n### 5. GET endpoints return `expire_at`\n\nAfter creating a token with expiration, verify both list and single-key\nresponses include `expire_at`:\n\n```\nGET kbn:/api/fleet/enrollment_api_keys\nGET kbn:/api/fleet/enrollment_api_keys/<key-id>\n```\n\nTokens created without expiration should not have the `expire_at` field.\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Non-breaking additive change**: the `expiration` field was already\naccepted by the schema and already existed in the index mapping —\nexisting clients sending no `expiration` are unaffected.\n- **New `expire_at` field in API response**: clients that do strict\nresponse shape validation could be affected. The field is optional and\nonly present when expiration was set.\n- No data loss risk: the fix only adds a write path that was previously\nmissing.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"26a72e6696bedabaa798be181702da137618cafd"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/281691","number":281691,"state":"OPEN"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/281689","number":281689,"state":"OPEN"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281324","number":281324,"mergeCommit":{"message":"[Fleet] Pass existing expiration field in POST /enrollment_api_keys to security APIs (#281324)\n\nFixes #191575.\n\n## Summary\n\nThe `POST /enrollment_api_keys` endpoint has accepted an optional\n`expiration` parameter for long time, but the value was silently dropped\nbefore reaching ES, meaning enrollment tokens always had no expiration\nregardless of what was passed.\n\n- The value is now validated against the Elasticsearch duration format\n(e.g. `7d`, `24h`, `30m`) and invalid values are rejected with a 400.\n- Valid durations are forwarded to the ES Security API when creating the\nAPI key.\n- The resolved expiry date (returned by ES as epoch-ms) is stored as\n`expire_at` in the enrollment token index document and returned in the\nAPI response, including on GET list and GET single endpoints.\n- A new optional **Expiration** field is added to the \"Create enrollment\ntoken\" modal in the Fleet UI, with client-side format validation.\n\nThe `expire_at` field and its index mapping already existed but were\nnever populated, so no migration is needed.\n\n\n## Testing\n\n### Prerequisites\n- Kibana + Elasticsearch running locally\n- A valid Fleet agent policy ID (visible in Fleet → Agent policies, or\nuse the default)\n\n\n### 1. Expiration is applied end-to-end\n\nCreate an enrollment token with a 2-day expiration via the Kibana Dev\nTools console:\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\",\n  \"expiration\": \"2d\"\n}\n```\n\nExpected: response includes `expire_at` set to ~2 days from now.\n\nConfirm in Elasticsearch using the `api_key_id` from the response:\n\n```\nGET _security/api_key?id=<api_key_id>&owner=false\n```\n\nExpected: `expiration` field is set in the returned key, and `new\nDate(expiration).toISOString()` matches the `expire_at` in the Fleet\nresponse.\n\n### 2. Invalid duration returns 400\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\",\n  \"expiration\": \"notaduration\"\n}\n```\n\nExpected: **400** with `expiration must be a valid duration`. Also test\n`\"7D\"` (uppercase), `\"7\"` (no unit), `\"1.5d\"` (decimal), `\"500ms\"` (ms\nnot supported).\n\n### 3. No expiration works as before\n\n```\nPOST kbn:/api/fleet/enrollment_api_keys\n{\n  \"policy_id\": \"<your-policy-id>\"\n}\n```\n\nExpected: **200**, no `expire_at` field in response, ES key has no\n`expiration`.\n\n### 4. UI — new Expiration field in the modal\n\n1. Open Fleet → **Enrollment tokens** → **Create enrollment token**\n2. An optional **Expiration** field is visible between \"Token name\" and\n\"Policy\"\n3. Enter `notaduration` → clicking \"Create enrollment token\" shows an\ninline validation error\n4. Enter `30d` → token creates successfully, response includes\n`expire_at`\n5. Leave empty → token creates with no expiration\n\n<img width=\"508\" height=\"489\" alt=\"Screenshot 2026-07-28 at 17 51 20\"\nsrc=\"https://github.com/user-attachments/assets/cd9322fb-f84f-489f-a223-1e10821226c4\"\n/>\n<img width=\"502\" height=\"518\" alt=\"Screenshot 2026-07-28 at 17 51 33\"\nsrc=\"https://github.com/user-attachments/assets/87e43ace-0a5b-43d3-8771-6db2923401d8\"\n/>\n\n\n\n### 5. GET endpoints return `expire_at`\n\nAfter creating a token with expiration, verify both list and single-key\nresponses include `expire_at`:\n\n```\nGET kbn:/api/fleet/enrollment_api_keys\nGET kbn:/api/fleet/enrollment_api_keys/<key-id>\n```\n\nTokens created without expiration should not have the `expire_at` field.\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Non-breaking additive change**: the `expiration` field was already\naccepted by the schema and already existed in the index mapping —\nexisting clients sending no `expiration` are unaffected.\n- **New `expire_at` field in API response**: clients that do strict\nresponse shape validation could be affected. The field is optional and\nonly present when expiration was set.\n- No data loss risk: the fix only adds a write path that was previously\nmissing.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"26a72e6696bedabaa798be181702da137618cafd"}},{"url":"https://github.com/elastic/kibana/pull/281692","number":281692,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->