### PR TITLE
[ci] Fix storybooks

### DIFF
--- a/src/platform/packages/shared/kbn-storybook/preset.js
+++ b/src/platform/packages/shared/kbn-storybook/preset.js
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-const webpackConfig = require('./src/webpack.config');
+const { default: webpackConfig } = require('./src/webpack.config');
 
 module.exports = {
   managerEntries: (entry = []) => {


### PR DESCRIPTION
Fixes a storybooks build issue introduced by https://github.com/elastic/kibana/pull/269972, where swc outputs default exports differently than babel.

https://buildkite.com/elastic/kibana-on-merge/builds/104595#019fb47c-e61c-4fff-ab17-2c4ad573eaef