### PR TITLE
[Synthetics] Fix 0% availability for heartbeat monitors in overview flyout

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_monitor_summary_stats.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_monitor_summary_stats.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getMonitorSummaryStatsRoute } from './get_monitor_summary_stats';
+import { HEARTBEAT_UNMAPPED_LOCATION_LABEL } from '../../../common/runtime_types/heartbeat_monitor';
+
+const aggregations = {
+  total: { value: 100 },
+  up: { doc_count: 96 },
+  down: { doc_count: 4 },
+  median_duration: { values: { '50.0': 250000 } },
+};
+
+const runHandler = async (locationLabel: string) => {
+  const search = jest.fn().mockResolvedValue({ body: { aggregations } });
+  const route = getMonitorSummaryStatsRoute();
+  const result = await route.handler({
+    // @ts-expect-error partial implementation for testing
+    request: { query: { monitorId: 'my-monitor', locationLabel, from: 'now-30d', to: 'now' } },
+    // @ts-expect-error partial implementation for testing
+    syntheticsEsClient: { search, heartbeatIndices: 'synthetics-*' },
+  });
+  return { result, filters: search.mock.calls[0][0].query.bool.filter };
+};
+
+describe('getMonitorSummaryStatsRoute', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('filters by observer.geo.name for a real location', async () => {
+    const { filters, result } = await runHandler('North America - US East');
+
+    expect(filters).toContainEqual({
+      term: { 'observer.geo.name': 'North America - US East' },
+    });
+    // Sanity: aggregations are turned into the summary payload.
+    expect(result).toEqual({ availability: 96, medianDuration: 250, errorCount: 4, totalRuns: 100 });
+  });
+
+  // Regression: autodiscovery/heartbeat pings carry no observer.geo.name and are
+  // surfaced under the "Heartbeat" placeholder. A plain term on the placeholder
+  // label matches zero pings, so availability/duration wrongly render as 0.
+  it('matches location-less pings for the Heartbeat placeholder', async () => {
+    const { filters, result } = await runHandler(HEARTBEAT_UNMAPPED_LOCATION_LABEL);
+
+    expect(filters).toContainEqual({
+      bool: { must_not: { exists: { field: 'observer.geo.name' } } },
+    });
+    expect(filters).not.toContainEqual({
+      term: { 'observer.geo.name': HEARTBEAT_UNMAPPED_LOCATION_LABEL },
+    });
+    expect(result).toEqual({ availability: 96, medianDuration: 250, errorCount: 4, totalRuns: 100 });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_monitor_summary_stats.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_monitor_summary_stats.test.ts
@@ -37,7 +37,12 @@ describe('getMonitorSummaryStatsRoute', () => {
       term: { 'observer.geo.name': 'North America - US East' },
     });
     // Sanity: aggregations are turned into the summary payload.
-    expect(result).toEqual({ availability: 96, medianDuration: 250, errorCount: 4, totalRuns: 100 });
+    expect(result).toEqual({
+      availability: 96,
+      medianDuration: 250,
+      errorCount: 4,
+      totalRuns: 100,
+    });
   });
 
   // Regression: autodiscovery/heartbeat pings carry no observer.geo.name and are
@@ -52,6 +57,11 @@ describe('getMonitorSummaryStatsRoute', () => {
     expect(filters).not.toContainEqual({
       term: { 'observer.geo.name': HEARTBEAT_UNMAPPED_LOCATION_LABEL },
     });
-    expect(result).toEqual({ availability: 96, medianDuration: 250, errorCount: 4, totalRuns: 100 });
+    expect(result).toEqual({
+      availability: 96,
+      medianDuration: 250,
+      errorCount: 4,
+      totalRuns: 100,
+    });
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_monitor_summary_stats.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_monitor_summary_stats.ts
@@ -11,6 +11,7 @@ import {
   EXCLUDE_RUN_ONCE_FILTER,
   FINAL_SUMMARY_FILTER,
 } from '../../../common/constants/client_defaults';
+import { getHeartbeatLocationFilter } from '../../../common/lib';
 import { getSyntheticsScopedIndex } from '../../../common/get_synthetics_indices';
 import type { SyntheticsRestApiRouteFactory } from '../types';
 
@@ -54,7 +55,7 @@ export const getMonitorSummaryStatsRoute: SyntheticsRestApiRouteFactory<
             FINAL_SUMMARY_FILTER,
             EXCLUDE_RUN_ONCE_FILTER,
             { term: { 'monitor.id': monitorId } },
-            { term: { 'observer.geo.name': locationLabel } },
+            ...getHeartbeatLocationFilter({ field: 'observer.geo.name', value: locationLabel }),
             { range: { '@timestamp': { gte: from, lte: to } } },
           ],
         },


### PR DESCRIPTION
## Summary

Closes #281760.

Heartbeat / Kubernetes-autodiscovery monitors (Elastic Agent–run, no Kibana saved object) always showed **Availability = 0.00%** and **Duration (median) = 0 ms** in the Synthetics overview flyout's "Summary (Last 30 days)" panel, even while the monitor reported `up` with thousands of pings.

Root cause: `get_monitor_summary_stats.ts` filtered the location with a plain `term` on `observer.geo.name`. Autodiscovery pings carry no `observer.geo.name`, so they surface under the placeholder location label `"Heartbeat"` — and a `term` on that placeholder matches **zero** documents, so `total = 0` and availability/duration fall back to `0`.

This is the same class of issue #274947 fixed for `get_latest_test_run.ts` and `query_pings.ts` via the shared `getHeartbeatLocationFilter` helper (which turns the placeholder into a `must_not exists` clause); this route was simply missed.

## Before
<img width="700" height="390" alt="Screenshot 2026-07-30 at 14 43 07" src="https://github.com/user-attachments/assets/ed969476-e30c-4c39-a7ab-f9d920bf5c25" />

## After

<img width="700" height="350" alt="Screenshot 2026-07-30 at 17 19 29" src="https://github.com/user-attachments/assets/001b8c78-1b6c-45b0-9ee7-68afee64ceaa" />


### Change
Use `getHeartbeatLocationFilter({ field: 'observer.geo.name', value: locationLabel })` instead of the hardcoded `term`:
- **Real location** → returns the same `term` clause (no behavior change for regular/remote monitors).
- **`"Heartbeat"` placeholder** → returns a `must_not exists` clause, matching the location-less autodiscovery pings.

Adds a regression test (`get_monitor_summary_stats.test.ts`) covering both the real-location and placeholder paths.

### Evidence
For one autodiscovery monitor over the last 30 days:

| Location filter | Matched summary docs | up |
| --- | --- | --- |
| `term observer.geo.name = "Heartbeat"` (before) | 0 | 0 |
| `must_not exists observer.geo.name` (after) | 11,699 | 11,232 (~96%) |

## How to test
1. Have k8s-autodiscovery heartbeat monitors reporting to `synthetics-*` (they appear under the "Heartbeat" placeholder location in the overview).
2. Open a monitor's flyout → **Overview** tab → "Summary (Last 30 days)".
3. Before: Availability `0.00%` / Duration `0 ms`. After: real availability (e.g. ~96%) and a real median duration.

