### PR TITLE
Update APMLocatorPayloadValidator to make serviceName optional in the payload schema

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/locator/helpers.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/locator/helpers.test.ts
@@ -45,6 +45,19 @@ describe('getPathForServiceDetail', () => {
       expect(query.get('kuery')).toBe('');
       expect(query.get('serviceGroup')).toBe('');
     });
+
+    it('returns the service inventory link when the serviceName key is omitted', () => {
+      const path = getPathForServiceDetail({}, defaultOptions);
+      const { pathname, query } = splitPath(path);
+
+      expect(pathname).toBe('/services');
+      expect(query.get('environment')).toBe(ENVIRONMENT_ALL.value);
+      expect(query.get('rangeFrom')).toBe('now-15m');
+      expect(query.get('rangeTo')).toBe('now');
+      expect(query.get('comparisonEnabled')).toBe('false');
+      expect(query.get('kuery')).toBe('');
+      expect(query.get('serviceGroup')).toBe('');
+    });
   });
 
   describe('when dashboardId is provided', () => {

--- a/x-pack/solutions/observability/plugins/apm/public/locator/helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/locator/helpers.ts
@@ -29,7 +29,7 @@ const SERVICE_OVERVIEW_TAB_PATHS = {
 } as const;
 
 export const APMLocatorPayloadValidator = z.union([
-  z.object({ serviceName: z.undefined() }),
+  z.object({ serviceName: z.undefined().optional() }),
   z
     .object({ serviceName: z.string() })
     .merge(z.object({ dashboardId: z.string() }))


### PR DESCRIPTION
Closes: #281991

## Summary

Closes https://github.com/elastic/kibana/issues/281991

The union branch meant to accept "link to the service inventory, no specific service" is
`z.object({ serviceName: z.undefined() })`. Under Zod v4 this requires the **key to be present**,
so a payload of `{}` fails the branch, fails the whole union, and `getPathForServiceDetail` throws
`Error: ": Invalid input"`.

```diff
-  z.object({ serviceName: z.undefined() }),
+  z.object({ serviceName: z.undefined().optional() }),
```

This is what makes the Observability landing page render blank: it calls `locators.apm.navigate({})`
when the user has APM data but no logs data, and the throw is an unhandled rejection, so no
navigation happens. `navigate({})` is a normal calling pattern — the logs and onboarding locators
both accept it — so the APM locator was the outlier.

## Before

<img width="3006" height="1830" alt="image" src="https://github.com/user-attachments/assets/bda81127-5865-4dcc-8818-dd65353cbbae" />

## After

https://github.com/user-attachments/assets/9f10417b-bece-4258-8df9-f69bab11bfe4

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



