### PR TITLE
Store Nightshift memory in a visible AI index

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/common/memory_and_investigation.ts
+++ b/x-pack/platform/plugins/shared/significant_events/common/memory_and_investigation.ts
@@ -8,4 +8,4 @@
 /**
  * Sigevents memory data stream backing MemoryServiceImpl.
  */
-export const MEMORIES_DATA_STREAM = '.significant_events-memories';
+export const MEMORIES_DATA_STREAM = 'ai-nightshift-memory';

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/data_stream.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DataStreamDefinition } from '@kbn/data-streams';
-import type { MappingsDefinition } from '@kbn/es-mappings';
+import type { GetFieldsOf, MappingsDefinition } from '@kbn/es-mappings';
 import { mappings } from '@kbn/es-mappings';
 import { MEMORIES_DATA_STREAM } from '../../../../common/memory_and_investigation';
 
@@ -56,6 +56,17 @@ export interface StoredMemoryPage {
   updated_by: string;
   is_deleted: boolean;
 }
+
+type MappedMemoryPage = GetFieldsOf<typeof memoriesMappings>;
+type StoredMemoryPageMappingCheck = StoredMemoryPage extends MappedMemoryPage
+  ? Exclude<keyof StoredMemoryPage, keyof MappedMemoryPage> extends never
+    ? Exclude<keyof MappedMemoryPage, keyof StoredMemoryPage> extends never
+      ? true
+      : never
+    : never
+  : never;
+
+true satisfies StoredMemoryPageMappingCheck;
 
 export const memoriesDataStream: DataStreamDefinition<typeof memoriesMappings, StoredMemoryPage> = {
   name: MEMORIES_DATA_STREAM,

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/data_stream.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/data_stream.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DataStreamDefinition } from '@kbn/data-streams';
-import type { GetFieldsOf, MappingsDefinition } from '@kbn/es-mappings';
+import type { MappingsDefinition } from '@kbn/es-mappings';
 import { mappings } from '@kbn/es-mappings';
 import { MEMORIES_DATA_STREAM } from '../../../../common/memory_and_investigation';
 
@@ -14,34 +14,53 @@ export const memoriesMappings = {
   dynamic: false,
   properties: {
     '@timestamp': mappings.date({ format: 'strict_date_optional_time' }),
-    // Core identity
-    id: mappings.keyword(),
-    name: mappings.keyword(),
+    // Knowledge Item base fields
+    type: mappings.keyword(),
     title: mappings.text({ fields: { keyword: { type: 'keyword', ignore_above: 512 } } }),
     content: mappings.text(),
-    // Semantic embedding — populated on write, queried via 'semantic' or 'hybrid' search mode
     search_embedding: mappings.semanticText(),
-    // Classification
-    categories: mappings.keyword(),
     tags: mappings.keyword(),
-    references: mappings.keyword(),
-    // Versioning & authorship
-    version: mappings.long(),
+    references: mappings.object({ properties: { uri: mappings.keyword() } }),
+    origin: mappings.object({ properties: { uri: mappings.keyword() } }),
     created_at: mappings.date({ format: 'strict_date_optional_time' }),
     updated_at: mappings.date({ format: 'strict_date_optional_time' }),
+    user_id: mappings.keyword(),
+    // Nightshift memory extension fields
+    id: mappings.keyword(),
+    name: mappings.keyword(),
+    categories: mappings.keyword(),
+    version: mappings.long(),
     created_by: mappings.keyword(),
     updated_by: mappings.keyword(),
-    // Soft-delete flag: true on tombstone documents written by MemoryServiceImpl.delete()
     is_deleted: mappings.boolean(),
   },
 } satisfies MappingsDefinition;
 
