### PR TITLE
[Cases][Template] Fix all cases table column and template activity

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithTestingProviders } from '../../common/mock';
+import type { CaseUI } from '../../../common/ui/types';
+import type { InlineField } from '../../../common/types/domain/template/fields';
+import { FieldType } from '../../../common/types/domain/template/fields';
+import {
+  getExtendedFieldCellValue,
+  getExtendedFieldColumnKey,
+  renderExtendedFieldValue,
+} from './extended_field_columns';
+
+const field = (control: FieldType, type = 'keyword'): InlineField =>
+  ({ name: 'my_field', type, control } as InlineField);
+
+describe('extended_field_columns helpers', () => {
+  describe('getExtendedFieldColumnKey', () => {
+    it('builds the `<name>_as_<type>` storage key', () => {
+      expect(getExtendedFieldColumnKey(field(FieldType.INPUT_TEXT))).toBe('my_field_as_keyword');
+      expect(getExtendedFieldColumnKey(field(FieldType.TOGGLE, 'boolean'))).toBe(
+        'my_field_as_boolean'
+      );
+    });
+  });
+
+  describe('renderExtendedFieldValue', () => {
+    it('renders an empty cell for missing values', () => {
+      const { container } = renderWithTestingProviders(
+        <>{renderExtendedFieldValue(field(FieldType.INPUT_TEXT), '')}</>
+      );
+      expect(container).toHaveTextContent('—');
+    });
+
+    it('maps a toggle value to On/Off', () => {
+      renderWithTestingProviders(
+        <>{renderExtendedFieldValue(field(FieldType.TOGGLE, 'boolean'), 'true')}</>
+      );
+      expect(screen.getByText('On')).toBeInTheDocument();
+
+      renderWithTestingProviders(
+        <>{renderExtendedFieldValue(field(FieldType.TOGGLE, 'boolean'), 'false')}</>
+      );
+      expect(screen.getByText('Off')).toBeInTheDocument();
+    });
+
+    it('joins a checkbox group JSON array', () => {
+      renderWithTestingProviders(
+        <>{renderExtendedFieldValue(field(FieldType.CHECKBOX_GROUP), '["a","b"]')}</>
+      );
+      expect(screen.getByText('a, b')).toBeInTheDocument();
+    });
+
+    it('extracts user picker names', () => {
+      renderWithTestingProviders(
+        <>
+          {renderExtendedFieldValue(
+            field(FieldType.USER_PICKER),
+            '[{"name":"jdoe"},{"name":"asmith"}]'
+          )}
+        </>
+      );
+      expect(screen.getByText('jdoe, asmith')).toBeInTheDocument();
+    });
+
+    it('renders a plain text value as-is', () => {
+      renderWithTestingProviders(
+        <>{renderExtendedFieldValue(field(FieldType.INPUT_TEXT), 'hello')}</>
+      );
+      expect(screen.getByText('hello')).toBeInTheDocument();
+    });
+  });
+
+  describe('getExtendedFieldCellValue', () => {
+    // convertToCamelCase recurses into extended_fields, so client keys are camelCased.
+    const priorityField = {
+      name: 'priority',
+      type: 'keyword',
+      control: FieldType.INPUT_TEXT,
+    } as InlineField;
+    const theCase = { extendedFields: { priorityAsKeyword: 'high' } } as unknown as CaseUI;
+
+    it('reads the value using the camelCased key', () => {
+      renderWithTestingProviders(<>{getExtendedFieldCellValue(priorityField, theCase)}</>);
+      expect(screen.getByText('high')).toBeInTheDocument();
+    });
+
+    it('renders an empty cell when the field has no stored value', () => {
+      const { container } = renderWithTestingProviders(
+        <>
+          {getExtendedFieldCellValue(field(FieldType.INPUT_TEXT), { extendedFields: {} } as CaseUI)}
+        </>
+      );
+      expect(container).toHaveTextContent('—');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.tsx
@@ -5,46 +5,14 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
+import type { EuiBasicTableColumn } from '@elastic/eui';
 import type { CaseUI } from '../../../common/ui/types';
 import type { InlineField } from '../../../common/types/domain/template/fields';
 import { FieldType } from '../../../common/types/domain/template/fields';
-import {
-  getFieldCamelKey,
-  getFieldSnakeKey,
-  parseFieldDefinitionsToInlineFields,
-} from '../../../common/utils';
-import { useCasesContext } from '../cases_context/use_cases_context';
-import { useGetFieldDefinitions } from '../field_library/hooks/use_get_field_definitions';
+import { getFieldCamelKey, getFieldSnakeKey } from '../../../common/utils';
 import { getEmptyCellValue } from '../empty_value';
 import { TOGGLE_FIELD_ON_LABEL, TOGGLE_FIELD_OFF_LABEL } from '../custom_fields/translations';
-
-/**
- * Fetches and parses the owner's global field definitions into inline fields.
- * Global (isGlobal) fields apply to every case, so they map 1:1 to columns; migrated
- * legacy custom fields also surface here (migration writes them as global fields).
- * The fetch is skipped (owner undefined) when `enabled` is false so the legacy
- * customFields path pays no extra request.
- */
-export const useGlobalInlineFields = ({ enabled = true }: { enabled?: boolean } = {}): {
-  globalInlineFields: InlineField[];
-  isLoading: boolean;
-} => {
-  const { owner } = useCasesContext();
-  const { data, isFetching } = useGetFieldDefinitions({
-    owner: enabled ? owner : undefined,
-    isGlobal: true,
-    // Fetch once per session; a new array reference on refetch would churn the column memos.
-    staleTime: Infinity,
-  });
-
-  const globalInlineFields = useMemo(
-    () => parseFieldDefinitionsToInlineFields(data?.fieldDefinitions ?? []),
-    [data]
-  );
-
-  return { globalInlineFields, isLoading: enabled && isFetching };
-};
 
 /**
  * Stable column/config identity for a global field (e.g. `priority_as_keyword`). Kept snake so the
@@ -74,11 +42,13 @@ export const renderExtendedFieldValue = (
     return getEmptyCellValue();
   }
 
+  // `eui-textTruncate` keeps long values inside the column's bounded width (see
+  // getExtendedFieldTableColumn) so one field can't stretch the whole table.
   const dataTestSubj = `case-table-column-extendedField-${getExtendedFieldColumnKey(field)}`;
 
   if (field.control === FieldType.TOGGLE) {
     return (
-      <span data-test-subj={dataTestSubj}>
+      <span className="eui-textTruncate" data-test-subj={dataTestSubj}>
         {rawValue === 'true' ? TOGGLE_FIELD_ON_LABEL : TOGGLE_FIELD_OFF_LABEL}
       </span>
     );
@@ -86,15 +56,27 @@ export const renderExtendedFieldValue = (
 
   if (field.control === FieldType.CHECKBOX_GROUP) {
     const values = parseJsonArray(rawValue);
-    return <span data-test-subj={dataTestSubj}>{values ? values.join(', ') : rawValue}</span>;
+    return (
+      <span className="eui-textTruncate" data-test-subj={dataTestSubj}>
+        {values ? values.join(', ') : rawValue}
+      </span>
+    );
   }
 
   if (field.control === FieldType.USER_PICKER) {
     const names = [...rawValue.matchAll(/"name":"([^"]*)"/g)].map((match) => match[1]);
-    return <span data-test-subj={dataTestSubj}>{names.length ? names.join(', ') : rawValue}</span>;
+    return (
+      <span className="eui-textTruncate" data-test-subj={dataTestSubj}>
+        {names.length ? names.join(', ') : rawValue}
+      </span>
+    );
   }
 
-  return <span data-test-subj={dataTestSubj}>{rawValue}</span>;
+  return (
+    <span className="eui-textTruncate" data-test-subj={dataTestSubj}>
+      {rawValue}
+    </span>
+  );
 };
 
 /**
@@ -107,3 +89,14 @@ export const getExtendedFieldCellValue = (field: InlineField, theCase: CaseUI): 
     field,
     theCase.extendedFields?.[getFieldCamelKey(field.name, field.type)]
   );
+
+/**
+ * Builds the all-cases table column for a global field. Width is bounded (matching the legacy
+ * text custom-field column) so a single extended-field column can't push the rest off-screen.
+ */
+export const getExtendedFieldTableColumn = (field: InlineField): EuiBasicTableColumn<CaseUI> => ({
+  name: field.label ?? field.name,
+  maxWidth: '18em',
+  minWidth: '6em',
+  render: (theCase: CaseUI) => getExtendedFieldCellValue(field, theCase),
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import type { CaseUI } from '../../../common/ui/types';
+import type { InlineField } from '../../../common/types/domain/template/fields';
+import { FieldType } from '../../../common/types/domain/template/fields';
+import {
+  getFieldCamelKey,
+  getFieldSnakeKey,
+  parseFieldDefinitionsToInlineFields,
+} from '../../../common/utils';
+import { useCasesContext } from '../cases_context/use_cases_context';
+import { useGetFieldDefinitions } from '../field_library/hooks/use_get_field_definitions';
+import { getEmptyCellValue } from '../empty_value';
+import { TOGGLE_FIELD_ON_LABEL, TOGGLE_FIELD_OFF_LABEL } from '../custom_fields/translations';
+
+/**
+ * Fetches and parses the owner's global field definitions into inline fields.
+ * Global (isGlobal) fields apply to every case, so they map 1:1 to columns; migrated
+ * legacy custom fields also surface here (migration writes them as global fields).
+ * The fetch is skipped (owner undefined) when `enabled` is false so the legacy
+ * customFields path pays no extra request.
+ */
+export const useGlobalInlineFields = ({ enabled = true }: { enabled?: boolean } = {}): {
+  globalInlineFields: InlineField[];
+  isLoading: boolean;
+} => {
+  const { owner } = useCasesContext();
+  const { data, isFetching } = useGetFieldDefinitions({
+    owner: enabled ? owner : undefined,
+    isGlobal: true,
+    // Fetch once per session; a new array reference on refetch would churn the column memos.
+    staleTime: Infinity,
+  });
+
+  const globalInlineFields = useMemo(
+    () => parseFieldDefinitionsToInlineFields(data?.fieldDefinitions ?? []),
+    [data]
+  );
+
+  return { globalInlineFields, isLoading: enabled && isFetching };
+};
+
+/**
+ * Stable column/config identity for a global field (e.g. `priority_as_keyword`). Kept snake so the
+ * `_as_<type>` suffix aliasing in mergeSelectedColumnsWithConfiguration survives a flag flip.
+ */
+export const getExtendedFieldColumnKey = (field: InlineField): string =>
+  getFieldSnakeKey(field.name, field.type);
+
+const parseJsonArray = (raw: string): string[] | null => {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map(String) : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Renders a case's stored `extended_fields` value for a global field column. Values are
+ * persisted as strings; this coerces the common controls back to a readable cell.
+ */
+export const renderExtendedFieldValue = (
+  field: InlineField,
+  rawValue: string | undefined
+): React.ReactNode => {
+  if (rawValue == null || rawValue === '') {
+    return getEmptyCellValue();
+  }
+
+  const dataTestSubj = `case-table-column-extendedField-${getExtendedFieldColumnKey(field)}`;
+
+  if (field.control === FieldType.TOGGLE) {
+    return (
+      <span data-test-subj={dataTestSubj}>
+        {rawValue === 'true' ? TOGGLE_FIELD_ON_LABEL : TOGGLE_FIELD_OFF_LABEL}
+      </span>
+    );
+  }
+
+  if (field.control === FieldType.CHECKBOX_GROUP) {
+    const values = parseJsonArray(rawValue);
+    return <span data-test-subj={dataTestSubj}>{values ? values.join(', ') : rawValue}</span>;
+  }
+
+  if (field.control === FieldType.USER_PICKER) {
+    const names = [...rawValue.matchAll(/"name":"([^"]*)"/g)].map((match) => match[1]);
+    return <span data-test-subj={dataTestSubj}>{names.length ? names.join(', ') : rawValue}</span>;
+  }
+
+  return <span data-test-subj={dataTestSubj}>{rawValue}</span>;
+};
+
+/**
+ * Reads the extended-field value off a case for the given global field. `convertToCamelCase`
+ * recurses into the `extended_fields` record, so its keys are camelCased on the client
+ * (e.g. `priorityAsKeyword`) — look up with the camel key, not the snake storage key.
+ */
+export const getExtendedFieldCellValue = (field: InlineField, theCase: CaseUI): React.ReactNode =>
+  renderExtendedFieldValue(
+    field,
+    theCase.extendedFields?.[getFieldCamelKey(field.name, field.type)]
+  );

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/hooks/use_global_inline_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/hooks/use_global_inline_fields.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { InlineField } from '../../../../common/types/domain/template/fields';
+import { parseFieldDefinitionsToInlineFields } from '../../../../common/utils';
+import { useCasesContext } from '../../cases_context/use_cases_context';
+import { useGetFieldDefinitions } from '../../field_library/hooks/use_get_field_definitions';
+
+/**
+ * Fetches and parses the owner's global field definitions into inline fields.
+ */
+export const useGlobalInlineFields = ({ enabled = true }: { enabled?: boolean } = {}): {
+  globalInlineFields: InlineField[];
+  isLoading: boolean;
+} => {
+  const { owner } = useCasesContext();
+  const { data, isFetching } = useGetFieldDefinitions({
+    owner: enabled ? owner : undefined,
+    isGlobal: true,
+    // Fetch once per session; a new array reference on refetch would churn the column memos.
+    staleTime: Infinity,
+  });
+
+  const globalInlineFields = useMemo(
+    () => parseFieldDefinitionsToInlineFields(data?.fieldDefinitions ?? []),
+    [data]
+  );
+
+  return { globalInlineFields, isLoading: enabled && isFetching };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
@@ -34,11 +34,8 @@ import * as i18n from './translations';
 import { useActions } from './use_actions';
 import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
 import { useApplicationCapabilities, useCasesConfig, useKibana } from '../../common/lib/kibana';
-import {
-  getExtendedFieldCellValue,
-  getExtendedFieldColumnKey,
-  useGlobalInlineFields,
-} from './extended_field_columns';
+import { getExtendedFieldColumnKey, getExtendedFieldTableColumn } from './extended_field_columns';
+import { useGlobalInlineFields } from './hooks/use_global_inline_fields';
 import { TruncatedText } from '../truncated_text';
 import { getConnectorIcon } from '../utils';
 import { AssigneesColumn } from './assignees_column';
@@ -354,10 +351,7 @@ export const useCasesColumns = ({
   // `extendedFields`; otherwise they come from the legacy customFields config.
   if (templatesEnabled) {
     globalInlineFields.forEach((field) => {
-      columnsDict[getExtendedFieldColumnKey(field)] = {
-        name: field.label ?? field.name,
-        render: (theCase: CaseUI) => getExtendedFieldCellValue(field, theCase),
-      };
+      columnsDict[getExtendedFieldColumnKey(field)] = getExtendedFieldTableColumn(field);
     });
   } else {
     customFields.forEach(({ key, type, label }) => {

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
@@ -33,7 +33,12 @@ import { CaseDetailsLink } from '../links';
 import * as i18n from './translations';
 import { useActions } from './use_actions';
 import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
-import { useApplicationCapabilities, useKibana } from '../../common/lib/kibana';
+import { useApplicationCapabilities, useCasesConfig, useKibana } from '../../common/lib/kibana';
+import {
+  getExtendedFieldCellValue,
+  getExtendedFieldColumnKey,
+  useGlobalInlineFields,
+} from './extended_field_columns';
 import { TruncatedText } from '../truncated_text';
 import { getConnectorIcon } from '../utils';
 import { AssigneesColumn } from './assignees_column';
@@ -83,11 +88,18 @@ export const useCasesColumns = ({
 }: GetCasesColumn): UseCasesColumnsReturnValue => {
   const casesColumnsConfig = useCasesColumnsConfiguration(isSelectorView);
   const { actions } = useActions({ disableActions });
+  const { templatesEnabled } = useCasesConfig();
 
   const {
     data: { customFields },
-    isFetching: isLoadingColumns,
+    isFetching: isLoadingConfiguration,
   } = useGetCaseConfiguration({ keepPreviousData: true });
+
+  const { globalInlineFields, isLoading: isLoadingGlobalFields } = useGlobalInlineFields({
+    enabled: templatesEnabled,
+  });
+
+  const isLoadingColumns = isLoadingConfiguration || isLoadingGlobalFields;
 
   const assignCaseAction = useCallback(
     async (theCase: CaseUI) => {
@@ -337,28 +349,38 @@ export const useCasesColumns = ({
     [assignCaseAction, casesColumnsConfig, connectors, isSelectorView, userProfiles, disabledCases]
   );
 
-  // we need to extend the columnsDict with the columns of
-  // the customFields
-  customFields.forEach(({ key, type, label }) => {
-    if (type in customFieldsBuilderMap) {
-      const columnDefinition = customFieldsBuilderMap[type]().getEuiTableColumn({ label });
-
-      columnsDict[key] = {
-        ...columnDefinition,
-        render: (theCase: CaseUI) => {
-          const customField = theCase.customFields.find(
-            (element) => element.key === key && element.value !== null
-          );
-
-          if (!customField) {
-            return getEmptyCellValue();
-          }
-
-          return columnDefinition.render(customField);
-        },
+  // we need to extend the columnsDict with the columns of the custom/extended fields.
+  // With templates v2, columns come from global field definitions and read live values from
+  // `extendedFields`; otherwise they come from the legacy customFields config.
+  if (templatesEnabled) {
+    globalInlineFields.forEach((field) => {
+      columnsDict[getExtendedFieldColumnKey(field)] = {
+        name: field.label ?? field.name,
+        render: (theCase: CaseUI) => getExtendedFieldCellValue(field, theCase),
       };
-    }
-  });
+    });
+  } else {
+    customFields.forEach(({ key, type, label }) => {
+      if (type in customFieldsBuilderMap) {
+        const columnDefinition = customFieldsBuilderMap[type]().getEuiTableColumn({ label });
+
+        columnsDict[key] = {
+          ...columnDefinition,
+          render: (theCase: CaseUI) => {
+            const customField = theCase.customFields.find(
+              (element) => element.key === key && element.value !== null
+            );
+
+            if (!customField) {
+              return getEmptyCellValue();
+            }
+
+            return columnDefinition.render(customField);
+          },
+        };
+      }
+    });
+  }
 
   const columns: CasesColumns[] = [];
 

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
@@ -15,13 +15,26 @@ import { useCasesColumnsConfiguration } from './use_cases_columns_configuration'
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
 import { useCaseConfigureResponse } from '../configure_cases/__mock__';
 import { CustomFieldTypes } from '../../../common/types/domain';
+import { FieldType } from '../../../common/types/domain/template/fields';
+import { useCasesConfig } from '../../common/lib/kibana';
+import { useGlobalInlineFields } from './extended_field_columns';
 import React from 'react';
 
 jest.mock('../../common/use_cases_features');
 jest.mock('../../containers/configure/use_get_case_configuration');
+jest.mock('../../common/lib/kibana', () => ({
+  ...jest.requireActual('../../common/lib/kibana'),
+  useCasesConfig: jest.fn(),
+}));
+jest.mock('./extended_field_columns', () => ({
+  ...jest.requireActual('./extended_field_columns'),
+  useGlobalInlineFields: jest.fn(),
+}));
 
 const useGetCaseConfigurationMock = useGetCaseConfiguration as jest.Mock;
 const useCasesFeaturesMock = useCasesFeatures as jest.Mock;
+const useCasesConfigMock = useCasesConfig as jest.Mock;
+const useGlobalInlineFieldsMock = useGlobalInlineFields as jest.Mock;
 
 describe('useCasesColumnsConfiguration ', () => {
   const license = licensingMock.createLicense({
@@ -35,6 +48,8 @@ describe('useCasesColumnsConfiguration ', () => {
       isAlertsEnabled: true,
     });
     useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
+    useCasesConfigMock.mockReturnValue({ templatesEnabled: false });
+    useGlobalInlineFieldsMock.mockReturnValue({ globalInlineFields: [], isLoading: false });
   });
 
   afterEach(() => {
@@ -200,6 +215,35 @@ describe('useCasesColumnsConfiguration ', () => {
     expect(result.current[toggleKey]).toEqual({
       field: toggleKey,
       name: toggleLabel,
+      canDisplay: true,
+      isCheckedDefault: false,
+    });
+  });
+
+  it('sources columns from global extended fields when templates v2 is enabled', async () => {
+    useCasesConfigMock.mockReturnValue({ templatesEnabled: true });
+    // Legacy customFields must be ignored in favor of global field definitions.
+    useGetCaseConfigurationMock.mockImplementation(() => ({
+      data: {
+        ...useCaseConfigureResponse.data,
+        customFields: [{ key: 'legacy_key', label: 'Legacy', type: CustomFieldTypes.TEXT }],
+      },
+    }));
+    useGlobalInlineFieldsMock.mockReturnValue({
+      globalInlineFields: [
+        { name: 'priority', type: 'keyword', control: FieldType.INPUT_TEXT, label: 'Priority' },
+      ],
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
+      wrapper: (props) => <TestProviders {...props} license={license} />,
+    });
+
+    expect(result.current.legacy_key).toBeUndefined();
+    expect(result.current.priority_as_keyword).toEqual({
+      field: 'priority_as_keyword',
+      name: 'Priority',
       canDisplay: true,
       isCheckedDefault: false,
     });

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
@@ -17,7 +17,7 @@ import { useCaseConfigureResponse } from '../configure_cases/__mock__';
 import { CustomFieldTypes } from '../../../common/types/domain';
 import { FieldType } from '../../../common/types/domain/template/fields';
 import { useCasesConfig } from '../../common/lib/kibana';
-import { useGlobalInlineFields } from './extended_field_columns';
+import { useGlobalInlineFields } from './hooks/use_global_inline_fields';
 import React from 'react';
 
 jest.mock('../../common/use_cases_features');
@@ -26,8 +26,8 @@ jest.mock('../../common/lib/kibana', () => ({
   ...jest.requireActual('../../common/lib/kibana'),
   useCasesConfig: jest.fn(),
 }));
-jest.mock('./extended_field_columns', () => ({
-  ...jest.requireActual('./extended_field_columns'),
+jest.mock('./hooks/use_global_inline_fields', () => ({
+  ...jest.requireActual('./hooks/use_global_inline_fields'),
   useGlobalInlineFields: jest.fn(),
 }));
 

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.tsx
@@ -8,7 +8,9 @@
 import * as i18n from './translations';
 import { ALERTS, EVENTS } from '../../common/translations';
 import { useCasesFeatures } from '../../common/use_cases_features';
+import { useCasesConfig } from '../../common/lib/kibana';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
+import { getExtendedFieldColumnKey, useGlobalInlineFields } from './extended_field_columns';
 
 export type CasesColumnsConfiguration = Record<
   string,
@@ -24,9 +26,13 @@ export const useCasesColumnsConfiguration = (
   isSelectorView?: boolean
 ): CasesColumnsConfiguration => {
   const { isAlertsEnabled, caseAssignmentAuthorized } = useCasesFeatures();
+  const { templatesEnabled } = useCasesConfig();
   const {
     data: { customFields },
   } = useGetCaseConfiguration();
+  // With templates v2, columns come from global field definitions (extended fields), not the
+  // legacy customFields config — this surfaces new global fields and reads live migrated values.
+  const { globalInlineFields } = useGlobalInlineFields({ enabled: templatesEnabled });
 
   const canDisplayDefault = true;
 
@@ -111,15 +117,27 @@ export const useCasesColumnsConfiguration = (
     },
   };
 
-  // we need to extend the configuration with the customFields
-  customFields.forEach(({ key, label }) => {
-    result[key] = {
-      field: key,
-      name: label,
-      canDisplay: canDisplayDefault && !isSelectorView,
-      isCheckedDefault: false,
-    };
-  });
+  if (templatesEnabled) {
+    globalInlineFields.forEach((field) => {
+      const key = getExtendedFieldColumnKey(field);
+      result[key] = {
+        field: key,
+        name: field.label ?? field.name,
+        canDisplay: canDisplayDefault && !isSelectorView,
+        isCheckedDefault: false,
+      };
+    });
+  } else {
+    // we need to extend the configuration with the customFields
+    customFields.forEach(({ key, label }) => {
+      result[key] = {
+        field: key,
+        name: label,
+        canDisplay: canDisplayDefault && !isSelectorView,
+        isCheckedDefault: false,
+      };
+    });
+  }
 
   return result;
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.tsx
@@ -10,7 +10,8 @@ import { ALERTS, EVENTS } from '../../common/translations';
 import { useCasesFeatures } from '../../common/use_cases_features';
 import { useCasesConfig } from '../../common/lib/kibana';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
-import { getExtendedFieldColumnKey, useGlobalInlineFields } from './extended_field_columns';
+import { getExtendedFieldColumnKey } from './extended_field_columns';
+import { useGlobalInlineFields } from './hooks/use_global_inline_fields';
 
 export type CasesColumnsConfiguration = Record<
   string,

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/utils/merge_selected_columns_with_configuration.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/utils/merge_selected_columns_with_configuration.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CasesColumnsConfiguration } from '../use_cases_columns_configuration';
+import {
+  getColumnBaseKey,
+  mergeSelectedColumnsWithConfiguration,
+} from './merge_selected_columns_with_configuration';
+
+const configEntry = (field: string, overrides = {}) => ({
+  field,
+  name: field,
+  canDisplay: true,
+  isCheckedDefault: false,
+  ...overrides,
+});
+
+describe('mergeSelectedColumnsWithConfiguration', () => {
+  it('keeps the stored checked state for columns present in the configuration', () => {
+    const casesColumnsConfig: CasesColumnsConfiguration = {
+      title: configEntry('title', { isCheckedDefault: true }),
+      status: configEntry('status', { isCheckedDefault: true }),
+    };
+
+    const result = mergeSelectedColumnsWithConfiguration({
+      selectedColumns: [{ field: 'title', name: 'title', isChecked: false }],
+      casesColumnsConfig,
+    });
+
+    expect(result).toEqual([
+      { field: 'title', name: 'title', isChecked: false },
+      { field: 'status', name: 'status', isChecked: true },
+    ]);
+  });
+
+  it('carries a legacy custom-field selection onto the extended-field column after a flag flip', () => {
+    // pre-flip storage keyed by the bare legacy key; post-flip config keyed `<key>_as_<type>`.
+    const casesColumnsConfig: CasesColumnsConfiguration = {
+      title: configEntry('title', { isCheckedDefault: true }),
+      abc_as_boolean: configEntry('abc_as_boolean'),
+    };
+
+    const result = mergeSelectedColumnsWithConfiguration({
+      selectedColumns: [{ field: 'abc', name: 'abc', isChecked: true }],
+      casesColumnsConfig,
+    });
+
+    expect(result).toContainEqual({
+      field: 'abc_as_boolean',
+      name: 'abc_as_boolean',
+      isChecked: true,
+    });
+    // no orphan/duplicate for the stored legacy key
+    expect(result.filter(({ field }) => getColumnBaseKey(field) === 'abc')).toHaveLength(1);
+  });
+
+  it('carries an extended-field selection back onto the legacy column after a flag revert', () => {
+    const casesColumnsConfig: CasesColumnsConfiguration = {
+      title: configEntry('title', { isCheckedDefault: true }),
+      abc: configEntry('abc'),
+    };
+
+    const result = mergeSelectedColumnsWithConfiguration({
+      selectedColumns: [{ field: 'abc_as_boolean', name: 'abc_as_boolean', isChecked: true }],
+      casesColumnsConfig,
+    });
+
+    expect(result).toContainEqual({ field: 'abc', name: 'abc', isChecked: true });
+  });
+
+  it('does not strip suffixes that are not known v2 field types (bare keys untouched)', () => {
+    expect(getColumnBaseKey('abc')).toBe('abc');
+    expect(getColumnBaseKey('abc_as_boolean')).toBe('abc');
+    expect(getColumnBaseKey('foo_as_bar')).toBe('foo_as_bar');
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/utils/merge_selected_columns_with_configuration.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/utils/merge_selected_columns_with_configuration.ts
@@ -9,6 +9,15 @@ import { difference } from 'lodash';
 import type { CasesColumnSelection } from '../types';
 import type { CasesColumnsConfiguration } from '../use_cases_columns_configuration';
 
+// Extended-field columns are keyed `<name>_as_<type>` under templates v2, whereas the same
+// migrated field is keyed by its bare legacy key when the flag is off. Stripping the suffix
+// yields a flag-independent "base" so a stored selection matches the current config across a
+// flag flip (and revert) instead of being dropped. Bounded to known v2 field types so bare
+// legacy keys (uuids, no `_as_`) are never mangled.
+const EXTENDED_FIELD_SUFFIX = /_as_(?:boolean|integer|keyword|long|double|date)$/;
+
+export const getColumnBaseKey = (field: string): string => field.replace(EXTENDED_FIELD_SUFFIX, '');
+
 export const mergeSelectedColumnsWithConfiguration = ({
   selectedColumns,
   casesColumnsConfig,
@@ -16,15 +25,29 @@ export const mergeSelectedColumnsWithConfiguration = ({
   selectedColumns: CasesColumnSelection[];
   casesColumnsConfig: CasesColumnsConfiguration;
 }): CasesColumnSelection[] => {
+  // Maps each config column's base key to its current (possibly suffixed) key, so a stored
+  // selection under the other flag's key still resolves to the active column.
+  const baseKeyToConfigKey = new Map<string, string>();
+  for (const configKey of Object.keys(casesColumnsConfig)) {
+    baseKeyToConfigKey.set(getColumnBaseKey(configKey), configKey);
+  }
+
+  const resolveConfigKey = (field: string): string | undefined =>
+    field in casesColumnsConfig ? field : baseKeyToConfigKey.get(getColumnBaseKey(field));
+
+  const consumedConfigKeys = new Set<string>();
   const result = selectedColumns.reduce((accumulator, { field, isChecked }) => {
+    const configKey = resolveConfigKey(field);
     if (
-      field in casesColumnsConfig &&
-      casesColumnsConfig[field].field !== '' &&
-      casesColumnsConfig[field].canDisplay
+      configKey != null &&
+      !consumedConfigKeys.has(configKey) &&
+      casesColumnsConfig[configKey].field !== '' &&
+      casesColumnsConfig[configKey].canDisplay
     ) {
+      consumedConfigKeys.add(configKey);
       accumulator.push({
-        field: casesColumnsConfig[field].field,
-        name: casesColumnsConfig[field].name,
+        field: casesColumnsConfig[configKey].field,
+        name: casesColumnsConfig[configKey].name,
         isChecked,
       });
     }
@@ -32,10 +55,7 @@ export const mergeSelectedColumnsWithConfiguration = ({
   }, [] as CasesColumnSelection[]);
 
   // This will include any new customFields and/or changes to the case attributes
-  const missingColumns = difference(
-    Object.keys(casesColumnsConfig),
-    selectedColumns.map(({ field }) => field)
-  );
+  const missingColumns = difference(Object.keys(casesColumnsConfig), [...consumedConfigKeys]);
 
   missingColumns.forEach((field) => {
     // can be an empty string

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/field_content_getters.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/field_content_getters.tsx
@@ -10,7 +10,13 @@ import { EuiLink } from '@elastic/eui';
 import { CaseStatuses } from '@kbn/cases-components';
 
 import type { CaseUI, CaseUICustomField } from '../../../../../../../common/ui/types';
+import type { InlineField } from '../../../../../../../common/types/domain/template/fields';
+import { getFieldCamelKey } from '../../../../../../../common/utils';
 import { FormattedRelativePreferenceDate } from '../../../../../formatted_date';
+import {
+  getExtendedFieldColumnKey,
+  renderExtendedFieldValue,
+} from '../../../../../all_cases/extended_field_columns';
 import type { ListItemFieldContent } from './types';
 import * as i18n from '../../../translations';
 
@@ -81,6 +87,24 @@ const getCustomFieldContent = (field: string, theCase: CaseUI): ListItemFieldCon
     label: field,
     content: displayValue,
     testSubj: `cases-list-item-field-${field}`,
+  };
+};
+
+// Templates v2 renders global/extended fields (keyed `<name>_as_<type>`) instead of legacy
+// customFields. Values live on `theCase.extendedFields` under the camelCased key; empty values are
+// omitted so the card doesn't show a dangling label.
+export const getExtendedFieldContent = (
+  field: InlineField,
+  theCase: CaseUI
+): ListItemFieldContent | null => {
+  const rawValue = theCase.extendedFields?.[getFieldCamelKey(field.name, field.type)];
+  if (rawValue == null || rawValue === '') {
+    return null;
+  }
+  return {
+    label: field.label ?? field.name,
+    content: renderExtendedFieldValue(field, rawValue),
+    testSubj: `cases-list-item-field-${getExtendedFieldColumnKey(field)}`,
   };
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.test.tsx
@@ -9,12 +9,33 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { CustomFieldTypes } from '../../../../../../../common/types/domain';
+import { FieldType } from '../../../../../../../common/types/domain/template/fields';
 import { renderWithTestingProviders } from '../../../../../../common/mock';
 import { basicCase } from '../../../../../../containers/mock';
+import { useCasesConfig } from '../../../../../../common/lib/kibana';
+import { useGlobalInlineFields } from '../../../../../all_cases/hooks/use_global_inline_fields';
 import { ListItemOptionalFields } from './list_item_optional_fields';
 import * as i18n from '../../../translations';
 
+jest.mock('../../../../../../common/lib/kibana', () => ({
+  ...jest.requireActual('../../../../../../common/lib/kibana'),
+  useCasesConfig: jest.fn(),
+}));
+jest.mock('../../../../../all_cases/hooks/use_global_inline_fields', () => ({
+  ...jest.requireActual('../../../../../all_cases/hooks/use_global_inline_fields'),
+  useGlobalInlineFields: jest.fn(),
+}));
+
+const useCasesConfigMock = useCasesConfig as jest.Mock;
+const useGlobalInlineFieldsMock = useGlobalInlineFields as jest.Mock;
+
 describe('ListItemOptionalFields', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCasesConfigMock.mockReturnValue({ templatesEnabled: false });
+    useGlobalInlineFieldsMock.mockReturnValue({ globalInlineFields: [], isLoading: false });
+  });
+
   it('returns null when no fields are checked', () => {
     const { container } = renderWithTestingProviders(
       <ListItemOptionalFields
@@ -52,5 +73,45 @@ describe('ListItemOptionalFields', () => {
     expect(screen.getByTestId('cases-list-item-field-priority')).toHaveTextContent(
       'Priority: high'
     );
+  });
+
+  it('renders extended field values from extendedFields when templates v2 is enabled', () => {
+    useCasesConfigMock.mockReturnValue({ templatesEnabled: true });
+    useGlobalInlineFieldsMock.mockReturnValue({
+      globalInlineFields: [
+        { name: 'priority', type: 'keyword', control: FieldType.INPUT_TEXT, label: 'Priority' },
+      ],
+      isLoading: false,
+    });
+
+    renderWithTestingProviders(
+      <ListItemOptionalFields
+        theCase={{ ...basicCase, extendedFields: { priorityAsKeyword: 'high' } } as never}
+        selectedFields={[{ field: 'priority_as_keyword', name: 'Priority', isChecked: true }]}
+      />
+    );
+
+    expect(screen.getByTestId('cases-list-item-field-priority_as_keyword')).toHaveTextContent(
+      'Priority: high'
+    );
+  });
+
+  it('omits an extended field with no stored value', () => {
+    useCasesConfigMock.mockReturnValue({ templatesEnabled: true });
+    useGlobalInlineFieldsMock.mockReturnValue({
+      globalInlineFields: [
+        { name: 'priority', type: 'keyword', control: FieldType.INPUT_TEXT, label: 'Priority' },
+      ],
+      isLoading: false,
+    });
+
+    const { container } = renderWithTestingProviders(
+      <ListItemOptionalFields
+        theCase={{ ...basicCase, extendedFields: {} } as never}
+        selectedFields={[{ field: 'priority_as_keyword', name: 'Priority', isChecked: true }]}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.tsx
@@ -9,15 +9,32 @@ import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { EuiFlexGroup, useEuiTheme } from '@elastic/eui';
 
-import { getListItemFieldContent } from './field_content_getters';
+import { getExtendedFieldContent, getListItemFieldContent } from './field_content_getters';
 import { ListItemFieldText } from './list_item_field_text';
 import type { ListItemFieldContent, ListItemOptionalFieldsProps } from './types';
+import { useCasesConfig } from '../../../../../../common/lib/kibana';
+import { getExtendedFieldColumnKey } from '../../../../../all_cases/extended_field_columns';
+import { useGlobalInlineFields } from '../../../../../all_cases/hooks/use_global_inline_fields';
 
 export const ListItemOptionalFields: React.FC<ListItemOptionalFieldsProps> = ({
   theCase,
   selectedFields,
 }) => {
   const { euiTheme } = useEuiTheme();
+  const { templatesEnabled } = useCasesConfig();
+  const { globalInlineFields } = useGlobalInlineFields({ enabled: templatesEnabled });
+
+  // Under templates v2 the selected "custom" fields are extended fields keyed `<name>_as_<type>`;
+  // map each key to its definition so values resolve from `extendedFields` (parity with the table).
+  const globalInlineFieldsByKey = useMemo(() => {
+    const map = new Map<string, (typeof globalInlineFields)[number]>();
+    if (templatesEnabled) {
+      for (const field of globalInlineFields) {
+        map.set(getExtendedFieldColumnKey(field), field);
+      }
+    }
+    return map;
+  }, [templatesEnabled, globalInlineFields]);
 
   const styles = useMemo(
     () => ({
@@ -34,7 +51,10 @@ export const ListItemOptionalFields: React.FC<ListItemOptionalFieldsProps> = ({
       selectedFields.reduce<Array<ListItemFieldContent & { field: string }>>(
         (acc, { isChecked, field, name }) => {
           if (isChecked) {
-            const fieldContent = getListItemFieldContent(field, theCase);
+            const globalInlineField = globalInlineFieldsByKey.get(field);
+            const fieldContent = globalInlineField
+              ? getExtendedFieldContent(globalInlineField, theCase)
+              : getListItemFieldContent(field, theCase);
             if (fieldContent != null) {
               acc.push({ ...fieldContent, field, label: name ?? fieldContent.label });
             }
@@ -43,7 +63,7 @@ export const ListItemOptionalFields: React.FC<ListItemOptionalFieldsProps> = ({
         },
         []
       ),
-    [selectedFields, theCase]
+    [selectedFields, theCase, globalInlineFieldsByKey]
   );
 
   if (visibleFields.length === 0) {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.tsx
@@ -32,7 +32,16 @@ import { CaseDetailsLink } from '../../../links';
 import * as i18n from '../translations';
 import { useActions } from '../../../all_cases/use_actions';
 import { useCasesColumnsConfiguration } from '../../../all_cases/use_cases_columns_configuration';
-import { useApplicationCapabilities, useKibana } from '../../../../common/lib/kibana';
+import {
+  useApplicationCapabilities,
+  useCasesConfig,
+  useKibana,
+} from '../../../../common/lib/kibana';
+import {
+  getExtendedFieldCellValue,
+  getExtendedFieldColumnKey,
+  useGlobalInlineFields,
+} from '../../../all_cases/extended_field_columns';
 import { TruncatedText } from '../../../truncated_text';
 import { getConnectorIcon } from '../../../utils';
 import { AssigneesColumn } from '../../../all_cases/assignees_column';
@@ -83,11 +92,18 @@ export const useCasesColumns = ({
 }: GetCasesColumn): UseCasesColumnsReturnValue => {
   const casesColumnsConfig = useCasesColumnsConfiguration(isSelectorView);
   const { actions } = useActions({ disableActions });
+  const { templatesEnabled } = useCasesConfig();
 
   const {
     data: { customFields },
-    isFetching: isLoadingColumns,
+    isFetching: isLoadingConfiguration,
   } = useGetCaseConfiguration({ keepPreviousData: true });
+
+  const { globalInlineFields, isLoading: isLoadingGlobalFields } = useGlobalInlineFields({
+    enabled: templatesEnabled,
+  });
+
+  const isLoadingColumns = isLoadingConfiguration || isLoadingGlobalFields;
 
   const assignCaseAction = useCallback(
     async (theCase: CaseUI) => {
@@ -342,6 +358,19 @@ export const useCasesColumns = ({
   const allColumnsDict = useMemo(() => {
     const dict = { ...columnsDict };
 
+    // With templates v2, columns come from global field definitions and read live values from
+    // `extendedFields`; otherwise they come from the legacy customFields config.
+    if (templatesEnabled) {
+      globalInlineFields.forEach((field) => {
+        dict[getExtendedFieldColumnKey(field)] = {
+          name: field.label ?? field.name,
+          render: (theCase: CaseUI) => getExtendedFieldCellValue(field, theCase),
+        };
+      });
+
+      return dict;
+    }
+
     customFields.forEach(({ key, type, label }) => {
       if (type in customFieldsBuilderMap) {
         const columnDefinition = customFieldsBuilderMap[type]().getEuiTableColumn({ label });
@@ -364,7 +393,7 @@ export const useCasesColumns = ({
     });
 
     return dict;
-  }, [columnsDict, customFields]);
+  }, [columnsDict, customFields, templatesEnabled, globalInlineFields]);
 
   const columns: CasesColumns[] = [];
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.tsx
@@ -38,10 +38,10 @@ import {
   useKibana,
 } from '../../../../common/lib/kibana';
 import {
-  getExtendedFieldCellValue,
   getExtendedFieldColumnKey,
-  useGlobalInlineFields,
+  getExtendedFieldTableColumn,
 } from '../../../all_cases/extended_field_columns';
+import { useGlobalInlineFields } from '../../../all_cases/hooks/use_global_inline_fields';
 import { TruncatedText } from '../../../truncated_text';
 import { getConnectorIcon } from '../../../utils';
 import { AssigneesColumn } from '../../../all_cases/assignees_column';
@@ -362,10 +362,7 @@ export const useCasesColumns = ({
     // `extendedFields`; otherwise they come from the legacy customFields config.
     if (templatesEnabled) {
       globalInlineFields.forEach((field) => {
-        dict[getExtendedFieldColumnKey(field)] = {
-          name: field.label ?? field.name,
-          render: (theCase: CaseUI) => getExtendedFieldCellValue(field, theCase),
-        };
+        dict[getExtendedFieldColumnKey(field)] = getExtendedFieldTableColumn(field);
       });
 
       return dict;

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_list_fields_selection.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_list_fields_selection.tsx
@@ -13,7 +13,10 @@ import type { CasesColumnSelection } from '../types';
 import { LOCAL_STORAGE_KEYS } from '../../../../../common/constants';
 import type { CasesColumnsConfiguration } from '../../../all_cases/use_cases_columns_configuration';
 import { useCasesColumnsConfiguration } from '../../../all_cases/use_cases_columns_configuration';
-import { mergeSelectedColumnsWithConfiguration } from '../../../all_cases/utils/merge_selected_columns_with_configuration';
+import {
+  getColumnBaseKey,
+  mergeSelectedColumnsWithConfiguration,
+} from '../../../all_cases/utils/merge_selected_columns_with_configuration';
 import { useCasesLocalStorage } from '../../../../common/use_cases_local_storage';
 import { LIST_ALWAYS_VISIBLE_FIELDS } from '../constants';
 
@@ -35,7 +38,9 @@ export function useListFieldsSelection() {
 
   const mergedFields = useMemo(() => {
     const fields = selectedFields || [];
-    const storedFieldKeys = new Set(fields.map(({ field }) => field));
+    // Match on the flag-independent base key so a migrated field stored under the other flag's
+    // key (`<key>` vs `<key>_as_<type>`) is still recognized as "already stored" and keeps its state.
+    const storedBaseKeys = new Set(fields.map(({ field }) => getColumnBaseKey(field)));
 
     const merged = mergeSelectedColumnsWithConfiguration({
       selectedColumns: fields,
@@ -44,7 +49,7 @@ export function useListFieldsSelection() {
 
     // Fields already in localStorage keep their checked state; newly added fields default to unchecked.
     const withDefaults = merged.map((column) =>
-      storedFieldKeys.has(column.field) ? column : { ...column, isChecked: false }
+      storedBaseKeys.has(getColumnBaseKey(column.field)) ? column : { ...column, isChecked: false }
     );
 
     return withDefaults;

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.test.tsx
@@ -43,6 +43,49 @@ describe('createExtendedFieldsUserActionBuilder', () => {
     expect(screen.getByText('set Risk Score to high')).toBeInTheDocument();
   });
 
+  it('resolves a migrated custom field uuid key to its configured label', () => {
+    // Migrated custom fields are stored under `${customFieldKey}_as_<type>`; the camelCased
+    // payload key (testKey1AsKeyword) must map back to the configured label, not startCase(key).
+    const userAction = getUserAction('extended_fields', UserActionActions.update, {
+      type: 'extended_fields',
+      payload: { extendedFields: { testKey1AsKeyword: 'migrated value' } },
+    });
+
+    const builder = createExtendedFieldsUserActionBuilder({
+      ...builderArgs,
+      userAction,
+    });
+
+    const createdUserAction = builder.build();
+    renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
+
+    expect(screen.getByText('set My test label 1 to migrated value')).toBeInTheDocument();
+  });
+
+  it('resolves a non-migrated global/template field key to its enriched label', () => {
+    // A natively-authored field (name: new_field, label: "My Field") is not in the customFields
+    // config; its label must come from the case's server-enriched extendedFieldsLabels
+    // (keyed by snake storage key `new_field_as_keyword`), not startCase("newField") → "New Field".
+    const userAction = getUserAction('extended_fields', UserActionActions.update, {
+      type: 'extended_fields',
+      payload: { extendedFields: { newFieldAsKeyword: 'yo' } },
+    });
+
+    const builder = createExtendedFieldsUserActionBuilder({
+      ...builderArgs,
+      caseData: {
+        ...builderArgs.caseData,
+        extendedFieldsLabels: { new_field_as_keyword: 'My Field' },
+      },
+      userAction,
+    });
+
+    const createdUserAction = builder.build();
+    renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
+
+    expect(screen.getByText('set My Field to yo')).toBeInTheDocument();
+  });
+
   it('renders generic label when multiple fields are updated at once', () => {
     const userAction = getUserAction('extended_fields', UserActionActions.update, {
       type: 'extended_fields',

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.tsx
@@ -6,9 +6,12 @@
  */
 
 import React from 'react';
-import { startCase } from 'lodash';
+import { camelCase, startCase } from 'lodash';
 import type { SnakeToCamelCase } from '../../../common/types';
 import type { ExtendedFieldsUserAction } from '../../../common/types/domain';
+import type { CasesConfigurationUI } from '../../../common/ui';
+import type { CaseUI } from '../../../common/ui/types';
+import { getFieldCamelKey, getV2FieldType } from '../../../common/utils/template_fields';
 import type { UserActionBuilder } from './types';
 import { createCommonUpdateUserActionBuilder } from './common';
 import { ScrollableMarkdown } from '../markdown_editor';
@@ -24,6 +27,26 @@ const getFieldDisplayName = (key: string): string => {
   return startCase(withoutTypeSuffix);
 };
 
+// Payload keys arrive camelCased (e.g. "newFieldAsKeyword"); this maps each back to its
+// human-readable label so the activity reads correctly instead of startCase(key).
+// Sources, in increasing priority:
+//  1. Migrated legacy custom fields (uuid-based keys) from the configuration.
+//  2. The case's server-enriched `extendedFieldsLabels` (covers template + global fields,
+//     keyed by snake storage key e.g. `new_field_as_keyword`), which wins on conflict.
+const buildFieldLabels = (
+  customFieldsConfiguration: CasesConfigurationUI['customFields'],
+  extendedFieldsLabels: CaseUI['extendedFieldsLabels'] | undefined
+): Map<string, string> => {
+  const labels = new Map<string, string>();
+  for (const { key, type, label } of customFieldsConfiguration ?? []) {
+    labels.set(getFieldCamelKey(key, getV2FieldType(type)), label);
+  }
+  for (const [storageKey, label] of Object.entries(extendedFieldsLabels ?? {})) {
+    labels.set(camelCase(storageKey), label);
+  }
+  return labels;
+};
+
 const isMultilineValue = (value: unknown): value is string =>
   typeof value === 'string' && value.includes('\n');
 
@@ -32,13 +55,16 @@ interface LabelAndBody {
   body?: React.ReactNode;
 }
 
-const getLabelAndBody = (userAction: SnakeToCamelCase<ExtendedFieldsUserAction>): LabelAndBody => {
+const getLabelAndBody = (
+  userAction: SnakeToCamelCase<ExtendedFieldsUserAction>,
+  fieldLabels: Map<string, string>
+): LabelAndBody => {
   const extendedFields = userAction.payload.extendedFields ?? {};
   const entries = Object.entries(extendedFields);
 
   if (entries.length === 1) {
     const [key, value] = entries[0];
-    const displayName = getFieldDisplayName(key);
+    const displayName = fieldLabels.get(key) ?? getFieldDisplayName(key);
 
     if (key.endsWith('AsDate') && typeof value === 'string') {
       const maybeDate = getMaybeDate(value);
@@ -71,10 +97,16 @@ export const createExtendedFieldsUserActionBuilder: UserActionBuilder = ({
   userAction,
   userProfiles,
   handleOutlineComment,
+  casesConfiguration,
+  caseData,
 }) => ({
   build: () => {
     const extendedFieldsUserAction = userAction as SnakeToCamelCase<ExtendedFieldsUserAction>;
-    const { label, body } = getLabelAndBody(extendedFieldsUserAction);
+    const fieldLabels = buildFieldLabels(
+      casesConfiguration.customFields,
+      caseData.extendedFieldsLabels
+    );
+    const { label, body } = getLabelAndBody(extendedFieldsUserAction, fieldLabels);
     const commonBuilder = createCommonUpdateUserActionBuilder({
       userAction,
       userProfiles,

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/get.test.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
+import type { SavedObject } from '@kbn/core/server';
+import type { Template } from '../../../common/types/domain';
+import type { CaseSavedObjectTransformed } from '../../common/types/case';
+import { mockCases } from '../../mocks';
 import { createCasesClientMockArgs } from '../mocks';
-import { getCasesByAlertID, getTags, getReporters, getCategories } from './get';
+import { get, resolve, getCasesByAlertID, getTags, getReporters, getCategories } from './get';
 
 describe('get', () => {
   const clientArgs = createCasesClientMockArgs();
@@ -51,6 +55,132 @@ describe('get', () => {
       await expect(getCategories({ owner: 'cases', foo: 'bar' }, clientArgs)).rejects.toThrow(
         'invalid keys "foo"'
       );
+    });
+  });
+
+  describe('extended field labels enrichment', () => {
+    const globalFieldDef = {
+      fieldDefinitionId: 'fd-priority',
+      name: 'priority',
+      owner: 'securitySolution',
+      definition: 'name: priority\nlabel: Priority\ncontrol: INPUT_TEXT\ntype: keyword\n',
+    };
+
+    const buildCaseSO = (
+      overrides: Partial<CaseSavedObjectTransformed['attributes']> = {}
+    ): CaseSavedObjectTransformed => ({
+      ...mockCases[0],
+      attributes: {
+        ...mockCases[0].attributes,
+        extended_fields: { priority_as_keyword: 'high' },
+        template: null,
+        ...overrides,
+      },
+    });
+
+    const withTemplatesEnabled = () => {
+      const args = createCasesClientMockArgs();
+      args.config = { ...args.config, templates: { enabled: true } };
+      args.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(new Map());
+      args.services.fieldDefinitionsService.getGlobalFieldDefinitionsForSearch.mockResolvedValue([
+        globalFieldDef,
+      ]);
+      return args;
+    };
+
+    describe('get', () => {
+      it('does not enrich when templates are disabled', async () => {
+        const args = createCasesClientMockArgs();
+        args.config = { ...args.config, templates: { enabled: false } };
+        args.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(new Map());
+        args.services.caseService.getCase.mockResolvedValue(buildCaseSO());
+
+        const result = await get({ id: 'mock-id-1', includeComments: false }, args);
+
+        expect(result.extended_fields_labels).toBeUndefined();
+        expect(
+          args.services.fieldDefinitionsService.getGlobalFieldDefinitionsForSearch
+        ).not.toHaveBeenCalled();
+      });
+
+      it('does not fetch definitions when the case has no extended fields', async () => {
+        const args = withTemplatesEnabled();
+        args.services.caseService.getCase.mockResolvedValue(
+          buildCaseSO({ extended_fields: undefined })
+        );
+
+        const result = await get({ id: 'mock-id-1', includeComments: false }, args);
+
+        expect(result.extended_fields_labels).toBeUndefined();
+        expect(
+          args.services.fieldDefinitionsService.getGlobalFieldDefinitionsForSearch
+        ).not.toHaveBeenCalled();
+      });
+
+      it('enriches global field labels and skips the template fetch when the case has no template', async () => {
+        const args = withTemplatesEnabled();
+        args.services.caseService.getCase.mockResolvedValue(buildCaseSO());
+
+        const result = await get({ id: 'mock-id-1', includeComments: false }, args);
+
+        expect(result.extended_fields_labels).toEqual({ priority_as_keyword: 'Priority' });
+        expect(args.services.templatesService.getTemplate).not.toHaveBeenCalled();
+      });
+
+      it('fetches only the case template version and applies its field labels', async () => {
+        const args = withTemplatesEnabled();
+        args.services.caseService.getCase.mockResolvedValue(
+          buildCaseSO({ template: { id: 'tmpl-1', version: 2 } })
+        );
+        args.services.templatesService.getTemplate.mockResolvedValue({
+          attributes: {
+            templateId: 'tmpl-1',
+            templateVersion: 2,
+            fieldDefinitions: [{ name: 'sev', type: 'keyword', label: 'Severity' }],
+          },
+        } as unknown as SavedObject<Template>);
+
+        const result = await get({ id: 'mock-id-1', includeComments: false }, args);
+
+        expect(args.services.templatesService.getTemplate).toHaveBeenCalledWith('tmpl-1', '2');
+        expect(
+          args.services.templatesService.getTemplateVersionsForExtendedFieldSearch
+        ).not.toHaveBeenCalled();
+        expect(result.extended_fields_labels).toEqual({
+          priority_as_keyword: 'Priority',
+          sev_as_keyword: 'Severity',
+        });
+      });
+
+      it('returns the un-enriched case (and warns) when enrichment fails', async () => {
+        const args = withTemplatesEnabled();
+        args.services.caseService.getCase.mockResolvedValue(buildCaseSO());
+        args.services.fieldDefinitionsService.getGlobalFieldDefinitionsForSearch.mockRejectedValue(
+          new Error('boom')
+        );
+
+        const result = await get({ id: 'mock-id-1', includeComments: false }, args);
+
+        expect(result.extended_fields_labels).toBeUndefined();
+        expect(result.id).toBe('mock-id-1');
+        expect(args.logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to enrich case id: mock-id-1')
+        );
+      });
+    });
+
+    describe('resolve', () => {
+      it('enriches the resolved case with field labels', async () => {
+        const args = withTemplatesEnabled();
+        args.services.caseService.getResolveCase.mockResolvedValue({
+          saved_object: buildCaseSO(),
+          outcome: 'exactMatch',
+        });
+
+        const { case: theCase } = await resolve({ id: 'mock-id-1', includeComments: false }, args);
+
+        expect(theCase.extended_fields_labels).toEqual({ priority_as_keyword: 'Priority' });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/get.ts
@@ -45,6 +45,8 @@ import {
   countUserAttachments,
   countEventsForID,
 } from '../../common/utils';
+import { parseFieldDefinitionsToInlineFields } from '../../../common/utils';
+import { enrichCasesWithFieldLabels } from './utils';
 import type { CasesClientArgs } from '..';
 import { Operations } from '../../authorization';
 import { getOwnersFilter } from '../../authorization/utils';
@@ -196,6 +198,49 @@ const getAttachmentTotalsForCaseId = (id: string, stats: Map<string, AttachmentT
 };
 
 /**
+ * Populates `extended_fields_labels` on a single case, mirroring the enrichment the search/find
+ * path performs (see search.ts). Without this, the case-view activity feed (which loads the case
+ * via GET, not search) has no labels and falls back to startCase(name).
+ */
+const enrichCaseWithFieldLabels = async (
+  theCase: Case,
+  clientArgs: CasesClientArgs
+): Promise<Case> => {
+  const {
+    services: { templatesService, fieldDefinitionsService },
+    config,
+    logger,
+  } = clientArgs;
+
+  if (!config.templates.enabled || theCase.extended_fields == null) {
+    return theCase;
+  }
+
+  try {
+    const owner = theCase.owner ? [theCase.owner] : undefined;
+    // Only the case's own template version is needed to label template-authored fields; global
+    // fields cover the rest. Fetching just that one version avoids the search-path scan of every
+    // owner template version, which is unnecessary when enriching a single case.
+    const [templateSO, globalFieldDefs] = await Promise.all([
+      theCase.template?.id != null
+        ? templatesService.getTemplate(theCase.template.id, String(theCase.template.version))
+        : undefined,
+      fieldDefinitionsService.getGlobalFieldDefinitionsForSearch({ owner }),
+    ]);
+
+    return enrichCasesWithFieldLabels(
+      [theCase],
+      templateSO != null ? [templateSO] : [],
+      parseFieldDefinitionsToInlineFields(globalFieldDefs)
+    )[0];
+  } catch (error) {
+    // Label enrichment is cosmetic; never fail the case GET/resolve because of it.
+    logger.warn(`Failed to enrich case id: ${theCase.id} with extended field labels: ${error}`);
+    return theCase;
+  }
+};
+
+/**
  * The parameters for retrieving a case
  */
 export interface GetParams {
@@ -243,18 +288,17 @@ export const get = async (
       const commentStats = await attachmentService.getter.getCaseAttatchmentStats({
         caseIds: [theCase.id],
       });
-      return decodeOrThrow(CaseRt)(
-        flattenCaseSavedObject({
-          savedObject: theCase,
-          ...(commentStats.has(theCase.id)
-            ? {
-                totalAlerts: commentStats.get(theCase.id)?.alerts,
-                totalComment: commentStats.get(theCase.id)?.userComments,
-                totalEvents: commentStats.get(theCase.id)?.events,
-              }
-            : {}),
-        })
-      );
+      const flattenedCase = flattenCaseSavedObject({
+        savedObject: theCase,
+        ...(commentStats.has(theCase.id)
+          ? {
+              totalAlerts: commentStats.get(theCase.id)?.alerts,
+              totalComment: commentStats.get(theCase.id)?.userComments,
+              totalEvents: commentStats.get(theCase.id)?.events,
+            }
+          : {}),
+      });
+      return decodeOrThrow(CaseRt)(await enrichCaseWithFieldLabels(flattenedCase, clientArgs));
     }
 
     const theComments = (await caseService.getAllCaseComments({
@@ -274,7 +318,7 @@ export const get = async (
       totalEvents: countEventsForID({ comments: theComments }),
     });
 
-    return decodeOrThrow(CaseRt)(res);
+    return decodeOrThrow(CaseRt)(await enrichCaseWithFieldLabels(res, clientArgs));
   } catch (error) {
     throw createCaseError({ message: `Failed to get case id: ${id}: ${error}`, error, logger });
   }
@@ -318,11 +362,10 @@ export const resolve = async (
     });
 
     if (!includeComments) {
+      const flattenedCase = flattenCaseSavedObject({ savedObject: resolvedSavedObject });
       return decodeOrThrow(CaseResolveResponseRt)({
         ...resolveData,
-        case: flattenCaseSavedObject({
-          savedObject: resolvedSavedObject,
-        }),
+        case: await enrichCaseWithFieldLabels(flattenedCase, clientArgs),
       });
     }
 
@@ -335,15 +378,17 @@ export const resolve = async (
       mode,
     })) as SavedObjectsFindResponse<AttachmentAttributes>;
 
+    const flattenedCase = flattenCaseSavedObject({
+      savedObject: resolvedSavedObject,
+      comments: theComments.saved_objects,
+      totalComment: theComments.total,
+      totalEvents: countEventsForID({ comments: theComments }),
+      totalAlerts: countAlertsForID({ comments: theComments, id: resolvedSavedObject.id }),
+    });
+
     const res = {
       ...resolveData,
-      case: flattenCaseSavedObject({
-        savedObject: resolvedSavedObject,
-        comments: theComments.saved_objects,
-        totalComment: theComments.total,
-        totalEvents: countEventsForID({ comments: theComments }),
-        totalAlerts: countAlertsForID({ comments: theComments, id: resolvedSavedObject.id }),
-      }),
+      case: await enrichCaseWithFieldLabels(flattenedCase, clientArgs),
     };
 
     return decodeOrThrow(CaseResolveResponseRt)(res);


### PR DESCRIPTION
## Summary

This PR fixed 2 UI bugs with templates

- When feature flag is on, the column selector now pulls from global fields (legacy custom fields + new global fields)
  - When user migrate to templates V2, there is a one time migration that transform column selection saved in local storage to match global field (a subset of the template v2 extended field) format, so that users do not lose enabled columns
  - All cases table now correctly pick up values in global fields not custom fields
<img width="918" height="719" alt="image" src="https://github.com/user-attachments/assets/d0117c0f-8a7a-4f58-aeae-22243dcafd02" />
<img width="1226" height="575" alt="image" src="https://github.com/user-attachments/assets/d003fca6-d88e-4253-baae-93586f02b887" />

- When updating a legacy custom field, instead of showing the key (generated uuid), activity correctly pulls the field label

<img width="900" height="391" alt="image" src="https://github.com/user-attachments/assets/56339ee1-7533-4945-8f29-4dccc9400a78" />

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->