### PR TITLE
[Workflows][Connectors][Skills] Add GraphQL introspection, numeric-widget, and query-param/body verification guidance

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md
@@ -44,7 +44,8 @@ Then begin working through the tasks in order.
 It's tempting, when asked to build many connectors, to build the code for all of them first (Task 1-3)
 and defer activation/live-testing (Tasks 4-11) until later. In practice this is where most real bugs
 surface — disabled test buttons, ICU parse errors, endpoints that reject partial updates, query params
-the vendor rejects, wrong auth scopes — none of which unit tests or a code-only review catch, because
+the vendor rejects, an optional modifier param silently sent to the wrong place (query string vs. body),
+wrong auth scopes — none of which unit tests or a code-only review catch, because
 they only show up when the spec is actually loaded and exercised in a running Kibana. If the user
 explicitly asks to defer live testing for a batch, still run the self-review checklist from
 `create-connector`'s Step 4 ("Self-review before handing off") on every connector before considering it
@@ -226,6 +227,14 @@ If tools failed (tool results contain `"status":"failed"`):
      temporary debug action, per "Verify GraphQL Schemas via Introspection" in
      `create-connector/reference/custom-connector-setup.md`, then fix every occurrence of the wrong name
      (check sibling queries/mutations in the same file for the same mistake) and re-test.
+   - **No error at all, but an optional modifier param (`scope`, a filter, an `all_X` flag) appears to have
+     no effect** — e.g. a scoped mute/unmute or a filtered update behaves like an unscoped/unfiltered one.
+     This is not a flaky vendor or a bad test value; it means the handler is sending that param in the
+     query string when the vendor expects the request body (or vice versa), and the vendor is silently
+     ignoring the misplaced field instead of erroring. Check the action's real API docs for where that
+     specific param belongs, fix the handler, and check any sibling action (e.g. the corresponding
+     mute/unmute or enable/disable pair) for the same mistake — don't assume the sibling is correct just
+     because it wasn't the one that failed.
 3. If the error is a **sub-action issue** (wrong name, invalid parameters) — this needs code fixes.
 4. If the error is a **connector issue** (wrong auth config, wrong server URL) — this needs code fixes.
 
@@ -282,6 +291,12 @@ Args: <agent-id>
 
 Use a more specific prompt this time, something like:
 > Search for recent items and give me a detailed summary of what you find.
+
+**If any action has optional modifier params** (`scope`, filters, `all_X` flags, an expiry timestamp)
+beyond its required fields, make sure this test (or an earlier one) actually causes the agent to set at
+least one of them to a non-default value, not just the required-fields-only happy path. A query-param-vs-
+body mismatch on an optional param doesn't error — the vendor silently ignores it — so a test that never
+sets the param will pass even though the feature is broken.
 
 Verify the agent successfully calls tools, gets results, and produces a useful response.
 

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md
@@ -146,6 +146,12 @@ Args: $ARGUMENTS
 
 This will list available types, ask the user for credentials, and create the connector instance via the Actions API. When `agentBuilder:experimentalFeatures` is true, the connector's sub-actions become available to agents.
 
+**If the user reports `Error: No widget found for schema type: ZodNumberFormat...`** when opening the
+connector creation form in the Kibana UI, a `z.number()` field was used in the connector's config
+`schema` — the form-generator has no numeric widget. Fix it per "There is no widget for `z.number()`
+config fields" in `create-connector/reference/connector-patterns.md` (regex-validated string + `text`
+widget, coerced to a number in the handler), then ask the user to retry.
+
 Mark task 5 as `completed`.
 
 ---

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md
@@ -213,6 +213,13 @@ If tools failed (tool results contain `"status":"failed"`):
      identity even though the ID format, payload shape, and endpoint are all otherwise correct. Retry with
      a different, real human user's ID from the same org before treating this as a connector bug — if that
      succeeds, the code is fine and this is just a property of the test data/account, not something to fix.
