### PR TITLE
[Synthetics][POC] HashiCorp Vault reference tokens for params

### DIFF
--- a/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
+++ b/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
@@ -20,7 +20,7 @@ import type { EncryptedSavedObjectsService } from '../../server/crypto';
 import * as EncryptedSavedObjectsModule from '../../server/saved_objects';
 
 // This will only change if new ESOs are introduced. This number should never get smaller.
-export const ESO_TYPES_COUNT = 24 as const;
+export const ESO_TYPES_COUNT = 25 as const;
 
 describe('checking changes on all registered encrypted SO types', () => {
   let esServer: TestElasticsearchUtils;
@@ -84,6 +84,7 @@ describe('checking changes on all registered encrypted SO types', () => {
         "synthetics-monitor": "f1c060b7be3b30187c4adcb35d74f1fa8a4290bd7faf04fec869de2aa387e21b",
         "synthetics-monitor-multi-space": "39c4c6abd28c4173f77c1c89306e92b6b92492c0029274e10620a170be4d4a67",
         "synthetics-param": "747ba9d1b7addf5b131713abe7868bd767af6ce0cf8b6b0f335f4ef34b280c7e",
+        "synthetics-vault-connection": "49f3960d2a4d2e8a71550c9c13fdcff111db60b3fb04a63f1f6bed036b2f59c2",
         "task": "d6cc30871dc78caf3f451de1275a3803879ec9935b4a2e34076dee56878c228f",
         "uptime-synthetics-api-key": "5ca81f180763e85397fa8c6508adcd60efd0f916e29bac6dcd5b4564f1db7375",
         "user_connector_token": "7f818fe3827daa31d23b874e480176d105e629cf5da88f5f4e56033e78c3acca",

--- a/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -73,6 +73,7 @@ export enum SYNTHETICS_API_URLS {
 
   DYNAMIC_SETTINGS = `/api/synthetics/settings`,
   VAULT_CONNECTION = `/internal/synthetics/settings/vault_connection`,
+  FLEET_SECRET_STORAGE_STATUS = `/internal/synthetics/settings/fleet_secret_storage_status`,
   MULTI_SPACE_SETTINGS = `/internal/synthetics/settings_multi_space`,
 
   INSPECT_STATUS_RULE = '/internal/synthetics/inspect_status_rule',

--- a/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -72,6 +72,7 @@ export enum SYNTHETICS_API_URLS {
   SYNTHETICS_MONITORS_PROJECT_DELETE = '/api/synthetics/project/{projectName}/monitors/_bulk_delete',
 
   DYNAMIC_SETTINGS = `/api/synthetics/settings`,
+  VAULT_CONNECTION = `/internal/synthetics/settings/vault_connection`,
   MULTI_SPACE_SETTINGS = `/internal/synthetics/settings_multi_space`,
 
   INSPECT_STATUS_RULE = '/internal/synthetics/inspect_status_rule',

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/index.ts
@@ -8,6 +8,7 @@ export * from './alerts';
 export * from './certs';
 export * from './common';
 export * from './dynamic_settings';
+export * from './settings/vault_connection';
 export * from './monitor';
 export * from './ping';
 export * from './snapshot';

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/synthetics_params.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/synthetics_params.ts
@@ -13,11 +13,17 @@ import * as t from 'io-ts';
  * fetches or stores the plaintext secret. The effective param `value` is the
  * edge-resolved token `${vault/<path>#<field>}`.
  */
-export const SyntheticsParamVaultSourceCodec = t.type({
-  type: t.literal('vault'),
-  path: t.string,
-  field: t.string,
-});
+export const SyntheticsParamVaultSourceCodec = t.intersection([
+  t.type({
+    type: t.literal('vault'),
+    path: t.string,
+    field: t.string,
+  }),
+  t.partial({
+    // Name of the Vault connection to resolve against (omit = default connection).
+    connection: t.string,
+  }),
+]);
 
 export type SyntheticsParamVaultSource = t.TypeOf<typeof SyntheticsParamVaultSourceCodec>;
 

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/synthetics_params.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/synthetics_params.ts
@@ -7,6 +7,20 @@
 
 import * as t from 'io-ts';
 
+/**
+ * A vault-backed param resolves its value from HashiCorp Vault at runtime,
+ * inside Heartbeat. Kibana only stores this reference (path + field); it never
+ * fetches or stores the plaintext secret. The effective param `value` is the
+ * edge-resolved token `${vault/<path>#<field>}`.
+ */
+export const SyntheticsParamVaultSourceCodec = t.type({
+  type: t.literal('vault'),
+  path: t.string,
+  field: t.string,
+});
+
+export type SyntheticsParamVaultSource = t.TypeOf<typeof SyntheticsParamVaultSourceCodec>;
+
 export const SyntheticsParamsReadonlyCodec = t.intersection([
   t.interface({
     id: t.string,
@@ -16,6 +30,7 @@ export const SyntheticsParamsReadonlyCodec = t.intersection([
     description: t.string,
     tags: t.array(t.string),
     namespaces: t.array(t.string),
+    source: SyntheticsParamVaultSourceCodec,
   }),
 ]);
 
@@ -47,9 +62,11 @@ export type DeleteParamsResponse = t.TypeOf<typeof DeleteParamsResponseCodec>;
 export const SyntheticsParamRequestCodec = t.intersection([
   t.interface({
     key: t.string,
-    value: t.string,
   }),
   t.partial({
+    // Either `value` (literal) or `source` (vault-backed) must be provided.
+    value: t.string,
+    source: SyntheticsParamVaultSourceCodec,
     description: t.string,
     tags: t.array(t.string),
     share_across_spaces: t.boolean,

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
@@ -7,20 +7,34 @@
 
 import * as t from 'io-ts';
 
+/**
+ * Secret-provider backend discriminator. Only HashiCorp Vault is implemented
+ * today, but the connection model below is deliberately shaped so other providers
+ * (CyberArk, Azure Key Vault, AWS Secrets Manager) are *additive*: to add one you
+ * add a literal here, a `<provider>Config`/`<provider>Secrets` pair, a member to
+ * `SecretProviderConnectionCodec`, and a resolver on the agent — with no change to
+ * the reference-token grammar, the saved-object schema, or the encryption model.
+ */
+export const SecretProviderTypeCodec = t.keyof({
+  hashicorp_vault: null,
+  // cyberark: null,
+  // azure_key_vault: null,
+  // aws_secrets_manager: null,
+});
+export type SecretProviderType = t.TypeOf<typeof SecretProviderTypeCodec>;
+
+export const SECRET_PROVIDER_HASHICORP_VAULT: SecretProviderType = 'hashicorp_vault';
+
 export const VaultAuthMethodCodec = t.union([t.literal('token'), t.literal('approle')]);
 export type VaultAuthMethod = t.TypeOf<typeof VaultAuthMethodCodec>;
 
-/**
- * The HashiCorp Vault connection Synthetics uses to resolve vault-backed params.
- * Stored as a single, space-scoped encrypted saved object; the `token`/`secretId`
- * secrets are encrypted at rest. This connection is propagated to Heartbeat via
- * the Fleet agent policy so the agent can resolve ${vault/...} references at the
- * edge.
- */
-export const SyntheticsVaultConnectionCodec = t.intersection([
+/* ------------------------------------------------------------------ *
+ * HashiCorp Vault provider
+ * ------------------------------------------------------------------ */
+
+/** Non-secret, provider-specific settings. Safe to return to the browser. */
+export const HashiCorpVaultConfigCodec = t.intersection([
   t.type({
-    // Unique connection name, addressed by params as ${vault/<name>@<path>#<field>}.
-    name: t.string,
     address: t.string,
     authMethod: VaultAuthMethodCodec,
   }),
@@ -28,38 +42,68 @@ export const SyntheticsVaultConnectionCodec = t.intersection([
     namespace: t.string,
     kvMount: t.string,
     tlsSkipVerify: t.boolean,
+    // approle: the role id is not a secret (the secret_id is).
+    roleId: t.string,
+  }),
+]);
+export type HashiCorpVaultConfig = t.TypeOf<typeof HashiCorpVaultConfigCodec>;
+
+/** Secret, provider-specific settings. Encrypted at rest as one blob. */
+export const HashiCorpVaultSecretsCodec = t.partial({
+  token: t.string,
+  secretId: t.string,
+});
+export type HashiCorpVaultSecrets = t.TypeOf<typeof HashiCorpVaultSecretsCodec>;
+
+const HashiCorpVaultConnectionCodec = t.intersection([
+  t.type({
+    // Unique connection name, addressed by params as ${vault/<name>@<path>#<field>}.
+    name: t.string,
+    type: t.literal('hashicorp_vault'),
+    config: HashiCorpVaultConfigCodec,
+  }),
+  t.partial({
     // How long the agent caches a resolved secret before re-reading (e.g. "5m").
+    // Common to every provider (it's the resolver cache window), so it lives at the
+    // top level rather than in a provider `config`.
     secretRefreshInterval: t.string,
     // Bumped on save / manual refresh; part of the delivered blob so a change
     // forces agents to re-resolve (and thus pick up a rotated secret).
     refreshedAt: t.string,
-    // token auth
-    token: t.string,
-    // approle auth
-    roleId: t.string,
-    secretId: t.string,
+    secrets: HashiCorpVaultSecretsCodec,
   }),
 ]);
 
-export type SyntheticsVaultConnection = t.TypeOf<typeof SyntheticsVaultConnectionCodec>;
+/**
+ * A stored secret-provider connection. A discriminated union on `type`; today it
+ * has a single member. When a second provider lands, change this to
+ * `t.union([HashiCorpVaultConnectionCodec, CyberArkConnectionCodec, ...])`.
+ *
+ * Stored as a space-scoped encrypted saved object: the whole `secrets` blob is
+ * encrypted at rest. The connection is propagated to Heartbeat via the Fleet agent
+ * policy so the agent can resolve ${vault/...} references at the edge.
+ */
+export const SecretProviderConnectionCodec = HashiCorpVaultConnectionCodec;
+export type SecretProviderConnection = t.TypeOf<typeof SecretProviderConnectionCodec>;
+
+/** Back-compat alias for the stored connection type. */
+export type SyntheticsVaultConnection = SecretProviderConnection;
 
 /**
- * The safe, secret-free view of the connection returned to the browser.
+ * The safe, secret-free view of a connection returned to the browser: the
+ * non-secret provider `config` verbatim, plus a `hasSecret` flag so the UI can
+ * render "•••• saved" without ever receiving the value.
  */
 export const VaultConnectionStatusCodec = t.intersection([
   t.type({ configured: t.boolean }),
   t.partial({
     name: t.string,
-    address: t.string,
-    namespace: t.string,
-    authMethod: VaultAuthMethodCodec,
-    roleId: t.string,
-    kvMount: t.string,
-    tlsSkipVerify: t.boolean,
+    type: SecretProviderTypeCodec,
     secretRefreshInterval: t.string,
     refreshedAt: t.string,
-    // whether an encrypted secret (token/secret_id) is stored, so the UI can show
-    // "•••• saved" without ever receiving the value.
+    // Non-secret provider config. A union of provider configs once there is more
+    // than one; HashiCorp Vault's shape today.
+    config: HashiCorpVaultConfigCodec,
     hasSecret: t.boolean,
   }),
 ]);

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+
+export const VaultAuthMethodCodec = t.union([t.literal('token'), t.literal('approle')]);
+export type VaultAuthMethod = t.TypeOf<typeof VaultAuthMethodCodec>;
+
+/**
+ * The HashiCorp Vault connection Synthetics uses to resolve vault-backed params.
+ * Stored as a single, space-scoped encrypted saved object; the `token`/`secretId`
+ * secrets are encrypted at rest. This connection is propagated to Heartbeat via
+ * the Fleet agent policy so the agent can resolve ${vault/...} references at the
+ * edge.
+ */
+export const SyntheticsVaultConnectionCodec = t.intersection([
+  t.type({
+    address: t.string,
+    authMethod: VaultAuthMethodCodec,
+  }),
+  t.partial({
+    namespace: t.string,
+    kvMount: t.string,
+    tlsSkipVerify: t.boolean,
+    // token auth
+    token: t.string,
+    // approle auth
+    roleId: t.string,
+    secretId: t.string,
+  }),
+]);
+
+export type SyntheticsVaultConnection = t.TypeOf<typeof SyntheticsVaultConnectionCodec>;
+
+/**
+ * The safe, secret-free view of the connection returned to the browser.
+ */
+export const VaultConnectionStatusCodec = t.intersection([
+  t.type({ configured: t.boolean }),
+  t.partial({
+    address: t.string,
+    namespace: t.string,
+    authMethod: VaultAuthMethodCodec,
+    roleId: t.string,
+    kvMount: t.string,
+    tlsSkipVerify: t.boolean,
+    // whether an encrypted secret (token/secret_id) is stored, so the UI can show
+    // "•••• saved" without ever receiving the value.
+    hasSecret: t.boolean,
+  }),
+]);
+
+export type VaultConnectionStatus = t.TypeOf<typeof VaultConnectionStatusCodec>;

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
@@ -71,6 +71,9 @@ const HashiCorpVaultConnectionCodec = t.intersection([
     // forces agents to re-resolve (and thus pick up a rotated secret).
     refreshedAt: t.string,
     secrets: HashiCorpVaultSecretsCodec,
+    // Non-secret marker: whether a provider secret is stored. Lets the (non-
+    // decrypting) list read report "secret saved" without reading the secret.
+    hasSecret: t.boolean,
   }),
 ]);
 

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
@@ -19,6 +19,8 @@ export type VaultAuthMethod = t.TypeOf<typeof VaultAuthMethodCodec>;
  */
 export const SyntheticsVaultConnectionCodec = t.intersection([
   t.type({
+    // Unique connection name, addressed by params as ${vault/<name>@<path>#<field>}.
+    name: t.string,
     address: t.string,
     authMethod: VaultAuthMethodCodec,
   }),
@@ -47,6 +49,7 @@ export type SyntheticsVaultConnection = t.TypeOf<typeof SyntheticsVaultConnectio
 export const VaultConnectionStatusCodec = t.intersection([
   t.type({ configured: t.boolean }),
   t.partial({
+    name: t.string,
     address: t.string,
     namespace: t.string,
     authMethod: VaultAuthMethodCodec,
@@ -62,3 +65,5 @@ export const VaultConnectionStatusCodec = t.intersection([
 ]);
 
 export type VaultConnectionStatus = t.TypeOf<typeof VaultConnectionStatusCodec>;
+
+export const VaultConnectionStatusListCodec = t.array(VaultConnectionStatusCodec);

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/settings/vault_connection.ts
@@ -26,6 +26,11 @@ export const SyntheticsVaultConnectionCodec = t.intersection([
     namespace: t.string,
     kvMount: t.string,
     tlsSkipVerify: t.boolean,
+    // How long the agent caches a resolved secret before re-reading (e.g. "5m").
+    secretRefreshInterval: t.string,
+    // Bumped on save / manual refresh; part of the delivered blob so a change
+    // forces agents to re-resolve (and thus pick up a rotated secret).
+    refreshedAt: t.string,
     // token auth
     token: t.string,
     // approle auth
@@ -48,6 +53,8 @@ export const VaultConnectionStatusCodec = t.intersection([
     roleId: t.string,
     kvMount: t.string,
     tlsSkipVerify: t.boolean,
+    secretRefreshInterval: t.string,
+    refreshedAt: t.string,
     // whether an encrypted secret (token/secret_id) is stored, so the UI can show
     // "•••• saved" without ever receiving the value.
     hasSecret: t.boolean,

--- a/x-pack/solutions/observability/plugins/synthetics/common/types/saved_objects.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/types/saved_objects.ts
@@ -13,6 +13,8 @@ export const syntheticsMonitorAttributes = `${syntheticsMonitorSavedObjectType}.
 
 export const syntheticsParamType = 'synthetics-param';
 
+export const syntheticsVaultConnectionType = 'synthetics-vault-connection';
+
 export const syntheticsMonitorSOTypes = [
   syntheticsMonitorSavedObjectType,
   legacySyntheticsMonitorTypeSingle,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/add_param_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/add_param_flyout.tsx
@@ -46,14 +46,21 @@ const toFormData = (item: ListParamItem | null): ParamFormData => {
       description: '',
       value: '',
       sourceType: 'value',
-      source: { type: 'vault', path: '', field: '' },
+      source: { type: 'vault', path: '', field: '', connection: undefined },
     };
   }
   const { id: _id, source, ...rest } = item;
   return {
     ...rest,
     sourceType: source?.type === 'vault' ? 'vault' : 'value',
-    source: { type: 'vault', path: source?.path ?? '', field: source?.field ?? '' },
+    // Preserve the selected connection — dropping it here silently rewrites a
+    // named reference (${vault/staging@..}) to the default connection on any edit.
+    source: {
+      type: 'vault',
+      path: source?.path ?? '',
+      field: source?.field ?? '',
+      connection: source?.connection,
+    },
   };
 };
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/add_param_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/add_param_flyout.tsx
@@ -104,6 +104,7 @@ export const AddParamFlyout = ({
         type: 'vault',
         path: (source?.path ?? '').trim(),
         field: (source?.field ?? '').trim(),
+        connection: source?.connection?.trim() || undefined,
       };
     } else if (!(isEditingItem && id && isEmpty(value))) {
       // include the literal value unless editing and left blank (keep current)

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/add_param_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/add_param_flyout.tsx
@@ -33,9 +33,29 @@ import {
 } from '../../../state/global_params';
 import type { ClientPluginsStart } from '../../../../../plugin';
 import type { ListParamItem } from './params_list';
-import type { SyntheticsParams } from '../../../../../../common/runtime_types';
+import type { SyntheticsParamRequest } from '../../../../../../common/runtime_types';
 import { useFormWrapped } from '../../../../../hooks/use_form_wrapped';
 import { AddParamForm } from './add_param_form';
+import type { ParamFormData } from './add_param_form';
+
+const toFormData = (item: ListParamItem | null): ParamFormData => {
+  if (!item) {
+    return {
+      key: '',
+      tags: [],
+      description: '',
+      value: '',
+      sourceType: 'value',
+      source: { type: 'vault', path: '', field: '' },
+    };
+  }
+  const { id: _id, source, ...rest } = item;
+  return {
+    ...rest,
+    sourceType: source?.type === 'vault' ? 'vault' : 'value',
+    source: { type: 'vault', path: source?.path ?? '', field: source?.field ?? '' },
+  };
+};
 
 export const AddParamFlyout = ({
   items,
@@ -48,24 +68,19 @@ export const AddParamFlyout = ({
 }) => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
 
-  const { id, ...dataToSave } = isEditingItem ?? {};
+  const { id } = isEditingItem ?? {};
 
-  const form = useFormWrapped<SyntheticsParams>({
+  const form = useFormWrapped<ParamFormData>({
     mode: 'onSubmit',
     reValidateMode: 'onChange',
     shouldFocusError: true,
-    defaultValues: dataToSave ?? {
-      key: '',
-      tags: [],
-      description: '',
-      value: '',
-    },
+    defaultValues: toFormData(isEditingItem),
   });
 
   const closeFlyout = useCallback(() => {
     setIsFlyoutVisible(false);
     setIsEditingItem(null);
-    form.reset({ key: '', tags: [], description: '', value: '' });
+    form.reset(toFormData(null));
     // no need to add form value, it keeps changing on reset
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setIsEditingItem]);
@@ -78,32 +93,29 @@ export const AddParamFlyout = ({
 
   const { isSaving, savedData } = useSelector(selectGlobalParamState);
 
-  const onSubmit = (formData: SyntheticsParams) => {
-    const { namespaces, ...paramRequest } = formData;
+  const onSubmit = (formData: ParamFormData) => {
+    const { namespaces, sourceType, source, value, key, description, tags } = formData;
     const shareAcrossSpaces = namespaces?.includes(ALL_SPACES_ID);
-    const newParamData = {
-      ...paramRequest,
-    };
+    const isVault = sourceType === 'vault';
 
-    if (isEditingItem && id) {
-      // omit value if it's empty
-      if (isEmpty(newParamData.value)) {
-        // @ts-ignore this is a valid check
-        delete newParamData.value;
-      }
+    const paramRequest: SyntheticsParamRequest = { key, description, tags };
+    if (isVault) {
+      paramRequest.source = {
+        type: 'vault',
+        path: (source?.path ?? '').trim(),
+        field: (source?.field ?? '').trim(),
+      };
+    } else if (!(isEditingItem && id && isEmpty(value))) {
+      // include the literal value unless editing and left blank (keep current)
+      paramRequest.value = value;
     }
 
     if (isEditingItem && id) {
-      dispatch(
-        editGlobalParamAction.get({
-          id,
-          paramRequest,
-        })
-      );
+      dispatch(editGlobalParamAction.get({ id, paramRequest }));
     } else {
       dispatch(
         addNewGlobalParamAction.get({
-          ...newParamData,
+          ...paramRequest,
           share_across_spaces: shareAcrossSpaces,
         })
       );
@@ -119,9 +131,8 @@ export const AddParamFlyout = ({
 
   useEffect(() => {
     if (isEditingItem) {
-      const { id: _id, ...dataToEdit } = isEditingItem;
       setIsFlyoutVisible(true);
-      form.reset(dataToEdit);
+      form.reset(toFormData(isEditingItem));
     }
     // no need to add form value, it keeps changing on reset
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/add_param_form.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/add_param_form.tsx
@@ -6,13 +6,31 @@
  */
 import React from 'react';
 import { ALL_SPACES_ID } from '@kbn/security-plugin/public';
-import { EuiCheckbox, EuiComboBox, EuiFieldText, EuiForm, EuiFormRow } from '@elastic/eui';
+import {
+  EuiButtonGroup,
+  EuiCheckbox,
+  EuiComboBox,
+  EuiFieldText,
+  EuiForm,
+  EuiFormRow,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Controller, useFormContext, useFormState } from 'react-hook-form';
+import { Controller, useFormContext, useFormState, useWatch } from 'react-hook-form';
 import { OptionalText } from '../components/optional_text';
 import { ParamValueField } from './param_value_field';
-import type { SyntheticsParams } from '../../../../../../common/runtime_types';
+import type {
+  SyntheticsParams,
+  SyntheticsParamVaultSource,
+} from '../../../../../../common/runtime_types';
 import type { ListParamItem } from './params_list';
+
+export type ParamValueSourceType = 'value' | 'vault';
+
+export interface ParamFormData extends Omit<SyntheticsParams, 'id' | 'value' | 'source'> {
+  value?: string;
+  sourceType?: ParamValueSourceType;
+  source?: Partial<SyntheticsParamVaultSource>;
+}
 
 export const AddParamForm = ({
   items,
@@ -21,8 +39,9 @@ export const AddParamForm = ({
   items: ListParamItem[];
   isEditingItem: ListParamItem | null;
 }) => {
-  const { register, control } = useFormContext<SyntheticsParams>();
-  const { errors } = useFormState<SyntheticsParams>();
+  const { register, control } = useFormContext<ParamFormData>();
+  const { errors } = useFormState<ParamFormData>();
+  const sourceType = (useWatch({ control, name: 'sourceType' }) ?? 'value') as ParamValueSourceType;
 
   const tagsList = items.reduce((acc, item) => {
     const tags = item.tags || [];
@@ -57,7 +76,35 @@ export const AddParamForm = ({
           })}
         />
       </EuiFormRow>
-      <ParamValueField isEditingItem={isEditingItem} />
+      <EuiFormRow fullWidth label={VALUE_SOURCE_LABEL}>
+        <Controller
+          control={control}
+          name="sourceType"
+          render={({ field }) => (
+            <EuiButtonGroup
+              legend={VALUE_SOURCE_LABEL}
+              buttonSize="compressed"
+              isFullWidth
+              options={[
+                {
+                  id: 'value',
+                  label: LITERAL_VALUE_LABEL,
+                  'data-test-subj': 'syntheticsParamSourceLiteral',
+                },
+                {
+                  id: 'vault',
+                  label: VAULT_SOURCE_OPTION_LABEL,
+                  iconType: 'lock',
+                  'data-test-subj': 'syntheticsParamSourceVault',
+                },
+              ]}
+              idSelected={sourceType}
+              onChange={(id) => field.onChange(id)}
+            />
+          )}
+        />
+      </EuiFormRow>
+      <ParamValueField isEditingItem={isEditingItem} sourceType={sourceType} />
       <EuiFormRow fullWidth label={TAGS_LABEL} labelAppend={<OptionalText />}>
         <Controller
           control={control}
@@ -154,3 +201,24 @@ const KEY_EXISTS = i18n.translate('xpack.synthetics.monitorManagement.param.keyE
 export const VALUE_REQUIRED = i18n.translate('xpack.synthetics.monitorManagement.value.required', {
   defaultMessage: 'Value is required',
 });
+
+export const VALUE_SOURCE_LABEL = i18n.translate(
+  'xpack.synthetics.monitorManagement.paramForm.valueSourceLabel',
+  {
+    defaultMessage: 'Value source',
+  }
+);
+
+export const LITERAL_VALUE_LABEL = i18n.translate(
+  'xpack.synthetics.monitorManagement.paramForm.literalValueLabel',
+  {
+    defaultMessage: 'Literal value',
+  }
+);
+
+export const VAULT_SOURCE_OPTION_LABEL = i18n.translate(
+  'xpack.synthetics.monitorManagement.paramForm.vaultSourceLabel',
+  {
+    defaultMessage: 'HashiCorp Vault',
+  }
+);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/param_value_field.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/param_value_field.tsx
@@ -113,7 +113,6 @@ const VaultSourceFields = () => {
         <EuiSelect
           fullWidth
           data-test-subj="syntheticsParamVaultConnection"
-          hasNoInitialSelection={connections.length > 1}
           options={[
             { value: '', text: VAULT_DEFAULT_CONNECTION },
             ...connections.map((n) => ({ value: n, text: n })),
@@ -164,7 +163,7 @@ const VaultSourceFields = () => {
         iconType="lock"
         title={i18n.translate('xpack.synthetics.paramValueField.vaultCallout', {
           defaultMessage:
-            'The secret is resolved at runtime by the agent (Heartbeat) from HashiCorp Vault. Kibana stores only this reference and never the plaintext secret.',
+            'The secret is resolved at runtime by the agent (Heartbeat) from HashiCorp Vault, so it only applies to monitors on private locations. Kibana stores only this reference and never the plaintext secret.',
         })}
       >
         <EuiCode>{'${vault/<connection>@<path>#<field>}'}</EuiCode>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/param_value_field.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/param_value_field.tsx
@@ -5,18 +5,35 @@
  * 2.0.
  */
 
-import { EuiCallOut, EuiFormRow, EuiSpacer, EuiTextArea } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiCode,
+  EuiFieldText,
+  EuiFormRow,
+  EuiSpacer,
+  EuiTextArea,
+} from '@elastic/eui';
 import React from 'react';
 import { useFormContext, useFormState } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import { OptionalText } from '../components/optional_text';
 import type { ListParamItem } from './params_list';
-import type { SyntheticsParams } from '../../../../../../common/runtime_types';
+import type { ParamFormData, ParamValueSourceType } from './add_param_form';
 import { VALUE_LABEL, VALUE_REQUIRED } from './add_param_form';
 
-export const ParamValueField = ({ isEditingItem }: { isEditingItem: ListParamItem | null }) => {
-  const { register } = useFormContext<SyntheticsParams>();
-  const { errors } = useFormState<SyntheticsParams>();
+export const ParamValueField = ({
+  isEditingItem,
+  sourceType,
+}: {
+  isEditingItem: ListParamItem | null;
+  sourceType: ParamValueSourceType;
+}) => {
+  const { register } = useFormContext<ParamFormData>();
+  const { errors } = useFormState<ParamFormData>();
+
+  if (sourceType === 'vault') {
+    return <VaultSourceFields />;
+  }
 
   if (isEditingItem) {
     return (
@@ -73,9 +90,91 @@ export const ParamValueField = ({ isEditingItem }: { isEditingItem: ListParamIte
   );
 };
 
+const VaultSourceFields = () => {
+  const { register } = useFormContext<ParamFormData>();
+  const { errors } = useFormState<ParamFormData>();
+
+  return (
+    <>
+      <EuiFormRow
+        fullWidth
+        label={VAULT_PATH_LABEL}
+        helpText={VAULT_PATH_HELP}
+        isInvalid={Boolean(errors?.source?.path)}
+        error={errors?.source?.path?.message}
+      >
+        <EuiFieldText
+          isInvalid={Boolean(errors?.source?.path)}
+          data-test-subj="syntheticsParamVaultPath"
+          fullWidth
+          placeholder="myapp/creds"
+          aria-label={VAULT_PATH_LABEL}
+          {...register('source.path', {
+            required: { value: true, message: VAULT_PATH_REQUIRED },
+          })}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        fullWidth
+        label={VAULT_FIELD_LABEL}
+        helpText={VAULT_FIELD_HELP}
+        isInvalid={Boolean(errors?.source?.field)}
+        error={errors?.source?.field?.message}
+      >
+        <EuiFieldText
+          isInvalid={Boolean(errors?.source?.field)}
+          data-test-subj="syntheticsParamVaultField"
+          fullWidth
+          placeholder="password"
+          aria-label={VAULT_FIELD_LABEL}
+          {...register('source.field', {
+            required: { value: true, message: VAULT_FIELD_REQUIRED },
+          })}
+        />
+      </EuiFormRow>
+      <EuiSpacer size="xs" />
+      <EuiCallOut
+        announceOnMount
+        size="s"
+        iconType="lock"
+        title={i18n.translate('xpack.synthetics.paramValueField.vaultCallout', {
+          defaultMessage:
+            'The secret is resolved at runtime by the agent (Heartbeat) from HashiCorp Vault. Kibana stores only this reference and never the plaintext secret.',
+        })}
+      >
+        <EuiCode>{'${vault/<path>#<field>}'}</EuiCode>
+      </EuiCallOut>
+    </>
+  );
+};
+
 export const NEW_VALUE_LABEL = i18n.translate(
   'xpack.synthetics.monitorManagement.paramForm.newValue',
   {
     defaultMessage: 'New value',
   }
 );
+
+const VAULT_PATH_LABEL = i18n.translate('xpack.synthetics.paramForm.vaultPathLabel', {
+  defaultMessage: 'Vault secret path',
+});
+
+const VAULT_PATH_HELP = i18n.translate('xpack.synthetics.paramForm.vaultPathHelp', {
+  defaultMessage: 'KV v2 secret path, e.g. myapp/creds',
+});
+
+const VAULT_FIELD_LABEL = i18n.translate('xpack.synthetics.paramForm.vaultFieldLabel', {
+  defaultMessage: 'Vault secret field',
+});
+
+const VAULT_FIELD_HELP = i18n.translate('xpack.synthetics.paramForm.vaultFieldHelp', {
+  defaultMessage: 'Key within the secret, e.g. password',
+});
+
+const VAULT_PATH_REQUIRED = i18n.translate('xpack.synthetics.paramForm.vaultPathRequired', {
+  defaultMessage: 'Vault secret path is required',
+});
+
+const VAULT_FIELD_REQUIRED = i18n.translate('xpack.synthetics.paramForm.vaultFieldRequired', {
+  defaultMessage: 'Vault secret field is required',
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/param_value_field.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/param_value_field.tsx
@@ -167,7 +167,7 @@ const VaultSourceFields = () => {
             'The secret is resolved at runtime by the agent (Heartbeat) from HashiCorp Vault. Kibana stores only this reference and never the plaintext secret.',
         })}
       >
-        <EuiCode>{'${vault/<path>#<field>}'}</EuiCode>
+        <EuiCode>{'${vault/<connection>@<path>#<field>}'}</EuiCode>
       </EuiCallOut>
     </>
   );

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/param_value_field.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/param_value_field.tsx
@@ -10,16 +10,20 @@ import {
   EuiCode,
   EuiFieldText,
   EuiFormRow,
+  EuiSelect,
   EuiSpacer,
   EuiTextArea,
 } from '@elastic/eui';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useFormContext, useFormState } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { OptionalText } from '../components/optional_text';
 import type { ListParamItem } from './params_list';
 import type { ParamFormData, ParamValueSourceType } from './add_param_form';
 import { VALUE_LABEL, VALUE_REQUIRED } from './add_param_form';
+import type { VaultConnectionStatus } from '../../../../../../common/runtime_types';
+import { SYNTHETICS_API_URLS } from '../../../../../../common/constants';
 
 export const ParamValueField = ({
   isEditingItem,
@@ -93,9 +97,30 @@ export const ParamValueField = ({
 const VaultSourceFields = () => {
   const { register } = useFormContext<ParamFormData>();
   const { errors } = useFormState<ParamFormData>();
+  const { http } = useKibana().services;
+  const [connections, setConnections] = useState<string[]>([]);
+
+  useEffect(() => {
+    http
+      ?.get<VaultConnectionStatus[]>(SYNTHETICS_API_URLS.VAULT_CONNECTION)
+      .then((res) => setConnections((Array.isArray(res) ? res : []).map((c) => c.name ?? '')))
+      .catch(() => {});
+  }, [http]);
 
   return (
     <>
+      <EuiFormRow fullWidth label={VAULT_CONNECTION_LABEL} helpText={VAULT_CONNECTION_HELP}>
+        <EuiSelect
+          fullWidth
+          data-test-subj="syntheticsParamVaultConnection"
+          hasNoInitialSelection={connections.length > 1}
+          options={[
+            { value: '', text: VAULT_DEFAULT_CONNECTION },
+            ...connections.map((n) => ({ value: n, text: n })),
+          ]}
+          {...register('source.connection')}
+        />
+      </EuiFormRow>
       <EuiFormRow
         fullWidth
         label={VAULT_PATH_LABEL}
@@ -155,6 +180,18 @@ export const NEW_VALUE_LABEL = i18n.translate(
   }
 );
 
+const VAULT_CONNECTION_LABEL = i18n.translate('xpack.synthetics.paramForm.vaultConnectionLabel', {
+  defaultMessage: 'Vault connection',
+});
+const VAULT_CONNECTION_HELP = i18n.translate('xpack.synthetics.paramForm.vaultConnectionHelp', {
+  defaultMessage: 'Which configured Vault connection to resolve this secret from.',
+});
+const VAULT_DEFAULT_CONNECTION = i18n.translate(
+  'xpack.synthetics.paramForm.vaultDefaultConnection',
+  {
+    defaultMessage: 'Default connection',
+  }
+);
 const VAULT_PATH_LABEL = i18n.translate('xpack.synthetics.paramForm.vaultPathLabel', {
   defaultMessage: 'Vault secret path',
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/params_list.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/params_list.tsx
@@ -28,6 +28,7 @@ import type { SyntheticsParams } from '../../../../../../common/runtime_types';
 import { useParamsList } from '../hooks/use_params_list';
 import { AddParamFlyout } from './add_param_flyout';
 import { DeleteParam } from './delete_param';
+import { VaultConnectionPanel } from './vault_connection_panel';
 
 export interface ListParamItem extends SyntheticsParams {
   id: string;
@@ -249,6 +250,8 @@ export const ParamsList = () => {
         />
       </EuiText>
       <EuiSpacer size="m" />
+      <VaultConnectionPanel />
+      <EuiSpacer size="l" />
       <EuiInMemoryTable<ListParamItem>
         data-test-subj={
           isLoading ? 'syntheticsParamsTable-loading' : 'syntheticsParamsTable-loaded'

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/params_list.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/params_list.tsx
@@ -64,7 +64,14 @@ export const ParamsList = () => {
       name: i18n.translate('xpack.synthetics.settingsRoute.params.value', {
         defaultMessage: 'Value',
       }),
-      render: (item: ListParamItem) => <ParamsText text={item.value ?? ''} />,
+      render: (item: ListParamItem) =>
+        item.source?.type === 'vault' ? (
+          <EuiBadge color="hollow" iconType="lock" data-test-subj="syntheticsParamVaultBadge">
+            {`vault: ${item.source.path}#${item.source.field}`}
+          </EuiBadge>
+        ) : (
+          <ParamsText text={item.value ?? ''} />
+        ),
     },
     {
       name: i18n.translate('xpack.synthetics.settingsRoute.params.description', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/params_list.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/params_list.tsx
@@ -68,7 +68,9 @@ export const ParamsList = () => {
       render: (item: ListParamItem) =>
         item.source?.type === 'vault' ? (
           <EuiBadge color="hollow" iconType="lock" data-test-subj="syntheticsParamVaultBadge">
-            {`vault: ${item.source.path}#${item.source.field}`}
+            {`vault: ${item.source.connection ? `${item.source.connection}@` : ''}${
+              item.source.path
+            }#${item.source.field}`}
           </EuiBadge>
         ) : (
           <ParamsText text={item.value ?? ''} />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
@@ -1,0 +1,330 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  EuiAccordion,
+  EuiBadge,
+  EuiButton,
+  EuiFieldPassword,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiForm,
+  EuiFormRow,
+  EuiPanel,
+  EuiSelect,
+  EuiSpacer,
+  EuiSwitch,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { ClientPluginsStart } from '../../../../../plugin';
+import type {
+  VaultAuthMethod,
+  VaultConnectionStatus,
+} from '../../../../../../common/runtime_types';
+import { SYNTHETICS_API_URLS } from '../../../../../../common/constants';
+
+interface FormState {
+  address: string;
+  authMethod: VaultAuthMethod;
+  namespace: string;
+  kvMount: string;
+  roleId: string;
+  token: string;
+  secretId: string;
+  tlsSkipVerify: boolean;
+}
+
+const emptyForm: FormState = {
+  address: '',
+  authMethod: 'approle',
+  namespace: '',
+  kvMount: 'secret',
+  roleId: '',
+  token: '',
+  secretId: '',
+  tlsSkipVerify: false,
+};
+
+export const VaultConnectionPanel = () => {
+  const { http, notifications, application } = useKibana<ClientPluginsStart>().services;
+  const canSave = (application?.capabilities.uptime.save ?? false) as boolean;
+
+  const [status, setStatus] = useState<VaultConnectionStatus | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [saving, setSaving] = useState(false);
+
+  const accordionId = useGeneratedHtmlId({ prefix: 'vaultConnection' });
+
+  const load = useCallback(async () => {
+    try {
+      const res = await http.get<VaultConnectionStatus>(SYNTHETICS_API_URLS.VAULT_CONNECTION);
+      setStatus(res);
+      if (res.configured) {
+        setForm((f) => ({
+          ...f,
+          address: res.address ?? '',
+          authMethod: res.authMethod ?? 'approle',
+          namespace: res.namespace ?? '',
+          kvMount: res.kvMount ?? 'secret',
+          roleId: res.roleId ?? '',
+          tlsSkipVerify: res.tlsSkipVerify ?? false,
+          token: '',
+          secretId: '',
+        }));
+      }
+    } catch (e) {
+      // non-fatal for the params page
+    }
+  }, [http]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((f) => ({ ...f, [key]: value }));
+
+  const onSave = async () => {
+    setSaving(true);
+    try {
+      const body: Record<string, unknown> = {
+        address: form.address.trim(),
+        authMethod: form.authMethod,
+        namespace: form.namespace.trim() || undefined,
+        kvMount: form.kvMount.trim() || undefined,
+        tlsSkipVerify: form.tlsSkipVerify,
+      };
+      if (form.authMethod === 'token') {
+        if (form.token) body.token = form.token;
+      } else {
+        body.roleId = form.roleId.trim();
+        if (form.secretId) body.secretId = form.secretId;
+      }
+      const res = await http.put<VaultConnectionStatus>(SYNTHETICS_API_URLS.VAULT_CONNECTION, {
+        body: JSON.stringify(body),
+      });
+      setStatus(res);
+      setForm((f) => ({ ...f, token: '', secretId: '' }));
+      notifications?.toasts.addSuccess(SAVED_TOAST);
+    } catch (e) {
+      notifications?.toasts.addError(e as Error, { title: SAVE_ERROR_TOAST });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const statusBadge = status?.configured ? (
+    <EuiBadge color="success" iconType="check">
+      {i18n.translate('xpack.synthetics.vaultConnection.connectedBadge', {
+        defaultMessage: 'Connected: {address}',
+        values: { address: status.address ?? '' },
+      })}
+    </EuiBadge>
+  ) : (
+    <EuiBadge color="hollow">
+      {i18n.translate('xpack.synthetics.vaultConnection.notConnectedBadge', {
+        defaultMessage: 'Not connected',
+      })}
+    </EuiBadge>
+  );
+
+  return (
+    <EuiPanel hasBorder paddingSize="m">
+      <EuiAccordion
+        id={accordionId}
+        initialIsOpen={!status?.configured}
+        buttonContent={
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                <strong>{TITLE}</strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>{statusBadge}</EuiFlexItem>
+          </EuiFlexGroup>
+        }
+      >
+        <EuiSpacer size="s" />
+        <EuiText size="s" color="subdued">
+          <FormattedMessage
+            id="xpack.synthetics.vaultConnection.description"
+            defaultMessage="Connect a HashiCorp Vault account. The connection is stored encrypted and propagated to your private-location agents (Heartbeat), which resolve vault-backed parameters at runtime. The secret values never leave Vault's trust boundary."
+          />
+        </EuiText>
+        <EuiSpacer size="m" />
+        <EuiForm component="form">
+          <EuiFormRow fullWidth label={ADDRESS_LABEL} helpText={ADDRESS_HELP}>
+            <EuiFieldText
+              fullWidth
+              data-test-subj="syntheticsVaultAddress"
+              placeholder="https://vault.internal:8200"
+              value={form.address}
+              onChange={(e) => set('address', e.target.value)}
+            />
+          </EuiFormRow>
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiFormRow fullWidth label={AUTH_METHOD_LABEL}>
+                <EuiSelect
+                  fullWidth
+                  data-test-subj="syntheticsVaultAuthMethod"
+                  value={form.authMethod}
+                  options={[
+                    { value: 'approle', text: 'AppRole' },
+                    { value: 'token', text: 'Token' },
+                  ]}
+                  onChange={(e) => set('authMethod', e.target.value as VaultAuthMethod)}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow fullWidth label={KV_MOUNT_LABEL} helpText={KV_MOUNT_HELP}>
+                <EuiFieldText
+                  fullWidth
+                  data-test-subj="syntheticsVaultKvMount"
+                  value={form.kvMount}
+                  onChange={(e) => set('kvMount', e.target.value)}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+
+          {form.authMethod === 'token' ? (
+            <EuiFormRow
+              fullWidth
+              label={TOKEN_LABEL}
+              helpText={status?.hasSecret ? SECRET_SAVED_HELP : undefined}
+            >
+              <EuiFieldPassword
+                fullWidth
+                type="dual"
+                data-test-subj="syntheticsVaultToken"
+                placeholder={status?.hasSecret ? '••••••••' : ''}
+                value={form.token}
+                onChange={(e) => set('token', e.target.value)}
+              />
+            </EuiFormRow>
+          ) : (
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiFormRow fullWidth label={ROLE_ID_LABEL}>
+                  <EuiFieldText
+                    fullWidth
+                    data-test-subj="syntheticsVaultRoleId"
+                    value={form.roleId}
+                    onChange={(e) => set('roleId', e.target.value)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFormRow
+                  fullWidth
+                  label={SECRET_ID_LABEL}
+                  helpText={status?.hasSecret ? SECRET_SAVED_HELP : undefined}
+                >
+                  <EuiFieldPassword
+                    fullWidth
+                    type="dual"
+                    data-test-subj="syntheticsVaultSecretId"
+                    placeholder={status?.hasSecret ? '••••••••' : ''}
+                    value={form.secretId}
+                    onChange={(e) => set('secretId', e.target.value)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+
+          <EuiFormRow fullWidth label={NAMESPACE_LABEL} helpText={NAMESPACE_HELP}>
+            <EuiFieldText
+              fullWidth
+              data-test-subj="syntheticsVaultNamespace"
+              value={form.namespace}
+              onChange={(e) => set('namespace', e.target.value)}
+            />
+          </EuiFormRow>
+          <EuiFormRow fullWidth>
+            <EuiSwitch
+              label={TLS_SKIP_LABEL}
+              data-test-subj="syntheticsVaultTlsSkip"
+              checked={form.tlsSkipVerify}
+              onChange={(e) => set('tlsSkipVerify', e.target.checked)}
+            />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiButton
+            fill
+            data-test-subj="syntheticsVaultSaveConnection"
+            isLoading={saving}
+            isDisabled={!canSave || !form.address}
+            onClick={onSave}
+          >
+            {status?.configured ? UPDATE_BUTTON : CONNECT_BUTTON}
+          </EuiButton>
+        </EuiForm>
+      </EuiAccordion>
+    </EuiPanel>
+  );
+};
+
+const TITLE = i18n.translate('xpack.synthetics.vaultConnection.title', {
+  defaultMessage: 'HashiCorp Vault connection',
+});
+const ADDRESS_LABEL = i18n.translate('xpack.synthetics.vaultConnection.address', {
+  defaultMessage: 'Vault address',
+});
+const ADDRESS_HELP = i18n.translate('xpack.synthetics.vaultConnection.addressHelp', {
+  defaultMessage: 'Base URL of your Vault server.',
+});
+const AUTH_METHOD_LABEL = i18n.translate('xpack.synthetics.vaultConnection.authMethod', {
+  defaultMessage: 'Authentication method',
+});
+const KV_MOUNT_LABEL = i18n.translate('xpack.synthetics.vaultConnection.kvMount', {
+  defaultMessage: 'KV v2 mount',
+});
+const KV_MOUNT_HELP = i18n.translate('xpack.synthetics.vaultConnection.kvMountHelp', {
+  defaultMessage: 'Secrets engine mount path (default "secret").',
+});
+const TOKEN_LABEL = i18n.translate('xpack.synthetics.vaultConnection.token', {
+  defaultMessage: 'Token',
+});
+const ROLE_ID_LABEL = i18n.translate('xpack.synthetics.vaultConnection.roleId', {
+  defaultMessage: 'Role ID',
+});
+const SECRET_ID_LABEL = i18n.translate('xpack.synthetics.vaultConnection.secretId', {
+  defaultMessage: 'Secret ID',
+});
+const NAMESPACE_LABEL = i18n.translate('xpack.synthetics.vaultConnection.namespace', {
+  defaultMessage: 'Vault namespace',
+});
+const NAMESPACE_HELP = i18n.translate('xpack.synthetics.vaultConnection.namespaceHelp', {
+  defaultMessage: 'Optional. Vault Enterprise namespace.',
+});
+const TLS_SKIP_LABEL = i18n.translate('xpack.synthetics.vaultConnection.tlsSkip', {
+  defaultMessage: 'Skip TLS verification (dev only)',
+});
+const SECRET_SAVED_HELP = i18n.translate('xpack.synthetics.vaultConnection.secretSaved', {
+  defaultMessage: 'A secret is already stored. Leave blank to keep it.',
+});
+const CONNECT_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.connect', {
+  defaultMessage: 'Connect',
+});
+const UPDATE_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.update', {
+  defaultMessage: 'Update connection',
+});
+const SAVED_TOAST = i18n.translate('xpack.synthetics.vaultConnection.savedToast', {
+  defaultMessage: 'Vault connection saved',
+});
+const SAVE_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.saveErrorToast', {
+  defaultMessage: 'Failed to save Vault connection',
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
@@ -38,6 +38,7 @@ interface FormState {
   authMethod: VaultAuthMethod;
   namespace: string;
   kvMount: string;
+  secretRefreshInterval: string;
   roleId: string;
   token: string;
   secretId: string;
@@ -49,6 +50,7 @@ const emptyForm: FormState = {
   authMethod: 'approle',
   namespace: '',
   kvMount: 'secret',
+  secretRefreshInterval: '5m',
   roleId: '',
   token: '',
   secretId: '',
@@ -62,6 +64,7 @@ export const VaultConnectionPanel = () => {
   const [status, setStatus] = useState<VaultConnectionStatus | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   const accordionId = useGeneratedHtmlId({ prefix: 'vaultConnection' });
 
@@ -76,6 +79,7 @@ export const VaultConnectionPanel = () => {
           authMethod: res.authMethod ?? 'approle',
           namespace: res.namespace ?? '',
           kvMount: res.kvMount ?? 'secret',
+          secretRefreshInterval: res.secretRefreshInterval ?? '5m',
           roleId: res.roleId ?? '',
           tlsSkipVerify: res.tlsSkipVerify ?? false,
           token: '',
@@ -102,6 +106,7 @@ export const VaultConnectionPanel = () => {
         authMethod: form.authMethod,
         namespace: form.namespace.trim() || undefined,
         kvMount: form.kvMount.trim() || undefined,
+        secretRefreshInterval: form.secretRefreshInterval.trim() || undefined,
         tlsSkipVerify: form.tlsSkipVerify,
       };
       if (form.authMethod === 'token') {
@@ -120,6 +125,23 @@ export const VaultConnectionPanel = () => {
       notifications?.toasts.addError(e as Error, { title: SAVE_ERROR_TOAST });
     } finally {
       setSaving(false);
+    }
+  };
+
+  // Manual refresh: bump the connection version + re-push configs so agents
+  // re-resolve every vault-backed secret (picks up rotations).
+  const onRefresh = async () => {
+    setRefreshing(true);
+    try {
+      const res = await http.post<VaultConnectionStatus>(
+        SYNTHETICS_API_URLS.VAULT_CONNECTION + '/_refresh'
+      );
+      setStatus(res);
+      notifications?.toasts.addSuccess(REFRESHED_TOAST);
+    } catch (e) {
+      notifications?.toasts.addError(e as Error, { title: REFRESH_ERROR_TOAST });
+    } finally {
+      setRefreshing(false);
     }
   };
 
@@ -197,6 +219,17 @@ export const VaultConnectionPanel = () => {
                 />
               </EuiFormRow>
             </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow fullWidth label={REFRESH_INTERVAL_LABEL} helpText={REFRESH_INTERVAL_HELP}>
+                <EuiFieldText
+                  fullWidth
+                  data-test-subj="syntheticsVaultRefreshInterval"
+                  placeholder="5m"
+                  value={form.secretRefreshInterval}
+                  onChange={(e) => set('secretRefreshInterval', e.target.value)}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
           </EuiFlexGroup>
 
           {form.authMethod === 'token' ? (
@@ -262,15 +295,42 @@ export const VaultConnectionPanel = () => {
             />
           </EuiFormRow>
           <EuiSpacer size="m" />
-          <EuiButton
-            fill
-            data-test-subj="syntheticsVaultSaveConnection"
-            isLoading={saving}
-            isDisabled={!canSave || !form.address}
-            onClick={onSave}
-          >
-            {status?.configured ? UPDATE_BUTTON : CONNECT_BUTTON}
-          </EuiButton>
+          <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                data-test-subj="syntheticsVaultSaveConnection"
+                isLoading={saving}
+                isDisabled={!canSave || !form.address}
+                onClick={onSave}
+              >
+                {status?.configured ? UPDATE_BUTTON : CONNECT_BUTTON}
+              </EuiButton>
+            </EuiFlexItem>
+            {status?.configured && (
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  iconType="refresh"
+                  data-test-subj="syntheticsVaultRefreshSecrets"
+                  isLoading={refreshing}
+                  isDisabled={!canSave}
+                  onClick={onRefresh}
+                >
+                  {REFRESH_BUTTON}
+                </EuiButton>
+              </EuiFlexItem>
+            )}
+            {status?.refreshedAt && (
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs" color="subdued">
+                  {i18n.translate('xpack.synthetics.vaultConnection.lastRefreshed', {
+                    defaultMessage: 'Last refreshed: {ts}',
+                    values: { ts: new Date(status.refreshedAt).toLocaleString() },
+                  })}
+                </EuiText>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
         </EuiForm>
       </EuiAccordion>
     </EuiPanel>
@@ -321,6 +381,24 @@ const CONNECT_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.connect'
 });
 const UPDATE_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.update', {
   defaultMessage: 'Update connection',
+});
+const REFRESH_INTERVAL_LABEL = i18n.translate('xpack.synthetics.vaultConnection.refreshInterval', {
+  defaultMessage: 'Secret refresh interval',
+});
+const REFRESH_INTERVAL_HELP = i18n.translate(
+  'xpack.synthetics.vaultConnection.refreshIntervalHelp',
+  {
+    defaultMessage: 'How long the agent caches a resolved secret, e.g. "5m", "1h".',
+  }
+);
+const REFRESH_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.refreshButton', {
+  defaultMessage: 'Refresh secrets',
+});
+const REFRESHED_TOAST = i18n.translate('xpack.synthetics.vaultConnection.refreshedToast', {
+  defaultMessage: 'Refreshing secrets — configs are being re-pushed to agents',
+});
+const REFRESH_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.refreshErrorToast', {
+  defaultMessage: 'Failed to refresh Vault secrets',
 });
 const SAVED_TOAST = i18n.translate('xpack.synthetics.vaultConnection.savedToast', {
   defaultMessage: 'Vault connection saved',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
@@ -9,7 +9,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   EuiAccordion,
   EuiBadge,
+  EuiBasicTable,
   EuiButton,
+  EuiButtonEmpty,
   EuiFieldPassword,
   EuiFieldText,
   EuiFlexGroup,
@@ -25,7 +27,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { FormattedMessage } from '@kbn/i18n-react';
+import type { EuiBasicTableColumn } from '@elastic/eui';
 import type { ClientPluginsStart } from '../../../../../plugin';
 import type {
   VaultAuthMethod,
@@ -34,6 +36,7 @@ import type {
 import { SYNTHETICS_API_URLS } from '../../../../../../common/constants';
 
 interface FormState {
+  name: string;
   address: string;
   authMethod: VaultAuthMethod;
   namespace: string;
@@ -43,9 +46,12 @@ interface FormState {
   token: string;
   secretId: string;
   tlsSkipVerify: boolean;
+  isNew: boolean;
+  hasSecret: boolean;
 }
 
-const emptyForm: FormState = {
+const blankForm = (): FormState => ({
+  name: '',
   address: '',
   authMethod: 'approle',
   namespace: '',
@@ -55,37 +61,40 @@ const emptyForm: FormState = {
   token: '',
   secretId: '',
   tlsSkipVerify: false,
-};
+  isNew: true,
+  hasSecret: false,
+});
+
+const toForm = (c: VaultConnectionStatus): FormState => ({
+  name: c.name ?? '',
+  address: c.address ?? '',
+  authMethod: c.authMethod ?? 'approle',
+  namespace: c.namespace ?? '',
+  kvMount: c.kvMount ?? 'secret',
+  secretRefreshInterval: c.secretRefreshInterval ?? '5m',
+  roleId: c.roleId ?? '',
+  token: '',
+  secretId: '',
+  tlsSkipVerify: c.tlsSkipVerify ?? false,
+  isNew: false,
+  hasSecret: c.hasSecret ?? false,
+});
 
 export const VaultConnectionPanel = () => {
   const { http, notifications, application } = useKibana<ClientPluginsStart>().services;
   const canSave = (application?.capabilities.uptime.save ?? false) as boolean;
 
-  const [status, setStatus] = useState<VaultConnectionStatus | null>(null);
-  const [form, setForm] = useState<FormState>(emptyForm);
+  const [connections, setConnections] = useState<VaultConnectionStatus[]>([]);
+  const [editing, setEditing] = useState<FormState | null>(null);
   const [saving, setSaving] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
-  const accordionId = useGeneratedHtmlId({ prefix: 'vaultConnection' });
+  const accordionId = useGeneratedHtmlId({ prefix: 'vaultConnections' });
 
   const load = useCallback(async () => {
     try {
-      const res = await http.get<VaultConnectionStatus>(SYNTHETICS_API_URLS.VAULT_CONNECTION);
-      setStatus(res);
-      if (res.configured) {
-        setForm((f) => ({
-          ...f,
-          address: res.address ?? '',
-          authMethod: res.authMethod ?? 'approle',
-          namespace: res.namespace ?? '',
-          kvMount: res.kvMount ?? 'secret',
-          secretRefreshInterval: res.secretRefreshInterval ?? '5m',
-          roleId: res.roleId ?? '',
-          tlsSkipVerify: res.tlsSkipVerify ?? false,
-          token: '',
-          secretId: '',
-        }));
-      }
+      const res = await http.get<VaultConnectionStatus[]>(SYNTHETICS_API_URLS.VAULT_CONNECTION);
+      setConnections(Array.isArray(res) ? res : []);
     } catch (e) {
       // non-fatal for the params page
     }
@@ -96,31 +105,31 @@ export const VaultConnectionPanel = () => {
   }, [load]);
 
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
-    setForm((f) => ({ ...f, [key]: value }));
+    setEditing((f) => (f ? { ...f, [key]: value } : f));
 
   const onSave = async () => {
+    if (!editing) return;
     setSaving(true);
     try {
       const body: Record<string, unknown> = {
-        address: form.address.trim(),
-        authMethod: form.authMethod,
-        namespace: form.namespace.trim() || undefined,
-        kvMount: form.kvMount.trim() || undefined,
-        secretRefreshInterval: form.secretRefreshInterval.trim() || undefined,
-        tlsSkipVerify: form.tlsSkipVerify,
+        name: editing.name.trim(),
+        address: editing.address.trim(),
+        authMethod: editing.authMethod,
+        namespace: editing.namespace.trim() || undefined,
+        kvMount: editing.kvMount.trim() || undefined,
+        secretRefreshInterval: editing.secretRefreshInterval.trim() || undefined,
+        tlsSkipVerify: editing.tlsSkipVerify,
       };
-      if (form.authMethod === 'token') {
-        if (form.token) body.token = form.token;
+      if (editing.authMethod === 'token') {
+        if (editing.token) body.token = editing.token;
       } else {
-        body.roleId = form.roleId.trim();
-        if (form.secretId) body.secretId = form.secretId;
+        body.roleId = editing.roleId.trim();
+        if (editing.secretId) body.secretId = editing.secretId;
       }
-      const res = await http.put<VaultConnectionStatus>(SYNTHETICS_API_URLS.VAULT_CONNECTION, {
-        body: JSON.stringify(body),
-      });
-      setStatus(res);
-      setForm((f) => ({ ...f, token: '', secretId: '' }));
+      await http.put(SYNTHETICS_API_URLS.VAULT_CONNECTION, { body: JSON.stringify(body) });
       notifications?.toasts.addSuccess(SAVED_TOAST);
+      setEditing(null);
+      await load();
     } catch (e) {
       notifications?.toasts.addError(e as Error, { title: SAVE_ERROR_TOAST });
     } finally {
@@ -128,16 +137,21 @@ export const VaultConnectionPanel = () => {
     }
   };
 
-  // Manual refresh: bump the connection version + re-push configs so agents
-  // re-resolve every vault-backed secret (picks up rotations).
-  const onRefresh = async () => {
+  const onDelete = async (name: string) => {
+    try {
+      await http.delete(`${SYNTHETICS_API_URLS.VAULT_CONNECTION}/${encodeURIComponent(name)}`);
+      await load();
+    } catch (e) {
+      notifications?.toasts.addError(e as Error, { title: DELETE_ERROR_TOAST });
+    }
+  };
+
+  const onRefreshAll = async () => {
     setRefreshing(true);
     try {
-      const res = await http.post<VaultConnectionStatus>(
-        SYNTHETICS_API_URLS.VAULT_CONNECTION + '/_refresh'
-      );
-      setStatus(res);
+      await http.post(`${SYNTHETICS_API_URLS.VAULT_CONNECTION}/_refresh`);
       notifications?.toasts.addSuccess(REFRESHED_TOAST);
+      await load();
     } catch (e) {
       notifications?.toasts.addError(e as Error, { title: REFRESH_ERROR_TOAST });
     } finally {
@@ -145,26 +159,48 @@ export const VaultConnectionPanel = () => {
     }
   };
 
-  const statusBadge = status?.configured ? (
-    <EuiBadge color="success" iconType="check">
-      {i18n.translate('xpack.synthetics.vaultConnection.connectedBadge', {
-        defaultMessage: 'Connected: {address}',
-        values: { address: status.address ?? '' },
-      })}
-    </EuiBadge>
-  ) : (
-    <EuiBadge color="hollow">
-      {i18n.translate('xpack.synthetics.vaultConnection.notConnectedBadge', {
-        defaultMessage: 'Not connected',
-      })}
-    </EuiBadge>
-  );
+  const columns: Array<EuiBasicTableColumn<VaultConnectionStatus>> = [
+    {
+      field: 'name',
+      name: NAME_LABEL,
+      render: (n: string) => <EuiBadge iconType="lock">{n}</EuiBadge>,
+    },
+    { field: 'address', name: ADDRESS_LABEL },
+    { field: 'authMethod', name: AUTH_METHOD_LABEL },
+    {
+      field: 'secretRefreshInterval',
+      name: REFRESH_INTERVAL_LABEL,
+      render: (v?: string) => v ?? '5m',
+    },
+    {
+      name: ACTIONS_LABEL,
+      actions: [
+        {
+          name: EDIT_LABEL,
+          description: EDIT_LABEL,
+          icon: 'pencil',
+          type: 'icon',
+          onClick: (c: VaultConnectionStatus) => setEditing(toForm(c)),
+          enabled: () => canSave,
+        },
+        {
+          name: DELETE_LABEL,
+          description: DELETE_LABEL,
+          icon: 'trash',
+          color: 'danger',
+          type: 'icon',
+          onClick: (c: VaultConnectionStatus) => onDelete(c.name ?? ''),
+          enabled: () => canSave,
+        },
+      ],
+    },
+  ];
 
   return (
     <EuiPanel hasBorder paddingSize="m">
       <EuiAccordion
         id={accordionId}
-        initialIsOpen={!status?.configured}
+        initialIsOpen={connections.length === 0}
         buttonContent={
           <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
             <EuiFlexItem grow={false}>
@@ -172,215 +208,236 @@ export const VaultConnectionPanel = () => {
                 <strong>{TITLE}</strong>
               </EuiText>
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>{statusBadge}</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color={connections.length ? 'success' : 'hollow'}>
+                {i18n.translate('xpack.synthetics.vaultConnection.count', {
+                  defaultMessage: '{n} connected',
+                  values: { n: connections.length },
+                })}
+              </EuiBadge>
+            </EuiFlexItem>
           </EuiFlexGroup>
         }
       >
         <EuiSpacer size="s" />
         <EuiText size="s" color="subdued">
-          <FormattedMessage
-            id="xpack.synthetics.vaultConnection.description"
-            defaultMessage="Connect a HashiCorp Vault account. The connection is stored encrypted and propagated to your private-location agents (Heartbeat), which resolve vault-backed parameters at runtime. The secret values never leave Vault's trust boundary."
-          />
+          {DESCRIPTION}
         </EuiText>
         <EuiSpacer size="m" />
-        <EuiForm component="form">
-          <EuiFormRow fullWidth label={ADDRESS_LABEL} helpText={ADDRESS_HELP}>
-            <EuiFieldText
-              fullWidth
-              data-test-subj="syntheticsVaultAddress"
-              placeholder="https://vault.internal:8200"
-              value={form.address}
-              onChange={(e) => set('address', e.target.value)}
-            />
-          </EuiFormRow>
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiFormRow fullWidth label={AUTH_METHOD_LABEL}>
-                <EuiSelect
-                  fullWidth
-                  data-test-subj="syntheticsVaultAuthMethod"
-                  value={form.authMethod}
-                  options={[
-                    { value: 'approle', text: 'AppRole' },
-                    { value: 'token', text: 'Token' },
-                  ]}
-                  onChange={(e) => set('authMethod', e.target.value as VaultAuthMethod)}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFormRow fullWidth label={KV_MOUNT_LABEL} helpText={KV_MOUNT_HELP}>
-                <EuiFieldText
-                  fullWidth
-                  data-test-subj="syntheticsVaultKvMount"
-                  value={form.kvMount}
-                  onChange={(e) => set('kvMount', e.target.value)}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFormRow fullWidth label={REFRESH_INTERVAL_LABEL} helpText={REFRESH_INTERVAL_HELP}>
-                <EuiFieldText
-                  fullWidth
-                  data-test-subj="syntheticsVaultRefreshInterval"
-                  placeholder="5m"
-                  value={form.secretRefreshInterval}
-                  onChange={(e) => set('secretRefreshInterval', e.target.value)}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-          </EuiFlexGroup>
 
-          {form.authMethod === 'token' ? (
-            <EuiFormRow
-              fullWidth
-              label={TOKEN_LABEL}
-              helpText={status?.hasSecret ? SECRET_SAVED_HELP : undefined}
+        {connections.length > 0 && (
+          <>
+            <EuiBasicTable
+              tableCaption={TITLE}
+              items={connections}
+              columns={columns}
+              itemId="name"
+            />
+            <EuiSpacer size="m" />
+          </>
+        )}
+
+        <EuiFlexGroup gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              iconType="plusInCircle"
+              data-test-subj="syntheticsVaultAddConnection"
+              isDisabled={!canSave || !!editing}
+              onClick={() => setEditing(blankForm())}
             >
-              <EuiFieldPassword
-                fullWidth
-                type="dual"
-                data-test-subj="syntheticsVaultToken"
-                placeholder={status?.hasSecret ? '••••••••' : ''}
-                value={form.token}
-                onChange={(e) => set('token', e.target.value)}
-              />
-            </EuiFormRow>
-          ) : (
-            <EuiFlexGroup>
-              <EuiFlexItem>
-                <EuiFormRow fullWidth label={ROLE_ID_LABEL}>
-                  <EuiFieldText
-                    fullWidth
-                    data-test-subj="syntheticsVaultRoleId"
-                    value={form.roleId}
-                    onChange={(e) => set('roleId', e.target.value)}
-                  />
-                </EuiFormRow>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiFormRow
-                  fullWidth
-                  label={SECRET_ID_LABEL}
-                  helpText={status?.hasSecret ? SECRET_SAVED_HELP : undefined}
-                >
-                  <EuiFieldPassword
-                    fullWidth
-                    type="dual"
-                    data-test-subj="syntheticsVaultSecretId"
-                    placeholder={status?.hasSecret ? '••••••••' : ''}
-                    value={form.secretId}
-                    onChange={(e) => set('secretId', e.target.value)}
-                  />
-                </EuiFormRow>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          )}
-
-          <EuiFormRow fullWidth label={NAMESPACE_LABEL} helpText={NAMESPACE_HELP}>
-            <EuiFieldText
-              fullWidth
-              data-test-subj="syntheticsVaultNamespace"
-              value={form.namespace}
-              onChange={(e) => set('namespace', e.target.value)}
-            />
-          </EuiFormRow>
-          <EuiFormRow fullWidth>
-            <EuiSwitch
-              label={TLS_SKIP_LABEL}
-              data-test-subj="syntheticsVaultTlsSkip"
-              checked={form.tlsSkipVerify}
-              onChange={(e) => set('tlsSkipVerify', e.target.checked)}
-            />
-          </EuiFormRow>
-          <EuiSpacer size="m" />
-          <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+              {ADD_LABEL}
+            </EuiButton>
+          </EuiFlexItem>
+          {connections.length > 0 && (
             <EuiFlexItem grow={false}>
               <EuiButton
-                fill
-                data-test-subj="syntheticsVaultSaveConnection"
-                isLoading={saving}
-                isDisabled={!canSave || !form.address}
-                onClick={onSave}
+                iconType="refresh"
+                data-test-subj="syntheticsVaultRefreshSecrets"
+                isLoading={refreshing}
+                isDisabled={!canSave}
+                onClick={onRefreshAll}
               >
-                {status?.configured ? UPDATE_BUTTON : CONNECT_BUTTON}
+                {REFRESH_BUTTON}
               </EuiButton>
             </EuiFlexItem>
-            {status?.configured && (
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  iconType="refresh"
-                  data-test-subj="syntheticsVaultRefreshSecrets"
-                  isLoading={refreshing}
-                  isDisabled={!canSave}
-                  onClick={onRefresh}
-                >
-                  {REFRESH_BUTTON}
-                </EuiButton>
-              </EuiFlexItem>
-            )}
-            {status?.refreshedAt && (
-              <EuiFlexItem grow={false}>
-                <EuiText size="xs" color="subdued">
-                  {i18n.translate('xpack.synthetics.vaultConnection.lastRefreshed', {
-                    defaultMessage: 'Last refreshed: {ts}',
-                    values: { ts: new Date(status.refreshedAt).toLocaleString() },
-                  })}
-                </EuiText>
-              </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-        </EuiForm>
+          )}
+        </EuiFlexGroup>
+
+        {editing && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiPanel hasBorder paddingSize="m" color="subdued">
+              <EuiForm component="form">
+                <EuiFlexGroup>
+                  <EuiFlexItem>
+                    <EuiFormRow fullWidth label={NAME_LABEL} helpText={NAME_HELP}>
+                      <EuiFieldText
+                        fullWidth
+                        data-test-subj="syntheticsVaultName"
+                        disabled={!editing.isNew}
+                        value={editing.name}
+                        onChange={(e) => set('name', e.target.value)}
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiFormRow fullWidth label={ADDRESS_LABEL}>
+                      <EuiFieldText
+                        fullWidth
+                        data-test-subj="syntheticsVaultAddress"
+                        placeholder="https://vault.internal:8200"
+                        value={editing.address}
+                        onChange={(e) => set('address', e.target.value)}
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+                <EuiFlexGroup>
+                  <EuiFlexItem>
+                    <EuiFormRow fullWidth label={AUTH_METHOD_LABEL}>
+                      <EuiSelect
+                        fullWidth
+                        data-test-subj="syntheticsVaultAuthMethod"
+                        value={editing.authMethod}
+                        options={[
+                          { value: 'approle', text: 'AppRole' },
+                          { value: 'token', text: 'Token' },
+                        ]}
+                        onChange={(e) => set('authMethod', e.target.value as VaultAuthMethod)}
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiFormRow fullWidth label={KV_MOUNT_LABEL}>
+                      <EuiFieldText
+                        fullWidth
+                        data-test-subj="syntheticsVaultKvMount"
+                        value={editing.kvMount}
+                        onChange={(e) => set('kvMount', e.target.value)}
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiFormRow
+                      fullWidth
+                      label={REFRESH_INTERVAL_LABEL}
+                      helpText={REFRESH_INTERVAL_HELP}
+                    >
+                      <EuiFieldText
+                        fullWidth
+                        data-test-subj="syntheticsVaultRefreshInterval"
+                        placeholder="5m"
+                        value={editing.secretRefreshInterval}
+                        onChange={(e) => set('secretRefreshInterval', e.target.value)}
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+                {editing.authMethod === 'token' ? (
+                  <EuiFormRow
+                    fullWidth
+                    label={TOKEN_LABEL}
+                    helpText={editing.hasSecret ? SECRET_SAVED_HELP : undefined}
+                  >
+                    <EuiFieldPassword
+                      fullWidth
+                      type="dual"
+                      data-test-subj="syntheticsVaultToken"
+                      placeholder={editing.hasSecret ? '••••••••' : ''}
+                      value={editing.token}
+                      onChange={(e) => set('token', e.target.value)}
+                    />
+                  </EuiFormRow>
+                ) : (
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                      <EuiFormRow fullWidth label={ROLE_ID_LABEL}>
+                        <EuiFieldText
+                          fullWidth
+                          data-test-subj="syntheticsVaultRoleId"
+                          value={editing.roleId}
+                          onChange={(e) => set('roleId', e.target.value)}
+                        />
+                      </EuiFormRow>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiFormRow
+                        fullWidth
+                        label={SECRET_ID_LABEL}
+                        helpText={editing.hasSecret ? SECRET_SAVED_HELP : undefined}
+                      >
+                        <EuiFieldPassword
+                          fullWidth
+                          type="dual"
+                          data-test-subj="syntheticsVaultSecretId"
+                          placeholder={editing.hasSecret ? '••••••••' : ''}
+                          value={editing.secretId}
+                          onChange={(e) => set('secretId', e.target.value)}
+                        />
+                      </EuiFormRow>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                )}
+                <EuiFormRow fullWidth>
+                  <EuiSwitch
+                    label={TLS_SKIP_LABEL}
+                    data-test-subj="syntheticsVaultTlsSkip"
+                    checked={editing.tlsSkipVerify}
+                    onChange={(e) => set('tlsSkipVerify', e.target.checked)}
+                  />
+                </EuiFormRow>
+                <EuiSpacer size="m" />
+                <EuiFlexGroup gutterSize="s" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      fill
+                      data-test-subj="syntheticsVaultSaveConnection"
+                      isLoading={saving}
+                      isDisabled={!editing.name || !editing.address}
+                      onClick={onSave}
+                    >
+                      {SAVE_LABEL}
+                    </EuiButton>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonEmpty
+                      data-test-subj="syntheticsVaultConnectionPanelButton"
+                      onClick={() => setEditing(null)}
+                    >
+                      {CANCEL_LABEL}
+                    </EuiButtonEmpty>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiForm>
+            </EuiPanel>
+          </>
+        )}
       </EuiAccordion>
     </EuiPanel>
   );
 };
 
 const TITLE = i18n.translate('xpack.synthetics.vaultConnection.title', {
-  defaultMessage: 'HashiCorp Vault connection',
+  defaultMessage: 'HashiCorp Vault connections',
+});
+const DESCRIPTION = i18n.translate('xpack.synthetics.vaultConnection.description', {
+  defaultMessage:
+    "Connect one or more HashiCorp Vault accounts. Connections are stored encrypted and propagated to your private-location agents (Heartbeat), which resolve vault-backed parameters at runtime. Secret values never leave Vault's trust boundary. Reference a connection from a parameter by its name.",
+});
+const NAME_LABEL = i18n.translate('xpack.synthetics.vaultConnection.name', {
+  defaultMessage: 'Name',
+});
+const NAME_HELP = i18n.translate('xpack.synthetics.vaultConnection.nameHelp', {
+  defaultMessage: 'Referenced by params, e.g. "prod". Cannot be changed after creation.',
 });
 const ADDRESS_LABEL = i18n.translate('xpack.synthetics.vaultConnection.address', {
   defaultMessage: 'Vault address',
 });
-const ADDRESS_HELP = i18n.translate('xpack.synthetics.vaultConnection.addressHelp', {
-  defaultMessage: 'Base URL of your Vault server.',
-});
 const AUTH_METHOD_LABEL = i18n.translate('xpack.synthetics.vaultConnection.authMethod', {
-  defaultMessage: 'Authentication method',
+  defaultMessage: 'Auth method',
 });
 const KV_MOUNT_LABEL = i18n.translate('xpack.synthetics.vaultConnection.kvMount', {
   defaultMessage: 'KV v2 mount',
-});
-const KV_MOUNT_HELP = i18n.translate('xpack.synthetics.vaultConnection.kvMountHelp', {
-  defaultMessage: 'Secrets engine mount path (default "secret").',
-});
-const TOKEN_LABEL = i18n.translate('xpack.synthetics.vaultConnection.token', {
-  defaultMessage: 'Token',
-});
-const ROLE_ID_LABEL = i18n.translate('xpack.synthetics.vaultConnection.roleId', {
-  defaultMessage: 'Role ID',
-});
-const SECRET_ID_LABEL = i18n.translate('xpack.synthetics.vaultConnection.secretId', {
-  defaultMessage: 'Secret ID',
-});
-const NAMESPACE_LABEL = i18n.translate('xpack.synthetics.vaultConnection.namespace', {
-  defaultMessage: 'Vault namespace',
-});
-const NAMESPACE_HELP = i18n.translate('xpack.synthetics.vaultConnection.namespaceHelp', {
-  defaultMessage: 'Optional. Vault Enterprise namespace.',
-});
-const TLS_SKIP_LABEL = i18n.translate('xpack.synthetics.vaultConnection.tlsSkip', {
-  defaultMessage: 'Skip TLS verification (dev only)',
-});
-const SECRET_SAVED_HELP = i18n.translate('xpack.synthetics.vaultConnection.secretSaved', {
-  defaultMessage: 'A secret is already stored. Leave blank to keep it.',
-});
-const CONNECT_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.connect', {
-  defaultMessage: 'Connect',
-});
-const UPDATE_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.update', {
-  defaultMessage: 'Update connection',
 });
 const REFRESH_INTERVAL_LABEL = i18n.translate('xpack.synthetics.vaultConnection.refreshInterval', {
   defaultMessage: 'Secret refresh interval',
@@ -391,18 +448,54 @@ const REFRESH_INTERVAL_HELP = i18n.translate(
     defaultMessage: 'How long the agent caches a resolved secret, e.g. "5m", "1h".',
   }
 );
+const TOKEN_LABEL = i18n.translate('xpack.synthetics.vaultConnection.token', {
+  defaultMessage: 'Token',
+});
+const ROLE_ID_LABEL = i18n.translate('xpack.synthetics.vaultConnection.roleId', {
+  defaultMessage: 'Role ID',
+});
+const SECRET_ID_LABEL = i18n.translate('xpack.synthetics.vaultConnection.secretId', {
+  defaultMessage: 'Secret ID',
+});
+const TLS_SKIP_LABEL = i18n.translate('xpack.synthetics.vaultConnection.tlsSkip', {
+  defaultMessage: 'Skip TLS verification (dev only)',
+});
+const SECRET_SAVED_HELP = i18n.translate('xpack.synthetics.vaultConnection.secretSaved', {
+  defaultMessage: 'A secret is already stored. Leave blank to keep it.',
+});
+const ACTIONS_LABEL = i18n.translate('xpack.synthetics.vaultConnection.actions', {
+  defaultMessage: 'Actions',
+});
+const ADD_LABEL = i18n.translate('xpack.synthetics.vaultConnection.add', {
+  defaultMessage: 'Add connection',
+});
+const EDIT_LABEL = i18n.translate('xpack.synthetics.vaultConnection.edit', {
+  defaultMessage: 'Edit',
+});
+const DELETE_LABEL = i18n.translate('xpack.synthetics.vaultConnection.delete', {
+  defaultMessage: 'Delete',
+});
+const SAVE_LABEL = i18n.translate('xpack.synthetics.vaultConnection.save', {
+  defaultMessage: 'Save connection',
+});
+const CANCEL_LABEL = i18n.translate('xpack.synthetics.vaultConnection.cancel', {
+  defaultMessage: 'Cancel',
+});
 const REFRESH_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.refreshButton', {
   defaultMessage: 'Refresh secrets',
-});
-const REFRESHED_TOAST = i18n.translate('xpack.synthetics.vaultConnection.refreshedToast', {
-  defaultMessage: 'Refreshing secrets — configs are being re-pushed to agents',
-});
-const REFRESH_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.refreshErrorToast', {
-  defaultMessage: 'Failed to refresh Vault secrets',
 });
 const SAVED_TOAST = i18n.translate('xpack.synthetics.vaultConnection.savedToast', {
   defaultMessage: 'Vault connection saved',
 });
 const SAVE_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.saveErrorToast', {
   defaultMessage: 'Failed to save Vault connection',
+});
+const DELETE_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.deleteErrorToast', {
+  defaultMessage: 'Failed to delete Vault connection',
+});
+const REFRESHED_TOAST = i18n.translate('xpack.synthetics.vaultConnection.refreshedToast', {
+  defaultMessage: 'Refreshing secrets — configs are being re-pushed to agents',
+});
+const REFRESH_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.refreshErrorToast', {
+  defaultMessage: 'Failed to refresh Vault secrets',
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
@@ -13,6 +13,7 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiCallOut,
+  EuiConfirmModal,
   EuiFieldPassword,
   EuiFieldText,
   EuiFlexGroup,
@@ -109,6 +110,7 @@ export const VaultConnectionPanel = () => {
   const [refreshing, setRefreshing] = useState(false);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   const accordionId = useGeneratedHtmlId({ prefix: 'vaultConnections' });
   const flyoutTitleId = useGeneratedHtmlId({ prefix: 'vaultConnectionFlyout' });
@@ -123,9 +125,11 @@ export const VaultConnectionPanel = () => {
       const res = await http.get<VaultConnectionStatus[]>(SYNTHETICS_API_URLS.VAULT_CONNECTION);
       setConnections(Array.isArray(res) ? res : []);
     } catch (e) {
-      // non-fatal for the params page
+      // Surface the failure rather than showing an empty list (which reads as
+      // "no connections configured").
+      notifications?.toasts.addError(e as Error, { title: LOAD_ERROR_TOAST });
     }
-  }, [http]);
+  }, [http, notifications]);
 
   useEffect(() => {
     load();
@@ -245,7 +249,7 @@ export const VaultConnectionPanel = () => {
     },
     {
       field: 'type',
-      name: TYPE_LABEL,
+      name: PROVIDER_LABEL,
       render: (ty?: SecretProviderType) => providerLabel(ty),
     },
     {
@@ -281,7 +285,10 @@ export const VaultConnectionPanel = () => {
           icon: 'trash',
           color: 'danger',
           type: 'icon',
-          onClick: (c: VaultConnectionStatus) => onDelete(c.name ?? ''),
+          // Confirm before deleting (and never issue a delete for an empty name).
+          onClick: (c: VaultConnectionStatus) => {
+            if (c.name) setDeleteTarget(c.name);
+          },
           enabled: () => canSave,
         },
       ],
@@ -372,7 +379,15 @@ export const VaultConnectionPanel = () => {
               </EuiTitle>
             </EuiFlyoutHeader>
             <EuiFlyoutBody>
-              <EuiForm component="form">
+              <EuiForm
+                component="form"
+                onSubmit={(e) => {
+                  // Without this, pressing Enter triggers a native form submit that
+                  // reloads the page and discards the typed secret.
+                  e.preventDefault();
+                  if (editing.name && editing.address && !saving) onSave();
+                }}
+              >
                 <EuiFormRow fullWidth label={PROVIDER_LABEL} helpText={PROVIDER_HELP}>
                   <EuiSelect
                     fullWidth
@@ -564,6 +579,29 @@ export const VaultConnectionPanel = () => {
           </EuiFlyout>
         )}
       </EuiAccordion>
+      {deleteTarget && (
+        <EuiConfirmModal
+          title={DELETE_CONFIRM_TITLE}
+          onCancel={() => setDeleteTarget(null)}
+          onConfirm={async () => {
+            const name = deleteTarget;
+            setDeleteTarget(null);
+            await onDelete(name);
+          }}
+          cancelButtonText={CANCEL_LABEL}
+          confirmButtonText={DELETE_LABEL}
+          buttonColor="danger"
+          data-test-subj="syntheticsVaultDeleteConfirm"
+        >
+          <p>
+            {i18n.translate('xpack.synthetics.vaultConnection.deleteConfirmBody', {
+              defaultMessage:
+                'Delete the Vault connection "{name}"? Parameters that reference it will stop resolving at the agent until they are pointed at another connection.',
+              values: { name: deleteTarget },
+            })}
+          </p>
+        </EuiConfirmModal>
+      )}
     </EuiPanel>
   );
 };
@@ -580,9 +618,6 @@ const PROVIDER_LABEL = i18n.translate('xpack.synthetics.vaultConnection.provider
 });
 const PROVIDER_HELP = i18n.translate('xpack.synthetics.vaultConnection.providerHelp', {
   defaultMessage: 'The secret-management backend this connection resolves secrets from.',
-});
-const TYPE_LABEL = i18n.translate('xpack.synthetics.vaultConnection.type', {
-  defaultMessage: 'Provider',
 });
 const NAME_LABEL = i18n.translate('xpack.synthetics.vaultConnection.name', {
   defaultMessage: 'Name',
@@ -662,6 +697,12 @@ const SAVE_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.saveEr
 });
 const DELETE_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.deleteErrorToast', {
   defaultMessage: 'Failed to delete Vault connection',
+});
+const DELETE_CONFIRM_TITLE = i18n.translate('xpack.synthetics.vaultConnection.deleteConfirmTitle', {
+  defaultMessage: 'Delete Vault connection?',
+});
+const LOAD_ERROR_TOAST = i18n.translate('xpack.synthetics.vaultConnection.loadErrorToast', {
+  defaultMessage: 'Failed to load Vault connections',
 });
 const REFRESHED_TOAST = i18n.translate('xpack.synthetics.vaultConnection.refreshedToast', {
   defaultMessage: 'Refreshing secrets — configs are being re-pushed to agents',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
@@ -30,13 +30,24 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import type { ClientPluginsStart } from '../../../../../plugin';
 import type {
+  SecretProviderType,
   VaultAuthMethod,
   VaultConnectionStatus,
 } from '../../../../../../common/runtime_types';
+import { SECRET_PROVIDER_HASHICORP_VAULT } from '../../../../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../../../../common/constants';
+
+// Selectable secret-provider backends. Only HashiCorp Vault is implemented today;
+// adding a provider means adding an option here and a matching field section below.
+const PROVIDER_OPTIONS: Array<{ value: SecretProviderType; text: string }> = [
+  { value: 'hashicorp_vault', text: 'HashiCorp Vault' },
+];
+const providerLabel = (type?: SecretProviderType) =>
+  PROVIDER_OPTIONS.find((o) => o.value === type)?.text ?? type ?? 'HashiCorp Vault';
 
 interface FormState {
   name: string;
+  type: SecretProviderType;
   address: string;
   authMethod: VaultAuthMethod;
   namespace: string;
@@ -52,6 +63,7 @@ interface FormState {
 
 const blankForm = (): FormState => ({
   name: '',
+  type: SECRET_PROVIDER_HASHICORP_VAULT,
   address: '',
   authMethod: 'approle',
   namespace: '',
@@ -67,15 +79,16 @@ const blankForm = (): FormState => ({
 
 const toForm = (c: VaultConnectionStatus): FormState => ({
   name: c.name ?? '',
-  address: c.address ?? '',
-  authMethod: c.authMethod ?? 'approle',
-  namespace: c.namespace ?? '',
-  kvMount: c.kvMount ?? 'secret',
+  type: c.type ?? SECRET_PROVIDER_HASHICORP_VAULT,
+  address: c.config?.address ?? '',
+  authMethod: c.config?.authMethod ?? 'approle',
+  namespace: c.config?.namespace ?? '',
+  kvMount: c.config?.kvMount ?? 'secret',
   secretRefreshInterval: c.secretRefreshInterval ?? '5m',
-  roleId: c.roleId ?? '',
+  roleId: c.config?.roleId ?? '',
   token: '',
   secretId: '',
-  tlsSkipVerify: c.tlsSkipVerify ?? false,
+  tlsSkipVerify: c.config?.tlsSkipVerify ?? false,
   isNew: false,
   hasSecret: c.hasSecret ?? false,
 });
@@ -111,21 +124,29 @@ export const VaultConnectionPanel = () => {
     if (!editing) return;
     setSaving(true);
     try {
-      const body: Record<string, unknown> = {
-        name: editing.name.trim(),
+      // Provider-specific, non-secret settings.
+      const config: Record<string, unknown> = {
         address: editing.address.trim(),
         authMethod: editing.authMethod,
         namespace: editing.namespace.trim() || undefined,
         kvMount: editing.kvMount.trim() || undefined,
-        secretRefreshInterval: editing.secretRefreshInterval.trim() || undefined,
         tlsSkipVerify: editing.tlsSkipVerify,
       };
+      // Provider-specific secrets. Blank = keep the stored value (handled server-side).
+      const secrets: Record<string, unknown> = {};
       if (editing.authMethod === 'token') {
-        if (editing.token) body.token = editing.token;
+        if (editing.token) secrets.token = editing.token;
       } else {
-        body.roleId = editing.roleId.trim();
-        if (editing.secretId) body.secretId = editing.secretId;
+        config.roleId = editing.roleId.trim();
+        if (editing.secretId) secrets.secretId = editing.secretId;
       }
+      const body = {
+        name: editing.name.trim(),
+        type: editing.type,
+        secretRefreshInterval: editing.secretRefreshInterval.trim() || undefined,
+        config,
+        secrets,
+      };
       await http.put(SYNTHETICS_API_URLS.VAULT_CONNECTION, { body: JSON.stringify(body) });
       notifications?.toasts.addSuccess(SAVED_TOAST);
       setEditing(null);
@@ -165,8 +186,19 @@ export const VaultConnectionPanel = () => {
       name: NAME_LABEL,
       render: (n: string) => <EuiBadge iconType="lock">{n}</EuiBadge>,
     },
-    { field: 'address', name: ADDRESS_LABEL },
-    { field: 'authMethod', name: AUTH_METHOD_LABEL },
+    {
+      field: 'type',
+      name: TYPE_LABEL,
+      render: (ty?: SecretProviderType) => providerLabel(ty),
+    },
+    {
+      name: ADDRESS_LABEL,
+      render: (c: VaultConnectionStatus) => c.config?.address ?? '',
+    },
+    {
+      name: AUTH_METHOD_LABEL,
+      render: (c: VaultConnectionStatus) => c.config?.authMethod ?? '',
+    },
     {
       field: 'secretRefreshInterval',
       name: REFRESH_INTERVAL_LABEL,
@@ -268,6 +300,19 @@ export const VaultConnectionPanel = () => {
             <EuiSpacer size="m" />
             <EuiPanel hasBorder paddingSize="m" color="subdued">
               <EuiForm component="form">
+                <EuiFormRow fullWidth label={PROVIDER_LABEL} helpText={PROVIDER_HELP}>
+                  <EuiSelect
+                    fullWidth
+                    data-test-subj="syntheticsVaultProvider"
+                    value={editing.type}
+                    options={PROVIDER_OPTIONS}
+                    disabled={!editing.isNew || PROVIDER_OPTIONS.length === 1}
+                    onChange={(e) => set('type', e.target.value as SecretProviderType)}
+                  />
+                </EuiFormRow>
+                {/* Fields below are the HashiCorp Vault provider's. When another
+                    provider is added, render its own field section keyed on
+                    editing.type. */}
                 <EuiFlexGroup>
                   <EuiFlexItem>
                     <EuiFormRow fullWidth label={NAME_LABEL} helpText={NAME_HELP}>
@@ -423,6 +468,15 @@ const TITLE = i18n.translate('xpack.synthetics.vaultConnection.title', {
 const DESCRIPTION = i18n.translate('xpack.synthetics.vaultConnection.description', {
   defaultMessage:
     "Connect one or more HashiCorp Vault accounts. Connections are stored encrypted and propagated to your private-location agents (Heartbeat), which resolve vault-backed parameters at runtime. Secret values never leave Vault's trust boundary. Reference a connection from a parameter by its name.",
+});
+const PROVIDER_LABEL = i18n.translate('xpack.synthetics.vaultConnection.provider', {
+  defaultMessage: 'Provider',
+});
+const PROVIDER_HELP = i18n.translate('xpack.synthetics.vaultConnection.providerHelp', {
+  defaultMessage: 'The secret-management backend this connection resolves secrets from.',
+});
+const TYPE_LABEL = i18n.translate('xpack.synthetics.vaultConnection.type', {
+  defaultMessage: 'Provider',
 });
 const NAME_LABEL = i18n.translate('xpack.synthetics.vaultConnection.name', {
   defaultMessage: 'Name',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/global_params/vault_connection_panel.tsx
@@ -12,10 +12,15 @@ import {
   EuiBasicTable,
   EuiButton,
   EuiButtonEmpty,
+  EuiCallOut,
   EuiFieldPassword,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
   EuiForm,
   EuiFormRow,
   EuiPanel,
@@ -23,6 +28,7 @@ import {
   EuiSpacer,
   EuiSwitch,
   EuiText,
+  EuiTitle,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -101,8 +107,16 @@ export const VaultConnectionPanel = () => {
   const [editing, setEditing] = useState<FormState | null>(null);
   const [saving, setSaving] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
 
   const accordionId = useGeneratedHtmlId({ prefix: 'vaultConnections' });
+  const flyoutTitleId = useGeneratedHtmlId({ prefix: 'vaultConnectionFlyout' });
+
+  const closeFlyout = () => {
+    setTestResult(null);
+    setEditing(null);
+  };
 
   const load = useCallback(async () => {
     try {
@@ -117,8 +131,51 @@ export const VaultConnectionPanel = () => {
     load();
   }, [load]);
 
-  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    // A field change invalidates any prior test result.
+    if (testResult) setTestResult(null);
     setEditing((f) => (f ? { ...f, [key]: value } : f));
+  };
+
+  const onTest = async () => {
+    if (!editing) return;
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const config: Record<string, unknown> = {
+        address: editing.address.trim(),
+        authMethod: editing.authMethod,
+        namespace: editing.namespace.trim() || undefined,
+        kvMount: editing.kvMount.trim() || undefined,
+        tlsSkipVerify: editing.tlsSkipVerify,
+      };
+      const secrets: Record<string, unknown> = {};
+      if (editing.authMethod === 'token') {
+        if (editing.token) secrets.token = editing.token;
+      } else {
+        config.roleId = editing.roleId.trim();
+        if (editing.secretId) secrets.secretId = editing.secretId;
+      }
+      const res = await http.post<{ ok: boolean; message: string }>(
+        `${SYNTHETICS_API_URLS.VAULT_CONNECTION}/_test`,
+        {
+          body: JSON.stringify({
+            // Existing connection: let the server fall back to the stored secret
+            // when the secret field is left blank.
+            name: editing.isNew ? undefined : editing.name.trim(),
+            type: editing.type,
+            config,
+            secrets,
+          }),
+        }
+      );
+      setTestResult(res);
+    } catch (e) {
+      setTestResult({ ok: false, message: (e as Error)?.message ?? 'Test failed' });
+    } finally {
+      setTesting(false);
+    }
+  };
 
   const onSave = async () => {
     if (!editing) return;
@@ -212,7 +269,10 @@ export const VaultConnectionPanel = () => {
           description: EDIT_LABEL,
           icon: 'pencil',
           type: 'icon',
-          onClick: (c: VaultConnectionStatus) => setEditing(toForm(c)),
+          onClick: (c: VaultConnectionStatus) => {
+            setTestResult(null);
+            setEditing(toForm(c));
+          },
           enabled: () => canSave,
         },
         {
@@ -275,7 +335,10 @@ export const VaultConnectionPanel = () => {
               iconType="plusInCircle"
               data-test-subj="syntheticsVaultAddConnection"
               isDisabled={!canSave || !!editing}
-              onClick={() => setEditing(blankForm())}
+              onClick={() => {
+                setTestResult(null);
+                setEditing(blankForm());
+              }}
             >
               {ADD_LABEL}
             </EuiButton>
@@ -296,9 +359,19 @@ export const VaultConnectionPanel = () => {
         </EuiFlexGroup>
 
         {editing && (
-          <>
-            <EuiSpacer size="m" />
-            <EuiPanel hasBorder paddingSize="m" color="subdued">
+          <EuiFlyout
+            ownFocus
+            size="m"
+            onClose={closeFlyout}
+            aria-labelledby={flyoutTitleId}
+            data-test-subj="syntheticsVaultConnectionFlyout"
+          >
+            <EuiFlyoutHeader hasBorder>
+              <EuiTitle size="m">
+                <h2 id={flyoutTitleId}>{editing.isNew ? ADD_LABEL : EDIT_TITLE}</h2>
+              </EuiTitle>
+            </EuiFlyoutHeader>
+            <EuiFlyoutBody>
               <EuiForm component="form">
                 <EuiFormRow fullWidth label={PROVIDER_LABEL} helpText={PROVIDER_HELP}>
                   <EuiSelect
@@ -431,31 +504,64 @@ export const VaultConnectionPanel = () => {
                     onChange={(e) => set('tlsSkipVerify', e.target.checked)}
                   />
                 </EuiFormRow>
-                <EuiSpacer size="m" />
-                <EuiFlexGroup gutterSize="s" responsive={false}>
-                  <EuiFlexItem grow={false}>
-                    <EuiButton
-                      fill
-                      data-test-subj="syntheticsVaultSaveConnection"
-                      isLoading={saving}
-                      isDisabled={!editing.name || !editing.address}
-                      onClick={onSave}
-                    >
-                      {SAVE_LABEL}
-                    </EuiButton>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonEmpty
-                      data-test-subj="syntheticsVaultConnectionPanelButton"
-                      onClick={() => setEditing(null)}
-                    >
-                      {CANCEL_LABEL}
-                    </EuiButtonEmpty>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
+                {testResult && (
+                  <>
+                    <EuiSpacer size="s" />
+                    <EuiCallOut
+                      size="s"
+                      color={testResult.ok ? 'success' : 'danger'}
+                      iconType={testResult.ok ? 'check' : 'warning'}
+                      title={testResult.message}
+                    />
+                  </>
+                )}
               </EuiForm>
-            </EuiPanel>
-          </>
+            </EuiFlyoutBody>
+            <EuiFlyoutFooter>
+              <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    iconType="cross"
+                    flush="left"
+                    data-test-subj="syntheticsVaultConnectionPanelButton"
+                    onClick={closeFlyout}
+                  >
+                    {CANCEL_LABEL}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiFlexGroup gutterSize="s" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiButton
+                        data-test-subj="syntheticsVaultTestConnection"
+                        iconType="online"
+                        isLoading={testing}
+                        isDisabled={!editing.address}
+                        onClick={onTest}
+                      >
+                        {TEST_LABEL}
+                      </EuiButton>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiButton
+                        fill
+                        data-test-subj="syntheticsVaultSaveConnection"
+                        isLoading={saving}
+                        isDisabled={!editing.name || !editing.address}
+                        onClick={onSave}
+                      >
+                        {SAVE_LABEL}
+                      </EuiButton>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiSpacer size="xs" />
+              <EuiText size="xs" color="subdued">
+                {TEST_NOTE}
+              </EuiText>
+            </EuiFlyoutFooter>
+          </EuiFlyout>
         )}
       </EuiAccordion>
     </EuiPanel>
@@ -523,6 +629,9 @@ const ACTIONS_LABEL = i18n.translate('xpack.synthetics.vaultConnection.actions',
 const ADD_LABEL = i18n.translate('xpack.synthetics.vaultConnection.add', {
   defaultMessage: 'Add connection',
 });
+const EDIT_TITLE = i18n.translate('xpack.synthetics.vaultConnection.editTitle', {
+  defaultMessage: 'Edit connection',
+});
 const EDIT_LABEL = i18n.translate('xpack.synthetics.vaultConnection.edit', {
   defaultMessage: 'Edit',
 });
@@ -537,6 +646,13 @@ const CANCEL_LABEL = i18n.translate('xpack.synthetics.vaultConnection.cancel', {
 });
 const REFRESH_BUTTON = i18n.translate('xpack.synthetics.vaultConnection.refreshButton', {
   defaultMessage: 'Refresh secrets',
+});
+const TEST_LABEL = i18n.translate('xpack.synthetics.vaultConnection.test', {
+  defaultMessage: 'Test connection',
+});
+const TEST_NOTE = i18n.translate('xpack.synthetics.vaultConnection.testNote', {
+  defaultMessage:
+    '“Test connection” checks reachability and authentication from Kibana. At runtime the agent (Heartbeat) resolves secrets from its own network, which may differ.',
 });
 const SAVED_TOAST = i18n.translate('xpack.synthetics.vaultConnection.savedToast', {
   defaultMessage: 'Vault connection saved',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/manage_private_locations.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/manage_private_locations.tsx
@@ -4,12 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useEffect, useCallback, useMemo } from 'react';
+import React, { useEffect, useCallback, useMemo, useState } from 'react';
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useDispatch, useSelector } from 'react-redux-v7';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { SpacesContextProps } from '@kbn/spaces-plugin/public';
 import { isEqual } from 'lodash';
 import type { PrivateLocation } from '../../../../../../common/runtime_types';
+import { SYNTHETICS_API_URLS } from '../../../../../../common/constants';
 import { LoadingState } from '../../monitors_page/overview/overview/monitor_detail_flyout';
 import { PrivateLocationsTable } from './locations_table';
 import { ManageEmptyState } from './manage_empty_state';
@@ -65,6 +68,33 @@ export const ManagePrivateLocations = () => {
     dispatch(setIsPrivateLocationFlyoutVisible(false));
   }, [dispatch]);
 
+  // Warn when Fleet secret storage is off AND this space has Vault connections:
+  // in that case the delivered Vault credentials are stored unencrypted in the
+  // agent policy rather than as a Fleet secret.
+  const { http } = services;
+  const [showSecretStorageWarning, setShowSecretStorageWarning] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await http?.get<{
+          secretStorageEnabled: boolean;
+          hasVaultConnections: boolean;
+        }>(SYNTHETICS_API_URLS.FLEET_SECRET_STORAGE_STATUS);
+        if (!cancelled) {
+          setShowSecretStorageWarning(
+            Boolean(res && !res.secretStorageEnabled && res.hasVaultConnections)
+          );
+        }
+      } catch {
+        // Non-fatal: leave the warning hidden if the status can't be fetched.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [http]);
+
   const handleSubmit = (formData: NewLocation) => {
     if (privateLocationToEdit) {
       const isLabelChanged = formData.label !== privateLocationToEdit.label;
@@ -93,6 +123,19 @@ export const ManagePrivateLocations = () => {
 
   return (
     <SpacesContextProvider>
+      {showSecretStorageWarning && (
+        <>
+          <EuiCallOut
+            color="warning"
+            iconType="warning"
+            title={SECRET_STORAGE_WARNING_TITLE}
+            data-test-subj="syntheticsVaultSecretStorageWarning"
+          >
+            {SECRET_STORAGE_WARNING_BODY}
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
       {loading ? (
         <LoadingState />
       ) : (
@@ -117,3 +160,15 @@ export const ManagePrivateLocations = () => {
     </SpacesContextProvider>
   );
 };
+
+const SECRET_STORAGE_WARNING_TITLE = i18n.translate(
+  'xpack.synthetics.privateLocations.secretStorageWarning.title',
+  { defaultMessage: 'Vault credentials may be stored unencrypted' }
+);
+const SECRET_STORAGE_WARNING_BODY = i18n.translate(
+  'xpack.synthetics.privateLocations.secretStorageWarning.body',
+  {
+    defaultMessage:
+      'Fleet secret storage is not enabled, so HashiCorp Vault connection credentials delivered to private-location agents are stored unencrypted in the agent policy. Secret storage turns on once all Fleet Servers meet the minimum required version — upgrade your Fleet Server(s) to secure these credentials.',
+  }
+);

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -8,9 +8,10 @@
 import { syncParamsSettingsParamsRoute } from './settings/params/sync_global_params_settings';
 import { syncParamsSyntheticsParamsRoute } from './settings/params/sync_global_params';
 import {
-  getVaultConnectionRoute,
+  getVaultConnectionsRoute,
   saveVaultConnectionRoute,
-  refreshVaultConnectionRoute,
+  deleteVaultConnectionRoute,
+  refreshVaultConnectionsRoute,
 } from './settings/vault/vault_connection';
 import { cleanupPrivateLocationRoute } from './settings/private_locations/cleanup_private_locations';
 import { getSyntheticsTriggerTaskRun } from './tasks/trigger_task_run';
@@ -137,9 +138,10 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   resetSyntheticsMonitorBulkRoute,
   cleanupPrivateLocationRoute,
   syncParamsSyntheticsParamsRoute,
-  getVaultConnectionRoute,
+  getVaultConnectionsRoute,
   saveVaultConnectionRoute,
-  refreshVaultConnectionRoute,
+  deleteVaultConnectionRoute,
+  refreshVaultConnectionsRoute,
   syncParamsSettingsParamsRoute,
   getMonitorsHealthRoute,
   getMonitorHealthRoute,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -10,6 +10,7 @@ import { syncParamsSyntheticsParamsRoute } from './settings/params/sync_global_p
 import {
   getVaultConnectionRoute,
   saveVaultConnectionRoute,
+  refreshVaultConnectionRoute,
 } from './settings/vault/vault_connection';
 import { cleanupPrivateLocationRoute } from './settings/private_locations/cleanup_private_locations';
 import { getSyntheticsTriggerTaskRun } from './tasks/trigger_task_run';
@@ -138,6 +139,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   syncParamsSyntheticsParamsRoute,
   getVaultConnectionRoute,
   saveVaultConnectionRoute,
+  refreshVaultConnectionRoute,
   syncParamsSettingsParamsRoute,
   getMonitorsHealthRoute,
   getMonitorHealthRoute,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -13,6 +13,7 @@ import {
   deleteVaultConnectionRoute,
   refreshVaultConnectionsRoute,
   testVaultConnectionRoute,
+  getFleetSecretStorageStatusRoute,
 } from './settings/vault/vault_connection';
 import { cleanupPrivateLocationRoute } from './settings/private_locations/cleanup_private_locations';
 import { getSyntheticsTriggerTaskRun } from './tasks/trigger_task_run';
@@ -144,6 +145,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   deleteVaultConnectionRoute,
   refreshVaultConnectionsRoute,
   testVaultConnectionRoute,
+  getFleetSecretStorageStatusRoute,
   syncParamsSettingsParamsRoute,
   getMonitorsHealthRoute,
   getMonitorHealthRoute,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -12,6 +12,7 @@ import {
   saveVaultConnectionRoute,
   deleteVaultConnectionRoute,
   refreshVaultConnectionsRoute,
+  testVaultConnectionRoute,
 } from './settings/vault/vault_connection';
 import { cleanupPrivateLocationRoute } from './settings/private_locations/cleanup_private_locations';
 import { getSyntheticsTriggerTaskRun } from './tasks/trigger_task_run';
@@ -142,6 +143,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   saveVaultConnectionRoute,
   deleteVaultConnectionRoute,
   refreshVaultConnectionsRoute,
+  testVaultConnectionRoute,
   syncParamsSettingsParamsRoute,
   getMonitorsHealthRoute,
   getMonitorHealthRoute,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -7,6 +7,10 @@
 
 import { syncParamsSettingsParamsRoute } from './settings/params/sync_global_params_settings';
 import { syncParamsSyntheticsParamsRoute } from './settings/params/sync_global_params';
+import {
+  getVaultConnectionRoute,
+  saveVaultConnectionRoute,
+} from './settings/vault/vault_connection';
 import { cleanupPrivateLocationRoute } from './settings/private_locations/cleanup_private_locations';
 import { getSyntheticsTriggerTaskRun } from './tasks/trigger_task_run';
 import { syntheticsInspectStatusRuleRoute } from './rules/inspect_status_rule';
@@ -132,6 +136,8 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   resetSyntheticsMonitorBulkRoute,
   cleanupPrivateLocationRoute,
   syncParamsSyntheticsParamsRoute,
+  getVaultConnectionRoute,
+  saveVaultConnectionRoute,
   syncParamsSettingsParamsRoute,
   getMonitorsHealthRoute,
   getMonitorHealthRoute,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
@@ -25,6 +25,7 @@ const VaultSourceSchema = schema.object({
   type: schema.literal('vault'),
   path: schema.string({ minLength: 1 }),
   field: schema.string({ minLength: 1 }),
+  connection: schema.maybe(schema.string()),
 });
 
 const ParamsObjectSchema = schema.object({
@@ -149,7 +150,9 @@ const toParamAttributes = (
   param: SyntheticsParamRequest
 ): Omit<SyntheticsParamSOAttributes, 'id'> => {
   const { share_across_spaces: _shareAcrossSpaces, value, source, ...rest } = param;
-  const effectiveValue = source ? buildVaultReference(source.path, source.field) : value ?? '';
+  const effectiveValue = source
+    ? buildVaultReference(source.path, source.field, source.connection)
+    : value ?? '';
   return {
     ...rest,
     ...(source ? { source } : {}),

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
@@ -19,18 +19,15 @@ import type {
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
-import { buildVaultReference } from '../../../synthetics_service/formatters/vault_param_formatter';
-
-const VaultSourceSchema = schema.object({
-  type: schema.literal('vault'),
-  path: schema.string({ minLength: 1 }),
-  field: schema.string({ minLength: 1 }),
-  connection: schema.maybe(schema.string()),
-});
+import {
+  buildVaultReference,
+  VaultParamSourceSchema,
+} from '../../../synthetics_service/formatters/vault_param_formatter';
 
 const ParamsObjectSchema = schema.object({
   key: schema.string({
     minLength: 1,
+    maxLength: 1024,
   }),
   // Either `value` (literal) or `source` (vault-backed) must be provided.
   value: schema.maybe(
@@ -38,7 +35,7 @@ const ParamsObjectSchema = schema.object({
       minLength: 1,
     })
   ),
-  source: schema.maybe(VaultSourceSchema),
+  source: schema.maybe(VaultParamSourceSchema),
   description: schema.maybe(schema.string()),
   tags: schema.maybe(schema.arrayOf(schema.string())),
   share_across_spaces: schema.maybe(schema.boolean()),

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
@@ -19,14 +19,25 @@ import type {
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
+import { buildVaultReference } from '../../../synthetics_service/formatters/vault_param_formatter';
+
+const VaultSourceSchema = schema.object({
+  type: schema.literal('vault'),
+  path: schema.string({ minLength: 1 }),
+  field: schema.string({ minLength: 1 }),
+});
 
 const ParamsObjectSchema = schema.object({
   key: schema.string({
     minLength: 1,
   }),
-  value: schema.string({
-    minLength: 1,
-  }),
+  // Either `value` (literal) or `source` (vault-backed) must be provided.
+  value: schema.maybe(
+    schema.string({
+      minLength: 1,
+    })
+  ),
+  source: schema.maybe(VaultSourceSchema),
   description: schema.maybe(schema.string()),
   tags: schema.maybe(schema.arrayOf(schema.string())),
   share_across_spaces: schema.maybe(schema.boolean()),
@@ -48,6 +59,16 @@ export const addSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       const { id: spaceId } = (await server.spaces?.spacesService.getActiveSpace(request)) ?? {
         id: DEFAULT_SPACE_ID,
       };
+
+      const paramsToValidate = Array.isArray(request.body) ? request.body : [request.body];
+      const invalid = (paramsToValidate as SyntheticsParamRequest[]).find(
+        (param) => !param.value && !param.source
+      );
+      if (invalid) {
+        return response.badRequest({
+          body: { message: `Param "${invalid.key}" must have either a value or a vault source` },
+        });
+      }
 
       const savedObjectsData = parseParamBody(
         spaceId,
@@ -106,7 +127,7 @@ export const addSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
 
 const toClientResponse = (savedObject: SavedObject<Omit<SyntheticsParamSOAttributes, 'id'>>) => {
   const { id, attributes: data, namespaces } = savedObject;
-  const { description, key, tags } = data;
+  const { description, key, tags, source } = data;
   return {
     id,
     description,
@@ -114,6 +135,25 @@ const toClientResponse = (savedObject: SavedObject<Omit<SyntheticsParamSOAttribu
     namespaces,
     tags,
     value: data.value,
+    source,
+  };
+};
+
+/**
+ * Builds the stored SO attributes for a param request. For a vault-backed param
+ * the effective `value` is derived as an edge-resolved reference token
+ * (${vault/<path>#<field>}) and the structured `source` is persisted so the UI
+ * can round-trip it. Kibana never resolves the reference — Heartbeat does.
+ */
+const toParamAttributes = (
+  param: SyntheticsParamRequest
+): Omit<SyntheticsParamSOAttributes, 'id'> => {
+  const { share_across_spaces: _shareAcrossSpaces, value, source, ...rest } = param;
+  const effectiveValue = source ? buildVaultReference(source.path, source.field) : value ?? '';
+  return {
+    ...rest,
+    ...(source ? { source } : {}),
+    value: effectiveValue,
   };
 };
 
@@ -121,24 +161,10 @@ const parseParamBody = (
   spaceId: string,
   body: SyntheticsParamRequest[] | SyntheticsParamRequest
 ): Array<SavedObjectsBulkCreateObject<Omit<SyntheticsParamSOAttributes, 'id'>>> => {
-  if (Array.isArray(body)) {
-    const params = body as SyntheticsParamRequest[];
-    return params.map((param) => {
-      const { share_across_spaces: shareAcrossSpaces, ...data } = param;
-      return {
-        type: syntheticsParamType,
-        attributes: data,
-        initialNamespaces: shareAcrossSpaces ? [ALL_SPACES_ID] : [spaceId],
-      };
-    });
-  }
-
-  const { share_across_spaces: shareAcrossSpaces, ...data } = body;
-  return [
-    {
-      type: syntheticsParamType,
-      attributes: data,
-      initialNamespaces: shareAcrossSpaces ? [ALL_SPACES_ID] : [spaceId],
-    },
-  ];
+  const params = Array.isArray(body) ? body : [body];
+  return params.map((param) => ({
+    type: syntheticsParamType,
+    attributes: toParamAttributes(param),
+    initialNamespaces: param.share_across_spaces ? [ALL_SPACES_ID] : [spaceId],
+  }));
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
@@ -67,6 +67,17 @@ export const addSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
           body: { message: `Param "${invalid.key}" must have either a value or a vault source` },
         });
       }
+      // D4: a param is either a literal value or a vault source, not both.
+      const ambiguous = (paramsToValidate as SyntheticsParamRequest[]).find(
+        (param) => param.value && param.source
+      );
+      if (ambiguous) {
+        return response.badRequest({
+          body: {
+            message: `Param "${ambiguous.key}" must not set both a value and a vault source`,
+          },
+        });
+      }
 
       const savedObjectsData = parseParamBody(
         spaceId,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
@@ -50,6 +50,7 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
             type: schema.literal('vault'),
             path: schema.string({ minLength: 1 }),
             field: schema.string({ minLength: 1 }),
+            connection: schema.maybe(schema.string()),
           })
         ),
         description: schema.maybe(schema.string()),
@@ -86,7 +87,11 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       // persist the structured source. When switching (back) to a literal value,
       // drop any previously-stored vault source.
       if (data.source) {
-        newParam.value = buildVaultReference(data.source.path, data.source.field);
+        newParam.value = buildVaultReference(
+          data.source.path,
+          data.source.field,
+          data.source.connection
+        );
         newParam.source = data.source;
       } else if (data.value) {
         newParam.value = data.value;

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
@@ -16,7 +16,10 @@ import type { SyntheticsParamRequest, SyntheticsParams } from '../../../../commo
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
-import { buildVaultReference } from '../../../synthetics_service/formatters/vault_param_formatter';
+import {
+  buildVaultReference,
+  VaultParamSourceSchema,
+} from '../../../synthetics_service/formatters/vault_param_formatter';
 
 const RequestParamsSchema = schema.object({
   id: schema.string(),
@@ -45,14 +48,7 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
             minLength: 1,
           })
         ),
-        source: schema.maybe(
-          schema.object({
-            type: schema.literal('vault'),
-            path: schema.string({ minLength: 1 }),
-            field: schema.string({ minLength: 1 }),
-            connection: schema.maybe(schema.string()),
-          })
-        ),
+        source: schema.maybe(VaultParamSourceSchema),
         description: schema.maybe(schema.string()),
         tags: schema.maybe(schema.arrayOf(schema.string())),
       }),
@@ -86,6 +82,7 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       // For a vault-backed edit, derive the effective value from the source and
       // persist the structured source. When switching (back) to a literal value,
       // drop any previously-stored vault source.
+      let clearingSource = false;
       if (data.source) {
         newParam.value = buildVaultReference(
           data.source.path,
@@ -96,9 +93,15 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       } else if (data.value) {
         newParam.value = data.value;
         delete newParam.source;
+        clearingSource = true;
       }
 
       const { key: existingKey } = existingParam.attributes;
+
+      // A merge update never removes an absent key, so clearing `source` (vault →
+      // literal) would leave a stale `source` on the stored doc — the UI would keep
+      // showing the Vault badge and the param would still look vault-backed. Replace
+      // the full attribute set in that case so `source` is actually dropped.
       const {
         id: responseId,
         attributes: { key, tags, description, value, source },
@@ -106,7 +109,8 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       } = (await savedObjectsClient.update<SyntheticsParams>(
         syntheticsParamType,
         paramId,
-        newParam
+        newParam,
+        clearingSource ? { mergeAttributes: false } : undefined
       )) as SavedObject<SyntheticsParams>;
 
       // Include both old and new key if the key was renamed

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
@@ -64,6 +64,12 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
     if (isEmpty(data)) {
       return response.badRequest({ body: { message: 'Request body cannot be empty' } });
     }
+    // D4: a parameter is either a literal value or a vault source, not both.
+    if (data.value && data.source) {
+      return response.badRequest({
+        body: { message: 'A parameter cannot set both a value and a vault source' },
+      });
+    }
     const encryptedSavedObjectsClient = server.encryptedSavedObjects.getClient();
 
     try {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
@@ -16,6 +16,7 @@ import type { SyntheticsParamRequest, SyntheticsParams } from '../../../../commo
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
+import { buildVaultReference } from '../../../synthetics_service/formatters/vault_param_formatter';
 
 const RequestParamsSchema = schema.object({
   id: schema.string(),
@@ -44,6 +45,13 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
             minLength: 1,
           })
         ),
+        source: schema.maybe(
+          schema.object({
+            type: schema.literal('vault'),
+            path: schema.string({ minLength: 1 }),
+            field: schema.string({ minLength: 1 }),
+          })
+        ),
         description: schema.maybe(schema.string()),
         tags: schema.maybe(schema.arrayOf(schema.string())),
       }),
@@ -69,16 +77,26 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
           { namespace: spaceId }
         );
 
-      const newParam = {
+      const newParam: SyntheticsParams = {
         ...existingParam.attributes,
         ...data,
       };
 
-      // value from data since we aren't using encrypted client
-      const { value, key: existingKey } = existingParam.attributes;
+      // For a vault-backed edit, derive the effective value from the source and
+      // persist the structured source. When switching (back) to a literal value,
+      // drop any previously-stored vault source.
+      if (data.source) {
+        newParam.value = buildVaultReference(data.source.path, data.source.field);
+        newParam.source = data.source;
+      } else if (data.value) {
+        newParam.value = data.value;
+        delete newParam.source;
+      }
+
+      const { key: existingKey } = existingParam.attributes;
       const {
         id: responseId,
-        attributes: { key, tags, description },
+        attributes: { key, tags, description, value, source },
         namespaces,
       } = (await savedObjectsClient.update<SyntheticsParams>(
         syntheticsParamType,
@@ -95,7 +113,7 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
         modifiedParamKeys,
       });
 
-      return { id: responseId, key, tags, description, namespaces, value };
+      return { id: responseId, key, tags, description, namespaces, value, source };
     } catch (getErr) {
       if (SavedObjectsErrorHelpers.isNotFoundError(getErr)) {
         return response.notFound({ body: { message: 'Param not found' } });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
@@ -6,23 +6,20 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { SyntheticsServerSetup } from '../../../types';
-import type { SyntheticsRestApiRouteFactory } from '../../types';
+import type { RouteContext, SyntheticsRestApiRouteFactory } from '../../types';
 import type {
   SyntheticsVaultConnection,
   VaultConnectionStatus,
 } from '../../../../common/runtime_types';
 import { syntheticsVaultConnectionType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
-import { VAULT_CONNECTION_SO_ID } from '../../../saved_objects/synthetics_vault_connection';
+import { vaultConnectionId } from '../../../saved_objects/synthetics_vault_connection';
 import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
 
-const toStatus = (
-  attributes: SyntheticsVaultConnection,
-  hasSecret: boolean
-): VaultConnectionStatus => ({
+const toStatus = (attributes: SyntheticsVaultConnection): VaultConnectionStatus => ({
   configured: true,
+  name: attributes.name,
   address: attributes.address,
   namespace: attributes.namespace,
   authMethod: attributes.authMethod,
@@ -31,42 +28,43 @@ const toStatus = (
   tlsSkipVerify: attributes.tlsSkipVerify,
   secretRefreshInterval: attributes.secretRefreshInterval,
   refreshedAt: attributes.refreshedAt,
-  hasSecret,
+  hasSecret: Boolean(attributes.authMethod === 'token' ? attributes.token : attributes.secretId),
 });
 
-// Re-push private-location configs so the updated connection (new refreshedAt =
-// new blob) reaches agents, forcing Heartbeat to re-resolve — this is how a
-// manual refresh / rotation propagates.
+// Re-push private-location configs so the updated connections reach agents,
+// forcing Heartbeat to re-resolve — how a save/refresh/delete propagates.
 const propagate = (server: SyntheticsServerSetup, spaceId: string) =>
   asyncGlobalParamsPropagation({ server, paramsSpacesToSync: [spaceId] });
 
-/**
- * Returns the current Vault connection as a secret-free status view. The
- * encrypted token / secret_id are never returned to the browser.
- */
-export const getVaultConnectionRoute: SyntheticsRestApiRouteFactory<
-  VaultConnectionStatus
+const listConnections = async ({
+  savedObjectsClient,
+}: RouteContext): Promise<VaultConnectionStatus[]> => {
+  const finder = savedObjectsClient.createPointInTimeFinder<SyntheticsVaultConnection>({
+    type: syntheticsVaultConnectionType,
+    perPage: 1000,
+  });
+  const out: VaultConnectionStatus[] = [];
+  for await (const result of finder.find()) {
+    for (const so of result.saved_objects) {
+      out.push(toStatus(so.attributes));
+    }
+  }
+  finder.close().catch(() => {});
+  return out;
+};
+
+/** GET: list all Vault connections (secret-free). */
+export const getVaultConnectionsRoute: SyntheticsRestApiRouteFactory<
+  VaultConnectionStatus[]
 > = () => ({
   method: 'GET',
   path: SYNTHETICS_API_URLS.VAULT_CONNECTION,
   validate: {},
-  handler: async ({ savedObjectsClient }): Promise<VaultConnectionStatus> => {
-    try {
-      const so = await savedObjectsClient.get<SyntheticsVaultConnection>(
-        syntheticsVaultConnectionType,
-        VAULT_CONNECTION_SO_ID
-      );
-      return toStatus(so.attributes, true);
-    } catch (error) {
-      if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
-        return { configured: false };
-      }
-      throw error;
-    }
-  },
+  handler: async (routeContext) => listConnections(routeContext),
 });
 
 const SaveBodySchema = schema.object({
+  name: schema.string({ minLength: 1 }),
   address: schema.string({ minLength: 1 }),
   authMethod: schema.oneOf([schema.literal('token'), schema.literal('approle')]),
   namespace: schema.maybe(schema.string()),
@@ -78,35 +76,27 @@ const SaveBodySchema = schema.object({
   secretId: schema.maybe(schema.string()),
 });
 
-/**
- * Creates or updates the single Vault connection for the active space. Secrets
- * left blank are preserved so a user can edit non-secret fields without
- * re-entering credentials. Every save stamps a fresh refreshedAt and re-pushes
- * configs.
- */
+/** PUT: create or update a connection (keyed by name). Blank secrets are kept. */
 export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
   VaultConnectionStatus
 > = () => ({
   method: 'PUT',
   path: SYNTHETICS_API_URLS.VAULT_CONNECTION,
-  validate: {
-    body: SaveBodySchema,
-  },
+  validate: { body: SaveBodySchema },
   writeAccess: true,
   handler: async ({ request, response, savedObjectsClient, server, spaceId }) => {
     const body = request.body as SyntheticsVaultConnection;
-
     if (body.authMethod === 'approle' && !body.roleId) {
       return response.badRequest({ body: { message: 'approle auth requires a role_id' } });
     }
 
-    // Preserve existing secrets when the corresponding field is left blank.
+    const id = vaultConnectionId(body.name);
     const encryptedClient = server.encryptedSavedObjects.getClient();
     let existing: SyntheticsVaultConnection | undefined;
     try {
       const decrypted = await encryptedClient.getDecryptedAsInternalUser<SyntheticsVaultConnection>(
         syntheticsVaultConnectionType,
-        VAULT_CONNECTION_SO_ID,
+        id,
         { namespace: spaceId }
       );
       existing = decrypted.attributes;
@@ -115,6 +105,7 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
     }
 
     const attributes: SyntheticsVaultConnection = {
+      name: body.name,
       address: body.address,
       authMethod: body.authMethod,
       namespace: body.namespace,
@@ -130,59 +121,63 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
     await savedObjectsClient.create<SyntheticsVaultConnection>(
       syntheticsVaultConnectionType,
       attributes,
-      { id: VAULT_CONNECTION_SO_ID, overwrite: true, initialNamespaces: [spaceId] }
+      { id, overwrite: true, initialNamespaces: [spaceId] }
     );
-
     await propagate(server, spaceId);
+    return toStatus(attributes);
+  },
+});
 
-    const hasSecret = Boolean(body.authMethod === 'token' ? attributes.token : attributes.secretId);
-    return toStatus(attributes, hasSecret);
+/** DELETE /{name}: remove a connection. */
+export const deleteVaultConnectionRoute: SyntheticsRestApiRouteFactory<
+  { deleted: boolean },
+  { name: string }
+> = () => ({
+  method: 'DELETE',
+  path: SYNTHETICS_API_URLS.VAULT_CONNECTION + '/{name}',
+  validate: { params: schema.object({ name: schema.string() }) },
+  writeAccess: true,
+  handler: async ({ request, savedObjectsClient, server, spaceId }) => {
+    const { name } = request.params as { name: string };
+    await savedObjectsClient.delete(syntheticsVaultConnectionType, vaultConnectionId(name));
+    await propagate(server, spaceId);
+    return { deleted: true };
   },
 });
 
 /**
- * Manual "Refresh secrets": bumps refreshedAt (which changes the delivered blob)
- * and re-pushes configs so agents re-resolve every vault-backed secret from
- * Vault — picking up rotations without editing the connection.
+ * POST /_refresh: bump refreshedAt on every connection (which changes the blob)
+ * and re-push configs, so agents re-resolve all vault-backed secrets.
  */
-export const refreshVaultConnectionRoute: SyntheticsRestApiRouteFactory<
-  VaultConnectionStatus
+export const refreshVaultConnectionsRoute: SyntheticsRestApiRouteFactory<
+  VaultConnectionStatus[]
 > = () => ({
   method: 'POST',
   path: SYNTHETICS_API_URLS.VAULT_CONNECTION + '/_refresh',
   validate: {},
   writeAccess: true,
-  handler: async ({ response, savedObjectsClient, server, spaceId }) => {
+  handler: async (routeContext) => {
+    const { savedObjectsClient, server, spaceId } = routeContext;
     const encryptedClient = server.encryptedSavedObjects.getClient();
-    let existing: SyntheticsVaultConnection;
-    try {
-      const decrypted = await encryptedClient.getDecryptedAsInternalUser<SyntheticsVaultConnection>(
-        syntheticsVaultConnectionType,
-        VAULT_CONNECTION_SO_ID,
-        { namespace: spaceId }
+    const finder =
+      await encryptedClient.createPointInTimeFinderDecryptedAsInternalUser<SyntheticsVaultConnection>(
+        { type: syntheticsVaultConnectionType, perPage: 1000, namespaces: [spaceId] }
       );
-      existing = decrypted.attributes;
-    } catch (error) {
-      if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
-        return response.notFound({ body: { message: 'No Vault connection configured' } });
+
+    const refreshedAt = new Date().toISOString();
+    for await (const result of finder.find()) {
+      for (const so of result.saved_objects) {
+        if (!so.attributes) continue;
+        await savedObjectsClient.create<SyntheticsVaultConnection>(
+          syntheticsVaultConnectionType,
+          { ...so.attributes, refreshedAt },
+          { id: so.id, overwrite: true, initialNamespaces: [spaceId] }
+        );
       }
-      throw error;
     }
-
-    const attributes: SyntheticsVaultConnection = {
-      ...existing,
-      refreshedAt: new Date().toISOString(),
-    };
-
-    await savedObjectsClient.create<SyntheticsVaultConnection>(
-      syntheticsVaultConnectionType,
-      attributes,
-      { id: VAULT_CONNECTION_SO_ID, overwrite: true, initialNamespaces: [spaceId] }
-    );
+    finder.close().catch(() => {});
 
     await propagate(server, spaceId);
-
-    const hasSecret = Boolean(existing.authMethod === 'token' ? existing.token : existing.secretId);
-    return toStatus(attributes, hasSecret);
+    return listConnections(routeContext);
   },
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import type { TypeOf } from '@kbn/config-schema';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest } from 'http';
 import type { SyntheticsServerSetup } from '../../../types';
@@ -20,6 +21,7 @@ import { SECRET_PROVIDER_HASHICORP_VAULT } from '../../../../common/runtime_type
 import { syntheticsVaultConnectionType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { vaultConnectionId } from '../../../saved_objects/synthetics_vault_connection';
+import { VAULT_CONNECTION_NAME_REGEX } from '../../../synthetics_service/formatters/vault_param_formatter';
 import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
 
 // Whether the connection has its provider secret stored, so the UI can render
@@ -93,7 +95,14 @@ const HashiCorpVaultSecretsSchema = schema.object({
 });
 
 const SaveBodySchema = schema.object({
-  name: schema.string({ minLength: 1 }),
+  name: schema.string({
+    minLength: 1,
+    maxLength: 1024,
+    validate: (v) =>
+      VAULT_CONNECTION_NAME_REGEX.test(v)
+        ? undefined
+        : 'must contain only letters, numbers, and . _ -',
+  }),
   type: schema.maybe(schema.literal('hashicorp_vault')),
   secretRefreshInterval: schema.maybe(schema.string()),
   config: HashiCorpVaultConfigSchema,
@@ -118,7 +127,7 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
       return response.badRequest({ body: { message: 'approle auth requires a role_id' } });
     }
 
-    const id = vaultConnectionId(body.name);
+    const id = vaultConnectionId(body.name, spaceId);
     const encryptedClient = server.encryptedSavedObjects.getClient();
     let existing: SyntheticsVaultConnection | undefined;
     try {
@@ -129,15 +138,45 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
       );
       existing = decrypted.attributes;
     } catch (e) {
+      // Only a genuine "not found" means this is a brand-new connection. Any other
+      // error (decrypt failure, ES outage, key rotation) must NOT be swallowed:
+      // treating it as "new" would let a blank-secret edit overwrite the stored
+      // credential with `undefined` and silently destroy it.
+      if (!SavedObjectsErrorHelpers.isNotFoundError(e)) {
+        throw e;
+      }
       existing = undefined;
     }
 
-    // Preserve stored secrets when the client submits blanks (editing a connection
-    // without re-entering its secret).
-    const secrets = {
-      token: body.secrets?.token || existing?.secrets?.token,
-      secretId: body.secrets?.secretId || existing?.secrets?.secretId,
-    };
+    // A5: re-pointing an existing connection is credential-sensitive. If the
+    // address or auth method changes, require the secret to be re-entered rather
+    // than silently reusing the stored one — otherwise a write-capable user could
+    // aim an existing connection at an attacker-controlled endpoint (leaving the
+    // secret blank to preserve it) and have private agents authenticate there with
+    // the real credential.
+    const providedSecret =
+      body.config.authMethod === 'token' ? body.secrets?.token : body.secrets?.secretId;
+    const credentialSensitiveChange =
+      !!existing &&
+      (existing.config.address !== body.config.address ||
+        existing.config.authMethod !== body.config.authMethod);
+    if (credentialSensitiveChange && !providedSecret) {
+      return response.badRequest({
+        body: {
+          message:
+            'The Vault secret must be re-entered when changing the connection address or auth method.',
+        },
+      });
+    }
+
+    // Preserve the stored secret on a blank edit ONLY when the endpoint and auth
+    // method are unchanged (see A5 above).
+    const secrets = credentialSensitiveChange
+      ? { token: body.secrets?.token, secretId: body.secrets?.secretId }
+      : {
+          token: body.secrets?.token || existing?.secrets?.token,
+          secretId: body.secrets?.secretId || existing?.secrets?.secretId,
+        };
     // Non-secret marker so the (non-decrypting) list read can report "secret saved".
     const hasSecret =
       body.config.authMethod === 'token' ? Boolean(secrets.token) : Boolean(secrets.secretId);
@@ -169,11 +208,14 @@ export const deleteVaultConnectionRoute: SyntheticsRestApiRouteFactory<
 > = () => ({
   method: 'DELETE',
   path: SYNTHETICS_API_URLS.VAULT_CONNECTION + '/{name}',
-  validate: { params: schema.object({ name: schema.string() }) },
+  validate: { params: schema.object({ name: schema.string({ minLength: 1, maxLength: 1024 }) }) },
   writeAccess: true,
   handler: async ({ request, savedObjectsClient, server, spaceId }) => {
     const { name } = request.params as { name: string };
-    await savedObjectsClient.delete(syntheticsVaultConnectionType, vaultConnectionId(name));
+    await savedObjectsClient.delete(
+      syntheticsVaultConnectionType,
+      vaultConnectionId(name, spaceId)
+    );
     await propagate(server, spaceId);
     return { deleted: true };
   },
@@ -386,7 +428,7 @@ export const testVaultConnectionRoute: SyntheticsRestApiRouteFactory<TestResult>
           .getClient()
           .getDecryptedAsInternalUser<SyntheticsVaultConnection>(
             syntheticsVaultConnectionType,
-            vaultConnectionId(body.name),
+            vaultConnectionId(body.name, spaceId),
             { namespace: spaceId }
           );
         token = token || decrypted.attributes.secrets?.token;

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
@@ -7,6 +7,8 @@
 
 import { schema } from '@kbn/config-schema';
 import type { TypeOf } from '@kbn/config-schema';
+import { request as httpsRequest } from 'https';
+import { request as httpRequest } from 'http';
 import type { SyntheticsServerSetup } from '../../../types';
 import type { RouteContext, SyntheticsRestApiRouteFactory } from '../../types';
 import type {
@@ -21,9 +23,11 @@ import { vaultConnectionId } from '../../../saved_objects/synthetics_vault_conne
 import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
 
 // Whether the connection has its provider secret stored, so the UI can render
-// "•••• saved" without receiving the value. Per-provider: HashiCorp Vault stores a
-// token (token auth) or a secret_id (approle).
+// "•••• saved" without receiving the value. Prefers the stored `hasSecret` marker
+// (present on the non-decrypting list read); falls back to inspecting the secrets
+// for the just-saved attributes, whose secrets are still in memory.
 const hasStoredSecret = (a: SyntheticsVaultConnection): boolean => {
+  if (typeof a.hasSecret === 'boolean') return a.hasSecret;
   const secrets = a.secrets ?? {};
   return a.config.authMethod === 'token' ? Boolean(secrets.token) : Boolean(secrets.secretId);
 };
@@ -134,6 +138,9 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
       token: body.secrets?.token || existing?.secrets?.token,
       secretId: body.secrets?.secretId || existing?.secrets?.secretId,
     };
+    // Non-secret marker so the (non-decrypting) list read can report "secret saved".
+    const hasSecret =
+      body.config.authMethod === 'token' ? Boolean(secrets.token) : Boolean(secrets.secretId);
 
     const attributes: SyntheticsVaultConnection = {
       name: body.name,
@@ -142,6 +149,7 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
       secretRefreshInterval: body.secretRefreshInterval,
       refreshedAt: new Date().toISOString(),
       secrets,
+      hasSecret,
     };
 
     await savedObjectsClient.create<SyntheticsVaultConnection>(
@@ -205,5 +213,197 @@ export const refreshVaultConnectionsRoute: SyntheticsRestApiRouteFactory<
 
     await propagate(server, spaceId);
     return listConnections(routeContext);
+  },
+});
+
+interface TestResult {
+  ok: boolean;
+  message: string;
+}
+
+const errText = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+interface VaultHttpResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+/**
+ * Minimal Vault HTTP call using Node's http(s) client — there is no official Node
+ * Vault client, and new Kibana code must use fetch/node http rather than axios.
+ * Resolves on any HTTP status (a sealed/standby Vault is still "reachable"); only
+ * transport failures reject.
+ */
+const vaultHttp = (
+  urlStr: string,
+  opts: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    tlsSkipVerify?: boolean;
+  }
+): Promise<VaultHttpResponse> =>
+  new Promise((resolve, reject) => {
+    let url: URL;
+    try {
+      url = new URL(urlStr);
+    } catch (e) {
+      reject(new Error('invalid Vault address'));
+      return;
+    }
+    const isHttps = url.protocol === 'https:';
+    const doRequest = isHttps ? httpsRequest : httpRequest;
+    const req = doRequest(
+      url,
+      {
+        method: opts.method ?? 'GET',
+        headers: {
+          ...(opts.body ? { 'Content-Type': 'application/json' } : {}),
+          ...opts.headers,
+        },
+        timeout: 8000,
+        ...(isHttps && opts.tlsSkipVerify ? { rejectUnauthorized: false } : {}),
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          let body: Record<string, unknown> = {};
+          try {
+            body = data ? JSON.parse(data) : {};
+          } catch (e) {
+            body = {};
+          }
+          resolve({ status: res.statusCode ?? 0, body });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.on('timeout', () => req.destroy(new Error('request timed out')));
+    if (opts.body) req.write(opts.body);
+    req.end();
+  });
+
+/**
+ * Verifies Kibana can reach the Vault address and authenticate with the given
+ * credentials. This checks reachability *from Kibana*; the agent (Heartbeat)
+ * resolves from its own network at runtime, which may differ. Secrets are never
+ * returned or logged — only a pass/fail plus the Vault version.
+ */
+const testHashiCorpVault = async (c: {
+  address: string;
+  authMethod: 'token' | 'approle';
+  namespace?: string;
+  tlsSkipVerify?: boolean;
+  roleId?: string;
+  token?: string;
+  secretId?: string;
+}): Promise<TestResult> => {
+  if (!c.address) return { ok: false, message: 'Vault address is required' };
+
+  const base = c.address.replace(/\/+$/, '');
+  const nsHeader: Record<string, string> = c.namespace ? { 'X-Vault-Namespace': c.namespace } : {};
+  const call = (path: string, opts: Parameters<typeof vaultHttp>[1] = {}) =>
+    vaultHttp(`${base}${path}`, {
+      ...opts,
+      tlsSkipVerify: c.tlsSkipVerify,
+      headers: { ...nsHeader, ...opts.headers },
+    });
+
+  // 1) Reachability + version (unauthenticated health endpoint).
+  let versionNote = '';
+  try {
+    const health = await call(
+      '/v1/sys/health?standbyok=true&perfstandbyok=true&sealedok=true&uninitcode=200'
+    );
+    const version = health.body?.version;
+    if (typeof version === 'string') versionNote = ` (Vault ${version})`;
+  } catch (e) {
+    return { ok: false, message: `Could not reach ${base}: ${errText(e)}` };
+  }
+
+  // 2) Authenticate with the configured method.
+  try {
+    if (c.authMethod === 'token') {
+      if (!c.token) return { ok: false, message: 'Token auth requires a token' };
+      const res = await call('/v1/auth/token/lookup-self', {
+        headers: { 'X-Vault-Token': c.token },
+      });
+      return res.status >= 200 && res.status < 300
+        ? { ok: true, message: `Token authenticated${versionNote}.` }
+        : { ok: false, message: `Token rejected (HTTP ${res.status})${versionNote}.` };
+    }
+
+    if (!c.roleId || !c.secretId) {
+      return { ok: false, message: 'AppRole auth requires role_id and secret_id' };
+    }
+    const res = await call('/v1/auth/approle/login', {
+      method: 'POST',
+      body: JSON.stringify({ role_id: c.roleId, secret_id: c.secretId }),
+    });
+    const auth = res.body?.auth as { client_token?: string } | undefined;
+    if (res.status >= 200 && res.status < 300 && auth?.client_token) {
+      return { ok: true, message: `AppRole authenticated${versionNote}.` };
+    }
+    const errs = Array.isArray(res.body?.errors) ? (res.body.errors as string[]).join('; ') : '';
+    return {
+      ok: false,
+      message: `AppRole login failed (HTTP ${res.status})${errs ? `: ${errs}` : ''}${versionNote}.`,
+    };
+  } catch (e) {
+    return { ok: false, message: `Authentication error: ${errText(e)}` };
+  }
+};
+
+const TestBodySchema = schema.object({
+  // When editing a saved connection with the secret left blank, `name` lets the
+  // server fall back to the stored secret so Test works without re-entry.
+  name: schema.maybe(schema.string()),
+  type: schema.maybe(schema.literal('hashicorp_vault')),
+  config: HashiCorpVaultConfigSchema,
+  secrets: schema.maybe(HashiCorpVaultSecretsSchema),
+});
+
+type TestBody = TypeOf<typeof TestBodySchema>;
+
+/** POST /_test: check reachability + auth from Kibana. Never persists anything. */
+export const testVaultConnectionRoute: SyntheticsRestApiRouteFactory<TestResult> = () => ({
+  method: 'POST',
+  path: SYNTHETICS_API_URLS.VAULT_CONNECTION + '/_test',
+  validate: { body: TestBodySchema },
+  writeAccess: true,
+  handler: async ({ request, server, spaceId }) => {
+    const body = request.body as TestBody;
+    const { address, authMethod, namespace, tlsSkipVerify, roleId } = body.config;
+
+    // Fall back to the stored secret when the client submits a blank (editing).
+    let token = body.secrets?.token;
+    let secretId = body.secrets?.secretId;
+    const missingSecret = authMethod === 'token' ? !token : !secretId;
+    if (missingSecret && body.name) {
+      try {
+        const decrypted = await server.encryptedSavedObjects
+          .getClient()
+          .getDecryptedAsInternalUser<SyntheticsVaultConnection>(
+            syntheticsVaultConnectionType,
+            vaultConnectionId(body.name),
+            { namespace: spaceId }
+          );
+        token = token || decrypted.attributes.secrets?.token;
+        secretId = secretId || decrypted.attributes.secrets?.secretId;
+      } catch (e) {
+        // No stored connection; testHashiCorpVault reports the missing secret.
+      }
+    }
+
+    return testHashiCorpVault({
+      address,
+      authMethod,
+      namespace,
+      tlsSkipVerify,
+      roleId,
+      token,
+      secretId,
+    });
   },
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
@@ -6,29 +6,37 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import type { TypeOf } from '@kbn/config-schema';
 import type { SyntheticsServerSetup } from '../../../types';
 import type { RouteContext, SyntheticsRestApiRouteFactory } from '../../types';
 import type {
+  SecretProviderType,
   SyntheticsVaultConnection,
   VaultConnectionStatus,
 } from '../../../../common/runtime_types';
+import { SECRET_PROVIDER_HASHICORP_VAULT } from '../../../../common/runtime_types';
 import { syntheticsVaultConnectionType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { vaultConnectionId } from '../../../saved_objects/synthetics_vault_connection';
 import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
 
+// Whether the connection has its provider secret stored, so the UI can render
+// "•••• saved" without receiving the value. Per-provider: HashiCorp Vault stores a
+// token (token auth) or a secret_id (approle).
+const hasStoredSecret = (a: SyntheticsVaultConnection): boolean => {
+  const secrets = a.secrets ?? {};
+  return a.config.authMethod === 'token' ? Boolean(secrets.token) : Boolean(secrets.secretId);
+};
+
 const toStatus = (attributes: SyntheticsVaultConnection): VaultConnectionStatus => ({
   configured: true,
   name: attributes.name,
-  address: attributes.address,
-  namespace: attributes.namespace,
-  authMethod: attributes.authMethod,
-  roleId: attributes.roleId,
-  kvMount: attributes.kvMount,
-  tlsSkipVerify: attributes.tlsSkipVerify,
+  type: attributes.type,
   secretRefreshInterval: attributes.secretRefreshInterval,
   refreshedAt: attributes.refreshedAt,
-  hasSecret: Boolean(attributes.authMethod === 'token' ? attributes.token : attributes.secretId),
+  // Non-secret provider config, returned verbatim.
+  config: attributes.config,
+  hasSecret: hasStoredSecret(attributes),
 });
 
 // Re-push private-location configs so the updated connections reach agents,
@@ -63,18 +71,32 @@ export const getVaultConnectionsRoute: SyntheticsRestApiRouteFactory<
   handler: async (routeContext) => listConnections(routeContext),
 });
 
-const SaveBodySchema = schema.object({
-  name: schema.string({ minLength: 1 }),
+// HashiCorp Vault provider request shapes. Adding a provider means adding its
+// config/secrets schema and turning `type`/`config`/`secrets` into a discriminated
+// `schema.oneOf` keyed on `type`.
+const HashiCorpVaultConfigSchema = schema.object({
   address: schema.string({ minLength: 1 }),
   authMethod: schema.oneOf([schema.literal('token'), schema.literal('approle')]),
   namespace: schema.maybe(schema.string()),
   kvMount: schema.maybe(schema.string()),
   tlsSkipVerify: schema.maybe(schema.boolean()),
-  secretRefreshInterval: schema.maybe(schema.string()),
-  token: schema.maybe(schema.string()),
   roleId: schema.maybe(schema.string()),
+});
+
+const HashiCorpVaultSecretsSchema = schema.object({
+  token: schema.maybe(schema.string()),
   secretId: schema.maybe(schema.string()),
 });
+
+const SaveBodySchema = schema.object({
+  name: schema.string({ minLength: 1 }),
+  type: schema.maybe(schema.literal('hashicorp_vault')),
+  secretRefreshInterval: schema.maybe(schema.string()),
+  config: HashiCorpVaultConfigSchema,
+  secrets: schema.maybe(HashiCorpVaultSecretsSchema),
+});
+
+type SaveBody = TypeOf<typeof SaveBodySchema>;
 
 /** PUT: create or update a connection (keyed by name). Blank secrets are kept. */
 export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
@@ -85,8 +107,10 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
   validate: { body: SaveBodySchema },
   writeAccess: true,
   handler: async ({ request, response, savedObjectsClient, server, spaceId }) => {
-    const body = request.body as SyntheticsVaultConnection;
-    if (body.authMethod === 'approle' && !body.roleId) {
+    const body = request.body as SaveBody;
+    const type: SecretProviderType = body.type ?? SECRET_PROVIDER_HASHICORP_VAULT;
+
+    if (body.config.authMethod === 'approle' && !body.config.roleId) {
       return response.badRequest({ body: { message: 'approle auth requires a role_id' } });
     }
 
@@ -104,18 +128,20 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
       existing = undefined;
     }
 
+    // Preserve stored secrets when the client submits blanks (editing a connection
+    // without re-entering its secret).
+    const secrets = {
+      token: body.secrets?.token || existing?.secrets?.token,
+      secretId: body.secrets?.secretId || existing?.secrets?.secretId,
+    };
+
     const attributes: SyntheticsVaultConnection = {
       name: body.name,
-      address: body.address,
-      authMethod: body.authMethod,
-      namespace: body.namespace,
-      kvMount: body.kvMount,
-      tlsSkipVerify: body.tlsSkipVerify,
+      type,
+      config: body.config,
       secretRefreshInterval: body.secretRefreshInterval,
       refreshedAt: new Date().toISOString(),
-      token: body.token || existing?.token,
-      roleId: body.roleId,
-      secretId: body.secretId || existing?.secretId,
+      secrets,
     };
 
     await savedObjectsClient.create<SyntheticsVaultConnection>(

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
@@ -8,6 +8,8 @@
 import { schema } from '@kbn/config-schema';
 import type { TypeOf } from '@kbn/config-schema';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { appContextService } from '@kbn/fleet-plugin/server/services';
+import { isSecretStorageEnabled } from '@kbn/fleet-plugin/server/services/secrets';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest } from 'http';
 import type { SyntheticsServerSetup } from '../../../types';
@@ -447,5 +449,40 @@ export const testVaultConnectionRoute: SyntheticsRestApiRouteFactory<TestResult>
       token,
       secretId,
     });
+  },
+});
+
+/**
+ * Whether Fleet secret storage is enabled. Runs as the internal user (so the
+ * caller needs no Fleet privileges). When it is disabled, Fleet stores the
+ * delivered Vault credential blob in plaintext in the agent policy rather than as
+ * a Fleet secret — which is what the Private Locations UI warns about.
+ */
+const getFleetSecretStorageEnabled = async (server: SyntheticsServerSetup): Promise<boolean> => {
+  try {
+    const esClient = server.coreStart.elasticsearch.client.asInternalUser;
+    const soClient = appContextService.getInternalUserSOClientWithoutSpaceExtension();
+    return await isSecretStorageEnabled(esClient, soClient);
+  } catch (e) {
+    server.logger.error(`Vault: failed to determine Fleet secret storage status: ${e.message}`);
+    // Don't raise a false alarm if the check itself fails.
+    return true;
+  }
+};
+
+/** GET: secret-storage status + whether this space has any Vault connections. */
+export const getFleetSecretStorageStatusRoute: SyntheticsRestApiRouteFactory<{
+  secretStorageEnabled: boolean;
+  hasVaultConnections: boolean;
+}> = () => ({
+  method: 'GET',
+  path: SYNTHETICS_API_URLS.FLEET_SECRET_STORAGE_STATUS,
+  validate: {},
+  handler: async (routeContext) => {
+    const [secretStorageEnabled, connections] = await Promise.all([
+      getFleetSecretStorageEnabled(routeContext.server),
+      listConnections(routeContext),
+    ]);
+    return { secretStorageEnabled, hasVaultConnections: connections.length > 0 };
   },
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { SyntheticsRestApiRouteFactory } from '../../types';
+import type {
+  SyntheticsVaultConnection,
+  VaultConnectionStatus,
+} from '../../../../common/runtime_types';
+import { syntheticsVaultConnectionType } from '../../../../common/types/saved_objects';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { VAULT_CONNECTION_SO_ID } from '../../../saved_objects/synthetics_vault_connection';
+
+/**
+ * Returns the current Vault connection as a secret-free status view. The
+ * encrypted token / secret_id are never returned to the browser.
+ */
+export const getVaultConnectionRoute: SyntheticsRestApiRouteFactory<
+  VaultConnectionStatus
+> = () => ({
+  method: 'GET',
+  path: SYNTHETICS_API_URLS.VAULT_CONNECTION,
+  validate: {},
+  handler: async ({ savedObjectsClient }): Promise<VaultConnectionStatus> => {
+    try {
+      const so = await savedObjectsClient.get<SyntheticsVaultConnection>(
+        syntheticsVaultConnectionType,
+        VAULT_CONNECTION_SO_ID
+      );
+      const { address, namespace, authMethod, roleId, kvMount, tlsSkipVerify } = so.attributes;
+      return {
+        configured: true,
+        address,
+        namespace,
+        authMethod,
+        roleId,
+        kvMount,
+        tlsSkipVerify,
+        // A configured connection always has a stored secret; the value itself
+        // is never read back here.
+        hasSecret: true,
+      };
+    } catch (error) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
+        return { configured: false };
+      }
+      throw error;
+    }
+  },
+});
+
+const SaveBodySchema = schema.object({
+  address: schema.string({ minLength: 1 }),
+  authMethod: schema.oneOf([schema.literal('token'), schema.literal('approle')]),
+  namespace: schema.maybe(schema.string()),
+  kvMount: schema.maybe(schema.string()),
+  tlsSkipVerify: schema.maybe(schema.boolean()),
+  token: schema.maybe(schema.string()),
+  roleId: schema.maybe(schema.string()),
+  secretId: schema.maybe(schema.string()),
+});
+
+/**
+ * Creates or updates the single Vault connection for the active space. Secrets
+ * left blank are preserved from the existing connection so a user can edit
+ * non-secret fields without re-entering credentials.
+ */
+export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
+  VaultConnectionStatus
+> = () => ({
+  method: 'PUT',
+  path: SYNTHETICS_API_URLS.VAULT_CONNECTION,
+  validate: {
+    body: SaveBodySchema,
+  },
+  writeAccess: true,
+  handler: async ({ request, response, savedObjectsClient, server, spaceId }) => {
+    const body = request.body as SyntheticsVaultConnection;
+
+    if (body.authMethod === 'approle' && !body.roleId) {
+      return response.badRequest({ body: { message: 'approle auth requires a role_id' } });
+    }
+
+    // Preserve existing secrets when the corresponding field is left blank.
+    const encryptedClient = server.encryptedSavedObjects.getClient();
+    let existing: SyntheticsVaultConnection | undefined;
+    try {
+      const decrypted = await encryptedClient.getDecryptedAsInternalUser<SyntheticsVaultConnection>(
+        syntheticsVaultConnectionType,
+        VAULT_CONNECTION_SO_ID,
+        { namespace: spaceId }
+      );
+      existing = decrypted.attributes;
+    } catch (e) {
+      existing = undefined;
+    }
+
+    const attributes: SyntheticsVaultConnection = {
+      address: body.address,
+      authMethod: body.authMethod,
+      namespace: body.namespace,
+      kvMount: body.kvMount,
+      tlsSkipVerify: body.tlsSkipVerify,
+      token: body.token || existing?.token,
+      roleId: body.roleId,
+      secretId: body.secretId || existing?.secretId,
+    };
+
+    await savedObjectsClient.create<SyntheticsVaultConnection>(
+      syntheticsVaultConnectionType,
+      attributes,
+      { id: VAULT_CONNECTION_SO_ID, overwrite: true, initialNamespaces: [spaceId] }
+    );
+
+    const hasSecret = Boolean(body.authMethod === 'token' ? attributes.token : attributes.secretId);
+
+    return {
+      configured: true,
+      address: attributes.address,
+      namespace: attributes.namespace,
+      authMethod: attributes.authMethod,
+      roleId: attributes.roleId,
+      kvMount: attributes.kvMount,
+      tlsSkipVerify: attributes.tlsSkipVerify,
+      hasSecret,
+    };
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { SyntheticsServerSetup } from '../../../types';
 import type { SyntheticsRestApiRouteFactory } from '../../types';
 import type {
   SyntheticsVaultConnection,
@@ -15,6 +16,29 @@ import type {
 import { syntheticsVaultConnectionType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { VAULT_CONNECTION_SO_ID } from '../../../saved_objects/synthetics_vault_connection';
+import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
+
+const toStatus = (
+  attributes: SyntheticsVaultConnection,
+  hasSecret: boolean
+): VaultConnectionStatus => ({
+  configured: true,
+  address: attributes.address,
+  namespace: attributes.namespace,
+  authMethod: attributes.authMethod,
+  roleId: attributes.roleId,
+  kvMount: attributes.kvMount,
+  tlsSkipVerify: attributes.tlsSkipVerify,
+  secretRefreshInterval: attributes.secretRefreshInterval,
+  refreshedAt: attributes.refreshedAt,
+  hasSecret,
+});
+
+// Re-push private-location configs so the updated connection (new refreshedAt =
+// new blob) reaches agents, forcing Heartbeat to re-resolve — this is how a
+// manual refresh / rotation propagates.
+const propagate = (server: SyntheticsServerSetup, spaceId: string) =>
+  asyncGlobalParamsPropagation({ server, paramsSpacesToSync: [spaceId] });
 
 /**
  * Returns the current Vault connection as a secret-free status view. The
@@ -32,19 +56,7 @@ export const getVaultConnectionRoute: SyntheticsRestApiRouteFactory<
         syntheticsVaultConnectionType,
         VAULT_CONNECTION_SO_ID
       );
-      const { address, namespace, authMethod, roleId, kvMount, tlsSkipVerify } = so.attributes;
-      return {
-        configured: true,
-        address,
-        namespace,
-        authMethod,
-        roleId,
-        kvMount,
-        tlsSkipVerify,
-        // A configured connection always has a stored secret; the value itself
-        // is never read back here.
-        hasSecret: true,
-      };
+      return toStatus(so.attributes, true);
     } catch (error) {
       if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
         return { configured: false };
@@ -60,6 +72,7 @@ const SaveBodySchema = schema.object({
   namespace: schema.maybe(schema.string()),
   kvMount: schema.maybe(schema.string()),
   tlsSkipVerify: schema.maybe(schema.boolean()),
+  secretRefreshInterval: schema.maybe(schema.string()),
   token: schema.maybe(schema.string()),
   roleId: schema.maybe(schema.string()),
   secretId: schema.maybe(schema.string()),
@@ -67,8 +80,9 @@ const SaveBodySchema = schema.object({
 
 /**
  * Creates or updates the single Vault connection for the active space. Secrets
- * left blank are preserved from the existing connection so a user can edit
- * non-secret fields without re-entering credentials.
+ * left blank are preserved so a user can edit non-secret fields without
+ * re-entering credentials. Every save stamps a fresh refreshedAt and re-pushes
+ * configs.
  */
 export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
   VaultConnectionStatus
@@ -106,6 +120,8 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
       namespace: body.namespace,
       kvMount: body.kvMount,
       tlsSkipVerify: body.tlsSkipVerify,
+      secretRefreshInterval: body.secretRefreshInterval,
+      refreshedAt: new Date().toISOString(),
       token: body.token || existing?.token,
       roleId: body.roleId,
       secretId: body.secretId || existing?.secretId,
@@ -117,17 +133,56 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
       { id: VAULT_CONNECTION_SO_ID, overwrite: true, initialNamespaces: [spaceId] }
     );
 
-    const hasSecret = Boolean(body.authMethod === 'token' ? attributes.token : attributes.secretId);
+    await propagate(server, spaceId);
 
-    return {
-      configured: true,
-      address: attributes.address,
-      namespace: attributes.namespace,
-      authMethod: attributes.authMethod,
-      roleId: attributes.roleId,
-      kvMount: attributes.kvMount,
-      tlsSkipVerify: attributes.tlsSkipVerify,
-      hasSecret,
+    const hasSecret = Boolean(body.authMethod === 'token' ? attributes.token : attributes.secretId);
+    return toStatus(attributes, hasSecret);
+  },
+});
+
+/**
+ * Manual "Refresh secrets": bumps refreshedAt (which changes the delivered blob)
+ * and re-pushes configs so agents re-resolve every vault-backed secret from
+ * Vault — picking up rotations without editing the connection.
+ */
+export const refreshVaultConnectionRoute: SyntheticsRestApiRouteFactory<
+  VaultConnectionStatus
+> = () => ({
+  method: 'POST',
+  path: SYNTHETICS_API_URLS.VAULT_CONNECTION + '/_refresh',
+  validate: {},
+  writeAccess: true,
+  handler: async ({ response, savedObjectsClient, server, spaceId }) => {
+    const encryptedClient = server.encryptedSavedObjects.getClient();
+    let existing: SyntheticsVaultConnection;
+    try {
+      const decrypted = await encryptedClient.getDecryptedAsInternalUser<SyntheticsVaultConnection>(
+        syntheticsVaultConnectionType,
+        VAULT_CONNECTION_SO_ID,
+        { namespace: spaceId }
+      );
+      existing = decrypted.attributes;
+    } catch (error) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
+        return response.notFound({ body: { message: 'No Vault connection configured' } });
+      }
+      throw error;
+    }
+
+    const attributes: SyntheticsVaultConnection = {
+      ...existing,
+      refreshedAt: new Date().toISOString(),
     };
+
+    await savedObjectsClient.create<SyntheticsVaultConnection>(
+      syntheticsVaultConnectionType,
+      attributes,
+      { id: VAULT_CONNECTION_SO_ID, overwrite: true, initialNamespaces: [spaceId] }
+    );
+
+    await propagate(server, spaceId);
+
+    const hasSecret = Boolean(existing.authMethod === 'token' ? existing.token : existing.secretId);
+    return toStatus(attributes, hasSecret);
   },
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/vault/vault_connection.ts
@@ -79,34 +79,52 @@ export const getVaultConnectionsRoute: SyntheticsRestApiRouteFactory<
   handler: async (routeContext) => listConnections(routeContext),
 });
 
+// Upper bound for any single connection string; these flow into SO docs and the
+// delivered policy blob, so keep them bounded (AGENTS.md).
+const MAX_LEN = 2048;
+
+const isHttpUrl = (v: string): string | undefined => {
+  try {
+    const { protocol } = new URL(v);
+    return protocol === 'http:' || protocol === 'https:' ? undefined : 'must be an http(s) URL';
+  } catch (e) {
+    return 'must be a valid URL';
+  }
+};
+
+// A Go duration string, e.g. "5m", "30s", "1.5h" — matches Heartbeat's parser so a
+// value that would fail at config-unpack on every agent is rejected up front.
+const isDuration = (v: string): string | undefined =>
+  /^\d+(\.\d+)?(ms|s|m|h)$/.test(v) ? undefined : 'must be a duration like "5m", "30s", or "1h"';
+
 // HashiCorp Vault provider request shapes. Adding a provider means adding its
 // config/secrets schema and turning `type`/`config`/`secrets` into a discriminated
 // `schema.oneOf` keyed on `type`.
 const HashiCorpVaultConfigSchema = schema.object({
-  address: schema.string({ minLength: 1 }),
+  address: schema.string({ minLength: 1, maxLength: MAX_LEN, validate: isHttpUrl }),
   authMethod: schema.oneOf([schema.literal('token'), schema.literal('approle')]),
-  namespace: schema.maybe(schema.string()),
-  kvMount: schema.maybe(schema.string()),
+  namespace: schema.maybe(schema.string({ maxLength: MAX_LEN })),
+  kvMount: schema.maybe(schema.string({ maxLength: MAX_LEN })),
   tlsSkipVerify: schema.maybe(schema.boolean()),
-  roleId: schema.maybe(schema.string()),
+  roleId: schema.maybe(schema.string({ maxLength: MAX_LEN })),
 });
 
 const HashiCorpVaultSecretsSchema = schema.object({
-  token: schema.maybe(schema.string()),
-  secretId: schema.maybe(schema.string()),
+  token: schema.maybe(schema.string({ maxLength: MAX_LEN })),
+  secretId: schema.maybe(schema.string({ maxLength: MAX_LEN })),
 });
 
 const SaveBodySchema = schema.object({
   name: schema.string({
     minLength: 1,
-    maxLength: 1024,
+    maxLength: MAX_LEN,
     validate: (v) =>
       VAULT_CONNECTION_NAME_REGEX.test(v)
         ? undefined
         : 'must contain only letters, numbers, and . _ -',
   }),
   type: schema.maybe(schema.literal('hashicorp_vault')),
-  secretRefreshInterval: schema.maybe(schema.string()),
+  secretRefreshInterval: schema.maybe(schema.string({ maxLength: 32, validate: isDuration })),
   config: HashiCorpVaultConfigSchema,
   secrets: schema.maybe(HashiCorpVaultSecretsSchema),
 });
@@ -179,6 +197,20 @@ export const saveVaultConnectionRoute: SyntheticsRestApiRouteFactory<
           token: body.secrets?.token || existing?.secrets?.token,
           secretId: body.secrets?.secretId || existing?.secrets?.secretId,
         };
+
+    // C9: a new connection must carry a usable credential — otherwise it saves,
+    // propagates, and only fails later at the agent.
+    const effectiveSecret = body.config.authMethod === 'token' ? secrets.token : secrets.secretId;
+    if (!existing && !effectiveSecret) {
+      return response.badRequest({
+        body: {
+          message:
+            body.config.authMethod === 'token'
+              ? 'A token is required to create a token-auth connection'
+              : 'A secret_id is required to create an approle connection',
+        },
+      });
+    }
     // Non-secret marker so the (non-decrypting) list read can report "secret saved".
     const hasSecret =
       body.config.authMethod === 'token' ? Boolean(secrets.token) : Boolean(secrets.secretId);
@@ -245,11 +277,16 @@ export const refreshVaultConnectionsRoute: SyntheticsRestApiRouteFactory<
     const refreshedAt = new Date().toISOString();
     for await (const result of finder.find()) {
       for (const so of result.saved_objects) {
-        if (!so.attributes) continue;
+        // B3: the decrypting finder returns decrypt-failed objects with `error`
+        // set and their attributes stripped — re-creating those would wipe the
+        // secret. Skip them.
+        if (so.error || !so.attributes) continue;
         await savedObjectsClient.create<SyntheticsVaultConnection>(
           syntheticsVaultConnectionType,
           { ...so.attributes, refreshedAt },
-          { id: so.id, overwrite: true, initialNamespaces: [spaceId] }
+          // B5: preserve the object's actual namespaces on overwrite rather than
+          // forcing [spaceId], which would narrow (or error on) a shared object.
+          { id: so.id, overwrite: true, initialNamespaces: so.namespaces ?? [spaceId] }
         );
       }
     }

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/saved_objects.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/saved_objects.ts
@@ -19,6 +19,10 @@ import {
   syntheticsParamSavedObjectType,
 } from './synthetics_param';
 import {
+  SYNTHETICS_VAULT_CONNECTION_ENCRYPTED_TYPE,
+  syntheticsVaultConnectionSavedObjectType,
+} from './synthetics_vault_connection';
+import {
   LEGACY_PRIVATE_LOCATIONS_SAVED_OBJECT_TYPE,
   PRIVATE_LOCATION_SAVED_OBJECT_TYPE,
 } from './private_locations';
@@ -59,4 +63,8 @@ export const registerSyntheticsSavedObjects = (
   // global params saved object type
   savedObjectsService.registerType(syntheticsParamSavedObjectType);
   encryptedSavedObjects.registerType(SYNTHETICS_PARAMS_SECRET_ENCRYPTED_TYPE);
+
+  // HashiCorp Vault connection saved object type
+  savedObjectsService.registerType(syntheticsVaultConnectionSavedObjectType);
+  encryptedSavedObjects.registerType(SYNTHETICS_VAULT_CONNECTION_ENCRYPTED_TYPE);
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_param.ts
@@ -10,7 +10,7 @@ import { syntheticsParamType } from '../../common/types/saved_objects';
 export const SYNTHETICS_PARAMS_SECRET_ENCRYPTED_TYPE = {
   type: syntheticsParamType,
   attributesToEncrypt: new Set(['value']),
-  attributesToIncludeInAAD: new Set(['key', 'description', 'tags']),
+  attributesToIncludeInAAD: new Set(['key', 'description', 'tags', 'source']),
 };
 
 export const syntheticsParamSavedObjectType: SavedObjectsType = {

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_param.ts
@@ -10,7 +10,14 @@ import { syntheticsParamType } from '../../common/types/saved_objects';
 export const SYNTHETICS_PARAMS_SECRET_ENCRYPTED_TYPE = {
   type: syntheticsParamType,
   attributesToEncrypt: new Set(['value']),
-  attributesToIncludeInAAD: new Set(['key', 'description', 'tags', 'source']),
+  // `source` is deliberately NOT in the AAD. Adding an attribute to the AAD set
+  // in-place is unsafe for zero-downtime upgrades — during a rolling upgrade an
+  // older node cannot rebuild the new AAD, so it fails to decrypt `value` for any
+  // vault-backed param a newer node wrote. `source` is only non-secret UI metadata
+  // that mirrors the already-encrypted ${vault/..} token, so binding it adds no
+  // meaningful protection. Keeping the AAD equal to previous releases avoids the
+  // ZDU hazard (and the decrypt-corruption when `source` is later cleared).
+  attributesToIncludeInAAD: new Set(['key', 'description', 'tags']),
 };
 
 export const syntheticsParamSavedObjectType: SavedObjectsType = {

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
@@ -5,16 +5,20 @@
  * 2.0.
  */
 import type { SavedObjectsType } from '@kbn/core/server';
+import { v5 as uuidv5 } from 'uuid';
 import { syntheticsVaultConnectionType } from '../../common/types/saved_objects';
 
-// A single connection per space; a fixed id keeps it a singleton. Encrypted
-// saved objects require predefined ids to be UUIDs, so we use a fixed UUID.
-export const VAULT_CONNECTION_SO_ID = '5efab9a0-0000-4000-8000-000000000001';
+// Encrypted saved objects require predefined ids to be UUIDs. We derive a stable
+// UUID per connection name so the name is the key (upsert by name) while the SO
+// id stays a valid UUID.
+const VAULT_CONNECTION_NAMESPACE = '5efab9a0-0000-4000-8000-000000000001';
+export const vaultConnectionId = (name: string) => uuidv5(name, VAULT_CONNECTION_NAMESPACE);
 
 export const SYNTHETICS_VAULT_CONNECTION_ENCRYPTED_TYPE = {
   type: syntheticsVaultConnectionType,
   attributesToEncrypt: new Set(['token', 'secretId']),
   attributesToIncludeInAAD: new Set([
+    'name',
     'address',
     'namespace',
     'authMethod',

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
@@ -21,6 +21,8 @@ export const SYNTHETICS_VAULT_CONNECTION_ENCRYPTED_TYPE = {
     'roleId',
     'kvMount',
     'tlsSkipVerify',
+    'secretRefreshInterval',
+    'refreshedAt',
   ]),
 };
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
@@ -9,10 +9,16 @@ import { v5 as uuidv5 } from 'uuid';
 import { syntheticsVaultConnectionType } from '../../common/types/saved_objects';
 
 // Encrypted saved objects require predefined ids to be UUIDs. We derive a stable
-// UUID per connection name so the name is the key (upsert by name) while the SO
-// id stays a valid UUID.
+// UUID per (space, connection name) so the name is the key (upsert by name) while
+// the SO id stays a valid UUID.
+//
+// The space MUST be part of the id: the type is `namespaceType: 'multiple'` (a
+// single global id space), so deriving from the name alone collides across spaces
+// — creating "prod" in one space would fail with an unresolvable-conflict when
+// another space already has it, and the 409 would leak which names exist elsewhere.
 const VAULT_CONNECTION_NAMESPACE = '5efab9a0-0000-4000-8000-000000000001';
-export const vaultConnectionId = (name: string) => uuidv5(name, VAULT_CONNECTION_NAMESPACE);
+export const vaultConnectionId = (name: string, spaceId: string) =>
+  uuidv5(`${spaceId}:${name}`, VAULT_CONNECTION_NAMESPACE);
 
 // The provider-specific secret fields live under a single `secrets` attribute,
 // which is encrypted as one blob. This is what keeps the encryption model stable

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { SavedObjectsType } from '@kbn/core/server';
+import { syntheticsVaultConnectionType } from '../../common/types/saved_objects';
+
+// A single connection per space; a fixed id keeps it a singleton. Encrypted
+// saved objects require predefined ids to be UUIDs, so we use a fixed UUID.
+export const VAULT_CONNECTION_SO_ID = '5efab9a0-0000-4000-8000-000000000001';
+
+export const SYNTHETICS_VAULT_CONNECTION_ENCRYPTED_TYPE = {
+  type: syntheticsVaultConnectionType,
+  attributesToEncrypt: new Set(['token', 'secretId']),
+  attributesToIncludeInAAD: new Set([
+    'address',
+    'namespace',
+    'authMethod',
+    'roleId',
+    'kvMount',
+    'tlsSkipVerify',
+  ]),
+};
+
+export const syntheticsVaultConnectionSavedObjectType: SavedObjectsType = {
+  name: syntheticsVaultConnectionType,
+  hidden: false,
+  namespaceType: 'multiple',
+  mappings: {
+    dynamic: false,
+    properties: {},
+  },
+  management: {
+    importableAndExportable: false,
+    icon: 'lock',
+  },
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_vault_connection.ts
@@ -14,17 +14,17 @@ import { syntheticsVaultConnectionType } from '../../common/types/saved_objects'
 const VAULT_CONNECTION_NAMESPACE = '5efab9a0-0000-4000-8000-000000000001';
 export const vaultConnectionId = (name: string) => uuidv5(name, VAULT_CONNECTION_NAMESPACE);
 
+// The provider-specific secret fields live under a single `secrets` attribute,
+// which is encrypted as one blob. This is what keeps the encryption model stable
+// as providers are added: a new provider adds fields inside `secrets`/`config`,
+// never a new top-level attribute, so this declaration never has to change.
 export const SYNTHETICS_VAULT_CONNECTION_ENCRYPTED_TYPE = {
   type: syntheticsVaultConnectionType,
-  attributesToEncrypt: new Set(['token', 'secretId']),
+  attributesToEncrypt: new Set(['secrets']),
   attributesToIncludeInAAD: new Set([
     'name',
-    'address',
-    'namespace',
-    'authMethod',
-    'roleId',
-    'kvMount',
-    'tlsSkipVerify',
+    'type',
+    'config',
     'secretRefreshInterval',
     'refreshedAt',
   ]),

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/format_synthetics_policy.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/format_synthetics_policy.ts
@@ -18,6 +18,7 @@ import {
   handleMultilineStringFormatter,
   replaceStringWithParams,
 } from '../formatting_utils';
+import { valueContainsVaultReference } from '../vault_param_formatter';
 import { syntheticsPolicyFormatters } from './formatters';
 import { PARAMS_KEYS_TO_SKIP } from '../common';
 
@@ -39,7 +40,8 @@ export const formatSyntheticsPolicy = (
   config: Partial<MonitorFields & ProcessorFields>,
   params: Record<string, string>,
   mws: MaintenanceWindow[],
-  isLegacy?: boolean
+  isLegacy?: boolean,
+  vaultConfigB64?: string
 ) => {
   const configKeys = Object.keys(config) as ConfigKey[];
 
@@ -128,6 +130,21 @@ export const formatSyntheticsPolicy = (
   const throttling = dataStream?.vars?.[LegacyConfigKey.THROTTLING_CONFIG];
   if (throttling) {
     throttling.value = throttlingFormatter?.(config, ConfigKey.THROTTLING_CONFIG);
+  }
+
+  // Vault connection: when this monitor references a vault-backed secret
+  // (${vault/<path>#<field>} in any field) and a connection is configured, set
+  // the base64 connection on the `vault` var. That var is `secret: true` in the
+  // package, so Fleet stores the whole connection as a single Fleet secret and
+  // the compiled policy carries only a $co.elastic.secret{...} reference.
+  const vaultItem = dataStream?.vars?.vault;
+  if (vaultItem && vaultConfigB64) {
+    const usesVault = Object.values(dataStream?.vars ?? {}).some((v) =>
+      valueContainsVaultReference(v?.value)
+    );
+    if (usesVault) {
+      vaultItem.value = vaultConfigB64;
+    }
   }
 
   return { formattedPolicy, hasDataStream: Boolean(dataStream), hasInput: Boolean(currentInput) };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/format_synthetics_policy.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/format_synthetics_policy.ts
@@ -129,6 +129,15 @@ export const formatSyntheticsPolicy = (
     }
   });
 
+  // Collect the vault connection names this monitor references BEFORE any value is
+  // transformed below — the browser inline script is base64-encoded a few lines
+  // down, which would otherwise hide a ${vault/..} token inside it from detection
+  // (C3). Empty when the monitor references no vault-backed secret.
+  const referencedVaultConnections = new Set<string | undefined>();
+  Object.values(dataStream?.vars ?? {}).forEach((v) => {
+    referencedConnectionNames(v?.value).forEach((n) => referencedVaultConnections.add(n));
+  });
+
   // This field is NOT in the monitor config, but needs to be set in the policy
   // so Heartbeat knows to decode the base64-encoded script
   const encodingVar = dataStream?.vars?.['source.inline.encoding'];
@@ -174,16 +183,14 @@ export const formatSyntheticsPolicy = (
   // as a single Fleet secret and the compiled policy carries only a
   // $co.elastic.secret{...} reference.
   const vaultItem = dataStream?.vars?.vault;
-  if (vaultItem && vaultConnections?.length) {
-    const referenced = new Set<string | undefined>();
-    Object.values(dataStream?.vars ?? {}).forEach((v) => {
-      referencedConnectionNames(v?.value).forEach((n) => referenced.add(n));
-    });
-    if (referenced.size > 0) {
-      const scoped = scopeVaultConnections(vaultConnections, referenced, config[ConfigKey.NAME]);
-      if (scoped.length > 0) {
-        vaultItem.value = Buffer.from(JSON.stringify(scoped)).toString('base64');
-      }
+  if (vaultItem && vaultConnections?.length && referencedVaultConnections.size > 0) {
+    const scoped = scopeVaultConnections(
+      vaultConnections,
+      referencedVaultConnections,
+      config[ConfigKey.NAME]
+    );
+    if (scoped.length > 0) {
+      vaultItem.value = Buffer.from(JSON.stringify(scoped)).toString('base64');
     }
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/format_synthetics_policy.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/format_synthetics_policy.ts
@@ -18,9 +18,44 @@ import {
   handleMultilineStringFormatter,
   replaceStringWithParams,
 } from '../formatting_utils';
-import { valueContainsVaultReference } from '../vault_param_formatter';
+import { referencedConnectionNames } from '../vault_param_formatter';
+import type { HeartbeatVaultConfig } from '../../get_vault_connection';
 import { syntheticsPolicyFormatters } from './formatters';
 import { PARAMS_KEYS_TO_SKIP } from '../common';
+
+/**
+ * Selects only the Vault connections a monitor actually references (by name;
+ * undefined = the default connection), so an agent never receives credentials for
+ * connections the monitor does not use. Fails closed: a reference to a connection
+ * that is not configured throws rather than silently shipping nothing (or all).
+ */
+export const scopeVaultConnections = (
+  all: HeartbeatVaultConfig[],
+  referenced: Set<string | undefined>,
+  monitorName?: string
+): HeartbeatVaultConfig[] => {
+  const byName = new Map(all.map((c) => [c.name, c]));
+  const scoped = new Map<string, HeartbeatVaultConfig>();
+  for (const name of referenced) {
+    if (name === undefined) {
+      // The default connection is only well-defined when exactly one exists. With
+      // several, an unqualified ${vault/..} has no default — don't over-ship; the
+      // agent reports the unresolved reference at runtime.
+      if (all.length === 1) scoped.set(all[0].name, all[0]);
+      continue;
+    }
+    const conn = byName.get(name);
+    if (!conn) {
+      throw new Error(
+        `Monitor "${
+          monitorName ?? ''
+        }" references Vault connection "${name}", which is not configured`
+      );
+    }
+    scoped.set(conn.name, conn);
+  }
+  return [...scoped.values()];
+};
 
 export interface ProcessorFields {
   location_name: string;
@@ -41,7 +76,7 @@ export const formatSyntheticsPolicy = (
   params: Record<string, string>,
   mws: MaintenanceWindow[],
   isLegacy?: boolean,
-  vaultConfigB64?: string
+  vaultConnections?: HeartbeatVaultConfig[]
 ) => {
   const configKeys = Object.keys(config) as ConfigKey[];
 
@@ -132,18 +167,23 @@ export const formatSyntheticsPolicy = (
     throttling.value = throttlingFormatter?.(config, ConfigKey.THROTTLING_CONFIG);
   }
 
-  // Vault connection: when this monitor references a vault-backed secret
-  // (${vault/<path>#<field>} in any field) and a connection is configured, set
-  // the base64 connection on the `vault` var. That var is `secret: true` in the
-  // package, so Fleet stores the whole connection as a single Fleet secret and
-  // the compiled policy carries only a $co.elastic.secret{...} reference.
+  // Vault connections: when this monitor references a vault-backed secret
+  // (${vault/[<name>@]<path>#<field>} in any resolved field) attach ONLY the
+  // referenced connections (not every connection in the space) to the `vault` var,
+  // base64-encoded. That var is `secret: true` in the package, so Fleet stores it
+  // as a single Fleet secret and the compiled policy carries only a
+  // $co.elastic.secret{...} reference.
   const vaultItem = dataStream?.vars?.vault;
-  if (vaultItem && vaultConfigB64) {
-    const usesVault = Object.values(dataStream?.vars ?? {}).some((v) =>
-      valueContainsVaultReference(v?.value)
-    );
-    if (usesVault) {
-      vaultItem.value = vaultConfigB64;
+  if (vaultItem && vaultConnections?.length) {
+    const referenced = new Set<string | undefined>();
+    Object.values(dataStream?.vars ?? {}).forEach((v) => {
+      referencedConnectionNames(v?.value).forEach((n) => referenced.add(n));
+    });
+    if (referenced.size > 0) {
+      const scoped = scopeVaultConnections(vaultConnections, referenced, config[ConfigKey.NAME]);
+      if (scoped.length > 0) {
+        vaultItem.value = Buffer.from(JSON.stringify(scoped)).toString('base64');
+      }
     }
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/format_synthetics_policy.vault.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/format_synthetics_policy.vault.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { scopeVaultConnections } from './format_synthetics_policy';
+import type { HeartbeatVaultConfig } from '../../get_vault_connection';
+
+const conn = (name: string): HeartbeatVaultConfig => ({
+  enabled: true,
+  name,
+  type: 'hashicorp_vault',
+  address: `http://${name}:8200`,
+  auth_method: 'token',
+  token: `${name}-token`,
+});
+
+describe('scopeVaultConnections', () => {
+  const conns = [conn('prod'), conn('staging')];
+
+  it('returns only the referenced named connections (never the others)', () => {
+    const scoped = scopeVaultConnections(conns, new Set(['staging']));
+    expect(scoped.map((c) => c.name)).toEqual(['staging']);
+    // prod's secret must not be shipped to a monitor that only uses staging.
+    expect(scoped.some((c) => c.name === 'prod')).toBe(false);
+  });
+
+  it('treats a single connection as the default for an unqualified reference', () => {
+    expect(scopeVaultConnections([conn('only')], new Set([undefined])).map((c) => c.name)).toEqual([
+      'only',
+    ]);
+  });
+
+  it('does not over-ship a default reference when multiple connections exist', () => {
+    // No default is well-defined with several connections — ship nothing rather
+    // than every credential.
+    expect(scopeVaultConnections(conns, new Set([undefined]))).toEqual([]);
+  });
+
+  it('fails closed on a reference to a connection that is not configured', () => {
+    expect(() => scopeVaultConnections(conns, new Set(['nope']), 'm1')).toThrow(
+      /references Vault connection "nope", which is not configured/
+    );
+  });
+
+  it('dedupes a connection referenced more than once', () => {
+    expect(scopeVaultConnections(conns, new Set(['prod']))).toHaveLength(1);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.test.ts
@@ -10,6 +10,9 @@ import {
   hasVaultReference,
   valueContainsVaultReference,
   extractVaultReferences,
+  buildVaultReference,
+  referencedConnectionNames,
+  VaultParamSourceSchema,
 } from './vault_param_formatter';
 
 describe('vault reference helpers', () => {
@@ -28,12 +31,89 @@ describe('vault reference helpers', () => {
 
   it('extracts path and field from references', () => {
     expect(extractVaultReferences('${vault/myapp/creds#password}')).toEqual([
-      { path: 'myapp/creds', field: 'password' },
+      { connection: undefined, path: 'myapp/creds', field: 'password' },
     ]);
     expect(extractVaultReferences('a=${vault/one/two#a} b=${vault/three#b}')).toEqual([
-      { path: 'one/two', field: 'a' },
-      { path: 'three', field: 'b' },
+      { connection: undefined, path: 'one/two', field: 'a' },
+      { connection: undefined, path: 'three', field: 'b' },
     ]);
+  });
+
+  it('parses the named connection@ form', () => {
+    expect(extractVaultReferences('${vault/staging@myapp/creds#password}')).toEqual([
+      { connection: 'staging', path: 'myapp/creds', field: 'password' },
+    ]);
+  });
+
+  it('collects referenced connection names (undefined = default)', () => {
+    const v = 'a=${vault/prod@x/y#a};b=${vault/z#b};c=${vault/prod@m/n#c}';
+    expect(referencedConnectionNames(v)).toEqual(new Set(['prod', undefined]));
+    expect(referencedConnectionNames({ h: '${vault/staging@a/b#c}' })).toEqual(
+      new Set(['staging'])
+    );
+  });
+});
+
+describe('buildVaultReference', () => {
+  it('builds the default and named forms and strips outer slashes', () => {
+    expect(buildVaultReference('myapp/creds', 'password')).toBe('${vault/myapp/creds#password}');
+    expect(buildVaultReference('/myapp/creds/', 'password', 'staging')).toBe(
+      '${vault/staging@myapp/creds#password}'
+    );
+  });
+
+  it('round-trips with extractVaultReferences', () => {
+    expect(extractVaultReferences(buildVaultReference('myapp/creds', 'password'))).toEqual([
+      { connection: undefined, path: 'myapp/creds', field: 'password' },
+    ]);
+    expect(extractVaultReferences(buildVaultReference('myapp/creds', 'password', 'prod'))).toEqual([
+      { connection: 'prod', path: 'myapp/creds', field: 'password' },
+    ]);
+  });
+
+  it('refuses hostile input that would escape the opaque token', () => {
+    // A `}` in the field would close the token early and let a trailing
+    // ${otherParam} be substituted with another param's value — must be refused.
+    expect(() => buildVaultReference('p', 'f}${otherParam')).toThrow(/Invalid Vault field/);
+    expect(() => buildVaultReference('p', 'a#b')).toThrow(/Invalid Vault field/);
+    expect(() => buildVaultReference('p', 'a@b')).toThrow(/Invalid Vault field/);
+    expect(() => buildVaultReference('a#b', 'f')).toThrow(/Invalid Vault path/);
+    expect(() => buildVaultReference('a b', 'f')).toThrow(/Invalid Vault path/);
+    expect(() => buildVaultReference('p', 'f', 'na@me')).toThrow(/Invalid Vault connection name/);
+  });
+
+  it('a refused token can never inject another param', () => {
+    // Because the builder throws, no injectable string is produced for
+    // replaceStringWithParams to expand.
+    expect(() => buildVaultReference('p', 'f}${environment')).toThrow();
+  });
+});
+
+describe('VaultParamSourceSchema', () => {
+  it('accepts a valid vault source (default and named)', () => {
+    expect(() =>
+      VaultParamSourceSchema.validate({ type: 'vault', path: 'myapp/creds', field: 'password' })
+    ).not.toThrow();
+    expect(() =>
+      VaultParamSourceSchema.validate({
+        type: 'vault',
+        path: 'myapp/creds',
+        field: 'password',
+        connection: 'staging',
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects hostile path/field/connection', () => {
+    expect(() =>
+      VaultParamSourceSchema.validate({ type: 'vault', path: 'a', field: 'f}${x' })
+    ).toThrow();
+    expect(() =>
+      VaultParamSourceSchema.validate({ type: 'vault', path: 'a#b', field: 'f' })
+    ).toThrow();
+    expect(() =>
+      VaultParamSourceSchema.validate({ type: 'vault', path: 'a', field: 'f', connection: 'na@me' })
+    ).toThrow();
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { replaceStringWithParams } from './formatting_utils';
+import {
+  hasVaultReference,
+  valueContainsVaultReference,
+  extractVaultReferences,
+} from './vault_param_formatter';
+
+describe('vault reference helpers', () => {
+  it('detects vault references', () => {
+    expect(hasVaultReference('${vault/myapp/creds#password}')).toBe(true);
+    expect(hasVaultReference('Bearer ${vault/tokens/api#value}')).toBe(true);
+    expect(hasVaultReference('${normalParam}')).toBe(false);
+    expect(hasVaultReference('no refs here')).toBe(false);
+  });
+
+  it('detects vault references inside objects', () => {
+    expect(valueContainsVaultReference({ headers: { auth: '${vault/x/y#z}' } })).toBe(true);
+    expect(valueContainsVaultReference({ headers: { auth: 'static' } })).toBe(false);
+    expect(valueContainsVaultReference(null)).toBe(false);
+  });
+
+  it('extracts path and field from references', () => {
+    expect(extractVaultReferences('${vault/myapp/creds#password}')).toEqual([
+      { path: 'myapp/creds', field: 'password' },
+    ]);
+    expect(extractVaultReferences('a=${vault/one/two#a} b=${vault/three#b}')).toEqual([
+      { path: 'one/two', field: 'a' },
+      { path: 'three', field: 'b' },
+    ]);
+  });
+});
+
+describe('replaceStringWithParams leaves vault references untouched', () => {
+  const params = { environment: 'prod', apiHost: 'example.com' };
+
+  it('passes a bare vault reference through unchanged', () => {
+    const value = '${vault/myapp/creds#password}';
+    expect(replaceStringWithParams(value, params)).toBe(value);
+  });
+
+  it('passes a vault reference embedded in a header value through unchanged', () => {
+    const value = 'Bearer ${vault/tokens/api#value}';
+    expect(replaceStringWithParams(value, params)).toBe(value);
+  });
+
+  it('resolves normal params but preserves vault references in the same value', () => {
+    // Only the ${environment} param is resolved; the vault token is preserved
+    // verbatim for edge resolution by Heartbeat.
+    const value = 'env=${environment};secret=${vault/myapp/creds#password}';
+    expect(replaceStringWithParams(value, params)).toBe(
+      'env=prod;secret=${vault/myapp/creds#password}'
+    );
+  });
+
+  it('preserves vault references inside object field values', () => {
+    const value = { 'X-Secret': '${vault/myapp/creds#password}', host: '${apiHost}' };
+    expect(replaceStringWithParams(value, params)).toEqual({
+      'X-Secret': '${vault/myapp/creds#password}',
+      host: 'example.com',
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.ts
@@ -37,12 +37,15 @@ export const VAULT_REF_REGEX = /\$\{vault\/[^#{}]+#[^{}]+\}/g;
 
 /**
  * Builds the edge-resolved reference token stored as a vault-backed param's
- * value, e.g. buildVaultReference('myapp/creds', 'password') ->
- * '${vault/myapp/creds#password}'. Heartbeat expands this token at runtime.
+ * value. With a connection name it emits ${vault/<connection>@<path>#<field>}
+ * (routes to that named Vault connection); without one it emits
+ * ${vault/<path>#<field>} (the default connection). Heartbeat expands the token
+ * at runtime.
  */
-export const buildVaultReference = (path: string, field: string): string => {
+export const buildVaultReference = (path: string, field: string, connection?: string): string => {
   const cleanPath = path.replace(/^\/+|\/+$/g, '');
-  return '${vault/' + cleanPath + '#' + field + '}';
+  const prefix = connection ? `vault/${connection}@` : 'vault/';
+  return '${' + prefix + cleanPath + '#' + field + '}';
 };
 
 /**

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.ts
@@ -36,6 +36,16 @@
 export const VAULT_REF_REGEX = /\$\{vault\/[^#{}]+#[^{}]+\}/g;
 
 /**
+ * Builds the edge-resolved reference token stored as a vault-backed param's
+ * value, e.g. buildVaultReference('myapp/creds', 'password') ->
+ * '${vault/myapp/creds#password}'. Heartbeat expands this token at runtime.
+ */
+export const buildVaultReference = (path: string, field: string): string => {
+  const cleanPath = path.replace(/^\/+|\/+$/g, '');
+  return '${vault/' + cleanPath + '#' + field + '}';
+};
+
+/**
  * Returns true if the given string contains at least one Vault reference.
  */
 export const hasVaultReference = (strVal: string): boolean => {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * HashiCorp Vault reference support (POC).
+ *
+ * A Vault reference lets a monitor field (or a global param value) point at a
+ * secret stored in HashiCorp Vault instead of embedding the secret in Kibana.
+ * The reference uses the syntax:
+ *
+ *     ${vault/<secret-path>#<field>}
+ *
+ * e.g. ${vault/myapp/creds#password}
+ *
+ * Contract (this is the entire Kibana-side responsibility):
+ *
+ *   Kibana MUST NOT resolve these references. It stores and forwards the token
+ *   verbatim into the generated Fleet package policy. The plaintext secret is
+ *   resolved at the edge, at runtime, by Heartbeat (which authenticates to the
+ *   customer's Vault and expands the token during config unpack). This keeps the
+ *   secret entirely within the customer's trust boundary — it never touches
+ *   Kibana or Elasticsearch.
+ *
+ * The `/` and `#` characters are deliberately chosen: they fall OUTSIDE the
+ * global-param grammar (`SHELL_PARAMS_REGEX`), so the existing param
+ * substitution in `replaceStringWithParams` already leaves Vault references
+ * untouched. This module makes that behavior explicit and testable, and exposes
+ * helpers the UI can use to detect/annotate Vault-backed fields.
+ */
+
+// Matches ${vault/<path>#<field>} anywhere in a string.
+export const VAULT_REF_REGEX = /\$\{vault\/[^#{}]+#[^{}]+\}/g;
+
+/**
+ * Returns true if the given string contains at least one Vault reference.
+ */
+export const hasVaultReference = (strVal: string): boolean => {
+  // Reset lastIndex because the regex is declared with the global flag.
+  VAULT_REF_REGEX.lastIndex = 0;
+  return VAULT_REF_REGEX.test(strVal);
+};
+
+/**
+ * Checks whether an arbitrary value (string, object, or array) contains a Vault
+ * reference. Objects/arrays are stringified before matching.
+ */
+export const valueContainsVaultReference = (value: unknown): boolean => {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    return hasVaultReference(value);
+  }
+  if (typeof value === 'object') {
+    return hasVaultReference(JSON.stringify(value));
+  }
+  return false;
+};
+
+/**
+ * Extracts the { path, field } pairs referenced in a string. Intended for UI
+ * annotation / validation; not used for resolution (Kibana never resolves).
+ */
+export const extractVaultReferences = (strVal: string): Array<{ path: string; field: string }> => {
+  VAULT_REF_REGEX.lastIndex = 0;
+  const refs: Array<{ path: string; field: string }> = [];
+  const matches = strVal.match(VAULT_REF_REGEX) ?? [];
+  for (const match of matches) {
+    // strip `${vault/` prefix and trailing `}`
+    const inner = match.slice('${vault/'.length, -1);
+    const hashIdx = inner.lastIndexOf('#');
+    if (hashIdx <= 0 || hashIdx === inner.length - 1) {
+      continue;
+    }
+    refs.push({ path: inner.slice(0, hashIdx), field: inner.slice(hashIdx + 1) });
+  }
+  return refs;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/vault_param_formatter.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { schema } from '@kbn/config-schema';
+
 /**
  * HashiCorp Vault reference support (POC).
  *
@@ -32,8 +34,26 @@
  * helpers the UI can use to detect/annotate Vault-backed fields.
  */
 
-// Matches ${vault/<path>#<field>} anywhere in a string.
+// Matches ${vault/[<connection>@]<path>#<field>} anywhere in a string.
 export const VAULT_REF_REGEX = /\$\{vault\/[^#{}]+#[^{}]+\}/g;
+
+// Charset allowlists for the parts of a ${vault/[<connection>@]<path>#<field>}
+// reference. These keep the token opaque and un-injectable: without them a field
+// like `f}${otherParam` would close the token early and let the trailing fragment
+// match SHELL_PARAMS_REGEX (substituted with another global param's value), and
+// `@`, `#`, `{`, `}` would corrupt parsing/delivery.
+export const VAULT_PATH_REGEX = /^[A-Za-z0-9._/-]+$/;
+export const VAULT_FIELD_REGEX = /^[A-Za-z0-9._-]+$/;
+export const VAULT_CONNECTION_NAME_REGEX = /^[A-Za-z0-9._-]+$/;
+
+// Generous upper bound for any single reference part (path/field/connection).
+const MAX_REF_PART = 1024;
+
+const stripSlashes = (p: string) => p.replace(/^\/+|\/+$/g, '');
+
+export const isValidVaultPath = (p: string) => VAULT_PATH_REGEX.test(stripSlashes(p));
+export const isValidVaultField = (f: string) => VAULT_FIELD_REGEX.test(f);
+export const isValidVaultConnectionName = (c: string) => VAULT_CONNECTION_NAME_REGEX.test(c);
 
 /**
  * Builds the edge-resolved reference token stored as a vault-backed param's
@@ -43,7 +63,25 @@ export const VAULT_REF_REGEX = /\$\{vault\/[^#{}]+#[^{}]+\}/g;
  * at runtime.
  */
 export const buildVaultReference = (path: string, field: string, connection?: string): string => {
-  const cleanPath = path.replace(/^\/+|\/+$/g, '');
+  const cleanPath = stripSlashes(path);
+  // Defense in depth: routes validate the same charset via config-schema, but a
+  // bad token here would silently corrupt the compiled agent policy, so refuse to
+  // build one rather than emit something injectable.
+  if (!VAULT_PATH_REGEX.test(cleanPath)) {
+    throw new Error(
+      `Invalid Vault path "${path}": allowed characters are letters, numbers, and . _ - /`
+    );
+  }
+  if (!VAULT_FIELD_REGEX.test(field)) {
+    throw new Error(
+      `Invalid Vault field "${field}": allowed characters are letters, numbers, and . _ -`
+    );
+  }
+  if (connection && !VAULT_CONNECTION_NAME_REGEX.test(connection)) {
+    throw new Error(
+      `Invalid Vault connection name "${connection}": allowed characters are letters, numbers, and . _ -`
+    );
+  }
   const prefix = connection ? `vault/${connection}@` : 'vault/';
   return '${' + prefix + cleanPath + '#' + field + '}';
 };
@@ -75,12 +113,17 @@ export const valueContainsVaultReference = (value: unknown): boolean => {
 };
 
 /**
- * Extracts the { path, field } pairs referenced in a string. Intended for UI
- * annotation / validation; not used for resolution (Kibana never resolves).
+ * Extracts the { connection?, path, field } tuples referenced in a string.
+ * Understands both the default form (${vault/<path>#<field>}) and the named form
+ * (${vault/<connection>@<path>#<field>}). Used to annotate the UI and — crucially
+ * — to ship only the referenced connections to the agent (not every connection in
+ * the space). Kibana never resolves the reference.
  */
-export const extractVaultReferences = (strVal: string): Array<{ path: string; field: string }> => {
+export const extractVaultReferences = (
+  strVal: string
+): Array<{ connection?: string; path: string; field: string }> => {
   VAULT_REF_REGEX.lastIndex = 0;
-  const refs: Array<{ path: string; field: string }> = [];
+  const refs: Array<{ connection?: string; path: string; field: string }> = [];
   const matches = strVal.match(VAULT_REF_REGEX) ?? [];
   for (const match of matches) {
     // strip `${vault/` prefix and trailing `}`
@@ -89,7 +132,61 @@ export const extractVaultReferences = (strVal: string): Array<{ path: string; fi
     if (hashIdx <= 0 || hashIdx === inner.length - 1) {
       continue;
     }
-    refs.push({ path: inner.slice(0, hashIdx), field: inner.slice(hashIdx + 1) });
+    let spec = inner.slice(0, hashIdx);
+    const field = inner.slice(hashIdx + 1);
+    // Split an optional `<connection>@` prefix off the path.
+    let connection: string | undefined;
+    const atIdx = spec.indexOf('@');
+    if (atIdx >= 0) {
+      connection = spec.slice(0, atIdx) || undefined;
+      spec = spec.slice(atIdx + 1);
+    }
+    refs.push({ connection, path: spec, field });
   }
   return refs;
 };
+
+/**
+ * The distinct connection names referenced in a value (undefined = the default
+ * connection). Used to scope which connections are delivered to an agent.
+ */
+export const referencedConnectionNames = (value: unknown): Set<string | undefined> => {
+  const names = new Set<string | undefined>();
+  const scan = (s: string) => extractVaultReferences(s).forEach((r) => names.add(r.connection));
+  if (typeof value === 'string') {
+    scan(value);
+  } else if (value && typeof value === 'object') {
+    scan(JSON.stringify(value));
+  }
+  return names;
+};
+
+/**
+ * Shared request schema for a vault-backed param `source`, with the charset +
+ * length validation the reference grammar depends on. Used by both the add and
+ * edit param routes so the two never drift.
+ */
+export const VaultParamSourceSchema = schema.object({
+  type: schema.literal('vault'),
+  path: schema.string({
+    minLength: 1,
+    maxLength: MAX_REF_PART,
+    validate: (v) =>
+      isValidVaultPath(v) ? undefined : 'must contain only letters, numbers, and . _ - /',
+  }),
+  field: schema.string({
+    minLength: 1,
+    maxLength: MAX_REF_PART,
+    validate: (v) =>
+      VAULT_FIELD_REGEX.test(v) ? undefined : 'must contain only letters, numbers, and . _ -',
+  }),
+  connection: schema.maybe(
+    schema.string({
+      maxLength: MAX_REF_PART,
+      validate: (v) =>
+        v === '' || VAULT_CONNECTION_NAME_REGEX.test(v)
+          ? undefined
+          : 'must contain only letters, numbers, and . _ -',
+    })
+  ),
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
@@ -18,6 +18,11 @@ import type { SyntheticsServerSetup } from '../types';
 export interface HeartbeatVaultConfig {
   enabled: true;
   name: string;
+  // Secret-provider backend. Heartbeat's resolver factory switches on this; it
+  // defaults to hashicorp_vault when absent. The provider-specific fields below are
+  // flattened onto the wire blob (the stored connection keeps them under
+  // config/secrets), so a new provider adds fields here plus an agent resolver.
+  type: string;
   address: string;
   auth_method: 'token' | 'approle';
   kv_mount?: string;
@@ -35,16 +40,17 @@ export interface HeartbeatVaultConfig {
 const toHeartbeatConfig = (attributes: SyntheticsVaultConnection): HeartbeatVaultConfig => ({
   enabled: true,
   name: attributes.name,
-  address: attributes.address,
-  auth_method: attributes.authMethod,
-  kv_mount: attributes.kvMount,
-  namespace: attributes.namespace,
-  tls_skip_verify: attributes.tlsSkipVerify,
+  type: attributes.type,
+  address: attributes.config.address,
+  auth_method: attributes.config.authMethod,
+  kv_mount: attributes.config.kvMount,
+  namespace: attributes.config.namespace,
+  tls_skip_verify: attributes.config.tlsSkipVerify,
   secret_refresh_interval: attributes.secretRefreshInterval,
   version: attributes.refreshedAt,
-  token: attributes.token,
-  role_id: attributes.roleId,
-  secret_id: attributes.secretId,
+  token: attributes.secrets?.token,
+  role_id: attributes.config.roleId,
+  secret_id: attributes.secrets?.secretId,
 });
 
 /**

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
@@ -24,6 +24,10 @@ export interface HeartbeatVaultConfig {
   kv_mount?: string;
   namespace?: string;
   tls_skip_verify?: boolean;
+  secret_refresh_interval?: string;
+  // Opaque version (the connection's refreshedAt). Bumping it changes the blob,
+  // which forces the agent to re-resolve — the manual "refresh" mechanism.
+  version?: string;
   token?: string;
   role_id?: string;
   secret_id?: string;
@@ -59,6 +63,8 @@ export const getVaultConnectionConfig = async (
       kv_mount: attributes.kvMount,
       namespace: attributes.namespace,
       tls_skip_verify: attributes.tlsSkipVerify,
+      secret_refresh_interval: attributes.secretRefreshInterval,
+      version: attributes.refreshedAt,
       token: attributes.token,
       role_id: attributes.roleId,
       secret_id: attributes.secretId,

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
@@ -65,25 +65,35 @@ export const getVaultConnectionConfigs = async (
   server: SyntheticsServerSetup,
   spaceId: string
 ): Promise<HeartbeatVaultConfig[]> => {
-  const encryptedClient = server.encryptedSavedObjects.getClient();
-  const finder =
-    await encryptedClient.createPointInTimeFinderDecryptedAsInternalUser<SyntheticsVaultConnection>(
-      {
-        type: syntheticsVaultConnectionType,
-        perPage: 1000,
-        namespaces: [spaceId],
-      }
-    );
+  // Resilient by design: this is fetched once per policy-sync (E1) up front, so a
+  // failure here must NOT break the whole batch (including monitors that use no
+  // vault). Degrade to "no connections" — non-vault monitors are unaffected, and a
+  // vault monitor with a now-missing connection fails closed at its own policy
+  // generation rather than taking the sync down.
+  try {
+    const encryptedClient = server.encryptedSavedObjects.getClient();
+    const finder =
+      await encryptedClient.createPointInTimeFinderDecryptedAsInternalUser<SyntheticsVaultConnection>(
+        {
+          type: syntheticsVaultConnectionType,
+          perPage: 1000,
+          namespaces: [spaceId],
+        }
+      );
 
-  const configs: HeartbeatVaultConfig[] = [];
-  for await (const result of finder.find()) {
-    for (const so of result.saved_objects) {
-      if (so.attributes) {
+    const configs: HeartbeatVaultConfig[] = [];
+    for await (const result of finder.find()) {
+      for (const so of result.saved_objects) {
+        // Skip decrypt-failed objects (attributes stripped) rather than emitting a
+        // connection with no secret.
+        if (so.error || !so.attributes) continue;
         configs.push(toHeartbeatConfig(so.attributes));
       }
     }
+    finder.close().catch(() => {});
+    return configs;
+  } catch (e) {
+    server.logger?.error(`Vault: failed to load connections for space "${spaceId}": ${e.message}`);
+    return [];
   }
-  finder.close().catch(() => {});
-
-  return configs;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { SyntheticsVaultConnection } from '../../common/runtime_types';
+import { syntheticsVaultConnectionType } from '../../common/types/saved_objects';
+import { VAULT_CONNECTION_SO_ID } from '../saved_objects/synthetics_vault_connection';
+import type { SyntheticsServerSetup } from '../types';
+
+/**
+ * The Heartbeat-shaped `vault:` config block, assembled from the encrypted
+ * connection saved object. This is the block Heartbeat's config resolver reads
+ * to expand ${vault/<path>#<field>} references. Snake-cased to match Heartbeat
+ * (go-ucfg) config keys.
+ */
+export interface HeartbeatVaultConfig {
+  enabled: true;
+  address: string;
+  auth_method: 'token' | 'approle';
+  kv_mount?: string;
+  namespace?: string;
+  tls_skip_verify?: boolean;
+  token?: string;
+  role_id?: string;
+  secret_id?: string;
+}
+
+/**
+ * Reads and decrypts the Vault connection for a space and returns it as a
+ * Heartbeat `vault:` config block, or null when no connection is configured.
+ *
+ * Note: this yields the plaintext secret, so it must only be used when
+ * assembling the config delivered to a private-location agent — never returned
+ * to the browser. Delivering this block to agent-run Heartbeat through the
+ * Fleet policy requires the synthetics integration package to carry it; see the
+ * POC notes.
+ */
+export const getVaultConnectionConfig = async (
+  server: SyntheticsServerSetup,
+  spaceId: string
+): Promise<HeartbeatVaultConfig | null> => {
+  const encryptedClient = server.encryptedSavedObjects.getClient();
+  try {
+    const { attributes } =
+      await encryptedClient.getDecryptedAsInternalUser<SyntheticsVaultConnection>(
+        syntheticsVaultConnectionType,
+        VAULT_CONNECTION_SO_ID,
+        { namespace: spaceId }
+      );
+
+    return {
+      enabled: true,
+      address: attributes.address,
+      auth_method: attributes.authMethod,
+      kv_mount: attributes.kvMount,
+      namespace: attributes.namespace,
+      tls_skip_verify: attributes.tlsSkipVerify,
+      token: attributes.token,
+      role_id: attributes.roleId,
+      secret_id: attributes.secretId,
+    };
+  } catch (error) {
+    if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_vault_connection.ts
@@ -5,20 +5,19 @@
  * 2.0.
  */
 
-import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { SyntheticsVaultConnection } from '../../common/runtime_types';
 import { syntheticsVaultConnectionType } from '../../common/types/saved_objects';
-import { VAULT_CONNECTION_SO_ID } from '../saved_objects/synthetics_vault_connection';
 import type { SyntheticsServerSetup } from '../types';
 
 /**
- * The Heartbeat-shaped `vault:` config block, assembled from the encrypted
- * connection saved object. This is the block Heartbeat's config resolver reads
- * to expand ${vault/<path>#<field>} references. Snake-cased to match Heartbeat
+ * A Heartbeat-shaped `vault:` connection, assembled from an encrypted connection
+ * saved object. This is what Heartbeat's resolver reads to expand
+ * ${vault/[<name>@]<path>#<field>} references. Snake-cased to match Heartbeat
  * (go-ucfg) config keys.
  */
 export interface HeartbeatVaultConfig {
   enabled: true;
+  name: string;
   address: string;
   auth_method: 'token' | 'approle';
   kv_mount?: string;
@@ -33,46 +32,52 @@ export interface HeartbeatVaultConfig {
   secret_id?: string;
 }
 
+const toHeartbeatConfig = (attributes: SyntheticsVaultConnection): HeartbeatVaultConfig => ({
+  enabled: true,
+  name: attributes.name,
+  address: attributes.address,
+  auth_method: attributes.authMethod,
+  kv_mount: attributes.kvMount,
+  namespace: attributes.namespace,
+  tls_skip_verify: attributes.tlsSkipVerify,
+  secret_refresh_interval: attributes.secretRefreshInterval,
+  version: attributes.refreshedAt,
+  token: attributes.token,
+  role_id: attributes.roleId,
+  secret_id: attributes.secretId,
+});
+
 /**
- * Reads and decrypts the Vault connection for a space and returns it as a
- * Heartbeat `vault:` config block, or null when no connection is configured.
+ * Reads and decrypts every Vault connection for a space and returns them as an
+ * array of Heartbeat `vault:` connection blocks. Empty when none are configured.
  *
- * Note: this yields the plaintext secret, so it must only be used when
- * assembling the config delivered to a private-location agent — never returned
- * to the browser. Delivering this block to agent-run Heartbeat through the
- * Fleet policy requires the synthetics integration package to carry it; see the
- * POC notes.
+ * Note: this yields plaintext secrets, so it must only be used when assembling
+ * the config delivered to a private-location agent (via a Fleet secret) — never
+ * returned to the browser.
  */
-export const getVaultConnectionConfig = async (
+export const getVaultConnectionConfigs = async (
   server: SyntheticsServerSetup,
   spaceId: string
-): Promise<HeartbeatVaultConfig | null> => {
+): Promise<HeartbeatVaultConfig[]> => {
   const encryptedClient = server.encryptedSavedObjects.getClient();
-  try {
-    const { attributes } =
-      await encryptedClient.getDecryptedAsInternalUser<SyntheticsVaultConnection>(
-        syntheticsVaultConnectionType,
-        VAULT_CONNECTION_SO_ID,
-        { namespace: spaceId }
-      );
+  const finder =
+    await encryptedClient.createPointInTimeFinderDecryptedAsInternalUser<SyntheticsVaultConnection>(
+      {
+        type: syntheticsVaultConnectionType,
+        perPage: 1000,
+        namespaces: [spaceId],
+      }
+    );
 
-    return {
-      enabled: true,
-      address: attributes.address,
-      auth_method: attributes.authMethod,
-      kv_mount: attributes.kvMount,
-      namespace: attributes.namespace,
-      tls_skip_verify: attributes.tlsSkipVerify,
-      secret_refresh_interval: attributes.secretRefreshInterval,
-      version: attributes.refreshedAt,
-      token: attributes.token,
-      role_id: attributes.roleId,
-      secret_id: attributes.secretId,
-    };
-  } catch (error) {
-    if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
-      return null;
+  const configs: HeartbeatVaultConfig[] = [];
+  for await (const result of finder.find()) {
+    for (const so of result.saved_objects) {
+      if (so.attributes) {
+        configs.push(toHeartbeatConfig(so.attributes));
+      }
     }
-    throw error;
   }
+  finder.close().catch(() => {});
+
+  return configs;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -24,7 +24,7 @@ import {
 import { scheduleCleanUpTask } from './clean_up_task';
 import type { SyntheticsServerSetup } from '../../types';
 import { formatSyntheticsPolicy } from '../formatters/private_formatters/format_synthetics_policy';
-import { getVaultConnectionConfigs } from '../get_vault_connection';
+import { getVaultConnectionConfigs, type HeartbeatVaultConfig } from '../get_vault_connection';
 import type {
   HeartbeatConfig,
   MonitorFields,
@@ -198,7 +198,7 @@ export class SyntheticsPrivateLocation {
     maintenanceWindows: MaintenanceWindow[],
     testRunId?: string,
     runOnce?: boolean,
-    forInspect?: boolean
+    vaultConnections?: HeartbeatVaultConfig[]
   ): Promise<NewPackagePolicy | null> {
     const { label: locName } = privateLocation;
 
@@ -218,22 +218,17 @@ export class SyntheticsPrivateLocation {
 
       newPolicy.namespace = await this.getPolicyNamespace(configNamespace);
 
-      // Assemble the vault connections so vault-backed monitors can resolve
-      // ${vault/..} refs at the edge; formatSyntheticsPolicy attaches only the
-      // ones THIS monitor references (A2), as a single Fleet secret. Skipped on the
-      // inspect path (A1): Fleet's inspect() compiles vars verbatim (no
-      // secret-ization), so attaching them would return plaintext credentials to
-      // the caller.
+      // `vaultConnections` is fetched ONCE per space by the caller
+      // (createPackagePolicies / editMonitors) — E1 — and formatSyntheticsPolicy
+      // attaches only the ones THIS monitor references (A2), as a single Fleet
+      // secret. It is undefined on the inspect path (A1): Fleet's inspect()
+      // compiles vars verbatim (no secret-ization), so attaching them would return
+      // plaintext credentials to the caller.
       //
-      // A3 (residual): the `vault` var is `secret: true` in the package, so on the
-      // persist path Fleet stores it as a Fleet secret WHEN secret storage is
-      // enabled. Hard-failing when it is NOT (old/absent Fleet Server) requires
-      // Fleet to expose `isSecretStorageEnabled` to consumers — it is not on
-      // FleetStartContract today. Tracked on the meta issue as a Fleet dependency.
-      const vaultConnections = forInspect
-        ? undefined
-        : await getVaultConnectionConfigs(this.server, spaceId);
-
+      // A3 (residual): when Fleet secret storage is disabled the persist path
+      // stores the blob in plaintext rather than as a Fleet secret; hard-failing
+      // in that case needs Fleet to expose `isSecretStorageEnabled` (tracked on the
+      // meta issue). The Private Locations UI warns when this is the case.
       const { formattedPolicy } = formatSyntheticsPolicy(
         newPolicy,
         config.type,
@@ -283,6 +278,9 @@ export class SyntheticsPrivateLocation {
     }
     const newPolicies: NewPackagePolicyWithId[] = [];
     const newPolicyTemplate = await this.buildNewPolicy(spaceId);
+    // E1: fetch the space's vault connections ONCE (they're decrypted), not per
+    // monitor × location.
+    const vaultConnections = await getVaultConnectionConfigs(this.server, spaceId);
 
     for (const { config, globalParams } of configs) {
       try {
@@ -305,7 +303,8 @@ export class SyntheticsPrivateLocation {
             globalParams,
             maintenanceWindows,
             testRunId,
-            runOnce
+            runOnce,
+            vaultConnections
           );
 
           if (!newPolicy) {
@@ -382,10 +381,9 @@ export class SyntheticsPrivateLocation {
         newPolicyTemplate,
         spaceId,
         globalParams,
-        maintenanceWindows,
-        undefined,
-        undefined,
-        true // forInspect: never attach vault credentials to inspect output
+        maintenanceWindows
+        // vaultConnections omitted (A1): never attach vault credentials to inspect
+        // output — Fleet's inspect() compiles vars verbatim, with no secret-ization.
       );
 
       const pkgPolicy = {
@@ -415,14 +413,17 @@ export class SyntheticsPrivateLocation {
       };
     }
 
-    const [newPolicyTemplate, { policies: existingPolicies, allSpaces }] = await Promise.all([
-      this.buildNewPolicy(spaceId),
-      this.getExistingPolicies(
-        configs.map(({ config }) => config),
-        allPrivateLocations,
-        spaceId
-      ),
-    ]);
+    // E1: fetch the space's vault connections ONCE, not per monitor × location.
+    const [newPolicyTemplate, { policies: existingPolicies, allSpaces }, vaultConnections] =
+      await Promise.all([
+        this.buildNewPolicy(spaceId),
+        this.getExistingPolicies(
+          configs.map(({ config }) => config),
+          allPrivateLocations,
+          spaceId
+        ),
+        getVaultConnectionConfigs(this.server, spaceId),
+      ]);
 
     const policiesToUpdate: UpdatePackagePolicyWithId[] = [];
     const policiesToCreate: NewPackagePolicyWithId[] = [];
@@ -448,7 +449,10 @@ export class SyntheticsPrivateLocation {
               newPolicyTemplate,
               spaceId,
               globalParams,
-              maintenanceWindows
+              maintenanceWindows,
+              undefined,
+              undefined,
+              vaultConnections
             );
 
             if (!newPolicy) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -197,7 +197,8 @@ export class SyntheticsPrivateLocation {
     globalParams: Record<string, string>,
     maintenanceWindows: MaintenanceWindow[],
     testRunId?: string,
-    runOnce?: boolean
+    runOnce?: boolean,
+    forInspect?: boolean
   ): Promise<NewPackagePolicy | null> {
     const { label: locName } = privateLocation;
 
@@ -217,13 +218,21 @@ export class SyntheticsPrivateLocation {
 
       newPolicy.namespace = await this.getPolicyNamespace(configNamespace);
 
-      // Assemble the vault connections (base64 JSON array) so vault-backed
-      // monitors can resolve ${vault/..} refs at the edge. Fleet stores it as a
-      // single Fleet secret.
-      const vaultConnections = await getVaultConnectionConfigs(this.server, spaceId);
-      const vaultConfigB64 = vaultConnections.length
-        ? Buffer.from(JSON.stringify(vaultConnections)).toString('base64')
-        : undefined;
+      // Assemble the vault connections so vault-backed monitors can resolve
+      // ${vault/..} refs at the edge; formatSyntheticsPolicy attaches only the
+      // ones THIS monitor references (A2), as a single Fleet secret. Skipped on the
+      // inspect path (A1): Fleet's inspect() compiles vars verbatim (no
+      // secret-ization), so attaching them would return plaintext credentials to
+      // the caller.
+      //
+      // A3 (residual): the `vault` var is `secret: true` in the package, so on the
+      // persist path Fleet stores it as a Fleet secret WHEN secret storage is
+      // enabled. Hard-failing when it is NOT (old/absent Fleet Server) requires
+      // Fleet to expose `isSecretStorageEnabled` to consumers — it is not on
+      // FleetStartContract today. Tracked on the meta issue as a Fleet dependency.
+      const vaultConnections = forInspect
+        ? undefined
+        : await getVaultConnectionConfigs(this.server, spaceId);
 
       const { formattedPolicy } = formatSyntheticsPolicy(
         newPolicy,
@@ -251,7 +260,7 @@ export class SyntheticsPrivateLocation {
         globalParams,
         maintenanceWindows,
         undefined,
-        vaultConfigB64
+        vaultConnections
       );
 
       return formattedPolicy;
@@ -373,7 +382,10 @@ export class SyntheticsPrivateLocation {
         newPolicyTemplate,
         spaceId,
         globalParams,
-        maintenanceWindows
+        maintenanceWindows,
+        undefined,
+        undefined,
+        true // forInspect: never attach vault credentials to inspect output
       );
 
       const pkgPolicy = {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -24,6 +24,7 @@ import {
 import { scheduleCleanUpTask } from './clean_up_task';
 import type { SyntheticsServerSetup } from '../../types';
 import { formatSyntheticsPolicy } from '../formatters/private_formatters/format_synthetics_policy';
+import { getVaultConnectionConfig } from '../get_vault_connection';
 import type {
   HeartbeatConfig,
   MonitorFields,
@@ -216,6 +217,13 @@ export class SyntheticsPrivateLocation {
 
       newPolicy.namespace = await this.getPolicyNamespace(configNamespace);
 
+      // Assemble the vault connection (base64 JSON) so vault-backed monitors can
+      // resolve ${vault/..} refs at the edge. Fleet stores it as a Fleet secret.
+      const vaultConnection = await getVaultConnectionConfig(this.server, spaceId);
+      const vaultConfigB64 = vaultConnection
+        ? Buffer.from(JSON.stringify(vaultConnection)).toString('base64')
+        : undefined;
+
       const { formattedPolicy } = formatSyntheticsPolicy(
         newPolicy,
         config.type,
@@ -240,7 +248,9 @@ export class SyntheticsPrivateLocation {
           ...(config.fields?.kibanaUrl ? { kibanaUrl: config.fields.kibanaUrl } : {}),
         },
         globalParams,
-        maintenanceWindows
+        maintenanceWindows,
+        undefined,
+        vaultConfigB64
       );
 
       return formattedPolicy;

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -24,7 +24,7 @@ import {
 import { scheduleCleanUpTask } from './clean_up_task';
 import type { SyntheticsServerSetup } from '../../types';
 import { formatSyntheticsPolicy } from '../formatters/private_formatters/format_synthetics_policy';
-import { getVaultConnectionConfig } from '../get_vault_connection';
+import { getVaultConnectionConfigs } from '../get_vault_connection';
 import type {
   HeartbeatConfig,
   MonitorFields,
@@ -217,11 +217,12 @@ export class SyntheticsPrivateLocation {
 
       newPolicy.namespace = await this.getPolicyNamespace(configNamespace);
 
-      // Assemble the vault connection (base64 JSON) so vault-backed monitors can
-      // resolve ${vault/..} refs at the edge. Fleet stores it as a Fleet secret.
-      const vaultConnection = await getVaultConnectionConfig(this.server, spaceId);
-      const vaultConfigB64 = vaultConnection
-        ? Buffer.from(JSON.stringify(vaultConnection)).toString('base64')
+      // Assemble the vault connections (base64 JSON array) so vault-backed
+      // monitors can resolve ${vault/..} refs at the edge. Fleet stores it as a
+      // single Fleet secret.
+      const vaultConnections = await getVaultConnectionConfigs(this.server, spaceId);
+      const vaultConfigB64 = vaultConnections.length
+        ? Buffer.from(JSON.stringify(vaultConnections)).toString('base64')
         : undefined;
 
       const { formattedPolicy } = formatSyntheticsPolicy(

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/utils/redact_inspected_secrets.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/utils/redact_inspected_secrets.ts
@@ -22,9 +22,12 @@ const INSPECT_UNREDACTED_SECRET_KEYS = new Set<string>([
   ConfigKey.SOURCE_PROJECT_CONTENT,
 ]);
 
-export const INSPECT_REDACTED_SECRET_KEYS: ReadonlySet<string> = new Set(
-  secretKeys.filter((key) => !INSPECT_UNREDACTED_SECRET_KEYS.has(key))
-);
+export const INSPECT_REDACTED_SECRET_KEYS: ReadonlySet<string> = new Set([
+  ...secretKeys.filter((key) => !INSPECT_UNREDACTED_SECRET_KEYS.has(key)),
+  // The Fleet `vault` var carries the base64 connection blob (Vault credentials).
+  // It is never attached on the inspect path, but redact it as defense in depth.
+  'vault',
+]);
 
 /**
  * Fleet policy `vars` entries have a `{ value, type }` shape. Redact those in


### PR DESCRIPTION
## 🔐 POC: HashiCorp Vault reference tokens for Synthetics params

> **Proof of concept** — companion to [elastic/beats#52368](https://github.com/elastic/beats/pull/52368). Opening as a draft to align on the approach.

### 🎯 Problem
Synthetics global params today store secrets as **plaintext key/value pairs** in Kibana. Users want running monitors to pull secrets from **HashiCorp Vault** instead — the way Datadog, Dynatrace and Grafana offer.

### 🧭 Approach: Kibana = control plane, Heartbeat = data plane
The secret is resolved **at the edge by Heartbeat** (companion beats PR), so the plaintext **never touches Kibana or Elasticsearch** and stays inside the customer's trust boundary. Kibana's only job is to carry an opaque **reference**:

```
${vault/<secret-path>#<field>}      e.g. ${vault/myapp/creds#password}
```

### 🧩 What this PR does
- Establishes and **locks the contract** that Kibana must **never resolve** Vault references — it forwards the token verbatim into the generated Fleet package policy.
- The `/` and `#` characters intentionally fall **outside** the global-param grammar (`SHELL_PARAMS_REGEX`), so the existing `replaceStringWithParams` substitution already leaves Vault references untouched. This PR makes that behavior **explicit and testable** rather than accidental.
- Adds helpers the UI will use to detect/annotate Vault-backed fields: `hasVaultReference`, `valueContainsVaultReference`, `extractVaultReferences`.

### ✅ Tests
`vault_param_formatter.test.ts` (all green) proves the contract through the **real** `replaceStringWithParams`:
- Bare and embedded Vault tokens pass through unchanged.
- A mixed value resolves normal params **while preserving** the Vault token:
  `env=${environment};secret=${vault/myapp/creds#password}` → `env=prod;secret=${vault/myapp/creds#password}`.
- Vault tokens inside object field values are preserved.

Type-check (per-project oblt CLI) and ESLint pass.

### 🔗 How the two PRs fit together
1. Kibana emits `${vault/...#...}` into the agent policy (this PR) — no secret in Kibana/ES.
2. Heartbeat authenticates to Vault and expands the token at config-unpack ([beats#52368](https://github.com/elastic/beats/pull/52368)).

*Verified end-to-end locally:* a monitor field `${vault/myapp/creds#password}` was resolved by Heartbeat to the real Vault secret at runtime (monitor `up`, target received the exact secret).

### 🚧 Follow-ups (out of scope for the POC)
- Param create/edit UX to author Vault-backed fields.
- A first-class `source: vault` param model + Vault connection management.
- Docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
