### PR TITLE
CI: Remove us-west1 zones from c4d machine type jobs

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -38,7 +38,7 @@ steps:
       provider: gcp
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
+      zones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d
       diskSizeGb: 200
     key: build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,7 +7,7 @@ steps:
     agents:
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
+      zones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d
       diskSizeGb: 200
     key: build
     # [rspack-transition] Original condition (restore when legacy optimizer is removed):

--- a/.buildkite/pipelines/rspack_e2e_test.yml
+++ b/.buildkite/pipelines/rspack_e2e_test.yml
@@ -39,7 +39,7 @@ steps:
       provider: gcp
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
+      zones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d
       diskSizeGb: 200
     key: build
     timeout_in_minutes: 60


### PR DESCRIPTION
Temporarily removing us-west1-a/b/c from c4d zones while awaiting a quota increase in that region.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->