### PR TITLE
[Alerting V2] [Bugfix] Timestamp selecion can't be changed in sandbox 

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
@@ -84,6 +84,7 @@ jest.mock('./compose_discover_form', () => {
       const { setValue, getValues } = useFormContext<FormValues>();
       readCommittedQuery = () => getValues('query');
       readRecoveryStrategy = () => getValues('recoveryStrategy');
+      readTimeField = () => getValues('timeField');
       return (
         <div data-test-subj="composeDiscoverFormMock">
           {/* Keep query rules mounted so validateStep → trigger(['query']) can fail. */}
@@ -104,6 +105,9 @@ jest.mock('./compose_discover_form', () => {
 interface SandboxFlyoutMockProps {
   query: RuleQuery;
   onQueryChange?: (query: RuleQuery) => void;
+  timeField?: string;
+  onTimeFieldChange?: (timeField: string) => void;
+  timeFieldOptions?: Array<{ value: string; text: string }>;
   onApply?: () => void;
   onClose: () => void;
   helpText?: React.ReactNode;
@@ -113,6 +117,7 @@ interface SandboxFlyoutMockProps {
 let sandboxFlyoutProps: SandboxFlyoutMockProps | undefined;
 let readCommittedQuery: (() => RuleQuery) | undefined;
 let readRecoveryStrategy: (() => FormValues['recoveryStrategy']) | undefined;
+let readTimeField: (() => FormValues['timeField']) | undefined;
 
 jest.mock('./query_sandbox_flyout', () => ({
   QuerySandboxFlyout: (props: SandboxFlyoutMockProps) => {
@@ -121,6 +126,20 @@ jest.mock('./query_sandbox_flyout', () => ({
       <div data-test-subj="composeDiscoverChildMock">
         <div data-test-subj="mockSandboxHelpText">{props.helpText}</div>
         <div data-test-subj="mockSandboxHeaderActions">{props.headerActions}</div>
+        {props.onTimeFieldChange ? (
+          // eslint-disable-next-line jsx-a11y/no-onchange
+          <select
+            data-test-subj="querySandboxTimeField"
+            value={props.timeField}
+            onChange={(e) => props.onTimeFieldChange?.(e.target.value)}
+          >
+            {props.timeFieldOptions?.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.text}
+              </option>
+            ))}
+          </select>
+        ) : null}
         {props.onApply ? (
           <button type="button" data-test-subj="mockSandboxApply" onClick={() => props.onApply?.()}>
             Apply
@@ -148,7 +167,10 @@ jest.mock('./use_split_query_completion', () => ({
 
 jest.mock('./use_resolve_time_field', () => ({
   useResolveTimeField: () => ({
-    timeFieldOptions: [{ value: '@timestamp', text: '@timestamp' }],
+    timeFieldOptions: [
+      { value: '@timestamp', text: '@timestamp' },
+      { value: 'event.ingested', text: 'event.ingested' },
+    ],
     isTimeFieldResolved: true,
   }),
 }));
@@ -268,6 +290,7 @@ describe('ComposeDiscoverFlyout', () => {
     sandboxFlyoutProps = undefined;
     readCommittedQuery = undefined;
     readRecoveryStrategy = undefined;
+    readTimeField = undefined;
     mockParseYamlToFormValues = (yaml) => ({
       values: yaml ? defaultYamlFormValues : null,
       error: null,
@@ -1116,6 +1139,53 @@ describe('ComposeDiscoverFlyout', () => {
       });
 
       expect(readCommittedQuery?.()).toEqual(secondRecoveryEdit);
+    });
+  });
+
+  describe('sandbox time field selection', () => {
+    it('keeps a manually selected sandbox time field instead of reverting to the form value (#281806)', () => {
+      renderFlyout({
+        mode: 'edit',
+        rule: {
+          id: 'rule-1',
+          kind: 'alert',
+          enabled: true,
+          metadata: { name: 'Edit rule', owner: 'test', tags: [] },
+          time_field: '@timestamp',
+          schedule: { every: '1m', lookback: '5m' },
+          query: {
+            format: 'composed',
+            base: 'FROM logs-*',
+            breach: { segment: '| WHERE count > 100' },
+          },
+          createdBy: 'test',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedBy: 'test',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      });
+
+      act(() => {
+        mockComposeDiscoverForm.mock.calls[
+          mockComposeDiscoverForm.mock.calls.length - 1
+        ][0].dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: 0, isAlert: true });
+      });
+
+      const select = screen.getByTestId('querySandboxTimeField') as HTMLSelectElement;
+      expect(select.value).toBe('@timestamp');
+
+      act(() => {
+        fireEvent.change(select, { target: { value: 'event.ingested' } });
+      });
+
+      // Flush any effects that could revert the draft before Apply runs.
+      expect(select.value).toBe('event.ingested');
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('mockSandboxApply'));
+      });
+
+      expect(readTimeField?.()).toBe('event.ingested');
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
@@ -96,6 +96,13 @@ jest.mock('./compose_discover_form', () => {
           >
             Make dirty
           </button>
+          <button
+            data-test-subj="mockSetFormTimeField"
+            onClick={() => setValue('timeField', 'event.ingested', { shouldDirty: true })}
+            type="button"
+          >
+            Set form time field
+          </button>
         </div>
       );
     },
@@ -1144,32 +1151,7 @@ describe('ComposeDiscoverFlyout', () => {
 
   describe('sandbox time field selection', () => {
     it('keeps a manually selected sandbox time field instead of reverting to the form value (#281806)', () => {
-      renderFlyout({
-        mode: 'edit',
-        rule: {
-          id: 'rule-1',
-          kind: 'alert',
-          enabled: true,
-          metadata: { name: 'Edit rule', owner: 'test', tags: [] },
-          time_field: '@timestamp',
-          schedule: { every: '1m', lookback: '5m' },
-          query: {
-            format: 'composed',
-            base: 'FROM logs-*',
-            breach: { segment: '| WHERE count > 100' },
-          },
-          createdBy: 'test',
-          createdAt: '2026-01-01T00:00:00Z',
-          updatedBy: 'test',
-          updatedAt: '2026-01-01T00:00:00Z',
-        },
-      });
-
-      act(() => {
-        mockComposeDiscoverForm.mock.calls[
-          mockComposeDiscoverForm.mock.calls.length - 1
-        ][0].dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: 0, isAlert: true });
-      });
+      renderFlyout({ mode: 'create' });
 
       const select = screen.getByTestId('querySandboxTimeField') as HTMLSelectElement;
       expect(select.value).toBe('@timestamp');
@@ -1178,7 +1160,6 @@ describe('ComposeDiscoverFlyout', () => {
         fireEvent.change(select, { target: { value: 'event.ingested' } });
       });
 
-      // Flush any effects that could revert the draft before Apply runs.
       expect(select.value).toBe('event.ingested');
 
       act(() => {
@@ -1186,6 +1167,20 @@ describe('ComposeDiscoverFlyout', () => {
       });
 
       expect(readTimeField?.()).toBe('event.ingested');
+    });
+
+    it('syncs a form-step time field change into the draft while the sandbox is closed', () => {
+      renderFlyout({ mode: 'create' });
+      fireEvent.click(screen.getByTestId('composeDiscoverChildMockClose'));
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('mockSetFormTimeField'));
+      });
+      act(() => {
+        getLatestFormProps().dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: 0, isAlert: true });
+      });
+
+      expect(sandboxFlyoutProps?.timeField).toBe('event.ingested');
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -463,6 +463,11 @@ export function ComposeDiscoverFlyout({
   const [dateRange, setDateRange] = useState({ dateStart: 'now-15m', dateEnd: 'now' });
 
   const watchedTimeField = useWatch({ control: methods.control, name: 'timeField' });
+  /*
+   * One-way RHF -> sandbox draft push. `sandboxTimeField` must stay out of the deps:
+   * with it, the effect re-fires on its own output and reverts the user's in-progress
+   * sandbox selection back to the committed form value (#281806).
+   */
   useEffect(() => {
     if (watchedTimeField) {
       setSandboxTimeField(watchedTimeField);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -464,10 +464,10 @@ export function ComposeDiscoverFlyout({
 
   const watchedTimeField = useWatch({ control: methods.control, name: 'timeField' });
   useEffect(() => {
-    if (watchedTimeField && watchedTimeField !== sandboxTimeField) {
+    if (watchedTimeField) {
       setSandboxTimeField(watchedTimeField);
     }
-  }, [watchedTimeField, sandboxTimeField]);
+  }, [watchedTimeField]);
 
   const isAlert = useWatch({ control: methods.control, name: 'kind' }) === 'alert';
   const watchedQuery = useWatch({ control: methods.control, name: 'query' });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_time_field.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_time_field.ts
@@ -32,7 +32,7 @@ export interface ComposeDiscoverTimeFieldValue {
 export const useComposeDiscoverTimeField = (): ComposeDiscoverTimeFieldValue => {
   const { watch } = useFormContext<FormValues>();
   const query = watch('query');
-  const timeField = watch('timeField') ?? '@timestamp';
+  const timeField = watch('timeField');
   const isAlert = watch('kind') === 'alert';
   const { http, dataViews } = useRuleFormServices();
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/compose_discover_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/compose_discover_flyout.spec.ts
@@ -396,7 +396,6 @@ test.describe(
     });
 
     test('create flow: manually selected sandbox time field holds and persists (#281806)', async ({
-      page,
       pageObjects,
       apiServices,
     }) => {
@@ -408,25 +407,17 @@ test.describe(
       });
 
       await test.step('the auto-detected time field is @timestamp', async () => {
+        await pageObjects.composeDiscover.waitForTimeFieldOption(
+          pageObjects.composeDiscover.sandboxTimeFieldSelector,
+          'event.ingested'
+        );
         await expect(pageObjects.composeDiscover.sandboxTimeFieldSelector).toHaveValue(
           '@timestamp'
         );
       });
 
-      await test.step('manually picking event.ingested in the sandbox does not revert on the next render', async () => {
+      await test.step('manually picking event.ingested in the sandbox holds through Apply, not reverted to @timestamp', async () => {
         await pageObjects.composeDiscover.selectSandboxTimeField('event.ingested');
-        // Give the buggy self-referential effect a chance to fire and revert the
-        // selection before asserting it held.
-        await expect(pageObjects.composeDiscover.sandboxTimeFieldSelector).toHaveValue(
-          'event.ingested'
-        );
-        await page.waitForTimeout(500);
-        await expect(pageObjects.composeDiscover.sandboxTimeFieldSelector).toHaveValue(
-          'event.ingested'
-        );
-      });
-
-      await test.step('Apply persists the manually selected field, not the auto-detected one', async () => {
         await pageObjects.composeDiscover.clickApply();
         await expect(pageObjects.composeDiscover.sandboxApplyButton).toBeHidden();
         await expect(pageObjects.composeDiscover.timeFieldSelector).toHaveValue('event.ingested');
@@ -436,6 +427,7 @@ test.describe(
         await pageObjects.composeDiscover.clickNext(); // Recovery Condition
         await pageObjects.composeDiscover.clickNext(); // Details
         await pageObjects.composeDiscover.setRuleName(TWO_DATE_FIELDS_RULE_NAME);
+        await pageObjects.composeDiscover.clickNext(); // Actions
         await pageObjects.composeDiscover.clickSubmit();
         await expect(pageObjects.composeDiscover.flyout).toBeHidden({ timeout: 30_000 });
       });

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/compose_discover_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/compose_discover_flyout.spec.ts
@@ -42,6 +42,16 @@ const CREATE_SIGNAL_TIMESTAMP_QUERY = `FROM ${TIMESTAMP_ONLY_INDEX} | WHERE Carr
 const BROKEN_TIME_FIELD_RULE_NAME = 'scout-compose-discover-broken-time-field';
 const CREATE_SIGNAL_TIMESTAMP_RULE_NAME = 'scout-compose-discover-standalone-time-field';
 const RUNBOOK_TEXT = 'Investigate failed transactions';
+/**
+ * Index with a valid `@timestamp` (so it auto-detects) plus a second date
+ * field — covers the truthy-guard path that the single-date-field indices
+ * above (`TEST_INDEX`, `TIMESTAMP_ONLY_INDEX`) never exercise. Regression
+ * coverage for #281806.
+ */
+const TWO_DATE_FIELDS_INDEX = 'test-compose-discover-two-date-fields';
+const TWO_DATE_FIELDS_BASE_QUERY = `FROM ${TWO_DATE_FIELDS_INDEX} | STATS count = COUNT(*)`;
+const TWO_DATE_FIELDS_UNIFIED_QUERY = `${TWO_DATE_FIELDS_BASE_QUERY} ${ALERT_SEGMENT}`;
+const TWO_DATE_FIELDS_RULE_NAME = 'scout-compose-discover-two-date-fields';
 
 test.describe(
   'ComposeDiscoverFlyout — create and edit flows',
@@ -86,6 +96,26 @@ test.describe(
         },
         refresh: 'wait_for',
       });
+      await esClient.indices.create(
+        {
+          index: TWO_DATE_FIELDS_INDEX,
+          mappings: {
+            properties: {
+              '@timestamp': { type: 'date' },
+              event: { properties: { ingested: { type: 'date' } } },
+            },
+          },
+        },
+        { ignore: [400] }
+      );
+      await esClient.index({
+        index: TWO_DATE_FIELDS_INDEX,
+        document: {
+          '@timestamp': new Date().toISOString(),
+          event: { ingested: new Date().toISOString() },
+        },
+        refresh: 'wait_for',
+      });
     });
 
     test.beforeEach(async ({ browserAuth, page, pageObjects }) => {
@@ -98,6 +128,7 @@ test.describe(
       await apiServices.alertingV2.rules.cleanUp();
       await esClient.indices.delete({ index: TEST_INDEX }, { ignore: [404] });
       await esClient.indices.delete({ index: TIMESTAMP_ONLY_INDEX }, { ignore: [404] });
+      await esClient.indices.delete({ index: TWO_DATE_FIELDS_INDEX }, { ignore: [404] });
     });
 
     test('create flow: open flyout, define query, step through, and submit', async ({
@@ -361,6 +392,66 @@ test.describe(
             timeout: 30_000,
           })
           .toBe('timestamp');
+      });
+    });
+
+    test('create flow: manually selected sandbox time field holds and persists (#281806)', async ({
+      page,
+      pageObjects,
+      apiServices,
+    }) => {
+      await test.step('open create flyout and type a query against an index with two date fields', async () => {
+        await pageObjects.composeDiscover.openCreateFlyout();
+        await expect(pageObjects.composeDiscover.flyout).toBeVisible();
+        await expect(pageObjects.composeDiscover.sandboxApplyButton).toBeVisible();
+        await pageObjects.composeDiscover.setSandboxQuery(TWO_DATE_FIELDS_UNIFIED_QUERY);
+      });
+
+      await test.step('the auto-detected time field is @timestamp', async () => {
+        await expect(pageObjects.composeDiscover.sandboxTimeFieldSelector).toHaveValue(
+          '@timestamp'
+        );
+      });
+
+      await test.step('manually picking event.ingested in the sandbox does not revert on the next render', async () => {
+        await pageObjects.composeDiscover.selectSandboxTimeField('event.ingested');
+        // Give the buggy self-referential effect a chance to fire and revert the
+        // selection before asserting it held.
+        await expect(pageObjects.composeDiscover.sandboxTimeFieldSelector).toHaveValue(
+          'event.ingested'
+        );
+        await page.waitForTimeout(500);
+        await expect(pageObjects.composeDiscover.sandboxTimeFieldSelector).toHaveValue(
+          'event.ingested'
+        );
+      });
+
+      await test.step('Apply persists the manually selected field, not the auto-detected one', async () => {
+        await pageObjects.composeDiscover.clickApply();
+        await expect(pageObjects.composeDiscover.sandboxApplyButton).toBeHidden();
+        await expect(pageObjects.composeDiscover.timeFieldSelector).toHaveValue('event.ingested');
+      });
+
+      await test.step('name the rule and submit', async () => {
+        await pageObjects.composeDiscover.clickNext(); // Recovery Condition
+        await pageObjects.composeDiscover.clickNext(); // Details
+        await pageObjects.composeDiscover.setRuleName(TWO_DATE_FIELDS_RULE_NAME);
+        await pageObjects.composeDiscover.clickSubmit();
+        await expect(pageObjects.composeDiscover.flyout).toBeHidden({ timeout: 30_000 });
+      });
+
+      await test.step('the created rule persists event.ingested, not @timestamp', async () => {
+        await expect
+          .poll(
+            async () => {
+              const { items } = await apiServices.alertingV2.rules.find({
+                search: TWO_DATE_FIELDS_RULE_NAME,
+              });
+              return items[0]?.time_field;
+            },
+            { timeout: 30_000 }
+          )
+          .toBe('event.ingested');
       });
     });
 


### PR DESCRIPTION
## Release Notes

Fixes bug where alerting v2 rule query sandbox timestamp cannot be changed from first assigned option.

## Summary

Closes #281806 

https://github.com/user-attachments/assets/7420f28d-ceb2-4773-8b39-ff4d83b08503


- useEffect to sync timeField in flyout was dependent on the **_sandboxTimeField_** in addition to watchedTimeField, causing the state to reset itself.
Also removes a fallback in form state to `@timestamp` since this is not always a safe assumption.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->