### PR TITLE
chore(security, axios): migrate ui_capabilities FTR services to fetch (phase 6)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -449,7 +449,6 @@ const AXIOS_LEGACY_CONSUMERS = [
   'x-pack/examples/alerting_example/server/rule_types/**/*.{js,mjs,ts,tsx}',
   'x-pack/packages/kbn-synthetics-private-location/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/packages/shared/kbn-data-forge/**/*.{js,mjs,ts,tsx}',
-  'x-pack/platform/packages/shared/kbn-evals/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/plugins/private/canvas/common/lib/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/plugins/private/data_usage/server/services/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/plugins/private/indices_metadata/server/lib/services/**/*.{js,mjs,ts,tsx}',
@@ -460,7 +459,6 @@ const AXIOS_LEGACY_CONSUMERS = [
   'x-pack/platform/plugins/shared/fleet/server/services/agents/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/plugins/shared/fleet/server/telemetry/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/plugins/shared/inference/scripts/**/*.{js,mjs,ts,tsx}',
-  'x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/plugins/shared/observability_ai_assistant/server/service/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/plugins/shared/osquery/cypress/**/*.{js,mjs,ts,tsx}',
   'x-pack/platform/plugins/shared/screenshotting/server/browsers/chromium/**/*.{js,mjs,ts,tsx}',
@@ -474,21 +472,18 @@ const AXIOS_LEGACY_CONSUMERS = [
   'x-pack/platform/test/fleet_cypress/artifact_manager.ts',
   'x-pack/platform/test/fleet_cypress/fleet_server.ts',
   'x-pack/platform/test/fleet_multi_cluster/**/*.{js,mjs,ts,tsx}',
-  'x-pack/platform/test/ui_capabilities/common/services/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/packages/alerting-test-data/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/packages/kbn-synthetics-forge/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/plugins/apm/scripts/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/plugins/apm/server/test_helpers/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/**/*.{js,mjs,ts,tsx}',
-  'x-pack/solutions/observability/plugins/observability_onboarding/server/test_helpers/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/plugins/synthetics/scripts/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/plugins/synthetics/server/telemetry/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/packages/kbn-securitysolution-utils/src/axios/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/common/endpoint/format_axios_error.ts',
-  'x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/scripts/endpoint/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/server/integration_tests/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/**/*.{js,mjs,ts,tsx}',
@@ -3128,10 +3123,12 @@ module.exports = {
       // globally by RESTRICTED_IMPORTS; this allowlist should only ever shrink
       // as consumers migrate to the native `fetch` API. Placed last so it wins
       // over any earlier override that re-applies RESTRICTED_IMPORTS (e.g. the
-      // security_solution and workflows_management blocks). The trade-off: the
-      // allowlisted files that overlap with those blocks lose their `*legacy*`
-      // pattern check; verified that none of them currently import any path
-      // matching `*legacy*`. The js-yaml freeze is handled separately via
+      // security_solution block). The trade-off: the allowlisted files that
+      // overlap with that block lose their `*legacy*` pattern check; verified
+      // that none of them currently import any path matching `*legacy*`. The
+      // workflows_management overlap is gone, and this comment can be dropped
+      // entirely once the remaining security_solution consumers migrate. The
+      // js-yaml freeze is handled separately via
       // @kbn/eslint/module_migration in packages/kbn-eslint-config/.eslintrc.js
       // so it does not interact with this override.
       files: AXIOS_LEGACY_CONSUMERS,

--- a/x-pack/platform/test/ui_capabilities/common/services/features.ts
+++ b/x-pack/platform/test/ui_capabilities/common/services/features.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import type { AxiosInstance } from 'axios';
-import axios from 'axios';
 import { format as formatUrl } from 'url';
 import util from 'util';
 import type { ToolingLog } from '@kbn/tooling-log';
@@ -14,49 +12,51 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 import type { Features } from '../features';
 
 export class FeaturesService {
-  private readonly axios: AxiosInstance;
-
-  constructor(url: string, private readonly log: ToolingLog) {
-    this.axios = axios.create({
-      headers: { 'kbn-xsrf': 'x-pack/ftr/services/features' },
-      baseURL: url,
-      allowAbsoluteUrls: false,
-      maxRedirects: 0,
-      validateStatus: () => true, // we'll handle our own statusCodes and throw informative errors
-    });
-  }
+  constructor(
+    private readonly url: string,
+    private readonly credentials: { username: string; password: string },
+    private readonly log: ToolingLog
+  ) {}
 
   public async get({ ignoreValidLicenses } = { ignoreValidLicenses: false }): Promise<Features> {
     this.log.debug('requesting /api/features to get the features');
-    const response = await this.axios.get(
-      `/api/features?ignoreValidLicenses=${ignoreValidLicenses}`
+    const { username, password } = this.credentials;
+    const response = await fetch(
+      `${this.url}/api/features?ignoreValidLicenses=${ignoreValidLicenses}`,
+      {
+        headers: {
+          'kbn-xsrf': 'x-pack/ftr/services/features',
+          authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+        },
+        redirect: 'manual', // we'll handle our own statusCodes and throw informative errors
+      }
     );
 
     if (response.status !== 200) {
       throw new Error(
         `Expected status code of 200, received ${response.status} ${
           response.statusText
-        }: ${util.inspect(response.data)}`
+        }: ${util.inspect(await response.text())}`
       );
     }
 
-    const features = response.data.reduce(
-      (acc: Features, feature: any) => ({
+    return ((await response.json()) as Array<{ id: string; app: string[] }>).reduce<Features>(
+      (acc, feature) => ({
         ...acc,
-        [feature.id]: {
-          app: feature.app,
-        },
+        [feature.id]: { app: feature.app },
       }),
       {}
     );
-    return features;
   }
 }
 
 export function FeaturesProvider({ getService }: FtrProviderContext) {
   const log = getService('log');
   const config = getService('config');
-  const url = formatUrl(config.get('servers.kibana'));
+  // `fetch` rejects URLs that embed credentials, so keep them out of the URL
+  // and send them as a Basic auth header instead.
+  const { username, password } = config.get('servers.kibana');
+  const url = formatUrl({ ...config.get('servers.kibana'), auth: undefined });
 
-  return new FeaturesService(url, log);
+  return new FeaturesService(url, { username, password }, log);
 }

--- a/x-pack/platform/test/ui_capabilities/common/services/ui_capabilities.ts
+++ b/x-pack/platform/test/ui_capabilities/common/services/ui_capabilities.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import type { AxiosInstance } from 'axios';
-import axios from 'axios';
 import type { Capabilities as UICapabilities } from '@kbn/core/types';
 import { format as formatUrl } from 'url';
 import util from 'util';
@@ -33,18 +31,12 @@ interface GetUICapabilitiesResult {
 
 export class UICapabilitiesService {
   private readonly log: ToolingLog;
-  private readonly axios: AxiosInstance;
+  private readonly url: string;
   private readonly featureService: FeaturesService;
 
   constructor(url: string, log: ToolingLog, featureService: FeaturesService) {
     this.log = log;
-    this.axios = axios.create({
-      headers: { 'kbn-xsrf': 'x-pack/ftr/services/ui_capabilities' },
-      baseURL: url,
-      allowAbsoluteUrls: false,
-      maxRedirects: 0,
-      validateStatus: () => true, // we'll handle our own statusCodes and throw informative errors
-    });
+    this.url = url;
     this.featureService = featureService;
   }
 
@@ -71,15 +63,18 @@ export class UICapabilitiesService {
           ).toString('base64')}`,
         }
       : {};
-    const response = await this.axios.post(
-      `${spaceUrlPrefix}/api/core/capabilities`,
-      { applications: [...applications, 'kibana:stack_management'] },
-      {
-        headers: requestHeaders,
-      }
-    );
+    const response = await fetch(`${this.url}${spaceUrlPrefix}/api/core/capabilities`, {
+      method: 'POST',
+      headers: {
+        'kbn-xsrf': 'x-pack/ftr/services/ui_capabilities',
+        'content-type': 'application/json',
+        ...requestHeaders,
+      },
+      body: JSON.stringify({ applications: [...applications, 'kibana:stack_management'] }),
+      redirect: 'manual', // we'll handle our own statusCodes and throw informative errors
+    });
 
-    if (response.status === 302 && response.headers.location === '/spaces/space_selector') {
+    if (response.status === 302 && response.headers.get('location') === '/spaces/space_selector') {
       return {
         success: false,
         failureReason: GetUICapabilitiesFailureReason.RedirectedToSpaceSelector,
@@ -97,13 +92,13 @@ export class UICapabilitiesService {
       throw new Error(
         `Expected status code of 200, received ${response.status} ${
           response.statusText
-        }: ${util.inspect(response.data)}`
+        }: ${util.inspect(await response.text())}`
       );
     }
 
     return {
       success: true,
-      value: response.data,
+      value: (await response.json()) as UICapabilities,
     };
   }
 }


### PR DESCRIPTION
## Summary

Part of the incremental [`axios` to native `fetch` migration](https://github.com/elastic/kibana/pull/266556) (the lint-freeze PR). Phase 6 drains the `@elastic/kibana-security` bucket: the two `ui_capabilities` FTR services.

**Tier: MEDIUM.** Both files used `axios.create(...)` instances (no interceptors, no custom adapter).

Each service now calls `fetch` directly at the call site, in place, matching the earlier phases of this migration. The axios settings both instances shared map over as:

| axios config | fetch equivalent |
| --- | --- |
| `maxRedirects: 0` | `redirect: 'manual'` |
| `validateStatus: () => true` | statuses are inspected and never thrown on, so the existing 302/404 branches and error messages are unchanged |
| implicit JSON `Content-Type` on POST | set explicitly |
| `transformResponse` | `await response.json()` on success, `await response.text()` in the error path |

### Behavior notes for reviewers

Two things worth a close look, both verified rather than assumed:

1. **`features.ts` was authenticated via credentials embedded in its base URL.** It built the URL with `formatUrl(config.get('servers.kibana'))`, which includes the `auth` field, and axios silently converted that into a `Basic` header. Native `fetch` instead throws `TypeError: Request cannot be constructed from a URL that includes credentials`. Rather than parsing them back out of the URL, `FeaturesProvider` now strips `auth` and passes `{ username, password }` to the service, which sends the header itself. That mirrors what `UICapabilitiesService` already did with its per-request credentials, and keeps both services structurally parallel. Only the providers construct these classes, so the constructor change is contained.
2. **The 302 space-selector detection still works.** In Node/undici, `redirect: 'manual'` returns the real response with status `302` and a readable `location` header, unlike browsers, which return an opaque redirect with status `0` and no headers. `response.headers.location` became `response.headers.get('location')`.

### eslint allowlist

- Removed `x-pack/platform/test/ui_capabilities/common/services/**` from `AXIOS_LEGACY_CONSUMERS`, and confirmed the global ban now fires on these files by temporarily re-adding an `axios` import.
- Also pruned four globs whose files no longer import axios at all (`kbn-evals`, `observability_ai_assistant/server/functions`, `observability_onboarding/server/test_helpers`, `security_solution/common/endpoint/utils`), and trimmed the now-obsolete `workflows_management` half of the override's trade-off comment (that overlap is gone). `AXIOS_LEGACY_CONSUMERS` is now 54 globs covering all 239 remaining consumers exactly: no leaks, no dead globs.

### Testing

- `node scripts/eslint` on the touched files: clean; the ban is verified to fire when axios is re-added.
- `node scripts/type_check --project x-pack/platform/test/tsconfig.json`: green.
- `node scripts/check_changes.ts`: all pre-commit checks passed.
- Exercised both services against a mock Kibana covering every branch: credentials to `Basic` header, `kbn-xsrf`, 200 + body parsing, `302` to `RedirectedToSpaceSelector`, `404` to `NotFound`, per-request credentials, and a `503` producing the informative throw (status + statusText + body).

The FTR configs that consume these services (`x-pack/platform/test/ui_capabilities/{security_and_spaces,spaces_only}`) are the real proof and run in CI.

### Risk

Low and contained. Every other reference to these classes is a type-only import inside the same test tree that calls only `.get()`, so there is no contract change and no ripple outside `x-pack/platform/test/ui_capabilities/`.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->