### PR TITLE
Restore Chrome Next page announcements

### DIFF
--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
@@ -13,18 +13,31 @@ import { SearchButton } from './search_button';
 import { AiButtonSlot } from './ai_button_slot';
 import { HelpButton } from './help_button';
 import { ChromeNextGlobalHeaderShell } from './global_header_shell';
-import { useContextSwitcher, useProjectPicker, useUserMenu } from '../../shared/chrome_hooks';
+import {
+  useContextSwitcher,
+  useProjectBreadcrumbs,
+  useProjectPicker,
+  useUserMenu,
+} from '../../shared/chrome_hooks';
+import { HeaderPageAnnouncer } from '../../shared/header_page_announcer';
 
-export const ChromeNextGlobalHeader = React.memo(() => (
-  <ChromeNextGlobalHeaderShell
-    logo={<ChromeNextGlobalHeaderLogo />}
-    search={<SearchButton />}
-    actions={<AiButtonSlot />}
-    help={<HelpButton />}
-    switcher={useContextSwitcher()}
-    projectPicker={useProjectPicker()}
-    userMenu={useUserMenu()}
-  />
-));
+export const ChromeNextGlobalHeader = React.memo(() => {
+  const breadcrumbs = useProjectBreadcrumbs();
+
+  return (
+    <>
+      <HeaderPageAnnouncer breadcrumbs={breadcrumbs} />
+      <ChromeNextGlobalHeaderShell
+        logo={<ChromeNextGlobalHeaderLogo />}
+        search={<SearchButton />}
+        actions={<AiButtonSlot />}
+        help={<HelpButton />}
+        switcher={useContextSwitcher()}
+        projectPicker={useProjectPicker()}
+        userMenu={useUserMenu()}
+      />
+    </>
+  );
+});
 
 ChromeNextGlobalHeader.displayName = 'ChromeNextGlobalHeader';


### PR DESCRIPTION
Related to #281953

## Summary

Chrome Next did not mount the shared page announcer used by the existing project header. This restores the skip-to-main link, first-Tab focus handling, and live route announcements while keeping the current breadcrumb-based behavior.

The related issue tracks choosing a better title source for Chrome Next once app header titles can feed one shared announcement path.