### PR TITLE
Fix dashboards listing page not loading when savedObjects:listingLimi…

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.test.tsx
@@ -9,6 +9,7 @@
 
 import type { OpenContentEditorParams } from '@kbn/content-management-content-editor';
 import { renderHook, act } from '@testing-library/react';
+import { PAGINATION_MAX_SIZE } from '@kbn/as-code-shared-schemas';
 import { coreServices } from '../../services/kibana_services';
 import { dashboardClient, findService } from '../../dashboard_client';
 import { confirmCreateWithUnsaved } from '../confirm_overlays';
@@ -52,6 +53,7 @@ jest.mock('../../dashboard_client', () => ({
   },
   findService: {
     findById: jest.fn(),
+    search: jest.fn().mockResolvedValue({ data: [], meta: { total: 0, page: 1, per_page: 20 } }),
   },
   checkForDuplicateDashboardTitle: jest.fn(),
 }));
@@ -69,6 +71,7 @@ describe('useDashboardListingTable', () => {
     dashboardBackupService.clearState = clearStateMock;
     coreServices.uiSettings.get = getUiSettingsMock;
     coreServices.notifications.toasts.addError = jest.fn();
+    coreServices.userProfile.getCurrent = jest.fn().mockResolvedValue({ uid: 'test-user' });
   });
 
   test('should return the correct initial hasInitialFetchReturned state', () => {
@@ -319,6 +322,41 @@ describe('useDashboardListingTable', () => {
     );
 
     expect(result.current.tableListViewTableProps.editItem).toBeUndefined();
+  });
+
+  describe('findItems per_page clamping', () => {
+    test('passes listingLimit directly when it is below PAGINATION_MAX_SIZE', async () => {
+      // default mock returns 20 for savedObjects:listingLimit
+      const { result } = renderHook(() =>
+        useDashboardListingTable({ getDashboardUrl, goToDashboard })
+      );
+
+      await act(async () => {
+        await result.current.tableListViewTableProps.findItems('');
+      });
+
+      expect(findService.search).toHaveBeenCalledWith(expect.objectContaining({ per_page: 20 }));
+    });
+
+    test('clamps per_page to PAGINATION_MAX_SIZE when listingLimit exceeds it', async () => {
+      coreServices.uiSettings.get = jest.fn().mockImplementation((key) => {
+        if (key === 'savedObjects:listingLimit') return PAGINATION_MAX_SIZE + 9000;
+        if (key === 'savedObjects:perPage') return 5;
+        return null;
+      });
+
+      const { result } = renderHook(() =>
+        useDashboardListingTable({ getDashboardUrl, goToDashboard })
+      );
+
+      await act(async () => {
+        await result.current.tableListViewTableProps.findItems('');
+      });
+
+      expect(findService.search).toHaveBeenCalledWith(
+        expect.objectContaining({ per_page: PAGINATION_MAX_SIZE })
+      );
+    });
   });
 
   describe('rowItemActions', () => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
@@ -17,6 +17,7 @@ import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 import type { ViewMode } from '@kbn/presentation-publishing';
 
 import { asyncMap } from '@kbn/std';
+import { PAGINATION_MAX_SIZE } from '@kbn/as-code-shared-schemas';
 import { DASHBOARD_SAVED_OBJECT_TYPE } from '../../../common/constants';
 import { contentEditorFlyoutStrings } from '../../dashboard_app/_dashboard_app_strings';
 import { dashboardClient, findService, hasLibraryItemWithTitle } from '../../dashboard_client';
@@ -203,7 +204,7 @@ export const useDashboardListingTable = ({
       return findService
         .search({
           query: searchTerm,
-          per_page: listingLimit,
+          per_page: Math.min(listingLimit, PAGINATION_MAX_SIZE),
           tags: (references ?? []).map(({ id }) => id),
           excluded_tags: (referencesToExclude ?? []).map(({ id }) => id),
         })


### PR DESCRIPTION
Fixes #281972

## Summary

Fixes a bug where dashboards listing page would error if the `savedObject:listingLimit` advanced setting exceeds 1000. 

The dashboards list endpoint maximum `per_page` setting is 1000 starting in 9.5.0 and it can not be exceeded. This PR clamps the per_page setting to the minimum of the `savedObject:listingLimit` or 1000. Users who have customized their `savedObject:listingLimit` beyond 1000 should use the "Search" field and/or the Tags filters to find their dashboards.

In the future we should allow the listing page to use native endpoint pagination rather than client-side pagination as discussed in https://github.com/elastic/kibana/issues/207135.

## Testing this PR

1. Import the saved object below which creates 10000 dashboards. 
[10000-dashboards.ndjson.zip](https://github.com/user-attachments/files/30595737/10000-dashboards.ndjson.zip)
2. Change the `savedObject:listingLimit` advanced setting in your space to any number higher than 1000
3. Reload Kibana and open the dashboard listing page. With 50 rows per page you should only see 20 pages (50 x 20 = 1000) which confirms the per_page is clamped to the maximum allowed by the endpoint.
4. Change the `savedObject:listingLimit` advanced setting to 20
5. Reload Kibana and open the dashboard listing page. You should only see 20 items listed confirming the per_page setting is clamped to the advanced setting limit.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->