### PR TITLE
Bump undici to 7.29.0 and 6.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1604,7 +1604,7 @@
     "type-fest": "4.41.0",
     "typescript-fsa": "3.0.0",
     "typescript-fsa-reducers": "1.2.2",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "unidiff": "1.0.4",
     "unified": "9.2.2",
     "use-resize-observer": "9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34308,15 +34308,15 @@ undici-types@~7.16.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
-undici@7.28.0, undici@^7.19.1:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
-  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+undici@7.29.0, undici@^7.19.1:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 undici@^6.21.1, undici@^6.21.2:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unherit@^1.0.4:
   version "1.1.0"


### PR DESCRIPTION
## Summary

Bumps `undici`:
- **direct dependency** `7.28.0` → `7.29.0` (`package.json`)
- **transitive 6.x copy** `6.27.0` → `6.28.0` — pulled in via `@elastic/transport@8.x` and `@elastic/opentelemetry-node`; `6.28.0` satisfies the existing `^6.21.x` ranges

`undici` is dependency-free, so this is a `package.json` + `yarn.lock` change only (no other tree movement). Routine dependency maintenance.

> Opened as a **draft**: the lockfile was updated by hand (undici is zero-dep, and the fixed versions satisfy the existing ranges), so a `yarn kbn bootstrap` pass may be wanted to normalize — flagging for `@elastic/kibana-operations` to confirm before marking ready.

## Release note

`release_note:skip`
