### PR TITLE
[Discover] Support cmd/ctrl click on Explore in Lens in Field statistics

### DIFF
--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/field_data_row/action_menu/actions.test.ts
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/field_data_row/action_menu/actions.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { DefaultItemAction } from '@elastic/eui/src/components/basic_table/action_types';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import { getActions } from './actions';
+import type { FieldVisConfig } from '../../stats_table/types';
+import type { CombinedQuery } from '../../../../index_data_visualizer/types/combined_query';
+import type { DataVisualizerKibanaReactContextValue } from '../../../../kibana_context';
+
+const mockTimeRange = { from: 'now-15m', to: 'now' };
+
+const mouseEvent = (init: MouseEventInit = {}) =>
+  new MouseEvent('click', init) as unknown as ReactMouseEvent;
+
+const getServicesMock = () => {
+  const navigateToPrefilledEditor = jest.fn();
+  const services = {
+    application: { capabilities: { visualize_v2: { show: true } } },
+    lens: {
+      canUseEditor: () => true,
+      navigateToPrefilledEditor,
+    },
+    data: {
+      query: {
+        filterManager: { getFilters: () => [] },
+        timefilter: { timefilter: { getTime: () => mockTimeRange } },
+      },
+    },
+  } as unknown as Partial<DataVisualizerKibanaReactContextValue['services']>;
+  return { services, navigateToPrefilledEditor };
+};
+
+const dataView = {
+  id: 'test-data-view-id',
+  timeFieldName: '@timestamp',
+} as DataView;
+
+const combinedQuery: CombinedQuery = {
+  searchQueryLanguage: 'kuery',
+  searchString: '',
+};
+
+const item = {
+  type: 'keyword',
+  fieldName: 'airline',
+} as FieldVisConfig;
+
+describe('getActions', () => {
+  describe('Explore in Lens action', () => {
+    const getLensAction = (services: Partial<DataVisualizerKibanaReactContextValue['services']>) =>
+      getActions(dataView, services, combinedQuery, undefined).find(
+        (action): action is DefaultItemAction<FieldVisConfig> =>
+          'data-test-subj' in action &&
+          action['data-test-subj'] === 'dataVisualizerActionViewInLensButton'
+      );
+
+    it('navigates in the current tab on a plain click', () => {
+      const { services, navigateToPrefilledEditor } = getServicesMock();
+      const action = getLensAction(services);
+
+      action!.onClick!(item, mouseEvent());
+
+      expect(navigateToPrefilledEditor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'dataVisualizer-airline',
+          attributes: expect.objectContaining({ visualizationType: 'lnsXY' }),
+          time_range: mockTimeRange,
+        }),
+        { openInNewTab: false }
+      );
+    });
+
+    it('opens in a new tab on a modified click', () => {
+      const { services, navigateToPrefilledEditor } = getServicesMock();
+      const action = getLensAction(services);
+
+      action!.onClick!(item, mouseEvent({ metaKey: true }));
+
+      expect(navigateToPrefilledEditor).toHaveBeenCalledWith(expect.anything(), {
+        openInNewTab: true,
+      });
+
+      action!.onClick!(item, mouseEvent({ ctrlKey: true }));
+
+      expect(navigateToPrefilledEditor).toHaveBeenLastCalledWith(expect.anything(), {
+        openInNewTab: true,
+      });
+    });
+
+    it('does not navigate for fields without Lens attributes', () => {
+      const { services, navigateToPrefilledEditor } = getServicesMock();
+      const action = getLensAction(services);
+
+      action!.onClick!({ type: 'geo_point', fieldName: 'coords' } as FieldVisConfig, mouseEvent());
+
+      expect(navigateToPrefilledEditor).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/field_data_row/action_menu/actions.ts
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/field_data_row/action_menu/actions.ts
@@ -7,7 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 import type { Action } from '@elastic/eui/src/components/basic_table/action_types';
-import type { MutableRefObject } from 'react';
+import type { MouseEvent, MutableRefObject } from 'react';
+import { hasActiveModifierKey } from '@kbn/shared-ux-utility';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { type VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import type { Refresh } from '@kbn/ml-date-picker';
@@ -51,13 +52,18 @@ export function getActions(
       icon: 'lensApp',
       available: (item: FieldVisConfig) =>
         getCompatibleLensDataType(item.type) !== undefined && canUseLensEditor,
-      onClick: (item: FieldVisConfig) => {
+      onClick: (item: FieldVisConfig, event: MouseEvent) => {
         const lensAttributes = getLensAttributes(dataView, combinedQuery, filters, item);
         if (lensAttributes) {
-          lensPlugin.navigateToPrefilledEditor({
-            id: `dataVisualizer-${item.fieldName}`,
-            attributes: lensAttributes,
-          });
+          lensPlugin.navigateToPrefilledEditor(
+            {
+              id: `dataVisualizer-${item.fieldName}`,
+              attributes: lensAttributes,
+              // when opening in a new tab, the time range travels in the URL instead of the shared timefilter
+              time_range: data?.query.timefilter.timefilter.getTime(),
+            },
+            { openInNewTab: hasActiveModifierKey(event) }
+          );
         }
       },
       'data-test-subj': 'dataVisualizerActionViewInLensButton',


### PR DESCRIPTION
## Summary

Part of #136043, closes #211773

Allows opening the prefilled Lens editor in a **new browser tab** via cmd/ctrl (or shift/alt) + click on the "Explore in Lens" action in the Field statistics table, so the current view is not lost.

The EUI table item action already receives the originating `MouseEvent` — it was just unused. When a modifier key is active, the action now passes `openInNewTab: true` to `lens.navigateToPrefilledEditor`, which transfers the attributes via session storage and opens the editor in a new tab. The current time range is now passed explicitly as `time_range`, since the new tab cannot rely on the shared timefilter of the current one (in the same-tab case this is a no-op).

A plain click behaves exactly as before.

### How to test

1. Open Discover with time-based sample data, switch to the **Field statistics** tab.
2. Cmd/ctrl+click the "Explore in Lens" action of a field row → Lens opens in a new tab with the prefilled chart and the same time range.
3. Plain click → Lens opens in the current tab as before.

## Release note

Discover: cmd/ctrl + click on "Explore in Lens" in Field statistics now opens the Lens editor in a new browser tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
