### PR TITLE
[Security Solution] Restore "Toggle column in table" action in the new alerts flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/actions/register.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/actions/register.ts
@@ -9,11 +9,11 @@ import type { History } from 'history';
 import type { CoreSetup } from '@kbn/core/public';
 import {
   CELL_VALUE_TRIGGER,
+  SEARCH_EMBEDDABLE_CELL_ACTIONS_TRIGGER_ID,
   SECURITY_CELL_ACTIONS_ALERTS_COUNT,
   SECURITY_CELL_ACTIONS_CASE_EVENTS,
   SECURITY_CELL_ACTIONS_DEFAULT,
   SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
-  SEARCH_EMBEDDABLE_CELL_ACTIONS_TRIGGER_ID,
 } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
@@ -24,16 +24,16 @@ import {
   createFilterOutDiscoverCellActionFactory,
 } from './filter';
 import {
-  createAddToTimelineLensAction,
   createAddToTimelineCellActionFactory,
-  createInvestigateInNewTimelineCellActionFactory,
   createAddToTimelineDiscoverCellActionFactory,
+  createAddToTimelineLensAction,
+  createInvestigateInNewTimelineCellActionFactory,
 } from './add_to_timeline';
 import { createShowTopNCellActionFactory } from './show_top_n';
 import {
-  createCopyToClipboardLensAction,
   createCopyToClipboardCellActionFactory,
   createCopyToClipboardDiscoverCellActionFactory,
+  createCopyToClipboardLensAction,
 } from './copy_to_clipboard';
 import { createToggleColumnCellActionFactory } from './toggle_column';
 import { createToggleUserAssetFieldCellActionFactory } from './toggle_asset_column';
