### PR TITLE
[Lens] Fix default cell/badge coloring for data outside the 0-100 range

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.test.tsx
@@ -823,6 +823,33 @@ describe('DatatableComponent', () => {
         });
       });
 
+      test('should use percent-space range bounds when applying default colors to data outside 0-100', () => {
+        // no palette or color mapping persisted -> render-time defaults path
+        args.columns[2].colorMode = 'cell';
+        data.rows = [
+          { a: 'shoe', b: 1588024800000, c: 200 },
+          { a: 'hat', b: 1588024800000, c: 1000 },
+        ];
+
+        renderDatatableComponent({
+          getType: jest.fn().mockReturnValue({ type: 'metrics' }),
+        });
+
+        expect(getCellColorFn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ type: 'ranges', min: 200, max: 1000 }),
+          false,
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({
+            name: 'custom',
+            params: expect.objectContaining({ range: 'percent', rangeMin: 0, rangeMax: 100 }),
+          }),
+          undefined
+        );
+      });
+
       const color = 'red';
 
       test('should correctly color numerical values', () => {

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.tsx
@@ -468,8 +468,10 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
               stops: stops.map(({ stop }) => stop),
               gradient: false,
               range: defaultPalette.params?.rangeType ?? 'percent',
-              rangeMin: dataBounds.min,
-              rangeMax: dataBounds.max,
+              // rangeMin/rangeMax must be in the same space as the stops (percent by default),
+              // not in absolute data space
+              rangeMin: defaultPalette.params?.rangeMin ?? dataBounds.min,
+              rangeMax: defaultPalette.params?.rangeMax ?? dataBounds.max,
               continuity: defaultPalette.params?.continuity,
             },
           };


### PR DESCRIPTION
## Summary

Closes #281868

The render-time coloring defaults path (added in #252571 for API-configured tables) built a `'custom'` palette whose stops are computed in percent space (`rangeType: 'percent'` → stops in `[0..100]`), but set `rangeMin`/`rangeMax` to the **absolute** data bounds. `workoutColorForValue` normalizes cell values into percent space and compares them against those bounds verbatim, so:

- data min > 100 (latency ms, bytes…) → every value is "below range" → **no colors at all** (default continuity `'above'` doesn't color below-min values);
- data max < 100 (ratios…) → almost every value clamps to the last palette color;
- only data straddling `[0, 100]` colored correctly.

The fix uses the percent-space bounds already present in the default palette params (0/100 by default) so `rangeMin`/`rangeMax` live in the same space as the stops. The `?? dataBounds` fallbacks keep the value-space semantics correct in case a non-percent `rangeType` ever flows through this path. Badges and link-cell backgrounds share the same construction and are fixed by the same change.

Adds a regression test asserting the defaults path hands `getCellColorFn` a percent-space palette for data bounds `[200, 1000]` (verified to fail against the unfixed code, which passed `rangeMin: 200, rangeMax: 1000`).

## Testing

- `node scripts/jest .../table_basic.test.tsx` — 41/41 pass (1 new; fails without the fix)
- ESLint and type check (`lens` project) clean
