### PR TITLE
[Lens as Code] Generate unique ad hoc Data View IDs from full spec

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/common.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/common.ts
@@ -33,6 +33,7 @@ import { getValues, type NormalizerConfig } from './normalize';
 import { getContinuity, getRangeValue } from '../../../../transforms/coloring';
 import { stripUndefined } from '../../../../transforms/charts/utils';
 import { generateAdHocDataViewId, getAdHocDataViewSpec } from '../../../../transforms/utils';
+import { toApiFieldSettings } from '../../../../transforms/columns/field_settings';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
@@ -200,35 +201,54 @@ function normalizeFormBasedAdHocDataViews(
   const adHocDataViews = attributes.state.adHocDataViews ?? {};
   const refs = [...internalReferences];
 
+  // Compute the deterministic id for every form-based ad-hoc data view once. The
+  // transform dedupes views by id, so several layers can reference the same view;
+  // remapping per data view (instead of per layer) keeps every referencing layer
+  // pointing at the same new id. Doing it per layer would delete the entry on the
+  // first layer and leave the rest pointing at the stale id.
+  const idRemap = new Map<string, string>();
+  for (const [oldId, adHocDataView] of Object.entries(adHocDataViews)) {
+    // ES|QL ad-hoc data views are handled by normalizeESQLAdHocDataViews; skip them here.
+    if (adHocDataView.type === 'esql') {
+      continue;
+    }
+    const newId = generateAdHocDataViewId({
+      index: adHocDataView.title ?? '',
+      timeFieldName: adHocDataView.timeFieldName,
+      name: adHocDataView.name,
+      allowHidden: adHocDataView.allowHidden,
+      fieldSettings: toApiFieldSettings(adHocDataView),
+    });
+    idRemap.set(oldId, newId);
+
+    if (oldId !== newId) {
+      delete adHocDataViews[oldId];
+      adHocDataView.id = newId;
+      adHocDataViews[newId] = adHocDataView;
+    }
+    // mirror the transform's `name = name ?? index` (title === index for form-based)
+    adHocDataView.name = adHocDataView.name ?? adHocDataView.title;
+  }
+
   for (const [layerId, layer] of Object.entries(formBasedLayers)) {
     const layerRefName = `indexpattern-datasource-layer-${layerId}`;
     const ref = refs.find((r) => r.name === layerRefName);
     const adHocId = ref?.id ?? (layer as any).indexPatternId;
+    const newId = adHocId ? idRemap.get(adHocId) : undefined;
 
-    if (adHocId && adHocDataViews[adHocId]) {
-      const adHocDataView: DataViewSpec = adHocDataViews[adHocId];
-      const newId = generateAdHocDataViewId({
-        index: adHocDataView.title ?? '',
-        timeFieldName: adHocDataView.timeFieldName,
+    if (!newId) {
+      continue;
+    }
+
+    if (ref) {
+      ref.id = newId;
+      // Keep the original layerId in the name so getCommonNormalizer can apply layerRemapping to it.
+    } else {
+      refs.push({
+        id: newId,
+        name: layerRefName,
+        type: 'index-pattern',
       });
-
-      delete adHocDataViews[adHocId];
-      adHocDataView.id = newId;
-      // A custom form-based name round-trips verbatim
-      adHocDataViews[newId] = adHocDataView;
-      // mirror the transform's `name = name ?? index` (title === index for form-based)
-      adHocDataView.name = adHocDataView.name ?? adHocDataView.title;
-
-      if (ref) {
-        ref.id = newId;
-        // Keep the original layerId in the name so getCommonNormalizer can apply layerRemapping to it.
-      } else {
-        refs.push({
-          id: newId,
-          name: `indexpattern-datasource-layer-${layerId}`,
-          type: 'index-pattern',
-        });
-      }
     }
   }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -958,7 +958,7 @@ describe('filtersAndQueryToApiFormat', () => {
 });
 
 describe('generateAdHocDataViewId', () => {
-  test('form-based views differing only in name get distinct ids', () => {
+  test('form-based data views differing only in name get distinct ids', () => {
     const idA = generateAdHocDataViewId({
       index: 'logs-*',
       timeFieldName: '@timestamp',
@@ -976,7 +976,7 @@ describe('generateAdHocDataViewId', () => {
     expect(idB.startsWith('logs-*-@timestamp-')).toBe(true);
   });
 
-  test('identical form-based views share the same base-<hash> id', () => {
+  test('identical form-based data views share the same base-<hash> id', () => {
     const idA = generateAdHocDataViewId({
       index: 'logs-*',
       timeFieldName: '@timestamp',
@@ -991,7 +991,7 @@ describe('generateAdHocDataViewId', () => {
     expect(idA).toBe(idB);
   });
 
-  test('form-based views over the same index+timeField but different field settings get distinct ids', () => {
+  test('form-based data views over the same index+timeField but different field settings get distinct ids', () => {
     const base = {
       index: 'logs-*',
       timeFieldName: '@timestamp',
@@ -1007,7 +1007,7 @@ describe('generateAdHocDataViewId', () => {
     expect(withoutRuntimeField).not.toBe(withRuntimeField);
   });
 
-  test('form-based views over the same index+timeField but different allowHidden get distinct ids', () => {
+  test('form-based data views over the same index+timeField but different allowHidden get distinct ids', () => {
     const base = {
       index: 'logs-*',
       timeFieldName: '@timestamp',
@@ -1021,7 +1021,7 @@ describe('generateAdHocDataViewId', () => {
     expect(withoutAllowHidden).not.toBe(withAllowHidden);
   });
 
-  test('form-based views with name undefined === name === index, get the same id', () => {
+  test('form-based data views with name undefined === name === index, get the same id', () => {
     const noName = generateAdHocDataViewId({
       index: 'logs-*',
       timeFieldName: '@timestamp',
@@ -1033,5 +1033,61 @@ describe('generateAdHocDataViewId', () => {
     });
 
     expect(noName).toBe(nameEqualsIndex);
+  });
+
+  test('form-based data views with allowHidden false === allowHidden omitted, get the same id', () => {
+    const omitted = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+    });
+    const explicitFalse = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      allowHidden: false,
+    });
+
+    expect(explicitFalse).toBe(omitted);
+  });
+
+  test('form-based data views with empty field settings === no field settings, get the same id', () => {
+    const noFieldSettings = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+    });
+    const emptyFieldSettings = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      fieldSettings: {},
+    });
+
+    expect(emptyFieldSettings).toBe(noFieldSettings);
+  });
+
+  test('ES|QL data views with an explicit time field keep the readable base id (no canonical hash)', () => {
+    const id = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      dataSourceType: 'esql',
+      esqlQuery: 'FROM logs-*',
+    });
+
+    expect(id).toBe('logs-*-@timestamp');
+  });
+
+  test('ES|QL data views without an explicit time field disambiguate distinct queries by query hash', () => {
+    const idA = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: undefined,
+      dataSourceType: 'esql',
+      esqlQuery: 'FROM logs-* | LIMIT 10',
+    });
+    const idB = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: undefined,
+      dataSourceType: 'esql',
+      esqlQuery: 'FROM logs-* | LIMIT 20',
+    });
+
+    expect(idA).not.toBe(idB);
   });
 });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -12,6 +12,8 @@ import {
   buildReferences,
   getDataSourceIndex,
   getAdHocDataViewSpec,
+  generateAdHocDataViewId,
+  getAdhocDataviews,
   addLayerColumn,
   operationFromColumn,
   buildDataSourceState,
@@ -30,6 +32,7 @@ import type {
 } from '@kbn/lens-common';
 import type { TextBasedLayer } from '@kbn/lens-common';
 import { AS_CODE_DATA_VIEW_SPEC_TYPE } from '@kbn/as-code-data-views-schema';
+import type { APIAdHocDataView } from './columns/types';
 import type { LensApiConfig, MetricConfig } from '../schema';
 import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { LensAttributes } from '../types';
@@ -953,5 +956,84 @@ describe('filtersAndQueryToApiFormat', () => {
     const result = filtersAndQueryToApiFormat(lensState);
 
     expect(result).toEqual({});
+  });
+});
+
+describe('generateAdHocDataViewId', () => {
+  test('form-based views differing only in name get distinct ids', () => {
+    const idA = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      name: 'Logs A',
+    });
+    const idB = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      name: 'Logs B',
+    });
+
+    expect(idA).not.toBe(idB);
+    // Both keep the readable `index-timeField` base
+    expect(idA.startsWith('logs-*-@timestamp-')).toBe(true);
+    expect(idB.startsWith('logs-*-@timestamp-')).toBe(true);
+  });
+
+  test('identical form-based views share the same base-<hash> id', () => {
+    const idA = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      name: 'Logs',
+    });
+    const idB = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      name: 'Logs',
+    });
+
+    expect(idA).toBe(idB);
+  });
+
+  test('form-based views over the same index+timeField but different field settings get distinct ids', () => {
+    const base = {
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+    };
+    const withoutRuntimeField = generateAdHocDataViewId(base);
+    const withRuntimeField = generateAdHocDataViewId({
+      ...base,
+      fieldSettings: {
+        my_runtime_field: { type: 'keyword', script: "emit('x')" },
+      },
+    });
+
+    expect(withoutRuntimeField).not.toBe(withRuntimeField);
+  });
+
+  test('form-based views over the same index+timeField but different allowHidden get distinct ids', () => {
+    const base = {
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+    };
+    const withoutAllowHidden = generateAdHocDataViewId(base);
+    const withAllowHidden = generateAdHocDataViewId({
+      ...base,
+      allowHidden: true,
+    });
+
+    expect(withoutAllowHidden).not.toBe(withAllowHidden);
+  });
+
+  test('form-based views with name undefined === name === index, get the same id', () => {
+    const noName = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+    });
+    const nameEqualsIndex = generateAdHocDataViewId({
+      index: 'logs-*',
+      timeFieldName: '@timestamp',
+      name: 'logs-*',
+    });
+
+    expect(noName).toBe(nameEqualsIndex);
   });
 });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -13,7 +13,6 @@ import {
   getDataSourceIndex,
   getAdHocDataViewSpec,
   generateAdHocDataViewId,
-  getAdhocDataviews,
   addLayerColumn,
   operationFromColumn,
   buildDataSourceState,
@@ -32,7 +31,6 @@ import type {
 } from '@kbn/lens-common';
 import type { TextBasedLayer } from '@kbn/lens-common';
 import { AS_CODE_DATA_VIEW_SPEC_TYPE } from '@kbn/as-code-data-views-schema';
-import type { APIAdHocDataView } from './columns/types';
 import type { LensApiConfig, MetricConfig } from '../schema';
 import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { LensAttributes } from '../types';

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -23,6 +23,7 @@ import type {
 import { cleanupFormulaReferenceColumns } from '@kbn/lens-common';
 import { getIndexPatternFromESQLQuery, parseTimeFieldFromESQLQuery } from '@kbn/esql-utils';
 import { Sha256 } from '@kbn/crypto-browser';
+import { stableStringify } from '@kbn/std';
 import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { FILTERS, isOfAggregateQueryType, type Filter, type Query } from '@kbn/es-query';
 import type { AsCodeFilter } from '@kbn/as-code-filters-schema';
@@ -156,7 +157,16 @@ function normalizeWhitespace(str: string): string {
 }
 
 export function generateAdHocDataViewId(
-  dataView: Pick<APIAdHocDataView, 'index' | 'timeFieldName' | 'esqlQuery' | 'dataSourceType'>
+  dataView: Pick<
+    APIAdHocDataView,
+    | 'index'
+    | 'timeFieldName'
+    | 'esqlQuery'
+    | 'dataSourceType'
+    | 'name'
+    | 'allowHidden'
+    | 'fieldSettings'
+  >
 ): string {
   const base = `${dataView.index}${dataView.timeFieldName ? `-${dataView.timeFieldName}` : ''}`;
   // When timeFieldName is not explicitly provided in the query, then it is not persisted during the transformations and
@@ -166,7 +176,25 @@ export function generateAdHocDataViewId(
   if (dataView.dataSourceType === 'esql' && !dataView.timeFieldName && dataView.esqlQuery) {
     return `${base}-${sha256Sync(normalizeWhitespace(dataView.esqlQuery))}`;
   }
-  return base;
+
+  // For form-based ad hoc data views, two over the same index+timeField can
+  // still differ in specifications (custom name, allowHidden, or runtime/scripted
+  // field settings). Always append a hash of the canonical specification fields so t
+  // hat identical specs map to the same id and different specs get distinct ids.
+  // Mirrors the ES|QL `base-<hash>` pattern above.
+  //
+  // `stableStringify` sorts keys and omits `undefined` values, so key order and
+  // absent/optional field settings can't perturb the hash.
+  const canonical = {
+    name: dataView.name ?? dataView.index,
+    allowHidden: dataView.allowHidden,
+    fieldSettings:
+      dataView.fieldSettings && Object.keys(dataView.fieldSettings).length > 0
+        ? dataView.fieldSettings
+        : undefined,
+  };
+
+  return `${base}-${sha256Sync(stableStringify(canonical))}`;
 }
 
 export function getAdHocDataViewSpec(dataView: APIAdHocDataView) {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -173,21 +173,23 @@ export function generateAdHocDataViewId(
   // at runtime we fallback to @timestamp if it exists in the index.
   // But different ES|QL queries against the same index can resolve to different time fields. See: https://github.com/elastic/kibana/pull/256764
   // Including a hash of the query in the ID ensures each distinct query gets its own cached DataView, preventing stale time-field resolution.
-  if (dataView.dataSourceType === 'esql' && !dataView.timeFieldName && dataView.esqlQuery) {
-    return `${base}-${sha256Sync(normalizeWhitespace(dataView.esqlQuery))}`;
+  if (dataView.dataSourceType === 'esql') {
+    return !dataView.timeFieldName && dataView.esqlQuery
+      ? `${base}-${sha256Sync(normalizeWhitespace(dataView.esqlQuery))}`
+      : base;
   }
 
   // For form-based ad hoc data views, two over the same index+timeField can
   // still differ in specifications (custom name, allowHidden, or runtime/scripted
-  // field settings). Always append a hash of the canonical specification fields so t
-  // hat identical specs map to the same id and different specs get distinct ids.
+  // field settings). Always append a hash of the canonical specification fields so
+  // that identical specs map to the same id and different specs get distinct ids.
   // Mirrors the ES|QL `base-<hash>` pattern above.
   //
   // `stableStringify` sorts keys and omits `undefined` values, so key order and
   // absent/optional field settings can't perturb the hash.
   const canonical = {
     name: dataView.name ?? dataView.index,
-    allowHidden: dataView.allowHidden,
+    allowHidden: dataView.allowHidden ? true : undefined, // treat false as undefined
     fieldSettings:
       dataView.fieldSettings && Object.keys(dataView.fieldSettings).length > 0
         ? dataView.fieldSettings

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/moon.yml
@@ -37,6 +37,7 @@ dependsOn:
   - '@kbn/transpose-utils'
   - '@kbn/palettes'
   - '@kbn/crypto-browser'
+  - '@kbn/std'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/tsconfig.json
@@ -30,5 +30,6 @@
     "@kbn/transpose-utils",
     "@kbn/palettes",
     "@kbn/crypto-browser",
+    "@kbn/std",
   ]
 }


### PR DESCRIPTION
## Summary

After these adhoc dataview roundtrip fixes: 

- https://github.com/elastic/kibana/pull/280086
- https://github.com/elastic/kibana/pull/280546

an issue with ad hoc Data View ID collisions emerged in the Lens config builder. 

Previously, `generateAdHocDataViewId` derived form-based ad hoc Data View IDs solely from `index` + `timeFieldName`, so two Data Views over the same index/time field, but with different specs (custom `name`, `allowHidden`, or runtime/scripted `fieldSettings`) collided onto the same ID.

Now the ID always appends a SHA-256 hash of the canonical spec fields, so identical specs map to the same ID and differing specs get distinct IDs, mirroring the existing base-<hash> pattern used for ES|QL Data Views.

## Repro
- Create a dashboard with a Lens panel backed by a form-based ad hoc Data View.
- Duplicate the panel, then change the Data View name and add an extra runtime field to the second panel's Data Viiew.
- Before the fix, both panels resolve to the same ad hoc Data View ID → the second panel fails to load.

## Screenshots

- Left (API Flag off)
- Right (API Flag on)

Before:

- a duplicate adhoc dataview with different name --> shows the original adhoc dataview name

<img width="2548" height="1205" alt="Screenshot 2026-07-30 at 1 45 21 PM" src="https://github.com/user-attachments/assets/0bba2ba2-dc5b-49d4-8254-db8ad6c4d2ed" />

- a duplicate adhoc dataview with an additional runtime field --> shows the newly added field as missing 
<img width="2546" height="1203" alt="Screenshot 2026-07-30 at 1 45 02 PM" src="https://github.com/user-attachments/assets/737f06c6-d2c2-47cf-ab15-bc7d24748b73" />

After: 

- a duplicate adhoc dataview with different name --> shows the new adhoc dataview name
<img width="2545" height="1203" alt="Screenshot 2026-07-30 at 3 25 16 PM" src="https://github.com/user-attachments/assets/f0a39c6c-5aa1-4d00-9445-051d49a0dea6" />

- a duplicate adhoc dataview with an additional runtime field --> resolves the newly added field and renders correctly

<img width="2545" height="1200" alt="Screenshot 2026-07-30 at 3 25 32 PM" src="https://github.com/user-attachments/assets/677c6d8b-761c-482d-9629-9c55fed46ea2" />

## Release Notes
Fixed an issue where duplicating a Lens panel backed by a form-based ad hoc Data View and then modifying the Data View (e.g. renaming it or adding a runtime field) could cause the panel to fail to load, due to colliding ad hoc Data View IDs.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->