+   - `Unknown type "..."` or `Cannot query field "..." on type "..."` on a GraphQL-backed connector — the
+     hardcoded query/mutation string references a type or field name that doesn't exist in the vendor's
+     real schema (a guessed/hallucinated name, not a live-data problem). Don't guess a fix from docs
+     alone — verify the real name with a GraphQL introspection query (`__schema`/`__type`) run through a
+     temporary debug action, per "Verify GraphQL Schemas via Introspection" in
+     `create-connector/reference/custom-connector-setup.md`, then fix every occurrence of the wrong name
+     (check sibling queries/mutations in the same file for the same mistake) and re-test.
 3. If the error is a **sub-action issue** (wrong name, invalid parameters) — this needs code fixes.
 4. If the error is a **connector issue** (wrong auth config, wrong server URL) — this needs code fixes.
 

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/SKILL.md
@@ -35,6 +35,11 @@ regional/self-hosted domain variants. See "Research the Vendor API Before Writin
 found late (during manual testing or review) that trace back to skipping this step are expensive to fix
 one action at a time — verifying up front is cheaper.
 
+**If the vendor API is GraphQL**, docs examples and general familiarity are not enough to get input type
+names and field selections right — verify every hardcoded type/field name against the real schema via
+introspection before writing the handler. See "Verify GraphQL Schemas via Introspection" in
+[reference/custom-connector-setup.md](reference/custom-connector-setup.md).
+
 ## Step 2: Create the Connector Spec
 
 Create the connector spec in `src/platform/packages/shared/kbn-connector-specs/src/specs/{connector_name}/`.
@@ -140,6 +145,10 @@ Before treating the connector as done, re-read the whole diff once, end to end, 
   required scope appears in all of them, not just one
 - Naming/casing inconsistencies vs. sibling connectors (e.g. `webpackChunkName` casing)
 - Doc wording that could misread "required" as applying only to the last-listed parameter
+- For GraphQL-backed connectors: every input type name and response field selection in a hardcoded
+  query/mutation string has been checked against the real schema via introspection, not just written from
+  a docs example or general knowledge — see "Verify GraphQL Schemas via Introspection" in
+  [reference/custom-connector-setup.md](reference/custom-connector-setup.md)
 
 This mirrors what the `review-connector` skill checks — running it yourself first means real review
 cycles catch new problems instead of re-flagging things you could have caught alone.

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/SKILL.md
@@ -29,8 +29,10 @@ Follow only the steps for the chosen path. Do not mix them.
 
 For a custom (non-MCP) connector, do this before Step 2. For each action you plan to implement, find the
 vendor's real API docs and verify — don't assume: update semantics (partial vs. full-replace), how array
-query params are encoded, the auth scope each action actually needs, and whether the service has
-regional/self-hosted domain variants. See "Research the Vendor API Before Writing Any Code" in
+query params are encoded, whether optional modifier params (`scope`, filters, flags) on `POST`/`PATCH`
+actions belong in the query string or the JSON body, the auth scope each action actually needs, and
+whether the service has regional/self-hosted domain variants. See "Research the Vendor API Before Writing
+Any Code" in
 [reference/custom-connector-setup.md](reference/custom-connector-setup.md) for the full checklist. Bugs
 found late (during manual testing or review) that trace back to skipping this step are expensive to fix
 one action at a time — verifying up front is cheaper.
@@ -115,14 +117,20 @@ Add tests following the existing examples:
 
 1. **Connector spec tests** — See `google_drive/google_drive.test.ts` or `slack/slack.test.ts` for the pattern.
 
