### PR TITLE
[Lens] Stop dropping custom range bounds with more than two decimal digits

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/advanced_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/advanced_editor.tsx
@@ -33,9 +33,14 @@ import { css } from '@emotion/react';
 import type { RangeTypeLens } from '@kbn/lens-common';
 import { useDebounceWithOptions } from '../../../../../shared_components';
 import { isValidRange } from './ranges';
-import { FROM_PLACEHOLDER, TO_PLACEHOLDER, TYPING_DEBOUNCE_TIME } from './constants';
+import {
+  FROM_PLACEHOLDER,
+  TO_PLACEHOLDER,
+  TYPING_DEBOUNCE_TIME,
+  isValidRangeBound,
+} from './constants';
 import { LabelInput } from '../shared_components';
-import { isValidNumber } from '../helpers';
+
 import { draggablePopoverButtonStyles } from '../styles';
 
 const generateId = htmlIdGenerator();
@@ -45,8 +50,8 @@ type LocalRangeType = RangeTypeLens & { id: string };
 const getBetterLabel = (range: RangeTypeLens, formatter: IFieldFormat) =>
   range.label ||
   formatter.convertToText({
-    gte: isValidNumber(range.from) ? range.from : -Infinity,
-    lt: isValidNumber(range.to) ? range.to : Infinity,
+    gte: isValidRangeBound(range.from) ? range.from : -Infinity,
+    lt: isValidRangeBound(range.to) ? range.to : Infinity,
   });
 
 export const RangePopover = ({
@@ -111,7 +116,7 @@ export const RangePopover = ({
               css={css`
                 width: 14ch; // Roughly 10 characters plus extra for the padding
               `}
-              value={isValidNumber(from) ? Number(from) : ''}
+              value={isValidRangeBound(from) ? Number(from) : ''}
               onChange={({ target }) => {
                 const newRange = {
                   ...tempRange,
@@ -144,7 +149,7 @@ export const RangePopover = ({
               css={css`
                 width: 14ch; // Roughly 10 characters plus extra for the padding
               `}
-              value={isValidNumber(to) ? Number(to) : ''}
+              value={isValidRangeBound(to) ? Number(to) : ''}
               inputRef={(node) => {
                 if (toRef && node) {
                   toRef.current = node;

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/constants.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/constants.ts
@@ -5,6 +5,15 @@
  * 2.0.
  */
 
+import { isValidNumber } from '../helpers';
+
+/**
+ * Range boundaries are arbitrary `range` aggregation bounds: unlike other numeric
+ * inputs sharing `isValidNumber` (e.g. percentiles), any number of decimal digits is valid.
+ */
+export const isValidRangeBound = (value: string | number | null | undefined): boolean =>
+  isValidNumber(value, false, undefined, undefined, Infinity);
+
 export const TYPING_DEBOUNCE_TIME = 256;
 // Taken from the Visualize editor
 export const FROM_PLACEHOLDER = '\u2212\u221E';

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/ranges.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/ranges.test.tsx
@@ -331,6 +331,30 @@ describe('ranges', () => {
         })
       );
     });
+
+    it('should keep range bounds with more than two decimal digits', () => {
+      setToRangeMode();
+      (layer.columns.col1 as RangeIndexPatternColumn).params.ranges = [
+        { from: 0.001, to: 0.125, label: '' },
+      ];
+
+      const esAggsFn = rangeOperation.toEsAggsFn(
+        layer.columns.col1 as RangeIndexPatternColumn,
+        'col1',
+        {} as IndexPattern,
+        layer,
+        uiSettingsMock,
+        []
+      );
+
+      expect(esAggsFn).toHaveProperty(
+        'arguments.ranges.0.chain.0.arguments',
+        expect.objectContaining({
+          from: [0.001],
+          to: [0.125],
+        })
+      );
+    });
   });
 
   describe('getPossibleOperationForField', () => {

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/ranges.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/ranges.tsx
@@ -25,8 +25,15 @@ import { RangeEditor } from './range_editor';
 import type { OperationDefinition } from '..';
 import { updateColumnParam } from '../../layer_helpers';
 import { supportedFormats } from '../../../../../../common/expressions/defs/format_column/supported_formats';
-import { MODES, AUTO_BARS, DEFAULT_INTERVAL, MIN_HISTOGRAM_BARS, SLICES } from './constants';
-import { getInvalidFieldMessage, isValidNumber } from '../helpers';
+import {
+  MODES,
+  AUTO_BARS,
+  DEFAULT_INTERVAL,
+  MIN_HISTOGRAM_BARS,
+  SLICES,
+  isValidRangeBound,
+} from './constants';
+import { getInvalidFieldMessage } from '../helpers';
 
 export type RangeColumnParams = RangeIndexPatternColumn['params'];
 export type UpdateParamsFnType = <K extends keyof RangeColumnParams>(
@@ -36,7 +43,7 @@ export type UpdateParamsFnType = <K extends keyof RangeColumnParams>(
 
 export const isRangeWithin = (range: RangeType): boolean => range.from <= range.to;
 const isFullRange = (range: RangeTypeLens): range is FullRangeTypeLens =>
-  isValidNumber(range.from) && isValidNumber(range.to);
+  isValidRangeBound(range.from) && isValidRangeBound(range.to);
 export const isValidRange = (range: RangeTypeLens): boolean => {
   if (isFullRange(range)) {
     return isRangeWithin(range);
@@ -142,10 +149,10 @@ export const rangeOperation: OperationDefinition<
             }
             const partialRange: Partial<RangeType> = { label: range.label };
             // be careful with the fields to set on partial ranges
-            if (isValidNumber(range.from)) {
+            if (isValidRangeBound(range.from)) {
               partialRange.from = Number(range.from);
             }
-            if (isValidNumber(range.to)) {
+            if (isValidRangeBound(range.to)) {
               partialRange.to = Number(range.to);
             }
             return partialRange;


### PR DESCRIPTION
## Summary

Closes #281863

#165703 added a `digits = 2` default to the shared `isValidNumber` helper for percentile inputs, silently changing custom-range validation, which calls the helper without a `digits` argument. Since 8.10, a range bound with more than two decimal digits (e.g. `0.001`) fails validation, so `toEsAggsFn` serializes the range open-ended — the ES bucket quietly includes all documents beyond the intended bound, the bound renders as an empty input in the ranges popover, and the auto-label shows `−∞`.

Range boundaries are arbitrary `range` aggregation bounds, so this PR validates them without a decimals cap via a dedicated `isValidRangeBound` helper in `ranges/constants.ts`, used by both `ranges.tsx` (serialization) and `advanced_editor.tsx` (rendering/labels). The shared `isValidNumber` default is left untouched, since `percentile_ranks` and `percentile` rely on it intentionally.

Adds a regression test asserting 3-decimal bounds survive into the es-aggs AST (verified to fail against the unfixed code).

## Testing

- `node scripts/jest .../ranges.test.tsx` — 24/24 pass (1 new; fails without the fix)
- ESLint and type check (`lens` project) clean