@@ -188,6 +188,8 @@ const registerCellActions = (
 
   registerCellActionsTrigger(SECURITY_CELL_ACTIONS_CASE_EVENTS, [
     'addToTimeline',
+    'toggleColumn',
+    'showTopN',
     'copyToClipboard',
   ]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { TableId } from '@kbn/securitysolution-data-table';
+import { SECURITY_CELL_ACTIONS_DETAILS_FLYOUT } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import type { RowActionProps } from '.';
@@ -193,6 +194,37 @@ describe('RowAction', () => {
     const { onAlertUpdated } = flyoutApi.openDocumentFlyoutFromIndex.mock.calls[0][0];
     onAlertUpdated?.();
     expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('binds the new document flyout cell actions to the table scope and details-flyout trigger', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    const wrapper = render(
+      <TestProviders>
+        <RowAction {...defaultProps} tableId={TableId.hostsPageEvents} />
+      </TestProviders>
+    );
+
+    fireEvent.click(wrapper.getByTestId('expand-event'));
+
+    const { renderCellActions } = flyoutApi.openDocumentFlyoutFromIndex.mock.calls[0][0];
+
+    // Event tables (e.g. Explore host/user pages) have no alerts table ref, but the renderer must
+    // still bind the table scope and use the details-flyout trigger so the "Toggle column in table"
+    // action is available and dispatches against the correct data table store.
+    const cellAction = renderCellActions?.({
+      field: 'host.name',
+      value: ['host-1'],
+      scopeId: '',
+      children: null,
+    }) as React.ReactElement;
+
+    expect(cellAction.props.triggerId).toEqual(SECURITY_CELL_ACTIONS_DETAILS_FLYOUT);
+    expect(cellAction.props.visibleCellActions).toEqual(6);
+    expect(cellAction.props.metadata).toEqual({
+      scopeId: TableId.hostsPageEvents,
+      alertsTableRef: undefined,
+    });
   });
 
   describe('notes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -12,13 +12,12 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { TableId } from '@kbn/securitysolution-data-table';
-import { SECURITY_CELL_ACTIONS_DETAILS_FLYOUT } from '@kbn/ui-actions-plugin/common/trigger_ids';
-import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
 import {
-  casesCellActionRenderer,
-  cellActionRenderer,
-  createCellActionRenderer,
-} from '../../../../flyout_v2/shared/components/cell_actions';
+  SECURITY_CELL_ACTIONS_CASE_EVENTS,
+  SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
+} from '@kbn/ui-actions-plugin/common/trigger_ids';
+import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
+import { createCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
 import { useKibana } from '../../../lib/kibana';
@@ -127,25 +126,27 @@ const RowActionComponent = ({
   }, [refetch]);
 
   // Cell action renderer for the new document details flyout opened from this table.
-  // - Cases uses its own dedicated renderer.
-  // - An alerts table (identified by the presence of `alertsTableRef`) uses the details-flyout
-  //   trigger — which is the only trigger that registers the "Toggle column in table" action — with
-  //   the table scope bound and the table handle forwarded, so the column toggle both shows up and
-  //   targets the imperatively-controlled alerts table.
-  // - Any other table keeps the default renderer.
-  const documentFlyoutCellActionRenderer = useMemo(() => {
-    if (tableId === TableId.alertsOnCasePage) {
-      return casesCellActionRenderer;
-    }
-    if (alertsTableRef) {
-      return createCellActionRenderer(tableId, {
-        triggerId: SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
+  // The table scope is always bound and the details-flyout trigger is used — that trigger is the
+  // only one that registers the "Toggle column in table" action, and binding the scope makes the
+  // action compatible for both Timeline/table scopes. How the column toggle is applied depends on
+  // the table:
+  // - Alerts tables forward their `alertsTableRef` so the toggle targets the imperatively-controlled
+  //   table.
+  // - Event tables (e.g. the Explore host/user pages) have no ref; the toggle dispatches to the
+  //   Redux data table store keyed by the bound scope instead.
+  // - The alerts table on the Cases page uses the case-events trigger.
+  const documentFlyoutCellActionRenderer = useMemo(
+    () =>
+      createCellActionRenderer(tableId, {
+        triggerId:
+          tableId === TableId.alertsOnCasePage
+            ? SECURITY_CELL_ACTIONS_CASE_EVENTS
+            : SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
         visibleCellActions: 6,
         alertsTableRef,
-      });
-    }
-    return cellActionRenderer;
-  }, [tableId, alertsTableRef]);
+      }),
+    [tableId, alertsTableRef]
+  );
 
   const handleOnEventDetailPanelOpened = useCallback(() => {
     if (enableNewFlyout && hit) {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -6,14 +6,18 @@
  */
 
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
+import type { RefObject } from 'react';
 import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { SECURITY_CELL_ACTIONS_DETAILS_FLYOUT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
 import {
   casesCellActionRenderer,
   cellActionRenderer,
+  createCellActionRenderer,
 } from '../../../../flyout_v2/shared/components/cell_actions';
 import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
@@ -54,6 +58,11 @@ export type RowActionProps = EuiDataGridCellValueElementProps & {
   showCheckboxes: boolean;
   tabType?: string;
   tableId: string;
+  /**
+   * Handle to the alerts table this row belongs to. Provided by the alerts table so the document
+   * flyout's "Toggle column in table" action can add/remove columns on it. Absent for other tables.
+   */
+  alertsTableRef?: RefObject<AlertsTableImperativeApi>;
   width: number;
 };
 
@@ -77,6 +86,7 @@ const RowActionComponent = ({
   showCheckboxes,
   tabType,
   tableId,
+  alertsTableRef,
   width,
 }: RowActionProps) => {
   const { data: timelineNonEcsData, ecs: ecsData, _id: eventId, _index: indexName } = data ?? {};
@@ -116,13 +126,33 @@ const RowActionComponent = ({
     refetch?.();
   }, [refetch]);
 
+  // Cell action renderer for the new document details flyout opened from this table.
+  // - Cases uses its own dedicated renderer.
+  // - An alerts table (identified by the presence of `alertsTableRef`) uses the details-flyout
+  //   trigger — which is the only trigger that registers the "Toggle column in table" action — with
+  //   the table scope bound and the table handle forwarded, so the column toggle both shows up and
+  //   targets the imperatively-controlled alerts table.
+  // - Any other table keeps the default renderer.
+  const documentFlyoutCellActionRenderer = useMemo(() => {
+    if (tableId === TableId.alertsOnCasePage) {
+      return casesCellActionRenderer;
+    }
+    if (alertsTableRef) {
+      return createCellActionRenderer(tableId, {
+        triggerId: SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
+        visibleCellActions: 6,
+        alertsTableRef,
+      });
+    }
+    return cellActionRenderer;
+  }, [tableId, alertsTableRef]);
+
   const handleOnEventDetailPanelOpened = useCallback(() => {
     if (enableNewFlyout && hit) {
       openDocumentFlyoutFromIndex({
         documentId: eventId,
         indexName: indexName ?? undefined,
-        renderCellActions:
-          tableId === TableId.alertsOnCasePage ? casesCellActionRenderer : cellActionRenderer,
+        renderCellActions: documentFlyoutCellActionRenderer,
         onAlertUpdated: handleAlertUpdated,
         origin: FLYOUT_ORIGIN.ALERTS_TABLE,
         title: getDocumentHistoryTitle(hit),
@@ -147,6 +177,7 @@ const RowActionComponent = ({
     enableNewFlyout,
     hit,
     openDocumentFlyoutFromIndex,
+    documentFlyoutCellActionRenderer,
     eventId,
     indexName,
     handleAlertUpdated,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/actions_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/actions_cell.tsx
@@ -20,6 +20,7 @@ import type { State } from '../../../common/store';
 import { RowAction } from '../../../common/components/control_columns/row_action';
 import type { GetSecurityAlertsTableProp } from './types';
 import { expandDottedObject } from '../../../../common/utils/expand_dotted';
+import { useAlertsContext } from './alerts_context';
 
 const onRowSelected = () => {};
 
@@ -38,6 +39,7 @@ export const ActionsCellComponent: GetSecurityAlertsTableProp<'renderActionsCell
   leadingControlColumn,
 }) => {
   const license = useLicense();
+  const { alertsTableRef } = useAlertsContext();
   const defaults = useMemo(() => getAlertsDefaultModel(license), [license]);
   const selectTableById = useMemo(() => getTableByIdSelector(), []);
   const {
@@ -117,6 +119,7 @@ export const ActionsCellComponent: GetSecurityAlertsTableProp<'renderActionsCell
       onRuleChange={eventContext?.onRuleChange}
       tabType={'query'}
       tableId={tableType}
+      alertsTableRef={alertsTableRef}
       width={0}
       setEventsLoading={setEventsLoading}
       setEventsDeleted={noop}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.test.tsx
@@ -7,6 +7,12 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import { TableId } from '@kbn/securitysolution-data-table';
+import {
+  SECURITY_CELL_ACTIONS_DEFAULT,
+  SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
+} from '@kbn/ui-actions-plugin/common/trigger_ids';
+import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
 import { TimelineId } from '../../../../common/types/timeline';
 import { PageScope } from '../../../data_view_manager/constants';
 import { cellActionRenderer, createCellActionRenderer } from './cell_actions';
@@ -67,6 +73,38 @@ describe('cellActionRenderer', () => {
         expect.objectContaining({
           metadata: { scopeId: TimelineId.active },
           sourcererScopeId: PageScope.timeline,
+        })
+      );
+    });
+
+    it('defaults to the slim default trigger with 5 visible actions', () => {
+      renderCellAction(createCellActionRenderer(TimelineId.active), '');
+
+      expect(mockSecurityCellActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          triggerId: SECURITY_CELL_ACTIONS_DEFAULT,
+          visibleCellActions: 5,
+        })
+      );
+    });
+
+    it('uses the details-flyout trigger, visible count and alertsTableRef when provided', () => {
+      const alertsTableRef = React.createRef<AlertsTableImperativeApi>();
+
+      renderCellAction(
+        createCellActionRenderer(TableId.alertsOnAlertsPage, {
+          triggerId: SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
+          visibleCellActions: 6,
+          alertsTableRef,
+        }),
+        ''
+      );
+
+      expect(mockSecurityCellActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          triggerId: SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
+          visibleCellActions: 6,
+          metadata: { scopeId: TableId.alertsOnAlertsPage, alertsTableRef },
         })
       );
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import React from 'react';
 import type { RefObject } from 'react';
+import React from 'react';
 import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
 import {
   SECURITY_CELL_ACTIONS_CASE_EVENTS,
@@ -109,23 +109,7 @@ export const cellActionRenderer: CellActionRenderer = createCellActionRenderer('
  * Cell action renderer for Cases.
  * This is used in the expandable flyout and in the new flyout (though only when used in Security Solution).
  */
-export const casesCellActionRenderer: CellActionRenderer = ({
-  field,
-  value,
-  children,
-  scopeId,
-}: CellActionRendererProps) => (
-  <SecurityCellActions
-    data={{
-      field,
-      value: value ?? [],
-    }}
-    triggerId={SECURITY_CELL_ACTIONS_CASE_EVENTS}
-    mode={CellActionsMode.HOVER_DOWN}
-    visibleCellActions={2}
-    sourcererScopeId={getSourcererScopeId(scopeId)}
-    metadata={{ scopeId }}
-  >
-    {children}
-  </SecurityCellActions>
-);
+export const casesCellActionRenderer: CellActionRenderer = createCellActionRenderer('', {
+  triggerId: SECURITY_CELL_ACTIONS_CASE_EVENTS,
+  visibleCellActions: 4,
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
@@ -6,6 +6,8 @@
  */
 
 import React from 'react';
+import type { RefObject } from 'react';
+import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
 import {
   SECURITY_CELL_ACTIONS_CASE_EVENTS,
   SECURITY_CELL_ACTIONS_DEFAULT,
@@ -31,16 +33,46 @@ export type CellActionRenderer = (props: CellActionRendererProps) => React.React
  */
 export const noopCellActionRenderer: CellActionRenderer = ({ children }) => <>{children}</>;
 
+export interface CreateCellActionRendererOptions {
+  /**
+   * Trigger the cell actions are rendered against. Defaults to the slim `SECURITY_CELL_ACTIONS_DEFAULT`
+   * trigger. The document details flyout (alerts table / Timeline) passes
+   * `SECURITY_CELL_ACTIONS_DETAILS_FLYOUT` so that the "Toggle column in table" (and "Toggle user asset
+   * field") actions — which are only registered on that trigger — are available on alert fields.
+   */
+  triggerId?: string;
+  /**
+   * Number of actions shown before the overflow menu. Defaults to `5` (the default trigger's action
+   * count); the details-flyout trigger uses `6` to match the legacy flyout.
+   */
+  visibleCellActions?: number;
+  /**
+   * Handle to the currently visible alerts table, forwarded to the cell action metadata so the
+   * "Toggle column in table" action can add/remove columns on the imperatively-controlled alerts table.
+   */
+  alertsTableRef?: RefObject<AlertsTableImperativeApi>;
+}
+
 /**
- * Creates a default Security Solution cell action renderer bound to a specific scope.
+ * Creates a Security Solution cell action renderer bound to a specific scope.
  *
  * `boundScopeId` takes precedence over the per-render `scopeId` when non-empty. This lets callers
  * that know the scope up front (e.g. Timeline, which opens the flyout from `timeline-1`) ensure every
  * cell action inside the flyout reports the correct scope, so Filter In/Out route to the Timeline's
  * own filter manager instead of the page's global one. When `boundScopeId` is empty, it falls back to
  * the per-render `scopeId`, preserving the default behavior.
+ *
+ * The document details flyout additionally passes a details-flyout `triggerId` (and, for the alerts
+ * table, an `alertsTableRef`) so the column-toggle action is both available and functional.
  */
-export const createCellActionRenderer = (boundScopeId: string): CellActionRenderer => {
+export const createCellActionRenderer = (
+  boundScopeId: string,
+  {
+    triggerId = SECURITY_CELL_ACTIONS_DEFAULT,
+    visibleCellActions = 5,
+    alertsTableRef,
+  }: CreateCellActionRendererOptions = {}
+): CellActionRenderer => {
   const boundCellActionRenderer: CellActionRenderer = ({
     field,
     value,
@@ -54,11 +86,11 @@ export const createCellActionRenderer = (boundScopeId: string): CellActionRender
           field,
           value: value ?? [],
         }}
-        triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
+        triggerId={triggerId}
         mode={CellActionsMode.HOVER_DOWN}
-        visibleCellActions={5}
+        visibleCellActions={visibleCellActions}
         sourcererScopeId={getSourcererScopeId(effectiveScopeId)}
-        metadata={{ scopeId: effectiveScopeId }}
+        metadata={{ scopeId: effectiveScopeId, alertsTableRef }}
       >
         {children}
       </SecurityCellActions>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -23,6 +23,7 @@ import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_fl
 import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
 import { PageScope } from '../../../../../data_view_manager/constants';
+import { SECURITY_CELL_ACTIONS_DETAILS_FLYOUT } from '@kbn/ui-actions-plugin/common/trigger_ids';
 
 jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
   useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
@@ -253,6 +254,10 @@ describe('unified data table', () => {
 
       expect(cellAction.props.metadata).toEqual({ scopeId: TimelineId.test });
       expect(cellAction.props.sourcererScopeId).toEqual(PageScope.timeline);
+      // The details-flyout trigger is required so the "Toggle column in table" action (only
+      // registered on that trigger) is available on Timeline alert/event fields in the new flyout.
+      expect(cellAction.props.triggerId).toEqual(SECURITY_CELL_ACTIONS_DETAILS_FLYOUT);
+      expect(cellAction.props.visibleCellActions).toEqual(6);
     },
     SPECIAL_TEST_TIMEOUT
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -20,7 +20,10 @@ import type {
   EuiDataGridProps,
 } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import {
+  SECURITY_CELL_ACTIONS_DEFAULT,
+  SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
+} from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { createCellActionRenderer } from '../../../../../flyout_v2/shared/components/cell_actions';
 import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { JEST_ENVIRONMENT } from '../../../../../../common/constants';
@@ -181,8 +184,16 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       [events, dataView]
     );
 
+    // The new document details flyout opened from Timeline must render alert/event field cell actions
+    // on the details-flyout trigger so the "Toggle column in table" action is available (it is not
+    // registered on the default trigger). The scope is bound to `timelineId`, so the action toggles
+    // columns on this Timeline via the Redux store; no alerts table ref is needed here.
     const timelineCellActionRenderer = useMemo(
-      () => createCellActionRenderer(timelineId),
+      () =>
+        createCellActionRenderer(timelineId, {
+          triggerId: SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
+          visibleCellActions: 6,
+        }),
       [timelineId]
     );
 


### PR DESCRIPTION
## Summary

Fixes elastic/kibana#281979

In 9.5 the new document details flyout became the default. When an alert is opened from a Security **alerts table** (Alerts page, per-rule alerts table, Attacks page, risk inputs), the **"Toggle column in table"** action disappeared from the field hover actions in the flyout **Table** tab, so users could no longer add a field from an alert as a column. Only that icon was missing (5 actions instead of 6); Filter In/Out, Add to Timeline, Show top N and Copy still rendered.

### Root cause

The action's availability depends on three things, and the new-flyout alerts-table path broke all three (the legacy flyout got them right):

1. **Trigger (primary).** The new flyout renders alert-field cell actions through the default `cellActionRenderer`, which uses the `SECURITY_CELL_ACTIONS_DEFAULT` trigger. That trigger **never registered `toggleColumn`** (see `public/app/actions/register.ts`) — only `SECURITY_CELL_ACTIONS_DETAILS_FLYOUT` does. The legacy flyout used `SECURITY_CELL_ACTIONS_DETAILS_FLYOUT`, so the action was present there. So on the default trigger the column-toggle action isn't even a candidate.
2. **Scope.** `toggleColumn`'s `isCompatible` requires `metadata.scopeId` to be a Timeline/Table scope. `openDocumentFlyoutFromIndex` has no `scopeId` param, and the flyout's Table tab defaults `scopeId` to `''`, so even on the right trigger the action would be filtered out.
3. **Table handle.** The generic alerts table toggles columns imperatively via `alertsTableRef.current.toggleColumn(...)`. The new renderer dropped `alertsTableRef` from the cell-action metadata (the legacy renderer included it), so `execute` couldn't move the column.

### What changed

Route the **alerts-table → new-flyout** cell actions through a details-flyout-aware renderer, mirroring how Timeline already binds its scope via `createCellActionRenderer`:

- `flyout_v2/shared/components/cell_actions.tsx` — `createCellActionRenderer(scopeId, options?)` now accepts `{ triggerId, visibleCellActions, alertsTableRef }` (defaults preserve the previous behavior: `SECURITY_CELL_ACTIONS_DEFAULT`, 5 visible, no ref) and forwards `alertsTableRef` in the cell-action metadata.
- `common/components/control_columns/row_action/index.tsx` — accepts an optional `alertsTableRef`. When it's present (i.e. an alerts table, not Cases), the document flyout is opened with a renderer bound to the table's `scopeId`, the `SECURITY_CELL_ACTIONS_DETAILS_FLYOUT` trigger, 6 visible actions, and the table ref. Other tables keep the default renderer; Cases keeps its dedicated renderer.
- `detections/components/alerts_table/actions_cell.tsx` — reads `alertsTableRef` from `useAlertsContext()` and passes it to `RowAction`.

### Testing

- Unit: `flyout_v2/shared/components/cell_actions.test.tsx` (extended with coverage for the new options), `app/actions/toggle_column/cell_action/toggle_column.test.ts`, `common/components/control_columns/row_action/index.test.tsx` — all green.
- Type check + ESLint on the changed files.
- Manual: open an alert from the Alerts page / a rule's alerts table with the new flyout enabled → Table tab → the "Toggle column in table" action is present and toggling adds/removes the column in the alerts table.

### Notes / follow-ups

- **Timeline and Explore event tables** open the same new flyout and, being on the default trigger, are similarly missing the column-toggle action. This PR scopes the fix to the reported alerts-table case; the same `createCellActionRenderer` option can be applied to those call sites in a follow-up.
- **Rule preview:** the legacy flyout disabled Filter and Toggle-column for `rulePreview` scope via `disabledActionTypes`; the new renderer doesn't replicate that yet. Out of scope here, worth confirming separately.
- **Restore-from-URL:** the flyout restore path can't carry a function renderer and defaults to the unbound `cellActionRenderer`, so a flyout reopened from a URL would not have the column toggle. Pre-existing limitation of the new-flyout restore path.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->