### PR TITLE
[Observability Onboarding] Fix endpoint i18n and icon accessibility

### DIFF
--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -36230,7 +36230,6 @@
     "xpack.observability_onboarding.addDataPageV2.subtitle": "Verbinden Sie Ihre Systeme und erhalten Sie vollen Einblick in Logs, Metriken und Traces.",
     "xpack.observability_onboarding.apiEndpoints.apiKeyLabel": "API-Schlüssel",
     "xpack.observability_onboarding.apiEndpoints.apiKeyPlaceholder": "Noch kein API-Schlüssel vorhanden",
-    "xpack.observability_onboarding.apiEndpoints.copyButton": "In die Zwischenablage kopieren",
     "xpack.observability_onboarding.apiEndpoints.createKey": "Schlüssel erstellen",
     "xpack.observability_onboarding.apiEndpoints.createKeyError": "Der API-Schlüssel konnte nicht erstellt werden",
     "xpack.observability_onboarding.apiEndpoints.createKeyErrorFallback": "Beim Erstellen des API-Schlüssels ist ein Fehler aufgetreten. Versuchen Sie es erneut oder wenden Sie sich an Ihren Administrator.",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -36138,7 +36138,6 @@
     "xpack.observability_onboarding.addDataPageV2.subtitle": "Connectez vos systèmes et bénéficiez d'une visibilité complète sur les logs, les indicateurs et les traces.",
     "xpack.observability_onboarding.apiEndpoints.apiKeyLabel": "Clé API",
     "xpack.observability_onboarding.apiEndpoints.apiKeyPlaceholder": "Aucune clé API pour l'instant",
-    "xpack.observability_onboarding.apiEndpoints.copyButton": "Copier dans le presse-papiers",
     "xpack.observability_onboarding.apiEndpoints.createKey": "Créer une clé",
     "xpack.observability_onboarding.apiEndpoints.createKeyError": "Échec de la création de la clé API",
     "xpack.observability_onboarding.apiEndpoints.createKeyErrorFallback": "Un problème est survenu lors de la création de la clé API. Réessayez ou contactez votre administrateur.",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -36341,7 +36341,6 @@
     "xpack.observability_onboarding.addDataPageV2.subtitle": "システムを接続し、ログ、メトリクス、トレースの状況を網羅的に確認できます。",
     "xpack.observability_onboarding.apiEndpoints.apiKeyLabel": "APIキー",
     "xpack.observability_onboarding.apiEndpoints.apiKeyPlaceholder": "APIキーはまだありません",
-    "xpack.observability_onboarding.apiEndpoints.copyButton": "クリップボードにコピー",
     "xpack.observability_onboarding.apiEndpoints.createKey": "キーを作成",
     "xpack.observability_onboarding.apiEndpoints.createKeyError": "APIキーを作成できませんでした",
     "xpack.observability_onboarding.apiEndpoints.createKeyErrorFallback": "APIキーの作成中に問題が発生しました。もう一度試すか、管理者に連絡してください。",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -36349,7 +36349,6 @@
     "xpack.observability_onboarding.addDataPageV2.subtitle": "连接您的系统，全面了解日志、指标和跟踪。",
     "xpack.observability_onboarding.apiEndpoints.apiKeyLabel": "API 密钥",
     "xpack.observability_onboarding.apiEndpoints.apiKeyPlaceholder": "暂无 API 密钥",
-    "xpack.observability_onboarding.apiEndpoints.copyButton": "复制到剪贴板",
     "xpack.observability_onboarding.apiEndpoints.createKey": "创建密钥",
     "xpack.observability_onboarding.apiEndpoints.createKeyError": "无法创建 API 密钥",
     "xpack.observability_onboarding.apiEndpoints.createKeyErrorFallback": "创建 API 密钥时出现问题。请重试或联系您的管理员。",

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/more_endpoints_popover.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/more_endpoints_popover.tsx
@@ -79,6 +79,7 @@ export const MoreEndpointsPopover = ({
               <EuiIcon
                 type={isPopoverOpen ? 'arrowUp' : 'arrowDown'}
                 size="s"
+                aria-hidden={true}
                 css={css`
                   margin-left: ${euiTheme.size.xs};
                 `}


### PR DESCRIPTION
## Summary
- remove obsolete API endpoints copy-button translations
- mark the More endpoints toggle icon as decorative

## Testing
- `.buildkite/scripts/steps/checks/i18n.sh`
- `node scripts/eslint x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/more_endpoints_popover.tsx`