### PR TITLE
[kbn-swc-register] Avoid eval-based LMDB key decoding

### DIFF
--- a/src/platform/packages/shared/kbn-swc-register/cache/lmdb_cache.js
+++ b/src/platform/packages/shared/kbn-swc-register/cache/lmdb_cache.js
@@ -14,6 +14,8 @@ const Crypto = require('crypto');
 const chalk = require('chalk');
 const LmdbStore = require('lmdb');
 
+const { utf8StringKeyEncoder } = require('./lmdb_key_encoder');
+
 const GLOBAL_ATIME = new Date().setHours(0, 0, 0, 0);
 const MINUTE = 1000 * 60;
 const HOUR = MINUTE * 60;
@@ -116,10 +118,18 @@ class LmdbCache {
   constructor(config) {
     this.#log = config.log;
     this.#prefix = config.prefix;
-    this.#db = LmdbStore.open(Path.resolve(config.dir, 'v1'), {
+    // LMDB's default ordered-binary key decoder uses eval, which Kibana disallows.
+    // Ideally ordered-binary will provide a CSP-safe decoder and this custom encoder can be removed.
+    /**
+     * `keyEncoder` is supported by lmdb but missing from its DatabaseOptions type.
+     * @type {import('lmdb').RootDatabaseOptions & { keyEncoder: typeof utf8StringKeyEncoder }}
+     */
+    const databaseOptions = {
       name: 'db',
       encoding: 'json',
-    });
+      keyEncoder: utf8StringKeyEncoder,
+    };
+    this.#db = LmdbStore.open(Path.resolve(config.dir, 'v2'), databaseOptions);
 
     const lastClean = this.#db.get(LAST_CLEAN_KEY);
     if (!isCacheCodeEntry(lastClean) || lastClean[0] < GLOBAL_ATIME - 7 * DAY) {

--- a/src/platform/packages/shared/kbn-swc-register/cache/lmdb_cache.test.ts
+++ b/src/platform/packages/shared/kbn-swc-register/cache/lmdb_cache.test.ts
@@ -13,11 +13,13 @@ import { Writable } from 'stream';
 
 import del from 'del';
 import LmdbStore = require('lmdb');
+import type { RootDatabaseOptions } from 'lmdb';
 
 import { LmdbCache } from './lmdb_cache';
+import { utf8StringKeyEncoder } from './lmdb_key_encoder';
 
 const DIR = Path.resolve(__dirname, '../__tmp__/cache');
-const DB_DIR = Path.resolve(DIR, 'v1');
+const DB_DIR = Path.resolve(DIR, 'v2');
 const DAY = 1000 * 60 * 60 * 24;
 const GLOBAL_ATIME = new Date().setHours(0, 0, 0, 0);
 
@@ -40,11 +42,17 @@ const getExpectedMetadataKey = (path: string) => {
   return `prefix:stat:${keyParts.join(':')}:${Path.resolve(path)}`;
 };
 
-const openDb = () =>
-  LmdbStore.open<unknown, string>(DB_DIR, {
+const openDb = () => {
+  const databaseOptions: RootDatabaseOptions & {
+    keyEncoder: typeof utf8StringKeyEncoder;
+  } = {
     name: 'db',
     encoding: 'json',
-  });
+    keyEncoder: utf8StringKeyEncoder,
+  };
+
+  return LmdbStore.open<unknown, string>(DB_DIR, databaseOptions);
+};
 
 const waitForAsyncWrites = () => new Promise((resolve) => setTimeout(resolve, 50));
 
@@ -153,6 +161,23 @@ it('stores code and source maps separately', async () => {
   const db = openDb();
   expect(db.get(getCodeKey(key))).toEqual([GLOBAL_ATIME, 'var x = 1']);
   expect(db.get(getMapKey(key))).toEqual({ foo: 'bar' });
+  await db.close();
+});
+
+it('supports UTF-8 cache keys', async () => {
+  const cache = makeCache({
+    dir: DIR,
+    prefix: 'prefix',
+  });
+  const key = 'prefix:日本語:🚀';
+
+  await cache.update(key, {
+    code: 'var utf8 = true',
+  });
+  await cache.close();
+
+  const db = openDb();
+  expect(Array.from(db.getKeys())).toContain(`code:${key}`);
   await db.close();
 });
 

--- a/src/platform/packages/shared/kbn-swc-register/cache/lmdb_key_encoder.js
+++ b/src/platform/packages/shared/kbn-swc-register/cache/lmdb_key_encoder.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * @param {string | Uint8Array} key
+ * @param {Uint8Array} target
+ * @param {number} start
+ * @returns {number}
+ */
+const writeKey = (key, target, start) => {
+  const encodedKey = typeof key === 'string' ? Buffer.from(key, 'utf8') : key;
+  target.set(encodedKey, start);
+  return start + encodedKey.length;
+};
+
+/**
+ * @param {Uint8Array} source
+ * @param {number} start
+ * @param {number} end
+ * @returns {string}
+ */
+const readKey = (source, start, end) => Buffer.from(source.subarray(start, end)).toString('utf8');
+
+exports.utf8StringKeyEncoder = {
+  writeKey,
+  readKey,
+};


### PR DESCRIPTION
LMDB uses `ordered-binary` for keys by default. Its string-key decoder is generated with `eval()`, which is incompatible with Kibana's runtime code-generation restrictions and can lose access to its module-scoped state when Jest wraps `eval`. That caused SWC cache pruning to fail while enumerating keys.

This change:

- uses a small UTF-8 encoder for the cache's string keys, avoiding the `ordered-binary` decoder
- bumps the disposable on-disk cache directory from `v1` to `v2` because the key encoding changed
- adds coverage for enumerating UTF-8 cache keys

The ideal long-term solution is a CSP-safe decoder in `ordered-binary`, at which point the custom encoder can be removed.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->