### PR TITLE
[Agent Builder] Support Confirmation (HITL) for user defined tools

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -4489,6 +4489,17 @@ paths:
                     nullable: true
                   description: Tool-specific configuration parameters. See examples for details.
                   type: object
+                confirmation:
+                  additionalProperties: false
+                  description: Optional tool call policy to control tool call confirmation behavior
+                  type: object
+                  properties:
+                    askUser:
+                      enum:
+                        - once
+                        - always
+                        - never
+                      type: string
                 description:
                   default: ''
                   description: Description of what the tool does.
@@ -5126,6 +5137,17 @@ paths:
                     nullable: true
                   description: Updated tool-specific configuration parameters. See examples for details.
                   type: object
+                confirmation:
+                  additionalProperties: false
+                  description: Updated tool call policy to control tool call confirmation behavior
+                  type: object
+                  properties:
+                    askUser:
+                      enum:
+                        - once
+                        - always
+                        - never
+                      type: string
                 description:
                   description: Updated description of what the tool does.
                   type: string

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -4560,6 +4560,17 @@ paths:
                     nullable: true
                   description: Tool-specific configuration parameters. See examples for details.
                   type: object
+                confirmation:
+                  additionalProperties: false
+                  description: Optional tool call policy to control tool call confirmation behavior
+                  type: object
+                  properties:
+                    askUser:
+                      enum:
+                        - once
+                        - always
+                        - never
+                      type: string
                 description:
                   default: ''
                   description: Description of what the tool does.
@@ -5197,6 +5208,17 @@ paths:
                     nullable: true
                   description: Updated tool-specific configuration parameters. See examples for details.
                   type: object
