### PR TITLE
Add required cloud tags to local Serverless projects

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/utils/docker.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.test.ts
@@ -905,6 +905,9 @@ describe('setupServerlessVolumes()', () => {
     const settings = JSON.parse(
       await Fsp.readFile(join(SERVERLESS_OPERATOR_PATH, 'settings.json'), 'utf-8')
     );
+    expect(settings.state.project.tags).toEqual(
+      expect.objectContaining({ _csp: 'aws', _region: 'eu-west-1' })
+    );
     expect(settings.state.cluster_secrets.string_secrets).toEqual(stringSecretsFixture);
   });
 

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -1286,6 +1286,8 @@ async function registerLinkedProjectInOriginSettings(log: ToolingLog, options: S
       _id: linkedProject.projectId,
       _organization: MOCK_IDP_UIAM_ORGANIZATION_ID,
       _type: esProjectType,
+      _csp: 'aws',
+      _region: 'eu-west-1',
       env: 'local',
     },
   };
@@ -1423,6 +1425,8 @@ async function getOperatorVolume(
   };
   const projectTags = {
     ...Object.fromEntries(Object.entries(projectInfo).map(([key, value]) => [`_${key}`, value])),
+    _csp: 'aws',
+    _region: 'eu-west-1',
     env: 'local',
   };
 


### PR DESCRIPTION
## Summary

- add the required `_csp` and `_region` tags to local Serverless project metadata
- add the same tags when registering linked projects for cross-project search
- cover the generated origin project tags in the Docker utility tests

This keeps the local test setup compatible with the project metadata requirements introduced by elastic/elasticsearch#155073.

## Validation

- `env -u NO_COLOR FORCE_COLOR=1 node scripts/jest src/platform/packages/shared/kbn-es/src/utils/docker.test.ts`
- `node scripts/type_check --project src/platform/packages/shared/kbn-es/tsconfig.json`
- `git diff --check`