### PR TITLE
[Automatic Migrations] Fix migration tables showing "No items found" when fetching new data

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/index.test.tsx
@@ -182,11 +182,37 @@ jest.spyOn(useInstallMigrationDashboardModule, 'useInstallMigrationDashboard').m
 } as unknown as ReturnType<typeof useInstallMigrationDashboardModule.useInstallMigrationDashboard>);
 
 describe('MigrationDashboardsTable', () => {
-  it('should render table and dashboards', () => {
+  it('should show table and dashboards', () => {
     renderTestComponent();
     expect(screen.getByTestId('siemMigrationsDashboardsTable')).toBeInTheDocument();
     expect(screen.getByText('Elastic Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Original Dashboard 2')).toBeInTheDocument();
+  });
+
+  it('should keep showing the previous rows with a loading indicator while re-fetching after a search or filter change', () => {
+    jest.spyOn(useGetMigrationDashboardsModule, 'useGetMigrationDashboards').mockReturnValueOnce({
+      data: { migrationDashboards: mockDashboards, total: 2 },
+      isLoading: false,
+      isFetching: true,
+    } as unknown as ReturnType<typeof useGetMigrationDashboardsModule.useGetMigrationDashboards>);
+
+    renderTestComponent();
+
+    const table = screen.getByTestId('dashboards-translation-table');
+    expect(table).toHaveClass('euiBasicTable-loading');
+    expect(screen.getByText('Elastic Dashboard')).toBeInTheDocument();
+  });
+
+  it('should disable the install action while re-fetching after a search or filter change', () => {
+    jest.spyOn(useGetMigrationDashboardsModule, 'useGetMigrationDashboards').mockReturnValueOnce({
+      data: { migrationDashboards: mockDashboards, total: 2 },
+      isLoading: false,
+      isFetching: true,
+    } as unknown as ReturnType<typeof useGetMigrationDashboardsModule.useGetMigrationDashboards>);
+
+    renderTestComponent();
+
+    expect(screen.getByTestId('installDashboard')).toBeDisabled();
   });
 
   describe('Actions', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/index.tsx
@@ -94,6 +94,7 @@ export const MigrationDashboardsTable: React.FC<MigrationDashboardsTableProps> =
     const {
       data: { migrationDashboards, total } = { migrationDashboards: [], total: 0 },
       isLoading: isDataLoading,
+      isFetching: isDataFetching,
     } = useGetMigrationDashboards({
       migrationId,
       page: pageIndex,
@@ -186,7 +187,7 @@ export const MigrationDashboardsTable: React.FC<MigrationDashboardsTableProps> =
 
     const [isTableLoading, setTableLoading] = useState(false);
 
-    const isDashboardsLoading = isDataLoading || isTableLoading || isRetryLoading;
+    const isDashboardsLoading = isDataLoading || isDataFetching || isTableLoading || isRetryLoading;
 
     const installSelectedDashboards = useCallback(async () => {
       setTableLoading(true);
@@ -322,7 +323,7 @@ export const MigrationDashboardsTable: React.FC<MigrationDashboardsTableProps> =
                 <EuiSpacer size="m" />
                 <EuiBasicTable<DashboardMigrationDashboard>
                   tableCaption={i18n.DASHBOARDS_MIGRATION_TABLE_CAPTION}
-                  loading={false}
+                  loading={isDashboardsLoading}
                   items={migrationDashboards}
                   pagination={pagination}
                   sorting={sorting}

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/logic/use_get_migration_dashboards.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/logic/use_get_migration_dashboards.ts
@@ -39,6 +39,7 @@ export const useGetMigrationDashboards = (params: {
     },
     {
       ...DEFAULT_QUERY_OPTIONS,
+      keepPreviousData: true,
       onError: (error) => {
         addError(error, { title: i18n.GET_MIGRATION_DASHBOARDS_FAILURE });
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.test.tsx
@@ -232,6 +232,22 @@ describe('MigrationRulesTable', () => {
     expect(getByTestId('siemMigrationsRulesTable')).toBeInTheDocument();
   });
 
+  test('should keep showing the previous rows with a loading indicator while re-fetching after a search or filter change', () => {
+    (useGetMigrationRules as jest.Mock).mockReturnValue({
+      data: { migrationRules: [mockRule], total: 1 },
+      isLoading: false,
+      isFetching: true,
+    });
+
+    render(<MigrationRulesTable migrationStats={mockMigrationStats} />, {
+      wrapper: TestProviders,
+    });
+
+    const table = screen.getByTestId('rules-translation-table');
+    expect(table).toHaveClass('euiBasicTable-loading');
+    expect(table.querySelectorAll('.euiTableRow')).toHaveLength(1);
+  });
+
   describe('Table results', () => {
     const statusColumns: TableColumn[] = [
       {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.tsx
@@ -119,6 +119,7 @@ export const MigrationRulesTable: React.FC<MigrationRulesTableProps> = React.mem
     const {
       data: { migrationRules, total } = { migrationRules: [], total: 0 },
       isLoading: isDataLoading,
+      isFetching: isDataFetching,
     } = useGetMigrationRules({
       migrationId,
       page: pageIndex,
@@ -284,7 +285,8 @@ export const MigrationRulesTable: React.FC<MigrationRulesTableProps> = React.mem
         onStartMigrationWithSettings,
       });
 
-    const isRulesLoading = isPrebuiltRulesLoading || isDataLoading || isTableLoading || isStarting;
+    const isRulesLoading =
+      isPrebuiltRulesLoading || isDataLoading || isDataFetching || isTableLoading || isStarting;
 
     const ruleActionsFactory = useCallback(
       (migrationRule: RuleMigrationRule, closeRulePreview: () => void) => {
@@ -367,7 +369,7 @@ export const MigrationRulesTable: React.FC<MigrationRulesTableProps> = React.mem
     });
 
     const rulesColumns = useMigrationRulesTableColumns({
-      disableActions: isTableLoading,
+      disableActions: isRulesLoading,
       openMigrationRuleDetails: openRulePreview,
       installMigrationRule: installSingleRule,
       getMigrationRuleData,
@@ -443,7 +445,7 @@ export const MigrationRulesTable: React.FC<MigrationRulesTableProps> = React.mem
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiBasicTable<RuleMigrationRule>
-                  loading={isTableLoading}
+                  loading={isTableLoading || isDataFetching}
                   items={migrationRules}
                   pagination={pagination}
                   sorting={sorting}

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/logic/use_get_migration_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/logic/use_get_migration_rules.ts
@@ -39,6 +39,7 @@ export const useGetMigrationRules = (params: {
     },
     {
       ...DEFAULT_QUERY_OPTIONS,
+      keepPreviousData: true,
       onError: (error) => {
         addError(error, { title: i18n.GET_MIGRATION_RULES_FAILURE });
       },


### PR DESCRIPTION
## Summary

The Translated Rules and Translated Dashboards tables in SIEM Migrations briefly flashed an empty "No items found" state while re-fetching after a search-query or status-filter change. The table `loading` prop ignored the data query's fetching state (the dashboards table hard-coded `loading={false}`), so when the filtered query key changed and the cache reset, the table rendered zero rows with no loading indicator.

This PR:
- Drives each table's `loading` indicator off the data query's fetching state.
- Enables react-query `keepPreviousData` on both migration-list queries so the previous page's rows stay visible with a loading overlay during a refetch, instead of blanking out.
- Disables row and bulk actions while the table is loading or fetching.

## Before/After

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/d898155a-8493-4562-a5c8-0d93ef6141fa"/>|<video src="https://github.com/user-attachments/assets/cad693b9-b967-4ee2-af3d-5e3c7ba980cb"/>|


## Test Plan

1. Open Security → SIEM Migrations and open a completed rule migration with translated rules.
2. Type in the search box (or change the status filter).
3. Observe the table keeps showing the current rows with a loading indicator, then updates — it no longer flashes "No items found".
4. Confirm row and bulk actions are disabled while the table is loading.
5. Repeat for a dashboard migration's Translated Dashboards table.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- No significant risks identified. The change is confined to the migrations table loading/fetching UI state; there are no API, schema, or persisted-data changes.

### Release note

> Fixes an issue where the SIEM rule and dashboard migration tables briefly showed "No items found" while filtering or searching; the tables now keep the current results visible with a loading indicator during refetch.

**Suggested label:** `release_note:fix`
