### PR TITLE
fix(kbn-std): use Object.is in onceCacheOnSuccess property test to handle NaN

### DIFF
--- a/src/platform/packages/shared/kbn-std/src/once_cache_on_success.test.ts
+++ b/src/platform/packages/shared/kbn-std/src/once_cache_on_success.test.ts
@@ -79,8 +79,7 @@ describe('onceCacheOnSuccess', () => {
         const results = Array.from({ length: callCount }, () => memoized());
 
         expect(factory).toHaveBeenCalledTimes(1);
-        // All results are the same reference
-        expect(results.every((r) => r === results[0])).toBe(true);
+        expect(results.every((r) => Object.is(r, results[0]))).toBe(true);
       })
     );
   });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/280852

## Summary

The property test for `onceCacheOnSuccess` was using `===` to verify that all calls to the memoized function return the same value. This fails when `fast-check`'s `fc.anything()` generates `NaN`, because `NaN === NaN` is `false` per IEEE 754 — even though the cache is working correctly.

Fixed by using `Object.is` instead, which correctly returns `true` for `Object.is(NaN, NaN)`.

## Reproduce locally

Add the seed to the `fc.assert` call in `once_cache_on_success.test.ts`:

```ts
fc.assert(
  fc.property(...),
  { seed: -1098307036, path: '25:63' }
);
```

Then run:

```
node scripts/jest src/platform/packages/shared/kbn-std/src/once_cache_on_success.test.ts
```