### PR TITLE
[AWS Onboarding] UI enhancements to onboarding step 1

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_hub/common/constants.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/common/constants.ts
@@ -7,6 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 
+export const ELASTIC_PACKAGE_REGISTRY_URL = 'https://epr.elastic.co';
+
 export const INGEST_HUB_ENABLED_FLAG = 'ingestHub.enabled';
 export const INGEST_HUB_ONBOARDING_ENABLED_FLAG = 'ingestHub.onboardingEnabled';
 

--- a/x-pack/platform/plugins/shared/ingest_hub/common/constants.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/common/constants.ts
@@ -7,8 +7,6 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const ELASTIC_PACKAGE_REGISTRY_URL = 'https://epr.elastic.co';
-
 export const INGEST_HUB_ENABLED_FLAG = 'ingestHub.enabled';
 export const INGEST_HUB_ONBOARDING_ENABLED_FLAG = 'ingestHub.onboardingEnabled';
 

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/onboarding_shell.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/onboarding_shell.tsx
@@ -160,7 +160,7 @@ export function OnboardingShell() {
 
   return (
     <EuiPageTemplate data-test-subj="onboardingShell">
-      <EuiPageTemplate.Section grow={false} paddingSize="m" restrictWidth>
+      <EuiPageTemplate.Section paddingSize="m" restrictWidth>
         <EuiFlexGroup direction="column" alignItems="center" gutterSize="s">
           <EuiFlexGroup direction="row" alignItems="flexEnd" gutterSize="m">
             <EuiIcon type={meta.icon} size="xl" aria-hidden={true} />

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/onboarding_shell.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/onboarding_shell.tsx
@@ -17,7 +17,6 @@ import {
   EuiStepsHorizontal,
   EuiText,
   EuiTitle,
-  useEuiTheme,
 } from '@elastic/eui';
 
 import { AWS_ONBOARDING_TITLE, AWS_ONBOARDING_DESCRIPTION } from '../../common/constants';
@@ -60,7 +59,6 @@ export function OnboardingShell() {
   const { integrationId } = useParams<{ integrationId: string }>();
   const history = useHistory();
   const location = useLocation();
-  const { euiTheme } = useEuiTheme();
   const meta = INTEGRATION_META[integrationId];
 
   useEffect(() => {
@@ -162,24 +160,27 @@ export function OnboardingShell() {
 
   return (
     <EuiPageTemplate data-test-subj="onboardingShell">
-      <EuiPageTemplate.Section
-        grow={false}
-        paddingSize="l"
-        restrictWidth
-        css={css`
-          border-bottom: ${euiTheme.border.thin};
-        `}
-      >
-        <EuiFlexGroup alignItems="center" gutterSize="l">
+      <EuiPageTemplate.Section grow={false} paddingSize="l" restrictWidth>
+        <EuiFlexGroup direction="column" alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon type={meta.icon} size="xxl" aria-hidden={true} />
+            <EuiIcon type={meta.icon} size="xl" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiTitle size="l">
+            <EuiTitle
+              size="m"
+              css={css`
+                text-align: center;
+              `}
+            >
               <h1>{meta.title}</h1>
             </EuiTitle>
-            <EuiSpacer size="xs" />
-            <EuiText size="m" color="subdued">
+            <EuiText
+              size="s"
+              color="subdued"
+              css={css`
+                text-align: center;
+              `}
+            >
               <p>{meta.description}</p>
             </EuiText>
           </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/onboarding_shell.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/onboarding_shell.tsx
@@ -160,22 +160,22 @@ export function OnboardingShell() {
 
   return (
     <EuiPageTemplate data-test-subj="onboardingShell">
-      <EuiPageTemplate.Section grow={false} paddingSize="l" restrictWidth>
+      <EuiPageTemplate.Section grow={false} paddingSize="m" restrictWidth>
         <EuiFlexGroup direction="column" alignItems="center" gutterSize="s">
-          <EuiFlexItem grow={false}>
+          <EuiFlexGroup direction="row" alignItems="flexEnd" gutterSize="m">
             <EuiIcon type={meta.icon} size="xl" aria-hidden={true} />
-          </EuiFlexItem>
-          <EuiFlexItem>
             <EuiTitle
-              size="m"
+              size="l"
               css={css`
                 text-align: center;
               `}
             >
               <h1>{meta.title}</h1>
             </EuiTitle>
+          </EuiFlexGroup>
+          <EuiFlexItem grow={false}>
             <EuiText
-              size="s"
+              size="m"
               color="subdued"
               css={css`
                 text-align: center;
@@ -185,8 +185,7 @@ export function OnboardingShell() {
             </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiPageTemplate.Section>
-      <EuiPageTemplate.Section paddingSize="xl" restrictWidth>
+        <EuiSpacer size="xs" />
         <EuiStepsHorizontal steps={horizontalStepsConfig} />
         <EuiSpacer size="xl" />
         {CurrentStepComponent && <CurrentStepComponent onContinue={onContinue} onBack={onBack} />}

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/index.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/index.tsx
@@ -15,19 +15,17 @@ import {
   EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHealth,
   EuiPanel,
   EuiSpacer,
   EuiText,
   EuiTitle,
-  euiPaletteColorBlind,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { ServiceRow } from './service_row';
 import { SIGNAL_TYPE_LABELS } from './signal_type_badge';
-import { useServicesStep, CATEGORY_ORDER } from './use_services_step';
+import { useServicesStep } from './use_services_step';
 import type { SignalFilter } from './use_services_step';
 
 interface ServicesStepProps {
@@ -51,13 +49,6 @@ const SIGNAL_FILTER_OPTIONS = [
     }),
   },
 ];
-
-const CATEGORY_COLORS = euiPaletteColorBlind({ rotations: 2 });
-
-function categoryColor(category: string): string {
-  const index = CATEGORY_ORDER.indexOf(category as (typeof CATEGORY_ORDER)[number]);
-  return CATEGORY_COLORS[Math.max(0, index)];
-}
 
 export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
   const {
@@ -151,10 +142,10 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
               >
                 <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
                   <EuiFlexItem>
-                    <EuiHealth color={categoryColor(cat)} textSize="s">
-                      {cat}
-                    </EuiHealth>
-                    <EuiText size="xs" color="subdued" style={{ paddingLeft: 20 }}>
+                    <EuiText size="s">
+                      <strong>{cat}</strong>
+                    </EuiText>
+                    <EuiText size="xs" color="subdued">
                       {preview}
                     </EuiText>
                   </EuiFlexItem>
@@ -169,7 +160,7 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
                         }
                       )}
                     >
-                      {selected}/{total}
+                      {selected > 0 ? `${selected}/${total}` : total}
                     </EuiBadge>
                   </EuiFlexItem>
                 </EuiFlexGroup>
@@ -179,58 +170,71 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
         </EuiFlexItem>
 
         <EuiFlexItem>
-          <EuiPanel paddingSize="m" hasBorder>
+          <EuiPanel paddingSize="none" hasBorder>
             {activeCategory ? (
               <>
-                <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle size="xs">
-                      <h3>{activeCategory}</h3>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    {allInCategorySelected ? (
-                      <EuiButtonEmpty
-                        size="s"
-                        onClick={handleDeselectAllInCategory}
-                        data-test-subj="servicesStep-deselectAllButton"
-                      >
-                        <FormattedMessage
-                          id="xpack.ingestHub.servicesStep.deselectAll"
-                          defaultMessage="Deselect all"
-                        />
-                      </EuiButtonEmpty>
-                    ) : (
-                      <EuiButtonEmpty
-                        size="s"
-                        onClick={handleSelectAllInCategory}
-                        data-test-subj="servicesStep-selectAllButton"
-                      >
-                        <FormattedMessage
-                          id="xpack.ingestHub.servicesStep.selectAll"
-                          defaultMessage="Select all"
-                        />
-                      </EuiButtonEmpty>
-                    )}
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-                <EuiSpacer size="s" />
-                <EuiFlexGrid columns={2} gutterSize="m">
-                  {servicesInCategory.map((service) => (
-                    <EuiFlexItem key={service.id}>
-                      <ServiceRow
-                        service={service}
-                        isSelected={selectedSet.has(service.id)}
-                        onToggle={handleToggle}
-                        displayName={
-                          duplicateNamesInCategory.has(service.name)
-                            ? `${service.name} ${SIGNAL_TYPE_LABELS[service.signalType]}`
-                            : undefined
-                        }
-                      />
+                <EuiPanel
+                  color="subdued"
+                  hasBorder={false}
+                  hasShadow={false}
+                  paddingSize="m"
+                  borderRadius="none"
+                >
+                  <EuiFlexGroup
+                    alignItems="center"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <EuiFlexItem grow={false}>
+                      <EuiTitle size="xs">
+                        <h3>{activeCategory}</h3>
+                      </EuiTitle>
                     </EuiFlexItem>
-                  ))}
-                </EuiFlexGrid>
+                    <EuiFlexItem grow={false}>
+                      {allInCategorySelected ? (
+                        <EuiButtonEmpty
+                          size="s"
+                          onClick={handleDeselectAllInCategory}
+                          data-test-subj="servicesStep-deselectAllButton"
+                        >
+                          <FormattedMessage
+                            id="xpack.ingestHub.servicesStep.deselectAll"
+                            defaultMessage="Deselect all"
+                          />
+                        </EuiButtonEmpty>
+                      ) : (
+                        <EuiButtonEmpty
+                          size="s"
+                          onClick={handleSelectAllInCategory}
+                          data-test-subj="servicesStep-selectAllButton"
+                        >
+                          <FormattedMessage
+                            id="xpack.ingestHub.servicesStep.selectAll"
+                            defaultMessage="Select all"
+                          />
+                        </EuiButtonEmpty>
+                      )}
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiPanel>
+                <EuiPanel paddingSize="m" hasBorder={false} hasShadow={false}>
+                  <EuiFlexGrid columns={2} gutterSize="m">
+                    {servicesInCategory.map((service) => (
+                      <EuiFlexItem key={service.id}>
+                        <ServiceRow
+                          service={service}
+                          isSelected={selectedSet.has(service.id)}
+                          onToggle={handleToggle}
+                          displayName={
+                            duplicateNamesInCategory.has(service.name)
+                              ? `${service.name} ${SIGNAL_TYPE_LABELS[service.signalType]}`
+                              : undefined
+                          }
+                        />
+                      </EuiFlexItem>
+                    ))}
+                  </EuiFlexGrid>
+                </EuiPanel>
               </>
             ) : null}
           </EuiPanel>

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/index.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/index.tsx
@@ -65,13 +65,13 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
     setSignalFilter,
     searchQuery,
     setSearchQuery,
-    filteredServices,
     categories,
     activeCategory,
     setSelectedCategory,
     servicesInCategory,
     duplicateNamesInCategory,
     selectedSet,
+    categoryStats,
     isReady,
     handleToggle,
     allInCategorySelected,
@@ -129,15 +129,14 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
 
       <EuiSpacer size="s" />
 
-      <EuiFlexGroup gutterSize="m" alignItems="flexStart" responsive={false}>
-        <EuiFlexItem grow={false} style={{ width: 240 }}>
+      <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false}>
+        <EuiFlexItem grow={false} style={{ maxWidth: 350 }}>
           {categories.map((cat) => {
             const isActive = cat === activeCategory;
-            const catServices = filteredServices.filter((s) => s.category === cat);
-            const catSelectedCount = catServices.filter((s) => selectedSet.has(s.id)).length;
-            const uniqueNames = [...new Set(catServices.map((s) => s.name))];
-            const preview =
-              uniqueNames.slice(0, 2).join(', ') + (uniqueNames.length > 2 ? ', ...' : '');
+            const stats = categoryStats.get(cat);
+            const selected = stats?.selected ?? 0;
+            const total = stats?.total ?? 0;
+            const preview = stats?.preview ?? '';
 
             return (
               <EuiPanel
@@ -150,7 +149,7 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
                 style={{ cursor: 'pointer' }}
                 data-test-subj={`servicesStep-category-${cat}`}
               >
-                <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
                   <EuiFlexItem>
                     <EuiHealth color={categoryColor(cat)} textSize="s">
                       {cat}
@@ -159,11 +158,20 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
                       {preview}
                     </EuiText>
                   </EuiFlexItem>
-                  {catSelectedCount > 0 && (
-                    <EuiFlexItem grow={false}>
-                      <EuiBadge color="hollow">{catSelectedCount}</EuiBadge>
-                    </EuiFlexItem>
-                  )}
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge
+                      color="default"
+                      aria-label={i18n.translate(
+                        'xpack.ingestHub.servicesStep.categoryBadgeAriaLabel',
+                        {
+                          defaultMessage: '{selected} of {total} services selected',
+                          values: { selected, total },
+                        }
+                      )}
+                    >
+                      {selected}/{total}
+                    </EuiBadge>
+                  </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiPanel>
             );
@@ -207,7 +215,7 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiSpacer size="s" />
-                <EuiFlexGrid columns={2} gutterSize="s">
+                <EuiFlexGrid columns={2} gutterSize="m">
                   {servicesInCategory.map((service) => (
                     <EuiFlexItem key={service.id}>
                       <ServiceRow

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/index.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/index.tsx
@@ -82,7 +82,7 @@ export function ServicesStep({ onContinue, onBack }: ServicesStepProps) {
 
   return (
     <div data-test-subj="onboardingStep-services">
-      <EuiTitle size="l">
+      <EuiTitle size="m">
         <h2>
           <FormattedMessage
             id="xpack.ingestHub.servicesStep.title"

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_icon.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_icon.test.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+
+jest.mock('@kbn/fleet-plugin/public', () => ({
+  useGetPackageInfoByKeyQuery: jest.fn(),
+}));
+
+import { useGetPackageInfoByKeyQuery } from '@kbn/fleet-plugin/public';
+import { ELASTIC_PACKAGE_REGISTRY_URL } from '../../../../common/constants';
+import { ServiceIcon } from './service_icon';
+import type { AwsServiceMatrixEntry } from '../../aws_service_matrix';
+
+const mockUseGetPackageInfoByKeyQuery = useGetPackageInfoByKeyQuery as jest.Mock;
+
+const BASE_SERVICE: AwsServiceMatrixEntry = {
+  id: 's3_logs',
+  name: 'Amazon S3',
+  category: 'Storage',
+  signalType: 'logs',
+  packageName: 'aws',
+  policyTemplate: 's3',
+  deliveryMethods: [{ method: 'agentless' }],
+  defaultEnabled: false,
+  showInUI: true,
+};
+
+const S3_ICON = {
+  src: '/img/logo_s3.svg',
+  path: '/package/aws/7.1.0/img/logo_s3.svg',
+  type: 'image/svg+xml',
+};
+const AWS_PKG_ICON = {
+  src: '/img/logo_aws.svg',
+  path: '/package/aws/7.1.0/img/logo_aws.svg',
+  type: 'image/svg+xml',
+};
+const FARGATE_ICON = {
+  src: '/img/logo_fargate.svg',
+  path: '/package/awsfargate/1.3.0/img/logo_fargate.svg',
+  type: 'image/svg+xml',
+};
+
+const renderIcon = (service: AwsServiceMatrixEntry) =>
+  render(
+    <I18nProvider>
+      <ServiceIcon service={service} />
+    </I18nProvider>
+  );
+
+describe('ServiceIcon', () => {
+  beforeEach(() => {
+    mockUseGetPackageInfoByKeyQuery.mockClear();
+  });
+
+  it('shows a skeleton while the query is loading', () => {
+    mockUseGetPackageInfoByKeyQuery.mockReturnValue({ isLoading: true, data: undefined });
+    const { container } = renderIcon(BASE_SERVICE);
+    expect(container.querySelector('.euiSkeletonRectangle')).not.toBeNull();
+  });
+
+  it('tier 1: renders an img with the policy-template icon URL', () => {
+    mockUseGetPackageInfoByKeyQuery.mockReturnValue({
+      isLoading: false,
+      data: {
+        item: {
+          version: '7.1.0',
+          icons: [AWS_PKG_ICON],
+          policy_templates: [{ name: 's3', icons: [S3_ICON] }],
+        },
+      },
+    });
+
+    const { container } = renderIcon(BASE_SERVICE);
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe(
+      `${ELASTIC_PACKAGE_REGISTRY_URL}/package/aws/7.1.0/img/logo_s3.svg`
+    );
+  });
+
+  it('tier 2: falls back to the package-level icon when no policy-template match', () => {
+    const service: AwsServiceMatrixEntry = {
+      ...BASE_SERVICE,
+      packageName: 'awsfargate',
+      policyTemplate: undefined,
+    };
+
+    mockUseGetPackageInfoByKeyQuery.mockReturnValue({
+      isLoading: false,
+      data: {
+        item: {
+          version: '1.3.0',
+          icons: [FARGATE_ICON],
+          policy_templates: [],
+        },
+      },
+    });
+
+    const { container } = renderIcon(service);
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe(
+      `${ELASTIC_PACKAGE_REGISTRY_URL}/package/awsfargate/1.3.0/img/logo_fargate.svg`
+    );
+  });
+
+  it('tier 3: renders logoAWS EuiIcon when package returns no icons', () => {
+    mockUseGetPackageInfoByKeyQuery.mockReturnValue({
+      isLoading: false,
+      data: { item: { version: '7.1.0', icons: [], policy_templates: [] } },
+    });
+
+    const { container } = renderIcon(BASE_SERVICE);
+    expect(container.querySelector('img')).toBeNull();
+    expect(document.querySelector('[data-euiicon-type="logoAWS"]')).not.toBeNull();
+  });
+
+  it('tier 3: renders logoAWS EuiIcon when query returns no data', () => {
+    mockUseGetPackageInfoByKeyQuery.mockReturnValue({ isLoading: false, data: undefined });
+
+    const { container } = renderIcon(BASE_SERVICE);
+    expect(container.querySelector('img')).toBeNull();
+    expect(document.querySelector('[data-euiicon-type="logoAWS"]')).not.toBeNull();
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_icon.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_icon.test.tsx
@@ -13,8 +13,23 @@ jest.mock('@kbn/fleet-plugin/public', () => ({
   useGetPackageInfoByKeyQuery: jest.fn(),
 }));
 
+jest.mock('@kbn/fleet-plugin/common', () => ({
+  epmRouteService: {
+    getFilePath: (path: string) => `/api/fleet/epm${path.replace('/package', '/packages')}`,
+  },
+}));
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => ({
+    services: {
+      http: {
+        basePath: { prepend: (path: string) => path },
+      },
+    },
+  }),
+}));
+
 import { useGetPackageInfoByKeyQuery } from '@kbn/fleet-plugin/public';
-import { ELASTIC_PACKAGE_REGISTRY_URL } from '../../../../common/constants';
 import { ServiceIcon } from './service_icon';
 import type { AwsServiceMatrixEntry } from '../../aws_service_matrix';
 
@@ -71,6 +86,7 @@ describe('ServiceIcon', () => {
       isLoading: false,
       data: {
         item: {
+          name: 'aws',
           version: '7.1.0',
           icons: [AWS_PKG_ICON],
           policy_templates: [{ name: 's3', icons: [S3_ICON] }],
@@ -80,9 +96,7 @@ describe('ServiceIcon', () => {
 
     const { container } = renderIcon(BASE_SERVICE);
     const img = container.querySelector('img');
-    expect(img?.getAttribute('src')).toBe(
-      `${ELASTIC_PACKAGE_REGISTRY_URL}/package/aws/7.1.0/img/logo_s3.svg`
-    );
+    expect(img?.getAttribute('src')).toBe('/api/fleet/epm/packages/aws/7.1.0/img/logo_s3.svg');
   });
 
   it('tier 2: falls back to the package-level icon when no policy-template match', () => {
@@ -96,6 +110,7 @@ describe('ServiceIcon', () => {
       isLoading: false,
       data: {
         item: {
+          name: 'awsfargate',
           version: '1.3.0',
           icons: [FARGATE_ICON],
           policy_templates: [],
@@ -106,14 +121,14 @@ describe('ServiceIcon', () => {
     const { container } = renderIcon(service);
     const img = container.querySelector('img');
     expect(img?.getAttribute('src')).toBe(
-      `${ELASTIC_PACKAGE_REGISTRY_URL}/package/awsfargate/1.3.0/img/logo_fargate.svg`
+      '/api/fleet/epm/packages/awsfargate/1.3.0/img/logo_fargate.svg'
     );
   });
 
   it('tier 3: renders logoAWS EuiIcon when package returns no icons', () => {
     mockUseGetPackageInfoByKeyQuery.mockReturnValue({
       isLoading: false,
-      data: { item: { version: '7.1.0', icons: [], policy_templates: [] } },
+      data: { item: { name: 'aws', version: '7.1.0', icons: [], policy_templates: [] } },
     });
 
     const { container } = renderIcon(BASE_SERVICE);

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_icon.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_icon.tsx
@@ -8,8 +8,11 @@
 import React from 'react';
 import { EuiIcon, EuiSkeletonRectangle } from '@elastic/eui';
 import { useGetPackageInfoByKeyQuery } from '@kbn/fleet-plugin/public';
+import { epmRouteService } from '@kbn/fleet-plugin/common';
 
-import { ELASTIC_PACKAGE_REGISTRY_URL } from '../../../../common/constants';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { CoreStart } from '@kbn/core/public';
+
 import type { AwsServiceMatrixEntry } from '../../aws_service_matrix';
 
 const ICON_SIZE = 24;
@@ -19,32 +22,41 @@ interface ServiceIconProps {
 }
 
 export const ServiceIcon: React.FC<ServiceIconProps> = ({ service }) => {
+  const { services } = useKibana<CoreStart>();
   const { data, isLoading } = useGetPackageInfoByKeyQuery(service.packageName);
 
   if (isLoading) {
-    return <EuiSkeletonRectangle width="16px" height="16px" borderRadius="s" />;
+    return (
+      <EuiSkeletonRectangle width={`${ICON_SIZE}px`} height={`${ICON_SIZE}px`} borderRadius="s" />
+    );
   }
 
   const packageInfo = data?.item;
 
-  // Tier 1: icon from the matching policy template (RegistryImage, always has path at runtime)
-  const policyTemplateIcon = packageInfo?.policy_templates?.find(
-    (pt) => pt.name === service.policyTemplate
-  )?.icons?.[0] as { path?: string } | undefined;
+  // Tier 1: icon from the matching policy template
+  const policyTemplateIcon = packageInfo?.policy_templates
+    ?.find((pt) => pt.name === service.policyTemplate)
+    ?.icons?.find((icon) => icon.type === 'image/svg+xml');
 
-  // Tier 2: package-level icon (PackageSpecIcon from manifest, path present at runtime)
-  const packageIcon = packageInfo?.icons?.[0] as { path?: string } | undefined;
+  // Tier 2: package-level icon
+  const packageIcon = packageInfo?.icons?.find((icon) => icon.type === 'image/svg+xml');
 
-  const iconPath = policyTemplateIcon?.path ?? packageIcon?.path;
+  const icon = policyTemplateIcon ?? packageIcon;
 
-  if (iconPath) {
+  if (icon && packageInfo) {
+    // Use .src (relative path within the package) the same way Fleet's getEuiIconType does,
+    // so epmRouteService.getFilePath builds a valid Kibana proxy URL instead of a malformed one.
+    const src = services.http.basePath.prepend(
+      epmRouteService.getFilePath(`/package/${packageInfo.name}/${packageInfo.version}${icon.src}`)
+    );
     return (
       <img
-        src={ELASTIC_PACKAGE_REGISTRY_URL + iconPath}
+        src={src}
         width={ICON_SIZE}
         height={ICON_SIZE}
         alt=""
         aria-hidden={true}
+        loading="lazy"
         style={{ flexShrink: 0 }}
       />
     );

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_icon.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_icon.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiIcon, EuiSkeletonRectangle } from '@elastic/eui';
+import { useGetPackageInfoByKeyQuery } from '@kbn/fleet-plugin/public';
+
+import { ELASTIC_PACKAGE_REGISTRY_URL } from '../../../../common/constants';
+import type { AwsServiceMatrixEntry } from '../../aws_service_matrix';
+
+const ICON_SIZE = 24;
+
+interface ServiceIconProps {
+  service: AwsServiceMatrixEntry;
+}
+
+export const ServiceIcon: React.FC<ServiceIconProps> = ({ service }) => {
+  const { data, isLoading } = useGetPackageInfoByKeyQuery(service.packageName);
+
+  if (isLoading) {
+    return <EuiSkeletonRectangle width="16px" height="16px" borderRadius="s" />;
+  }
+
+  const packageInfo = data?.item;
+
+  // Tier 1: icon from the matching policy template (RegistryImage, always has path at runtime)
+  const policyTemplateIcon = packageInfo?.policy_templates?.find(
+    (pt) => pt.name === service.policyTemplate
+  )?.icons?.[0] as { path?: string } | undefined;
+
+  // Tier 2: package-level icon (PackageSpecIcon from manifest, path present at runtime)
+  const packageIcon = packageInfo?.icons?.[0] as { path?: string } | undefined;
+
+  const iconPath = policyTemplateIcon?.path ?? packageIcon?.path;
+
+  if (iconPath) {
+    return (
+      <img
+        src={ELASTIC_PACKAGE_REGISTRY_URL + iconPath}
+        width={ICON_SIZE}
+        height={ICON_SIZE}
+        alt=""
+        aria-hidden={true}
+        style={{ flexShrink: 0 }}
+      />
+    );
+  }
+
+  // Tier 3: generic AWS logo
+  return <EuiIcon type="logoAWS" size="l" aria-hidden={true} />;
+};

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_row.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_row.tsx
@@ -10,6 +10,7 @@ import { EuiCheckableCard, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/e
 
 import type { AwsServiceMatrixEntry } from '../../aws_service_matrix';
 import { SignalTypeBadge } from './signal_type_badge';
+import { ServiceIcon } from './service_icon';
 
 interface ServiceRowProps {
   service: AwsServiceMatrixEntry;
@@ -25,30 +26,28 @@ export const ServiceRow: React.FC<ServiceRowProps> = ({
   displayName,
 }) => {
   return (
-    <div data-test-subj={`servicesStep-serviceRow-${service.id}`}>
-      <EuiCheckableCard
-        id={`service-toggle-${service.id}`}
-        label={
-          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
-            <EuiFlexItem>
-              <EuiText size="s">
-                <strong>{displayName ?? service.name}</strong>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                <EuiFlexItem grow={false}>
-                  <SignalTypeBadge signalType={service.signalType} />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        }
-        checkableType="checkbox"
-        checked={isSelected}
-        onChange={(e) => onToggle(service.id, e.target.checked)}
-        data-test-subj={`servicesStep-toggle-${service.id}`}
-      />
-    </div>
+    <EuiCheckableCard
+      id={`service-toggle-${service.id}`}
+      css={{ flex: 1 }}
+      data-test-subj={`servicesStep-serviceRow-${service.id}`}
+      label={
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <ServiceIcon service={service} />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s">
+              <strong>{displayName ?? service.name}</strong>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <SignalTypeBadge signalType={service.signalType} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+      checkableType="checkbox"
+      checked={isSelected}
+      onChange={(e) => onToggle(service.id, e.target.checked)}
+    />
   );
 };

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_row.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/service_row.tsx
@@ -26,28 +26,30 @@ export const ServiceRow: React.FC<ServiceRowProps> = ({
   displayName,
 }) => {
   return (
-    <EuiCheckableCard
-      id={`service-toggle-${service.id}`}
-      css={{ flex: 1 }}
-      data-test-subj={`servicesStep-serviceRow-${service.id}`}
-      label={
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <ServiceIcon service={service} />
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size="s">
-              <strong>{displayName ?? service.name}</strong>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <SignalTypeBadge signalType={service.signalType} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-      checkableType="checkbox"
-      checked={isSelected}
-      onChange={(e) => onToggle(service.id, e.target.checked)}
-    />
+    <div data-test-subj={`servicesStep-serviceRow-${service.id}`} css={{ flex: 1 }}>
+      <EuiCheckableCard
+        id={`service-toggle-${service.id}`}
+        css={{ height: '100%' }}
+        data-test-subj={`servicesStep-toggle-${service.id}`}
+        label={
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <ServiceIcon service={service} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="s">
+                <strong>{displayName ?? service.name}</strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <SignalTypeBadge signalType={service.signalType} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        checkableType="checkbox"
+        checked={isSelected}
+        onChange={(e) => onToggle(service.id, e.target.checked)}
+      />
+    </div>
   );
 };

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/signal_type_badge.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/signal_type_badge.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { css } from '@emotion/react';
-import { EuiBadge, useEuiTheme } from '@elastic/eui';
+import { EuiBadge } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import type { SignalType } from '../../aws_service_matrix';
@@ -26,17 +25,5 @@ interface SignalTypeBadgeProps {
 }
 
 export const SignalTypeBadge: React.FC<SignalTypeBadgeProps> = ({ signalType }) => {
-  const { euiTheme } = useEuiTheme();
-  const color = signalType === 'logs' ? euiTheme.colors.textPrimary : euiTheme.colors.textSuccess;
-  return (
-    <EuiBadge
-      color="hollow"
-      css={css`
-        color: ${color} !important;
-        border-color: ${color};
-      `}
-    >
-      {SIGNAL_TYPE_LABELS[signalType]}
-    </EuiBadge>
-  );
+  return <EuiBadge color="hollow">{SIGNAL_TYPE_LABELS[signalType]}</EuiBadge>;
 };

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/signal_type_badge.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/signal_type_badge.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiBadge } from '@elastic/eui';
+import { EuiBadge, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import type { SignalType } from '../../aws_service_matrix';
@@ -20,15 +20,16 @@ export const SIGNAL_TYPE_LABELS: Record<SignalType, string> = {
   }),
 };
 
-const COLORS: Record<SignalType, string> = {
-  logs: 'primary',
-  metrics: 'success',
-};
-
 interface SignalTypeBadgeProps {
   signalType: SignalType;
 }
 
-export const SignalTypeBadge: React.FC<SignalTypeBadgeProps> = ({ signalType }) => (
-  <EuiBadge color={COLORS[signalType]}>{SIGNAL_TYPE_LABELS[signalType]}</EuiBadge>
-);
+export const SignalTypeBadge: React.FC<SignalTypeBadgeProps> = ({ signalType }) => {
+  const { euiTheme } = useEuiTheme();
+  const color = signalType === 'logs' ? euiTheme.colors.primary : euiTheme.colors.success;
+  return (
+    <EuiBadge color="hollow" style={{ color, borderColor: color }}>
+      {SIGNAL_TYPE_LABELS[signalType]}
+    </EuiBadge>
+  );
+};

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/signal_type_badge.tsx
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/signal_type_badge.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/react';
 import { EuiBadge, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -26,9 +27,15 @@ interface SignalTypeBadgeProps {
 
 export const SignalTypeBadge: React.FC<SignalTypeBadgeProps> = ({ signalType }) => {
   const { euiTheme } = useEuiTheme();
-  const color = signalType === 'logs' ? euiTheme.colors.primary : euiTheme.colors.success;
+  const color = signalType === 'logs' ? euiTheme.colors.textPrimary : euiTheme.colors.textSuccess;
   return (
-    <EuiBadge color="hollow" style={{ color, borderColor: color }}>
+    <EuiBadge
+      color="hollow"
+      css={css`
+        color: ${color} !important;
+        border-color: ${color};
+      `}
+    >
       {SIGNAL_TYPE_LABELS[signalType]}
     </EuiBadge>
   );

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/use_services_step.test.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/use_services_step.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+
+jest.mock('../../onboarding_flow_context', () => ({
+  useOnboardingFlow: jest.fn(),
+}));
+
+import { useOnboardingFlow } from '../../onboarding_flow_context';
+import { useServicesStep } from './use_services_step';
+import { AWS_SERVICES_MATRIX } from '../../aws_service_matrix';
+
+const mockUseOnboardingFlow = useOnboardingFlow as jest.Mock;
+
+// Use a real writable ref so setSelectedServiceIds triggers re-renders.
+function setupFlow(initial: string[] = []) {
+  let ids = initial;
+  mockUseOnboardingFlow.mockImplementation(() => ({
+    servicesStep: { selectedServiceIds: ids },
+    setSelectedServiceIds: jest.fn((next: string[]) => {
+      ids = next;
+      // Re-mock so next render picks up the new ids.
+      setupFlow(ids);
+    }),
+  }));
+}
+
+describe('useServicesStep — categoryStats signal-filter consistency', () => {
+  beforeEach(() => setupFlow());
+
+  it('badge total is not narrowed by the search query', () => {
+    const { result } = renderHook(() => useServicesStep({ onContinue: jest.fn() }));
+
+    const [firstCat] = result.current.categories;
+    const totalBeforeSearch = result.current.categoryStats.get(firstCat)?.total ?? 0;
+    expect(totalBeforeSearch).toBeGreaterThan(0);
+
+    // Apply a search that matches nothing — categories list collapses, but we
+    // saved firstCat above. Re-render with a search that matches the category name
+    // so the category stays visible but the service count would shrink if we used
+    // filteredServices. Instead use a partial match that hits at least one service.
+    const firstService = AWS_SERVICES_MATRIX.find((s) => s.showInUI && s.category === firstCat);
+    expect(firstService).toBeDefined();
+
+    act(() => {
+      result.current.setSearchQuery(firstService!.name.slice(0, 5));
+    });
+
+    // The category should still be present (search matched at least one service in it).
+    const statsAfterSearch = result.current.categoryStats.get(firstCat);
+    expect(statsAfterSearch).toBeDefined();
+    // total must be the full signal-filtered count for the category, not just the search hits.
+    expect(statsAfterSearch!.total).toBe(totalBeforeSearch);
+  });
+
+  it('badge total matches the signal-filtered count, not the full category count', () => {
+    const { result } = renderHook(() => useServicesStep({ onContinue: jest.fn() }));
+
+    // Find a category that has services of both signal types.
+    const mixedCat = result.current.categories.find((cat) => {
+      const allInCat = AWS_SERVICES_MATRIX.filter((s) => s.showInUI && s.category === cat);
+      const hasLogs = allInCat.some((s) => s.signalType === 'logs');
+      const hasMetrics = allInCat.some((s) => s.signalType === 'metrics');
+      return hasLogs && hasMetrics;
+    });
+
+    if (!mixedCat) return; // No mixed category in the matrix — skip.
+
+    const allInMixed = AWS_SERVICES_MATRIX.filter((s) => s.showInUI && s.category === mixedCat);
+    const expectedLogsTotal = allInMixed.filter((s) => s.signalType === 'logs').length;
+    const expectedMetricsTotal = allInMixed.filter((s) => s.signalType === 'metrics').length;
+
+    act(() => result.current.setSignalFilter('logs'));
+    const logsStats = result.current.categoryStats.get(mixedCat);
+    expect(logsStats?.total).toBe(expectedLogsTotal);
+
+    act(() => result.current.setSignalFilter('metrics'));
+    const metricsStats = result.current.categoryStats.get(mixedCat);
+    expect(metricsStats?.total).toBe(expectedMetricsTotal);
+  });
+
+  it('selected count only includes signal-filtered services', () => {
+    const { result } = renderHook(() => useServicesStep({ onContinue: jest.fn() }));
+
+    // Find a category with metrics services.
+    act(() => result.current.setSignalFilter('metrics'));
+
+    const [firstCat] = result.current.categories;
+    expect(firstCat).toBeDefined();
+
+    const metricsInCat = AWS_SERVICES_MATRIX.filter(
+      (s) => s.showInUI && s.category === firstCat && s.signalType === 'metrics'
+    );
+    expect(metricsInCat.length).toBeGreaterThan(0);
+
+    // Manually pre-select all metrics services in that category.
+    setupFlow(metricsInCat.map((s) => s.id));
+
+    const { result: result2 } = renderHook(() => useServicesStep({ onContinue: jest.fn() }));
+    act(() => result2.current.setSignalFilter('metrics'));
+
+    const stats = result2.current.categoryStats.get(firstCat);
+    expect(stats?.selected).toBe(metricsInCat.length);
+    expect(stats?.total).toBe(metricsInCat.length);
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/use_services_step.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/use_services_step.ts
@@ -72,6 +72,19 @@ export function useServicesStep({ onContinue }: { onContinue: () => void }) {
 
   const selectedSet = useMemo(() => new Set(selectedServiceIds), [selectedServiceIds]);
 
+  const categoryStats = useMemo(() => {
+    const stats = new Map<ServiceCategory, { total: number; selected: number; preview: string }>();
+    for (const cat of categories) {
+      const catServices = filteredServices.filter((s) => s.category === cat);
+      const total = catServices.length;
+      const selected = catServices.filter((s) => selectedSet.has(s.id)).length;
+      const uniqueNames = [...new Set(catServices.map((s) => s.name))];
+      const preview = uniqueNames.slice(0, 2).join(', ') + (uniqueNames.length > 2 ? ', ...' : '');
+      stats.set(cat, { total, selected, preview });
+    }
+    return stats;
+  }, [categories, filteredServices, selectedSet]);
+
   const isReady = selectedServiceIds.length > 0;
 
   const handleToggle = useCallback(
@@ -116,6 +129,7 @@ export function useServicesStep({ onContinue }: { onContinue: () => void }) {
     servicesInCategory,
     duplicateNamesInCategory,
     selectedSet,
+    categoryStats,
     isReady,
     handleToggle,
     allInCategorySelected,

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/use_services_step.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/use_services_step.ts
@@ -72,19 +72,28 @@ export function useServicesStep({ onContinue }: { onContinue: () => void }) {
 
   const selectedSet = useMemo(() => new Set(selectedServiceIds), [selectedServiceIds]);
 
+  // Signal-filtered but search-independent set: matches what "Select all" operates on,
+  // so total/selected in the badge stay reachable under the active signal filter.
+  const signalFilteredServices = useMemo(
+    () =>
+      AWS_SERVICES_MATRIX.filter(
+        (s) => s.showInUI && (signalFilter === 'all' || s.signalType === signalFilter)
+      ),
+    [signalFilter]
+  );
+
   const categoryStats = useMemo(() => {
     const stats = new Map<ServiceCategory, { total: number; selected: number; preview: string }>();
     for (const cat of categories) {
-      // Use the unfiltered matrix so total/selected are stable while search is active.
-      const allCatServices = AWS_SERVICES_MATRIX.filter((s) => s.showInUI && s.category === cat);
-      const total = allCatServices.length;
-      const selected = allCatServices.filter((s) => selectedSet.has(s.id)).length;
-      const uniqueNames = [...new Set(allCatServices.map((s) => s.name))];
+      const catServices = signalFilteredServices.filter((s) => s.category === cat);
+      const total = catServices.length;
+      const selected = catServices.filter((s) => selectedSet.has(s.id)).length;
+      const uniqueNames = [...new Set(catServices.map((s) => s.name))];
       const preview = uniqueNames.slice(0, 2).join(', ') + (uniqueNames.length > 2 ? ', ...' : '');
       stats.set(cat, { total, selected, preview });
     }
     return stats;
-  }, [categories, selectedSet]);
+  }, [categories, signalFilteredServices, selectedSet]);
 
   const isReady = selectedServiceIds.length > 0;
 

--- a/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/use_services_step.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/public/onboarding/step_components/services_step/use_services_step.ts
@@ -75,15 +75,16 @@ export function useServicesStep({ onContinue }: { onContinue: () => void }) {
   const categoryStats = useMemo(() => {
     const stats = new Map<ServiceCategory, { total: number; selected: number; preview: string }>();
     for (const cat of categories) {
-      const catServices = filteredServices.filter((s) => s.category === cat);
-      const total = catServices.length;
-      const selected = catServices.filter((s) => selectedSet.has(s.id)).length;
-      const uniqueNames = [...new Set(catServices.map((s) => s.name))];
+      // Use the unfiltered matrix so total/selected are stable while search is active.
+      const allCatServices = AWS_SERVICES_MATRIX.filter((s) => s.showInUI && s.category === cat);
+      const total = allCatServices.length;
+      const selected = allCatServices.filter((s) => selectedSet.has(s.id)).length;
+      const uniqueNames = [...new Set(allCatServices.map((s) => s.name))];
       const preview = uniqueNames.slice(0, 2).join(', ') + (uniqueNames.length > 2 ? ', ...' : '');
       stats.set(cat, { total, selected, preview });
     }
     return stats;
-  }, [categories, filteredServices, selectedSet]);
+  }, [categories, selectedSet]);
 
   const isReady = selectedServiceIds.length > 0;
 


### PR DESCRIPTION
Closes https://github.com/elastic/ingest-dev/issues/8944

## Summary

This PR implements several visual enhancements to step 1 of AWS onboarding, based on new designs.

1.  Added service icons
2. Implemented selection count per category, visible on a badge in the category column
3. Visual changes to the header
4. Various visual adjustments: spacing, layout, styling etc

### Testing 
Enable feature flag:
```
feature_flags.overrides:
  ingestHub.onboardingEnabled: true
```
Navigate to `http://localhost:5601/app/onboarding/aws#services`

https://github.com/user-attachments/assets/6d797b7e-3299-4a63-a504-d672968acc4e



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




