### PR TITLE
[Workflows][Connectors] Minor tweaks to Sentry connector

### DIFF
--- a/docs/reference/connectors-kibana/sentry-action-type.md
+++ b/docs/reference/connectors-kibana/sentry-action-type.md
@@ -28,7 +28,7 @@ API base URL
 :   Optional. Leave empty to use Sentry SaaS (`https://sentry.io/api/0`). If your organization uses a region-specific data storage location, use its regional domain instead, for example `https://us.sentry.io/api/0` or `https://de.sentry.io/api/0`. Set this for a self-hosted Sentry instance, for example `https://sentry.example.com/api/0`.
 
 Authentication
-:   Bearer token. Use a Sentry auth token with `org:read`, `project:read`, `event:read`, and `event:write` scopes (add `event:admin` too if you plan to use `deleteIssue`).
+:   Bearer token. Use a Sentry auth token with `org:read`, `project:read`, `event:read`, and `event:write` scopes (add `alerts:write` if you plan to provision issue alert rules, and `event:admin` if you plan to use `deleteIssue`).
 
 ## Available actions [sentry-available-actions]
 
@@ -46,8 +46,8 @@ Authentication
 | `deleteIssue` | Permanently delete an issue. Requires the `event:admin` scope. Parameters: `issueId` (required). |
 | `listProjects` | List the organization's projects. Parameters: `cursor`. |
 | `listIssueAlertRules` | List issue alert rules configured on a project. Parameters: `project` (required), `cursor`. |
-| `createIssueAlertRule` | Create a new issue alert rule. Parameters: `project` (required), `name` (required), `conditions` (required), `actions` (required), `actionMatch`, `frequency`. |
-| `updateIssueAlertRule` | Update an existing issue alert rule. Parameters: `project` (required), `ruleId` (required), `name`, `actionMatch`, `conditions`, `actions`, `frequency`. |
+| `createIssueAlertRule` | Create a new issue alert rule. Requires the `alerts:write` scope. Parameters: `project` (required), `name` (required), `conditions` (required), `actions` (required), `actionMatch`, `frequency`. |
+| `updateIssueAlertRule` | Update an existing issue alert rule. Requires the `alerts:write` scope. Parameters: `project` (required), `ruleId` (required), `name`, `actionMatch`, `conditions`, `actions`, `frequency`. |
 
 ## Connector networking configuration [sentry-connector-networking-configuration]
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sentry/sentry.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sentry/sentry.test.ts
@@ -104,6 +104,14 @@ describe('Sentry', () => {
       expect(mockClient.get).toHaveBeenCalledWith('https://sentry.io/api/0/issues/123/');
       expect(result).toEqual(expect.objectContaining({ id: '123', title: 'TypeError' }));
     });
+
+    it('should URL-encode an issue ID containing reserved characters', async () => {
+      mockClient.get.mockResolvedValue({ data: { id: 'a/b#c', title: 'TypeError' } });
+
+      await Sentry.actions.getIssue.handler(mockContext, { issueId: 'a/b#c' });
+
+      expect(mockClient.get).toHaveBeenCalledWith('https://sentry.io/api/0/issues/a%2Fb%23c/');
+    });
   });
 
   describe('resolveIssue action', () => {
@@ -235,6 +243,19 @@ describe('Sentry', () => {
       );
       expect(result).toEqual({ id: 'e1', tags: [] });
     });
+
+    it('should URL-encode a project slug and event ID containing reserved characters', async () => {
+      mockClient.get.mockResolvedValue({ data: { id: 'e/1', tags: [] } });
+
+      await Sentry.actions.getEvent.handler(mockContext, {
+        project: 'back end',
+        eventId: 'e/1',
+      });
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        'https://sentry.io/api/0/projects/my-org/back%20end/events/e%2F1/'
+      );
+    });
   });
 
   describe('bulkUpdateIssues action', () => {
@@ -329,6 +350,21 @@ describe('Sentry', () => {
           { id: '1', slug: 'backend', name: 'Backend', platform: 'node', status: undefined },
         ],
       });
+    });
+
+    it('should URL-encode an organization slug containing reserved characters', async () => {
+      const contextWithReservedSlug = {
+        ...mockContext,
+        config: { organizationSlug: 'my org/co' },
+      } as unknown as ActionContext;
+      mockClient.get.mockResolvedValue({ data: [] });
+
+      await Sentry.actions.listProjects.handler(contextWithReservedSlug, {});
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        'https://sentry.io/api/0/organizations/my%20org%2Fco/projects/',
+        { params: {} }
+      );
     });
   });
 
@@ -457,6 +493,28 @@ describe('Sentry', () => {
           name: 'Updated',
         })
       ).rejects.toThrow('Sentry updateIssueAlertRule failed (status 404): Rule not found');
