### PR TITLE
[Fleet] Fix enrollment token toast translations

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/hooks/use_bulk_actions.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/hooks/use_bulk_actions.ts
@@ -47,48 +47,31 @@ export const useBulkActions = ({
       const count = res.data?.count ?? 0;
       const successCount = res.data?.successCount ?? 0;
       const errorCount = res.data?.errorCount ?? 0;
+      const actionLabel = action === 'delete' ? 'deleted' : 'revoked';
 
       if (count === successCount) {
         notifications.toasts.addSuccess(
-          action === 'delete'
-            ? i18n.translate('xpack.fleet.enrollmentTokensList.bulkDeleteSuccess', {
-                defaultMessage:
-                  '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} deleted',
-                values: { successCount },
-              })
-            : i18n.translate('xpack.fleet.enrollmentTokensList.bulkRevokeSuccess', {
-                defaultMessage:
-                  '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} revoked',
-                values: { successCount },
-              })
+          i18n.translate('xpack.fleet.enrollmentTokensList.bulkActionSuccess', {
+            defaultMessage:
+              '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} {actionLabel}',
+            values: { successCount, actionLabel },
+          })
         );
       } else if (count === errorCount) {
         notifications.toasts.addDanger(
-          action === 'delete'
-            ? i18n.translate('xpack.fleet.enrollmentTokensList.bulkDeleteAllErrors', {
-                defaultMessage:
-                  'Failed to delete {errorCount, plural, one {# enrollment token} other {# enrollment tokens}}',
-                values: { errorCount },
-              })
-            : i18n.translate('xpack.fleet.enrollmentTokensList.bulkRevokeAllErrors', {
-                defaultMessage:
-                  'Failed to revoke {errorCount, plural, one {# enrollment token} other {# enrollment tokens}}',
-                values: { errorCount },
-              })
+          i18n.translate('xpack.fleet.enrollmentTokensList.bulkActionAllErrors', {
+            defaultMessage:
+              'Failed to {actionLabel} {errorCount, plural, one {# enrollment token} other {# enrollment tokens}}',
+            values: { errorCount, actionLabel },
+          })
         );
       } else {
         notifications.toasts.addWarning(
-          action === 'delete'
-            ? i18n.translate('xpack.fleet.enrollmentTokensList.bulkDeletePartialErrors', {
-                defaultMessage:
-                  '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} deleted, {errorCount, plural, one {# token} other {# tokens}} failed',
-                values: { successCount, errorCount },
-              })
-            : i18n.translate('xpack.fleet.enrollmentTokensList.bulkRevokePartialErrors', {
-                defaultMessage:
-                  '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} revoked, {errorCount, plural, one {# token} other {# tokens}} failed',
-                values: { successCount, errorCount },
-              })
+          i18n.translate('xpack.fleet.enrollmentTokensList.bulkActionPartialErrors', {
+            defaultMessage:
+              '{successCount, plural, one {# enrollment token} other {# enrollment tokens}} {actionLabel}, {errorCount, plural, one {# token} other {# tokens}} failed',
+            values: { successCount, errorCount, actionLabel },
+          })
         );
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Restores the existing enrollment token bulk-action translation IDs so the translated catalogs and extracted messages remain in sync. This fixes the i18n Quick Check failure introduced when the three established IDs were replaced with six new IDs.

## Testing

- `node scripts/i18n_check --quiet`
- `node scripts/eslint x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/hooks/use_bulk_actions.ts`
- `git diff --check`