### PR TITLE
Check the connector 2-step release policy (advisory)

### DIFF
--- a/.buildkite/pipeline-utils/github/github.ts
+++ b/.buildkite/pipeline-utils/github/github.ts
@@ -185,6 +185,43 @@ export async function upsertComment(
   }
 }
 
+/**
+ * Deletes a previously upserted comment for the given context, if one exists. Used by checks
+ * whose finding can be fully resolved within a PR, so a stale advisory does not outlive it.
+ * Returns true when a comment was removed.
+ */
+export async function removeComment(
+  commentContext: string,
+  owner = process.env.GITHUB_PR_BASE_OWNER,
+  repo = process.env.GITHUB_PR_BASE_REPO,
+  prNumber: undefined | string | number = process.env.GITHUB_PR_NUMBER
+) {
+  if (!owner || !repo || !prNumber) {
+    throw Error(
+      "Couldn't retrieve Github PR info from environment variables in order to remove a comment"
+    );
+  }
+  if (!commentContext) {
+    throw Error('Comment context is required when removing a comment');
+  }
+
+  const commentMarker = `<!-- ${KIBANA_COMMENT_SIGIL}:${commentContext} -->`;
+  const existingComment = (
+    await github.paginate(github.issues.listComments, {
+      owner,
+      repo,
+      issue_number: typeof prNumber === 'number' ? prNumber : parseInt(prNumber, 10),
+    })
+  ).find((comment) => comment.body?.includes(commentMarker));
+
+  if (!existingComment) {
+    return false;
+  }
+
+  await github.issues.deleteComment({ owner, repo, comment_id: existingComment.id });
+  return true;
+}
+
 export function getGithubClient() {
   return github;
 }

--- a/.buildkite/pipeline-utils/github/github.ts
+++ b/.buildkite/pipeline-utils/github/github.ts
@@ -185,43 +185,6 @@ export async function upsertComment(
   }
 }
 
-/**
- * Deletes a previously upserted comment for the given context, if one exists. Used by checks
- * whose finding can be fully resolved within a PR, so a stale advisory does not outlive it.
- * Returns true when a comment was removed.
- */
-export async function removeComment(
-  commentContext: string,
-  owner = process.env.GITHUB_PR_BASE_OWNER,
-  repo = process.env.GITHUB_PR_BASE_REPO,
-  prNumber: undefined | string | number = process.env.GITHUB_PR_NUMBER
-) {
-  if (!owner || !repo || !prNumber) {
-    throw Error(
-      "Couldn't retrieve Github PR info from environment variables in order to remove a comment"
-    );
-  }
-  if (!commentContext) {
-    throw Error('Comment context is required when removing a comment');
-  }
-
-  const commentMarker = `<!-- ${KIBANA_COMMENT_SIGIL}:${commentContext} -->`;
-  const existingComment = (
-    await github.paginate(github.issues.listComments, {
-      owner,
-      repo,
-      issue_number: typeof prNumber === 'number' ? prNumber : parseInt(prNumber, 10),
-    })
-  ).find((comment) => comment.body?.includes(commentMarker));
-
-  if (!existingComment) {
-    return false;
-  }
-
-  await github.issues.deleteComment({ owner, repo, comment_id: existingComment.id });
-  return true;
-}
-
 export function getGithubClient() {
   return github;
 }

--- a/.buildkite/pipelines/pull_request/check_connector_specs.yml
+++ b/.buildkite/pipelines/pull_request/check_connector_specs.yml
@@ -1,0 +1,15 @@
+steps:
+  - command: .buildkite/scripts/steps/checks/check_connector_specs.sh
+    label: 'Check connector specs release'
+    key: check_connector_specs
+    # Advisory: this check reports on the 2-step release policy, it never blocks a PR.
+    soft_fail: true
+    agents:
+      machineType: n2-standard-2
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 15
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -673,7 +673,6 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
         /^\.buildkite\/pipelines\/pull_request\/check_connector_specs\.yml/,
         // Trailing `\.` rather than a concrete extension, so `.test.js` / `.test.ts` match too.
         /^\.buildkite\/scripts\/steps\/checks\/(check_connector_specs|connector_release_check|run_connector_release_check|notify_connector_specs_changes)\./,
-        /^\.buildkite\/pipeline-utils\/github\/github\.ts/,
       ])
     ) {
       pipeline.push(

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -666,6 +666,21 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       );
     }
 
+    // Run the connector spec release check when connector specs change
+    if (
+      await doAnyChangesMatch([
+        /^src\/platform\/packages\/shared\/kbn-connector-specs\//,
+        /^\.buildkite\/pipelines\/pull_request\/check_connector_specs\.yml/,
+        // Trailing `\.` rather than a concrete extension, so `.test.js` / `.test.ts` match too.
+        /^\.buildkite\/scripts\/steps\/checks\/(check_connector_specs|connector_release_check|run_connector_release_check|notify_connector_specs_changes)\./,
+        /^\.buildkite\/pipeline-utils\/github\/github\.ts/,
+      ])
+    ) {
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/check_connector_specs.yml', cancelable)
+      );
+    }
+
     // Run Workflow Schema OOM prevention test when schema or connector whitelist changes
     if (
       GITHUB_PR_LABELS.includes('ci:workflow-oom-test') ||

--- a/.buildkite/scripts/steps/checks/check_connector_specs.sh
+++ b/.buildkite/scripts/steps/checks/check_connector_specs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
+.buildkite/scripts/bootstrap.sh
+
+echo --- Check connector specs release
+
+if ! is_pr; then
+  echo "Not a PR build; skipping connector spec release check."
+  exit 0
+fi
+
+# Production-NonCanary only tracks main, so the policy is meaningless on other targets.
+if [[ "${GITHUB_PR_TARGET_BRANCH:-}" != "main" ]]; then
+  echo "PR does not target main; skipping connector spec release check."
+  exit 0
+fi
+
+# Advisory 2-step release check. This NEVER fails the build; it checks the policy and
+# posts an advisory PR comment. The runner resolves the Production-NonCanary versions
+# itself — the `scripts/get_serverless_release_sha` helper resolves QA, not PNC.
+REPORT_PATH="$(mktemp -t connector-release-report.XXXXXX).json"
+node .buildkite/scripts/steps/checks/run_connector_release_check.js \
+  --report-path "$REPORT_PATH" \
+  --base-ref "${GITHUB_PR_MERGE_BASE:-}"
+
+echo --- Post connector spec release PR comment
+ts-node .buildkite/scripts/steps/checks/notify_connector_specs_changes.ts --report-path "$REPORT_PATH" \
+  || echo "Warning: failed to post connector spec release PR comment"
+
+exit 0

--- a/.buildkite/scripts/steps/checks/connector_release_check.js
+++ b/.buildkite/scripts/steps/checks/connector_release_check.js
@@ -10,22 +10,26 @@
 /**
  * Pure classifier for the connector 2-step release check.
  *
- * A connector type must be registered in every Production-NonCanary (PNC) Kibana
- * version before it can declare user-facing features. Serverless rollouts and
- * rollbacks leave nodes on different versions for a while, and an action persisted
- * against a connector type that a node does not have breaks on that node. Once the
- * type is registered in every PNC version, anything else is safe (every node can
- * already handle actions of that type).
+ * A connector type should be registered in every version currently pinned for the
+ * Production-NonCanary (PNC) slices before it declares user-facing features. Serverless
+ * rollouts and rollbacks leave nodes on different versions for a while, and an action
+ * persisted against a connector type that a node does not have breaks on that node.
+ * Once the type is registered in every pinned version, this advisory allows any
+ * `supportedFeatureIds`.
+ *
+ * The GitOps pins are an approximation of what is actually running, and this check only
+ * decides whether feature exposure is allowed — it is not a guarantee about any node.
  *
  * This module is pure. The runner resolves the PNC versions, decides which connectors
  * this PR makes applicable, and hands plain data here.
  */
 
-// ponytail: allowlist, not a config file — these are the only feature ids safe to ship
-// on a connector that is not yet registered in every PNC version, because they persist
-// no rollback-fragile user actions.
-// NOTE: `agentBuilder` is allowlisted only while the feature is not yet GA. Revisit and
-// remove this entry once agentBuilder reaches GA.
+// ponytail: allowlist, not a config file — these are the only feature ids allowed on a
+// connector that is not yet registered in every pinned PNC version.
+// NOTE: `agentBuilder` is allowlisted only while the feature is not yet GA. Its execution is
+// request-scoped and schedules no durable background work, so a rollback cannot leave
+// scheduled work behind pointing at a missing type. Revisit and remove this entry once
+// agentBuilder reaches GA.
 const ALLOWED_INITIAL_FEATURE_IDS = ['agentBuilder'];
 
 const shortSha = (sha) => sha.slice(0, 12);
@@ -56,7 +60,7 @@ function classifyConnectorRelease(applicableConnectors, release = {}, opts = {})
   const findings = [];
 
   for (const connector of applicableConnectors) {
-    // Registered in every PNC version → every node can handle actions of this type.
+    // Registered in every pinned PNC version → this advisory allows any feature ids.
     const missingFromRefs = connector.missingFromRefs ?? [];
     if (missingFromRefs.length === 0) continue;
 
@@ -70,11 +74,12 @@ function classifyConnectorRelease(applicableConnectors, release = {}, opts = {})
       disallowedFeatureIds,
       missingFromRefs,
       message:
-        `Connector \`${connector.id}\` is not registered in Production-NonCanary ` +
-        `(missing from ${missingFromRefs.map(shortSha).join(', ')}) but already declares ` +
-        `feature(s) [${disallowedFeatureIds.join(', ')}]. Ship it with ` +
-        `\`supportedFeatureIds: []\`${allowedHint} first; once it is registered in every ` +
-        `Production-NonCanary version, add the remaining feature IDs in a follow-up PR.`,
+        `Connector \`${connector.id}\` is not registered in every version currently pinned for ` +
+        `the Production-NonCanary slices (missing from ${missingFromRefs
+          .map(shortSha)
+          .join(', ')}) but already declares feature(s) [${disallowedFeatureIds.join(', ')}]. ` +
+        `Ship it with \`supportedFeatureIds: []\`${allowedHint} first; once it is registered in ` +
+        `every pinned version, add the remaining feature IDs in a follow-up PR.`,
     });
   }
 