-You do not need to execute the tests — just create the files.
+You do not need to execute the tests — just create the files. You should, however, run
+`node scripts/eslint <path>` on every file you create or edit (including test files) before moving on.
+This is fast, requires no running Kibana/Elasticsearch, and catches mechanical rule violations — e.g. a
+forbidden non-null assertion (`@typescript-eslint/no-non-null-assertion`) in a test file's
+`Connector.action!.handler` — that a code-reading self-review or an AI PR reviewer can miss, and that
+otherwise only surface once CI's lint step fails the build.
 
 Unit tests that mock `ctx.client`/`ctx.request` yourself cannot catch bugs where the mock encodes the same
 wrong assumption as the handler (e.g. asserting on the axios default array-param serialization when the
-vendor actually needs a different form). For any handler you flagged during vendor API research as having
-non-obvious update or serialization semantics, add a test that asserts on the *exact* request shape sent
-(URL, method, body, and params/paramsSerializer) against what the docs say the vendor expects — not just
-that the handler resolves without throwing.
+vendor actually needs a different form, or asserting that an optional modifier param is sent as a query
+param when the vendor actually expects it in the body). For any handler you flagged during vendor API
+research as having non-obvious update, serialization, or query-string-vs-body semantics, add a test that
+asserts on the *exact* request shape sent (URL, method, body, and params/paramsSerializer) against what the
+docs say the vendor expects — not just that the handler resolves without throwing.
 
 ### Self-review before handing off
 
@@ -145,6 +153,9 @@ Before treating the connector as done, re-read the whole diff once, end to end, 
   required scope appears in all of them, not just one
 - Naming/casing inconsistencies vs. sibling connectors (e.g. `webpackChunkName` casing)
 - Doc wording that could misread "required" as applying only to the last-listed parameter
