### PR TITLE
[Core] Fix flaky idle socket timeout test

### DIFF
--- a/src/platform/test/plugin_functional/test_suites/core/route.ts
+++ b/src/platform/test/plugin_functional/test_suites/core/route.ts
@@ -122,7 +122,9 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
               throw new Error('Expected idle socket timeout error but request succeeded');
             },
             (err) => {
-              expect(err.message).to.be('socket hang up');
+              // The server closing the socket surfaces as either 'socket hang up'
+              // or 'read ECONNRESET' depending on the client's read/write timing.
+              expect(err.message).to.match(/^(socket hang up|read ECONNRESET)$/);
             }
           );
         });
@@ -154,7 +156,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
             .set('Content-Type', 'application/json')
             .set('kbn-xsrf', 'true')
             .then(() => expect('to throw').to.be('but it did NOT'))
-            .catch((error) => expect(error.message).to.be('socket hang up'));
+            .catch((error) => expect(error.message).to.match(/^(socket hang up|read ECONNRESET)$/));
         });
 
         it('should not timeout if servers response is fast enough', async () => {


### PR DESCRIPTION
## Summary

Relaxes two assertions in the idle socket timeout FTR test that were hard-coded to `'socket hang up'`. When the server destroys the socket mid-request, Node's HTTP client surfaces the same condition as either `'socket hang up'` or `'read ECONNRESET'` depending on event-loop timing — both carry `code: ECONNRESET`. The test now accepts either message, fixing a flake that had re-opened across `main`, `8.x`, `9.1`, and `9.2` despite three prior timing-tweak attempts.

Closes #216499

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/en/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed