### PR TITLE
[8.19][Canvas] Document TinyMath expression nesting and length limits

### DIFF
--- a/docs/canvas/canvas-tinymath-functions.asciidoc
+++ b/docs/canvas/canvas-tinymath-functions.asciidoc
@@ -14,6 +14,10 @@ parameters, the function generally does the calculation index by index.
 Any function can be wrapped by another function as long as the return type
 of the inner function matches the acceptable parameter type of the outer function.
 
+NOTE: A TinyMath expression can contain up to 20 levels of parenthesis nesting and
+up to 1,000 characters. Expressions that exceed either limit are rejected before
+they're parsed. Typical expressions stay well within both limits.
+
 [float]
 === abs( a )
 


### PR DESCRIPTION
## Summary

Documents the two new hard input limits on TinyMath expressions in the 8.19 Canvas function reference: up to 20 levels of parenthesis nesting and up to 1,000 characters, with expressions exceeding either limit rejected before parsing.

This is the 8.19 (AsciiDoc) companion to the V3 docs update in elastic/docs-content#7676. On the `8.19` branch the TinyMath reference is still the legacy AsciiDoc, so the docs-content change (scoped `stack: ga 9.4`) does not reach 8.19 readers.

The limits shipped in the `kbn-tinymath` package via elastic/kibana#276783 (`backport:all-open`) and are present on the `8.19` branch: `MAX_NESTING_DEPTH = 20` and `MAX_EXPRESSION_LENGTH = 1000` in `src/platform/packages/private/kbn-tinymath/src/index.js`, checked before parsing. Per the issue availability table, the fix ships to users in 8.19.20.

- **`docs/canvas/canvas-tinymath-functions.asciidoc`**: Add a note to the page introduction stating the nesting-depth and length limits.

## Related

- V3 companion: elastic/docs-content#7676
- Docs issue: elastic/docs-content#7623
- Implementation: elastic/kibana#276783

## Labels needed

Docs-only backport to the 8.19 branch. Please add `release_note:skip` and the `v8.19.20` version label on merge.

---

> **AI-generated draft** — created with Claude.
> Review all generated content for factual accuracy before merging.