### PR TITLE
[evals] Add GPT-5.6 models to weekly EIS eval suites

### DIFF
--- a/.buildkite/pipelines/evals/evals.suites.json
+++ b/.buildkite/pipelines/evals/evals.suites.json
@@ -95,7 +95,6 @@
         "eis/openai-gpt-5.4-mini",
         "eis/openai-gpt-5.4-nano",
         "eis/openai-gpt-5.6-luna",
-        "eis/openai-gpt-5.6-sol",
         "eis/openai-gpt-5.6-terra",
         "eis/openai-gpt-oss-120b"
       ]

--- a/.buildkite/pipelines/evals/evals.suites.json
+++ b/.buildkite/pipelines/evals/evals.suites.json
@@ -94,6 +94,9 @@
         "eis/openai-gpt-5.4",
         "eis/openai-gpt-5.4-mini",
         "eis/openai-gpt-5.4-nano",
+        "eis/openai-gpt-5.6-luna",
+        "eis/openai-gpt-5.6-sol",
+        "eis/openai-gpt-5.6-terra",
         "eis/openai-gpt-oss-120b"
       ]
     },

--- a/.buildkite/pipelines/evals/llm_evals.yml
+++ b/.buildkite/pipelines/evals/llm_evals.yml
@@ -187,7 +187,7 @@ steps:
           EVAL_INCLUDE_EIS_MODELS: '1'
           # Extended tier: includes smaller/cheaper models for cost-performance evaluation.
           # Keep in sync with `weeklyEisModelGroups` for significant-events in evals.suites.json.
-          EVAL_MODEL_GROUPS: &weekly_eis_extended_models 'eis/anthropic-claude-4.6-sonnet,eis/anthropic-claude-4.6-opus,eis/anthropic-claude-4.7-opus,eis/anthropic-claude-4.8-opus,eis/google-gemini-3.0-flash,eis/google-gemini-3.1-flash-lite,eis/google-gemini-3.5-flash,eis/openai-gpt-5.2,eis/openai-gpt-5.4,eis/openai-gpt-5.4-mini,eis/openai-gpt-5.4-nano,eis/openai-gpt-oss-120b'
+          EVAL_MODEL_GROUPS: &weekly_eis_extended_models 'eis/anthropic-claude-4.6-sonnet,eis/anthropic-claude-4.6-opus,eis/anthropic-claude-4.7-opus,eis/anthropic-claude-4.8-opus,eis/google-gemini-3.0-flash,eis/google-gemini-3.1-flash-lite,eis/google-gemini-3.5-flash,eis/openai-gpt-5.2,eis/openai-gpt-5.4,eis/openai-gpt-5.4-mini,eis/openai-gpt-5.4-nano,eis/openai-gpt-5.6-luna,eis/openai-gpt-5.6-sol,eis/openai-gpt-5.6-terra,eis/openai-gpt-oss-120b'
         timeout_in_minutes: 60
         agents:
           image: family/kibana-ubuntu-2404

--- a/.buildkite/pipelines/evals/llm_evals.yml
+++ b/.buildkite/pipelines/evals/llm_evals.yml
@@ -187,7 +187,7 @@ steps:
           EVAL_INCLUDE_EIS_MODELS: '1'
           # Extended tier: includes smaller/cheaper models for cost-performance evaluation.
           # Keep in sync with `weeklyEisModelGroups` for significant-events in evals.suites.json.
-          EVAL_MODEL_GROUPS: &weekly_eis_extended_models 'eis/anthropic-claude-4.6-sonnet,eis/anthropic-claude-4.6-opus,eis/anthropic-claude-4.7-opus,eis/anthropic-claude-4.8-opus,eis/google-gemini-3.0-flash,eis/google-gemini-3.1-flash-lite,eis/google-gemini-3.5-flash,eis/openai-gpt-5.2,eis/openai-gpt-5.4,eis/openai-gpt-5.4-mini,eis/openai-gpt-5.4-nano,eis/openai-gpt-5.6-luna,eis/openai-gpt-5.6-sol,eis/openai-gpt-5.6-terra,eis/openai-gpt-oss-120b'
+          EVAL_MODEL_GROUPS: &weekly_eis_extended_models 'eis/anthropic-claude-4.6-sonnet,eis/anthropic-claude-4.6-opus,eis/anthropic-claude-4.7-opus,eis/anthropic-claude-4.8-opus,eis/google-gemini-3.0-flash,eis/google-gemini-3.1-flash-lite,eis/google-gemini-3.5-flash,eis/openai-gpt-5.2,eis/openai-gpt-5.4,eis/openai-gpt-5.4-mini,eis/openai-gpt-5.4-nano,eis/openai-gpt-5.6-luna,eis/openai-gpt-5.6-terra,eis/openai-gpt-oss-120b'
         timeout_in_minutes: 60
         agents:
           image: family/kibana-ubuntu-2404


### PR DESCRIPTION
## Description

Adds `eis/openai-gpt-5.6-luna` and `eis/openai-gpt-5.6-terra` to the extended model list in `.buildkite/pipelines/evals/evals.suites.json` and `.buildkite/pipelines/evals/llm_evals.yml`.