### PR TITLE
[One Workflow] Fix execution highlight in graph view on branching scenarios

### DIFF
--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.test.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.test.ts
@@ -8,7 +8,8 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import type { WorkflowYaml } from '@kbn/workflows';
+import type { WorkflowStepExecutionDto, WorkflowYaml } from '@kbn/workflows';
+import { ExecutionStatus } from '@kbn/workflows';
 import { useWorkflowLayout } from './use_workflow_layout';
 
 const minimal = (overrides: Partial<WorkflowYaml> = {}): WorkflowYaml =>
@@ -19,6 +20,31 @@ const minimal = (overrides: Partial<WorkflowYaml> = {}): WorkflowYaml =>
     steps: [],
     ...overrides,
   } as unknown as WorkflowYaml);
+
+/** Minimal step-execution factory — only the fields the layout hook reads. */
+const stepExec = (
+  stepId: string,
+  status: ExecutionStatus,
+  branchScope?: { gate: string; scopeId: string }
+): WorkflowStepExecutionDto =>
+  ({
+    id: stepId,
+    stepId,
+    status,
+    scopeStack: branchScope
+      ? [
+          {
+            stepId: branchScope.gate,
+            nestedScopes: [
+              { nodeId: branchScope.gate, nodeType: 'if', scopeId: branchScope.scopeId },
+            ],
+          },
+        ]
+      : [],
+  } as unknown as WorkflowStepExecutionDto);
+
+const traversedOf = (edge: { data?: unknown } | undefined): boolean | undefined =>
+  (edge?.data as Record<string, unknown> | undefined)?.traversed as boolean | undefined;
 
 describe('useWorkflowLayout', () => {
   describe('isMerge / hideEndMarker edge tagging', () => {
@@ -128,5 +154,262 @@ describe('useWorkflowLayout', () => {
 
     const edgeIds = result.current.edges.map((e) => e.id);
     expect(edgeIds).toEqual(expect.arrayContaining(['inner-a:inner-b']));
+  });
+
+  describe('branch-aware execution highlighting', () => {
+    const findForkEdge = <T extends { source: string; target: string; data?: unknown }>(
+      edges: T[],
+      gate: string,
+      branchType: string
+    ): T | undefined =>
+      edges.find(
+        (e) =>
+          e.source === gate &&
+          (e.data as Record<string, unknown> | undefined)?.branchType === branchType
+      );
+
+    it('highlights only the taken (true) branch and greys the empty else lane', () => {
+      const workflow = minimal({
+        steps: [
+          {
+            name: 'gate',
+            type: 'if',
+            condition: 'x > 1',
+            steps: [{ name: 'then_step', type: 'http' }],
+          },
+          { name: 'after', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      const stepExecutions = [
+        stepExec('gate', ExecutionStatus.COMPLETED),
+        stepExec('then_step', ExecutionStatus.COMPLETED, { gate: 'gate', scopeId: 'true' }),
+        stepExec('after', ExecutionStatus.COMPLETED),
+      ];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const { edges } = result.current;
+
+      const thenEdge = findForkEdge(edges, 'gate', 'then');
+      const elseEdge = findForkEdge(edges, 'gate', 'else');
+      expect(traversedOf(thenEdge)).toBe(true);
+      expect(traversedOf(elseEdge)).toBe(false);
+
+      // then-step -> merge is green; the empty else lane (bypass -> merge) is grey.
+      const thenLeafEdge = edges.find((e) => e.source === 'then-step' && e.target === 'after');
+      expect(traversedOf(thenLeafEdge)).toBe(true);
+      const bypassId = elseEdge!.target;
+      const bypassLeafEdge = edges.find((e) => e.source === bypassId && e.target === 'after');
+      expect(traversedOf(bypassLeafEdge)).toBe(false);
+    });
+
+    it('highlights the empty else lane via elimination when the false path is taken', () => {
+      const workflow = minimal({
+        steps: [
+          {
+            name: 'gate',
+            type: 'if',
+            condition: 'x > 1',
+            steps: [{ name: 'then_step', type: 'http' }],
+          },
+          { name: 'after', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      // Only the gate ran (condition false, empty else) — no child scopes exist.
+      const stepExecutions = [
+        stepExec('gate', ExecutionStatus.COMPLETED),
+        stepExec('after', ExecutionStatus.COMPLETED),
+      ];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const { edges, nodes } = result.current;
+
+      const thenEdge = findForkEdge(edges, 'gate', 'then');
+      const elseEdge = findForkEdge(edges, 'gate', 'else');
+      expect(traversedOf(elseEdge)).toBe(true);
+      expect(traversedOf(thenEdge)).toBe(false);
+
+      const bypassId = elseEdge!.target;
+      const bypassLeafEdge = edges.find((e) => e.source === bypassId && e.target === 'after');
+      expect(traversedOf(bypassLeafEdge)).toBe(true);
+      // The un-taken then step and its leaf edge stay grey.
+      const thenLeafEdge = edges.find((e) => e.source === 'then-step' && e.target === 'after');
+      expect(traversedOf(thenLeafEdge)).toBe(false);
+
+      // The bypass lane node itself is marked traversed so the bridge line greens.
+      const bypassNode = nodes.find((n) => n.id === bypassId);
+      expect((bypassNode?.data as Record<string, unknown>)?.traversed).toBe(true);
+    });
+
+    it('highlights only the executed branch when both branches are populated', () => {
+      const workflow = minimal({
+        steps: [
+          {
+            name: 'gate',
+            type: 'if',
+            condition: 'x',
+            steps: [{ name: 'yes', type: 'http' }],
+            else: [{ name: 'no', type: 'http' }],
+          },
+          { name: 'after', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      const stepExecutions = [
+        stepExec('gate', ExecutionStatus.COMPLETED),
+        stepExec('yes', ExecutionStatus.COMPLETED, { gate: 'gate', scopeId: 'true' }),
+        stepExec('after', ExecutionStatus.COMPLETED),
+      ];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const { edges } = result.current;
+
+      expect(traversedOf(findForkEdge(edges, 'gate', 'then'))).toBe(true);
+      expect(traversedOf(findForkEdge(edges, 'gate', 'else'))).toBe(false);
+      expect(traversedOf(edges.find((e) => e.source === 'yes' && e.target === 'after'))).toBe(true);
+      expect(traversedOf(edges.find((e) => e.source === 'no' && e.target === 'after'))).toBe(false);
+    });
+
+    it('highlights the matched switch case and greys the default bypass lane', () => {
+      const workflow = minimal({
+        steps: [
+          {
+            name: 'sw',
+            type: 'switch',
+            expression: 'x',
+            cases: [{ match: 'a', steps: [{ name: 'on_a', type: 'http' }] }],
+          },
+          { name: 'after', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      const stepExecutions = [
+        stepExec('sw', ExecutionStatus.COMPLETED),
+        stepExec('on_a', ExecutionStatus.COMPLETED, { gate: 'sw', scopeId: 'case_a' }),
+        stepExec('after', ExecutionStatus.COMPLETED),
+      ];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const { edges } = result.current;
+
+      const caseEdge = edges.find(
+        (e) =>
+          e.source === 'sw' && (e.data as Record<string, unknown> | undefined)?.label === 'a'
+      );
+      const defaultEdge = edges.find(
+        (e) =>
+          e.source === 'sw' &&
+          (e.data as Record<string, unknown> | undefined)?.label === 'default'
+      );
+      expect(traversedOf(caseEdge)).toBe(true);
+      expect(traversedOf(defaultEdge)).toBe(false);
+      expect(traversedOf(edges.find((e) => e.source === 'on-a' && e.target === 'after'))).toBe(true);
+      const bypassId = defaultEdge!.target;
+      expect(traversedOf(edges.find((e) => e.source === bypassId && e.target === 'after'))).toBe(
+        false
+      );
+    });
+
+    it('highlights the implicit default lane when a switch falls through (no case matched)', () => {
+      const workflow = minimal({
+        steps: [
+          {
+            name: 'sw',
+            type: 'switch',
+            expression: 'x',
+            cases: [{ match: 'a', steps: [{ name: 'on_a', type: 'http' }] }],
+          },
+          { name: 'after', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      // Only the switch gate ran — no case scope exists, so the completed switch
+      // must have fallen through its (synthesized, empty) default lane.
+      const stepExecutions = [
+        stepExec('sw', ExecutionStatus.COMPLETED),
+        stepExec('after', ExecutionStatus.COMPLETED),
+      ];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const { edges, nodes } = result.current;
+
+      const caseEdge = edges.find(
+        (e) => e.source === 'sw' && (e.data as Record<string, unknown> | undefined)?.label === 'a'
+      );
+      const defaultEdge = edges.find(
+        (e) =>
+          e.source === 'sw' &&
+          (e.data as Record<string, unknown> | undefined)?.label === 'default'
+      );
+      expect(traversedOf(defaultEdge)).toBe(true);
+      expect(traversedOf(caseEdge)).toBe(false);
+
+      const bypassId = defaultEdge!.target;
+      expect(traversedOf(edges.find((e) => e.source === bypassId && e.target === 'after'))).toBe(
+        true
+      );
+      const bypassNode = nodes.find((n) => n.id === bypassId);
+      expect((bypassNode?.data as Record<string, unknown>)?.traversed).toBe(true);
+    });
+
+    it('orders edges so traversed ones paint last (over the shared fork/merge trunk)', () => {
+      const workflow = minimal({
+        steps: [
+          {
+            name: 'gate',
+            type: 'if',
+            condition: 'x',
+            steps: [{ name: 'yes', type: 'http' }],
+            else: [{ name: 'no', type: 'http' }],
+          },
+          { name: 'after', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      const stepExecutions = [
+        stepExec('gate', ExecutionStatus.COMPLETED),
+        stepExec('yes', ExecutionStatus.COMPLETED, { gate: 'gate', scopeId: 'true' }),
+        stepExec('after', ExecutionStatus.COMPLETED),
+      ];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const flags = result.current.edges.map((e) => Boolean(traversedOf(e)));
+      // Both groups are non-empty here, and every traversed edge must come after
+      // every non-traversed edge (a single false→true transition, never back).
+      expect(flags).toContain(true);
+      expect(flags).toContain(false);
+      const firstTraversed = flags.indexOf(true);
+      expect(flags.slice(firstTraversed).every(Boolean)).toBe(true);
+    });
+
+    it('highlights the edge leaving the trigger node once the run has started', () => {
+      const workflow = minimal({
+        steps: [
+          { name: 'first', type: 'http' },
+          { name: 'second', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      const stepExecutions = [
+        stepExec('first', ExecutionStatus.COMPLETED),
+        stepExec('second', ExecutionStatus.COMPLETED),
+      ];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const { edges, nodes } = result.current;
+
+      const triggerNode = nodes.find((n) => n.type === 'trigger');
+      expect(triggerNode).toBeDefined();
+      const triggerEdge = edges.find((e) => e.source === triggerNode!.id);
+      expect(triggerEdge).toBeDefined();
+      expect(traversedOf(triggerEdge)).toBe(true);
+    });
+
+    it('does not highlight any branch while the gate is still running', () => {
+      const workflow = minimal({
+        steps: [
+          {
+            name: 'gate',
+            type: 'if',
+            condition: 'x',
+            steps: [{ name: 'then_step', type: 'http' }],
+          },
+          { name: 'after', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      const stepExecutions = [stepExec('gate', ExecutionStatus.RUNNING)];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const { edges } = result.current;
+
+      expect(traversedOf(findForkEdge(edges, 'gate', 'then'))).toBe(false);
+      expect(traversedOf(findForkEdge(edges, 'gate', 'else'))).toBe(false);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.test.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.test.ts
@@ -41,7 +41,7 @@ const stepExec = (
           },
         ]
       : [],
-  } as unknown as WorkflowStepExecutionDto);
+  } satisfies Partial<WorkflowStepExecutionDto> as WorkflowStepExecutionDto);
 
 const traversedOf = (edge: { data?: unknown } | undefined): boolean | undefined =>
   (edge?.data as Record<string, unknown> | undefined)?.traversed as boolean | undefined;
@@ -263,6 +263,35 @@ describe('useWorkflowLayout', () => {
       expect(traversedOf(findForkEdge(edges, 'gate', 'else'))).toBe(false);
       expect(traversedOf(edges.find((e) => e.source === 'yes' && e.target === 'after'))).toBe(true);
       expect(traversedOf(edges.find((e) => e.source === 'no' && e.target === 'after'))).toBe(false);
+    });
+
+    it('highlights the else branch when the false path is taken (both populated)', () => {
+      const workflow = minimal({
+        steps: [
+          {
+            name: 'gate',
+            type: 'if',
+            condition: 'x',
+            steps: [{ name: 'yes', type: 'http' }],
+            else: [{ name: 'no', type: 'http' }],
+          },
+          { name: 'after', type: 'http' },
+        ] as unknown as WorkflowYaml['steps'],
+      });
+      const stepExecutions = [
+        stepExec('gate', ExecutionStatus.COMPLETED),
+        stepExec('no', ExecutionStatus.COMPLETED, { gate: 'gate', scopeId: 'false' }),
+        stepExec('after', ExecutionStatus.COMPLETED),
+      ];
+      const { result } = renderHook(() => useWorkflowLayout({ workflow, stepExecutions }));
+      const { edges } = result.current;
+
+      expect(traversedOf(findForkEdge(edges, 'gate', 'else'))).toBe(true);
+      expect(traversedOf(findForkEdge(edges, 'gate', 'then'))).toBe(false);
+      expect(traversedOf(edges.find((e) => e.source === 'no' && e.target === 'after'))).toBe(true);
+      expect(traversedOf(edges.find((e) => e.source === 'yes' && e.target === 'after'))).toBe(
+        false
+      );
     });
 
     it('highlights the matched switch case and greys the default bypass lane', () => {

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.test.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.test.ts
@@ -286,17 +286,17 @@ describe('useWorkflowLayout', () => {
       const { edges } = result.current;
 
       const caseEdge = edges.find(
-        (e) =>
-          e.source === 'sw' && (e.data as Record<string, unknown> | undefined)?.label === 'a'
+        (e) => e.source === 'sw' && (e.data as Record<string, unknown> | undefined)?.label === 'a'
       );
       const defaultEdge = edges.find(
         (e) =>
-          e.source === 'sw' &&
-          (e.data as Record<string, unknown> | undefined)?.label === 'default'
+          e.source === 'sw' && (e.data as Record<string, unknown> | undefined)?.label === 'default'
       );
       expect(traversedOf(caseEdge)).toBe(true);
       expect(traversedOf(defaultEdge)).toBe(false);
-      expect(traversedOf(edges.find((e) => e.source === 'on-a' && e.target === 'after'))).toBe(true);
+      expect(traversedOf(edges.find((e) => e.source === 'on-a' && e.target === 'after'))).toBe(
+        true
+      );
       const bypassId = defaultEdge!.target;
       expect(traversedOf(edges.find((e) => e.source === bypassId && e.target === 'after'))).toBe(
         false
@@ -329,8 +329,7 @@ describe('useWorkflowLayout', () => {
       );
       const defaultEdge = edges.find(
         (e) =>
-          e.source === 'sw' &&
-          (e.data as Record<string, unknown> | undefined)?.label === 'default'
+          e.source === 'sw' && (e.data as Record<string, unknown> | undefined)?.label === 'default'
       );
       expect(traversedOf(defaultEdge)).toBe(true);
       expect(traversedOf(caseEdge)).toBe(false);

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.ts
@@ -129,10 +129,11 @@ export function useWorkflowLayout({
     for (const exec of stepExecutions) {
       for (const frame of exec.scopeStack ?? []) {
         for (const scope of frame.nestedScopes ?? []) {
-          if (!scope.scopeId) continue;
-          const set = map.get(frame.stepId);
-          if (set) set.add(scope.scopeId);
-          else map.set(frame.stepId, new Set([scope.scopeId]));
+          if (scope.scopeId) {
+            const set = map.get(frame.stepId);
+            if (set) set.add(scope.scopeId);
+            else map.set(frame.stepId, new Set([scope.scopeId]));
+          }
         }
       }
     }
@@ -206,6 +207,7 @@ export function useWorkflowLayout({
   // not on structural changes.
   const branchTraversal = useMemo(() => {
     const { allBypassLaneIds, nodeById, allEdges } = topologyMeta;
+    type ForkEdge = (typeof allEdges)[number];
 
     const getStatus = (nodeId: string): ExecutionStatus | undefined => {
       const nodeData = nodeById.get(nodeId)?.data as Record<string, unknown> | undefined;
@@ -214,55 +216,34 @@ export function useWorkflowLayout({
       return exec?.status;
     };
 
-    // Fork edges (those carrying a `branchType`) grouped by their gate (source).
-    type ForkEdge = (typeof allEdges)[number];
-    const forkEdgesByGate = new Map<string, ForkEdge[]>();
-    for (const e of allEdges) {
-      if (!e.branchType) continue;
-      const arr = forkEdgesByGate.get(e.source);
-      if (arr) arr.push(e);
-      else forkEdgesByGate.set(e.source, [e]);
-    }
-
-    const traversedForkEdgeIds = new Set<string>();
-    const traversedBypassIds = new Set<string>();
-
-    const markTraversed = (edge: ForkEdge) => {
-      traversedForkEdgeIds.add(edge.id);
-      if (allBypassLaneIds.has(edge.target)) traversedBypassIds.add(edge.target);
+    // Switch: a case edge (`label` = match value) maps to scope `case_<match>`;
+    // the default edge maps to scope `default`.
+    //
+    // Limitation: the edge `label` is the raw YAML `match` literal, whereas the
+    // runtime scope is `case_<renderedValue>`. For a templated match (e.g.
+    // `'{{ variables.status }}'`) the two never line up, so a matched templated
+    // case is not highlighted and this falls through to greening the default
+    // lane instead. Static matches (`'a'`, `42`, `true`) align exactly.
+    const resolveSwitchTakenEdges = (
+      forkEdges: ForkEdge[],
+      scopeIds: Set<string> | undefined
+    ): ForkEdge[] => {
+      const matched = forkEdges.filter((e) =>
+        scopeIds?.has(e.label === 'default' ? 'default' : `case_${e.label}`)
+      );
+      if (matched.length > 0) return matched;
+      // No case matched and no default body ran → the completed switch fell
+      // through its default lane (the transform always emits one default edge,
+      // whether a real branch or a synthesized bypass).
+      const defaultEdge = forkEdges.find((e) => e.label === 'default');
+      return defaultEdge ? [defaultEdge] : [];
     };
 
-    for (const [gateId, forkEdges] of forkEdgesByGate) {
-      // Only completed gates highlight a branch; running/unfinished gates stay
-      // neutral until they resolve.
-      if (getStatus(gateId) !== ExecutionStatus.COMPLETED) continue;
-
-      const nodeData = nodeById.get(gateId)?.data as Record<string, unknown> | undefined;
-      const gateLabel = typeof nodeData?.label === 'string' ? nodeData.label : gateId;
-      const scopeIds = scopeIdsByStepId.get(gateLabel) ?? scopeIdsByStepId.get(gateId);
-
-      if (forkEdges.some((e) => e.branchType === 'switch')) {
-        // Switch: a case edge (`label` = match value) maps to scope
-        // `case_<match>`; the default edge maps to scope `default`.
-        let anyMatched = false;
-        for (const e of forkEdges) {
-          const scope = e.label === 'default' ? 'default' : `case_${e.label}`;
-          if (scopeIds?.has(scope)) {
-            markTraversed(e);
-            anyMatched = true;
-          }
-        }
-        // No case matched and no default body ran → the completed switch fell
-        // through its default lane (the transform always emits one default edge,
-        // whether a real branch or a synthesized bypass).
-        if (!anyMatched) {
-          const defaultEdge = forkEdges.find((e) => e.label === 'default');
-          if (defaultEdge) markTraversed(defaultEdge);
-        }
-        continue;
-      }
-
-      // `if`: 'true' → then branch, 'false' → else branch.
+    // `if`: 'true' → then branch, 'false' → else branch.
+    const resolveIfTakenEdges = (
+      forkEdges: ForkEdge[],
+      scopeIds: Set<string> | undefined
+    ): ForkEdge[] => {
       let thenTaken = scopeIds?.has('true') ?? false;
       let elseTaken = scopeIds?.has('false') ?? false;
 
@@ -278,12 +259,41 @@ export function useWorkflowLayout({
         else if (elseEmpty && !thenEmpty) elseTaken = true;
       }
 
-      for (const e of forkEdges) {
-        if (e.branchType === 'then' ? thenTaken : e.branchType === 'else' ? elseTaken : false) {
-          markTraversed(e);
-        }
-      }
+      return forkEdges.filter((e) =>
+        e.branchType === 'then' ? thenTaken : e.branchType === 'else' ? elseTaken : false
+      );
+    };
+
+    // Fork edges (those carrying a `branchType`) grouped by their gate (source).
+    const forkEdgesByGate = new Map<string, ForkEdge[]>();
+    for (const e of allEdges.filter((edge) => edge.branchType)) {
+      const arr = forkEdgesByGate.get(e.source);
+      if (arr) arr.push(e);
+      else forkEdgesByGate.set(e.source, [e]);
     }
+
+    const traversedForkEdgeIds = new Set<string>();
+    const traversedBypassIds = new Set<string>();
+
+    forkEdgesByGate.forEach((forkEdges, gateId) => {
+      // Only completed gates highlight a branch; running/unfinished gates stay
+      // neutral until they resolve.
+      if (getStatus(gateId) !== ExecutionStatus.COMPLETED) return;
+
+      const nodeData = nodeById.get(gateId)?.data as Record<string, unknown> | undefined;
+      const gateLabel = typeof nodeData?.label === 'string' ? nodeData.label : gateId;
+      const scopeIds = scopeIdsByStepId.get(gateLabel) ?? scopeIdsByStepId.get(gateId);
+
+      const isSwitch = forkEdges.some((e) => e.branchType === 'switch');
+      const takenEdges = isSwitch
+        ? resolveSwitchTakenEdges(forkEdges, scopeIds)
+        : resolveIfTakenEdges(forkEdges, scopeIds);
+
+      for (const edge of takenEdges) {
+        traversedForkEdgeIds.add(edge.id);
+        if (allBypassLaneIds.has(edge.target)) traversedBypassIds.add(edge.target);
+      }
+    });
 
     return { traversedForkEdgeIds, traversedBypassIds };
   }, [stepExecutionMap, scopeIdsByStepId, topologyMeta]);

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.ts
@@ -116,6 +116,29 @@ export function useWorkflowLayout({
     }, {});
   }, [stepExecutions]);
 
+  // Which branch scopes each gate (`if`/`switch`) actually entered, keyed by the
+  // gate's step name. A taken branch's child steps carry a `scopeStack` frame
+  // `{ stepId: <gateName>, nestedScopes: [{ scopeId: 'true' | 'false' |
+  // 'case_<match>' | 'default' }] }`. The gate's own `conditionResult` /
+  // `matchedIndex` lives in `output`, which is stripped from the execution-detail
+  // fetch, so branch detection relies on these child scopes (unions naturally
+  // across loop iterations).
+  const scopeIdsByStepId = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    if (!stepExecutions) return map;
+    for (const exec of stepExecutions) {
+      for (const frame of exec.scopeStack ?? []) {
+        for (const scope of frame.nestedScopes ?? []) {
+          if (!scope.scopeId) continue;
+          const set = map.get(frame.stepId);
+          if (set) set.add(scope.scopeId);
+          else map.set(frame.stepId, new Set([scope.scopeId]));
+        }
+      }
+    }
+    return map;
+  }, [stepExecutions]);
+
   const syntheticTriggerExecution = useMemo<WorkflowStepExecutionDto | null>(() => {
     if (!stepExecutions || stepExecutions.length === 0) return null;
     return { status: ExecutionStatus.COMPLETED } as WorkflowStepExecutionDto;
@@ -176,6 +199,94 @@ export function useWorkflowLayout({
     transformed.nodes,
     transformed.edges,
   ]);
+
+  // Branch-aware execution highlighting. Computes which fork edges (and which
+  // bypass lanes) belong to the branch that actually executed, so only the
+  // taken path is drawn as traversed. Recomputed on status polls (cheap) but
+  // not on structural changes.
+  const branchTraversal = useMemo(() => {
+    const { allBypassLaneIds, nodeById, allEdges } = topologyMeta;
+
+    const getStatus = (nodeId: string): ExecutionStatus | undefined => {
+      const nodeData = nodeById.get(nodeId)?.data as Record<string, unknown> | undefined;
+      const label = typeof nodeData?.label === 'string' ? nodeData.label : undefined;
+      const exec = (label ? stepExecutionMap?.[label] : undefined) ?? stepExecutionMap?.[nodeId];
+      return exec?.status;
+    };
+
+    // Fork edges (those carrying a `branchType`) grouped by their gate (source).
+    type ForkEdge = (typeof allEdges)[number];
+    const forkEdgesByGate = new Map<string, ForkEdge[]>();
+    for (const e of allEdges) {
+      if (!e.branchType) continue;
+      const arr = forkEdgesByGate.get(e.source);
+      if (arr) arr.push(e);
+      else forkEdgesByGate.set(e.source, [e]);
+    }
+
+    const traversedForkEdgeIds = new Set<string>();
+    const traversedBypassIds = new Set<string>();
+
+    const markTraversed = (edge: ForkEdge) => {
+      traversedForkEdgeIds.add(edge.id);
+      if (allBypassLaneIds.has(edge.target)) traversedBypassIds.add(edge.target);
+    };
+
+    for (const [gateId, forkEdges] of forkEdgesByGate) {
+      // Only completed gates highlight a branch; running/unfinished gates stay
+      // neutral until they resolve.
+      if (getStatus(gateId) !== ExecutionStatus.COMPLETED) continue;
+
+      const nodeData = nodeById.get(gateId)?.data as Record<string, unknown> | undefined;
+      const gateLabel = typeof nodeData?.label === 'string' ? nodeData.label : gateId;
+      const scopeIds = scopeIdsByStepId.get(gateLabel) ?? scopeIdsByStepId.get(gateId);
+
+      if (forkEdges.some((e) => e.branchType === 'switch')) {
+        // Switch: a case edge (`label` = match value) maps to scope
+        // `case_<match>`; the default edge maps to scope `default`.
+        let anyMatched = false;
+        for (const e of forkEdges) {
+          const scope = e.label === 'default' ? 'default' : `case_${e.label}`;
+          if (scopeIds?.has(scope)) {
+            markTraversed(e);
+            anyMatched = true;
+          }
+        }
+        // No case matched and no default body ran → the completed switch fell
+        // through its default lane (the transform always emits one default edge,
+        // whether a real branch or a synthesized bypass).
+        if (!anyMatched) {
+          const defaultEdge = forkEdges.find((e) => e.label === 'default');
+          if (defaultEdge) markTraversed(defaultEdge);
+        }
+        continue;
+      }
+
+      // `if`: 'true' → then branch, 'false' → else branch.
+      let thenTaken = scopeIds?.has('true') ?? false;
+      let elseTaken = scopeIds?.has('false') ?? false;
+
+      // Empty taken branch (no child steps → no scope). Resolve by elimination:
+      // if exactly one branch is a bypass lane, the completed gate must have
+      // taken that empty branch. (A both-empty `if` produces no bypass lanes.)
+      if (!thenTaken && !elseTaken) {
+        const thenEdge = forkEdges.find((e) => e.branchType === 'then');
+        const elseEdge = forkEdges.find((e) => e.branchType === 'else');
+        const thenEmpty = thenEdge ? allBypassLaneIds.has(thenEdge.target) : false;
+        const elseEmpty = elseEdge ? allBypassLaneIds.has(elseEdge.target) : false;
+        if (thenEmpty && !elseEmpty) thenTaken = true;
+        else if (elseEmpty && !thenEmpty) elseTaken = true;
+      }
+
+      for (const e of forkEdges) {
+        if (e.branchType === 'then' ? thenTaken : e.branchType === 'else' ? elseTaken : false) {
+          markTraversed(e);
+        }
+      }
+    }
+
+    return { traversedForkEdgeIds, traversedBypassIds };
+  }, [stepExecutionMap, scopeIdsByStepId, topologyMeta]);
 
   const derivedNodes = useMemo<Node[]>(() => {
     const { allBypassLaneIds, innerNodeToGroupId, allDomainNodes } = topologyMeta;
@@ -262,16 +373,24 @@ export function useWorkflowLayout({
         },
         targetPosition,
         sourcePosition,
-        data: {},
+        data: { traversed: branchTraversal.traversedBypassIds.has(id) },
       };
     });
 
     return [...domainNodes, ...bypassLaneReactNodes];
-  }, [layoutSnapshot.nodes, stepExecutionMap, syntheticTriggerExecution, topologyMeta, direction]);
+  }, [
+    layoutSnapshot.nodes,
+    stepExecutionMap,
+    syntheticTriggerExecution,
+    topologyMeta,
+    direction,
+    branchTraversal,
+  ]);
 
   const derivedEdges = useMemo<Edge[]>(() => {
     const { allBypassLaneIds, nodeById, allEdges, mergeNodeIds } = topologyMeta;
     const layoutEdgeById = new Map(layoutSnapshot.edges.map((e) => [e.id, e]));
+    const { traversedForkEdgeIds, traversedBypassIds } = branchTraversal;
 
     const getExec = (nodeId: string): WorkflowStepExecutionDto | undefined => {
       const nodeData = nodeById.get(nodeId)?.data as Record<string, unknown> | undefined;
@@ -279,10 +398,27 @@ export function useWorkflowLayout({
       return (label ? stepExecutionMap?.[label] : undefined) ?? stepExecutionMap?.[nodeId];
     };
 
-    return allEdges.map((e) => {
+    const mapped = allEdges.map((e) => {
       const laid = layoutEdgeById.get(e.id);
-      const sourceExec = getExec(e.source);
-      const traversed = sourceExec?.status === ExecutionStatus.COMPLETED;
+      // Fork edges (if/switch branches) highlight only for the branch that ran;
+      // edges leaving an empty (bypass) lane inherit that lane's traversal;
+      // everything else falls back to source-step completion.
+      let traversed: boolean;
+      if (e.branchType) {
+        traversed = traversedForkEdgeIds.has(e.id);
+      } else if (allBypassLaneIds.has(e.source)) {
+        traversed = traversedBypassIds.has(e.source);
+      } else {
+        // Trigger nodes have no persisted step execution; mirror the node's
+        // synthetic "completed" status so the trigger's outgoing edge highlights
+        // alongside it once the run has started.
+        const sourceExec =
+          getExec(e.source) ??
+          (nodeById.get(e.source)?.type === 'trigger'
+            ? syntheticTriggerExecution ?? undefined
+            : undefined);
+        traversed = sourceExec?.status === ExecutionStatus.COMPLETED;
+      }
       return {
         id: e.id,
         source: e.source,
@@ -298,7 +434,22 @@ export function useWorkflowLayout({
         },
       };
     });
-  }, [layoutSnapshot.edges, stepExecutionMap, topologyMeta]);
+
+    // Fork/merge edges deliberately overlap into one shared trunk + bus (see
+    // compute_edge_path). On those shared pixels the last-painted edge wins, so
+    // render traversed edges last to ensure the green (taken) path is never
+    // hidden under a grey sibling's trunk/bus. Stable sort preserves the
+    // original order within each group.
+    return mapped.sort(
+      (a, b) => Number(Boolean(a.data.traversed)) - Number(Boolean(b.data.traversed))
+    );
+  }, [
+    layoutSnapshot.edges,
+    stepExecutionMap,
+    topologyMeta,
+    branchTraversal,
+    syntheticTriggerExecution,
+  ]);
 
   return { nodes: derivedNodes, edges: derivedEdges };
 }

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_bypass_lane_node.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_bypass_lane_node.tsx
@@ -23,8 +23,13 @@ import React, { memo } from 'react';
  * making the bypass lane appear continuous regardless of the rendered height.
  */
 function WorkflowGraphBypassLaneNodeInner(props: NodeProps) {
-  const { targetPosition = Position.Top, sourcePosition = Position.Bottom } = props;
+  const { targetPosition = Position.Top, sourcePosition = Position.Bottom, data } = props;
   const { euiTheme } = useEuiTheme();
+
+  // When this empty branch is the one that executed, tint the bridge line with
+  // the same `success` token as traversed edges so the lane reads as one
+  // continuous green path.
+  const traversed = (data as { traversed?: boolean } | undefined)?.traversed ?? false;
 
   return (
     <>
@@ -38,7 +43,7 @@ function WorkflowGraphBypassLaneNodeInner(props: NodeProps) {
           height: 12,
           width: 1,
           transform: 'translateX(-50%)',
-          background: euiTheme.colors.borderBasePlain,
+          background: traversed ? euiTheme.colors.success : euiTheme.colors.borderBasePlain,
           pointerEvents: 'none',
         }}
       />


### PR DESCRIPTION
## Summary

This PR introduces a better handling of the execution highlight in workflow graph mode, in branching scenarios like `if`, `switch` or `parallel` steps.

<img width="527" height="537" alt="Screenshot 2026-07-30 at 10 54 36" src="https://github.com/user-attachments/assets/5ec2cfe4-6828-45b4-9c46-5d2506e945f2" />


Testing workflow used
[test_branch_highlight_workflow.yaml](https://github.com/user-attachments/files/30538752/test_branch_highlight_workflow.yaml)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