+    });
+
+    it('should URL-encode a project slug and rule ID containing reserved characters', async () => {
+      mockClient.get.mockResolvedValue({
+        data: {
+          name: 'Existing rule',
+          actionMatch: 'any',
+          conditions: [],
+          actions: [],
+        },
+      });
+      mockClient.put.mockResolvedValue({ data: { id: 'r#1' } });
+
+      await Sentry.actions.updateIssueAlertRule.handler(mockContext, {
+        project: 'back end',
+        ruleId: 'r#1',
+        name: 'Updated',
+      });
+
+      const expectedUrl = 'https://sentry.io/api/0/projects/my-org/back%20end/rules/r%231/';
+      expect(mockClient.get).toHaveBeenCalledWith(expectedUrl);
+      expect(mockClient.put).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
     });
   });
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sentry/sentry.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sentry/sentry.ts
@@ -122,7 +122,7 @@ export const Sentry: ConnectorSpec = {
                 'core.kibanaConnectorSpecs.sentry.auth.bearer.token.helpText',
                 {
                   defaultMessage:
-                    'A Sentry auth token with org:read, project:read, event:read, and event:write scopes (add event:admin too if you plan to use deleteIssue). Create one as an internal integration (Settings > Developer Settings) or a personal auth token.',
+                    'A Sentry auth token with org:read, project:read, event:read, and event:write scopes (add alerts:write if you plan to provision issue alert rules, and event:admin if you plan to use deleteIssue). Create one as an internal integration (Settings > Developer Settings) or a personal auth token.',
                 }
               ),
             },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sentry/sentry.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sentry/sentry.ts
@@ -60,7 +60,9 @@ const getOrgSlug = (ctx: ActionContext): string => {
       'Sentry connector is missing the required organizationSlug configuration field.'
     );
   }
