### PR TITLE
[Data views as code] Validate field format type on creation and update

### DIFF
--- a/src/platform/plugins/shared/data_views_as_code/kibana.jsonc
+++ b/src/platform/plugins/shared/data_views_as_code/kibana.jsonc
@@ -9,7 +9,7 @@
     "id": "dataViewsAsCode",
     "browser": false,
     "server": true,
-    "requiredPlugins": ["dataViews"],
+    "requiredPlugins": ["dataViews", "fieldFormats"],
     "optionalPlugins": ["usageCollection"],
     "requiredBundles": [],
     "extraPublicDirs": []

--- a/src/platform/plugins/shared/data_views_as_code/moon.yml
+++ b/src/platform/plugins/shared/data_views_as_code/moon.yml
@@ -29,6 +29,7 @@ dependsOn:
   - '@kbn/as-code-utils'
   - '@kbn/logging-mocks'
   - '@kbn/core-http-server-mocks'
+  - '@kbn/field-formats-plugin'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/data_views_as_code/server/rest_routes/utils.test.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/rest_routes/utils.test.ts
@@ -111,6 +111,22 @@ describe('requestHandler', () => {
     expect(writeErrorHandler).not.toHaveBeenCalled();
   });
 
+  it('maps boom 400 errors to badRequest response', async () => {
+    const error = {
+      isBoom: true,
+      output: { statusCode: 400 },
+      message: 'bad request from boom',
+    };
+    const handler = jest.fn().mockRejectedValue(error);
+
+    const wrapped = requestHandler({ logger, usageCounter }, handler);
+    await wrapped(context, request, response);
+
+    expect(logRequest).toHaveBeenCalledWith(logger, request, 'warn', error.message);
+    expect(response.badRequest).toHaveBeenCalledWith({ body: { message: error.message } });
+    expect(writeErrorHandler).not.toHaveBeenCalled();
+  });
+
   it('rethrows validation errors after warning log', async () => {
     const error = new ValidationError({ message: 'invalid payload', path: [] } as any);
     const handler = jest.fn().mockRejectedValue(error);

--- a/src/platform/plugins/shared/data_views_as_code/server/rest_routes/utils.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/rest_routes/utils.ts
@@ -31,13 +31,22 @@ export async function getDataViewsAsCodeService(
   const core = await ctx.core;
   const savedObjectsClient = core.savedObjects.client;
   const elasticsearchClient = core.elasticsearch.client.asCurrentUser;
-  const [, { dataViews }] = await getStartServices();
+  const [{ uiSettings }, { dataViews, fieldFormats }] = await getStartServices();
+
   const dataViewsService = await dataViews.dataViewsServiceFactory(
     savedObjectsClient,
     elasticsearchClient,
     req
   );
-  return new DataViewsAsCodeService(dataViewsService, core.savedObjects.getClient());
+  const fieldFormatsRegistry = await fieldFormats.fieldFormatServiceFactory(
+    uiSettings.asScopedToClient(savedObjectsClient)
+  );
+
+  return new DataViewsAsCodeService(
+    dataViewsService,
+    core.savedObjects.getClient(),
+    fieldFormatsRegistry
+  );
 }
 
 /**
@@ -69,6 +78,12 @@ export const requestHandler =
         if (isConflict) {
           logRequest(args.logger, request, 'debug', error.message);
           return response.conflict({ body: { message: error.message } });
+        }
+
+        const isBadRequest = error.isBoom && error.output.statusCode === 400;
+        if (isBadRequest) {
+          logRequest(args.logger, request, 'warn', error.message);
+          return response.badRequest({ body: { message: error.message } });
         }
 
         if (error instanceof ValidationError) {

--- a/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.test.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.test.ts
@@ -20,6 +20,7 @@ import {
   type DataViewSpec,
 } from '@kbn/data-views-plugin/common';
 import { dataViewsService } from '@kbn/data-views-plugin/server/mocks';
+import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
 
 const createMockDataViewLazy = ({
   id = 'test-id',
@@ -54,8 +55,20 @@ const createMockDataViewLazy = ({
 const createService = () => {
   dataViewsService.clearInstanceCache = jest.fn();
   const mockSavedObjectsClient = savedObjectsClientMock.create();
-  const service = new DataViewsAsCodeService(dataViewsService, mockSavedObjectsClient);
-  return { service, mockDataViewsService: dataViewsService, mockSavedObjectsClient };
+  const mockFieldFormats = {
+    has: jest.fn().mockReturnValue(true),
+  } as unknown as jest.Mocked<FieldFormatsRegistry>;
+  const service = new DataViewsAsCodeService(
+    dataViewsService,
+    mockSavedObjectsClient,
+    mockFieldFormats
+  );
+  return {
+    service,
+    mockDataViewsService: dataViewsService,
+    mockSavedObjectsClient,
+    mockFieldFormats,
+  };
 };
 
 const getExpectedMappedData = (spec: DataViewSpec) => {
@@ -401,6 +414,28 @@ describe('DataViewsAsCodeService', () => {
         namespaces: ['default', 'space-a'],
       });
     });
+
+    it('should throw when field format type is invalid', async () => {
+      const { service, mockDataViewsService, mockFieldFormats } = createService();
+
+      mockFieldFormats.has.mockReturnValue(false);
+
+      await expect(
+        service.create({
+          id: 'dv-invalid-format',
+          index_pattern: 'logs-*',
+          field_settings: {
+            bytes: {
+              format: {
+                type: 'not-a-real-format',
+              },
+            },
+          },
+        })
+      ).rejects.toThrow('Invalid field format types: not-a-real-format');
+
+      expect(mockDataViewsService.createAndSaveDataViewLazy).not.toHaveBeenCalled();
+    });
   });
 
   describe('delete', () => {
@@ -552,6 +587,44 @@ describe('DataViewsAsCodeService', () => {
         updatableDataView.getAsSavedObjectBody(),
         { mergeAttributes: false, refresh: true }
       );
+    });
+
+    it('should throw a 400 boom when composite runtime field format type is invalid', async () => {
+      const { service, mockDataViewsService, mockFieldFormats } = createService();
+
+      mockFieldFormats.has.mockImplementation((type) => type === 'number');
+
+      await expect(
+        service.upsert('dv-invalid-upsert', {
+          index_pattern: 'logs-*',
+          field_settings: {
+            composite_field: {
+              type: 'composite',
+              script: 'emit("sub_a", "v1"); emit("sub_b", "v2");',
+              fields: {
+                sub_a: {
+                  type: 'keyword',
+                  format: {
+                    type: 'number',
+                  },
+                },
+                sub_b: {
+                  type: 'keyword',
+                  format: {
+                    type: 'invalid-format',
+                  },
+                },
+              },
+            },
+          },
+        })
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 400 },
+        message: 'Invalid field format types: invalid-format',
+      });
+
+      expect(mockDataViewsService.getDataViewLazy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.test.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.test.ts
@@ -415,7 +415,7 @@ describe('DataViewsAsCodeService', () => {
       });
     });
 
-    it('should throw when field format type is invalid', async () => {
+    it('should throw a 400 boom when field format type is invalid', async () => {
       const { service, mockDataViewsService, mockFieldFormats } = createService();
 
       mockFieldFormats.has.mockReturnValue(false);
@@ -432,7 +432,11 @@ describe('DataViewsAsCodeService', () => {
             },
           },
         })
-      ).rejects.toThrow('Invalid field format types: not-a-real-format');
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 400 },
+        message: 'Invalid field format types: not-a-real-format',
+      });
 
       expect(mockDataViewsService.createAndSaveDataViewLazy).not.toHaveBeenCalled();
     });

--- a/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.ts
@@ -21,7 +21,7 @@ import { omit } from 'lodash';
 import { getMeta } from '@kbn/as-code-shared-schemas';
 import type { TypeOf } from '@kbn/config-schema';
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
-import { Boom } from '@hapi/boom';
+import { badRequest } from '@hapi/boom';
 import type { asCodePaginatedResponseSchema } from '../rest_routes/schema';
 
 export class DataViewsAsCodeService {
@@ -39,7 +39,7 @@ export class DataViewsAsCodeService {
     this.fieldFormats = fieldFormats;
   }
 
-  private getInvalidFieldFormatTypes(spec: AsCodeSavedDataView) {
+  private validateFieldFormatTypes(spec: AsCodeSavedDataView) {
     const invalidFormatTypes = [];
 
     const allFieldSettings = Object.values(spec.field_settings || {});
@@ -55,7 +55,9 @@ export class DataViewsAsCodeService {
       if (!this.fieldFormats.has(fieldFormatType)) invalidFormatTypes.push(fieldFormatType);
     }
 
-    return invalidFormatTypes;
+    if (invalidFormatTypes.length > 0) {
+      throw badRequest(`Invalid field format types: ${invalidFormatTypes.join(', ')}`);
+    }
   }
 
   private async mapDataView(dataView: DataViewLazy) {
@@ -82,12 +84,7 @@ export class DataViewsAsCodeService {
   }
 
   public async create(spec: AsCodeSavedDataView) {
-    const invalidFormatTypes = this.getInvalidFieldFormatTypes(spec);
-    if (invalidFormatTypes.length > 0) {
-      throw new Boom(`Invalid field format types: ${invalidFormatTypes.join(', ')}`, {
-        statusCode: 400,
-      });
-    }
+    this.validateFieldFormatTypes(spec);
 
     const dataViewSpec = toStoredDataView(spec);
 
@@ -101,12 +98,7 @@ export class DataViewsAsCodeService {
   }
 
   public async upsert(id: string, spec: Omit<AsCodeSavedDataView, 'id'>) {
-    const invalidFormatTypes = this.getInvalidFieldFormatTypes(spec);
-    if (invalidFormatTypes.length > 0) {
-      throw new Boom(`Invalid field format types: ${invalidFormatTypes.join(', ')}`, {
-        statusCode: 400,
-      });
-    }
+    this.validateFieldFormatTypes(spec);
 
     const existingDataView = await this.getDataViewLazy(id);
 

--- a/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.ts
@@ -84,7 +84,9 @@ export class DataViewsAsCodeService {
   public async create(spec: AsCodeSavedDataView) {
     const invalidFormatTypes = this.getInvalidFieldFormatTypes(spec);
     if (invalidFormatTypes.length > 0) {
-      throw new Error(`Invalid field format types: ${invalidFormatTypes.join(', ')}`);
+      throw new Boom(`Invalid field format types: ${invalidFormatTypes.join(', ')}`, {
+        statusCode: 400,
+      });
     }
 
     const dataViewSpec = toStoredDataView(spec);

--- a/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/services/data_views_as_code_service.ts
@@ -10,6 +10,7 @@
 import type { AsCodeSavedDataView } from '@kbn/as-code-data-views-schema';
 import {
   fromStoredDataViewToAsCodeSavedSchema,
+  isCompositeRuntimeField,
   toStoredDataView,
 } from '@kbn/as-code-data-views-transforms';
 import type { DataViewAttributes } from '@kbn/data-views-plugin/common';
@@ -19,15 +20,42 @@ import type { DataViewsService } from '@kbn/data-views-plugin/server';
 import { omit } from 'lodash';
 import { getMeta } from '@kbn/as-code-shared-schemas';
 import type { TypeOf } from '@kbn/config-schema';
+import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
+import { Boom } from '@hapi/boom';
 import type { asCodePaginatedResponseSchema } from '../rest_routes/schema';
 
 export class DataViewsAsCodeService {
   private dataViewsService: DataViewsService;
   private savedObjectsClient: SavedObjectsClientContract;
+  private fieldFormats: FieldFormatsRegistry;
 
-  constructor(dataViewsService: DataViewsService, savedObjectsClient: SavedObjectsClientContract) {
+  constructor(
+    dataViewsService: DataViewsService,
+    savedObjectsClient: SavedObjectsClientContract,
+    fieldFormats: FieldFormatsRegistry
+  ) {
     this.dataViewsService = dataViewsService;
     this.savedObjectsClient = savedObjectsClient;
+    this.fieldFormats = fieldFormats;
+  }
+
+  private getInvalidFieldFormatTypes(spec: AsCodeSavedDataView) {
+    const invalidFormatTypes = [];
+
+    const allFieldSettings = Object.values(spec.field_settings || {});
+    const fieldFormatTypes = allFieldSettings.flatMap((fieldSettings) => {
+      if (isCompositeRuntimeField(fieldSettings)) {
+        return Object.values(fieldSettings.fields).map((field) => field.format?.type);
+      }
+      return fieldSettings.format?.type;
+    });
+
+    for (const fieldFormatType of fieldFormatTypes) {
+      if (!fieldFormatType) continue;
+      if (!this.fieldFormats.has(fieldFormatType)) invalidFormatTypes.push(fieldFormatType);
+    }
+
+    return invalidFormatTypes;
   }
 
   private async mapDataView(dataView: DataViewLazy) {
@@ -54,6 +82,11 @@ export class DataViewsAsCodeService {
   }
 
   public async create(spec: AsCodeSavedDataView) {
+    const invalidFormatTypes = this.getInvalidFieldFormatTypes(spec);
+    if (invalidFormatTypes.length > 0) {
+      throw new Error(`Invalid field format types: ${invalidFormatTypes.join(', ')}`);
+    }
+
     const dataViewSpec = toStoredDataView(spec);
 
     const result = await this.dataViewsService.createAndSaveDataViewLazy(dataViewSpec);
@@ -66,6 +99,13 @@ export class DataViewsAsCodeService {
   }
 
   public async upsert(id: string, spec: Omit<AsCodeSavedDataView, 'id'>) {
+    const invalidFormatTypes = this.getInvalidFieldFormatTypes(spec);
+    if (invalidFormatTypes.length > 0) {
+      throw new Boom(`Invalid field format types: ${invalidFormatTypes.join(', ')}`, {
+        statusCode: 400,
+      });
+    }
+
     const existingDataView = await this.getDataViewLazy(id);
 
     if (!!existingDataView) {

--- a/src/platform/plugins/shared/data_views_as_code/server/types.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/types.ts
@@ -10,6 +10,7 @@ import type {
   DataViewsServerPluginSetup,
   DataViewsServerPluginStart,
 } from '@kbn/data-views-plugin/server';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 
 export interface DataViewsAsCodeServerPluginSetupDependencies {
@@ -19,4 +20,5 @@ export interface DataViewsAsCodeServerPluginSetupDependencies {
 
 export interface DataViewsAsCodeServerPluginStartDependencies {
   dataViews: DataViewsServerPluginStart;
+  fieldFormats: FieldFormatsStart;
 }

--- a/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/post_data_view.spec.ts
+++ b/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/post_data_view.spec.ts
@@ -240,6 +240,33 @@ apiTest.describe('POST /api/data_views - as code', { tag: tags.deploymentAgnosti
     expect(response).toHaveStatusCode(400);
   });
 
+  apiTest(
+    'returns 400 when field_settings contains an invalid format type',
+    async ({ apiClient }) => {
+      const response = await apiClient.post(BASE_PATH, {
+        headers: {
+          ...COMMON_HEADERS,
+          ...adminApiCredentials.apiKeyHeader,
+        },
+        body: {
+          index_pattern: `invalid-format-create-${Date.now()}-*`,
+          field_settings: {
+            bytes_field: {
+              format: {
+                type: 'not-a-real-format-type',
+              },
+            },
+          },
+        },
+        responseType: 'json',
+      });
+
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.message).toContain('Invalid field format types');
+      expect(response.body.message).toContain('not-a-real-format-type');
+    }
+  );
+
   apiTest('returns 400 when id is provided in the request body', async ({ apiClient }) => {
     const response = await apiClient.post(BASE_PATH, {
       headers: {

--- a/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/put_data_view.spec.ts
+++ b/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/put_data_view.spec.ts
@@ -268,6 +268,96 @@ apiTest.describe('PUT /api/data_views/{id} - as code', { tag: tags.deploymentAgn
   });
 
   apiTest(
+    'returns 400 when creating via PUT and body contains composite field with invalid format type',
+    async ({ apiClient }) => {
+      const id = `dv-put-invalid-format-${Date.now()}-${Math.random()}`;
+
+      const response = await apiClient.put(`${BASE_PATH}/${id}`, {
+        headers: {
+          ...COMMON_HEADERS,
+          ...adminApiCredentials.apiKeyHeader,
+        },
+        body: {
+          index_pattern: `invalid-format-update-${Date.now()}-*`,
+          field_settings: {
+            composite_field: {
+              type: 'composite',
+              script: 'emit("sub_a", "v1"); emit("sub_b", "v2");',
+              fields: {
+                sub_a: {
+                  type: 'keyword',
+                  format: {
+                    type: 'number',
+                  },
+                },
+                sub_b: {
+                  type: 'keyword',
+                  format: {
+                    type: 'not-a-real-format-type',
+                  },
+                },
+              },
+            },
+          },
+        },
+        responseType: 'json',
+      });
+
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.message).toContain('Invalid field format types');
+      expect(response.body.message).toContain('not-a-real-format-type');
+    }
+  );
+
+  apiTest(
+    'returns 400 when updating via PUT and body contains composite field with invalid format type',
+    async ({ apiClient, apiServices }) => {
+      const id = `dv-put-invalid-format-update-${Date.now()}-${Math.random()}`;
+
+      await apiServices.dataViews.create({
+        id,
+        title: `put-invalid-format-existing-${Date.now()}-*`,
+      });
+      createdIds.push(id);
+
+      const response = await apiClient.put(`${BASE_PATH}/${id}`, {
+        headers: {
+          ...COMMON_HEADERS,
+          ...adminApiCredentials.apiKeyHeader,
+        },
+        body: {
+          index_pattern: `invalid-format-update-existing-${Date.now()}-*`,
+          field_settings: {
+            composite_field: {
+              type: 'composite',
+              script: 'emit("sub_a", "v1"); emit("sub_b", "v2");',
+              fields: {
+                sub_a: {
+                  type: 'keyword',
+                  format: {
+                    type: 'number',
+                  },
+                },
+                sub_b: {
+                  type: 'keyword',
+                  format: {
+                    type: 'not-a-real-format-type',
+                  },
+                },
+              },
+            },
+          },
+        },
+        responseType: 'json',
+      });
+
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.message).toContain('Invalid field format types');
+      expect(response.body.message).toContain('not-a-real-format-type');
+    }
+  );
+
+  apiTest(
     'returns 403 when user does not have indexPatterns manage privilege',
     async ({ apiClient }) => {
       const id = `dv-put-no-manage-${Date.now()}-${Math.random()}`;

--- a/src/platform/plugins/shared/data_views_as_code/tsconfig.json
+++ b/src/platform/plugins/shared/data_views_as_code/tsconfig.json
@@ -16,7 +16,8 @@
     "@kbn/as-code-shared-telemetry",
     "@kbn/as-code-utils",
     "@kbn/logging-mocks",
-    "@kbn/core-http-server-mocks"
+    "@kbn/core-http-server-mocks",
+    "@kbn/field-formats-plugin"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Right now it's possible to assign invalid field formatters through the as-code APIs, the problem with this is that if Discover tries to use one that doesn't exist, it just breaks. The current data views APIs also have validation around this, so adding it sounds like the best option here and it's not possible to just statically validate them through the schemas because custom formatters can be added through external plugins.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
