### PR TITLE
[Agent Builder] fix Overview Dashboard tool Success Rate ESQL

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/assets/overview_dashboard.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/assets/overview_dashboard.ts
@@ -2242,7 +2242,7 @@ Real-time observability for **Agent Builder** OTel traces (\`data_stream.dataset
                 layer_0: {
                   index: 'traces-agent_builder.otel-__AGENT_BUILDER_TRACES_NAMESPACE__-@timestamp',
                   query: {
-                    esql: 'FROM traces-agent_builder.otel-__AGENT_BUILDER_TRACES_NAMESPACE__\n| WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend\n| WHERE `span.name` LIKE "execute_tool *"\n| STATS total = COUNT(*), errors = COUNT(*) WHERE status.code == "Error"\n| EVAL `Success Rate (%)` = ROUND((total - errors) / total * 100, 2)\n| KEEP `Success Rate (%)`',
+                    esql: 'FROM traces-agent_builder.otel-__AGENT_BUILDER_TRACES_NAMESPACE__\n| WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend\n| WHERE `span.name` LIKE "execute_tool *"\n| STATS total = COUNT(*), errors = COUNT(*) WHERE status.code == "Error"\n| EVAL `Success Rate (%)` = ROUND(TO_DOUBLE(total - errors) / total * 100, 2)\n| KEEP `Success Rate (%)`',
                   },
                   timeField: '@timestamp',
                   columns: [
@@ -2348,7 +2348,7 @@ Real-time observability for **Agent Builder** OTel traces (\`data_stream.dataset
             },
           },
           query: {
-            esql: 'FROM traces-agent_builder.otel-__AGENT_BUILDER_TRACES_NAMESPACE__\n| WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend\n| WHERE `span.name` LIKE "execute_tool *"\n| STATS total = COUNT(*), errors = COUNT(*) WHERE status.code == "Error"\n| EVAL `Success Rate (%)` = ROUND((total - errors) / total * 100, 2)\n| KEEP `Success Rate (%)`',
+            esql: 'FROM traces-agent_builder.otel-__AGENT_BUILDER_TRACES_NAMESPACE__\n| WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend\n| WHERE `span.name` LIKE "execute_tool *"\n| STATS total = COUNT(*), errors = COUNT(*) WHERE status.code == "Error"\n| EVAL `Success Rate (%)` = ROUND(TO_DOUBLE(total - errors) / total * 100, 2)\n| KEEP `Success Rate (%)`',
           },
           filters: [],
         },


### PR DESCRIPTION
## Summary

The Tool Success Rate ESQL was truncating the sucess rate to 0.0% if there was even 1 failure. 

<img width="3456" height="460" alt="Screenshot 2026-07-30 at 5 58 36 PM" src="https://github.com/user-attachments/assets/43e2b22b-85af-4e37-930b-7f5e302235ef" />

This PR fixes it by wrapping the numerator in TO_DOUBLE() so the success rate isn’t truncated by integer division.

<img width="1625" height="800" alt="Screenshot 2026-07-31 at 6 03 38 AM" src="https://github.com/user-attachments/assets/82c01f30-89d5-49e6-82ae-b5853f93b535" />

## Release Note
Fixed ESQL to not truncate the Tool Success Rate panel in the Agent Builder Overview Dashboard 

## Checklist
Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->