--- a/.buildkite/scripts/steps/checks/connector_release_check.js
+++ b/.buildkite/scripts/steps/checks/connector_release_check.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Pure classifier for the connector 2-step release check.
+ *
+ * A connector type must be registered in every Production-NonCanary (PNC) Kibana
+ * version before it can declare user-facing features. Serverless rollouts and
+ * rollbacks leave nodes on different versions for a while, and an action persisted
+ * against a connector type that a node does not have breaks on that node. Once the
+ * type is registered in every PNC version, anything else is safe (every node can
+ * already handle actions of that type).
+ *
+ * This module is pure. The runner resolves the PNC versions, decides which connectors
+ * this PR makes applicable, and hands plain data here.
+ */
+
+// ponytail: allowlist, not a config file — these are the only feature ids safe to ship
+// on a connector that is not yet registered in every PNC version, because they persist
+// no rollback-fragile user actions.
+// NOTE: `agentBuilder` is allowlisted only while the feature is not yet GA. Revisit and
+// remove this entry once agentBuilder reaches GA.
+const ALLOWED_INITIAL_FEATURE_IDS = ['agentBuilder'];
+
+const shortSha = (sha) => sha.slice(0, 12);
+
+/**
+ * @param {Array<{id: string, supportedFeatureIds?: string[], missingFromRefs?: string[]}>} applicableConnectors
+ *   Connectors whose exposure this PR changes. `missingFromRefs` lists the PNC refs the
+ *   connector is not registered in; empty means it is registered in all of them.
+ * @param {{refs?: string[], inconclusiveReason?: string}} release
+ *   Resolved PNC refs, or the reason they could not be resolved.
+ * @param {{allowedInitialFeatures?: string[]}} [opts]
+ * @returns {{status: 'safe'|'unsafe'|'inconclusive', findings: Array<object>, refs: string[], reason?: string}}
+ */
+function classifyConnectorRelease(applicableConnectors, release = {}, opts = {}) {
+  const allowed = new Set(opts.allowedInitialFeatures ?? ALLOWED_INITIAL_FEATURE_IDS);
+  const refs = release.refs ?? [];
+
+  // Never report `safe` on missing data: without every PNC version we cannot tell what is
+  // registered, so the outcome is explicitly inconclusive.
+  const inconclusiveReason =
+    release.inconclusiveReason ||
+    (refs.length === 0 ? 'No Production-NonCanary versions were resolved.' : undefined);
+  if (inconclusiveReason) {
+    return { status: 'inconclusive', findings: [], refs, reason: inconclusiveReason };
+  }
+
+  const allowedHint = allowed.size ? ` or \`['${[...allowed].join("', '")}']\`` : '';
+  const findings = [];
+
+  for (const connector of applicableConnectors) {
+    // Registered in every PNC version → every node can handle actions of this type.
+    const missingFromRefs = connector.missingFromRefs ?? [];
+    if (missingFromRefs.length === 0) continue;
+
+    const supportedFeatureIds = connector.supportedFeatureIds ?? [];
+    const disallowedFeatureIds = supportedFeatureIds.filter((f) => !allowed.has(f));
+    if (disallowedFeatureIds.length === 0) continue; // empty, or only allowed initial features
+
+    findings.push({
+      id: connector.id,
+      supportedFeatureIds,
+      disallowedFeatureIds,
+      missingFromRefs,
+      message:
+        `Connector \`${connector.id}\` is not registered in Production-NonCanary ` +
+        `(missing from ${missingFromRefs.map(shortSha).join(', ')}) but already declares ` +
+        `feature(s) [${disallowedFeatureIds.join(', ')}]. Ship it with ` +
+        `\`supportedFeatureIds: []\`${allowedHint} first; once it is registered in every ` +
+        `Production-NonCanary version, add the remaining feature IDs in a follow-up PR.`,
+    });
+  }
+
+  return { status: findings.length > 0 ? 'unsafe' : 'safe', findings, refs };
+}
+
+module.exports = {
+  ALLOWED_INITIAL_FEATURE_IDS,
+  classifyConnectorRelease,
+};

--- a/.buildkite/scripts/steps/checks/connector_release_check.test.js
+++ b/.buildkite/scripts/steps/checks/connector_release_check.test.js
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { classifyConnectorRelease } = require('./connector_release_check');
+
+const PNC_A = 'a'.repeat(40);
+const PNC_B = 'b'.repeat(40);
+
+// A connector whose exposure this PR changes. `missingFromRefs` lists the PNC refs it is not
+// registered in; empty means it is registered in every one of them.
+const applicable = (id, supportedFeatureIds, missingFromRefs = [PNC_A]) => ({
+  id,
+  supportedFeatureIds,
+  missingFromRefs,
+});
+
+const resolved = (refs = [PNC_A]) => ({ refs });
+
+describe('classifyConnectorRelease', () => {
+  describe('normal rollout (every slice on the same version)', () => {
+    it('reports unsafe for a connector missing from the release that declares a feature', () => {
+      const { status, findings } = classifyConnectorRelease(
+        [applicable('.new', ['workflows'])],
+        resolved()
+      );
+
+      expect(status).toBe('unsafe');
+      expect(findings).toHaveLength(1);
+      expect(findings[0].id).toBe('.new');
+      expect(findings[0].disallowedFeatureIds).toEqual(['workflows']);
+      expect(findings[0].missingFromRefs).toEqual([PNC_A]);
+    });
+
+    it('reports safe for a connector shipping with no user-facing features', () => {
+      const { status, findings } = classifyConnectorRelease([applicable('.new', [])], resolved());
+
+      expect(status).toBe('safe');
+      expect(findings).toEqual([]);
+    });
+
+    it('reports safe for a connector shipping only agentBuilder', () => {
+      const { status, findings } = classifyConnectorRelease(
+        [applicable('.new', ['agentBuilder'])],
+        resolved()
+      );
+
+      expect(status).toBe('safe');
+      expect(findings).toEqual([]);
+    });
+
+    it('reports only the disallowed subset when agentBuilder is mixed with a disallowed feature', () => {
+      const { findings } = classifyConnectorRelease(
+        [applicable('.new', ['agentBuilder', 'workflows'])],
+        resolved()
+      );
+
+      expect(findings).toHaveLength(1);
+      expect(findings[0].disallowedFeatureIds).toEqual(['workflows']);
+    });
+
+    it('reports safe for any features once the connector is registered in the release', () => {
+      const { status, findings } = classifyConnectorRelease(
+        [applicable('.x', ['workflows', 'cases'], [])],
+        resolved()
+      );
+
+      expect(status).toBe('safe');
+      expect(findings).toEqual([]);
+    });
+
+    it('reports safe when this PR changes no connector exposure', () => {
+      const { status, findings } = classifyConnectorRelease([], resolved());
+
+      expect(status).toBe('safe');
+      expect(findings).toEqual([]);
+    });
+  });
+
+  describe('multiple distinct PNC versions (rollout or rollback in flight)', () => {
+    it('reports unsafe when the connector is missing from only one slice', () => {
+      const { status, findings } = classifyConnectorRelease(
+        [applicable('.new', ['workflows'], [PNC_B])],
+        resolved([PNC_A, PNC_B])
+      );
+
+      expect(status).toBe('unsafe');
+      expect(findings[0].missingFromRefs).toEqual([PNC_B]);
+      expect(findings[0].message).toContain(PNC_B.slice(0, 12));
+    });
+
+    it('reports safe only when the connector is registered in every slice', () => {
+      const { status } = classifyConnectorRelease(
+        [applicable('.x', ['workflows'], [])],
+        resolved([PNC_A, PNC_B])
+      );
+
+      expect(status).toBe('safe');
+    });
+
+    it('reports unsafe after a rollback removes the connector from a slice', () => {
+      // The slice pointer moved back to a version predating the connector.
+      const { status, findings } = classifyConnectorRelease(
+        [applicable('.rolled-back', ['workflows'], [PNC_A, PNC_B])],
+        resolved([PNC_A, PNC_B])
+      );
+
+      expect(status).toBe('unsafe');
+      expect(findings[0].missingFromRefs).toEqual([PNC_A, PNC_B]);
+    });
+  });
+
+  describe('inconclusive outcomes (never safe on missing data)', () => {
+    it('is inconclusive when no PNC versions were resolved', () => {
+      const result = classifyConnectorRelease([applicable('.new', ['workflows'])], { refs: [] });
+
+      expect(result.status).toBe('inconclusive');
+      expect(result.findings).toEqual([]);
+      expect(result.reason).toBeDefined();
+    });
+
+    it('is inconclusive when the release data is missing entirely', () => {
+      const result = classifyConnectorRelease([applicable('.new', ['workflows'])], {});
+
+      expect(result.status).toBe('inconclusive');
+      expect(result.reason).toBeDefined();
+    });
+
+    it('is inconclusive with the resolver reason when GitOps data is unavailable', () => {
+      const result = classifyConnectorRelease([applicable('.new', ['workflows'])], {
+        refs: [],
+        inconclusiveReason: 'Could not read serverless-gitops/services/kibana/versions.yaml: 404',
+      });
+
+      expect(result.status).toBe('inconclusive');
+      expect(result.reason).toContain('versions.yaml');
+    });
+
+    it('is inconclusive even when refs resolved but the resolver flagged a failure', () => {
+      const result = classifyConnectorRelease([applicable('.new', ['workflows'])], {
+        refs: [PNC_A],
+        inconclusiveReason: 'Could not read all_specs.ts at aaaa.',
+      });
+
+      expect(result.status).toBe('inconclusive');
+      expect(result.findings).toEqual([]);
+    });
+  });
+
+  it('honours a custom initial-feature allowlist', () => {
+    const { status } = classifyConnectorRelease([applicable('.new', ['workflows'])], resolved(), {
+      allowedInitialFeatures: ['workflows'],
+    });
+
+    expect(status).toBe('safe');
+  });
+
+  it('echoes the inspected refs so the advisory can name them', () => {
+    const { refs } = classifyConnectorRelease([], resolved([PNC_A, PNC_B]));
+
+    expect(refs).toEqual([PNC_A, PNC_B]);
+  });
+});

--- a/.buildkite/scripts/steps/checks/notify_connector_specs_changes.test.ts
+++ b/.buildkite/scripts/steps/checks/notify_connector_specs_changes.test.ts
@@ -9,12 +9,10 @@
 
 jest.mock('#pipeline-utils', () => ({
   upsertComment: jest.fn(),
-  removeComment: jest.fn(),
 }));
 
 import {
   buildCommentBody,
-  resolveAction,
   type ConnectorReleaseFinding,
   type ConnectorReleaseReport,
 } from './notify_connector_specs_changes';
@@ -115,30 +113,16 @@ describe('buildCommentBody', () => {
   });
 });
 
