### PR TITLE
[OpenAPI][Bundler] Strip stack version from x-state in serverless bundles

### DIFF
--- a/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/known_custom_props.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/known_custom_props.ts
@@ -38,3 +38,10 @@ export const X_CODEGEN_ENABLED = 'x-codegen-enabled';
  * marked with specific labels into the resulting bundle. See README for more details.
  */
 export const X_LABELS = 'x-labels';
+
+/**
+ * `x-state` describes an operation's stability tier ("Generally available", "Technical Preview",
+ * "Experimental") and, optionally, the stack version it was added in ("; added in <version>").
+ * The version is meaningful only for versioned deployments, not for Elastic Cloud Serverless.
+ */
+export const X_STATE = 'x-state';

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/document_processors/strip_x_state_version.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/document_processors/strip_x_state_version.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isPlainObjectType } from '../../../utils/is_plain_object_type';
+import { X_STATE } from '../../known_custom_props';
+import type { DocumentNodeProcessor } from './types/document_node_processor';
+
+/**
+ * Matches the version suffix `getXState` (in `@kbn/router-to-openapispec`) appends to an
+ * `x-state` that already carries a stability tier, for example
+ * `"Generally available; added in 9.5.0"`. Case-insensitive and whitespace-tolerant to
+ * also match the hand-written variants found in bundled specs (`"; Added in 9.5.0"`).
+ */
+const X_STATE_VERSION_SUFFIX = /;\s*added in\s+.+$/i;
+
+/**
+ * Matches a bare version `x-state` with no stability tier, for example `"Added in 9.5.0"`.
+ * `getXState` emits this form when a route declares `since` but no `stability`.
+ */
+const X_STATE_BARE_VERSION = /^\s*added in\s+.+$/i;
+
+/**
+ * Creates a node processor that removes the "added in <version>" fragment from `x-state`
+ * values.
+ *
+ * Elastic Cloud Serverless has no stack version, so an "added in <version>" note is
+ * meaningless there. The programmatic route already accounts for this: `getXState` in
+ * `@kbn/router-to-openapispec` appends the version only when `!env.serverless`. The
+ * manual-YAML route (this bundler) has no equivalent guard and copies `x-state` verbatim,
+ * so a hand-authored version leaks into the serverless bundle. This processor gives the
+ * serverless bundle the same result `getXState` produces:
+ *
+ * - `"Generally available; added in 9.5.0"` -> `"Generally available"`
+ * - `"Technical Preview; added in 9.4.0"`   -> `"Technical Preview"`
+ * - `"Added in 9.5.0"` (bare, no tier)       -> `""`
+ *
+ * The stability tier is always preserved; only the version is stripped. It is intended to
+ * run for serverless bundles only (see `withStripXStateVersionProcessor`).
+ */
+export const createStripXStateVersionProcessor = (): DocumentNodeProcessor => {
+  return {
+    onNodeLeave(node) {
+      if (!isPlainObjectType(node) || !Object.hasOwn(node, X_STATE)) {
+        return;
+      }
+
+      const xState = node[X_STATE];
+
+      if (typeof xState !== 'string') {
+        return;
+      }
+
+      // A bare version carries no stability tier, so nothing is left once the version goes.
+      // Mirror `getXState`, which produces an empty state string in this case.
+      if (X_STATE_BARE_VERSION.test(xState)) {
+        node[X_STATE] = '';
+        return;
+      }
+
+      node[X_STATE] = xState.replace(X_STATE_VERSION_SUFFIX, '');
+    },
+  };
+};

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/processor_sets.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/processor_sets.ts
@@ -21,6 +21,7 @@ import {
 import type { DocumentNodeProcessor } from './process_document/document_processors/types/document_node_processor';
 import { createIncludeLabelsProcessor } from './process_document/document_processors/include_labels';
 import { createNamespaceComponentsProcessor } from './process_document/document_processors/namespace_components';
+import { createStripXStateVersionProcessor } from './process_document/document_processors/strip_x_state_version';
 
 /**
  * Document modification includes the following
@@ -48,6 +49,17 @@ export function withIncludeLabelsProcessor(
   includeLabels: string[]
 ): Readonly<DocumentNodeProcessor[]> {
   return [...processors, createIncludeLabelsProcessor(includeLabels)];
+}
+
+/**
+ * Adds createStripXStateVersionProcessor processor, see createStripXStateVersionProcessor
+ * description for more details. Intended for serverless bundles, where an "added in
+ * <version>" note in `x-state` is meaningless.
+ */
+export function withStripXStateVersionProcessor(
+  processors: Readonly<DocumentNodeProcessor[]>
+): Readonly<DocumentNodeProcessor[]> {
+  return [...processors, createStripXStateVersionProcessor()];
 }
 
 export function withNamespaceComponentsProcessor(

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/openapi_bundler.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/openapi_bundler.ts
@@ -17,7 +17,11 @@ import { createBlankOpenApiDocument } from './bundler/merge_documents/create_bla
 import { writeDocuments } from './utils/write_documents';
 import type { ResolvedDocument } from './bundler/ref_resolver/resolved_document';
 import { resolveGlobs } from './utils/resolve_globs';
-import { DEFAULT_BUNDLING_PROCESSORS, withIncludeLabelsProcessor } from './bundler/processor_sets';
+import {
+  DEFAULT_BUNDLING_PROCESSORS,
+  withIncludeLabelsProcessor,
+  withStripXStateVersionProcessor,
+} from './bundler/processor_sets';
 import type { PrototypeDocument } from './prototype_document';
 import { validatePrototypeDocument } from './validate_prototype_document';
 
@@ -38,6 +42,13 @@ interface BundleOptions {
    */
   includeLabels?: string[];
 }
+
+/**
+ * The `x-labels` value marking an operation as available on Elastic Cloud Serverless.
+ * A serverless bundle has no stack version, so any "added in <version>" note in `x-state`
+ * is stripped from it (see `withStripXStateVersionProcessor`).
+ */
+const SERVERLESS_LABEL = 'serverless';
 
 export const bundle = async ({
   sourceGlob,
@@ -99,15 +110,20 @@ async function bundleDocuments(
   schemaFilePaths: string[],
   options?: BundleOptions
 ): Promise<ResolvedDocument[]> {
+  let processors = options?.includeLabels
+    ? withIncludeLabelsProcessor(DEFAULT_BUNDLING_PROCESSORS, options.includeLabels)
+    : DEFAULT_BUNDLING_PROCESSORS;
+
+  // Serverless has no stack version, so drop any "added in <version>" note from `x-state`,
+  // matching what `getXState` in `@kbn/router-to-openapispec` does for the programmatic route.
+  if (options?.includeLabels?.includes(SERVERLESS_LABEL)) {
+    processors = withStripXStateVersionProcessor(processors);
+  }
+
   const resolvedDocuments = await Promise.all(
     schemaFilePaths.map(async (schemaFilePath) => {
       try {
-        const resolvedDocument = await bundleDocument(
-          schemaFilePath,
-          options?.includeLabels
-            ? withIncludeLabelsProcessor(DEFAULT_BUNDLING_PROCESSORS, options.includeLabels)
-            : DEFAULT_BUNDLING_PROCESSORS
-        );
+        const resolvedDocument = await bundleDocument(schemaFilePath, processors);
 
         logger.debug(`Processed ${chalk.bold(basename(schemaFilePath))}`);
 

--- a/src/platform/packages/shared/kbn-openapi-bundler/tests/bundler/strip_x_state_version.test.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/tests/bundler/strip_x_state_version.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { OpenAPIV3 } from 'openapi-types';
+import { bundleSpecs } from './bundle_specs';
+import { createOASDocument } from '../create_oas_document';
+
+const createSpecWithXState = (xState: string, labels: string[]): OpenAPIV3.Document =>
+  createOASDocument({
+    paths: {
+      '/api/some_api': {
+        get: {
+          // @ts-expect-error custom properties are unexpected here
+          'x-labels': labels,
+          'x-state': xState,
+          responses: {
+            '200': {
+              description: 'Successful response',
+              content: {
+                'application/json': {
+                  schema: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+const getOperationXState = (spec: OpenAPIV3.Document): unknown =>
+  // @ts-expect-error `x-state` is a custom property
+  spec.paths['/api/some_api']?.get?.['x-state'];
+
+describe('OpenAPI Bundler - strip x-state version for serverless', () => {
+  describe('serverless bundle', () => {
+    it.each([
+      // Tier + version: the version is stripped, the tier is preserved.
+      { input: 'Generally available; added in 9.5.0', expected: 'Generally available' },
+      { input: 'Generally available; Added in 9.5.0', expected: 'Generally available' },
+      { input: 'Technical Preview; added in 9.4.0', expected: 'Technical Preview' },
+      { input: 'Experimental; added in 9.6.0', expected: 'Experimental' },
+      // Bare version (no tier): nothing is left, matching getXState's empty serverless state.
+      { input: 'Added in 9.5.0', expected: '' },
+      { input: 'added in 9.5.0', expected: '' },
+      // No version: left untouched.
+      { input: 'Generally available', expected: 'Generally available' },
+      { input: 'Technical Preview', expected: 'Technical Preview' },
+      { input: '', expected: '' },
+    ])('rewrites "$input" to "$expected"', async ({ input, expected }) => {
+      const spec = createSpecWithXState(input, ['serverless']);
+
+      const [bundledSpec] = Object.values(
+        await bundleSpecs({ 1: spec }, { includeLabels: ['serverless'] })
+      );
+
+      expect(getOperationXState(bundledSpec)).toBe(expected);
+    });
+  });
+
+  describe('non-serverless bundle', () => {
+    it.each([
+      'Generally available; added in 9.5.0',
+      'Technical Preview; added in 9.4.0',
+      'Added in 9.5.0',
+    ])('preserves "%s" verbatim for the ess bundle', async (input) => {
+      const spec = createSpecWithXState(input, ['ess']);
+
+      const [bundledSpec] = Object.values(
+        await bundleSpecs({ 1: spec }, { includeLabels: ['ess'] })
+      );
+
+      expect(getOperationXState(bundledSpec)).toBe(input);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

> [!NOTE]
> Draft / proposal. Opening this to discuss the approach before doing the (large) generated-artifact regeneration. See **Remaining work** below.

Elastic Cloud Serverless has no stack version, so an `Added in <version>` note in an operation's `x-state` is meaningless in the serverless API reference — yet it currently renders there. For example, [Copy a pack (serverless)](https://www.elastic.co/docs/api/doc/serverless/operation/operation-osquerycopypacks) shows **`Generally available; Added in 9.4.0`**.

### Root cause: two OAS generation routes, only one guarded

- **Programmatic route** (routes registered in TS with `availability`) — already correct. [`getXState`](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-router-to-openapispec/src/util.ts) appends the version **only** when `!env.serverless`:
  ```ts
  if (!env.serverless && availability.since) {
    state = state ? `${state}; added in ${availability.since}` : `Added in ${availability.since}`;
  }
  ```
- **Manual-YAML route** (hand-authored `*.schema.yaml` bundled by `@kbn/openapi-bundler`) — **no equivalent guard**. The bundler copies `x-state` verbatim into the serverless bundle, so a hand-authored version leaks through.

Every offender found today comes through the manual-YAML route: osquery (`live_queries`, `packs`, `saved_query`, `scheduled_results`, `unified_history`), Security detections `attacks/*`, and entity analytics `watchlists/entities/{assign,unassign}`.

### Fix

Add a `strip_x_state_version` document processor to `@kbn/openapi-bundler`, applied when a bundle is built for `serverless` (i.e. `includeLabels` contains `serverless`). It gives the manual-YAML route the same behavior `getXState` already gives the programmatic route:

| `x-state` (source) | serverless output |
|---|---|
| `Generally available; added in 9.5.0` | `Generally available` |
| `Technical Preview; added in 9.4.0` | `Technical Preview` |
| `Experimental; added in 9.6.0` | `Experimental` |
| `Added in 9.5.0` (bare, no tier) | `` (empty, matches `getXState`) |
| `Generally available` (no version) | `Generally available` (untouched) |

**The stability tier is always preserved; only the version is stripped.** The `ess` bundle is unchanged — the version stays where it is meaningful.

### Design note for reviewers

The processor is triggered automatically when the `serverless` label is present, mirroring how `getXState` keys off `env.serverless`. The alternative is an explicit `BundleOptions` flag threaded through every serverless `bundle.js`. I went with the label-based trigger to keep it single-source and zero-config, but happy to switch to an explicit opt-in if the platform team prefers not to couple bundler behavior to a label value.

## Remaining work (why this is a draft)

- [ ] **Regenerate the bundled artifacts.** This change alters the output of every serverless bundle. The committed `**/docs/openapi/serverless/*.bundled.schema.yaml` and `oas_docs/output/kibana.serverless.yaml` need regenerating (`node scripts/...` per plugin + the oas_docs merge). I couldn't run the full `yarn kbn bootstrap` in my environment, so those regenerated files are **not** in this PR yet — CI will flag them as stale until regenerated.
- [ ] Confirm the trigger design (label-based vs explicit flag).
- [ ] Consider normalizing the inconsistent hand-authored casing/format at source (`Added in` vs `added in`, bare vs `Generally available;`) in a follow-up.

## Testing

- Added `tests/bundler/strip_x_state_version.test.ts` covering the transformations above for the serverless bundle and asserting the `ess` bundle is untouched.
- Note: the unit test was **not** run locally (bootstrap unavailable in my environment); the core transformation logic was validated in isolation. Please rely on CI.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing)
- [ ] Unit tests added (pending CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)