+- `POST`/`PATCH` actions with optional modifier params (`scope`, filters, flags) — confirm against the
+  vendor's docs whether each one belongs in the query string or the JSON body, checked per action against
+  the docs rather than assumed from a similar-looking sibling action in the same file
 - For GraphQL-backed connectors: every input type name and response field selection in a hardcoded
   query/mutation string has been checked against the real schema via introspection, not just written from
   a docs example or general knowledge — see "Verify GraphQL Schemas via Introspection" in

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/connector-patterns.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/connector-patterns.md
@@ -240,6 +240,43 @@ schema: z.object({
 
 Available `.meta()` options: `label`, `widget`, `placeholder`, `helpText`, `hidden`, `sensitive`, `disabled`, `order`.
 
+**There is no widget for `z.number()` config fields — use a regex-validated string instead.** The
+form-generator's widget registry only has `text`, `password`, `select`, `formFieldset`, `hidden`, `object`,
+and `fileUpload`; there is no numeric widget. A config field typed `z.number()` (e.g. `z.number().int()`)
+throws `Error: No widget found for schema type: ZodNumberFormat. Please specify a widget in the schema
+metadata.` when the connector creation form renders it — and since this is a runtime UI error, not a type
+or lint error, it won't be caught by `node scripts/type_check` or unit tests. If a config value is
+conceptually numeric (an account ID, a port, a numeric tenant ID), define it as a `.regex()`-validated
+string with the `text` widget instead, and coerce it to a number in the handler where the underlying API
+needs a real number:
+
+```typescript
+schema: z.object({
+  accountId: z
+    .string()
+    .min(1)
+    .max(20)
+    .regex(/^\d+$/, 'Must be a numeric account ID.')
+    .describe('Numeric account ID this connector manages.')
+    .meta({ widget: 'text', label: 'Account ID', placeholder: '1234567' }),
+}),
+```
+
+```typescript
+const getAccountId = (ctx: ActionContext): number => {
+  const raw = ctx.config?.accountId as string | undefined;
+  const accountId = Number(raw);
+  if (!raw || Number.isNaN(accountId)) {
+    throw new Error('Connector is missing the required accountId configuration field.');
+  }
+  return accountId;
+};
+```
+
+This only applies to **connector-level `config` fields** (rendered by the form-generator). Action `input`
+schemas are never rendered as a form — `z.number()` is fine there since it's Agent Builder/Workflows that
+supplies the value, not a human typing into a UI widget.
+
 **ICU-unsafe characters in translated help text**: `metadata.description` and any `helpText`/label string
 that goes through `i18n.translate()` is parsed as an ICU message. A literal `<placeholder>` (e.g.
 `'found in the URL: example.com/<slug>/'`) is parsed as an unclosed XML tag and throws a `FORMAT_ERROR`

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/connector-patterns.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/connector-patterns.md
@@ -242,7 +242,7 @@ Available `.meta()` options: `label`, `widget`, `placeholder`, `helpText`, `hidd
 
 **There is no widget for `z.number()` config fields — use a regex-validated string instead.** The
 form-generator's widget registry only has `text`, `password`, `select`, `formFieldset`, `hidden`, `object`,
-and `fileUpload`; there is no numeric widget. A config field typed `z.number()` (e.g. `z.number().int()`)
+and `fileUpload`; there is no numeric widget. A config field typed `z.number()` (e.g. `z.int()`)
 throws `Error: No widget found for schema type: ZodNumberFormat. Please specify a widget in the schema
 metadata.` when the connector creation form renders it — and since this is a runtime UI error, not a type
 or lint error, it won't be caught by `node scripts/type_check` or unit tests. If a config value is

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/custom-connector-setup.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/custom-connector-setup.md
@@ -47,6 +47,15 @@ action you plan to implement, find the vendor's official API reference and confi
 - **Array/list query parameters**: how does the API expect repeated values encoded — `?id=1&id=2`,
   `?id[]=1&id[]=2`, or a comma-joined string? Axios's default array serialization (`id[]=1&id[]=2`) is
   not universal; check the docs and, if needed, set a custom `paramsSerializer`.
+- **Query string vs. request body for optional modifier params**: for a `POST`/`PATCH` action whose only
+  required input is a path segment (an ID) but that also accepts optional modifiers (`scope`, `filters`,
+  `all_X` flags, an expiry timestamp), check the vendor's docs for whether those modifiers are read from
+  the query string or the JSON body — do not assume, and do not infer it from a similar sibling action in
+  the same file. Two actions that look like a natural pair (e.g. a resource's mute/unmute, or enable/
+  disable) can each independently get this wrong; comparing them to each other won't surface the mistake
+  if both share it. A wrong transport here doesn't error — the vendor accepts the request and silently
+  ignores the misplaced param, so the bug only shows up if a test or live-testing pass actually sets that
+  optional param to a non-default value.
 - **Per-action auth scopes**: list every scope/permission each action actually requires (not just the
   minimum to authenticate), especially for destructive or admin actions (delete, bulk update) or actions
   that hit a different API sub-resource (e.g. an alert/rule endpoint vs. the main resource). Once you have

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/custom-connector-setup.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/custom-connector-setup.md
@@ -56,6 +56,19 @@ action you plan to implement, find the vendor's official API reference and confi
   if both share it. A wrong transport here doesn't error — the vendor accepts the request and silently
   ignores the misplaced param, so the bug only shows up if a test or live-testing pass actually sets that
   optional param to a non-default value.
+  - **Verify against the vendor's own docs page, not a derived source.** A vendor's official client
+    library's internal request-building code, or a third-party/community OpenAPI mirror, is not sufficient
+    evidence on its own for this specific question — both can encode the same wrong assumption the handler
+    does, or be independently wrong, and neither will tell you so. Find the actual parameter table on the
+    vendor's own API reference page for that endpoint (look for an explicit "Query String(s)" vs. "Request
+    Body"/"Body Data" heading) and treat that as authoritative over anything else. If the live docs page is
+    a heavy client-rendered SPA that a scraping/fetch tool can't render properly (parameter tables missing
+    from the extracted text), don't fall back to a lower-confidence secondary source — try an archived
+    static snapshot of the same page (e.g. via the Wayback Machine) or, if still unresolved, live-test the
+    specific optional param against a real account before merging. Getting this backwards is easy to miss
+    because the "fixed" code still looks more correct than the original — it changed something on purpose,
+    based on evidence that seemed reasonable — so a subsequent reviewer has to independently re-derive the
+    right answer rather than just trusting that a change already went through this reasoning correctly.
 - **Per-action auth scopes**: list every scope/permission each action actually requires (not just the
   minimum to authenticate), especially for destructive or admin actions (delete, bulk update) or actions
   that hit a different API sub-resource (e.g. an alert/rule endpoint vs. the main resource). Once you have

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/custom-connector-setup.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/reference/custom-connector-setup.md
@@ -77,6 +77,50 @@ action you plan to implement, find the vendor's official API reference and confi
 Cross-reference this research against the fields you're about to add `.describe()` text for — the
 description should state the *verified* format/constraint, not an assumed one.
 
+### Verify GraphQL Schemas via Introspection
+
+If the vendor's API is GraphQL (NerdGraph, a custom GraphQL backend, etc.), do **not** trust a docs example,
+a blog post, or general familiarity with the vendor to get input type names, field selections, and
+enum/mutation argument shapes right — even docs pages sometimes show inconsistent or outdated examples, and
+it's easy to write a plausible-sounding type name (e.g. guessing an `XyzFilterInput`/`XyzTimeWindowInput`
+suffix pattern, or assuming a field exists on a response type because a similar field exists elsewhere)
+that simply doesn't exist in the real schema. This class of bug compiles fine and passes unit tests that
+mock the HTTP client, then fails with `Unknown type "..."` or `Cannot query field "..." on type "..."` the
+first time a real request hits the live API — a `build-connector` chat test or manual verification pass is
+usually the first time anyone would catch it.
+
+Before finalizing any query/mutation string, verify every referenced type and field against the schema
+itself using standard GraphQL introspection (`__schema`, `__type`), run through the connector's own
+authenticated client so you're checking against the exact account/schema version you'll actually call:
+
+1. Find the root query/mutation type name if you don't already know it:
+   ```graphql
+   { __schema { queryType { name } mutationType { name } } }
+   ```
+   (Don't assume it's literally `Query`/`Mutation` — some APIs name these differently, e.g. NerdGraph's
+   mutation root is `RootMutationType`.)
+2. List a root type's fields and their argument/return types to confirm a query or mutation exists with the
+   name and shape you expect:
+   ```graphql
+   { __type(name: "RootMutationType") { fields { name args { name type { name kind ofType { name kind } } } type { name kind ofType { name kind } } } } }
+   ```
+3. Drill into a specific input or output type's fields before relying on them:
+   ```graphql
+   { __type(name: "SomeFilterInput") { inputFields { name type { name kind ofType { name kind } } } } }
+   { __type(name: "SomeResponseType") { fields { name type { name kind ofType { name kind } } } } }
+   ```
+
+The simplest way to run these during development: temporarily add a throwaway action to the connector spec
+(e.g. `debugIntrospect`, `isTool: false`) whose handler sends one of the queries above through the same
+`graphqlRequest`/client helper the real actions use, call it once Kibana has hot-reloaded via the Actions
+`_execute` API, read the result, then **delete the debug action before committing** — it must never ship.
+Repeat for each type/field you're unsure about; each round only needs a single narrow query, so this is
+fast even across several iterations.
+
+Do this proactively for every hardcoded query/mutation string before live-testing, not only after a request
+fails — the cost of one introspection round-trip is far lower than a failed live test plus a fix-and-retest
+cycle.
+
 ## Implement the Connector Spec
 
 Fill in the generated spec stub with actions, handlers, auth config, and tests. Additionally, create a `types.ts` file alongside the spec for input schemas and types.

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/review-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/review-connector/SKILL.md
@@ -84,6 +84,16 @@ actual documented behavior — flag them even without live access to the API, ba
   relies on the HTTP client's default. A vendor expecting the repeated-key form (`?id=1&id=2`) will reject
   the client library's default bracketed form (`?id[]=1&id[]=2]`), or vice versa — this doesn't show up in
   unit tests that mock the client.
+- **Query params vs. request body for optional modifier params**: If a `POST`/`PATCH` action's only
+  required input is a path segment (an ID) but it also accepts optional modifiers (`scope`, filters,
+  `all_X` flags, an expiry timestamp), verify against the vendor's docs whether those modifiers belong in
+  the query string or the JSON body — check each action independently, don't infer it from a similar
+  sibling action in the same file (e.g. a resource's mute/unmute, or enable/disable). Both halves of such a
+  pair can share the same wrong assumption, so contrasting them against each other won't reveal the bug;
+  only the vendor's own request example will. This doesn't throw — the vendor accepts the request and
+  silently ignores the misplaced param — so it won't show up in a test or live-testing pass unless the
+  optional param is actually set to a non-default value; flag it as unverified if the only tests/live runs
+  exercise the required-fields-only path.
 - **"At least one of" update inputs**: If every field on an update-action's input schema is optional, check
   for a `.refine()` (or equivalent) requiring at least one to be set. Without it, a call with no fields set
   silently no-ops instead of erroring.
@@ -192,6 +202,10 @@ Report documentation issues alongside code issues.
   the PR description
 - **TypeScript** (touched files): Use strict equality (`===` / `!==`), follow repo style (early returns, explicit
   types, no `any`)
+- **Lint**: Run `node scripts/eslint <touched files>` and treat any reported error as a must-fix. This is
+  fast, requires no running Kibana/Elasticsearch, and catches mechanical rule violations (e.g. a forbidden
+  non-null assertion, `@typescript-eslint/no-non-null-assertion`, in a freshly-written test file) that a
+  manual reading pass can miss and that would otherwise only surface once CI's lint step fails.
 - **Dead code from iteration**: Flag schemas, types, or constants that are defined but never referenced —
   common leftovers from an earlier design that was later simplified.
 - **Duplicated calls**: Flag a helper (e.g. a URL builder) called more than once within the same handler

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/review-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/review-connector/SKILL.md
@@ -30,6 +30,12 @@ Use this skill when reviewing or preparing changes to a **connector spec** (spec
   actions the connector actually provides. Keep to one sentence, ~15 words.
 - **Schema UI**: Every config field in `schema` has `.meta()` with at least `label` (or uses a `UISchemas.*` helper).
   Otherwise fields render as unlabeled.
+- **No numeric config fields**: Flag any `z.number()` (or `.int()`) field in the connector-level `config`
+  `schema`. The form-generator's widget registry has no numeric widget, so this throws `No widget found
+  for schema type: ZodNumberFormat` when a human opens the connector creation form — a runtime-only error
+  that passes type-check, lint, and mocked unit tests cleanly. It should instead be a `.regex(/^\d+$/)`-validated
+  string with `widget: 'text'`, coerced to a number in the handler. This does not apply to action `input`
+  schemas (never rendered as a form).
 - **Action param schema (Workflow editor)**: For custom connector actions, the Zod schema in the input handler should
   give each param a short, clear `.describe()` so the Workflow editor shows helpful descriptions when mapping inputs.
 - **Auth**: Auth type matches the service. **Auth format** (e.g. header value) must match the vendor's official docs;

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/review-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/review-connector/SKILL.md
@@ -93,7 +93,12 @@ actual documented behavior — flag them even without live access to the API, ba
   only the vendor's own request example will. This doesn't throw — the vendor accepts the request and
   silently ignores the misplaced param — so it won't show up in a test or live-testing pass unless the
   optional param is actually set to a non-default value; flag it as unverified if the only tests/live runs
-  exercise the required-fields-only path.
+  exercise the required-fields-only path. If the diff's commit history shows this was *already* "fixed"
+  once (moved from query to body or vice versa), don't treat that as settled — re-derive the answer from
+  the vendor's actual docs page yourself. A prior fix based on a client library's internal code or a
+  third-party OpenAPI mirror can be confidently wrong; those aren't a substitute for the vendor's own
+  parameter table (look for an explicit "Query String(s)" vs. "Request Body" heading on the vendor's own
+  endpoint reference page).
 - **"At least one of" update inputs**: If every field on an update-action's input schema is optional, check
   for a `.refine()` (or equivalent) requiring at least one to be set. Without it, a call with no fields set
   silently no-ops instead of erroring.

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/review-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/review-connector/SKILL.md
@@ -101,6 +101,19 @@ actual documented behavior — flag them even without live access to the API, ba
   promises (e.g. `?include=services,groups`). Without it, those fields come back `null`/empty on a
   successful 200 response — flag any handler returning a "flattened" relationship field with no
   corresponding `include`/field-selection param in the request.
+- **Hardcoded GraphQL type/field names not verified against the real schema**: For any GraphQL-backed
+  connector (queries/mutations built as string templates), every input type name (`$filter: SomeInput`),
+  field selection, and return-type field must be checked against the vendor's *actual* schema, not just
+  a docs example or general familiarity with the vendor. Vendor docs pages frequently show simplified,
+  inconsistent, or outdated examples, and it's easy to write a plausible-sounding but nonexistent type
+  name (e.g. inventing an `XyzFilterInput` suffix, or assuming a field like `routingKey` exists on a
+  response type because it "sounds right"). These errors compile and pass mocked unit tests cleanly —
+  they only surface as `Unknown type "..."` or `Cannot query field "..." on type "..."` errors when a real
+  request hits the live API, so a code-only review can't catch them by inspection alone. If live testing
+  hasn't run yet, flag every GraphQL type/field name in the diff as unverified and recommend confirming it
+  via schema introspection (see `create-connector/reference/custom-connector-setup.md`'s "Verify GraphQL
+  Schemas via Introspection" section) before merging. If live testing already ran, confirm the PR
+  description's `## Validated` table calls out which query/mutation shapes were actually schema-verified.
 
 ### LLM Descriptions and Skill Content
 


### PR DESCRIPTION
## Summary

Follow-up to [#281453](https://github.com/elastic/kibana/pull/281453). 

While live-testing the New Relic connector ([#281144](https://github.com/elastic/kibana/pull/281144)) against a real trial account, three of its hardcoded GraphQL query/mutation strings turned out to reference types and fields that don't exist in NerdGraph's actual schema:

- `listIssues`/`listIncidents` used non-existent input types (`AiIssuesFilterIssuesInput`, `AiIssuesFilterIncidentsInput`, `AiIssuesTimeWindowInput`) and requested a `totalCount` field that doesn't exist on `AiIssuesIssueData`.
- `createDeploymentMarker` sent a `deploymentType` field inside `categoryFields.deployment` that doesn't exist on `ChangeTrackingDeploymentFieldsInput`.
- `acknowledgeIssue`/`unacknowledgeIssue`/`resolveIssue` selected a `routingKey` field that doesn't exist on `AiIssuesIssueUserActionResult`.

These are plausible-sounding names (the kind an LLM or a developer skimming docs would reasonably guess), and none of them were checked against the real schema before being written. They compiled fine and passed mocked unit tests cleanly, only surfacing as `Unknown type "..."` / `Cannot query field "..." on type "..."` errors once a real request hit the live API during manual verification.

This PR adds guidance for GraphQL-backed connectors to the connector-authoring skills:

- **`create-connector/reference/custom-connector-setup.md`**: new "Verify GraphQL Schemas via Introspection" section documenting the `__schema`/`__type` introspection technique — including the pattern of adding a temporary `debugIntrospect` debug action (not shipped) to run introspection queries through the connector's own authenticated client during development.
- **`create-connector/SKILL.md`**: pointers to the new section from Step 1 (research) and the Step 4 self-review checklist.
- **`build-connector/SKILL.md`**: a new "Common errors" entry in the Task 8 failure-analysis section for `Unknown type`/`Cannot query field` errors, pointing at the introspection technique as the fix.
- **`review-connector/SKILL.md`**: a new "Vendor API Correctness" checklist item flagging hardcoded GraphQL type/field names that haven't been schema-verified.

### Second finding: no widget for numeric connector-config fields

Also while working on the New Relic connector, adding an `accountId` config field typed `z.number().int()` threw `Error: No widget found for schema type: ZodNumberFormat. Please specify a widget in the schema metadata.` when the connector creation form rendered it in the Kibana UI. The form-generator's widget registry (`x-pack/platform/packages/shared/response-ops/form-generator/src/widgets/registry.ts`) only has `text`/`password`/`select`/`formFieldset`/`hidden`/`object`/`fileUpload` — there's no numeric widget, and this had never been hit before because no existing connector spec had a numeric field in its connector-level `config`. Like the GraphQL schema issue above, this is a runtime-only UI error: it compiles, type-checks, lints, and passes mocked unit tests cleanly, and only surfaces when a human opens the form.

The fix applied to New Relic (and now documented here) is to store the value as a `.regex(/^\d+$/)`-validated string with the `text` widget instead, and coerce it to a number in the handler where the underlying API needs a real number. This does not apply to action `input` schemas, which are never rendered as a form.

- **`create-connector/reference/connector-patterns.md`**: new note in "Schema UI Configuration" with the failure mode and the regex-string-plus-coercion fix, with a worked example.
- **`review-connector/SKILL.md`**: a new "Connector Spec" checklist item flagging any `z.number()` field in a connector's `config` schema.
- **`build-connector/SKILL.md`**: a troubleshooting note in Task 5 (Activate the Connector) for when a user reports this exact error while creating the connector in the UI.

### Third finding: optional modifier params, an unreliable secondary source, and a lint gap

While fixing PR review feedback on the Datadog connector ([#281810](https://github.com/elastic/kibana/pull/281810)), two more gaps surfaced — including one that took two rounds to actually get right, which is itself part of what this finding documents:

1. A first automated review comment claimed `unmuteMonitor` sent its optional `scope`/`all_scopes` as query params when Datadog expects them in the POST body, and that `muteMonitor` was correct by contrast. Cross-checking this led to Datadog's official client library (`datadogpy`) internals and a third-party OpenAPI mirror, both of which modeled these fields as a request body — so both `muteMonitor` and `unmuteMonitor` were "fixed" to send `scope`/`end`/`all_scopes` in the body. **This fix was itself wrong.** A second review comment on the same PR correctly flagged the change as a regression; Datadog's actual docs page (confirmed via an archived static snapshot, since the live page is a client-rendered SPA that standard scraping doesn't render fully) lists these fields under **Query Strings**, not the request body, for both endpoints. The original, pre-"fix" code was correct all along. Both handlers were reverted back to query params.
   - The deeper lesson isn't just "check query vs. body" (already true) — it's that a vendor's own client library internals and third-party OpenAPI mirrors are not reliable evidence for this specific question. Both looked like reasonable secondary sources and both were wrong for this legacy Datadog v1 endpoint (which isn't covered by Datadog's current auto-generated OpenAPI spec at all). Only the vendor's own docs page settled it.
   - Neither the unit tests nor live/chat testing caught the regression on their own: the tests just assert whatever shape the handler builds, and every live-tested scenario left `scope`/`all_scopes` unset, exercising only the default path where query-vs-body placement doesn't matter — Datadog accepts the request either way and silently ignores a misplaced param instead of erroring.
2. A forbidden non-null assertion (`@typescript-eslint/no-non-null-assertion`) shipped in a freshly-written test file and only surfaced once CI's lint step failed the build. `create-connector`'s Step 4 explicitly says not to execute the tests, and nothing else prompted running `eslint` locally before treating the connector as done.

This PR closes both gaps in the skills:

- **`create-connector/reference/custom-connector-setup.md`**: new "Query string vs. request body for optional modifier params" item in the vendor-research checklist, stressing that (a) sibling actions (mute/unmute, enable/disable) must be checked independently against the vendor's docs rather than by comparing them to each other, and (b) a vendor client library's internals or a third-party OpenAPI mirror are not sufficient evidence on their own — verify against the vendor's own docs page, falling back to an archived snapshot or live-testing if the live page won't render cleanly.
- **`create-connector/SKILL.md`**: the same check added to Step 1's research summary and the Step 4 self-review checklist; explicit guidance to run `node scripts/eslint <path>` on every created/edited file (including test files) even though executing the test suite itself is still optional.
- **`review-connector/SKILL.md`**: a matching "Query params vs. request body" item in the Vendor API Correctness section (including the caution about not trusting a prior "fix" in the diff's history without independently re-deriving the answer), plus a "Lint" item under Naming and Conventions.
- **`build-connector/SKILL.md`**: a new Task 8 failure pattern for "no error, but the optional param seems to have no effect," and Task 7/11 guidance to exercise at least one optional modifier param during live testing rather than only the required-fields-only happy path.

No code changes — skill/documentation only.

## Test plan

- [x] Read through all modified files to confirm cross-references resolve and formatting is consistent with the surrounding content
- N/A — markdown-only change, no build/test/lint required

Made with [Cursor](https://cursor.com)

