### PR TITLE
[9.3] [js-yaml to yaml migration] @elastic/streams-ui (#281518)

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -45,7 +45,6 @@ const JS_YAML_LEGACY_CONSUMERS = [
   'src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts',
   'src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts',
   'src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.ts',
-  'src/platform/packages/shared/kbn-synthtrace/src/cli/utils/read_kibana_config.ts',
   'src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts',
   'src/platform/plugins/private/interactive_setup/server/kibana_config_writer.ts',
   'x-pack/platform/packages/shared/kbn-data-forge/src/lib/create_config.ts',

--- a/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/read_kibana_config.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/read_kibana_config.ts
@@ -9,7 +9,7 @@
 
 import path from 'path';
 import fs from 'fs';
-import yaml from 'js-yaml';
+import { parse } from 'yaml';
 import { REPO_ROOT } from '@kbn/repo-info';
 
 export type KibanaConfig = ReturnType<typeof readKibanaConfig>;
@@ -19,7 +19,7 @@ export const readKibanaConfig = () => {
   const kibanaDevConfig = path.join(kibanaConfigDir, 'kibana.dev.yml');
   const kibanaConfig = path.join(kibanaConfigDir, 'kibana.yml');
 
-  return (yaml.load(
+  return (parse(
     fs.readFileSync(fs.existsSync(kibanaDevConfig) ? kibanaDevConfig : kibanaConfig, 'utf8')
   ) || {}) as Record<string, any>;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[js-yaml to yaml migration] @elastic/streams-ui (#281518)](https://github.com/elastic/kibana/pull/281518)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-30T10:00:11Z","message":"[js-yaml to yaml migration] @elastic/streams-ui (#281518)\n\nCloses #281522\n\n## Summary\n\nMigrates the 8 files owned by @elastic/streams-ui from `js-yaml` to the\n`yaml` package, as part of the broader codebase-wide migration tracked\nin the `JS_YAML_LEGACY_CONSUMERS` allowlist in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\n- Replaces `import yaml from 'js-yaml'` / named imports (`dump`, `load`)\nwith the equivalent `yaml` package exports (`stringify`, `parse`)\n- `yaml.dump(x)` → `stringify(x)`; `yaml.dump(x, { lineWidth: -1 })` →\n`stringify(x, { lineWidth: 0 })` (both disable line wrapping);\n`yaml.load(x)` → `parse(x)`\n- Removes the 8 migrated files from the ESLint\n`JS_YAML_LEGACY_CONSUMERS` exception list\n\n**Files changed:**\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/aws_retail_store/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/bank_of_anthos/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/quarkus_super_heroes/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/rust_k8s_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_edot_k8s_collector_config.ts`\n-\n`src/platform/packages/shared/kbn-synthtrace/src/cli/utils/read_kibana_config.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/generate_agent_config.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/generate_agent_config.test.ts`\n\n## Test plan\n\n- [ ] ESLint passes on all changed files (`node scripts/eslint <files>`)\n- [ ] Existing unit tests for `generate_agent_config` pass\n- [ ] No type errors in affected packages\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"1d012bd8549d57c67437046b7b47df6680de5a5c","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","dependency-reduction","Team:obs-presentation","v9.6.0"],"title":"[js-yaml to yaml migration] @elastic/streams-ui","number":281518,"url":"https://github.com/elastic/kibana/pull/281518","mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/streams-ui (#281518)\n\nCloses #281522\n\n## Summary\n\nMigrates the 8 files owned by @elastic/streams-ui from `js-yaml` to the\n`yaml` package, as part of the broader codebase-wide migration tracked\nin the `JS_YAML_LEGACY_CONSUMERS` allowlist in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\n- Replaces `import yaml from 'js-yaml'` / named imports (`dump`, `load`)\nwith the equivalent `yaml` package exports (`stringify`, `parse`)\n- `yaml.dump(x)` → `stringify(x)`; `yaml.dump(x, { lineWidth: -1 })` →\n`stringify(x, { lineWidth: 0 })` (both disable line wrapping);\n`yaml.load(x)` → `parse(x)`\n- Removes the 8 migrated files from the ESLint\n`JS_YAML_LEGACY_CONSUMERS` exception list\n\n**Files changed:**\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/aws_retail_store/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/bank_of_anthos/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/quarkus_super_heroes/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/rust_k8s_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_edot_k8s_collector_config.ts`\n-\n`src/platform/packages/shared/kbn-synthtrace/src/cli/utils/read_kibana_config.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/generate_agent_config.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/generate_agent_config.test.ts`\n\n## Test plan\n\n- [ ] ESLint passes on all changed files (`node scripts/eslint <files>`)\n- [ ] Existing unit tests for `generate_agent_config` pass\n- [ ] No type errors in affected packages\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"1d012bd8549d57c67437046b7b47df6680de5a5c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281518","number":281518,"mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/streams-ui (#281518)\n\nCloses #281522\n\n## Summary\n\nMigrates the 8 files owned by @elastic/streams-ui from `js-yaml` to the\n`yaml` package, as part of the broader codebase-wide migration tracked\nin the `JS_YAML_LEGACY_CONSUMERS` allowlist in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\n- Replaces `import yaml from 'js-yaml'` / named imports (`dump`, `load`)\nwith the equivalent `yaml` package exports (`stringify`, `parse`)\n- `yaml.dump(x)` → `stringify(x)`; `yaml.dump(x, { lineWidth: -1 })` →\n`stringify(x, { lineWidth: 0 })` (both disable line wrapping);\n`yaml.load(x)` → `parse(x)`\n- Removes the 8 migrated files from the ESLint\n`JS_YAML_LEGACY_CONSUMERS` exception list\n\n**Files changed:**\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/aws_retail_store/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/bank_of_anthos/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/quarkus_super_heroes/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/rust_k8s_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_edot_k8s_collector_config.ts`\n-\n`src/platform/packages/shared/kbn-synthtrace/src/cli/utils/read_kibana_config.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/generate_agent_config.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/generate_agent_config.test.ts`\n\n## Test plan\n\n- [ ] ESLint passes on all changed files (`node scripts/eslint <files>`)\n- [ ] Existing unit tests for `generate_agent_config` pass\n- [ ] No type errors in affected packages\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"1d012bd8549d57c67437046b7b47df6680de5a5c"}},{"url":"https://github.com/elastic/kibana/pull/281718","number":281718,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/281719","number":281719,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->