### PR TITLE
[Fleet] Add toast notifications for revoking/deleting enrollment tokens

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/token_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/token_actions.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, waitFor, within } from '@testing-library/react';
+
+import { createFleetTestRendererMock } from '../../../../../../mock';
+import type { EnrollmentAPIKey } from '../../../../types';
+
+import { TokenActions } from './token_actions';
+
+const mockAddSuccess = jest.fn();
+const mockAddError = jest.fn();
+const mockSendDeleteOneEnrollmentAPIKey = jest.fn();
+
+jest.mock('../../../../hooks', () => ({
+  ...jest.requireActual('../../../../hooks'),
+  useStartServices: jest.fn().mockReturnValue({
+    notifications: {
+      toasts: {
+        addSuccess: (...args: unknown[]) => mockAddSuccess(...args),
+        addError: (...args: unknown[]) => mockAddError(...args),
+      },
+    },
+  }),
+  sendDeleteOneEnrollmentAPIKey: (...args: unknown[]) => mockSendDeleteOneEnrollmentAPIKey(...args),
+}));
+
+const MOCK_API_KEY: EnrollmentAPIKey = {
+  id: 'key-1',
+  api_key_id: 'api-key-id-1',
+  api_key: 'api-key-value',
+  name: 'Test token',
+  active: true,
+  policy_id: 'policy-1',
+  created_at: '2024-01-01T00:00:00.000Z',
+};
+
+type RenderResult = ReturnType<ReturnType<typeof createFleetTestRendererMock>['render']>;
+
+async function openMenuAndClickItem(result: RenderResult, itemTestSubj: string) {
+  const scope = within(result.baseElement);
+  await act(async () => {
+    scope.getByTestId('enrollmentTokenTable.actionsMenu').click();
+  });
+  await act(async () => {
+    scope.getByTestId(itemTestSubj).click();
+  });
+}
+
+async function clickConfirmButton(result: RenderResult) {
+  const scope = within(result.baseElement);
+  await act(async () => {
+    scope.getByTestId('confirmModalConfirmButton').click();
+  });
+}
+
+describe('TokenActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a success toast after revoking a token', async () => {
+    mockSendDeleteOneEnrollmentAPIKey.mockResolvedValue({ data: {} });
+    const refresh = jest.fn();
+    const testRenderer = createFleetTestRendererMock();
+    const result = testRenderer.render(<TokenActions apiKey={MOCK_API_KEY} refresh={refresh} />);
+
+    await openMenuAndClickItem(result, 'enrollmentTokenTable.revokeBtn');
+    await clickConfirmButton(result);
+
+    await waitFor(() => {
+      expect(mockSendDeleteOneEnrollmentAPIKey).toHaveBeenCalledWith(MOCK_API_KEY.id);
+      expect(mockAddSuccess).toHaveBeenCalledWith(
+        expect.stringContaining('Enrollment token revoked')
+      );
+      expect(mockAddError).not.toHaveBeenCalled();
+      expect(refresh).toHaveBeenCalled();
+    });
+  });
+
+  it('shows a success toast after deleting a token', async () => {
+    mockSendDeleteOneEnrollmentAPIKey.mockResolvedValue({ data: {} });
+    const refresh = jest.fn();
+    const testRenderer = createFleetTestRendererMock();
+    const result = testRenderer.render(<TokenActions apiKey={MOCK_API_KEY} refresh={refresh} />);
+
+    await openMenuAndClickItem(result, 'enrollmentTokenTable.deleteBtn');
+    await clickConfirmButton(result);
+
+    await waitFor(() => {
+      expect(mockSendDeleteOneEnrollmentAPIKey).toHaveBeenCalledWith(MOCK_API_KEY.id, {
+        forceDelete: true,
+      });
+      expect(mockAddSuccess).toHaveBeenCalledWith(
+        expect.stringContaining('Enrollment token successfully deleted')
+      );
+      expect(mockAddError).not.toHaveBeenCalled();
+      expect(refresh).toHaveBeenCalled();
+    });
+  });
+
+  it('shows an error toast and no success toast when the API call fails', async () => {
+    const apiError = new Error('API error');
+    mockSendDeleteOneEnrollmentAPIKey.mockResolvedValue({ error: apiError });
+    const refresh = jest.fn();
+    const testRenderer = createFleetTestRendererMock();
+    const result = testRenderer.render(<TokenActions apiKey={MOCK_API_KEY} refresh={refresh} />);
+
+    await openMenuAndClickItem(result, 'enrollmentTokenTable.revokeBtn');
+    await clickConfirmButton(result);
+
+    await waitFor(() => {
+      expect(mockAddError).toHaveBeenCalled();
+      expect(mockAddSuccess).not.toHaveBeenCalled();
+      // refresh still runs on error — the table re-fetches to show current state
+      expect(refresh).toHaveBeenCalled();
+    });
+  });
+
+  it('calls refresh on the success path', async () => {
+    mockSendDeleteOneEnrollmentAPIKey.mockResolvedValue({ data: {} });
+    const refresh = jest.fn();
+    const testRenderer = createFleetTestRendererMock();
+    const result = testRenderer.render(<TokenActions apiKey={MOCK_API_KEY} refresh={refresh} />);
+    await openMenuAndClickItem(result, 'enrollmentTokenTable.revokeBtn');
+    await clickConfirmButton(result);
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+  });
+
+  it('calls refresh on the error path', async () => {
+    mockSendDeleteOneEnrollmentAPIKey.mockResolvedValue({ error: new Error('fail') });
+    const refresh = jest.fn();
+    const testRenderer = createFleetTestRendererMock();
+    const result = testRenderer.render(<TokenActions apiKey={MOCK_API_KEY} refresh={refresh} />);
+    await openMenuAndClickItem(result, 'enrollmentTokenTable.revokeBtn');
+    await clickConfirmButton(result);
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/token_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/token_actions.test.tsx
@@ -76,7 +76,7 @@ describe('TokenActions', () => {
     await waitFor(() => {
       expect(mockSendDeleteOneEnrollmentAPIKey).toHaveBeenCalledWith(MOCK_API_KEY.id);
       expect(mockAddSuccess).toHaveBeenCalledWith(
-        expect.stringContaining('Enrollment token revoked')
+        expect.stringContaining('Enrollment token successfully revoked')
       );
       expect(mockAddError).not.toHaveBeenCalled();
       expect(refresh).toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/token_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/token_actions.tsx
@@ -47,6 +47,11 @@ export const TokenActions: React.FunctionComponent<{
     try {
       const res = await sendDeleteOneEnrollmentAPIKey(apiKey.id);
       if (res.error) throw res.error;
+      notifications.toasts.addSuccess(
+        i18n.translate('xpack.fleet.enrollmentTokensList.revokeTokenSuccess', {
+          defaultMessage: 'Enrollment token successfully revoked',
+        })
+      );
     } catch (err) {
       notifications.toasts.addError(err as Error, { title: 'Error' });
     }
@@ -61,6 +66,11 @@ export const TokenActions: React.FunctionComponent<{
     try {
       const res = await sendDeleteOneEnrollmentAPIKey(apiKey.id, { forceDelete: true });
       if (res.error) throw res.error;
+      notifications.toasts.addSuccess(
+        i18n.translate('xpack.fleet.enrollmentTokensList.deleteTokenSuccess', {
+          defaultMessage: 'Enrollment token successfully deleted',
+        })
+      );
     } catch (err) {
       notifications.toasts.addError(err as Error, { title: 'Error' });
     }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/hooks/use_bulk_actions.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/hooks/use_bulk_actions.ts
@@ -47,31 +47,48 @@ export const useBulkActions = ({
       const count = res.data?.count ?? 0;
       const successCount = res.data?.successCount ?? 0;
       const errorCount = res.data?.errorCount ?? 0;
-      const actionLabel = action === 'delete' ? 'deleted' : 'revoked';
 
       if (count === successCount) {
         notifications.toasts.addSuccess(
-          i18n.translate('xpack.fleet.enrollmentTokensList.bulkActionSuccess', {
-            defaultMessage:
-              '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} {actionLabel}',
-            values: { successCount, actionLabel },
-          })
+          action === 'delete'
+            ? i18n.translate('xpack.fleet.enrollmentTokensList.bulkDeleteSuccess', {
+                defaultMessage:
+                  '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} deleted',
+                values: { successCount },
+              })
+            : i18n.translate('xpack.fleet.enrollmentTokensList.bulkRevokeSuccess', {
+                defaultMessage:
+                  '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} revoked',
+                values: { successCount },
+              })
         );
       } else if (count === errorCount) {
         notifications.toasts.addDanger(
-          i18n.translate('xpack.fleet.enrollmentTokensList.bulkActionAllErrors', {
-            defaultMessage:
-              'Failed to {actionLabel} {errorCount, plural, one {# enrollment token} other {# enrollment tokens}}',
-            values: { errorCount, actionLabel },
-          })
+          action === 'delete'
+            ? i18n.translate('xpack.fleet.enrollmentTokensList.bulkDeleteAllErrors', {
+                defaultMessage:
+                  'Failed to delete {errorCount, plural, one {# enrollment token} other {# enrollment tokens}}',
+                values: { errorCount },
+              })
+            : i18n.translate('xpack.fleet.enrollmentTokensList.bulkRevokeAllErrors', {
+                defaultMessage:
+                  'Failed to revoke {errorCount, plural, one {# enrollment token} other {# enrollment tokens}}',
+                values: { errorCount },
+              })
         );
       } else {
         notifications.toasts.addWarning(
-          i18n.translate('xpack.fleet.enrollmentTokensList.bulkActionPartialErrors', {
-            defaultMessage:
-              '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} {actionLabel}, {errorCount, plural, one {# token} other {# tokens}} failed',
-            values: { successCount, errorCount, actionLabel },
-          })
+          action === 'delete'
+            ? i18n.translate('xpack.fleet.enrollmentTokensList.bulkDeletePartialErrors', {
+                defaultMessage:
+                  '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} deleted, {errorCount, plural, one {# token} other {# tokens}} failed',
+                values: { successCount, errorCount },
+              })
+            : i18n.translate('xpack.fleet.enrollmentTokensList.bulkRevokePartialErrors', {
+                defaultMessage:
+                  '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} revoked, {errorCount, plural, one {# token} other {# tokens}} failed',
+                values: { successCount, errorCount },
+              })
         );
       }
     } catch (err) {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/272824

## Summary

When enrollment tokens are revoked/deleted, the user will now see a toast notification showing confirmation of the action. Added for single and bulk actions:

https://github.com/user-attachments/assets/ab61eafc-8d26-4eff-95bf-6bc9ed70a180



### Checklist


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.3","9.4","9.5"]} ONMERGE-->