-describe('resolveAction', () => {
-  it('posts the advisory when a connector exposure changed', () => {
-    expect(resolveAction(report({ status: 'unsafe', findings: [finding()] }))).toEqual({
-      action: 'post',
-      body: expect.stringContaining('needs attention'),
-    });
+describe('buildCommentBody, no-comment cases', () => {
+  it('says nothing when applicability could not be determined', () => {
+    // Posting off an unknown diff would be guesswork, and the step is path-gated so it cannot be
+    // relied on to run again and correct itself.
+    expect(
+      buildCommentBody(report({ applicabilityKnown: false, status: 'inconclusive' }))
+    ).toBeNull();
   });
 
-  it('posts the safe outcome so it replaces a stale warning from an earlier run', () => {
-    expect(resolveAction(report())).toEqual({
-      action: 'post',
-      body: expect.stringContaining('no issues found'),
-    });
-  });
-
-  it('removes an existing advisory once every applicable connector change is reverted', () => {
-    // Applicability is computed against the merge base, so a fully reverted connector change
-    // leaves nothing applicable and the earlier warning must not outlive it.
-    expect(resolveAction(report({ applicableConnectors: [] }))).toEqual({ action: 'remove' });
-  });
-
-  it('leaves an existing advisory alone when applicability is unknown', () => {
-    expect(resolveAction(report({ applicabilityKnown: false, status: 'inconclusive' }))).toEqual({
-      action: 'skip',
-    });
+  it('says nothing when this PR changed no connector exposure', () => {
+    expect(buildCommentBody(report({ applicableConnectors: [] }))).toBeNull();
   });
 });

--- a/.buildkite/scripts/steps/checks/notify_connector_specs_changes.test.ts
+++ b/.buildkite/scripts/steps/checks/notify_connector_specs_changes.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+jest.mock('#pipeline-utils', () => ({
+  upsertComment: jest.fn(),
+  removeComment: jest.fn(),
+}));
+
+import {
+  buildCommentBody,
+  resolveAction,
+  type ConnectorReleaseFinding,
+  type ConnectorReleaseReport,
+} from './notify_connector_specs_changes';
+
+const PNC_A = 'a'.repeat(40);
+const PNC_B = 'b'.repeat(40);
+
+const finding = (overrides: Partial<ConnectorReleaseFinding> = {}): ConnectorReleaseFinding => ({
+  id: '.new',
+  supportedFeatureIds: ['workflows'],
+  disallowedFeatureIds: ['workflows'],
+  missingFromRefs: [PNC_A],
+  message: 'Connector `.new` is not registered in Production-NonCanary…',
+  ...overrides,
+});
+
+const report = (overrides: Partial<ConnectorReleaseReport> = {}): ConnectorReleaseReport => ({
+  status: 'safe',
+  applicabilityKnown: true,
+  refs: [PNC_A],
+  applicableConnectors: [{ id: '.new', supportedFeatureIds: [] }],
+  findings: [],
+  ...overrides,
+});
+
+describe('buildCommentBody', () => {
+  it('returns null when this PR changed no connector exposure', () => {
+    // A lib, docs, or icon edit inside kbn-connector-specs triggers the step but says nothing.
+    expect(buildCommentBody(report({ applicableConnectors: [] }))).toBeNull();
+  });
+
+  it('returns null for a package-only change even when the release is inconclusive', () => {
+    expect(
+      buildCommentBody(
+        report({ status: 'inconclusive', reason: 'GITHUB_TOKEN is not set', applicableConnectors: [] })
+      )
+    ).toBeNull();
+  });
+
+  it('builds the unsafe body with every finding message', () => {
+    const body = buildCommentBody(
+      report({
+        status: 'unsafe',
+        findings: [finding(), finding({ id: '.other', message: 'Connector `.other` …' })],
+      })
+    );
+
+    expect(body).toContain('needs attention');
+    expect(body).toContain('2 connector(s)');
+    expect(body).toContain('Connector `.other` …');
+  });
+
+  it('builds the safe body naming the checked connectors', () => {
+    const body = buildCommentBody(report());
+
+    expect(body).toContain('no issues found');
+    expect(body).toContain('`.new`');
+  });
+
+  it('builds the inconclusive body with the reason and never claims safety', () => {
+    const body = buildCommentBody(
+      report({ status: 'inconclusive', reason: 'Could not fetch aaaa from origin.' })
+    );
+
+    expect(body).toContain('inconclusive');
+    expect(body).toContain('Could not fetch aaaa from origin.');
+    expect(body).not.toContain('no issues found');
+  });
+
+  it('names every inspected Production-NonCanary version', () => {
+    const body = buildCommentBody(report({ refs: [PNC_A, PNC_B] }));
+
+    expect(body).toContain(PNC_A.slice(0, 12));
+    expect(body).toContain(PNC_B.slice(0, 12));
+  });
+
+  it('says so when no versions were inspected', () => {
+    const body = buildCommentBody(report({ status: 'inconclusive', refs: [], reason: 'no slices' }));
+
+    expect(body).toContain('No Production-NonCanary versions were inspected.');
+  });
+
+  it('marks every outcome as advisory', () => {
+    for (const status of ['safe', 'unsafe', 'inconclusive'] as const) {
+      const body = buildCommentBody(
+        report({ status, reason: 'r', findings: status === 'unsafe' ? [finding()] : [] })
+      );
+
+      expect(body).toContain('advisory');
+      expect(body).toContain('does not block the PR');
+    }
+  });
+});
+
+describe('resolveAction', () => {
+  it('posts the advisory when a connector exposure changed', () => {
+    expect(resolveAction(report({ status: 'unsafe', findings: [finding()] }))).toEqual({
+      action: 'post',
+      body: expect.stringContaining('needs attention'),
+    });
+  });
+
+  it('posts the safe outcome so it replaces a stale warning from an earlier run', () => {
+    expect(resolveAction(report())).toEqual({
+      action: 'post',
+      body: expect.stringContaining('no issues found'),
+    });
+  });
+
+  it('removes an existing advisory once every applicable connector change is reverted', () => {
+    // Applicability is computed against the merge base, so a fully reverted connector change
+    // leaves nothing applicable and the earlier warning must not outlive it.
+    expect(resolveAction(report({ applicableConnectors: [] }))).toEqual({ action: 'remove' });
+  });
+
+  it('leaves an existing advisory alone when applicability is unknown', () => {
+    expect(
+      resolveAction(report({ applicabilityKnown: false, status: 'inconclusive' }))
+    ).toEqual({ action: 'skip' });
+  });
+});

--- a/.buildkite/scripts/steps/checks/notify_connector_specs_changes.test.ts
+++ b/.buildkite/scripts/steps/checks/notify_connector_specs_changes.test.ts
@@ -49,7 +49,11 @@ describe('buildCommentBody', () => {
   it('returns null for a package-only change even when the release is inconclusive', () => {
     expect(
       buildCommentBody(
-        report({ status: 'inconclusive', reason: 'GITHUB_TOKEN is not set', applicableConnectors: [] })
+        report({
+          status: 'inconclusive',
+          reason: 'GITHUB_TOKEN is not set',
+          applicableConnectors: [],
+        })
       )
     ).toBeNull();
   });
@@ -92,7 +96,9 @@ describe('buildCommentBody', () => {
   });
 
   it('says so when no versions were inspected', () => {
-    const body = buildCommentBody(report({ status: 'inconclusive', refs: [], reason: 'no slices' }));
+    const body = buildCommentBody(
+      report({ status: 'inconclusive', refs: [], reason: 'no slices' })
+    );
 
     expect(body).toContain('No Production-NonCanary versions were inspected.');
   });
@@ -131,8 +137,8 @@ describe('resolveAction', () => {
   });
 
   it('leaves an existing advisory alone when applicability is unknown', () => {
-    expect(
-      resolveAction(report({ applicabilityKnown: false, status: 'inconclusive' }))
-    ).toEqual({ action: 'skip' });
+    expect(resolveAction(report({ applicabilityKnown: false, status: 'inconclusive' }))).toEqual({
+      action: 'skip',
+    });
   });
 });

--- a/.buildkite/scripts/steps/checks/notify_connector_specs_changes.ts
+++ b/.buildkite/scripts/steps/checks/notify_connector_specs_changes.ts
@@ -8,7 +8,7 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { upsertComment, removeComment } from '#pipeline-utils';
+import { upsertComment } from '#pipeline-utils';
 
 /**
  * Report shape produced by run_connector_release_check.js. Inlined here (rather than
@@ -39,14 +39,17 @@ const COMMENT_CONTEXT = 'connector-specs-check';
 const ADVISORY_NOTE =
   '> [!NOTE]\n' +
   '> This is **advisory** — it does not block the PR. It checks the 2-step release policy ' +
-  'for connector types: until a type is registered in every Production-NonCanary version, a ' +
-  'rollout or rollback can leave a node without it, breaking any user action that references it.';
+  'for connector types: until a type is registered in every version currently pinned for the ' +
+  'Production-NonCanary slices, a rollout or rollback can leave a node without it, breaking any ' +
+  'user action that references it.';
 
 const shortSha = (sha: string) => sha.slice(0, 12);
 
 const inspectedVersions = (refs: string[]) =>
   refs.length > 0
-    ? `Production-NonCanary versions inspected: ${refs.map(shortSha).join(', ')}.`
+    ? `Versions currently pinned for the Production-NonCanary slices: ${refs
+        .map(shortSha)
+        .join(', ')}.`
     : 'No Production-NonCanary versions were inspected.';
 
 export function buildUnsafeBody(report: ConnectorReleaseReport): string {
@@ -88,9 +91,10 @@ ${inspectedVersions(report.refs)}`;
 }
 
 export function buildCommentBody(report: ConnectorReleaseReport): string | null {
-  // Nothing connector-shaped changed (a lib, docs, or icon edit), so there is nothing to say.
-  // The caller removes any stale advisory in this case.
-  if (report.applicableConnectors.length === 0) {
+  // Nothing to say: either applicability could not be determined, or this PR changed no connector
+  // exposure (a lib, docs, or icon edit). Any existing comment is left alone — the step is
+  // path-gated on connector changes, so it cannot be relied on to run and clean up after itself.
+  if (!report.applicabilityKnown || report.applicableConnectors.length === 0) {
     return null;
   }
 
@@ -101,25 +105,6 @@ export function buildCommentBody(report: ConnectorReleaseReport): string | null 
     return buildInconclusiveBody(report);
   }
   return buildSafeBody(report);
-}
-
-/**
- * What to do with the PR comment for this report.
- *  - `skip`:   applicability is unknown, so leave whatever is on the PR alone rather than
- *              deleting a valid advisory or posting one off incomplete data.
- *  - `remove`: this PR changes no connector exposure, so a previous advisory (from a change
- *              that has since been reverted) must not outlive it.
- *  - `post`:   upsert the outcome, replacing any stale advisory.
- */
-export function resolveAction(
-  report: ConnectorReleaseReport
-): { action: 'skip' } | { action: 'remove' } | { action: 'post'; body: string } {
-  if (!report.applicabilityKnown) {
-    return { action: 'skip' };
-  }
-
-  const body = buildCommentBody(report);
-  return body ? { action: 'post', body } : { action: 'remove' };
 }
 
 async function main() {
@@ -142,26 +127,15 @@ async function main() {
     return;
   }
 
-  const resolved = resolveAction(report);
-
-  if (resolved.action === 'skip') {
-    console.log('Applicability could not be determined; leaving any existing comment untouched.');
-    return;
-  }
-
-  if (resolved.action === 'remove') {
-    const removed = await removeComment(COMMENT_CONTEXT);
-    console.log(
-      removed
-        ? 'No connector exposure changed; removed the stale connector spec release advisory.'
-        : 'No connector exposure changed; nothing to post.'
-    );
+  const body = buildCommentBody(report);
+  if (!body) {
+    console.log('Nothing to report for this PR; leaving any existing comment untouched.');
     return;
   }
 
   console.log(`Posting connector spec release check comment (${report.status})...`);
   await upsertComment({
-    commentBody: resolved.body,
+    commentBody: body,
     commentContext: COMMENT_CONTEXT,
     clearPrevious: true,
   });

--- a/.buildkite/scripts/steps/checks/notify_connector_specs_changes.ts
+++ b/.buildkite/scripts/steps/checks/notify_connector_specs_changes.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { upsertComment, removeComment } from '#pipeline-utils';
+
+/**
+ * Report shape produced by run_connector_release_check.js. Inlined here (rather than
+ * imported) to keep this Buildkite script's dependency surface minimal, matching
+ * notify_saved_objects_changes.ts.
+ */
+export interface ConnectorReleaseFinding {
+  id: string;
+  supportedFeatureIds: string[];
+  disallowedFeatureIds: string[];
+  missingFromRefs: string[];
+  message: string;
+}
+
+export interface ConnectorReleaseReport {
+  status: 'safe' | 'unsafe' | 'inconclusive';
+  reason?: string;
+  /** False when the merge-base diff could not be computed, so applicability is unknown. */
+  applicabilityKnown: boolean;
+  /** Every distinct Production-NonCanary Kibana ref that was inspected. */
+  refs: string[];
+  applicableConnectors: Array<{ id: string; supportedFeatureIds: string[] }>;
+  findings: ConnectorReleaseFinding[];
+}
+
+const COMMENT_CONTEXT = 'connector-specs-check';
+
+const ADVISORY_NOTE =
+  '> [!NOTE]\n' +
+  '> This is **advisory** — it does not block the PR. It checks the 2-step release policy ' +
+  'for connector types: until a type is registered in every Production-NonCanary version, a ' +
+  'rollout or rollback can leave a node without it, breaking any user action that references it.';
+
+const shortSha = (sha: string) => sha.slice(0, 12);
+
+const inspectedVersions = (refs: string[]) =>
+  refs.length > 0
+    ? `Production-NonCanary versions inspected: ${refs.map(shortSha).join(', ')}.`
+    : 'No Production-NonCanary versions were inspected.';
+
+export function buildUnsafeBody(report: ConnectorReleaseReport): string {
+  const bullets = report.findings.map((finding) => `- ${finding.message}`).join('\n');
+
+  return `## Connector spec release check: needs attention
+
+${ADVISORY_NOTE}
+
+${report.findings.length} connector(s) declare user-facing features before being released:
+
+${bullets}
+
+${inspectedVersions(report.refs)}`;
+}
+
+export function buildSafeBody(report: ConnectorReleaseReport): string {
+  const ids = report.applicableConnectors.map(({ id }) => `\`${id}\``).join(', ');
+
+  return `## Connector spec release check: no issues found
+
+${ADVISORY_NOTE}
+
+Checked ${ids}. As of this run, the declared feature IDs are compatible with the 2-step release policy.
+
+${inspectedVersions(report.refs)}`;
+}
+
+export function buildInconclusiveBody(report: ConnectorReleaseReport): string {
+  return `## Connector spec release check: inconclusive
+
+${ADVISORY_NOTE}
+
+The check could not determine what is released, so it is **not** reporting this PR as safe.
+
+Reason: ${report.reason ?? 'unknown'}
+
+${inspectedVersions(report.refs)}`;
+}
+
+export function buildCommentBody(report: ConnectorReleaseReport): string | null {
+  // Nothing connector-shaped changed (a lib, docs, or icon edit), so there is nothing to say.
+  // The caller removes any stale advisory in this case.
+  if (report.applicableConnectors.length === 0) {
+    return null;
+  }
+
+  if (report.status === 'unsafe') {
+    return buildUnsafeBody(report);
+  }
+  if (report.status === 'inconclusive') {
+    return buildInconclusiveBody(report);
+  }
+  return buildSafeBody(report);
+}
+
+/**
+ * What to do with the PR comment for this report.
+ *  - `skip`:   applicability is unknown, so leave whatever is on the PR alone rather than
+ *              deleting a valid advisory or posting one off incomplete data.
+ *  - `remove`: this PR changes no connector exposure, so a previous advisory (from a change
+ *              that has since been reverted) must not outlive it.
+ *  - `post`:   upsert the outcome, replacing any stale advisory.
+ */
+export function resolveAction(
+  report: ConnectorReleaseReport
+): { action: 'skip' } | { action: 'remove' } | { action: 'post'; body: string } {
+  if (!report.applicabilityKnown) {
+    return { action: 'skip' };
+  }
+
+  const body = buildCommentBody(report);
+  return body ? { action: 'post', body } : { action: 'remove' };
+}
+
+async function main() {
+  const reportPath = process.argv[2] === '--report-path' ? process.argv[3] : process.argv[2];
+  if (!reportPath) {
+    console.error('Usage: notify_connector_specs_changes --report-path <file>');
+    process.exit(2);
+  }
+
+  if (!existsSync(reportPath)) {
+    console.log(`No report found at ${reportPath}; nothing to post.`);
+    return;
+  }
+
+  let report: ConnectorReleaseReport;
+  try {
+    report = JSON.parse(readFileSync(reportPath, 'utf-8'));
+  } catch (err) {
+    console.error(`Failed to parse report at ${reportPath}:`, err);
+    return;
+  }
+
+  const resolved = resolveAction(report);
+
+  if (resolved.action === 'skip') {
+    console.log('Applicability could not be determined; leaving any existing comment untouched.');
+    return;
+  }
+
+  if (resolved.action === 'remove') {
+    const removed = await removeComment(COMMENT_CONTEXT);
+    console.log(
+      removed
+        ? 'No connector exposure changed; removed the stale connector spec release advisory.'
+        : 'No connector exposure changed; nothing to post.'
+    );
+    return;
+  }
+
+  console.log(`Posting connector spec release check comment (${report.status})...`);
+  await upsertComment({
+    commentBody: resolved.body,
+    commentContext: COMMENT_CONTEXT,
+    clearPrevious: true,
+  });
+
+  console.log('PR comment posted successfully');
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Failed to post connector spec release PR comment:', error);
+    process.exit(1);
+  });
+}

--- a/.buildkite/scripts/steps/checks/run_connector_release_check.js
+++ b/.buildkite/scripts/steps/checks/run_connector_release_check.js
@@ -18,9 +18,11 @@
  *                SHAs, and fetch each distinct ref. Always runs, and always logs, so a
  *                CI run proves this path works even when the PR changes no connector.
  *   2. applicable which connectors this PR changes the *exposure* of, computed against
- *                `<merge-base>..HEAD` (never the latest commit) so that a fully reverted
- *                connector change becomes non-applicable and clears its advisory, while a
- *                later unrelated commit cannot hide an earlier unsafe change.
+ *                `<merge-base>..HEAD` (never the latest commit), so a later unrelated commit
+ *                cannot hide an earlier unsafe change and an unrelated edit does not inherit
+ *                an advisory caused by an earlier PR. Note the step is path-gated on connector
+ *                changes, so it cannot be relied on to run once a change is fully reverted;
+ *                the notifier therefore never deletes an existing comment.
  *   3. registered whether each applicable connector is exported from `all_specs.ts` at
  *                every PNC ref. Registration iterates that barrel, so a spec file that
  *                exists at a ref without being exported there was never registered.
@@ -220,7 +222,7 @@ const toPathSet = (output) =>
  * Connectors whose exposure this PR changes: newly added modules, modules newly exported from
  * the barrel, and modules whose `supportedFeatureIds` value changed. Always computed against
  * the merge base, so an unrelated edit to a connector left unpublished by an earlier PR does
- * not inherit that PR's advisory, and a fully reverted change becomes non-applicable.
+ * not inherit that PR's advisory.
  *
  * @returns {{known: boolean, connectors: Array<object>}}
  */

--- a/.buildkite/scripts/steps/checks/run_connector_release_check.js
+++ b/.buildkite/scripts/steps/checks/run_connector_release_check.js
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Runs the connector 2-step release check and writes an advisory report.
+ *
+ * No manifest is stored. Everything comes from the source tree and from git:
+ *   1. resolve   every `production-noncanary-ds-*` (PNC) Kibana SHA pinned in
+ *                `serverless-gitops/services/kibana/versions.yaml`, expand abbreviated
+ *                SHAs, and fetch each distinct ref. Always runs, and always logs, so a
+ *                CI run proves this path works even when the PR changes no connector.
+ *   2. applicable which connectors this PR changes the *exposure* of, computed against
+ *                `<merge-base>..HEAD` (never the latest commit) so that a fully reverted
+ *                connector change becomes non-applicable and clears its advisory, while a
+ *                later unrelated commit cannot hide an earlier unsafe change.
+ *   3. registered whether each applicable connector is exported from `all_specs.ts` at
+ *                every PNC ref. Registration iterates that barrel, so a spec file that
+ *                exists at a ref without being exported there was never registered.
+ *   4. classify  hand the plain data to the pure classifier.
+ *
+ * Every side effect (git, GitHub, the filesystem, logging) is injected, so the whole flow
+ * is unit-testable. `main()` is the only place that builds real dependencies.
+ *
+ * This never fails the build — it only produces a report for the notifier.
+ *
+ * Usage:
+ *   node run_connector_release_check.js --report-path <file> [--base-ref <sha>]
+ */
+
+const { classifyConnectorRelease } = require('./connector_release_check');
+
+const PACKAGE_SRC_DIR = 'src/platform/packages/shared/kbn-connector-specs/src';
+const SPECS_DIR = `${PACKAGE_SRC_DIR}/specs`;
+const ALL_SPECS_PATH = `${PACKAGE_SRC_DIR}/all_specs.ts`;
+
+const GITOPS_VERSIONS_FILE = {
+  owner: 'elastic',
+  repo: 'serverless-gitops',
+  path: 'services/kibana/versions.yaml',
+};
+
+// Every PNC slice pins its own Kibana SHA. They are equal in steady state and differ while a
+// rollout or a rollback is in flight, so all of them have to be inspected. Keys are matched
+// separately from values: a slice whose value we cannot read must make the whole run
+// inconclusive, not silently disappear from the set we compare against.
+const PNC_KEY_RE = /^[ \t]*(production-noncanary-ds-\d+)[ \t]*:(.*)$/gm;
+const PNC_VALUE_RE = /^"([0-9a-f]{7,40})"$/;
+
+// `export * from './specs/<dir>/<file>';` — the list registration actually iterates.
+const BARREL_EXPORT_RE = /export \* from '(\.\/specs\/[^']+)'/g;
+
+// The bracketed feature list, spanning newlines. Used only to decide whether this PR changed
+// the declaration; the safety decision never depends on it.
+const FEATURE_LIST_RE = /supportedFeatureIds\s*:\s*\[([^\]]*)\]/;
+
+/**
+ * Splits the GitOps versions file into valid PNC entries and malformed ones. A key with an
+ * unreadable value lands in `malformed` so the caller can refuse to report a verdict.
+ */
+const parsePncEntries = (yaml) => {
+  const entries = [];
+  const malformed = [];
+
+  for (const match of yaml.matchAll(PNC_KEY_RE)) {
+    const [, slice, rawValue] = match;
+    const value = rawValue.trim();
+    const valueMatch = value.match(PNC_VALUE_RE);
+
+    if (valueMatch) {
+      entries.push({ slice, sha: valueMatch[1] });
+    } else {
+      malformed.push({ slice, value });
+    }
+  }
+
+  return { entries, malformed };
+};
+
+const barrelExports = (source) =>
+  new Set([...source.matchAll(BARREL_EXPORT_RE)].map((match) => match[1]));
+
+const isRegisteredIn = (barrel, moduleSpecifier) => barrelExports(barrel).has(moduleSpecifier);
+
+/** The declared feature list as normalized source text, or null when it cannot be extracted. */
+const featureListFrom = (source) => {
+  const match = source.match(FEATURE_LIST_RE);
+  return match ? match[1].replace(/\s+/g, ' ').trim() : null;
+};
+
+const fetchVersionsYaml = async (octokit) => {
+  const response = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+    ...GITOPS_VERSIONS_FILE,
+    mediaType: { format: 'raw' },
+  });
+
+  return typeof response.data === 'string'
+    ? response.data
+    : Buffer.from(response.data.content, 'base64').toString('utf8');
+};
+
+// versions.yaml may pin abbreviated SHAs, which git cannot fetch. The PR CI clone usually
+// already has the object, so expand locally first and only ask the commits API when it does not.
+const expandSha = async ({ git, octokit }, sha) => {
+  const local = git.read(['rev-parse', '--verify', `${sha}^{commit}`]);
+  if (local) {
+    return local.trim();
+  }
+
+  const commit = await octokit.repos.getCommit({ owner: 'elastic', repo: 'kibana', ref: sha });
+  return commit.data.sha;
+};
+
+/**
+ * Resolve every distinct PNC Kibana ref and read the registration barrel at each one.
+ *
+ * Any failure — no token, unreadable GitOps file, zero slices, a malformed value on *any*
+ * slice, an unresolvable commit, an unfetchable ref, an unreadable barrel — yields an
+ * inconclusive reason instead of a partial result, so the check can never report `safe`
+ * against a subset of production.
+ *
+ * @returns {Promise<{refs: string[], barrels?: Map<string, string>, inconclusiveReason?: string}>}
+ */
+const resolvePncRefs = async ({ git, octokit, hasToken, log }) => {
+  if (!hasToken) {
+    return {
+      refs: [],
+      inconclusiveReason: 'GITHUB_TOKEN is not set, so the GitOps versions file is unreadable.',
+    };
+  }
+
+  let yaml;
+  try {
+    yaml = await fetchVersionsYaml(octokit);
+  } catch (err) {
+    return {
+      refs: [],
+      inconclusiveReason: `Could not read ${GITOPS_VERSIONS_FILE.repo}/${GITOPS_VERSIONS_FILE.path}: ${err.message}`,
+    };
+  }
+
+  const { entries, malformed } = parsePncEntries(yaml);
+  for (const { slice, sha } of entries) {
+    log(`  ${slice}: ${sha}`);
+  }
+  for (const { slice, value } of malformed) {
+    log(`  ${slice}: ${value} (unreadable)`);
+  }
+
+  if (malformed.length > 0) {
+    return {
+      refs: [],
+      inconclusiveReason:
+        `Malformed Kibana SHA for ${malformed.map(({ slice }) => slice).join(', ')} in ` +
+        `${GITOPS_VERSIONS_FILE.path}; refusing to compare against a subset of Production-NonCanary.`,
+    };
+  }
+  if (entries.length === 0) {
+    return {
+      refs: [],
+      inconclusiveReason: `No production-noncanary-ds-* entries found in ${GITOPS_VERSIONS_FILE.path}.`,
+    };
+  }
+
+  const refs = [];
+  for (const sha of [...new Set(entries.map((entry) => entry.sha))]) {
+    let ref;
+    try {
+      ref = await expandSha({ git, octokit }, sha);
+    } catch (err) {
+      return {
+        refs: [],
+        inconclusiveReason: `Could not resolve ${sha} as an elastic/kibana commit: ${err.message}`,
+      };
+    }
+
+    if (
+      !git.ok(['rev-parse', '--verify', `${ref}^{commit}`]) &&
+      !git.ok(['fetch', '--quiet', '--depth=1', 'origin', ref])
+    ) {
+      return { refs: [], inconclusiveReason: `Could not fetch ${ref} from origin.` };
+    }
+
+    if (!refs.includes(ref)) {
+      refs.push(ref);
+    }
+  }
+
+  const barrels = new Map();
+  for (const ref of refs) {
+    const barrel = git.read(['show', `${ref}:${ALL_SPECS_PATH}`]);
+    if (barrel === null) {
+      return { refs: [], inconclusiveReason: `Could not read ${ALL_SPECS_PATH} at ${ref}.` };
+    }
+    barrels.set(ref, barrel);
+  }
+
+  return { refs, barrels };
+};
+
+const diffNames = ({ git, baseRef }, filterArgs) =>
+  git.read(['diff', '--name-only', ...filterArgs, baseRef, 'HEAD', '--', SPECS_DIR]);
+
+const toPathSet = (output) =>
+  new Set(
+    output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+  );
+
+/**
+ * Connectors whose exposure this PR changes: newly added modules, modules newly exported from
+ * the barrel, and modules whose `supportedFeatureIds` value changed. Always computed against
+ * the merge base, so an unrelated edit to a connector left unpublished by an earlier PR does
+ * not inherit that PR's advisory, and a fully reverted change becomes non-applicable.
+ *
+ * @returns {{known: boolean, connectors: Array<object>}}
+ */
+const scopeApplicableConnectors = ({ git, readFile, baseRef, connectors }) => {
+  if (!baseRef) {
+    return { known: false, connectors: [] };
+  }
+
+  const changedOutput = diffNames({ git, baseRef }, []);
+  const addedOutput = diffNames({ git, baseRef }, ['--diff-filter=A']);
+  const baseBarrel = git.read(['show', `${baseRef}:${ALL_SPECS_PATH}`]);
+  if (changedOutput === null || addedOutput === null || baseBarrel === null) {
+    return { known: false, connectors: [] };
+  }
+
+  const changed = toPathSet(changedOutput);
+  const added = toPathSet(addedOutput);
+  const baseExports = barrelExports(baseBarrel);
+
+  return {
+    known: true,
+    connectors: connectors.filter(({ relPath, moduleSpecifier }) => {
+      if (added.has(relPath)) return true; // new connector module
+      if (!baseExports.has(moduleSpecifier)) return true; // newly registered in the barrel
+      if (!changed.has(relPath)) return false; // untouched by this PR
+
+      const baseSource = git.read(['show', `${baseRef}:${relPath}`]);
+      if (baseSource === null) return true;
+
+      // Conservative: include the connector when either declaration cannot be extracted,
+      // rather than silently skipping a change we failed to read.
+      const baseList = featureListFrom(baseSource);
+      const headList = featureListFrom(readFile(relPath));
+      if (baseList === null || headList === null) return true;
+      return baseList !== headList;
+    }),
+  };
+};
+
+/**
+ * Resolve, then scope, then classify — in that order. Resolution runs and logs unconditionally,
+ * even when this PR changes no connector, so one CI log proves the multi-SHA path works.
+ */
+const runCheck = async ({ git, octokit, hasToken, readFile, baseRef, connectors, log }) => {
+  log('--- Resolving Production-NonCanary Kibana versions');
+  const release = await resolvePncRefs({ git, octokit, hasToken, log });
+  log(
+    release.inconclusiveReason
+      ? `  unresolved: ${release.inconclusiveReason}`
+      : `  distinct refs: ${release.refs.join(', ')}`
+  );
+
+  log('--- Scoping applicable connectors');
+  const { known, connectors: applicable } = scopeApplicableConnectors({
+    git,
+    readFile,
+    baseRef,
+    connectors,
+  });
+  if (!known) {
+    log(`  could not diff against base ref ${baseRef ?? '(none)'}; applicability unknown`);
+  } else {
+    log(
+      applicable.length === 0
+        ? '  no connector exposure changed by this PR'
+        : `  applicable: ${applicable.map(({ id }) => id).join(', ')}`
+    );
+  }
+
+  const withAvailability = applicable.map((connector) => ({
+    id: connector.id,
+    supportedFeatureIds: connector.supportedFeatureIds,
+    missingFromRefs: release.refs.filter(
+      (ref) => !isRegisteredIn(release.barrels.get(ref), connector.moduleSpecifier)
+    ),
+  }));
+
+  const { status, findings, reason, refs } = classifyConnectorRelease(withAvailability, release);
+
+  return {
+    status: known ? status : 'inconclusive',
+    reason: known ? reason : 'Could not determine which connectors this PR changes.',
+    applicabilityKnown: known,
+    refs,
+    baseRef: baseRef ?? null,
+    applicableConnectors: withAvailability,
+    findings,
+  };
+};
+
+/* istanbul ignore next -- dependency wiring, exercised by the CI step itself */
+const main = async () => {
+  require('@kbn/setup-node-env');
+
+  const fs = require('fs');
+  const path = require('path');
+  const { execFileSync } = require('child_process');
+
+  const REPO_ROOT = path.resolve(__dirname, '../../../..');
+  const SPECS_ABS = path.join(REPO_ROOT, SPECS_DIR);
+
+  const parseFlag = (name) => {
+    const idx = process.argv.indexOf(`--${name}`);
+    return idx !== -1 ? process.argv[idx + 1] : undefined;
+  };
+
+  const reportPath = parseFlag('report-path');
+  if (!reportPath) {
+    console.error('Usage: run_connector_release_check --report-path <file> [--base-ref <sha>]');
+    process.exit(2);
+  }
+
+  const exec = (args) =>
+    execFileSync('git', args, {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  const git = {
+    // Content, or null when the command fails. Never used for commands whose stdout is empty
+    // on success — there, `ok` distinguishes success from failure.
+    read: (args) => {
+      try {
+        return exec(args);
+      } catch (err) {
+        return null;
+      }
+    },
+    ok: (args) => {
+      try {
+        exec(args);
+        return true;
+      } catch (err) {
+        return false;
+      }
+    },
+  };
+
+  /**
+   * Every connector at the PR head, mapped to its spec file. Loading `all_specs` populates
+   * `require.cache` with one entry per spec module, so we can read each connector's id and
+   * features together with the path they came from (the id is not encoded in the path).
+   */
+  const readHeadConnectors = () => {
+    require('@kbn/connector-specs/src/all_specs');
+
+    const connectors = [];
+    for (const [absPath, mod] of Object.entries(require.cache)) {
+      if (!absPath.startsWith(SPECS_ABS + path.sep)) continue;
+      for (const exported of Object.values(mod.exports || {})) {
+        if (exported && exported.metadata && exported.metadata.id) {
+          const relPath = path.relative(REPO_ROOT, absPath);
+          connectors.push({
+            id: exported.metadata.id,
+            supportedFeatureIds: [].concat(exported.metadata.supportedFeatureIds ?? []),
+            relPath,
+            moduleSpecifier: `./${path.relative(PACKAGE_SRC_DIR, relPath).replace(/\.ts$/, '')}`,
+          });
+        }
+      }
+    }
+    return connectors;
+  };
+
+  const hasToken = Boolean(process.env.GITHUB_TOKEN);
+  const report = await runCheck({
+    git,
+    octokit: hasToken
+      ? new (require('@octokit/rest').Octokit)({ auth: process.env.GITHUB_TOKEN })
+      : null,
+    hasToken,
+    readFile: (relPath) => fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf8'),
+    baseRef: parseFlag('base-ref') || undefined,
+    connectors: readHeadConnectors(),
+    log: (message) => console.log(message),
+  });
+
+  fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+  console.log(
+    `--- Connector release check: ${report.status}` +
+      (report.reason ? ` (${report.reason})` : '') +
+      ` — ${report.findings.length} advisory finding(s)`
+  );
+};
+
+module.exports = {
+  ALL_SPECS_PATH,
+  SPECS_DIR,
+  barrelExports,
+  featureListFrom,
+  isRegisteredIn,
+  parsePncEntries,
+  resolvePncRefs,
+  runCheck,
+  scopeApplicableConnectors,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Connector release check failed to produce a report:', error);
+    process.exit(1);
+  });
+}

--- a/.buildkite/scripts/steps/checks/run_connector_release_check.test.js
+++ b/.buildkite/scripts/steps/checks/run_connector_release_check.test.js
@@ -1,0 +1,552 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const {
+  ALL_SPECS_PATH,
+  barrelExports,
+  featureListFrom,
+  isRegisteredIn,
+  parsePncEntries,
+  resolvePncRefs,
+  runCheck,
+  scopeApplicableConnectors,
+} = require('./run_connector_release_check');
+
+const SHA_A = 'a'.repeat(40);
+const SHA_B = 'b'.repeat(40);
+const SPEC_PATH = 'src/platform/packages/shared/kbn-connector-specs/src/specs/acme/acme.ts';
+const SPEC_MODULE = './specs/acme/acme';
+
+const versionsYaml = (body) => `qa-ds-1: "${'9'.repeat(40)}"\n${body}\n`;
+const barrelWith = (...modules) =>
+  modules.map((module) => `export * from '${module}';`).join('\n') + '\n';
+const specSource = (featureIds) =>
+  `export const Acme = { metadata: { id: '.acme', supportedFeatureIds: ${featureIds} } };`;
+
+/**
+ * Fake git that answers by matching the joined argument list, records every call, and throws
+ * for anything unhandled — the same failure shape `execFileSync` produces.
+ */
+const fakeGit = (handlers) => {
+  const calls = [];
+  const exec = (args) => {
+    calls.push(args.join(' '));
+    for (const [pattern, result] of Object.entries(handlers)) {
+      if (args.join(' ').includes(pattern)) {
+        if (result === null) throw new Error(`git failed: ${pattern}`);
+        return result;
+      }
+    }
+    throw new Error(`unhandled git call: ${args.join(' ')}`);
+  };
+
+  return {
+    calls,
+    read: (args) => {
+      try {
+        return exec(args);
+      } catch (err) {
+        return null;
+      }
+    },
+    ok: (args) => {
+      try {
+        exec(args);
+        return true;
+      } catch (err) {
+        return false;
+      }
+    },
+  };
+};
+
+const fakeOctokit = ({ yaml, getCommit } = {}) => ({
+  request: jest.fn(async () => {
+    if (yaml === undefined) throw new Error('404 Not Found');
+    return { data: yaml };
+  }),
+  repos: { getCommit: getCommit ?? jest.fn(async () => ({ data: { sha: SHA_A } })) },
+});
+
+describe('parsePncEntries', () => {
+  it('collects every production-noncanary slice and ignores other environments', () => {
+    const { entries, malformed } = parsePncEntries(
+      versionsYaml(
+        `production-canary-ds-1: "${SHA_B}"\n` +
+          `production-noncanary-ds-1: "${SHA_A}"\n` +
+          `production-noncanary-ds-5: "${SHA_B}"`
+      )
+    );
+
+    expect(entries).toEqual([
+      { slice: 'production-noncanary-ds-1', sha: SHA_A },
+      { slice: 'production-noncanary-ds-5', sha: SHA_B },
+    ]);
+    expect(malformed).toEqual([]);
+  });
+
+  it('accepts abbreviated SHAs', () => {
+    const { entries } = parsePncEntries(versionsYaml('production-noncanary-ds-1: "abc1234"'));
+
+    expect(entries).toEqual([{ slice: 'production-noncanary-ds-1', sha: 'abc1234' }]);
+  });
+
+  it('reports a slice with an unreadable value as malformed rather than dropping it', () => {
+    const { entries, malformed } = parsePncEntries(
+      versionsYaml(
+        `production-noncanary-ds-1: "${SHA_A}"\n` +
+          `production-noncanary-ds-2: "not-a-sha"\n` +
+          `production-noncanary-ds-3: ""\n` +
+          `production-noncanary-ds-4:\n` +
+          `production-noncanary-ds-5: ${SHA_B}`
+      )
+    );
+
+    expect(entries).toEqual([{ slice: 'production-noncanary-ds-1', sha: SHA_A }]);
+    expect(malformed.map(({ slice }) => slice)).toEqual([
+      'production-noncanary-ds-2',
+      'production-noncanary-ds-3',
+      'production-noncanary-ds-4',
+      'production-noncanary-ds-5',
+    ]);
+  });
+
+  it('returns nothing when the file has no PNC slices at all', () => {
+    expect(parsePncEntries(versionsYaml('staging-ds-1: "abc1234"'))).toEqual({
+      entries: [],
+      malformed: [],
+    });
+  });
+});
+
+describe('barrel registration', () => {
+  it('extracts the exported spec modules', () => {
+    expect([...barrelExports(barrelWith('./specs/acme/acme', './specs/other/other'))]).toEqual([
+      './specs/acme/acme',
+      './specs/other/other',
+    ]);
+  });
+
+  it('treats an unexported module as unregistered even though its file exists', () => {
+    expect(isRegisteredIn(barrelWith('./specs/other/other'), SPEC_MODULE)).toBe(false);
+    expect(isRegisteredIn(barrelWith(SPEC_MODULE), SPEC_MODULE)).toBe(true);
+  });
+});
+
+describe('featureListFrom', () => {
+  it('normalizes a single-line declaration', () => {
+    expect(featureListFrom(specSource(`['workflows', 'agentBuilder']`))).toBe(
+      `'workflows', 'agentBuilder'`
+    );
+  });
+
+  it('normalizes a multiline declaration to the same value as its single-line form', () => {
+    const multiline = specSource(`[\n      'workflows',\n      'agentBuilder',\n    ]`);
+
+    expect(featureListFrom(multiline)).toBe(`'workflows', 'agentBuilder',`);
+  });
+
+  it('returns null when the declaration cannot be extracted', () => {
+    expect(featureListFrom('export const Acme = { metadata: { id: ".acme" } };')).toBeNull();
+  });
+});
+
+describe('resolvePncRefs', () => {
+  const log = () => {};
+
+  it('resolves every distinct slice SHA and reads the barrel at each ref', async () => {
+    const git = fakeGit({
+      [`rev-parse --verify ${SHA_A}`]: `${SHA_A}\n`,
+      [`rev-parse --verify ${SHA_B}`]: `${SHA_B}\n`,
+      show: barrelWith(SPEC_MODULE),
+    });
+    const result = await resolvePncRefs({
+      git,
+      hasToken: true,
+      log,
+      octokit: fakeOctokit({
+        yaml: versionsYaml(
+          `production-noncanary-ds-1: "${SHA_A}"\nproduction-noncanary-ds-5: "${SHA_B}"`
+        ),
+      }),
+    });
+
+    expect(result.inconclusiveReason).toBeUndefined();
+    expect(result.refs).toEqual([SHA_A, SHA_B]);
+    expect(result.barrels.get(SHA_B)).toContain(SPEC_MODULE);
+  });
+
+  it('deduplicates slices that pin the same SHA', async () => {
+    const git = fakeGit({ 'rev-parse': `${SHA_A}\n`, show: barrelWith(SPEC_MODULE) });
+    const result = await resolvePncRefs({
+      git,
+      hasToken: true,
+      log,
+      octokit: fakeOctokit({
+        yaml: versionsYaml(
+          `production-noncanary-ds-1: "${SHA_A}"\nproduction-noncanary-ds-5: "${SHA_A}"`
+        ),
+      }),
+    });
+
+    expect(result.refs).toEqual([SHA_A]);
+  });
+
+  it('expands an abbreviated SHA locally without calling the commits API', async () => {
+    const getCommit = jest.fn();
+    const git = fakeGit({ 'rev-parse': `${SHA_A}\n`, show: barrelWith(SPEC_MODULE) });
+    const result = await resolvePncRefs({
+      git,
+      hasToken: true,
+      log,
+      octokit: fakeOctokit({
+        yaml: versionsYaml('production-noncanary-ds-1: "abc1234"'),
+        getCommit,
+      }),
+    });
+
+    expect(result.refs).toEqual([SHA_A]);
+    expect(getCommit).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the commits API when the object is not local, then fetches the ref', async () => {
+    const getCommit = jest.fn(async () => ({ data: { sha: SHA_A } }));
+    const git = fakeGit({
+      'rev-parse': null,
+      fetch: '',
+      show: barrelWith(SPEC_MODULE),
+    });
+    const result = await resolvePncRefs({
+      git,
+      hasToken: true,
+      log,
+      octokit: fakeOctokit({
+        yaml: versionsYaml('production-noncanary-ds-1: "abc1234"'),
+        getCommit,
+      }),
+    });
+
+    expect(getCommit).toHaveBeenCalledWith({ owner: 'elastic', repo: 'kibana', ref: 'abc1234' });
+    expect(git.calls).toContain(`fetch --quiet --depth=1 origin ${SHA_A}`);
+    expect(result.refs).toEqual([SHA_A]);
+  });
+
+  it.each([
+    [
+      'no token',
+      { hasToken: false, octokit: fakeOctokit({ yaml: '' }) },
+      /GITHUB_TOKEN is not set/,
+    ],
+    ['unreadable GitOps file', { hasToken: true, octokit: fakeOctokit() }, /Could not read/],
+    [
+      'zero slices',
+      { hasToken: true, octokit: fakeOctokit({ yaml: versionsYaml('staging-ds-1: "abc1234"') }) },
+      /No production-noncanary-ds-\* entries/,
+    ],
+  ])('is inconclusive on %s', async (_name, overrides, expected) => {
+    const result = await resolvePncRefs({
+      git: fakeGit({}),
+      log,
+      ...overrides,
+    });
+
+    expect(result.refs).toEqual([]);
+    expect(result.inconclusiveReason).toMatch(expected);
+  });
+
+  it('is inconclusive when one slice is malformed even though the others are valid', async () => {
+    const git = fakeGit({ 'rev-parse': `${SHA_A}\n`, show: barrelWith(SPEC_MODULE) });
+    const result = await resolvePncRefs({
+      git,
+      hasToken: true,
+      log,
+      octokit: fakeOctokit({
+        yaml: versionsYaml(
+          `production-noncanary-ds-1: "${SHA_A}"\n` +
+            `production-noncanary-ds-2: "${SHA_B}"\n` +
+            `production-noncanary-ds-3: "corrupted"`
+        ),
+      }),
+    });
+
+    expect(result.refs).toEqual([]);
+    expect(result.inconclusiveReason).toContain('production-noncanary-ds-3');
+    expect(result.inconclusiveReason).toContain('subset of Production-NonCanary');
+    // Never inspects anything: a partial comparison must not happen at all.
+    expect(git.calls).toEqual([]);
+  });
+
+  it('is inconclusive when a commit cannot be resolved', async () => {
+    const result = await resolvePncRefs({
+      git: fakeGit({ 'rev-parse': null }),
+      hasToken: true,
+      log,
+      octokit: fakeOctokit({
+        yaml: versionsYaml('production-noncanary-ds-1: "abc1234"'),
+        getCommit: jest.fn(async () => {
+          throw new Error('422 No commit found');
+        }),
+      }),
+    });
+
+    expect(result.inconclusiveReason).toMatch(/Could not resolve abc1234/);
+  });
+
+  it('is inconclusive when a ref cannot be fetched', async () => {
+    const result = await resolvePncRefs({
+      git: fakeGit({ 'rev-parse': null, fetch: null }),
+      hasToken: true,
+      log,
+      octokit: fakeOctokit({ yaml: versionsYaml(`production-noncanary-ds-1: "${SHA_A}"`) }),
+    });
+
+    expect(result.inconclusiveReason).toMatch(/Could not fetch/);
+  });
+
+  it('is inconclusive when the barrel cannot be read at a ref', async () => {
+    const result = await resolvePncRefs({
+      git: fakeGit({ 'rev-parse': `${SHA_A}\n`, show: null }),
+      hasToken: true,
+      log,
+      octokit: fakeOctokit({ yaml: versionsYaml(`production-noncanary-ds-1: "${SHA_A}"`) }),
+    });
+
+    expect(result.inconclusiveReason).toContain(ALL_SPECS_PATH);
+  });
+});
+
+describe('scopeApplicableConnectors', () => {
+  const connector = {
+    id: '.acme',
+    supportedFeatureIds: ['workflows'],
+    relPath: SPEC_PATH,
+    moduleSpecifier: SPEC_MODULE,
+  };
+  const scope = (handlers, headSource = specSource(`['workflows']`)) =>
+    scopeApplicableConnectors({
+      git: fakeGit(handlers),
+      readFile: () => headSource,
+      baseRef: 'base',
+      connectors: [connector],
+    });
+
+  it('includes a newly added connector module', () => {
+    const result = scope({
+      '--diff-filter=A': `${SPEC_PATH}\n`,
+      '--name-only': `${SPEC_PATH}\n`,
+      [`base:${ALL_SPECS_PATH}`]: barrelWith(),
+    });
+
+    expect(result.known).toBe(true);
+    expect(result.connectors).toHaveLength(1);
+  });
+
+  it('includes a module newly exported from the barrel even when its file is unchanged', () => {
+    const result = scope({
+      '--diff-filter=A': '\n',
+      '--name-only': '\n',
+      [`base:${ALL_SPECS_PATH}`]: barrelWith('./specs/other/other'),
+    });
+
+    expect(result.connectors).toHaveLength(1);
+  });
+
+  it('includes a connector whose feature list changed', () => {
+    const result = scope({
+      '--diff-filter=A': '\n',
+      '--name-only': `${SPEC_PATH}\n`,
+      [`base:${ALL_SPECS_PATH}`]: barrelWith(SPEC_MODULE),
+      [`base:${SPEC_PATH}`]: specSource(`['agentBuilder']`),
+    });
+
+    expect(result.connectors).toHaveLength(1);
+  });
+
+  it('excludes a reformatted feature list that declares the same features', () => {
+    const result = scope(
+      {
+        '--diff-filter=A': '\n',
+        '--name-only': `${SPEC_PATH}\n`,
+        [`base:${ALL_SPECS_PATH}`]: barrelWith(SPEC_MODULE),
+        [`base:${SPEC_PATH}`]: specSource(`[\n  'workflows',\n]`),
+      },
+      specSource(`['workflows',]`)
+    );
+
+    expect(result.connectors).toEqual([]);
+  });
+
+  it('excludes an unrelated edit, so an earlier PR advisory is not inherited', () => {
+    const result = scope({
+      '--diff-filter=A': '\n',
+      '--name-only': `${SPEC_PATH}\n`,
+      [`base:${ALL_SPECS_PATH}`]: barrelWith(SPEC_MODULE),
+      [`base:${SPEC_PATH}`]: specSource(`['workflows']`),
+    });
+
+    expect(result.connectors).toEqual([]);
+  });
+
+  it('excludes a connector this PR never touched', () => {
+    const result = scope({
+      '--diff-filter=A': '\n',
+      '--name-only': '\n',
+      [`base:${ALL_SPECS_PATH}`]: barrelWith(SPEC_MODULE),
+    });
+
+    expect(result.connectors).toEqual([]);
+  });
+
+  it('includes a connector whose declaration cannot be extracted on either side', () => {
+    const result = scope(
+      {
+        '--diff-filter=A': '\n',
+        '--name-only': `${SPEC_PATH}\n`,
+        [`base:${ALL_SPECS_PATH}`]: barrelWith(SPEC_MODULE),
+        [`base:${SPEC_PATH}`]: 'export const Acme = { metadata: { id: ".acme" } };',
+      },
+      specSource(`['workflows']`)
+    );
+
+    expect(result.connectors).toHaveLength(1);
+  });
+
+  it.each([
+    ['no base ref', undefined, {}],
+    ['an undiffable base ref', 'base', { '--name-only': null }],
+    ['an unreadable base barrel', 'base', { '--name-only': '\n', show: null }],
+  ])('reports applicability unknown for %s', (_name, baseRef, handlers) => {
+    const result = scopeApplicableConnectors({
+      git: fakeGit(handlers),
+      readFile: () => specSource(`['workflows']`),
+      baseRef,
+      connectors: [connector],
+    });
+
+    expect(result).toEqual({ known: false, connectors: [] });
+  });
+
+  it('always diffs against the merge base, never the latest commit', () => {
+    const git = fakeGit({
+      '--diff-filter=A': '\n',
+      '--name-only': '\n',
+      [`base:${ALL_SPECS_PATH}`]: barrelWith(SPEC_MODULE),
+    });
+    scopeApplicableConnectors({
+      git,
+      readFile: () => specSource(`['workflows']`),
+      baseRef: 'merge-base-sha',
+      connectors: [connector],
+    });
+
+    for (const call of git.calls.filter((c) => c.startsWith('diff'))) {
+      expect(call).toContain('merge-base-sha HEAD');
+      expect(call).not.toContain('HEAD~');
+    }
+  });
+});
+
+describe('runCheck', () => {
+  const connector = {
+    id: '.acme',
+    supportedFeatureIds: ['workflows'],
+    relPath: SPEC_PATH,
+    moduleSpecifier: SPEC_MODULE,
+  };
+
+  const run = ({ handlers, yaml, connectors = [connector], baseRef = 'base' }) => {
+    const messages = [];
+    const git = fakeGit(handlers);
+    return runCheck({
+      git,
+      octokit: fakeOctokit({ yaml }),
+      hasToken: true,
+      readFile: () => specSource(`['workflows']`),
+      baseRef,
+      connectors,
+      log: (message) => messages.push(message),
+    }).then((report) => ({ report, messages, git }));
+  };
+
+  const releasedHandlers = {
+    'rev-parse': `${SHA_A}\n`,
+    [`${SHA_A}:${ALL_SPECS_PATH}`]: barrelWith(SPEC_MODULE),
+    '--diff-filter=A': `${SPEC_PATH}\n`,
+    '--name-only': `${SPEC_PATH}\n`,
+    [`base:${ALL_SPECS_PATH}`]: barrelWith(),
+  };
+  const yaml = versionsYaml(`production-noncanary-ds-1: "${SHA_A}"`);
+
+  it('resolves and logs the PNC versions before scoping applicability', async () => {
+    const { messages } = await run({ handlers: releasedHandlers, yaml });
+
+    expect(messages.indexOf('--- Resolving Production-NonCanary Kibana versions')).toBe(0);
+    expect(messages).toContain(`  production-noncanary-ds-1: ${SHA_A}`);
+    expect(messages.indexOf('--- Resolving Production-NonCanary Kibana versions')).toBeLessThan(
+      messages.indexOf('--- Scoping applicable connectors')
+    );
+  });
+
+  it('resolves and logs the PNC versions even when this PR changes no connector', async () => {
+    const { report, messages } = await run({
+      handlers: { ...releasedHandlers, '--diff-filter=A': '\n', '--name-only': '\n' },
+      yaml,
+      connectors: [],
+    });
+
+    expect(messages).toContain(`  distinct refs: ${SHA_A}`);
+    expect(messages).toContain('  no connector exposure changed by this PR');
+    expect(report.applicableConnectors).toEqual([]);
+    expect(report.status).toBe('safe');
+  });
+
+  it('reports unsafe for a newly added connector that is not registered in the release', async () => {
+    const { report } = await run({
+      handlers: { ...releasedHandlers, [`${SHA_A}:${ALL_SPECS_PATH}`]: barrelWith() },
+      yaml,
+    });
+
+    expect(report.status).toBe('unsafe');
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0].missingFromRefs).toEqual([SHA_A]);
+    expect(report.applicabilityKnown).toBe(true);
+    expect(report.refs).toEqual([SHA_A]);
+  });
+
+  it('reports safe once the connector is registered in every PNC ref', async () => {
+    const { report } = await run({ handlers: releasedHandlers, yaml });
+
+    expect(report.status).toBe('safe');
+    expect(report.findings).toEqual([]);
+  });
+
+  it('reports inconclusive without findings when the release cannot be resolved', async () => {
+    const { report } = await run({
+      handlers: releasedHandlers,
+      yaml: versionsYaml(`production-noncanary-ds-1: "${SHA_A}"\nproduction-noncanary-ds-2: "??"`),
+    });
+
+    expect(report.status).toBe('inconclusive');
+    expect(report.findings).toEqual([]);
+    expect(report.reason).toContain('production-noncanary-ds-2');
+    // Applicability is still known, so the notifier can decide whether to comment at all.
+    expect(report.applicabilityKnown).toBe(true);
+    expect(report.applicableConnectors).toHaveLength(1);
+  });
+
+  it('reports inconclusive and applicabilityKnown false when the merge base is unusable', async () => {
+    // No `--base-ref` reached the runner, so there is nothing to diff HEAD against.
+    const { report } = await run({ handlers: releasedHandlers, yaml, baseRef: null });
+
+    expect(report.status).toBe('inconclusive');
+    expect(report.applicabilityKnown).toBe(false);
+    expect(report.applicableConnectors).toEqual([]);
+    expect(report.baseRef).toBeNull();
+  });
+});

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3845,6 +3845,13 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /.buildkite/scripts/steps/checks/notify_api_contract_owners.test.ts @elastic/kibana-core
 /.buildkite/scripts/steps/checks/unused_deps.sh @elastic/kibana-security
 /.buildkite/scripts/steps/checks/verify_codeowners_teams.ts @elastic/kibana-security
