### PR TITLE
[Scout] Add Buildkite pipeline for batch test channels

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-scout-batch-tests.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-scout-batch-tests.yml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: bk-kibana-scout-batch-tests
+  description: Runs Scout tests on a schedule for the batch test channels (ci-batch-3h, ci-batch-daily, ci-batch-weekly)
+  links:
+    - url: 'https://buildkite.com/elastic/kibana-scout-batch-tests'
+      title: Pipeline link
+spec:
+  type: buildkite-pipeline
+  owner: 'group:kibana-operations'
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana / scout / batch-tests
+      description: Runs Scout tests on a schedule for the batch test channels
+    spec:
+      env:
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
+        KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_SKIP_FOR_RETRIES: 'true'
+        REPORT_FAILED_TESTS_TO_GITHUB: 'true'
+      allow_rebuilds: true
+      branch_configuration: main
+      default_branch: main
+      repository: elastic/kibana
+      pipeline_file: .buildkite/pipelines/scout_batch_tests.yml
+      skip_intermediate_builds: false
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        publish_commit_status: false
+        trigger_mode: none
+        prefix_pull_request_fork_branch_names: false
+        skip_pull_request_builds_for_existing_commits: false
+      schedules:
+        'ci-batch-3h (main)':
+          cronline: '0 */3 * * *'
+          message: Scout batch tests - ci-batch-3h
+          branch: main
+          env:
+            SCOUT_TEST_CHANNELS: ci-batch-3h
+        'ci-batch-daily (main)':
+          cronline: '0 2 * * *'
+          message: Scout batch tests - ci-batch-daily
+          branch: main
+          env:
+            SCOUT_TEST_CHANNELS: ci-batch-daily
+        'ci-batch-weekly (main)':
+          cronline: '0 3 * * 1'
+          message: Scout batch tests - ci-batch-weekly
+          branch: main
+          env:
+            SCOUT_TEST_CHANNELS: ci-batch-weekly
+      teams:
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+        appex-qa:
+          access_level: MANAGE_BUILD_AND_READ
+        kibana-tech-leads:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipelines/scout_batch_tests.yml
+++ b/.buildkite/pipelines/scout_batch_tests.yml
@@ -1,0 +1,90 @@
+env:
+  TEST_BROWSER_HEADLESS: 1
+
+steps:
+  - command: .buildkite/scripts/lifecycle/pre_build.sh
+    label: Pre-Build
+    key: pre-build
+    timeout_in_minutes: 10
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-2
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - wait
+
+  - command: .buildkite/scripts/steps/store_cache.sh
+    label: Store Cache for build
+    timeout_in_minutes: 10
+    id: store_cache
+    soft_fail: true
+    depends_on:
+      - terrazzo-initial-pipeline-upload
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-highcpu-8
+      diskSizeGb: 130
+
+  - command: .buildkite/scripts/steps/build_kibana.sh
+    label: Build Kibana Distribution
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-8
+      preemptible: true
+      diskSizeGb: 150
+    key: build
+    if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
+    depends_on: pre-build
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+
+  - wait
+
+  # SCOUT_TEST_CHANNELS is set by each schedule in the pipeline resource definition,
+  # selecting the appropriate batch channel (ci-batch-3h, ci-batch-daily, or
+  # ci-batch-weekly). Manual builds default to testChannels.default if not set.
+  - command: .buildkite/scripts/steps/test/scout/test_run_builder.sh
+    label: 'Scout Test Run Builder'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2d-standard-8
+      diskSizeGb: 130
+    key: build_scout_tests
+    timeout_in_minutes: 20
+    env:
+      SCOUT_TEST_DISTRIBUTION_STRATEGY: 'lanes'
+      SCOUT_TEST_LANES_GROUP_DEPS: 'build_scout_tests,build'
+      SCOUT_TEST_SERVER_START_TIMEOUT_SECONDS: 300
+      SCOUT_TEST_LANE_ESTIMATED_SETUP_MINUTES: 5
+      SCOUT_TEST_LANE_TARGET_RUNTIME_MINUTES: 30
+      SELECTIVE_TESTING_ENABLED: 'false'
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - wait: ~
+    continue_on_failure: true
+
+  - command: .buildkite/scripts/lifecycle/post_build.sh
+    label: Post-Build
+    timeout_in_minutes: 10
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-2


### PR DESCRIPTION
## Summary

Adds a Buildkite pipeline that runs Scout tests on a schedule for the **batch test channels** introduced in #276667.

## New files

| File | Purpose |
|------|---------|
| `.buildkite/pipelines/scout_batch_tests.yml` | Pipeline definition: pre-build → Kibana build → Scout test run builder → post-build |
| `.buildkite/pipeline-resource-definitions/kibana-scout-batch-tests.yml` | Pipeline registration with three schedules, one per batch channel |

## How it works

`SCOUT_TEST_CHANNELS` is **not** hard-coded in the pipeline YAML — each Buildkite schedule sets it via schedule-level `env:`, letting `test_run_builder.sh` → `create-test-tracks` filter configs to the right channel. Selective testing is disabled (`SELECTIVE_TESTING_ENABLED: 'false'`) so all configs assigned to a channel run on every build.

### Schedules (on `main`)

| Schedule | Cron | Channel |
|----------|------|---------|
| `ci-batch-3h` | `0 */3 * * *` | `ci-batch-3h` |
| `ci-batch-daily` | `0 2 * * *` | `ci-batch-daily` |
| `ci-batch-weekly` | `0 3 * * 1` | `ci-batch-weekly` |

The `ci-batch-3h` schedule runs immediately against all configs that declare it (or default to it). The `ci-batch-daily` and `ci-batch-weekly` schedules are ready for configs that opt in via `metadata.scout.testChannels` in their Playwright config.

### Manual triggers

A manual build without `SCOUT_TEST_CHANNELS` set will fall back to `testChannels.default` (`['ci-on-commit', 'ci-batch-3h']`), which is safe.

## Test plan

- [ ] Trigger a manual build of the new pipeline with `SCOUT_TEST_CHANNELS=ci-batch-3h` and verify the Scout Test Run Builder emits lanes
- [ ] Confirm post-build lifecycle step reports success/failure correctly
- [ ] After merging, verify the three Buildkite schedules are active in the pipeline settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)