### PR TITLE
[Synthetics] Add "Run tests manually" sub-feature privilege (monitor:run-manually)

### DIFF
--- a/x-pack/platform/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/platform/test/api_integration/apis/security/privileges.ts
@@ -306,6 +306,7 @@ export default function ({ getService }: FtrProviderContext) {
         'read',
         'minimal_all',
         'minimal_read',
+        'can_run_test',
         'elastic_managed_locations_enabled',
         'can_manage_private_locations',
         'can_read_param_values',

--- a/x-pack/platform/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/platform/test/api_integration/apis/security/privileges.ts
@@ -306,7 +306,7 @@ export default function ({ getService }: FtrProviderContext) {
         'read',
         'minimal_all',
         'minimal_read',
-        'can_run_test',
+        'can_run_test_manually',
         'elastic_managed_locations_enabled',
         'can_manage_private_locations',
         'can_read_param_values',

--- a/x-pack/platform/test/api_integration_basic/apis/security/privileges.ts
+++ b/x-pack/platform/test/api_integration_basic/apis/security/privileges.ts
@@ -434,6 +434,7 @@ export default function ({ getService }: FtrProviderContext) {
               'all',
               'can_manage_private_locations',
               'can_read_param_values',
+              'can_run_test',
               'elastic_managed_locations_enabled',
               'read',
               'minimal_all',

--- a/x-pack/platform/test/api_integration_basic/apis/security/privileges.ts
+++ b/x-pack/platform/test/api_integration_basic/apis/security/privileges.ts
@@ -434,7 +434,7 @@ export default function ({ getService }: FtrProviderContext) {
               'all',
               'can_manage_private_locations',
               'can_read_param_values',
-              'can_run_test',
+              'can_run_test_manually',
               'elastic_managed_locations_enabled',
               'read',
               'minimal_all',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
@@ -15,10 +15,9 @@ import {
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { useDispatch, useSelector } from 'react-redux-v7';
-import { useSyntheticsSettingsContext } from '../../contexts';
 import { useKibanaSpace } from '../../../../hooks/use_kibana_space';
 import { NoPermissionsTooltip } from '../common/components/permissions';
-import { useCanUsePublicLocations } from '../../../../hooks/use_capabilities';
+import { useCanRunTest, useCanUsePublicLocations } from '../../../../hooks/use_capabilities';
 import { ConfigKey } from '../../../../../common/constants/monitor_management';
 import { TEST_NOW_ARIA_LABEL, TEST_SCHEDULED_LABEL } from '../monitor_add_edit/form/run_test_btn';
 import { useSelectedMonitor } from './hooks/use_selected_monitor';
@@ -41,7 +40,8 @@ export const RunTestManuallyContextItem = ({
 
   const canUsePublicLocations = useCanUsePublicLocations(monitor?.[ConfigKey.LOCATIONS]);
 
-  const { canSave } = useSyntheticsSettingsContext();
+  // Manual test runs are allowed for write users OR run-only (`canRunTest`) users.
+  const canRunTest = useCanRunTest();
 
   const { space } = useKibanaSpace();
 
@@ -76,13 +76,13 @@ export const RunTestManuallyContextItem = ({
   return (
     <NoPermissionsTooltip
       content={content}
-      canEditSynthetics={canSave}
+      canEditSynthetics={canRunTest}
       canUsePublicLocations={canUsePublicLocations}
     >
       <EuiContextMenuItem
         data-test-subj="syntheticsRunTestManuallyButton"
         color="success"
-        disabled={!canUsePublicLocations || !canSave}
+        disabled={!canUsePublicLocations || !canRunTest}
         onClick={() => {
           if (monitor) {
             const spaceId = 'spaceId' in monitor ? (monitor.spaceId as string) : undefined;

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
@@ -17,7 +17,10 @@ import { i18n } from '@kbn/i18n';
 import { useDispatch, useSelector } from 'react-redux-v7';
 import { useKibanaSpace } from '../../../../hooks/use_kibana_space';
 import { NoPermissionsTooltip } from '../common/components/permissions';
-import { useCanRunTest, useCanUsePublicLocations } from '../../../../hooks/use_capabilities';
+import {
+  useCanRunTestManually,
+  useCanUsePublicLocations,
+} from '../../../../hooks/use_capabilities';
 import { ConfigKey } from '../../../../../common/constants/monitor_management';
 import { TEST_NOW_ARIA_LABEL, TEST_SCHEDULED_LABEL } from '../monitor_add_edit/form/run_test_btn';
 import { useSelectedMonitor } from './hooks/use_selected_monitor';
@@ -40,8 +43,8 @@ export const RunTestManuallyContextItem = ({
 
   const canUsePublicLocations = useCanUsePublicLocations(monitor?.[ConfigKey.LOCATIONS]);
 
-  // Manual test runs are allowed for write users OR run-only (`canRunTest`) users.
-  const canRunTest = useCanRunTest();
+  // Manual test runs are allowed for write users OR run-only (`canRunTestManually`) users.
+  const canRunTestManually = useCanRunTestManually();
 
   const { space } = useKibanaSpace();
 
@@ -76,13 +79,13 @@ export const RunTestManuallyContextItem = ({
   return (
     <NoPermissionsTooltip
       content={content}
-      canEditSynthetics={canRunTest}
+      canEditSynthetics={canRunTestManually}
       canUsePublicLocations={canUsePublicLocations}
     >
       <EuiContextMenuItem
         data-test-subj="syntheticsRunTestManuallyButton"
         color="success"
-        disabled={!canUsePublicLocations || !canRunTest}
+        disabled={!canUsePublicLocations || !canRunTestManually}
         onClick={() => {
           if (monitor) {
             const spaceId = 'spaceId' in monitor ? (monitor.spaceId as string) : undefined;

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -34,7 +34,7 @@ import {
 import { useMonitorAlertEnable } from '../../../../hooks/use_monitor_alert_enable';
 import type { OverviewStatusMetaData } from '../../../../../../../common/runtime_types';
 import { ConfigKey } from '../../../../../../../common/runtime_types';
-import { useCanEditSynthetics } from '../../../../../../hooks/use_capabilities';
+import { useCanEditSynthetics, useCanRunTest } from '../../../../../../hooks/use_capabilities';
 import { useMonitorEnableHandler, useLocationName, useEnablement } from '../../../../hooks';
 import { setFlyoutConfig } from '../../../../state/overview/actions';
 import { useEditMonitorLocator } from '../../../../hooks/use_edit_monitor_locator';
@@ -196,6 +196,9 @@ export function ActionsPopover({
 
   const canEditSynthetics = useCanEditSynthetics();
 
+  // Manual test runs are allowed for write users OR run-only (`canRunTest`) users.
+  const canRunTest = useCanRunTest();
+
   const canUsePublicLocations = useCanUsePublicLocById(monitor.configId);
 
   const { isServiceAllowed } = useEnablement();
@@ -317,13 +320,14 @@ export function ActionsPopover({
       ) : (
         <NoPermissionsTooltip
           canUsePublicLocations={canUsePublicLocations}
-          canEditSynthetics={canEditSynthetics}
+          canEditSynthetics={canRunTest}
         >
           {runTestManually}
         </NoPermissionsTooltip>
       ),
       icon: 'flask',
-      disabled: isReadOnly || testInProgress || !canUsePublicLocations || !isServiceAllowed,
+      disabled:
+        isReadOnly || testInProgress || !canUsePublicLocations || !isServiceAllowed || !canRunTest,
       toolTipContent: readOnlyActionTooltip,
       onClick: isReadOnly
         ? undefined

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -34,7 +34,10 @@ import {
 import { useMonitorAlertEnable } from '../../../../hooks/use_monitor_alert_enable';
 import type { OverviewStatusMetaData } from '../../../../../../../common/runtime_types';
 import { ConfigKey } from '../../../../../../../common/runtime_types';
-import { useCanEditSynthetics, useCanRunTest } from '../../../../../../hooks/use_capabilities';
+import {
+  useCanEditSynthetics,
+  useCanRunTestManually,
+} from '../../../../../../hooks/use_capabilities';
 import { useMonitorEnableHandler, useLocationName, useEnablement } from '../../../../hooks';
 import { setFlyoutConfig } from '../../../../state/overview/actions';
 import { useEditMonitorLocator } from '../../../../hooks/use_edit_monitor_locator';
@@ -196,8 +199,8 @@ export function ActionsPopover({
 
   const canEditSynthetics = useCanEditSynthetics();
 
-  // Manual test runs are allowed for write users OR run-only (`canRunTest`) users.
-  const canRunTest = useCanRunTest();
+  // Manual test runs are allowed for write users OR run-only (`canRunTestManually`) users.
+  const canRunTestManually = useCanRunTestManually();
 
   const canUsePublicLocations = useCanUsePublicLocById(monitor.configId);
 
@@ -321,14 +324,18 @@ export function ActionsPopover({
       ) : (
         <NoPermissionsTooltip
           canUsePublicLocations={canUsePublicLocations}
-          canEditSynthetics={canRunTest}
+          canEditSynthetics={canRunTestManually}
         >
           {runTestManually}
         </NoPermissionsTooltip>
       ),
       icon: 'flask',
       disabled:
-        isReadOnly || testInProgress || !canUsePublicLocations || !isServiceAllowed || !canRunTest,
+        isReadOnly ||
+        testInProgress ||
+        !canUsePublicLocations ||
+        !isServiceAllowed ||
+        !canRunTestManually,
       toolTipContent: readOnlyActionTooltip,
       onClick: isReadOnly
         ? undefined

--- a/x-pack/solutions/observability/plugins/synthetics/public/hooks/use_capabilities.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/hooks/use_capabilities.ts
@@ -15,6 +15,15 @@ export const useCanEditSynthetics = () => {
   return !!useKibana().services?.application?.capabilities.uptime.save;
 };
 
+/**
+ * Whether the current user can trigger manual test runs. True when they can edit
+ * Synthetics (write) OR have been granted the run-only `canRunTest` sub-feature.
+ */
+export const useCanRunTest = () => {
+  const capabilities = useKibana().services?.application?.capabilities.uptime;
+  return !!(capabilities?.save || capabilities?.canRunTest);
+};
+
 export const useCanUsePublicLocationsPermission = (): boolean =>
   !!(useKibana().services?.application?.capabilities.uptime.elasticManagedLocationsEnabled ?? true);
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/hooks/use_capabilities.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/hooks/use_capabilities.ts
@@ -17,11 +17,11 @@ export const useCanEditSynthetics = () => {
 
 /**
  * Whether the current user can trigger manual test runs. True when they can edit
- * Synthetics (write) OR have been granted the run-only `canRunTest` sub-feature.
+ * Synthetics (write) OR have been granted the run-only `canRunTestManually` sub-feature.
  */
-export const useCanRunTest = () => {
+export const useCanRunTestManually = () => {
   const capabilities = useKibana().services?.application?.capabilities.uptime;
-  return !!(capabilities?.save || capabilities?.canRunTest);
+  return !!(capabilities?.save || capabilities?.canRunTestManually);
 };
 
 export const useCanUsePublicLocationsPermission = (): boolean =>

--- a/x-pack/solutions/observability/plugins/synthetics/server/feature.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/feature.ts
@@ -30,8 +30,32 @@ import {
 import { syntheticsApiKeyObjectType } from './saved_objects/service_api_key';
 
 export const PRIVATE_LOCATION_WRITE_API = 'private-location-write';
+export const MONITOR_RUN_API = 'monitor-run';
 
 const alertingFeatures = SYNTHETICS_ALERTING_FEATURES;
+
+const canRunTestPrivilege: SubFeaturePrivilegeGroupConfig = {
+  groupType: 'independent' as SubFeaturePrivilegeGroupType,
+  privileges: [
+    {
+      id: 'can_run_test',
+      name: i18n.translate('xpack.synthetics.features.canRunTest', {
+        defaultMessage: 'Can run tests manually',
+      }),
+      // `includeIn: 'none'` — never granted implicitly. The run-test route accepts
+      // EITHER `uptime-write` (which base `all` already has, so existing roles keep
+      // working) OR this `monitor-run` privilege, which lets an admin grant manual
+      // test runs to an otherwise read-only role without granting write access.
+      includeIn: 'none',
+      api: [MONITOR_RUN_API],
+      savedObject: {
+        all: [],
+        read: [],
+      },
+      ui: ['canRunTest'],
+    },
+  ],
+};
 
 const elasticManagedLocationsEnabledPrivilege: SubFeaturePrivilegeGroupConfig = {
   groupType: 'independent' as SubFeaturePrivilegeGroupType,
@@ -169,6 +193,16 @@ export const syntheticsFeature = {
     },
   },
   subFeatures: [
+    {
+      name: i18n.translate('xpack.synthetics.features.app.runTest', {
+        defaultMessage: 'Run tests manually',
+      }),
+      description: i18n.translate('xpack.synthetics.features.app.runTest.description', {
+        defaultMessage:
+          'This feature allows a read-only user to trigger manual test runs of existing monitors, without granting the ability to create, edit, or delete monitors.',
+      }),
+      privilegeGroups: [canRunTestPrivilege],
+    },
     {
       name: i18n.translate('xpack.synthetics.features.app.elastic', {
         defaultMessage: 'Elastic managed locations',

--- a/x-pack/solutions/observability/plugins/synthetics/server/feature.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/feature.ts
@@ -30,29 +30,29 @@ import {
 import { syntheticsApiKeyObjectType } from './saved_objects/service_api_key';
 
 export const PRIVATE_LOCATION_WRITE_API = 'private-location-write';
-export const MONITOR_RUN_API = 'monitor-run';
+export const MONITOR_RUN_MANUALLY_API = 'monitor-run-manually';
 
 const alertingFeatures = SYNTHETICS_ALERTING_FEATURES;
 
-const canRunTestPrivilege: SubFeaturePrivilegeGroupConfig = {
+const canRunTestManuallyPrivilege: SubFeaturePrivilegeGroupConfig = {
   groupType: 'independent' as SubFeaturePrivilegeGroupType,
   privileges: [
     {
-      id: 'can_run_test',
-      name: i18n.translate('xpack.synthetics.features.canRunTest', {
+      id: 'can_run_test_manually',
+      name: i18n.translate('xpack.synthetics.features.canRunTestManually', {
         defaultMessage: 'Can run tests manually',
       }),
       // `includeIn: 'none'` — never granted implicitly. The run-test route accepts
       // EITHER `uptime-write` (which base `all` already has, so existing roles keep
-      // working) OR this `monitor-run` privilege, which lets an admin grant manual
+      // working) OR this `monitor-run-manually` privilege, which lets an admin grant manual
       // test runs to an otherwise read-only role without granting write access.
       includeIn: 'none',
-      api: [MONITOR_RUN_API],
+      api: [MONITOR_RUN_MANUALLY_API],
       savedObject: {
         all: [],
         read: [],
       },
-      ui: ['canRunTest'],
+      ui: ['canRunTestManually'],
     },
   ],
 };
@@ -201,7 +201,7 @@ export const syntheticsFeature = {
         defaultMessage:
           'This feature allows a read-only user to trigger manual test runs of existing monitors, without granting the ability to create, edit, or delete monitors.',
       }),
-      privilegeGroups: [canRunTestPrivilege],
+      privilegeGroups: [canRunTestManuallyPrivilege],
     },
     {
       name: i18n.translate('xpack.synthetics.features.app.elastic', {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -15,6 +15,7 @@ import type { MonitorFields } from '../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { getPrivateLocationsForMonitor } from '../monitor_cruds/add_monitor/utils';
 import { getMonitorNotFoundResponse } from './service_errors';
+import { MONITOR_RUN_API } from '../../feature';
 
 export const testNowMonitorRoute: SyntheticsRestApiRouteFactory<TestNowResponse> = () => ({
   method: 'POST',
@@ -31,7 +32,12 @@ export const testNowMonitorRoute: SyntheticsRestApiRouteFactory<TestNowResponse>
     const { monitorId } = routeContext.request.params;
     return triggerTestNow(monitorId, routeContext);
   },
-  writeAccess: true,
+  // Running a monitor is read-plus-execute (it never mutates the monitor SO), so it
+  // does not require `uptime-write`. Instead it needs EITHER `uptime-write` (so existing
+  // write users keep working, non-breaking) OR the `monitor-run` sub-feature privilege,
+  // which grants manual runs to an otherwise read-only role.
+  writeAccess: false,
+  anyRequiredPrivileges: ['uptime-write', MONITOR_RUN_API],
   options: { availability: { since: '9.2.0' } },
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -15,7 +15,7 @@ import type { MonitorFields } from '../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { getPrivateLocationsForMonitor } from '../monitor_cruds/add_monitor/utils';
 import { getMonitorNotFoundResponse } from './service_errors';
-import { MONITOR_RUN_API } from '../../feature';
+import { MONITOR_RUN_MANUALLY_API } from '../../feature';
 
 export const testNowMonitorRoute: SyntheticsRestApiRouteFactory<TestNowResponse> = () => ({
   method: 'POST',
@@ -34,10 +34,10 @@ export const testNowMonitorRoute: SyntheticsRestApiRouteFactory<TestNowResponse>
   },
   // Running a monitor is read-plus-execute (it never mutates the monitor SO), so it
   // does not require `uptime-write`. Instead it needs EITHER `uptime-write` (so existing
-  // write users keep working, non-breaking) OR the `monitor-run` sub-feature privilege,
+  // write users keep working, non-breaking) OR the `monitor-run-manually` sub-feature privilege,
   // which grants manual runs to an otherwise read-only role.
   writeAccess: false,
-  anyRequiredPrivileges: ['uptime-write', MONITOR_RUN_API],
+  anyRequiredPrivileges: ['uptime-write', MONITOR_RUN_MANUALLY_API],
   options: { availability: { since: '9.2.0' } },
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/types.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/types.ts
@@ -42,6 +42,12 @@ export interface UMServerRoute<T> {
   method: SupportedMethod;
   writeAccess?: boolean;
   requiredPrivileges?: string[];
+  /**
+   * Privileges where at least ONE must be satisfied (in addition to the always-required
+   * `uptime-read`). Emitted as an `{ anyRequired }` set in the route's authz config, e.g.
+   * `['uptime-write', 'monitor-run']` allows either a full-write user or a run-only user.
+   */
+  anyRequiredPrivileges?: string[];
   handler: T;
   validation?: VersionedRouteValidation<any, any, any>;
   streamHandler?: (

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/types.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/types.ts
@@ -45,7 +45,7 @@ export interface UMServerRoute<T> {
   /**
    * Privileges where at least ONE must be satisfied (in addition to the always-required
    * `uptime-read`). Emitted as an `{ anyRequired }` set in the route's authz config, e.g.
-   * `['uptime-write', 'monitor-run']` allows either a full-write user or a run-only user.
+   * `['uptime-write', 'monitor-run-manually']` allows either a full-write user or a run-only user.
    */
   anyRequiredPrivileges?: string[];
   handler: T;

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_route_wrapper.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_route_wrapper.ts
@@ -34,6 +34,11 @@ export const syntheticsRouteWrapper: SyntheticsRouteWrapper = (
         'uptime-read',
         ...(syntheticsRoute.requiredPrivileges ?? []),
         ...(syntheticsRoute?.writeAccess ? ['uptime-write'] : []),
+        // OR-set: at least one of these privileges must be satisfied. Used to allow a
+        // route for either a full-write user or a more granular privilege holder.
+        ...(syntheticsRoute.anyRequiredPrivileges?.length
+          ? [{ anyRequired: syntheticsRoute.anyRequiredPrivileges }]
+          : []),
       ],
     },
   },

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/run_test_manually.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/run_test_manually.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { expect } from '@kbn/scout-oblt/api';
+import type { ApiClientFixture, KibanaRole } from '@kbn/scout-oblt';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { apiTest, mergeSyntheticsApiHeaders } from '../fixtures';
+
+/**
+ * "Run test manually" (`POST /api/synthetics/monitor/test/{monitorId}`) is gated by an
+ * OR-set: `uptime-read` AND (`uptime-write` OR `monitor-run`). This verifies:
+ *  - a plain `read` role is rejected (403) — no change from today,
+ *  - a `read` role WITH the `can_run_test` sub-feature is authorized (not 403),
+ *  - a base `all` role is still authorized via `uptime-write` (non-breaking),
+ *  - a user with no Synthetics access is rejected.
+ *
+ * We hit a non-existent monitor id, so an authorized request resolves past the authz
+ * layer to a 404 (monitor not found) rather than 403 — the authz boundary is what we assert.
+ */
+const ROLE_CONFIGS = {
+  SYNTHETICS_ALL: {
+    elasticsearch: { cluster: [], indices: [{ names: ['synthetics-*'], privileges: ['all'] }] },
+    kibana: [{ base: [], spaces: ['*'], feature: { uptime: ['all'] } }],
+  },
+  SYNTHETICS_READ_ONLY: {
+    elasticsearch: { cluster: [], indices: [{ names: ['synthetics-*'], privileges: ['read'] }] },
+    kibana: [{ base: [], spaces: ['*'], feature: { uptime: ['read'] } }],
+  },
+  SYNTHETICS_READ_WITH_RUN: {
+    elasticsearch: { cluster: [], indices: [{ names: ['synthetics-*'], privileges: ['read'] }] },
+    kibana: [{ base: [], spaces: ['*'], feature: { uptime: ['read', 'can_run_test'] } }],
+  },
+  NO_SYNTHETICS: {
+    elasticsearch: { cluster: [], indices: [{ names: ['log-*'], privileges: ['read'] }] },
+    kibana: [{ base: [], spaces: ['*'], feature: { dashboard: ['read'] } }],
+  },
+} satisfies Record<string, KibanaRole>;
+
+const runTest = (apiClient: ApiClientFixture, headers: Record<string, string>, monitorId: string) =>
+  apiClient.post(`${SYNTHETICS_API_URLS.TEST_NOW_MONITOR}/${monitorId}`.replace(/^\//, ''), {
+    headers,
+    body: {},
+    responseType: 'json',
+  });
+
+apiTest.describe('RunTestManuallyPermissions', { tag: ['@local-stateful-classic'] }, () => {
+  let allHeaders: Record<string, string>;
+  let readOnlyHeaders: Record<string, string>;
+  let readWithRunHeaders: Record<string, string>;
+  let noSyntheticsHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ requestAuth }) => {
+    const resolve = async (role: KibanaRole) => {
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(role);
+      return mergeSyntheticsApiHeaders(apiKeyHeader);
+    };
+    allHeaders = await resolve(ROLE_CONFIGS.SYNTHETICS_ALL);
+    readOnlyHeaders = await resolve(ROLE_CONFIGS.SYNTHETICS_READ_ONLY);
+    readWithRunHeaders = await resolve(ROLE_CONFIGS.SYNTHETICS_READ_WITH_RUN);
+    noSyntheticsHeaders = await resolve(ROLE_CONFIGS.NO_SYNTHETICS);
+  });
+
+  apiTest('read-only role cannot run tests (403)', async ({ apiClient }) => {
+    const res = await runTest(apiClient, readOnlyHeaders, uuidv4());
+    expect(res.statusCode).toBe(403);
+    expect(decodeURIComponent((res.body as { message?: string }).message ?? '')).toContain(
+      '[uptime-write,monitor-run]'
+    );
+  });
+
+  apiTest('user with no Synthetics access cannot run tests (403)', async ({ apiClient }) => {
+    const res = await runTest(apiClient, noSyntheticsHeaders, uuidv4());
+    expect(res.statusCode).toBe(403);
+  });
+
+  apiTest('read + can_run_test role is authorized to run tests', async ({ apiClient }) => {
+    const res = await runTest(apiClient, readWithRunHeaders, uuidv4());
+    // Passes authz; the dummy monitor does not exist → 404, not 403.
+    expect(res.statusCode).not.toBe(403);
+    expect(res.statusCode).toBe(404);
+  });
+
+  apiTest(
+    'base `all` role is still authorized to run tests (non-breaking)',
+    async ({ apiClient }) => {
+      const res = await runTest(apiClient, allHeaders, uuidv4());
+      expect(res.statusCode).not.toBe(403);
+      expect(res.statusCode).toBe(404);
+    }
+  );
+});

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/synthetics_api_security.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/synthetics_api_security.spec.ts
@@ -21,6 +21,7 @@ interface SweepRoute {
   method: Method;
   path: string;
   writeAccess: boolean;
+  anyRequiredPrivileges?: string[];
 }
 
 /**
@@ -41,6 +42,7 @@ const allRoutes: SweepRoute[] = syntheticsAppRestApiRoutes
       method: route.method as Method,
       path: route.path,
       writeAccess: route.writeAccess ?? true,
+      anyRequiredPrivileges: route.anyRequiredPrivileges,
     };
   });
 
@@ -55,6 +57,13 @@ const expectedBodyTag = (route: SweepRoute, readUser: boolean): string => {
     return readUser
       ? '[private-location-write,uptime-write]'
       : '[uptime-read,private-location-write,uptime-write]';
+  }
+
+  // Routes with an OR-set (e.g. run-test: `uptime-write` OR `monitor-run`). A read
+  // user is missing every OR member; a no-access user is additionally missing `uptime-read`.
+  if (route.anyRequiredPrivileges?.length) {
+    const anyPrivs = route.anyRequiredPrivileges.join(',');
+    return readUser ? `[${anyPrivs}]` : `[uptime-read,${anyPrivs}]`;
   }
 
   if (method === 'GET') {
@@ -156,7 +165,9 @@ apiTest.describe('SyntheticsAPISecurity', { tag: ['@local-stateful-classic'] }, 
 
   apiTest('throws permissions errors for read user', async ({ apiClient }) => {
     for (const route of allRoutes) {
-      if (!route.writeAccess) {
+      // Skip pure read routes, but keep OR-set routes (e.g. run-test) — a read user
+      // still lacks every OR member and should be rejected.
+      if (!route.writeAccess && !route.anyRequiredPrivileges?.length) {
         continue;
       }
       const res = await request(apiClient, route.method, `s/${spaceId}${route.path}`, readHeaders);

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/monitor_crud/api/tests/run_test_manually.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/monitor_crud/api/tests/run_test_manually.spec.ts
@@ -13,9 +13,9 @@ import { testNowMonitor } from '../../../common/fixtures/monitors';
 
 /**
  * "Run test manually" (`POST /api/synthetics/monitor/test/{monitorId}`) is gated by an
- * OR-set: `uptime-read` AND (`uptime-write` OR `monitor-run`). This verifies:
+ * OR-set: `uptime-read` AND (`uptime-write` OR `monitor-run-manually`). This verifies:
  *  - a plain `read` role is rejected (403) — no change from today,
- *  - a `read` role WITH the `can_run_test` sub-feature is authorized (not 403),
+ *  - a `read` role WITH the `can_run_test_manually` sub-feature is authorized (not 403),
  *  - a base `all` role is still authorized via `uptime-write` (non-breaking),
  *  - a user with no Synthetics access is rejected.
  *
@@ -33,7 +33,7 @@ const ROLE_CONFIGS = {
   },
   SYNTHETICS_READ_WITH_RUN: {
     elasticsearch: { cluster: [], indices: [{ names: ['synthetics-*'], privileges: ['read'] }] },
-    kibana: [{ base: [], spaces: ['*'], feature: { uptime: ['read', 'can_run_test'] } }],
+    kibana: [{ base: [], spaces: ['*'], feature: { uptime: ['read', 'can_run_test_manually'] } }],
   },
   NO_SYNTHETICS: {
     elasticsearch: { cluster: [], indices: [{ names: ['log-*'], privileges: ['read'] }] },
@@ -61,7 +61,7 @@ apiTest.describe('RunTestManuallyPermissions', { tag: ['@local-stateful-classic'
   apiTest('read-only role cannot run tests (403)', async ({ apiClient }) => {
     const res = await testNowMonitor(apiClient, readOnlyHeaders, uuidv4(), { statusCode: 403 });
     expect(decodeURIComponent((res.body as { message?: string }).message ?? '')).toContain(
-      '[uptime-write,monitor-run]'
+      '[uptime-write,monitor-run-manually]'
     );
   });
 
@@ -69,7 +69,7 @@ apiTest.describe('RunTestManuallyPermissions', { tag: ['@local-stateful-classic'
     await testNowMonitor(apiClient, noSyntheticsHeaders, uuidv4(), { statusCode: 403 });
   });
 
-  apiTest('read + can_run_test role is authorized to run tests', async ({ apiClient }) => {
+  apiTest('read + can_run_test_manually role is authorized to run tests', async ({ apiClient }) => {
     // Passes authz; the dummy monitor does not exist → 404, not 403.
     await testNowMonitor(apiClient, readWithRunHeaders, uuidv4(), { statusCode: 404 });
   });

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/monitor_crud/api/tests/synthetics_api_security.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/monitor_crud/api/tests/synthetics_api_security.spec.ts
@@ -59,7 +59,7 @@ const expectedBodyTag = (route: SweepRoute, readUser: boolean): string => {
       : '[uptime-read,private-location-write,uptime-write]';
   }
 
-  // Routes with an OR-set (e.g. run-test: `uptime-write` OR `monitor-run`). A read
+  // Routes with an OR-set (e.g. run-test: `uptime-write` OR `monitor-run-manually`). A read
   // user is missing every OR member; a no-access user is additionally missing `uptime-read`.
   if (route.anyRequiredPrivileges?.length) {
     const anyPrivs = route.anyRequiredPrivileges.join(',');

--- a/x-pack/solutions/observability/test/serverless/api_integration/test_suites/platform_security/authorization.ts
+++ b/x-pack/solutions/observability/test/serverless/api_integration/test_suites/platform_security/authorization.ts
@@ -10585,6 +10585,11 @@ export default function ({ getService }: FtrProviderContext) {
                 "login:",
                 "ui:uptime/canReadParamValues",
               ],
+              "can_run_test": Array [
+                "login:",
+                "api:monitor-run",
+                "ui:uptime/canRunTest",
+              ],
               "elastic_managed_locations_enabled": Array [
                 "login:",
                 "ui:uptime/elasticManagedLocationsEnabled",

--- a/x-pack/solutions/observability/test/serverless/api_integration/test_suites/platform_security/authorization.ts
+++ b/x-pack/solutions/observability/test/serverless/api_integration/test_suites/platform_security/authorization.ts
@@ -10601,10 +10601,10 @@ export default function ({ getService }: FtrProviderContext) {
                 "login:",
                 "ui:uptime/canReadParamValues",
               ],
-              "can_run_test": Array [
+              "can_run_test_manually": Array [
                 "login:",
-                "api:monitor-run",
-                "ui:uptime/canRunTest",
+                "api:monitor-run-manually",
+                "ui:uptime/canRunTestManually",
               ],
               "elastic_managed_locations_enabled": Array [
                 "login:",


### PR DESCRIPTION
## 📝 Summary

Let a **read-only** Synthetics user **trigger manual test runs** ("Run test manually") without granting create/edit/delete access.

Today, running a test requires `uptime-write` (bundled into `all`), so users who only need to trigger ad-hoc runs must be granted full write just to click "Run test manually". This adds a granular **`Can run tests manually`** sub-feature.

## 🧠 Design — OR-authz, fully non-breaking

"Run test manually" (`POST /api/synthetics/monitor/test/{monitorId}`) is **read-plus-execute**: it decrypts the existing monitor and dispatches a one-off run via the synthetics service. It never mutates the monitor saved object — it only required `uptime-write` because of the blanket "non-GET ⇒ write" default.

Instead of *moving* the capability out of `all` (which breaks customized `minimal_all` roles — see the sibling global-params PR), this route uses an **OR-set**:

```ts
// synthetics_route_wrapper builds:
requiredPrivileges: ['uptime-read', { anyRequired: ['uptime-write', 'monitor-run-manually'] }]
```

→ the route needs `uptime-read` **AND** (`uptime-write` **OR** `monitor-run-manually`). This means:

| Role | Runs a test? | Why |
|---|---|---|
| Base `all` | ✅ | has `uptime-write` |
| Customized `minimal_all` | ✅ | still has `uptime-write` |
| `read` only | ❌ (unchanged) | has neither |
| **`read` + `Can run tests manually`** | ✅ | has `monitor-run-manually` |

So it is **fully non-breaking** (nothing is removed from any existing role) and **purely additive** — the `can_run_test_manually` sub-feature is `includeIn: 'none'`, granted only when an admin explicitly toggles it onto a role.

## 🧩 What changed

| Layer | Change |
|---|---|
| **Route wrapper** | `synthetics_route_wrapper` now emits an `{ anyRequired }` set when a route sets `anyRequiredPrivileges` (new `types.ts` field). |
| **Feature** | New `MONITOR_RUN_MANUALLY_API = 'monitor-run-manually'` + `can_run_test_manually` sub-feature (`includeIn: 'none'`, UI cap `canRunTestManually`). |
| **Route** | `test_now_monitor` → `writeAccess: false` + `anyRequiredPrivileges: ['uptime-write', 'monitor-run-manually']`. |
| **UI** | "Run test manually" (overview popover + monitor detail) enabled for `canEditSynthetics` **OR** `canRunTestManually`. |
| **Tests** | Focused authz spec (read→403, read+run→404, `all`→404, no-access→403); route-auth sweep extended for OR-sets; privilege snapshots. |

## 🧪 Testing

Verified locally against a real ES + Kibana stack (Scout API tests):

- ✅ `read`-only role → **403** on `POST /monitor/test/{id}` with `[uptime-write,monitor-run-manually]`.
- ✅ `read` + `can_run_test_manually` role → authorized (**404** for a non-existent monitor, i.e. past the authz layer).
- ✅ Base `all` role → still authorized (non-breaking).
- ✅ Route-auth sweep passes with the new OR-set handling.

## 🚦 Release note

Synthetics: added a **Run tests manually** sub-feature privilege that lets an otherwise read-only role trigger on-demand test runs of existing monitors, without granting monitor write access. Existing roles are unaffected.


<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->