### PR TITLE
Ignore generated typecheck configs in RSPack watch mode

### DIFF
--- a/packages/kbn-cli-dev-mode/src/watcher.ts
+++ b/packages/kbn-cli-dev-mode/src/watcher.ts
@@ -144,6 +144,7 @@ export class Watcher {
           '**/{.cache,.temp,.tmp,temp,tmp}/**',
           '**/*.{test,spec,story,stories}.*',
           '**/*.{http,md,sh,txt,log,pid,swp,swo}',
+          '**/tsconfig*.type_check.json',
           '**/*~',
           '**/.DS_Store',
           '/data/**',

--- a/packages/kbn-rspack-optimizer/src/run_build.test.ts
+++ b/packages/kbn-rspack-optimizer/src/run_build.test.ts
@@ -55,6 +55,11 @@ describe('IGNORED_WATCH_PATTERNS', () => {
 
       ['tsbuildinfo at package root', p('repo', 'pkg', 'tsconfig.tsbuildinfo')],
       ['type_check tsbuildinfo variant', p('repo', 'pkg', 'tsconfig.type_check.tsbuildinfo')],
+      ['generated type_check tsconfig', p('repo', 'pkg', 'tsconfig.type_check.json')],
+      [
+        'generated variant type_check tsconfig',
+        p('repo', 'pkg', 'tsconfig.browser.type_check.json'),
+      ],
 
       ['unit test file (.test.ts)', p('repo', 'pkg', 'src', 'foo.test.ts')],
       ['unit test file (.test.tsx)', p('repo', 'pkg', 'src', 'foo.test.tsx')],

--- a/packages/kbn-rspack-optimizer/src/run_build.ts
+++ b/packages/kbn-rspack-optimizer/src/run_build.ts
@@ -22,6 +22,7 @@ export const IGNORED_WATCH_PATTERNS: RegExp[] = [
   /[\\/]node_modules[\\/]/,
   /[\\/]target[\\/]/,
   /\.tsbuildinfo$/,
+  /(^|[\\/])tsconfig[^\\/]*\.type_check\.json$/,
   /\.test\.[jt]sx?$/,
   /\.spec\.[jt]sx?$/,
   /\.stories\.[jt]sx?$/,


### PR DESCRIPTION
## Summary

- Ignore generated `tsconfig*.type_check.json` files in the RSPack watch-mode ignore list.
- Ignore the same generated type-check configs in the Kibana dev-mode server watcher.
- Add watch-ignore test coverage for generated type-check configs.

## Verification

- `node scripts/type_check --project x-pack/solutions/security/plugins/security_solution/tsconfig.json --verbose`
- `node scripts/jest packages/kbn-rspack-optimizer/src/run_build.test.ts`
- `node scripts/eslint packages/kbn-rspack-optimizer/src/run_build.ts packages/kbn-rspack-optimizer/src/run_build.test.ts packages/kbn-cli-dev-mode/src/watcher.ts`

No issue reference: searched for a matching RSPack/type_check/HMR issue and did not find one.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->