### PR TITLE
[Fleet] Fix agent upgrade rolled back tooltip text

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.test.tsx
@@ -324,7 +324,7 @@ describe('AgentUpgradeStatus', () => {
       });
 
       expectUpgradeStatusBadgeLabel(results, 'Upgrade rolled back');
-      await expectTooltip(results, 'Upgrade unsuccessful. Rolling back to previous version.');
+      await expectTooltip(results, 'Upgrade rolled back to previous version.');
     });
 
     it('should render UPG_FAILED state correctly', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.tsx
@@ -245,7 +245,7 @@ function getStatusComponents(agentUpgradeDetails?: AgentUpgradeDetails) {
         TooltipText: (
           <FormattedMessage
             id="xpack.fleet.agentUpgradeStatusTooltip.upgradeRolledBack"
-            defaultMessage="Upgrade unsuccessful. Rolling back to previous version."
+            defaultMessage="Upgrade rolled back to previous version."
           />
         ),
       };


### PR DESCRIPTION
## Summary

I realised while doing a demo that the current tooltip text for the "Upgrade rolled back" agent upgrade status in Fleet's table is misleading as rollback is a user action available after a successful upgrade. This PR fixes that.

Currently:
<img width="1915" height="648" alt="Screenshot 2026-07-28 at 10 37 35" src="https://github.com/user-attachments/assets/5d8d744b-1b87-4584-84c0-a45d57d8376b" />

Changed to "Upgrade rolled back to previous version."

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

N/A: UI string change

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->