### PR TITLE
[Serverless] Add Claude Opus 5, Gemini 3.6 Flash, Gemini 3.5 Flash-Lite, and GPT-5.6 preconfigured connectors

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -299,3 +299,63 @@ xpack.actions.preconfigured:
       inferenceId: ".google-gemini-3.0-flash-chat_completion"
       providerConfig:
         model_id: "google-gemini-3.0-flash"
+  Anthropic-Claude-Opus-5:
+    name: Anthropic Claude Opus 5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-5-opus"
+  Google-Gemini-3-6-Flash:
+    name: Google Gemini 3.6 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.6-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.6-flash"
+  Google-Gemini-3-5-Flash-Lite:
+    name: Google Gemini 3.5 Flash-Lite
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.5-flash-lite-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.5-flash-lite"
+  OpenAI-GPT-5-6-Sol:
+    name: OpenAI GPT-5.6 Sol
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-sol-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-sol"
+  OpenAI-GPT-5-6-Terra:
+    name: OpenAI GPT-5.6 Terra
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-terra-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-terra"
+  OpenAI-GPT-5-6-Luna:
+    name: OpenAI GPT-5.6 Luna
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-luna-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-luna"

--- a/config/serverless.oblt.complete.yml
+++ b/config/serverless.oblt.complete.yml
@@ -212,3 +212,63 @@ xpack.actions.preconfigured:
       inferenceId: ".google-gemini-3.0-flash-chat_completion"
       providerConfig:
         model_id: "google-gemini-3.0-flash"
+  Anthropic-Claude-Opus-5:
+    name: Anthropic Claude Opus 5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-5-opus"
+  Google-Gemini-3-6-Flash:
+    name: Google Gemini 3.6 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.6-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.6-flash"
+  Google-Gemini-3-5-Flash-Lite:
+    name: Google Gemini 3.5 Flash-Lite
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.5-flash-lite-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.5-flash-lite"
+  OpenAI-GPT-5-6-Sol:
+    name: OpenAI GPT-5.6 Sol
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-sol-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-sol"
+  OpenAI-GPT-5-6-Terra:
+    name: OpenAI GPT-5.6 Terra
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-terra-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-terra"
+  OpenAI-GPT-5-6-Luna:
+    name: OpenAI GPT-5.6 Luna
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-luna-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-luna"

--- a/config/serverless.security.complete.yml
+++ b/config/serverless.security.complete.yml
@@ -201,3 +201,63 @@ xpack.actions.preconfigured:
       inferenceId: ".google-gemini-3.0-flash-chat_completion"
       providerConfig:
         model_id: "google-gemini-3.0-flash"
+  Anthropic-Claude-Opus-5:
+    name: Anthropic Claude Opus 5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-5-opus"
+  Google-Gemini-3-6-Flash:
+    name: Google Gemini 3.6 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.6-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.6-flash"
+  Google-Gemini-3-5-Flash-Lite:
+    name: Google Gemini 3.5 Flash-Lite
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.5-flash-lite-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.5-flash-lite"
+  OpenAI-GPT-5-6-Sol:
+    name: OpenAI GPT-5.6 Sol
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-sol-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-sol"
+  OpenAI-GPT-5-6-Terra:
+    name: OpenAI GPT-5.6 Terra
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-terra-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-terra"
+  OpenAI-GPT-5-6-Luna:
+    name: OpenAI GPT-5.6 Luna
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-luna-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-luna"

--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -322,3 +322,63 @@ xpack.actions.preconfigured:
       inferenceId: ".google-gemini-3.0-flash-chat_completion"
       providerConfig:
         model_id: "google-gemini-3.0-flash"
