### PR TITLE
[Scout] Change tag from tags.stateful.classic to '@local-stateful-classic'

### DIFF
--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/ad_hoc_data_view.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/ad_hoc_data_view.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { enableElasticChartDebug, getChartDebugData } from '../fixtures/open_in_lens_helpers';
 import {
@@ -31,7 +31,7 @@ function getDiscoverDataViewIdFromUrl(url: string): string {
   return matches[0] ?? '';
 }
 
-spaceTest.describe('Lens ad hoc data view', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Lens ad hoc data view', { tag: '@local-stateful-classic' }, () => {
   spaceTest.beforeAll(async ({ scoutSpace }) => {
     await scoutSpace.uiSettings.set({
       defaultIndex: testData.DATA_VIEW_ID.LOGSTASH,

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/esql_dashboard_inline_editing.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/esql_dashboard_inline_editing.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { spaceTest, tags, KibanaCodeEditorWrapper } from '@kbn/scout';
+import { spaceTest, KibanaCodeEditorWrapper } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import type { PageObjects, ScoutPage } from '@kbn/scout';
 import { applyLensInlineEditorAndWaitClosed, testData } from '../fixtures';
@@ -24,7 +24,7 @@ const setEsqlQueryAndRun = async (
   await dashboard.waitForRenderComplete();
 };
 
-spaceTest.describe('Lens ESQL dashboard inline editing', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Lens ESQL dashboard inline editing', { tag: '@local-stateful-classic' }, () => {
   spaceTest.beforeAll(async ({ scoutSpace }) => {
     await scoutSpace.uiSettings.set({
       'dateFormat:tz': 'UTC',

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/inspector_pagination.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/inspector_pagination.spec.ts
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { spaceTest, testData } from '../fixtures';
 
 const INSPECTOR_PAGE_SIZE = 10;
 
-spaceTest.describe('Lens inspector pagination', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Lens inspector pagination', { tag: '@local-stateful-classic' }, () => {
   spaceTest.beforeAll(async ({ scoutSpace, apiServices }) => {
     await scoutSpace.uiSettings.set({
       defaultIndex: testData.DATA_VIEW_ID.LOGSTASH,

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_progress_bar.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_progress_bar.spec.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { testData } from '../fixtures';
 
 spaceTest.describe(
   'Lens metric progress bar on dashboard (DSL)',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     let storedDataViewId: string | undefined;
 

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_progress_bar_lens_editor.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_progress_bar_lens_editor.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import type { PageObjects, ScoutPage } from '@kbn/scout';
 import { testData } from '../fixtures';
@@ -82,7 +82,7 @@ async function setupMetricProgressBarInLensEditor(
 
 spaceTest.describe(
   'Lens metric progress bar in Lens editor',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     let storedDataViewId: string | undefined;
 

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline.spec.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { testData } from '../fixtures';
 
 spaceTest.describe(
   'Lens metric trendline on dashboard (DSL)',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     let storedDataViewId: string | undefined;
 

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql.spec.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { testData } from '../fixtures';
 
 spaceTest.describe(
   'Lens metric trendline on dashboard (ES|QL)',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     spaceTest.beforeAll(async ({ scoutSpace }) => {
       await scoutSpace.uiSettings.set({

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql_conversion.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql_conversion.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import {
   applyLensInlineEditorAndWaitClosed,
@@ -16,7 +16,7 @@ import {
 
 spaceTest.describe(
   'Lens metric trendline conversion to ES|QL',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     let dashboardId: string;
     let panelId: string;

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql_editor.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql_editor.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { spaceTest, tags, KibanaCodeEditorWrapper } from '@kbn/scout';
+import { spaceTest, KibanaCodeEditorWrapper } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import {
   applyLensInlineEditorAndWaitClosed,
@@ -16,7 +16,7 @@ import {
 
 spaceTest.describe(
   'Lens ES|QL metric trendline editor interactions',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     let dashboardId: string;
     let panelId: string;

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql_table_switch.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql_table_switch.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import {
   applyLensInlineEditorAndWaitClosed,
@@ -29,7 +29,7 @@ const expectMetricPanelHasNotCrashed = async (page: import('@kbn/scout').ScoutPa
 
 spaceTest.describe(
   'Lens ES|QL table to metric trendline editing',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     let dashboardId: string;
     let panelId: string;

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql_toggle.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline_esql_toggle.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import {
   applyLensInlineEditorAndWaitClosed,
@@ -14,7 +14,7 @@ import {
   testData,
 } from '../fixtures';
 
-spaceTest.describe('Lens ES|QL metric trendline toggle', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Lens ES|QL metric trendline toggle', { tag: '@local-stateful-classic' }, () => {
   let dashboardId: string;
   let panelId: string;
 

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/multiple_data_views.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/multiple_data_views.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DebugState } from '@elastic/charts';
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { enableElasticChartDebug, getChartDebugData } from '../fixtures/open_in_lens_helpers';
 import { addDataLayer, switchDataPanelIndexPattern, testData } from '../fixtures';
@@ -17,7 +17,7 @@ function getNonEmptyLineSeriesCount(state: DebugState): number {
   return state.lines?.filter((series) => series.points.length > 0).length ?? 0;
 }
 
-spaceTest.describe('Lens with multiple data views', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Lens with multiple data views', { tag: '@local-stateful-classic' }, () => {
   spaceTest.beforeAll(async ({ scoutSpace }) => {
     await scoutSpace.savedObjects.load(
       testData.KBN_ARCHIVE_PATHS.LONG_WINDOW_LOGSTASH_INDEX_PATTERN

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/open_in_lens/agg_based/visualize_navigation.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/open_in_lens/agg_based/visualize_navigation.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import {
   cleanupLogstashOpenInLensDefaults,
@@ -21,7 +21,7 @@ const TIMESTAMP_X_AXIS_DIMENSION = {
 
 spaceTest.describe(
   'Lens open in Lens — agg-based Visualize navigation',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     spaceTest.beforeAll(async ({ scoutSpace }) => {
       await scoutSpace.savedObjects.load(


### PR DESCRIPTION
## Summary

This PR changes `tags.stateful.classic` tag to `'@local-stateful-classic'` since it is semantically equivalent to how FTR tests are run. The `tags.stateful.classic` tag also runs the test in ECH.

We suspect that this is the reason for failure such as this one: https://github.com/elastic/kibana/issues/277935