### PR TITLE
[SLO] Fix TypeError on burn rate alert details page when window is missing

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/custom_kql/log_rate_analysis_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/custom_kql/log_rate_analysis_panel.tsx
@@ -75,6 +75,10 @@ export function LogRateAnalysisPanel({ slo, alert, rule }: Props) {
 
   const actionGroupWindow = getActionGroupWindow(alert);
 
+  if (!actionGroupWindow) {
+    return null;
+  }
+
   const alertRange = {
     from: moment(alert.start),
     to: alert.fields[ALERT_END] ? moment(alert.fields[ALERT_END]) : moment(new Date()),

--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/custom_kql/log_rate_analysis_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/custom_kql/log_rate_analysis_panel.tsx
@@ -75,6 +75,63 @@ export function LogRateAnalysisPanel({ slo, alert, rule }: Props) {
 
   const actionGroupWindow = getActionGroupWindow(alert);
 
+  const messages = useMemo<Message[] | undefined>(() => {
+    const hasLogRateAnalysisParams =
+      logRateAnalysisParams && logRateAnalysisParams.significantFieldValues?.length > 0;
+
+    if (!hasLogRateAnalysisParams) {
+      return undefined;
+    }
+
+    const { logRateAnalysisType } = logRateAnalysisParams;
+
+    const header = 'Field name,Field value,Doc count,p-value';
+    const rows = logRateAnalysisParams.significantFieldValues
+      .map((item) => Object.values(item).join(','))
+      .join('\n');
+
+    const content = `You are an observability expert using Elastic Observability Suite on call being consulted about a log threshold alert that got triggered by a ${logRateAnalysisType} in log messages. Your job is to take immediate action and proceed with both urgency and precision.
+      "Log Rate Analysis" is an AIOps feature that uses advanced statistical methods to identify reasons for increases and decreases in log rates. It makes it easy to find and investigate causes of unusual spikes or dips by using the analysis workflow view.
+      You are using "Log Rate Analysis" and ran the statistical analysis on the log messages which occured during the alert.
+      You received the following analysis results from "Log Rate Analysis" which list statistically significant co-occuring field/value combinations sorted from most significant (lower p-values) to least significant (higher p-values) that ${
+        logRateAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE
+          ? 'contribute to the log rate spike'
+          : 'are less or not present in the log rate dip'
+      }:
+
+      ${
+        logRateAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE
+          ? 'The median log rate in the selected deviation time range is higher than the baseline. Therefore, the results shows statistically significant items within the deviation time range that are contributors to the spike. The "doc count" column refers to the amount of documents in the deviation time range.'
+          : 'The median log rate in the selected deviation time range is lower than the baseline. Therefore, the analysis results table shows statistically significant items within the baseline time range that are less in number or missing within the deviation time range. The "doc count" column refers to the amount of documents in the baseline time range.'
+      }
+
+      ${header}
+      ${rows}
+
+      Based on the above analysis results and your observability expert knowledge, output the following:
+      Analyse the type of these logs and explain their usual purpose (1 paragraph).
+      ${
+        logRateAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE
+          ? 'Based on the type of these logs do a root cause analysis on why the field and value combinations from the analysis results are causing this log rate spike (2 parapraphs)'
+          : 'Based on the type of these logs explain why the statistically significant field and value combinations are less in number or missing from the log rate dip with concrete examples based on the analysis results data which contains items that are present in the baseline time range and are missing or less in number in the deviation time range (2 paragraphs)'
+      }.
+      ${
+        logRateAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE
+          ? 'Recommend concrete remediations to resolve the root cause (3 bullet points).'
+          : ''
+      }
+
+      Do not mention individual p-values from the analysis results.
+      Do not repeat the full list of field names and field values back to the user.
+      Do not guess, just say what you are sure of. Do not repeat the given instructions in your output.`;
+
+    return observabilityAIAssistant?.getContextualInsightMessages({
+      message:
+        'Can you identify possible causes and remediations for these log rate analysis results',
+      instructions: content,
+    });
+  }, [logRateAnalysisParams, observabilityAIAssistant]);
+
   if (!actionGroupWindow) {
     return null;
   }
@@ -133,63 +190,6 @@ export function LogRateAnalysisPanel({ slo, alert, rule }: Props) {
         : undefined
     );
   };
-
-  const messages = useMemo<Message[] | undefined>(() => {
-    const hasLogRateAnalysisParams =
-      logRateAnalysisParams && logRateAnalysisParams.significantFieldValues?.length > 0;
-
-    if (!hasLogRateAnalysisParams) {
-      return undefined;
-    }
-
-    const { logRateAnalysisType } = logRateAnalysisParams;
-
-    const header = 'Field name,Field value,Doc count,p-value';
-    const rows = logRateAnalysisParams.significantFieldValues
-      .map((item) => Object.values(item).join(','))
-      .join('\n');
-
-    const content = `You are an observability expert using Elastic Observability Suite on call being consulted about a log threshold alert that got triggered by a ${logRateAnalysisType} in log messages. Your job is to take immediate action and proceed with both urgency and precision.
-      "Log Rate Analysis" is an AIOps feature that uses advanced statistical methods to identify reasons for increases and decreases in log rates. It makes it easy to find and investigate causes of unusual spikes or dips by using the analysis workflow view.
-      You are using "Log Rate Analysis" and ran the statistical analysis on the log messages which occured during the alert.
-      You received the following analysis results from "Log Rate Analysis" which list statistically significant co-occuring field/value combinations sorted from most significant (lower p-values) to least significant (higher p-values) that ${
-        logRateAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE
-          ? 'contribute to the log rate spike'
-          : 'are less or not present in the log rate dip'
-      }:
-
-      ${
-        logRateAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE
-          ? 'The median log rate in the selected deviation time range is higher than the baseline. Therefore, the results shows statistically significant items within the deviation time range that are contributors to the spike. The "doc count" column refers to the amount of documents in the deviation time range.'
-          : 'The median log rate in the selected deviation time range is lower than the baseline. Therefore, the analysis results table shows statistically significant items within the baseline time range that are less in number or missing within the deviation time range. The "doc count" column refers to the amount of documents in the baseline time range.'
-      }
-
-      ${header}
-      ${rows}
-
-      Based on the above analysis results and your observability expert knowledge, output the following:
-      Analyse the type of these logs and explain their usual purpose (1 paragraph).
-      ${
-        logRateAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE
-          ? 'Based on the type of these logs do a root cause analysis on why the field and value combinations from the analysis results are causing this log rate spike (2 parapraphs)'
-          : 'Based on the type of these logs explain why the statistically significant field and value combinations are less in number or missing from the log rate dip with concrete examples based on the analysis results data which contains items that are present in the baseline time range and are missing or less in number in the deviation time range (2 paragraphs)'
-      }.
-      ${
-        logRateAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE
-          ? 'Recommend concrete remediations to resolve the root cause (3 bullet points).'
-          : ''
-      }
-
-      Do not mention individual p-values from the analysis results.
-      Do not repeat the full list of field names and field values back to the user.
-      Do not guess, just say what you are sure of. Do not repeat the given instructions in your output.`;
-
-    return observabilityAIAssistant?.getContextualInsightMessages({
-      message:
-        'Can you identify possible causes and remediations for these log rate analysis results',
-      instructions: content,
-    });
-  }, [logRateAnalysisParams, observabilityAIAssistant]);
 
   if (!dataView || !esSearchQuery) return null;
 

--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/error_rate/error_rate_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/error_rate/error_rate_panel.tsx
@@ -143,7 +143,7 @@ export function ErrorRatePanel({ alert, slo, isLoading }: Props) {
                             {
                               defaultMessage: 'Alert when > {threshold}x',
                               values: {
-                                threshold: numeral(actionGroupWindow!.burnRateThreshold).format(
+                                threshold: numeral(actionGroupWindow?.burnRateThreshold).format(
                                   '0.[00]'
                                 ),
                               },
@@ -162,7 +162,7 @@ export function ErrorRatePanel({ alert, slo, isLoading }: Props) {
               slo={slo}
               dataTimeRange={chartTimeRange}
               alertTimeRange={alertTimeRange}
-              threshold={actionGroupWindow!.burnRateThreshold}
+              threshold={actionGroupWindow?.burnRateThreshold}
               variant="danger"
             />
           </EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/utils/alert.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/utils/alert.test.ts
@@ -52,7 +52,12 @@ const mockWindows: WindowSchema[] = [
   },
 ];
 
-const buildAlert = (actionGroup: string, reason: string): BurnRateAlert =>
+// Pass null to omit `windows` from rule parameters entirely (simulates absent field).
+const buildAlert = (
+  actionGroup: string,
+  reason: string,
+  windows: WindowSchema[] | null = mockWindows
+): BurnRateAlert =>
   ({
     reason,
     start: Date.now(),
@@ -60,7 +65,7 @@ const buildAlert = (actionGroup: string, reason: string): BurnRateAlert =>
     active: true,
     fields: {
       [ALERT_ACTION_GROUP]: actionGroup,
-      [ALERT_RULE_PARAMETERS]: { sloId: 'test-slo', windows: mockWindows },
+      [ALERT_RULE_PARAMETERS]: { sloId: 'test-slo', ...(windows !== null && { windows }) },
     },
   } as unknown as BurnRateAlert);
 
@@ -108,5 +113,21 @@ describe('getActionGroupWindow', () => {
     expect(getActionGroupWindow(buildAlert(SUPPRESSED_PRIORITY_ACTION_ID, reason))).toBe(
       expectedWindow
     );
+  });
+
+  it('returns undefined when windows is an empty array', () => {
+    expect(getActionGroupWindow(buildAlert(ALERT_ACTION_ID, CRITICAL_REASON, []))).toBeUndefined();
+  });
+
+  it('returns undefined when windows is absent from rule parameters', () => {
+    expect(
+      getActionGroupWindow(buildAlert(ALERT_ACTION_ID, CRITICAL_REASON, null))
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when no window matches the action group', () => {
+    expect(
+      getActionGroupWindow(buildAlert('unknown-action-group', CRITICAL_REASON))
+    ).toBeUndefined();
   });
 });

--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/utils/alert.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/utils/alert.ts
@@ -38,6 +38,6 @@ export function getActionGroupWindow(alert: BurnRateAlert) {
       : alertActionGroup;
   const actionGroupWindow = (
     (alert.fields[ALERT_RULE_PARAMETERS]?.windows ?? []) as WindowSchema[]
-  ).find((window: WindowSchema) => window.actionGroup === actionGroup)!;
+  ).find((window: WindowSchema) => window.actionGroup === actionGroup);
   return actionGroupWindow;
 }

--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/utils/time_range.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/utils/time_range.ts
@@ -23,7 +23,9 @@ import { getActionGroupWindow } from './alert';
 export function getChartTimeRange(alert: BurnRateAlert): TimeRange {
   const timeRange = getPaddedAlertTimeRange(alert.fields[ALERT_START]!, alert.fields[ALERT_END]);
   const actionGroupWindow = getActionGroupWindow(alert);
-  const windowDurationInMs = actionGroupWindow.longWindow.value * 60 * 60 * 1000;
+  const windowDurationInMs = actionGroupWindow
+    ? actionGroupWindow.longWindow.value * 60 * 60 * 1000
+    : 0;
   return {
     from: new Date(new Date(timeRange.from).getTime() - windowDurationInMs),
     to: timeRange.to ? new Date(timeRange.to) : new Date(),


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/281792

- `getActionGroupWindow` used `.find()` with a non-null assertion (`!`), but the find returns `undefined` when `ALERT_RULE_PARAMETERS.windows` is absent or has no matching entry (e.g. older/malformed alerts).
- All callers then crashed with `TypeError: Cannot read properties of undefined (reading 'longWindow')`.
- Removed the `!`, updated `getChartTimeRange` to fall back to 0ms extension, added an early `return null` guard in `LogRateAnalysisPanel`, and switched `!.` to `?.` in `ErrorRatePanel`.

## Test plan

- [ ] Existing unit tests pass (`alert.test.ts` — 17/17)
- [ ] Type check passes (`tsconfig` exit 0)
- [ ] Open a burn rate alert with a valid rule — page loads and renders normally
- [ ] Verify no regression for alerts with all four action groups (critical / high / medium / low)

Fixes: `TypeError: Cannot read properties of undefined (reading 'longWindow')` seen in production on the SLO burn rate alert details page.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->