-  return orgSlug;
+  // Encode once here so every call site gets a URL-safe org slug without
+  // having to remember to do it themselves.
+  return encodeURIComponent(orgSlug);
 };
 
 function formatSentryError(action: string, error: unknown): Error {
@@ -189,7 +191,7 @@ export const Sentry: ConnectorSpec = {
 
         const baseUrl = buildBaseUrl(ctx);
         const url = input.project
-          ? `${baseUrl}/projects/${orgSlug}/${input.project}/issues/`
+          ? `${baseUrl}/projects/${orgSlug}/${encodeURIComponent(input.project)}/issues/`
           : `${baseUrl}/organizations/${orgSlug}/issues/`;
 
         try {
@@ -209,7 +211,7 @@ export const Sentry: ConnectorSpec = {
       handler: async (ctx, input: SentryGetIssueInput) => {
         try {
           const response = await ctx.client.get<SentryIssue>(
-            `${buildBaseUrl(ctx)}/issues/${input.issueId}/`
+            `${buildBaseUrl(ctx)}/issues/${encodeURIComponent(input.issueId)}/`
           );
           return projectIssue(response.data);
         } catch (error) {
@@ -229,7 +231,7 @@ export const Sentry: ConnectorSpec = {
           : { status: 'resolved' };
         try {
           const response = await ctx.client.put<SentryIssue>(
-            `${buildBaseUrl(ctx)}/issues/${input.issueId}/`,
+            `${buildBaseUrl(ctx)}/issues/${encodeURIComponent(input.issueId)}/`,
             body
           );
           return projectIssue(response.data);
@@ -251,7 +253,7 @@ export const Sentry: ConnectorSpec = {
         }
         try {
           const response = await ctx.client.put<SentryIssue>(
-            `${buildBaseUrl(ctx)}/issues/${input.issueId}/`,
+            `${buildBaseUrl(ctx)}/issues/${encodeURIComponent(input.issueId)}/`,
             body
           );
           return projectIssue(response.data);
@@ -269,7 +271,7 @@ export const Sentry: ConnectorSpec = {
       handler: async (ctx, input: SentryUnresolveIssueInput) => {
         try {
           const response = await ctx.client.put<SentryIssue>(
-            `${buildBaseUrl(ctx)}/issues/${input.issueId}/`,
+            `${buildBaseUrl(ctx)}/issues/${encodeURIComponent(input.issueId)}/`,
             { status: 'unresolved' }
           );
           return projectIssue(response.data);
@@ -287,7 +289,7 @@ export const Sentry: ConnectorSpec = {
       handler: async (ctx, input: SentryAssignIssueInput) => {
         try {
           const response = await ctx.client.put<SentryIssue>(
-            `${buildBaseUrl(ctx)}/issues/${input.issueId}/`,
+            `${buildBaseUrl(ctx)}/issues/${encodeURIComponent(input.issueId)}/`,
             { assignedTo: input.assignedTo }
           );
           return projectIssue(response.data);
@@ -308,7 +310,7 @@ export const Sentry: ConnectorSpec = {
         if (input.full !== undefined) params.full = input.full;
         try {
           const response = await ctx.client.get(
-            `${buildBaseUrl(ctx)}/issues/${input.issueId}/events/`,
+            `${buildBaseUrl(ctx)}/issues/${encodeURIComponent(input.issueId)}/events/`,
             { params }
           );
           return { events: response.data };
@@ -327,7 +329,9 @@ export const Sentry: ConnectorSpec = {
         const orgSlug = getOrgSlug(ctx);
         try {
           const response = await ctx.client.get(
-            `${buildBaseUrl(ctx)}/projects/${orgSlug}/${input.project}/events/${input.eventId}/`
+            `${buildBaseUrl(ctx)}/projects/${orgSlug}/${encodeURIComponent(
+              input.project
+            )}/events/${encodeURIComponent(input.eventId)}/`
           );
           return response.data;
         } catch (error) {
@@ -349,7 +353,7 @@ export const Sentry: ConnectorSpec = {
 
         try {
           const response = await ctx.client.put(
-            `${buildBaseUrl(ctx)}/projects/${orgSlug}/${input.project}/issues/`,
+            `${buildBaseUrl(ctx)}/projects/${orgSlug}/${encodeURIComponent(input.project)}/issues/`,
             body,
             {
               params: { id: input.issueIds },
@@ -372,7 +376,9 @@ export const Sentry: ConnectorSpec = {
       input: SentryDeleteIssueInputSchema,
       handler: async (ctx, input: SentryDeleteIssueInput) => {
         try {
-          await ctx.client.delete(`${buildBaseUrl(ctx)}/issues/${input.issueId}/`);
+          await ctx.client.delete(
+            `${buildBaseUrl(ctx)}/issues/${encodeURIComponent(input.issueId)}/`
+          );
           return { deleted: true, issueId: input.issueId };
         } catch (error) {
           throw formatSentryError('deleteIssue', error);
@@ -420,7 +426,7 @@ export const Sentry: ConnectorSpec = {
         if (input.cursor) params.cursor = input.cursor;
         try {
           const response = await ctx.client.get(
-            `${buildBaseUrl(ctx)}/projects/${orgSlug}/${input.project}/rules/`,
+            `${buildBaseUrl(ctx)}/projects/${orgSlug}/${encodeURIComponent(input.project)}/rules/`,
             { params }
           );
           return { rules: response.data };
@@ -439,7 +445,7 @@ export const Sentry: ConnectorSpec = {
         const orgSlug = getOrgSlug(ctx);
         try {
           const response = await ctx.client.post(
-            `${buildBaseUrl(ctx)}/projects/${orgSlug}/${input.project}/rules/`,
+            `${buildBaseUrl(ctx)}/projects/${orgSlug}/${encodeURIComponent(input.project)}/rules/`,
             {
               name: input.name,
               actionMatch: input.actionMatch,
@@ -462,9 +468,9 @@ export const Sentry: ConnectorSpec = {
       input: SentryUpdateIssueAlertRuleInputSchema,
       handler: async (ctx, input: SentryUpdateIssueAlertRuleInput) => {
         const orgSlug = getOrgSlug(ctx);
-        const ruleUrl = `${buildBaseUrl(ctx)}/projects/${orgSlug}/${input.project}/rules/${
-          input.ruleId
-        }/`;
+        const ruleUrl = `${buildBaseUrl(ctx)}/projects/${orgSlug}/${encodeURIComponent(
+          input.project
+        )}/rules/${encodeURIComponent(input.ruleId)}/`;
 
         try {
           // Sentry's rule-update endpoint replaces the whole rule rather than


### PR DESCRIPTION
## Summary

Two follow-up fixes for the Sentry connector spec (#281136), landed after that PR was already merged — this targets `main` directly since the original PR can no longer be reopened.

- **URL-encode path segments**: `getOrgSlug()`, and every handler that interpolates `issueId`/`project`/`eventId`/`ruleId` into a request URL, now wrap the value in `encodeURIComponent()`. Input schemas only bound length, not character set, so a value containing `/`, `?`, `#`, or a space would otherwise corrupt the request path instead of hitting the intended resource — flagged in [review](https://github.com/elastic/kibana/pull/281136#discussion_r3673243602) on the original PR.
- **Document `alerts:write` consistently**: `createIssueAlertRule`/`updateIssueAlertRule` call Sentry's project `rules/` endpoints, which require the `alerts:write` scope. The docs' "Get API credentials" steps already mentioned it, but the in-product auth token `helpText` and the docs' own "Authentication" summary line didn't — a token created by following either of those got a 403. Flagged in [review](https://github.com/elastic/kibana/pull/281136#discussion_r3681400371) on the original PR.

## Validated

| Change | What was tested | Result |
| --- | --- | --- |
| URL encoding | Unit tests assert the exact encoded URL for `issueId`, `project`, `eventId`, `ruleId`, and `organizationSlug` values containing reserved characters (`/`, `#`, space) | ✅ Pass |
| `alerts:write` docs/helpText consistency | Manual grep across `sentry.ts` helpText and both docs sections confirms all three now list the same scope set | ✅ Pass |

## Test plan

* `node scripts/jest src/platform/packages/shared/kbn-connector-specs/src/specs/sentry/sentry.test.ts` — 36 passing
* `node scripts/eslint` on changed files — clean
* Rebased on latest `main`; diff is scoped to just these two fixes

Made with Cursor