+                confirmation:
+                  additionalProperties: false
+                  description: Updated tool call policy to control tool call confirmation behavior
+                  type: object
+                  properties:
+                    askUser:
+                      enum:
+                        - once
+                        - always
+                        - never
+                      type: string
                 description:
                   description: Updated description of what the tool does.
                   type: string

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
@@ -17,6 +17,8 @@ export {
   ToolOrigin,
   type ToolDefinition,
   type ToolDefinitionWithSchema,
+  type ToolConfirmationPolicyMode,
+  type ToolConfirmationPolicy,
   platformCoreTools,
   platformCoreCasesTools,
   platformSignificantEventsTools,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/definition.ts
@@ -57,7 +57,8 @@ export type ToolConfirmationPolicyMode = 'once' | 'always' | 'never';
 
 export interface ToolConfirmationPolicy {
   /**
-   * If true, will prompt the user for confirmation when the agent wants to execute the tool, before the actual execution.
+   * Controls when the agent prompts the user for confirmation before executing the tool.
+   * Defaults to `never` if omitted.
    */
   askUser?: ToolConfirmationPolicyMode;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/definition.ts
@@ -44,6 +44,25 @@ export enum ToolOrigin {
 }
 
 /**
+ * Controls how often the user is prompted for confirmation when the agent calls a tool.
+ *
+ * - once:   prompt once per tool type for the entire conversation. After the user
+ *           accepts (or rejects), all subsequent calls to the same tool reuse that
+ *           response — including retries after failures.
+ * - always: prompt on every individual tool call. Each invocation gets its own
+ *           confirmation, even if it targets the same tool type.
+ * - never:  skip confirmation entirely.
+ */
+export type ToolConfirmationPolicyMode = 'once' | 'always' | 'never';
+
+export interface ToolConfirmationPolicy {
+  /**
+   * If true, will prompt the user for confirmation when the agent wants to execute the tool, before the actual execution.
+   */
+  askUser?: ToolConfirmationPolicyMode;
+}
+
+/**
  * Serializable representation of a tool, without its handler or schema.
  *
  * Use as a common base for browser-side and server-side tool types.
@@ -80,6 +99,10 @@ export interface ToolDefinition<
    * When true, this tool is only available when experimental features are enabled.
    */
   experimental: boolean;
+  /**
+   * Optional tool call policy to control tool call confirmation behavior
+   */
+  confirmation?: ToolConfirmationPolicy;
 }
 
 export interface ToolDefinitionWithSchema<

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/index.ts
@@ -10,6 +10,8 @@ export {
   ToolOrigin,
   type ToolDefinition,
   type ToolDefinitionWithSchema,
+  type ToolConfirmationPolicyMode,
+  type ToolConfirmationPolicy,
 } from './definition';
 export { isReservedToolId, validateToolId, toolIdRegexp, toolIdMaxLength } from './tool_ids';
 export {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/builtin.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/builtin.ts
@@ -8,7 +8,12 @@
 import type { MaybePromise } from '@kbn/utility-types';
 import type { z, ZodObject } from '@kbn/zod/v4';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-server';
-import type { ToolCallWithResult, ToolDefinition, ToolType } from '@kbn/agent-builder-common';
+import type {
+  ToolCallWithResult,
+  ToolDefinition,
+  ToolType,
+  ToolConfirmationPolicy,
+} from '@kbn/agent-builder-common';
 import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
 import type { EsqlToolDefinition } from '@kbn/agent-builder-common/tools/types/esql';
 import type { IndexSearchToolDefinition } from '@kbn/agent-builder-common/tools/types/index_search';
@@ -70,27 +75,11 @@ export interface ToolAvailabilityConfig {
   cacheTtl?: number;
 }
 
-/**
- * Controls how often the user is prompted for confirmation when the agent calls a tool.
- *
- * - once:   prompt once per tool type for the entire conversation. After the user
- *           accepts (or rejects), all subsequent calls to the same tool reuse that
- *           response — including retries after failures.
- * - always: prompt on every individual tool call. Each invocation gets its own
- *           confirmation, even if it targets the same tool type.
- * - never:  skip confirmation entirely.
- */
-export type ToolConfirmationPolicyMode = 'once' | 'always' | 'never';
-
 export type ToolPolicyConfirmationDefinition = Omit<ConfirmPromptDefinition, 'id'>;
 
-export interface ToolConfirmationPolicy<
+export interface BuiltInToolConfirmationPolicy<
   TParams extends Record<string, unknown> = Record<string, unknown>
-> {
-  /**
-   * If true, will prompt the user for confirmation when the agent wants to execute the tool, before the actual execution.
-   */
-  askUser?: ToolConfirmationPolicyMode;
+> extends ToolConfirmationPolicy {
   /**
    * If set, will be used to get the confirmation
    */
@@ -115,7 +104,7 @@ export interface BuiltInToolSpecificConfig<
   /**
    * Optional tool call policy to control tool call confirmation behavior
    */
-  confirmation?: ToolConfirmationPolicy<TParams>;
+  confirmation?: BuiltInToolConfirmationPolicy<TParams>;
   /**
    * Optional function to summarize a tool return for conversation history.
    * When provided, this function will be called when processing conversation history
@@ -152,7 +141,10 @@ export type ToolReturnSummarizerFn = (
 export interface BuiltinToolDefinition<
   RunInput extends ZodObject<any> = ZodObject<any>,
   TResult extends ToolResult = ToolResult
-> extends Omit<ToolDefinition, 'type' | 'readonly' | 'configuration' | 'experimental'>,
+> extends Omit<
+      ToolDefinition,
+      'type' | 'readonly' | 'configuration' | 'experimental' | 'confirmation'
+    >,
     BuiltInToolSpecificConfig<z.infer<RunInput>> {
   /**
    * built-in tool types

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/index.ts
@@ -16,8 +16,7 @@ export type {
   ToolAvailabilityResult,
   ToolAvailabilityConfig,
   ToolReturnSummarizerFn,
-  ToolConfirmationPolicy,
-  ToolConfirmationPolicyMode,
+  BuiltInToolConfirmationPolicy,
 } from './builtin';
 export {
   type ToolHandlerFn,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/internal.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/internal.ts
@@ -13,7 +13,7 @@ import type {
   ToolAvailabilityContext,
   ToolAvailabilityResult,
   ToolReturnSummarizerFn,
-  ToolConfirmationPolicy,
+  BuiltInToolConfirmationPolicy,
 } from './builtin';
 import type { LlmDescriptionHandler } from '../runner';
 
@@ -61,7 +61,7 @@ export interface InternalToolDefinition<
   /**
    * Tool call policy to control tool call confirmation behavior
    */
-  confirmation?: ToolConfirmationPolicy;
+  confirmation?: BuiltInToolConfirmationPolicy;
 }
 
 export type InternalToolAvailabilityHandler = (

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/registry.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/registry.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ToolType } from '@kbn/agent-builder-common';
+import type { ToolType, ToolConfirmationPolicy } from '@kbn/agent-builder-common';
 import type { ScopedRunnerRunToolsParams, RunToolReturn } from '../runner';
 import type { InternalToolDefinition } from './internal';
 
@@ -32,6 +32,7 @@ export interface ToolCreateParams<TConfig extends object = {}> {
   description?: string;
   tags?: string[];
   configuration: TConfig;
+  confirmation?: ToolConfirmationPolicy;
 }
 
 /**
@@ -41,6 +42,7 @@ export interface ToolUpdateParams<TConfig extends object = {}> {
   description?: string;
   tags?: string[];
   configuration?: Partial<TConfig>;
+  confirmation?: ToolConfirmationPolicy;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/tools.ts
@@ -38,7 +38,9 @@ export type CreateToolPayload = Omit<
 > &
   Partial<Pick<ToolDefinition, 'description' | 'tags'>>;
 
-export type UpdateToolPayload = Partial<Pick<ToolDefinition, 'description' | 'tags'>> & {
+export type UpdateToolPayload = Partial<
+  Pick<ToolDefinition, 'description' | 'tags' | 'confirmation'>
+> & {
   configuration?: Partial<ToolDefinition['configuration']>;
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/confirmation_policy_select.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/confirmation_policy_select.tsx
@@ -12,21 +12,13 @@ import type { ToolConfirmationPolicyMode } from '@kbn/agent-builder-common';
 import { i18nMessages } from '../i18n';
 import type { ToolConfirmationFormData } from '../types/tool_form_types';
 
-interface ConfirmationPolicySelectProps {
-  id: string;
-  'data-test-subj'?: string;
-}
-
 const confirmationOptions: Array<{ value: ToolConfirmationPolicyMode; text: string }> = [
   { value: 'never' as const, text: i18nMessages.configuration.form.confirmation.neverOption },
   { value: 'once' as const, text: i18nMessages.configuration.form.confirmation.onceOption },
   { value: 'always' as const, text: i18nMessages.configuration.form.confirmation.alwaysOption },
 ];
 
-export const ConfirmationPolicySelect = ({
-  id,
-  'data-test-subj': dataTestSubj = 'agentBuilderToolConfirmationPolicySelect',
-}: ConfirmationPolicySelectProps) => {
+export const ConfirmationPolicySelect = () => {
   const {
     control,
     formState: { errors },
@@ -44,8 +36,8 @@ export const ConfirmationPolicySelect = ({
         name="confirmation_ask_user"
         render={({ field: { ref, onChange, value, ...field } }) => (
           <EuiSelect
-            id={id}
-            data-test-subj={dataTestSubj}
+            id="agentBuilderToolConfirmationPolicySelect"
+            data-test-subj="agentBuilderToolConfirmationPolicySelect"
             options={confirmationOptions}
             value={value ?? 'never'}
             onChange={(e) => onChange(e.target.value)}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/confirmation_policy_select.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/confirmation_policy_select.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { EuiFormRow, EuiSelect } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
+import type { ToolConfirmationPolicyMode } from '@kbn/agent-builder-common';
 import { i18nMessages } from '../i18n';
 import type { ToolConfirmationFormData } from '../types/tool_form_types';
 
@@ -16,7 +17,7 @@ interface ConfirmationPolicySelectProps {
   'data-test-subj'?: string;
 }
 
-const confirmationOptions = [
+const confirmationOptions: Array<{ value: ToolConfirmationPolicyMode; text: string }> = [
   { value: 'never' as const, text: i18nMessages.configuration.form.confirmation.neverOption },
   { value: 'once' as const, text: i18nMessages.configuration.form.confirmation.onceOption },
   { value: 'always' as const, text: i18nMessages.configuration.form.confirmation.alwaysOption },

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/confirmation_policy_select.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/confirmation_policy_select.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { Controller, useFormContext } from 'react-hook-form';
+import { i18nMessages } from '../i18n';
+import type { ToolConfirmationFormData } from '../types/tool_form_types';
+
+interface ConfirmationPolicySelectProps {
+  id: string;
+  'data-test-subj'?: string;
+}
+
+const confirmationOptions = [
+  { value: 'never' as const, text: i18nMessages.configuration.form.confirmation.neverOption },
+  { value: 'once' as const, text: i18nMessages.configuration.form.confirmation.onceOption },
+  { value: 'always' as const, text: i18nMessages.configuration.form.confirmation.alwaysOption },
+];
+
+export const ConfirmationPolicySelect = ({
+  id,
+  'data-test-subj': dataTestSubj = 'agentBuilderToolConfirmationPolicySelect',
+}: ConfirmationPolicySelectProps) => {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<ToolConfirmationFormData>();
+
+  return (
+    <EuiFormRow
+      label={i18nMessages.configuration.form.confirmation.label}
+      helpText={i18nMessages.configuration.form.confirmation.helpText}
+      isInvalid={!!errors.confirmation_ask_user}
+      error={errors.confirmation_ask_user?.message}
+    >
+      <Controller
+        control={control}
+        name="confirmation_ask_user"
+        render={({ field: { ref, onChange, value, ...field } }) => (
+          <EuiSelect
+            id={id}
+            data-test-subj={dataTestSubj}
+            options={confirmationOptions}
+            value={value ?? 'never'}
+            onChange={(e) => onChange(e.target.value)}
+            {...field}
+          />
+        )}
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/i18n.ts
@@ -172,6 +172,39 @@ export const i18nMessages = {
           }
         ),
       },
+      confirmation: {
+        label: i18n.translate(
+          'xpack.agentBuilder.tools.newTool.configuration.form.confirmation.label',
+          {
+            defaultMessage: 'Require user confirmation',
+          }
+        ),
+        helpText: i18n.translate(
+          'xpack.agentBuilder.tools.newTool.configuration.form.confirmation.helpText',
+          {
+            defaultMessage:
+              'Sets the policy for when the agent should require user confirmation before executing the tool.',
+          }
+        ),
+        neverOption: i18n.translate(
+          'xpack.agentBuilder.tools.newTool.configuration.form.confirmation.neverOptionLabel',
+          {
+            defaultMessage: 'Never',
+          }
+        ),
+        onceOption: i18n.translate(
+          'xpack.agentBuilder.tools.newTool.configuration.form.confirmation.onceOptionLabel',
+          {
+            defaultMessage: 'Once',
+          }
+        ),
+        alwaysOption: i18n.translate(
+          'xpack.agentBuilder.tools.newTool.configuration.form.confirmation.alwaysOptionLabel',
+          {
+            defaultMessage: 'Always',
+          }
+        ),
+      },
       indexSearch: {
         patternLabel: i18n.translate(
           'xpack.agentBuilder.tools.newTool.configuration.form.indexSearch.patternLabel',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/registry/tool_types/mcp.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/registry/tool_types/mcp.tsx
@@ -29,6 +29,7 @@ export const mcpToolRegistryEntry: ToolTypeRegistryEntry<McpToolFormData> = {
     type: ToolType.mcp,
     connectorId: '',
     mcpToolName: '',
+    confirmation_ask_user: 'never',
   },
   toolToFormData: (tool: ToolDefinitionWithSchema) => {
     if (!isMcpTool(tool)) {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/registry/tool_types/workflow.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/registry/tool_types/workflow.tsx
@@ -32,6 +32,7 @@ export const workflowToolRegistryEntry: ToolTypeRegistryEntry<WorkflowToolFormDa
     type: ToolType.workflow,
     workflow_id: '',
     wait_for_completion: true,
+    confirmation_ask_user: 'never',
   },
   toolToFormData: (tool: ToolDefinitionWithSchema) => {
     if (!isWorkflowTool(tool)) {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/mcp_configuration_fields.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/mcp_configuration_fields.tsx
@@ -20,6 +20,7 @@ import { i18nMessages } from '../../i18n';
 import { ToolFormMode } from '../../tool_form';
 import { McpEditableFields } from '../../components/mcp/mcp_editable_fields';
 import { McpReadOnlyFields } from '../../components/mcp/mcp_readonly_fields';
+import { ConfirmationPolicySelect } from '../../components/confirmation_policy_select';
 
 export interface McpConfigurationProps {
   mode: ToolFormMode;
@@ -69,6 +70,11 @@ export const McpConfiguration = ({ mode }: McpConfigurationProps) => {
           />
         </EuiSplitPanel.Inner>
       </EuiSplitPanel.Outer>
+      <EuiSpacer />
+      <ConfirmationPolicySelect
+        id="agentBuilderMcpToolConfirmationPolicySelect"
+        data-test-subj="agentBuilderMcpToolConfirmationPolicySelect"
+      />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/mcp_configuration_fields.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/mcp_configuration_fields.tsx
@@ -71,10 +71,7 @@ export const McpConfiguration = ({ mode }: McpConfigurationProps) => {
         </EuiSplitPanel.Inner>
       </EuiSplitPanel.Outer>
       <EuiSpacer />
-      <ConfirmationPolicySelect
-        id="agentBuilderMcpToolConfirmationPolicySelect"
-        data-test-subj="agentBuilderMcpToolConfirmationPolicySelect"
-      />
+      <ConfirmationPolicySelect />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/workflow_configuration_fields.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/workflow_configuration_fields.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { EuiFormRow, EuiCheckbox, EuiSelect } from '@elastic/eui';
+import { EuiFormRow, EuiCheckbox } from '@elastic/eui';
 import { useFormContext, Controller } from 'react-hook-form';
+import { ConfirmationPolicySelect } from '../../components/confirmation_policy_select';
 import { WorkflowPicker } from '../../components/workflow/workflow_picker';
 import type { WorkflowToolFormData } from '../../types/tool_form_types';
 import { i18nMessages } from '../../i18n';
@@ -50,33 +51,10 @@ export const WorkflowConfiguration = () => {
           )}
         />
       </EuiFormRow>
-      <EuiFormRow
-        label={i18nMessages.configuration.form.confirmation.label}
-        helpText={i18nMessages.configuration.form.confirmation.helpText}
-        isInvalid={!!errors.confirmation_ask_user}
-        error={errors.confirmation_ask_user?.message}
-      >
-        <Controller
-          control={control}
-          name="confirmation_ask_user"
-          render={({ field: { ref, onChange, value, ...field } }) => (
-            <EuiSelect
-              id="agentBuilderWorkflowToolConfirmationPolicySelect"
-              options={[
-                { value: 'never', text: i18nMessages.configuration.form.confirmation.neverOption },
-                { value: 'once', text: i18nMessages.configuration.form.confirmation.onceOption },
-                {
-                  value: 'always',
-                  text: i18nMessages.configuration.form.confirmation.alwaysOption,
-                },
-              ]}
-              value={value ?? 'never'}
-              onChange={(e) => onChange(e.target.value)}
-              {...field}
-            />
-          )}
-        />
-      </EuiFormRow>
+      <ConfirmationPolicySelect
+        id="agentBuilderWorkflowToolConfirmationPolicySelect"
+        data-test-subj="agentBuilderWorkflowToolConfirmationPolicySelect"
+      />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/workflow_configuration_fields.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/workflow_configuration_fields.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiFormRow, EuiCheckbox } from '@elastic/eui';
+import { EuiFormRow, EuiCheckbox, EuiSelect } from '@elastic/eui';
 import { useFormContext, Controller } from 'react-hook-form';
 import { WorkflowPicker } from '../../components/workflow/workflow_picker';
 import type { WorkflowToolFormData } from '../../types/tool_form_types';
@@ -45,6 +45,33 @@ export const WorkflowConfiguration = () => {
                 onChange(e.target.checked);
               }}
               checked={value}
+              {...field}
+            />
+          )}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label={i18nMessages.configuration.form.confirmation.label}
+        helpText={i18nMessages.configuration.form.confirmation.helpText}
+        isInvalid={!!errors.confirmation_ask_user}
+        error={errors.confirmation_ask_user?.message}
+      >
+        <Controller
+          control={control}
+          name="confirmation_ask_user"
+          render={({ field: { ref, onChange, value, ...field } }) => (
+            <EuiSelect
+              id="agentBuilderWorkflowToolConfirmationPolicySelect"
+              options={[
+                { value: 'never', text: i18nMessages.configuration.form.confirmation.neverOption },
+                { value: 'once', text: i18nMessages.configuration.form.confirmation.onceOption },
+                {
+                  value: 'always',
+                  text: i18nMessages.configuration.form.confirmation.alwaysOption,
+                },
+              ]}
+              value={value ?? 'never'}
+              onChange={(e) => onChange(e.target.value)}
               {...field}
             />
           )}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/workflow_configuration_fields.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/configuration_fields/workflow_configuration_fields.tsx
@@ -51,10 +51,7 @@ export const WorkflowConfiguration = () => {
           )}
         />
       </EuiFormRow>
-      <ConfirmationPolicySelect
-        id="agentBuilderWorkflowToolConfirmationPolicySelect"
-        data-test-subj="agentBuilderWorkflowToolConfirmationPolicySelect"
-      />
+      <ConfirmationPolicySelect />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/type.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/type.tsx
@@ -8,14 +8,18 @@
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSuperSelect } from '@elastic/eui';
 import { ToolType } from '@kbn/agent-builder-common';
 import { i18n } from '@kbn/i18n';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useAgentBuilderServices } from '../../../../hooks/use_agent_builder_service';
 import { ToolFormSection } from '../components/tool_form_section';
 import { i18nMessages } from '../i18n';
 import { useToolTypes } from '../../../../hooks/tools/use_tool_type_info';
 import type { ToolFormData } from '../types/tool_form_types';
-import { getToolTypeConfig, getEditableToolTypes } from '../registry/tools_form_registry';
+import {
+  getToolTypeConfig,
+  getEditableToolTypes,
+  getToolTypeDefaultValues,
+} from '../registry/tools_form_registry';
 import { ToolFormMode } from '../tool_form';
 
 const TECH_PREVIEW_LABEL = i18n.translate('xpack.agentBuilder.tools.techPreviewBadgeLabel', {
@@ -28,6 +32,8 @@ export interface TypeProps {
 
 export const TypeSection = ({ mode }: TypeProps) => {
   const {
+    getValues,
+    reset: formReset,
     formState: { errors },
     control,
   } = useFormContext<ToolFormData>();
@@ -67,6 +73,20 @@ export const TypeSection = ({ mode }: TypeProps) => {
     }));
   }, [serverToolTypes, toolTypesLoading]);
 
+  const onToolTypeChange = useCallback(
+    (value: ToolType) => {
+      const { toolId, description, labels } = getValues();
+      formReset({
+        ...getToolTypeDefaultValues(value),
+        // Maintain common values between type changes
+        toolId,
+        description,
+        labels,
+      });
+    },
+    [formReset, getValues]
+  );
+
   return (
     <ToolFormSection
       title={i18nMessages.configuration.documentation.title}
@@ -81,12 +101,12 @@ export const TypeSection = ({ mode }: TypeProps) => {
         <Controller
           control={control}
           name="type"
-          render={({ field: { value, onChange } }) => (
+          render={({ field: { value } }) => (
             <EuiSuperSelect
               data-test-subj="agentBuilderToolTypeSelect"
               options={editableToolTypes}
               valueOfSelected={value}
-              onChange={onChange}
+              onChange={onToolTypeChange}
               disabled={mode === ToolFormMode.Edit}
               fullWidth
             />

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/types/tool_form_types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/types/tool_form_types.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import type { EsqlToolFieldTypes, EsqlToolParamValue, ToolType } from '@kbn/agent-builder-common';
+import type {
+  EsqlToolFieldTypes,
+  EsqlToolParamValue,
+  ToolType,
+  ToolConfirmationPolicyMode,
+} from '@kbn/agent-builder-common';
 
 export interface EsqlParam {
   name: string;
@@ -56,12 +61,14 @@ export interface WorkflowToolFormData extends BaseToolFormData {
   type: ToolType.workflow;
   workflow_id: string;
   wait_for_completion: boolean;
+  confirmation_ask_user?: ToolConfirmationPolicyMode;
 }
 
 export interface McpToolFormData extends BaseToolFormData {
   type: ToolType.mcp;
   connectorId: string;
   mcpToolName: string;
+  confirmation_ask_user?: ToolConfirmationPolicyMode;
 }
 
 export type ToolFormData =

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/types/tool_form_types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/types/tool_form_types.ts
@@ -36,6 +36,10 @@ export interface BaseToolFormData {
   labels: string[];
 }
 
+export interface ToolConfirmationFormData {
+  confirmation_ask_user?: ToolConfirmationPolicyMode;
+}
+
 export interface EsqlToolFormData extends BaseToolFormData {
   type: ToolType.esql;
   esql: string;
@@ -46,10 +50,6 @@ export interface BuiltinToolFormData extends BaseToolFormData {
   type: ToolType.builtin;
 }
 
-export interface McpToolFormData extends BaseToolFormData {
-  type: ToolType.mcp;
-}
-
 export interface IndexSearchToolFormData extends BaseToolFormData {
   type: ToolType.index_search;
   pattern: string;
@@ -57,18 +57,16 @@ export interface IndexSearchToolFormData extends BaseToolFormData {
   customInstructions?: string;
 }
 
-export interface WorkflowToolFormData extends BaseToolFormData {
+export interface WorkflowToolFormData extends BaseToolFormData, ToolConfirmationFormData {
   type: ToolType.workflow;
   workflow_id: string;
   wait_for_completion: boolean;
-  confirmation_ask_user?: ToolConfirmationPolicyMode;
 }
 
-export interface McpToolFormData extends BaseToolFormData {
+export interface McpToolFormData extends BaseToolFormData, ToolConfirmationFormData {
   type: ToolType.mcp;
   connectorId: string;
   mcpToolName: string;
-  confirmation_ask_user?: ToolConfirmationPolicyMode;
 }
 
 export type ToolFormData =

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/validation/shared_tool_validation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/validation/shared_tool_validation.ts
@@ -80,4 +80,6 @@ export const sharedValidationSchemas = {
   description: z.string().min(1, { message: sharedI18nMessages.description.requiredError }),
 
   labels: z.array(z.string()),
+
+  confirmation_ask_user: z.optional(z.literal(['never', 'once', 'always'])),
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/validation/workflow_tool_form_validation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/validation/workflow_tool_form_validation.ts
@@ -52,4 +52,6 @@ export const createWorkflowFormValidationSchema = (toolsService: ToolsService) =
     wait_for_completion: z.boolean(),
 
     type: z.literal(ToolType.workflow),
+
+    confirmation_ask_user: sharedValidationSchemas.confirmation_ask_user,
   });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.test.ts
@@ -36,6 +36,7 @@ describe('transformMcpFormData', () => {
       connector_id: 'connector-123',
       tool_name: 'my_mcp_tool_name',
     },
+    confirmation: { askUser: 'never' },
     type: ToolType.mcp,
     tags: ['test', 'mcp'],
   };
@@ -78,12 +79,12 @@ describe('transformMcpFormData', () => {
       expect(result).toEqual(defaultMcpTool);
     });
 
-    it('omits confirmation entirely when confirmation_ask_user is never', () => {
+    it('sets confirmation when confirmation_ask_user is never', () => {
       const result = transformFormDataToMcpTool({
         ...formData,
         confirmation_ask_user: 'never',
       });
-      expect(result.confirmation).toBeUndefined();
+      expect(result.confirmation).toEqual({ askUser: 'never' });
     });
 
     it('sets confirmation when confirmation_ask_user is once', () => {
@@ -123,7 +124,7 @@ describe('transformMcpFormData', () => {
         ...formData,
         confirmation_ask_user: 'never',
       });
-      expect(result.confirmation).toBeUndefined();
+      expect(result.confirmation).toMatchObject({ askUser: 'never' });
     });
   });
 
@@ -147,7 +148,7 @@ describe('transformMcpFormData', () => {
         ...formData,
         confirmation_ask_user: 'never',
       });
-      expect(result.confirmation).toBeUndefined();
+      expect(result.confirmation).toEqual({ askUser: 'never' });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { omit } from 'lodash';
+import type { McpToolDefinition } from '@kbn/agent-builder-common/tools';
+import { ToolType } from '@kbn/agent-builder-common';
+import type { McpToolFormData } from '../components/tools/form/types/tool_form_types';
+import {
+  transformMcpToolToFormData,
+  transformFormDataToMcpTool,
+  transformMcpFormDataForCreate,
+  transformMcpFormDataForUpdate,
+} from './transform_mcp_form_data';
+
+describe('transformMcpFormData', () => {
+  const formData: McpToolFormData = {
+    toolId: 'my-mcp-tool',
+    description: 'An MCP tool for testing.',
+    connectorId: 'connector-123',
+    mcpToolName: 'my_mcp_tool_name',
+    confirmation_ask_user: 'never',
+    labels: ['test', 'mcp'],
+    type: ToolType.mcp,
+  };
+
+  const defaultMcpTool: McpToolDefinition = {
+    id: 'my-mcp-tool',
+    description: 'An MCP tool for testing.',
+    readonly: false,
+    experimental: false,
+    configuration: {
+      connector_id: 'connector-123',
+      tool_name: 'my_mcp_tool_name',
+    },
+    type: ToolType.mcp,
+    tags: ['test', 'mcp'],
+  };
+
+  describe('transformMcpToolToFormData', () => {
+    it('should transform an MCP tool to form data', () => {
+      const result = transformMcpToolToFormData(defaultMcpTool);
+      expect(result).toEqual(formData);
+    });
+
+    it('defaults confirmation_ask_user to never when tool has no confirmation', () => {
+      const result = transformMcpToolToFormData(defaultMcpTool);
+      expect(result.confirmation_ask_user).toBe('never');
+    });
+
+    it('maps confirmation.askUser always to confirmation_ask_user', () => {
+      const toolWithConfirmation: McpToolDefinition = {
+        ...defaultMcpTool,
+        confirmation: { askUser: 'always' },
+      };
+
+      const result = transformMcpToolToFormData(toolWithConfirmation);
+      expect(result.confirmation_ask_user).toBe('always');
+    });
+
+    it('maps confirmation.askUser once to confirmation_ask_user', () => {
+      const toolWithConfirmation: McpToolDefinition = {
+        ...defaultMcpTool,
+        confirmation: { askUser: 'once' },
+      };
+
+      const result = transformMcpToolToFormData(toolWithConfirmation);
+      expect(result.confirmation_ask_user).toBe('once');
+    });
+  });
+
+  describe('transformFormDataToMcpTool', () => {
+    it('should transform form data to an MCP tool', () => {
+      const result = transformFormDataToMcpTool(formData);
+      expect(result).toEqual(defaultMcpTool);
+    });
+
+    it('omits confirmation entirely when confirmation_ask_user is never', () => {
+      const result = transformFormDataToMcpTool({
+        ...formData,
+        confirmation_ask_user: 'never',
+      });
+      expect(result.confirmation).toBeUndefined();
+    });
+
+    it('sets confirmation when confirmation_ask_user is once', () => {
+      const result = transformFormDataToMcpTool({
+        ...formData,
+        confirmation_ask_user: 'once',
+      });
+      expect(result.confirmation).toEqual({ askUser: 'once' });
+    });
+
+    it('sets confirmation when confirmation_ask_user is always', () => {
+      const result = transformFormDataToMcpTool({
+        ...formData,
+        confirmation_ask_user: 'always',
+      });
+      expect(result.confirmation).toEqual({ askUser: 'always' });
+    });
+  });
+
+  describe('transformMcpFormDataForCreate', () => {
+    it('should transform MCP form data to a create tool payload', () => {
+      const expectedPayload = omit(defaultMcpTool, ['readonly', 'experimental']);
+      const result = transformMcpFormDataForCreate(formData);
+      expect(result).toEqual(expectedPayload);
+    });
+
+    it('includes confirmation in the create payload when policy is not never', () => {
+      const result = transformMcpFormDataForCreate({
+        ...formData,
+        confirmation_ask_user: 'once',
+      });
+      expect(result.confirmation).toEqual({ askUser: 'once' });
+    });
+
+    it('omits confirmation from the create payload when policy is never', () => {
+      const result = transformMcpFormDataForCreate({
+        ...formData,
+        confirmation_ask_user: 'never',
+      });
+      expect(result.confirmation).toBeUndefined();
+    });
+  });
+
+  describe('transformMcpFormDataForUpdate', () => {
+    it('should transform MCP form data to an update tool payload', () => {
+      const expectedPayload = omit(defaultMcpTool, ['id', 'type', 'readonly', 'experimental']);
+      const result = transformMcpFormDataForUpdate(formData);
+      expect(result).toEqual(expectedPayload);
+    });
+
+    it('includes confirmation in the update payload when policy is not never', () => {
+      const result = transformMcpFormDataForUpdate({
+        ...formData,
+        confirmation_ask_user: 'always',
+      });
+      expect(result.confirmation).toEqual({ askUser: 'always' });
+    });
+
+    it('omits confirmation from the update payload when policy is never', () => {
+      const result = transformMcpFormDataForUpdate({
+        ...formData,
+        confirmation_ask_user: 'never',
+      });
+      expect(result.confirmation).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.test.ts
@@ -6,7 +6,10 @@
  */
 
 import { omit } from 'lodash';
-import type { McpToolDefinition } from '@kbn/agent-builder-common/tools';
+import type {
+  McpToolDefinition,
+  ToolConfirmationPolicyMode,
+} from '@kbn/agent-builder-common/tools';
 import { ToolType } from '@kbn/agent-builder-common';
 import type { McpToolFormData } from '../components/tools/form/types/tool_form_types';
 import {
@@ -111,20 +114,15 @@ describe('transformMcpFormData', () => {
       expect(result).toEqual(expectedPayload);
     });
 
-    it('includes confirmation in the create payload when policy is not never', () => {
-      const result = transformMcpFormDataForCreate({
-        ...formData,
-        confirmation_ask_user: 'once',
-      });
-      expect(result.confirmation).toEqual({ askUser: 'once' });
-    });
-
-    it('omits confirmation from the create payload when policy is never', () => {
-      const result = transformMcpFormDataForCreate({
-        ...formData,
-        confirmation_ask_user: 'never',
-      });
-      expect(result.confirmation).toMatchObject({ askUser: 'never' });
+    it('includes confirmation in the create payload', () => {
+      const values: ToolConfirmationPolicyMode[] = ['never', 'once', 'always'];
+      for (const value of values) {
+        const result = transformMcpFormDataForCreate({
+          ...formData,
+          confirmation_ask_user: value,
+        });
+        expect(result.confirmation).toEqual({ askUser: value });
+      }
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.ts
@@ -34,7 +34,7 @@ export const transformFormDataToMcpTool = (data: McpToolFormData): McpToolDefini
     },
     tags: data.labels,
     type: ToolType.mcp,
-    ...(data.confirmation_ask_user !== 'never'
+    ...(data.confirmation_ask_user
       ? { confirmation: { askUser: data.confirmation_ask_user } }
       : {}),
   };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_mcp_form_data.ts
@@ -16,6 +16,7 @@ export const transformMcpToolToFormData = (tool: McpToolDefinition): McpToolForm
     description: tool.description,
     connectorId: tool.configuration.connector_id,
     mcpToolName: tool.configuration.tool_name,
+    confirmation_ask_user: tool.confirmation?.askUser ?? 'never',
     labels: tool.tags,
     type: ToolType.mcp,
   };
@@ -33,6 +34,9 @@ export const transformFormDataToMcpTool = (data: McpToolFormData): McpToolDefini
     },
     tags: data.labels,
     type: ToolType.mcp,
+    ...(data.confirmation_ask_user !== 'never'
+      ? { confirmation: { askUser: data.confirmation_ask_user } }
+      : {}),
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_workflow_form_data.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_workflow_form_data.test.ts
@@ -40,6 +40,7 @@ describe('transformWorkflowFormData', () => {
         workflow_id: 'workflow-123',
         wait_for_completion: true,
       },
+      confirmation: { askUser: 'never' },
       type: ToolType.workflow,
       tags: ['test', 'workflow'],
     };
@@ -73,12 +74,12 @@ describe('transformWorkflowFormData', () => {
       expect(result).toEqual(mockTool);
     });
 
-    it('omits confirmation entirely when confirmation_ask_user is never', () => {
+    it('sets confirmation when confirmation_ask_user is never', () => {
       const result = transformFormDataToWorkflowTool({
         ...mockFormData,
         confirmation_ask_user: 'never',
       });
-      expect(result.confirmation).toBeUndefined();
+      expect(result.confirmation).toEqual({ askUser: 'never' });
     });
 
     it('sets confirmation when confirmation_ask_user is once', () => {
@@ -118,7 +119,7 @@ describe('transformWorkflowFormData', () => {
         ...mockFormData,
         confirmation_ask_user: 'never',
       });
-      expect(result.confirmation).toBeUndefined();
+      expect(result.confirmation).toEqual({ askUser: 'never' });
     });
   });
 
@@ -142,7 +143,7 @@ describe('transformWorkflowFormData', () => {
         ...mockFormData,
         confirmation_ask_user: 'never',
       });
-      expect(result.confirmation).toBeUndefined();
+      expect(result.confirmation).toEqual({ askUser: 'never' });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_workflow_form_data.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_workflow_form_data.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { omit } from 'lodash';
+import type { WorkflowToolDefinition } from '@kbn/agent-builder-common/tools';
+import { ToolType } from '@kbn/agent-builder-common';
+import type { WorkflowToolFormData } from '../components/tools/form/types/tool_form_types';
+import {
+  transformWorkflowToolToFormData,
+  transformFormDataToWorkflowTool,
+  transformWorkflowFormDataForCreate,
+  transformWorkflowFormDataForUpdate,
+} from './transform_workflow_form_data';
+
+describe('transformWorkflowFormData', () => {
+  let mockFormData: WorkflowToolFormData;
+  let mockTool: WorkflowToolDefinition;
+
+  beforeEach(() => {
+    mockFormData = {
+      toolId: 'my-workflow-tool',
+      description: 'A workflow tool for testing.',
+      workflow_id: 'workflow-123',
+      wait_for_completion: true,
+      confirmation_ask_user: 'never',
+      labels: ['test', 'workflow'],
+      type: ToolType.workflow,
+    };
+
+    mockTool = {
+      id: 'my-workflow-tool',
+      description: 'A workflow tool for testing.',
+      readonly: false,
+      experimental: false,
+      configuration: {
+        workflow_id: 'workflow-123',
+        wait_for_completion: true,
+      },
+      type: ToolType.workflow,
+      tags: ['test', 'workflow'],
+    };
+  });
+
+  describe('transformWorkflowToolToFormData', () => {
+    it('should transform a workflow tool to form data', () => {
+      const result = transformWorkflowToolToFormData(mockTool);
+      expect(result).toEqual(mockFormData);
+    });
+
+    it('defaults confirmation_ask_user to never when tool has no confirmation', () => {
+      const result = transformWorkflowToolToFormData(mockTool);
+      expect(result.confirmation_ask_user).toBe('never');
+    });
+
+    it('maps confirmation.askUser to confirmation_ask_user', () => {
+      const toolWithConfirmation: WorkflowToolDefinition = {
+        ...mockTool,
+        confirmation: { askUser: 'always' },
+      };
+
+      const result = transformWorkflowToolToFormData(toolWithConfirmation);
+      expect(result.confirmation_ask_user).toBe('always');
+    });
+  });
+
+  describe('transformFormDataToWorkflowTool', () => {
+    it('should transform form data to a workflow tool', () => {
+      const result = transformFormDataToWorkflowTool(mockFormData);
+      expect(result).toEqual(mockTool);
+    });
+
+    it('omits confirmation entirely when confirmation_ask_user is never', () => {
+      const result = transformFormDataToWorkflowTool({
+        ...mockFormData,
+        confirmation_ask_user: 'never',
+      });
+      expect(result.confirmation).toBeUndefined();
+    });
+
+    it('sets confirmation when confirmation_ask_user is once', () => {
+      const result = transformFormDataToWorkflowTool({
+        ...mockFormData,
+        confirmation_ask_user: 'once',
+      });
+      expect(result.confirmation).toEqual({ askUser: 'once' });
+    });
+
+    it('sets confirmation when confirmation_ask_user is always', () => {
+      const result = transformFormDataToWorkflowTool({
+        ...mockFormData,
+        confirmation_ask_user: 'always',
+      });
+      expect(result.confirmation).toEqual({ askUser: 'always' });
+    });
+  });
+
+  describe('transformWorkflowFormDataForCreate', () => {
+    it('should transform workflow form data to a create tool payload', () => {
+      const expectedPayload = omit(mockTool, ['readonly', 'experimental']);
+      const result = transformWorkflowFormDataForCreate(mockFormData);
+      expect(result).toEqual(expectedPayload);
+    });
+
+    it('includes confirmation in the create payload when policy is not never', () => {
+      const result = transformWorkflowFormDataForCreate({
+        ...mockFormData,
+        confirmation_ask_user: 'once',
+      });
+      expect(result.confirmation).toEqual({ askUser: 'once' });
+    });
+
+    it('omits confirmation from the create payload when policy is never', () => {
+      const result = transformWorkflowFormDataForCreate({
+        ...mockFormData,
+        confirmation_ask_user: 'never',
+      });
+      expect(result.confirmation).toBeUndefined();
+    });
+  });
+
+  describe('transformWorkflowFormDataForUpdate', () => {
+    it('should transform workflow form data to an update tool payload', () => {
+      const expectedPayload = omit(mockTool, ['id', 'type', 'readonly', 'experimental']);
+      const result = transformWorkflowFormDataForUpdate(mockFormData);
+      expect(result).toEqual(expectedPayload);
+    });
+
+    it('includes confirmation in the update payload when policy is not never', () => {
+      const result = transformWorkflowFormDataForUpdate({
+        ...mockFormData,
+        confirmation_ask_user: 'always',
+      });
+      expect(result.confirmation).toEqual({ askUser: 'always' });
+    });
+
+    it('omits confirmation from the update payload when policy is never', () => {
+      const result = transformWorkflowFormDataForUpdate({
+        ...mockFormData,
+        confirmation_ask_user: 'never',
+      });
+      expect(result.confirmation).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_workflow_form_data.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_workflow_form_data.ts
@@ -19,7 +19,7 @@ export const transformWorkflowToolToFormData = (
     description: tool.description,
     workflow_id: tool.configuration.workflow_id,
     wait_for_completion: tool.configuration.wait_for_completion ?? true,
-    confirmation_ask_user: tool.confirmation ? tool.confirmation.askUser ?? 'never' : 'never',
+    confirmation_ask_user: tool.confirmation?.askUser ?? 'never',
     labels: tool.tags,
     type: ToolType.workflow,
   };
@@ -39,7 +39,7 @@ export const transformFormDataToWorkflowTool = (
     },
     type: ToolType.workflow,
     tags: data.labels,
-    ...(data.confirmation_ask_user !== 'never'
+    ...(data.confirmation_ask_user
       ? { confirmation: { askUser: data.confirmation_ask_user } }
       : {}),
   };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_workflow_form_data.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/transform_workflow_form_data.ts
@@ -19,6 +19,7 @@ export const transformWorkflowToolToFormData = (
     description: tool.description,
     workflow_id: tool.configuration.workflow_id,
     wait_for_completion: tool.configuration.wait_for_completion ?? true,
+    confirmation_ask_user: tool.confirmation ? tool.confirmation.askUser ?? 'never' : 'never',
     labels: tool.tags,
     type: ToolType.workflow,
   };
@@ -38,6 +39,9 @@ export const transformFormDataToWorkflowTool = (
     },
     type: ToolType.workflow,
     tags: data.labels,
+    ...(data.confirmation_ask_user !== 'never'
+      ? { confirmation: { askUser: data.confirmation_ask_user } }
+      : {}),
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/tools.ts
@@ -167,11 +167,13 @@ export function registerToolsRoutes({
               confirmation: schema.maybe(
                 schema.object(
                   {
-                    askUser: schema.oneOf([
-                      schema.literal('once'),
-                      schema.literal('always'),
-                      schema.literal('never'),
-                    ]),
+                    askUser: schema.maybe(
+                      schema.oneOf([
+                        schema.literal('once'),
+                        schema.literal('always'),
+                        schema.literal('never'),
+                      ])
+                    ),
                   },
                   {
                     meta: {
@@ -270,11 +272,13 @@ export function registerToolsRoutes({
               confirmation: schema.maybe(
                 schema.object(
                   {
-                    askUser: schema.oneOf([
-                      schema.literal('once'),
-                      schema.literal('always'),
-                      schema.literal('never'),
-                    ]),
+                    askUser: schema.maybe(
+                      schema.oneOf([
+                        schema.literal('once'),
+                        schema.literal('always'),
+                        schema.literal('never'),
+                      ])
+                    ),
                   },
                   {
                     meta: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/tools.ts
@@ -164,6 +164,23 @@ export function registerToolsRoutes({
                   description: 'Tool-specific configuration parameters. See examples for details.',
                 },
               }),
+              confirmation: schema.maybe(
+                schema.object(
+                  {
+                    askUser: schema.oneOf([
+                      schema.literal('once'),
+                      schema.literal('always'),
+                      schema.literal('never'),
+                    ]),
+                  },
+                  {
+                    meta: {
+                      description:
+                        'Optional tool call policy to control tool call confirmation behavior',
+                    },
+                  }
+                )
+              ),
             }),
           },
         },
@@ -249,6 +266,23 @@ export function registerToolsRoutes({
                       'Updated tool-specific configuration parameters. See examples for details.',
                   },
                 })
+              ),
+              confirmation: schema.maybe(
+                schema.object(
+                  {
+                    askUser: schema.oneOf([
+                      schema.literal('once'),
+                      schema.literal('always'),
+                      schema.literal('never'),
+                    ]),
+                  },
+                  {
+                    meta: {
+                      description:
+                        'Updated tool call policy to control tool call confirmation behavior',
+                    },
+                  }
+                )
               ),
             }),
           },

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.ts
@@ -6,7 +6,10 @@
  */
 
 import type { Conversation, ConverseInput } from '@kbn/agent-builder-common';
-import { ConversationRoundStatus } from '@kbn/agent-builder-common';
+import {
+  ConversationRoundStatus,
+  type ToolConfirmationPolicyMode,
+} from '@kbn/agent-builder-common';
 import type {
   PromptManager,
   ToolPromptManager,
@@ -30,7 +33,6 @@ import {
   isConfirmationPromptResponse,
 } from '@kbn/agent-builder-common/agents/prompts';
 import type { InternalToolDefinition } from '@kbn/agent-builder-server';
-import type { ToolConfirmationPolicyMode } from '@kbn/agent-builder-server/tools';
 import type { ToolPolicyConfirmationDefinition } from '@kbn/agent-builder-server/tools/builtin';
 import { i18nBundles } from '../i18n';
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/converter.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/converter.test.ts
@@ -47,6 +47,27 @@ describe('fromEs', () => {
       updated_at: '2025-08-04T06:44:19.123Z',
     });
   });
+
+  it('includes confirmation when present in the source document', () => {
+    const document: ToolDocument = {
+      _id: '_id',
+      _source: {
+        id: 'id',
+        type: ToolType.esql,
+        space: 'space',
+        description: 'description',
+        configuration: {},
+        confirmation: { askUser: 'always' },
+        tags: [],
+        created_at: creationDate,
+        updated_at: updateDate,
+      },
+    };
+
+    const definition = fromEs(document);
+
+    expect(definition.confirmation).toEqual({ askUser: 'always' });
+  });
 });
 
 describe('createAttributes', () => {
@@ -79,6 +100,25 @@ describe('createAttributes', () => {
       created_at: actualCreationDate.toISOString(),
       updated_at: actualCreationDate.toISOString(),
     });
+  });
+
+  it('includes confirmation when provided in the creation request', () => {
+    const actualCreationDate = new Date();
+    const createRequest: ToolCreateParams = {
+      id: 'id',
+      type: ToolType.esql,
+      description: 'foo',
+      configuration: {},
+      confirmation: { askUser: 'once' },
+    };
+
+    const properties = createAttributes({
+      createRequest,
+      space: 'some-space',
+      creationDate: actualCreationDate,
+    });
+
+    expect(properties.confirmation).toEqual({ askUser: 'once' });
   });
 });
 
@@ -128,5 +168,61 @@ describe('updateDocument', () => {
       created_at: creationDate,
       updated_at: actualUpdateDate.toISOString(),
     });
+  });
+
+  it('removes confirmation when the update omits it', () => {
+    const actualUpdateDate = new Date();
+
+    const currentProps: ToolProperties = {
+      id: 'id',
+      type: ToolType.esql,
+      space: 'some-space',
+      description: 'foo',
+      configuration: {},
+      confirmation: { askUser: 'once' },
+      tags: [],
+      created_at: creationDate,
+      updated_at: updateDate,
+    };
+
+    const update: ToolTypeUpdateParams = {
+      description: 'updated desc',
+    };
+
+    const merged = updateDocument({
+      current: currentProps,
+      update,
+      updateDate: actualUpdateDate,
+    });
+
+    expect(merged.confirmation).toBeUndefined();
+  });
+
+  it('replaces confirmation entirely rather than merging it', () => {
+    const actualUpdateDate = new Date();
+
+    const currentProps: ToolProperties = {
+      id: 'id',
+      type: ToolType.esql,
+      space: 'some-space',
+      description: 'foo',
+      configuration: {},
+      confirmation: { askUser: 'once' },
+      tags: [],
+      created_at: creationDate,
+      updated_at: updateDate,
+    };
+
+    const update: ToolTypeUpdateParams = {
+      confirmation: { askUser: 'always' },
+    };
+
+    const merged = updateDocument({
+      current: currentProps,
+      update,
+      updateDate: actualUpdateDate,
+    });
+
+    expect(merged.confirmation).toEqual({ askUser: 'always' });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/converter.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/converter.test.ts
@@ -170,35 +170,7 @@ describe('updateDocument', () => {
     });
   });
 
-  it('removes confirmation when the update omits it', () => {
-    const actualUpdateDate = new Date();
-
-    const currentProps: ToolProperties = {
-      id: 'id',
-      type: ToolType.esql,
-      space: 'some-space',
-      description: 'foo',
-      configuration: {},
-      confirmation: { askUser: 'once' },
-      tags: [],
-      created_at: creationDate,
-      updated_at: updateDate,
-    };
-
-    const update: ToolTypeUpdateParams = {
-      description: 'updated desc',
-    };
-
-    const merged = updateDocument({
-      current: currentProps,
-      update,
-      updateDate: actualUpdateDate,
-    });
-
-    expect(merged.confirmation).toBeUndefined();
-  });
-
-  it('replaces confirmation entirely rather than merging it', () => {
+  it('updates confirmation when provided', () => {
     const actualUpdateDate = new Date();
 
     const currentProps: ToolProperties = {
@@ -224,5 +196,60 @@ describe('updateDocument', () => {
     });
 
     expect(merged.confirmation).toEqual({ askUser: 'always' });
+  });
+
+  it('can set confirmation if previously undefined', () => {
+    const actualUpdateDate = new Date();
+
+    const currentProps: ToolProperties = {
+      id: 'id',
+      type: ToolType.esql,
+      space: 'some-space',
+      description: 'foo',
+      configuration: {},
+      tags: [],
+      created_at: creationDate,
+      updated_at: updateDate,
+    };
+
+    const update: ToolTypeUpdateParams = {
+      confirmation: { askUser: 'always' },
+    };
+
+    const merged = updateDocument({
+      current: currentProps,
+      update,
+      updateDate: actualUpdateDate,
+    });
+
+    expect(merged.confirmation).toEqual({ askUser: 'always' });
+  });
+
+  it('retains existing confirmation if omitted from update', () => {
+    const actualUpdateDate = new Date();
+
+    const currentProps: ToolProperties = {
+      id: 'id',
+      type: ToolType.esql,
+      space: 'some-space',
+      description: 'foo',
+      configuration: {},
+      confirmation: { askUser: 'once' },
+      tags: [],
+      created_at: creationDate,
+      updated_at: updateDate,
+    };
+
+    const update: ToolTypeUpdateParams = {
+      description: 'foobar',
+    };
+
+    const merged = updateDocument({
+      current: currentProps,
+      update,
+      updateDate: actualUpdateDate,
+    });
+
+    expect(merged.confirmation?.askUser).toEqual('once');
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/converters.ts
@@ -66,7 +66,15 @@ export const updateDocument = ({
       ...current.configuration,
       ...update.configuration,
     },
-    confirmation: update.confirmation,
+    ...(current.confirmation || update.confirmation
+      ? {
+          confirmation: {
+            ...(current.confirmation ?? {}),
+            ...(update.confirmation ?? {}),
+          },
+        }
+      : {}),
+
     updated_at: updateDate.toISOString(),
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/converters.ts
@@ -22,6 +22,7 @@ export const fromEs = <TConfig extends object = {}>(
     description: document._source.description,
     tags: document._source.tags,
     configuration: document._source.configuration as TConfig,
+    confirmation: document._source.confirmation,
     updated_at: document._source.updated_at,
     created_at: document._source.created_at,
   };
@@ -43,6 +44,7 @@ export const createAttributes = ({
     description: createRequest.description ?? '',
     tags: createRequest.tags ?? [],
     configuration: createRequest.configuration,
+    confirmation: createRequest.confirmation,
     created_at: creationDate.toISOString(),
     updated_at: creationDate.toISOString(),
   };
@@ -64,6 +66,7 @@ export const updateDocument = ({
       ...current.configuration,
       ...update.configuration,
     },
+    confirmation: update.confirmation,
     updated_at: updateDate.toISOString(),
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/storage.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Logger, ElasticsearchClient } from '@kbn/core/server';
-import type { ToolType } from '@kbn/agent-builder-common';
+import type { ToolType, ToolConfirmationPolicy } from '@kbn/agent-builder-common';
 import type { IndexStorageSettings } from '@kbn/storage-adapter';
 import { StorageIndexAdapter, types } from '@kbn/storage-adapter';
 import { chatSystemIndex } from '@kbn/agent-builder-server';
@@ -25,6 +25,12 @@ const storageSettings = {
         dynamic: false,
         properties: {},
       }),
+      confirmation: types.object({
+        dynamic: false,
+        properties: {
+          askUser: types.keyword({}),
+        },
+      }),
       tags: types.keyword({}),
       created_at: types.date({}),
       updated_at: types.date({}),
@@ -38,6 +44,7 @@ export interface ToolProperties<TConfig extends object = Record<string, unknown>
   space: string;
   description: string;
   configuration: TConfig;
+  confirmation?: ToolConfirmationPolicy;
   tags: string[];
   created_at: string;
   updated_at: string;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/converter.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/converter.test.ts
@@ -97,6 +97,16 @@ describe('convertPersistedDefinition', () => {
     });
   });
 
+  it('defaults confirmation to never when not set on the persisted tool', () => {
+    const internal = convertPersistedDefinition({
+      tool: mockedTool,
+      definition: mockedDefinition,
+      context: mockedContext,
+    });
+
+    expect(internal.confirmation).toEqual({ askUser: 'never' });
+  });
+
   it('always sets experimental to false', () => {
     const internal = convertPersistedDefinition({
       tool: mockedTool,
@@ -104,5 +114,33 @@ describe('convertPersistedDefinition', () => {
       context: mockedContext,
     });
     expect(internal.experimental).toBe(false);
+  });
+
+  it('sets confirmation once when persisted', () => {
+    const mockedToolWithConfirmation: ToolPersistedDefinition = {
+      ...mockedTool,
+      confirmation: { askUser: 'once' },
+    };
+    const internal = convertPersistedDefinition({
+      tool: mockedToolWithConfirmation,
+      definition: mockedDefinition,
+      context: mockedContext,
+    });
+
+    expect(internal.confirmation).toMatchObject({ askUser: 'once' });
+  });
+
+  it('sets confirmation always when persisted', () => {
+    const mockedToolWithConfirmation: ToolPersistedDefinition = {
+      ...mockedTool,
+      confirmation: { askUser: 'always' },
+    };
+    const internal = convertPersistedDefinition({
+      tool: mockedToolWithConfirmation,
+      definition: mockedDefinition,
+      context: mockedContext,
+    });
+
+    expect(internal.confirmation).toMatchObject({ askUser: 'always' });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/converter.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/converter.ts
@@ -45,7 +45,7 @@ export const convertPersistedDefinition = <
     configuration: convertedConfiguration,
     readonly: false,
     experimental: false,
-    confirmation: {
+    confirmation: tool.confirmation ?? {
       askUser: 'never',
     },
     isAvailable: () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/utils/tool_conversion.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/utils/tool_conversion.ts
@@ -59,6 +59,6 @@ export const toDescriptorWithSchema = async (
 };
 
 export const toDescriptor = (tool: InternalToolDefinition): ToolDefinition => {
-  const { id, type, description, tags, configuration, readonly, experimental } = tool;
-  return { id, type, description, tags, configuration, readonly, experimental };
+  const { id, type, description, tags, configuration, readonly, experimental, confirmation } = tool;
+  return { id, type, description, tags, configuration, readonly, experimental, confirmation };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/fixtures/page_objects/agent_builder_app.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/fixtures/page_objects/agent_builder_app.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ToolType } from '@kbn/agent-builder-common';
+import type { ToolConfirmationPolicyMode, ToolType } from '@kbn/agent-builder-common';
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import type { LlmProxy } from '@kbn/ftr-llm-proxy';
 import type { ScoutPage } from '@kbn/scout';
@@ -266,6 +266,28 @@ export class AgentBuilderApp {
       .locator('agentBuilderToolFormPage')
       .locator('[data-test-subj="euiMarkdownEditorTextArea"]');
     return (await ta.inputValue()).trim();
+  }
+
+  async setConfirmationPolicyValue(value: ToolConfirmationPolicyMode) {
+    await this.page.testSubj
+      .locator('agentBuilderToolConfirmationPolicySelect')
+      .selectOption(value);
+  }
+
+  async getConfirmationPolicyValue(): Promise<string> {
+    return this.page.testSubj.locator('agentBuilderToolConfirmationPolicySelect').inputValue();
+  }
+
+  async expectConfirmationPolicyValueToBeVisible() {
+    await expect(
+      this.page.testSubj.locator('agentBuilderToolConfirmationPolicySelect')
+    ).toBeVisible();
+  }
+
+  async expectConfirmationPolicyValue(value: ToolConfirmationPolicyMode) {
+    await expect(
+      this.page.testSubj.locator('agentBuilderToolConfirmationPolicySelect')
+    ).toHaveValue(value);
   }
 
   async setIndexPattern(indexPattern: string) {

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/mcp_tools.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/mcp_tools.spec.ts
@@ -66,6 +66,9 @@ test.describe(
         await expect(page.testSubj.locator('agentBuilderMcpToolSelect')).toBeVisible();
         await pageObjects.agentBuilder.selectMcpTool('echo');
         await pageObjects.agentBuilder.setToolId(toolId);
+        await pageObjects.agentBuilder.expectConfirmationPolicyValueToBeVisible();
+        await pageObjects.agentBuilder.expectConfirmationPolicyValue('never');
+        await pageObjects.agentBuilder.setConfirmationPolicyValue('once');
         await pageObjects.agentBuilder.saveTool();
         await pageObjects.agentBuilder.navigateToToolsLanding();
         expect(await pageObjects.agentBuilder.isToolInTable(toolId)).toBe(true);
@@ -92,6 +95,30 @@ test.describe(
 
         await pageObjects.agentBuilder.navigateToTool(toolId);
         expect(await pageObjects.agentBuilder.getToolDescriptionValue()).toContain(newDescription);
+      });
+
+      await test.step('edits an MCP tool confirmation policy', async () => {
+        const toolId = `scout.mcp.edit.confirmation.${Date.now()}`;
+        await createToolViaKbn(kbnClient, {
+          id: toolId,
+          type: 'mcp',
+          description: 'description',
+          tags: [],
+          configuration: {
+            connector_id: connectorId,
+            tool_name: 'echo',
+          },
+        });
+
+        await pageObjects.agentBuilder.navigateToTool(toolId);
+        await expect(page.testSubj.locator('agentBuilderToolFormPage')).toBeVisible();
+        await pageObjects.agentBuilder.expectConfirmationPolicyValueToBeVisible();
+        await pageObjects.agentBuilder.expectConfirmationPolicyValue('never');
+        await pageObjects.agentBuilder.setConfirmationPolicyValue('always');
+        await pageObjects.agentBuilder.saveTool();
+
+        await pageObjects.agentBuilder.navigateToTool(toolId);
+        await pageObjects.agentBuilder.expectConfirmationPolicyValue('always');
       });
 
       await test.step('clones an MCP tool and selects a different server tool', async () => {


### PR DESCRIPTION
## Summary

Updates agent builder `ToolDefinition` to optional accept confirmation configuration to allow agents to ask the user for permission to run user defined tools.

It updates the tool create and update UIs to allow setting the policy on Workflows and MCP tools. It could technically be added to ES|QL and index search tools as well, but the benefit of confirmation for those tools didn't seem worth updating the UI for.

Additionally this [fix commit](https://github.com/elastic/kibana/pull/281896/commits/68738fd4df456c5c7610db0b88907e4a749cfde2) updated the tool create form to reset the form with default values when the tool type selection changes. This _may_ be worth cherrypicking to backport. I added this when I noticed for a workflow tool type you had to select then unselect the `Wait until the workflow completes` checkbox or else that value stayed `undefined` and failed validation. That value should default to `true` which is what happens now. The one trade-off is any common properties set before changing the type are lost, ie id, description tags.

### Screenshots
Workflow Create
<img width="1512" height="1010" alt="image" src="https://github.com/user-attachments/assets/ecfd77a5-f6e8-4298-ba5a-5a9f15ac664e" />

MCP Create
<img width="1512" height="1010" alt="image" src="https://github.com/user-attachments/assets/6e352230-75dc-4170-9cbf-90ccb4b2d27e" />

MCP Update
<img width="1512" height="1010" alt="image" src="https://github.com/user-attachments/assets/939a4d0c-c938-4630-88e7-d05b82dfae6b" />

Confirmation prompt in a chat:
<img width="1512" height="1010" alt="image" src="https://github.com/user-attachments/assets/786fd76f-2397-4bb6-8472-422a0de50cbd" />

Deny confirmation:
<img width="1512" height="1010" alt="image" src="https://github.com/user-attachments/assets/5eea8b36-9023-4065-91b0-258da856e209" />

Approved confirmation:
<img width="1512" height="1010" alt="image" src="https://github.com/user-attachments/assets/0d3f3fa2-6bae-4351-bdab-4c3c07d05dbb" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.