+  Anthropic-Claude-Opus-5:
+    name: Anthropic Claude Opus 5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-5-opus"
+  Google-Gemini-3-6-Flash:
+    name: Google Gemini 3.6 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.6-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.6-flash"
+  Google-Gemini-3-5-Flash-Lite:
+    name: Google Gemini 3.5 Flash-Lite
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.5-flash-lite-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.5-flash-lite"
+  OpenAI-GPT-5-6-Sol:
+    name: OpenAI GPT-5.6 Sol
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-sol-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-sol"
+  OpenAI-GPT-5-6-Terra:
+    name: OpenAI GPT-5.6 Terra
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-terra-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-terra"
+  OpenAI-GPT-5-6-Luna:
+    name: OpenAI GPT-5.6 Luna
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-luna-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-luna"

--- a/config/serverless.workplaceai.yml
+++ b/config/serverless.workplaceai.yml
@@ -214,3 +214,63 @@ xpack.actions.preconfigured:
       inferenceId: ".google-gemini-3.0-flash-chat_completion"
       providerConfig:
         model_id: "google-gemini-3.0-flash"
+  Anthropic-Claude-Opus-5:
+    name: Anthropic Claude Opus 5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-5-opus"
+  Google-Gemini-3-6-Flash:
+    name: Google Gemini 3.6 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.6-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.6-flash"
+  Google-Gemini-3-5-Flash-Lite:
+    name: Google Gemini 3.5 Flash-Lite
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.5-flash-lite-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.5-flash-lite"
+  OpenAI-GPT-5-6-Sol:
+    name: OpenAI GPT-5.6 Sol
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-sol-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-sol"
+  OpenAI-GPT-5-6-Terra:
+    name: OpenAI GPT-5.6 Terra
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-terra-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-terra"
+  OpenAI-GPT-5-6-Luna:
+    name: OpenAI GPT-5.6 Luna
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.6-luna-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.6-luna"

--- a/x-pack/platform/plugins/shared/fleet/cypress/tasks/api_calls/connectors.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/tasks/api_calls/connectors.ts
@@ -45,6 +45,12 @@ export const INTERNAL_INFERENCE_CONNECTORS = [
   'Google-Gemini-2-5-Flash-Lite',
   'Google-Gemini-3-0-Pro',
   'Google-Gemini-3-0-Flash',
+  'Anthropic-Claude-Opus-5',
+  'Google-Gemini-3-6-Flash',
+  'Google-Gemini-3-5-Flash-Lite',
+  'OpenAI-GPT-5-6-Sol',
+  'OpenAI-GPT-5-6-Terra',
+  'OpenAI-GPT-5-6-Luna',
 ];
 export const INTERNAL_CLOUD_CONNECTORS = ['Elastic-Cloud-SMTP'];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
@@ -38,6 +38,12 @@ const INTERNAL_INFERENCE_CONNECTORS = [
   'Google-Gemini-2-5-Flash-Lite',
   'Google-Gemini-3-0-Pro',
   'Google-Gemini-3-0-Flash',
+  'Anthropic-Claude-Opus-5',
+  'Google-Gemini-3-6-Flash',
+  'Google-Gemini-3-5-Flash-Lite',
+  'OpenAI-GPT-5-6-Sol',
+  'OpenAI-GPT-5-6-Terra',
+  'OpenAI-GPT-5-6-Luna',
 ];
 const INTERNAL_CONNECTORS = [...INTERNAL_CLOUD_CONNECTORS, ...INTERNAL_INFERENCE_CONNECTORS];
 


### PR DESCRIPTION
## Summary

Adds preconfigured `.inference` connectors for six new EIS chat models (pattern: #253109):

Anthropic Claude Opus 5 · Google Gemini 3.6 Flash · Google Gemini 3.5 Flash-Lite · OpenAI GPT-5.6 Sol / Terra / Luna

- Connector blocks added to the five serverless config files; connector IDs added to the Fleet and Security Solution Cypress allowlists.
- Display names and model IDs match the EIS gateway model catalog.

Part of elastic/search-team#15485, #15491, #15497, #15503, #15509, #15515 (tracker: elastic/search-team#15139)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->