+/.buildkite/scripts/steps/checks/check_connector_specs.sh @elastic/response-ops
+/.buildkite/scripts/steps/checks/connector_release_check.js @elastic/response-ops
+/.buildkite/scripts/steps/checks/connector_release_check.test.js @elastic/response-ops
+/.buildkite/scripts/steps/checks/run_connector_release_check.js @elastic/response-ops
+/.buildkite/scripts/steps/checks/run_connector_release_check.test.js @elastic/response-ops
+/.buildkite/scripts/steps/checks/notify_connector_specs_changes.ts @elastic/response-ops
+/.buildkite/scripts/steps/checks/notify_connector_specs_changes.test.ts @elastic/response-ops
 /.buildkite/pipelines/performance/streams_weekly.yml @elastic/obs-sig-events-team @elastic/streams-ui
 /.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml @elastic/streams-ui
 /.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml @elastic/obs-sig-events-team @elastic/streams-ui

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -67,13 +67,15 @@ export interface ConnectorMetadata {
   /**
    * Features this connector type is exposed through.
    *
-   * A brand-new connector type must reach Production-NonCanary before it can declare
+   * A brand-new connector type should reach Production-NonCanary before it declares
    * user-facing features: serverless rollouts and rollbacks leave nodes on different Kibana
    * versions for a while, and a user action referencing a type a node does not have breaks
-   * on that node. Ship a new connector with `['agentBuilder']`, or `[]` when it is
-   * Workflows-only (a support-only state: registered and executable, but hidden from pickers
-   * and not creatable), then add the remaining feature IDs in a follow-up PR. See the
-   * "Intermediate release state" section of the package README.
+   * on that node. So ship a new connector with `['agentBuilder']`, then add the remaining
+   * feature IDs in a follow-up PR.
+   *
+   * An empty array is the support-only state, for any connector that should not be exposed
+   * through Agent Builder initially: the type is registered and executable, but hidden from
+   * connector pickers and not creatable, so no user action can reference it yet.
    */
   supportedFeatureIds: Array<
     | 'alerting'

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -64,6 +64,17 @@ export interface ConnectorMetadata {
   docsUrl?: string;
   minimumLicense: LicenseType;
   isTechnicalPreview?: boolean;
+  /**
+   * Features this connector type is exposed through.
+   *
+   * A brand-new connector type must reach Production-NonCanary before it can declare
+   * user-facing features: serverless rollouts and rollbacks leave nodes on different Kibana
+   * versions for a while, and a user action referencing a type a node does not have breaks
+   * on that node. Ship a new connector with `['agentBuilder']`, or `[]` when it is
+   * Workflows-only (a support-only state: registered and executable, but hidden from pickers
+   * and not creatable), then add the remaining feature IDs in a follow-up PR. See the
+   * "Intermediate release state" section of the package README.
+   */
   supportedFeatureIds: Array<
     | 'alerting'
     | 'cases'

--- a/x-pack/platform/plugins/shared/actions/server/action_type_registry.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/action_type_registry.test.ts
@@ -8,6 +8,7 @@
 import { TaskCost } from '@kbn/task-manager-plugin/server';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { z } from '@kbn/zod/v4';
+import { ACTION_TYPE_SOURCES } from '@kbn/actions-types';
 import type { ActionTypeRegistryOpts } from './action_type_registry';
 import { ActionTypeRegistry } from './action_type_registry';
 import type { ActionType } from './types';
@@ -118,7 +119,7 @@ describe('actionTypeRegistry', () => {
       );
     });
 
-    test('throws if empty supported feature ids provided', () => {
+    test('throws if empty supported feature ids provided for non-spec source', () => {
       const actionTypeRegistry = new ActionTypeRegistry(actionTypeRegistryParams);
       expect(() =>
         actionTypeRegistry.register(
@@ -128,6 +129,52 @@ describe('actionTypeRegistry', () => {
         )
       ).toThrowErrorMatchingInlineSnapshot(
         `"At least one \\"supportedFeatureId\\" value must be supplied for connector type \\"my-connector-type\\"."`
+      );
+    });
+
+    test('allows registering spec connector type with empty supportedFeatureIds (support-only)', () => {
+      const actionTypeRegistry = new ActionTypeRegistry(actionTypeRegistryParams);
+      expect(() =>
+        actionTypeRegistry.register(
+          getConnectorType({
+            source: ACTION_TYPE_SOURCES.spec,
+            supportedFeatureIds: [],
+          })
+        )
+      ).not.toThrow();
+      expect(actionTypeRegistry.has('my-connector-type')).toBe(true);
+    });
+
+    test('throws if spec connector type has invalid non-empty feature id', () => {
+      const actionTypeRegistry = new ActionTypeRegistry(actionTypeRegistryParams);
+      expect(() =>
+        actionTypeRegistry.register(
+          getConnectorType({
+            source: ACTION_TYPE_SOURCES.spec,
+            supportedFeatureIds: ['notAValidFeatureId'],
+          })
+        )
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid feature ids \\"notAValidFeatureId\\" for connector type \\"my-connector-type\\"."`
+      );
+    });
+
+    test('list() excludes support-only spec connector when filtering by featureId', () => {
+      mockedLicenseState.isLicenseValidForActionType.mockReturnValue({ isValid: true });
+      const actionTypeRegistry = new ActionTypeRegistry(actionTypeRegistryParams);
+      actionTypeRegistry.register(
+        getConnectorType({
+          id: 'support-only',
+          name: 'Support Only',
+          source: ACTION_TYPE_SOURCES.spec,
+          supportedFeatureIds: [],
+        })
+      );
+      expect(actionTypeRegistry.list({ featureId: 'workflows' }).map((t) => t.id)).not.toContain(
+        'support-only'
+      );
+      expect(actionTypeRegistry.list({ featureId: 'agentBuilder' }).map((t) => t.id)).not.toContain(
+        'support-only'
       );
     });
 

--- a/x-pack/platform/plugins/shared/actions/server/action_type_registry.ts
+++ b/x-pack/platform/plugins/shared/actions/server/action_type_registry.ts
@@ -165,7 +165,11 @@ export class ActionTypeRegistry {
       );
     }
 
-    if (!actionType.supportedFeatureIds || actionType.supportedFeatureIds.length === 0) {
+    const isSpecConnector = actionType.source === ACTION_TYPE_SOURCES.spec;
+    if (
+      !actionType.supportedFeatureIds ||
+      (!isSpecConnector && actionType.supportedFeatureIds.length === 0)
+    ) {
       throw new Error(
         i18n.translate('xpack.actions.actionTypeRegistry.register.missingSupportedFeatureIds', {
           defaultMessage:
@@ -190,7 +194,10 @@ export class ActionTypeRegistry {
       );
     }
 
-    if (!areValidFeatures(actionType.supportedFeatureIds)) {
+    if (
+      actionType.supportedFeatureIds.length > 0 &&
+      !areValidFeatures(actionType.supportedFeatureIds)
+    ) {
       throw new Error(
         i18n.translate('xpack.actions.actionTypeRegistry.register.invalidConnectorFeatureIds', {
           defaultMessage: 'Invalid feature ids "{ids}" for connector type "{connectorTypeId}".',

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/create/create.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/create/create.test.ts
@@ -669,6 +669,35 @@ describe('create()', () => {
     });
   });
 
+  test('rejects public creation of a support-only spec connector', async () => {
+    (actionTypeRegistry.get as jest.Mock).mockReturnValue(
+      getConnectorType({
+        source: ACTION_TYPE_SOURCES.spec,
+        supportedFeatureIds: [],
+        validate: {
+          config: { schema: z.any() },
+          secrets: { schema: z.any() },
+          params: { schema: z.object({}) },
+        },
+      })
+    );
+
+    await expect(
+      create({
+        context: mockContext,
+        action: {
+          name: 'support-only',
+          actionTypeId: 'my-connector-type',
+          config: {},
+          secrets: {},
+        },
+      })
+    ).rejects.toThrow(
+      'Connector type my-connector-type is support-only and cannot be used to create connectors yet.'
+    );
+    expect(unsecuredSavedObjectsClient.create).not.toHaveBeenCalled();
+  });
+
   describe('spec connector config.authType', () => {
     test('persists config.authType from secrets when config is empty (spec source)', async () => {
       (authTypeRegistry.get as jest.Mock).mockReturnValue({

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/create/create.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/create/create.ts
@@ -74,6 +74,18 @@ export async function create({
   }
 
   const actionType = context.actionTypeRegistry.get(actionTypeId);
+  if (
+    actionType.source === ACTION_TYPE_SOURCES.spec &&
+    actionType.supportedFeatureIds.length === 0
+  ) {
+    throw Boom.badRequest(
+      i18n.translate('xpack.actions.serverSideErrors.supportOnlyConnectorCreationForbidden', {
+        defaultMessage:
+          'Connector type {actionTypeId} is support-only and cannot be used to create connectors yet.',
+        values: { actionTypeId },
+      })
+    );
+  }
   const configurationUtilities = context.actionTypeRegistry.getUtils();
   const validatedActionTypeConfig = validateConfig(actionType, config, {
     configurationUtilities,

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.test.ts
@@ -73,6 +73,24 @@ describe('createConnectorTypeFromSpec', () => {
     expect(connectorType.isExperimental).toBeUndefined();
   });
 
+  it('keeps support-only connectors executable without advertising a feature', () => {
+    const spec = createMockSpec({
+      metadata: {
+        id: 'support-only-connector',
+        displayName: 'Support-only Connector',
+        description: 'Deployed for rollback compatibility',
+        minimumLicense: 'basic',
+        supportedFeatureIds: [],
+      },
+    });
+
+    const connectorType = createConnectorTypeFromSpec(spec, mockActionsPlugin);
+
+    expect(connectorType.supportedFeatureIds).toEqual([]);
+    expect(connectorType.executor).toBeDefined();
+    expect(connectorType.validate.params).toBeDefined();
+  });
+
   it('sets isExperimental from metadata.isTechnicalPreview', () => {
     const spec = createMockSpec({
       metadata: {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.test.tsx
@@ -397,6 +397,34 @@ describe('connector_add_flyout', () => {
       expect(screen.getByText('Send data via spec connector')).toBeInTheDocument();
     });
 
+    it('does not render a support-only spec connector', async () => {
+      const onActionTypeChange = jest.fn();
+      loadActionTypes.mockResolvedValue([
+        {
+          id: 'support-only-spec-connector',
+          source: ACTION_TYPE_SOURCES.spec,
+          enabled: true,
+          name: 'Support-only Spec Connector',
+          description: 'Not ready for user creation',
+          enabledInConfig: true,
+          enabledInLicense: true,
+          minimumLicenseRequired: 'basic',
+          supportedFeatureIds: [],
+          isDeprecated: false,
+        },
+      ]);
+
+      appMockRenderer.render(
+        <ActionTypeMenu
+          onActionTypeChange={onActionTypeChange}
+          actionTypeRegistry={actionTypeRegistry}
+        />
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(screen.queryByTestId('support-only-spec-connector-card')).not.toBeInTheDocument();
+    });
+
     it('does not render a spec connector when enabledInConfig is false', async () => {
       const onActionTypeChange = jest.fn();
       loadActionTypes.mockResolvedValue([

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
@@ -162,6 +162,11 @@ export const ActionTypeMenu = ({
 
       const actionTypeModel = actionTypeRegistry.has(id) ? actionTypeRegistry.get(id) : undefined;
       if (actionType.source === ACTION_TYPE_SOURCES.spec) {
+        // Support-only connectors (empty supportedFeatureIds) are registered and executable
+        // but must not appear in generic creation pickers.
+        if (actionType.supportedFeatureIds.length === 0) {
+          return false;
+        }
         if (shouldHideWorkflowsOnlyConnector(actionType.supportedFeatureIds, uiSettings)) {
           return false;
         }


### PR DESCRIPTION
## Summary

Checks the 2-step release policy for spec connectors: a new connector type should be registered in every version currently pinned for the Production-NonCanary (PNC) slices before it declares user-facing features. Serverless rollouts and rollbacks leave nodes on different Kibana versions for a while, and a user action referencing a connector type that a node does not have breaks on that node.

This first iteration *checks* the policy, it does not enforce it. The advisory never blocks a PR.

**Step 1** — a new connector ships with `supportedFeatureIds: ['agentBuilder']`, or `[]` when it should not be exposed through Agent Builder initially. `[]` is the generic support-only state: the type is registered and executable, but hidden from connector pickers and not creatable, so no user action can reference it yet.

**Step 2** — once the connector is registered in every PNC version, a follow-up PR adds `'workflows'` and any other user-facing feature IDs.

### CI check (advisory, `soft_fail`)

- New Buildkite step `check_connector_specs` upserts a PR comment with an explicit `safe` / `unsafe` / `inconclusive` outcome and the PNC versions it inspected.
- Resolves **every** `production-noncanary-ds-*` SHA from `serverless-gitops/services/kibana/versions.yaml`, expands abbreviated SHAs with local `git rev-parse` (commits API as fallback), and inspects every distinct ref. The SHAs need not be equal: a connector counts as published only when registered in all of them, which handles both normal rollouts and rollbacks conservatively. The existing `scripts/get_serverless_release_sha` helper resolves QA, not PNC, so it is not used here.
- Registration is determined from the connector's export in `all_specs.ts` at each ref, not from spec-file existence: registration iterates that barrel, so a spec file present at a ref without being exported there was never registered.
- Zero, malformed, inaccessible, or unresolvable PNC SHAs report `inconclusive`, never `safe`.
- Findings are scoped to connectors whose exposure this PR changes (added modules, newly exported modules, changed `supportedFeatureIds`), always computed against `<merge-base>..HEAD`. A later unrelated commit cannot hide an earlier unsafe change, and an unrelated edit to a connector left unpublished by an earlier PR does not inherit that PR's advisory.
- The step is path-gated on connector changes, so it cannot be relied on to run once a change is fully reverted. The notifier therefore never deletes an existing comment, and no shared `pipeline-utils` change is needed. CODEOWNERS gives @elastic/response-ops the check's own files, following the `api_contracts.sh` precedent.
- No manifest to keep in sync: the connector list and the release state both come from git and the source tree.
- The step runs only when `kbn-connector-specs/` or the check's own files change.
- The step only runs on PRs targeting `main`, since Production-NonCanary tracks `main`. A PR stacked on another branch skips the check rather than reporting on it.

### Runtime support-only state

- `ActionTypeRegistry.register()` now accepts `supportedFeatureIds: []` for spec-sourced connectors (previously empty arrays were always rejected). Non-spec sources are unchanged.
- `create()` rejects spec connectors with zero feature IDs with a 400, so they cannot be persisted yet.
- `ActionTypeMenu` hides support-only spec connectors from the creation picker. They remain registered and executable for rollback compatibility.

### Verified

On CI for this PR (which changes no connector, so no comment is posted):

```
Resolving Production-NonCanary Kibana versions
  production-noncanary-ds-1: 130369694fb4
  production-noncanary-ds-2: 130369694fb4
  production-noncanary-ds-3: 130369694fb4
  production-noncanary-ds-4: 130369694fb4
  production-noncanary-ds-5: 130369694fb4
  distinct refs: 130369694fb4bf9785a7ad1170a0bba6842a943a
Scoping applicable connectors
  no connector exposure changed by this PR
Connector release check: safe — 0 advisory finding(s)
No connector exposure changed; nothing to post.
```

A `safe` rather than `inconclusive` result confirms PR CI can read `serverless-gitops`, and that all five slices are parsed, expanded, deduplicated, and inspected.

The other two outcomes were exercised locally against the same live GitOps pins, with a throwaway connector exported from `all_specs.ts`:

| the new connector declares | outcome |
| --- | --- |
| `['workflows', 'agentBuilder']` | `unsafe`, 1 finding — `disallowedFeatureIds: ["workflows"]`, `missingFromRefs: ["130369694fb4…"]` |
| `['agentBuilder']` | `safe`, 0 findings |

### Scope

The agent-facing guidance (`create-connector` / `review-connector` skills and the package README) is split out to #282061 so it can land independently. This PR will extend that guidance with the support-only (`[]`) case, which depends on the registry change above.

`agentBuilder` is allowed on an unpublished connector only while the feature is not yet GA: its execution is request-scoped and schedules no durable background work, so a rollback cannot leave scheduled work pointing at a missing type. Revisit before GA.

The GitOps pins approximate what is actually running. This check decides whether feature exposure is allowed; it is not a guarantee about any individual node.

Spec-contract tests (`connector_spec_contract.test.ts`, `no_sensitive_in_config.test.ts`, `opted_in_test_handlers.test.ts`) and reviewer-routing changes (per-spec CODEOWNERS enforcement, GitHub Action) are **not** in this PR and remain on #280401.

Partially addresses #279174.