-export type StoredMemoryPage = GetFieldsOf<typeof memoriesMappings>;
+export interface StoredMemoryPage {
+  '@timestamp': string;
+  type: 'memory';
+  title: string;
+  content: string;
+  search_embedding?: string;
+  tags: string[];
+  references: Array<{ uri: string }>;
+  origin: { uri: string };
+  created_at: string;
+  updated_at: string;
+  user_id: string;
+  id: string;
+  name: string;
+  categories: string[];
+  version: number;
+  created_by: string;
+  updated_by: string;
+  is_deleted: boolean;
+}
 
 export const memoriesDataStream: DataStreamDefinition<typeof memoriesMappings, StoredMemoryPage> = {
   name: MEMORIES_DATA_STREAM,
-  version: 2,
-  hidden: true,
+  version: 1,
+  hidden: false,
   template: {
     priority: 500,
     lifecycle: { data_retention: '90d' },

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/memory_service.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/memory_service.test.ts
@@ -8,7 +8,7 @@
 import type { Logger } from '@kbn/core/server';
 import { loggerMock } from '@kbn/logging-mocks';
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
-import type { MemoryEntry } from './types';
+import type { StoredMemoryPage } from './data_stream';
 import { MemoryServiceImpl } from './memory_service';
 import { MEMORIES_DATA_STREAM } from '../../../../common/memory_and_investigation';
 
@@ -20,7 +20,7 @@ import { v4 as uuidV4 } from 'uuid';
 
 const mockedUuidV4 = uuidV4 as jest.MockedFunction<() => string>;
 
-type MemoryDocument = MemoryEntry & { '@timestamp'?: string; _id?: string };
+type MemoryDocument = StoredMemoryPage & { _id?: string };
 
 const sortByLatest = (a: MemoryDocument, b: MemoryDocument) => {
   if (b.version !== a.version) {
@@ -29,12 +29,25 @@ const sortByLatest = (a: MemoryDocument, b: MemoryDocument) => {
   return b.updated_at.localeCompare(a.updated_at);
 };
 
+const getValuesAtPath = (value: unknown, path: string[]): unknown[] => {
+  if (path.length === 0) {
+    return Array.isArray(value) ? value.flatMap((item) => getValuesAtPath(item, [])) : [value];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => getValuesAtPath(item, path));
+  }
+  if (typeof value !== 'object' || value === null) {
+    return [];
+  }
+  const [head, ...tail] = path;
+  return getValuesAtPath((value as Record<string, unknown>)[head], tail);
+};
+
+const getFieldValues = (doc: MemoryDocument, field: string): unknown[] =>
+  getValuesAtPath(doc, field.split('.'));
+
 const matchesFilter = (doc: MemoryDocument, filter: Record<string, unknown>): boolean =>
-  Object.entries(filter).every(([field, value]) => {
-    const docValue = doc[field as keyof MemoryDocument];
-    // Array fields (categories/tags/references) match if the term is one of their values.
-    return Array.isArray(docValue) ? docValue.some((item) => item === value) : docValue === value;
-  });
+  Object.entries(filter).every(([field, value]) => getFieldValues(doc, field).includes(value));
 
 const filterByQuery = (
   docs: MemoryDocument[],
@@ -58,8 +71,8 @@ const filterByQuery = (
       if ('terms' in clause) {
         const terms = clause.terms as Record<string, unknown>;
         const [[field, values]] = Object.entries(terms);
-        const fieldValues = values as unknown[];
-        return fieldValues.includes(doc[field as keyof MemoryDocument]);
+        const queryValues = values as unknown[];
+        return getFieldValues(doc, field).some((value) => queryValues.includes(value));
       }
       if ('ids' in clause) {
         const ids = clause.ids as { values?: unknown[] };
@@ -172,8 +185,7 @@ const createInMemoryEsClient = () => {
           if (request.fields?.length) {
             hit.fields = {};
             for (const field of request.fields) {
-              const value = source[field as keyof MemoryDocument];
-              hit.fields[field] = Array.isArray(value) ? value : [value];
+              hit.fields[field] = getFieldValues(source, field);
             }
           }
           return hit;
@@ -197,9 +209,9 @@ describe('MemoryServiceImpl', () => {
   });
 
   const createService = () => {
-    const { esClient } = createInMemoryEsClient();
+    const { esClient, memoryDocs } = createInMemoryEsClient();
     const service = new MemoryServiceImpl({ logger, esClient });
-    return { service, esClient };
+    return { service, esClient, memoryDocs };
   };
 
   it('creates, reads, updates, and lists a memory page', async () => {
@@ -207,13 +219,14 @@ describe('MemoryServiceImpl', () => {
       .mockReturnValueOnce('entry-uuid-1')
       .mockReturnValueOnce('history-uuid-1')
       .mockReturnValueOnce('history-uuid-2');
-    const { service } = createService();
+    const { service, memoryDocs } = createService();
 
     const created = await service.create({
       name: 'nginx-overview',
       title: 'Nginx overview',
       content: '# Nginx',
       categories: ['services'],
+      references: ['related-entry'],
       user,
     });
 
@@ -222,9 +235,16 @@ describe('MemoryServiceImpl', () => {
       name: 'nginx-overview',
       version: 1,
     });
+    expect(memoryDocs[0]).toMatchObject({
+      type: 'memory',
+      origin: { uri: 'memory://entry-uuid-1' },
+      references: [{ uri: 'memory://related-entry' }],
+      user_id: user,
+    });
 
-    await expect(service.getByName({ name: 'nginx-overview' })).resolves.toMatchObject({
+    await expect(service.get({ id: created.id })).resolves.toMatchObject({
       title: 'Nginx overview',
+      references: ['related-entry'],
     });
 
     mockedUuidV4.mockReturnValueOnce('history-uuid-3');

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/memory_service.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/memory_service.ts
@@ -39,6 +39,27 @@ const isIndexNotFoundError = (err: unknown): boolean => {
   return message.includes('index_not_found_exception');
 };
 
+const MEMORY_URI_PREFIX = 'memory://';
+const toMemoryUri = (id: string): string => `${MEMORY_URI_PREFIX}${id}`;
+const fromMemoryUri = (uri: string): string =>
+  uri.startsWith(MEMORY_URI_PREFIX) ? uri.slice(MEMORY_URI_PREFIX.length) : uri;
+
+const storedPageToMemoryEntry = (page: StoredMemoryPage): MemoryEntry => ({
+  id: page.id,
+  name: page.name,
+  title: page.title,
+  content: page.content,
+  categories: page.categories,
+  references: page.references.map(({ uri }) => fromMemoryUri(uri)),
+  version: page.version,
+  tags: page.tags,
+  created_at: page.created_at,
+  updated_at: page.updated_at,
+  created_by: page.created_by,
+  updated_by: page.updated_by,
+  is_deleted: page.is_deleted,
+});
+
 type MemoryCollapseField = 'name' | 'id';
 
 /** Upper bound on distinct pages resolved in a single search (Elasticsearch's default max result window). */
@@ -46,7 +67,7 @@ const MAX_PAGES = 10000;
 
 /**
  * MemoryServiceImpl backed by two append-only data streams:
- *   - .significant_events-memories  (pages, latest version resolved via field collapse)
+ *   - ai-nightshift-memory  (pages, latest version resolved via field collapse)
  *   - .significant_events-memory-history  (version history, append-only)
  *
  * Pages are written by indexing a new document with the current @timestamp.
@@ -88,8 +109,7 @@ export class MemoryServiceImpl implements MemoryService {
     await bulkCreateWithInferenceFallback(this.logger, ({ includeEmbedding }) => {
       const document: StoredMemoryPage = {
         '@timestamp': entry.updated_at,
-        id: entry.id,
-        name: entry.name,
+        type: 'memory',
         title: entry.title,
         content: entry.content,
         // Populate search_embedding for live pages so semantic/hybrid search can rank them.
@@ -99,12 +119,16 @@ export class MemoryServiceImpl implements MemoryService {
           !entry.is_deleted && {
             search_embedding: `${entry.title}\n\n${entry.content}`,
           }),
-        categories: entry.categories,
         tags: entry.tags,
-        references: entry.references,
-        version: entry.version,
+        references: entry.references.map((id) => ({ uri: toMemoryUri(id) })),
+        origin: { uri: toMemoryUri(entry.id) },
         created_at: entry.created_at,
         updated_at: entry.updated_at,
+        user_id: entry.updated_by,
+        id: entry.id,
+        name: entry.name,
+        categories: entry.categories,
+        version: entry.version,
         created_by: entry.created_by,
         updated_by: entry.updated_by,
         is_deleted: entry.is_deleted ?? false,
@@ -134,7 +158,7 @@ export class MemoryServiceImpl implements MemoryService {
     size?: number;
   }): Promise<Array<{ _id: string; _source: MemoryEntry }>> {
     try {
-      const response = await this.esClient.search<MemoryEntry>({
+      const response = await this.esClient.search<StoredMemoryPage>({
         index: MEMORIES_DATA_STREAM,
         track_total_hits: false,
         size,
@@ -143,7 +167,9 @@ export class MemoryServiceImpl implements MemoryService {
         sort: [{ version: { order: 'desc' } }, { updated_at: { order: 'desc' } }],
       });
       return response.hits.hits.flatMap((hit) =>
-        typeof hit._id === 'string' && hit._source ? [{ _id: hit._id, _source: hit._source }] : []
+        typeof hit._id === 'string' && hit._source
+          ? [{ _id: hit._id, _source: storedPageToMemoryEntry(hit._source) }]
+          : []
       );
     } catch (err) {
       if (isIndexNotFoundError(err)) return [];
@@ -449,7 +475,7 @@ export class MemoryServiceImpl implements MemoryService {
     // referenced `id`. Phase 1: gather candidate page ids. Phase 2: resolve their current latest
     // versions and keep only those that STILL reference `id`.
     const candidateIds = await this._collectCandidateIds({
-      bool: { filter: [{ term: { references: id } }] },
+      bool: { filter: [{ term: { 'references.uri': toMemoryUri(id) } }] },
     });
     const latest = await this._resolveLatestByIds(candidateIds);
     return latest.map((hit) => hit._source).filter((entry) => entry.references.includes(id));
@@ -465,7 +491,9 @@ export class MemoryServiceImpl implements MemoryService {
     const structuredFilters: QueryDslQueryContainer[] = [];
     if (tags?.length) structuredFilters.push({ terms: { tags } });
     if (categories?.length) structuredFilters.push({ terms: { categories } });
-    if (references?.length) structuredFilters.push({ terms: { references } });
+    if (references?.length) {
+      structuredFilters.push({ terms: { 'references.uri': references.map(toMemoryUri) } });
+    }
 
     const fuzzyMatch: QueryDslQueryContainer = {
       bool: {
@@ -630,7 +658,7 @@ export class MemoryServiceImpl implements MemoryService {
 
     try {
       if (retriever) {
-        return await this.esClient.search<MemoryEntry>({
+        return await this.esClient.search<StoredMemoryPage>({
           index: MEMORIES_DATA_STREAM,
           track_total_hits: false,
           retriever,
@@ -642,7 +670,7 @@ export class MemoryServiceImpl implements MemoryService {
       }
 
       // keyword mode: plain bool query, no retriever
-      return await this.esClient.search<MemoryEntry>({
+      return await this.esClient.search<StoredMemoryPage>({
         index: MEMORIES_DATA_STREAM,
         track_total_hits: false,
         query: { bool: { filter: allFilters, must: [fuzzyMatch] } },
@@ -658,7 +686,7 @@ export class MemoryServiceImpl implements MemoryService {
         this.logger.warn(
           `Memory search mode "${mode}" failed, falling back to keyword: ${(err as Error).message}`
         );
-        return this.esClient.search<MemoryEntry>({
+        return this.esClient.search<StoredMemoryPage>({
           index: MEMORIES_DATA_STREAM,
           track_total_hits: false,
           query: { bool: { filter: allFilters, must: [fuzzyMatch] } },
@@ -679,7 +707,7 @@ export class MemoryServiceImpl implements MemoryService {
       // `hits.total` counts pre-collapse documents (every version of every page), so it can't tell
       // us how many distinct pages exist. Instead, detect truncation from the number of collapsed
       // hits returned: hitting `MAX_PAGES` distinct pages means there may be more we didn't fetch.
-      const response = await this.esClient.search<MemoryEntry>({
+      const response = await this.esClient.search<StoredMemoryPage>({
         index: MEMORIES_DATA_STREAM,
         track_total_hits: false,
         query: { match_all: {} },
@@ -689,11 +717,9 @@ export class MemoryServiceImpl implements MemoryService {
       });
 
       const hits = response.hits.hits;
-      const entries = hits
-        .map((hit) => hit._source)
-        .filter(
-          (source): source is MemoryEntry => source !== undefined && source.is_deleted !== true
-        );
+      const entries = hits.flatMap((hit) =>
+        hit._source && !hit._source.is_deleted ? [storedPageToMemoryEntry(hit._source)] : []
+      );
 
       // We only hit a wall if the search filled the entire window — then distinct pages beyond
       // `MAX_PAGES` were silently dropped. Tombstoned pages count toward the window too, so report

--- a/x-pack/platform/plugins/shared/significant_events/test/scout/api/fixtures/constants.ts
+++ b/x-pack/platform/plugins/shared/significant_events/test/scout/api/fixtures/constants.ts
@@ -56,6 +56,7 @@ export function getStreamsUsers(config: ScoutTestConfig): Record<string, KibanaR
           { names: ['.streams*'], privileges: ['all'] },
           { names: ['.kibana_streams*'], privileges: ['all'] },
           { names: ['.significant_events*'], privileges: ['all'] },
+          { names: ['ai-nightshift-memory'], privileges: ['all'] },
         ],
       },
     },
@@ -75,6 +76,10 @@ export function getStreamsUsers(config: ScoutTestConfig): Record<string, KibanaR
           { names: ['.ds-logs*'], privileges: ['read', 'view_index_metadata'] },
           { names: ['.kibana_streams*'], privileges: ['read', 'view_index_metadata'] },
           { names: ['.significant_events*'], privileges: ['read', 'view_index_metadata'] },
+          {
+            names: ['ai-nightshift-memory'],
+            privileges: ['read', 'view_index_metadata'],
+          },
         ],
       },
     },

--- a/x-pack/platform/plugins/shared/significant_events/test/scout/api/tests/memory_and_investigation/memory_esql.spec.ts
+++ b/x-pack/platform/plugins/shared/significant_events/test/scout/api/tests/memory_and_investigation/memory_esql.spec.ts
@@ -29,11 +29,8 @@ apiTest.describe(
     ];
     const entryIds: string[] = [];
 
-    apiTest.beforeAll(async ({ apiServices }) => {
-      await apiServices.significantEventsTest.enableMemory();
-    });
-
-    apiTest.afterAll(async ({ apiClient, apiServices, samlAuth }) => {
+    // Availability is owned by global.setup.ts / global.teardown.ts for the whole run.
+    apiTest.afterAll(async ({ apiClient, samlAuth }) => {
       const { cookieHeader } = await samlAuth.asStreamsAdmin();
       const headers = { ...COMMON_API_HEADERS, ...cookieHeader };
 
@@ -43,7 +40,6 @@ apiTest.describe(
           responseType: 'json',
         });
       }
-      await apiServices.significantEventsTest.disableMemory();
     });
 
     apiTest(

--- a/x-pack/platform/plugins/shared/significant_events/test/scout/api/tests/memory_and_investigation/memory_esql.spec.ts
+++ b/x-pack/platform/plugins/shared/significant_events/test/scout/api/tests/memory_and_investigation/memory_esql.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/api';
+import { tags } from '@kbn/scout';
+import { v4 as uuidv4 } from 'uuid';
+import { significantEventsApiTest as apiTest } from '../../fixtures';
+import { COMMON_API_HEADERS } from '../../fixtures/constants';
+
+const MEMORY_DATA_STREAM = 'ai-nightshift-memory';
+
+apiTest.describe(
+  'Memory ES|QL retrieval',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    const pages = [
+      {
+        name: `scout-memory-esql-a-${uuidv4().slice(0, 8)}`,
+        title: 'Scout memory ES|QL page A',
+      },
+      {
+        name: `scout-memory-esql-b-${uuidv4().slice(0, 8)}`,
+        title: 'Scout memory ES|QL page B',
+      },
+    ];
+    const entryIds: string[] = [];
+
+    apiTest.beforeAll(async ({ apiServices }) => {
+      await apiServices.significantEventsTest.enableMemory();
+    });
+
+    apiTest.afterAll(async ({ apiClient, apiServices, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+      const headers = { ...COMMON_API_HEADERS, ...cookieHeader };
+
+      for (const entryId of entryIds) {
+        await apiClient.delete(`internal/streams/memory/entries/${entryId}`, {
+          headers,
+          responseType: 'json',
+        });
+      }
+      await apiServices.significantEventsTest.disableMemory();
+    });
+
+    apiTest(
+      'retrieves memory pages directly from the visible data stream',
+      async ({ apiClient, esClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const headers = { ...COMMON_API_HEADERS, ...cookieHeader };
+
+        for (const page of pages) {
+          const response = await apiClient.post('internal/streams/memory/entries', {
+            headers,
+            body: {
+              ...page,
+              content: `Content for ${page.name}`,
+              tags: ['scout', 'esql'],
+            },
+            responseType: 'json',
+          });
+          expect(response.statusCode).toBe(200);
+          entryIds.push(response.body.id as string);
+        }
+
+        const { columns, values } = await esClient.esql.query({
+          query: `FROM ${MEMORY_DATA_STREAM} | WHERE type == "memory" | KEEP id, name, title, version`,
+        });
+        const nameColumn = columns.findIndex(({ name }) => name === 'name');
+        const titleColumn = columns.findIndex(({ name }) => name === 'title');
+        const returnedPages = new Map(
+          values.map((row) => [row[nameColumn] as string, row[titleColumn] as string])
+        );
+
+        expect(returnedPages.get(pages[0].name)).toBe(pages[0].title);
+        expect(returnedPages.get(pages[1].name)).toBe(pages[1].title);
+
+        const { data_streams: dataStreams } = await esClient.indices.getDataStream({
+          name: MEMORY_DATA_STREAM,
+        });
+        expect(dataStreams).toHaveLength(1);
+        expect(dataStreams[0].hidden).toBe(false);
+      }
+    );
+  }
+);


### PR DESCRIPTION
## What
Stores Nightshift memory pages in the visible `ai-nightshift-memory` data stream using a Knowledge Item-shaped document while preserving the existing memory service contract.

## How to Verify
1. Run `node scripts/jest x-pack/platform/plugins/shared/significant_events/server/lib/memory`.
2. Run `node scripts/type_check --project x-pack/platform/plugins/shared/significant_events/tsconfig.json`.
3. Run `node scripts/scout run-tests --arch stateful --domain classic --testFiles x-pack/platform/plugins/shared/significant_events/test/scout/api/tests/memory/memory_esql.spec.ts,x-pack/platform/plugins/shared/significant_events/test/scout/api/tests/memory/memory_crud.spec.ts`.

## Breaking Changes
None
