### PR TITLE
[9.4] [Field formats] Fix Date Nanos formatter ignoring dateFormat for numeric values (#281343)

### DIFF
--- a/src/platform/plugins/shared/field_formats/common/converters/date_nanos_shared.test.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/date_nanos_shared.test.ts
@@ -105,6 +105,37 @@ describe('Date Nanos Format', () => {
     const dateMath = 'now+1M/d';
     expect(convert(dateMath)).toBe(dateMath);
   });
+
+  test('should format numeric values (ms) with the dateFormat fallback pattern', () => {
+    const fallback = 'MMM D, YYYY @ HH:mm:ss.SSS';
+    const getConfig: FieldFormatsGetConfigFn = (key: string) =>
+      ({
+        dateNanosFormat: 'MMM D, YYYY @ HH:mm:ss.SSSSSSSSS',
+        dateFormat: fallback,
+        'dateFormat:tz': 'Browser',
+      }[key] as string);
+    const formatter = new DateNanosFormat({}, getConfig);
+
+    // e.g. a min/max aggregation result, returned by Elasticsearch in ms
+    const ms = 1558361096357;
+    expect(formatter.convert(ms)).toBe(moment(ms).format(fallback));
+  });
+
+  test('should clear the memoization cache when the fallback pattern changes', () => {
+    const config: Record<string, string> = {
+      dateNanosFormat: 'MMM D, YYYY @ HH:mm:ss.SSSSSSSSS',
+      dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
+      'dateFormat:tz': 'Browser',
+    };
+    const getConfig: FieldFormatsGetConfigFn = (key: string) => config[key];
+    const formatter = new DateNanosFormat({}, getConfig);
+
+    const ms = 1558361096357;
+    expect(formatter.convert(ms)).toBe(moment(ms).format('MMM D, YYYY @ HH:mm:ss.SSS'));
+
+    config.dateFormat = 'YYYY-MM-DD';
+    expect(formatter.convert(ms)).toBe(moment(ms).format('YYYY-MM-DD'));
+  });
 });
 
 describe('analysePatternForFract', () => {

--- a/src/platform/plugins/shared/field_formats/common/converters/date_nanos_shared.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/date_nanos_shared.ts
@@ -77,6 +77,7 @@ export class DateNanosFormat extends FieldFormat {
 
   protected memoizedConverter: Function = noop;
   protected memoizedPattern: string = '';
+  protected memoizedFallbackPattern: string = '';
   protected timeZone: string = '';
 
   getParamDefaults() {
@@ -93,13 +94,15 @@ export class DateNanosFormat extends FieldFormat {
     const pattern = this.param('pattern');
     const timezone = this.param('timezone');
     const fractPattern = analysePatternForFract(pattern);
-    const fallbackPattern = this.param('patternFallback');
+    const fallbackPattern = this.param('fallbackPattern');
 
     const timezoneChanged = this.timeZone !== timezone;
     const datePatternChanged = this.memoizedPattern !== pattern;
-    if (timezoneChanged || datePatternChanged) {
+    const fallbackPatternChanged = this.memoizedFallbackPattern !== fallbackPattern;
+    if (timezoneChanged || datePatternChanged || fallbackPatternChanged) {
       this.timeZone = timezone;
       this.memoizedPattern = pattern;
+      this.memoizedFallbackPattern = fallbackPattern;
 
       this.memoizedConverter = memoize(function converter(value: string | number) {
         if (value === null || value === undefined) {

--- a/src/platform/plugins/shared/field_formats/server/lib/converters/date_nanos_server.ts
+++ b/src/platform/plugins/shared/field_formats/server/lib/converters/date_nanos_server.ts
@@ -24,13 +24,15 @@ class DateNanosFormatServer extends DateNanosFormat {
     const pattern = this.param('pattern');
     const timezone = options?.timezone || this.param('timezone');
     const fractPattern = analysePatternForFract(pattern);
-    const fallbackPattern = this.param('patternFallback');
+    const fallbackPattern = this.param('fallbackPattern');
 
     const timezoneChanged = this.timeZone !== timezone;
     const datePatternChanged = this.memoizedPattern !== pattern;
-    if (timezoneChanged || datePatternChanged) {
+    const fallbackPatternChanged = this.memoizedFallbackPattern !== fallbackPattern;
+    if (timezoneChanged || datePatternChanged || fallbackPatternChanged) {
       this.timeZone = timezone;
       this.memoizedPattern = pattern;
+      this.memoizedFallbackPattern = fallbackPattern;
 
       this.memoizedConverter = memoize((value: string | number) => {
         if (value === null || value === undefined) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Field formats] Fix Date Nanos formatter ignoring dateFormat for numeric values (#281343)](https://github.com/elastic/kibana/pull/281343)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"bassem chagra","email":"chagra.bassem@yahoo.fr"},"sourceCommit":{"committedDate":"2026-07-29T21:58:36Z","message":"[Field formats] Fix Date Nanos formatter ignoring dateFormat for numeric values (#281343)\n\n## Summary\n\nCloses #281342\n\n`DateNanosFormat.getParamDefaults()` stores the fallback pattern under\nthe key `fallbackPattern`, but both converters read\n`this.param('patternFallback')` — a key that is never set anywhere in\nthe repo. As a result the fallback pattern was always `undefined`.\n\nThe fallback path is used when a `date_nanos` value arrives as a\n**number** (e.g. min/max aggregation results, which Elasticsearch\nreturns in milliseconds). `moment.format(undefined)` falls back to\nmoment's default ISO output, so the user's configured `dateFormat`\nadvanced setting was silently ignored for these values:\n`2020-05-18T20:45:05+00:00` instead of `May 18, 2020 @ 20:45:05.957`.\n\nThis PR aligns the reads with the defaults key in both\n`date_nanos_shared.ts` and `date_nanos_server.ts`, and adds a regression\ntest for the numeric fallback path (previously uncovered). The rename is\nsafe: `patternFallback` appears nowhere else, and the value is derived\nfrom uiSettings rather than persisted in saved objects.\n\n## Testing\n\n- `node scripts/jest .../date_nanos_shared.test.ts` — 11/11 pass\n(includes new regression test)\n- `node scripts/jest .../date_nanos_server.test.ts` — 4/4 pass\n- ESLint and type check (`field_formats` project) clean\n\n---------\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"de1bf516078d4edaa90d20486a451be5b667d4c0","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","💝community","Team:DataDiscovery","backport:version","v9.6.0","v9.4.5","v9.5.1"],"title":"[Field formats] Fix Date Nanos formatter ignoring dateFormat for numeric values","number":281343,"url":"https://github.com/elastic/kibana/pull/281343","mergeCommit":{"message":"[Field formats] Fix Date Nanos formatter ignoring dateFormat for numeric values (#281343)\n\n## Summary\n\nCloses #281342\n\n`DateNanosFormat.getParamDefaults()` stores the fallback pattern under\nthe key `fallbackPattern`, but both converters read\n`this.param('patternFallback')` — a key that is never set anywhere in\nthe repo. As a result the fallback pattern was always `undefined`.\n\nThe fallback path is used when a `date_nanos` value arrives as a\n**number** (e.g. min/max aggregation results, which Elasticsearch\nreturns in milliseconds). `moment.format(undefined)` falls back to\nmoment's default ISO output, so the user's configured `dateFormat`\nadvanced setting was silently ignored for these values:\n`2020-05-18T20:45:05+00:00` instead of `May 18, 2020 @ 20:45:05.957`.\n\nThis PR aligns the reads with the defaults key in both\n`date_nanos_shared.ts` and `date_nanos_server.ts`, and adds a regression\ntest for the numeric fallback path (previously uncovered). The rename is\nsafe: `patternFallback` appears nowhere else, and the value is derived\nfrom uiSettings rather than persisted in saved objects.\n\n## Testing\n\n- `node scripts/jest .../date_nanos_shared.test.ts` — 11/11 pass\n(includes new regression test)\n- `node scripts/jest .../date_nanos_server.test.ts` — 4/4 pass\n- ESLint and type check (`field_formats` project) clean\n\n---------\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"de1bf516078d4edaa90d20486a451be5b667d4c0"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281343","number":281343,"mergeCommit":{"message":"[Field formats] Fix Date Nanos formatter ignoring dateFormat for numeric values (#281343)\n\n## Summary\n\nCloses #281342\n\n`DateNanosFormat.getParamDefaults()` stores the fallback pattern under\nthe key `fallbackPattern`, but both converters read\n`this.param('patternFallback')` — a key that is never set anywhere in\nthe repo. As a result the fallback pattern was always `undefined`.\n\nThe fallback path is used when a `date_nanos` value arrives as a\n**number** (e.g. min/max aggregation results, which Elasticsearch\nreturns in milliseconds). `moment.format(undefined)` falls back to\nmoment's default ISO output, so the user's configured `dateFormat`\nadvanced setting was silently ignored for these values:\n`2020-05-18T20:45:05+00:00` instead of `May 18, 2020 @ 20:45:05.957`.\n\nThis PR aligns the reads with the defaults key in both\n`date_nanos_shared.ts` and `date_nanos_server.ts`, and adds a regression\ntest for the numeric fallback path (previously uncovered). The rename is\nsafe: `patternFallback` appears nowhere else, and the value is derived\nfrom uiSettings rather than persisted in saved objects.\n\n## Testing\n\n- `node scripts/jest .../date_nanos_shared.test.ts` — 11/11 pass\n(includes new regression test)\n- `node scripts/jest .../date_nanos_server.test.ts` — 4/4 pass\n- ESLint and type check (`field_formats` project) clean\n\n---------\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"de1bf516078d4edaa90d20486a451be5b667d4c0"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/281626","number":281626,"state":"OPEN"}]}] BACKPORT-->