### PR TITLE
Fix empty prompt test flakiness

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -81,17 +81,35 @@ describe('ApplicationConnections', () => {
       return `/mock/app/${appId}${options?.path ?? ''}`;
     });
 
-    const { findByText, findByTestId, getByTestId, getByPlaceholderText } = renderPage(coreStart);
+    const { findAllByTestId, getAllByTestId, getByTestId, getByPlaceholderText } =
+      renderPage(coreStart);
 
-    expect(await findByText(/No application connections/)).toBeInTheDocument();
-    expect(await findByText(/Get started by creating MCP clients/)).toBeInTheDocument();
-    const addButton = await findByTestId('applicationConnectionsEmptyPromptAddButton');
+    // `EuiBasicTable` renders its `noItemsMessage` twice: once in the visible table body and
+    // once inside a screen-reader-only `<caption>` that EUI mounts behind a 500ms `EuiDelayRender`.
+    // Both copies carry the `applicationConnectionsEmptyPrompt` test subject, so scope every
+    // assertion to the visible body copy — otherwise a slow first render races the delayed caption
+    // duplicate and the singular queries throw "Found multiple elements". A genuine double-render
+    // in the body would still fail the `toHaveLength(1)` guard below.
+    await findAllByTestId('applicationConnectionsEmptyPrompt');
+    const visiblePrompts = getAllByTestId('applicationConnectionsEmptyPrompt').filter(
+      (element) => !element.closest('caption')
+    );
+    expect(visiblePrompts).toHaveLength(1);
+    const [emptyPrompt] = visiblePrompts;
+
+    expect(within(emptyPrompt).getByText(/No application connections/)).toBeInTheDocument();
+    expect(
+      within(emptyPrompt).getByText(/Get started by creating MCP clients/)
+    ).toBeInTheDocument();
+    const addButton = within(emptyPrompt).getByTestId('applicationConnectionsEmptyPromptAddButton');
     expect(addButton).toBeInTheDocument();
     expect(addButton).toHaveAttribute(
       'href',
       '/mock/app/agent_builder/manage/tools/mcp_clients/new'
     );
-    const learnMoreLink = await findByTestId('applicationConnectionsEmptyPromptLearnMoreLink');
+    const learnMoreLink = within(emptyPrompt).getByTestId(
+      'applicationConnectionsEmptyPromptLearnMoreLink'
+    );
     expect(learnMoreLink).toBeInTheDocument();
     expect(learnMoreLink).toHaveAttribute(
       'href',


### PR DESCRIPTION
## Summary

Fixes test flakiness by accounting for the fact that the screen reader caption may render a duplicate DOM element after a delay.

Resolves #272764

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->