### PR TITLE
[Discover] Support cmd/ctrl click on Edit visualization in the histogram

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.test.tsx
@@ -310,6 +310,19 @@ describe('Chart', () => {
     expect(mockOnEditVisualization).toHaveBeenCalled();
   });
 
+  test('passes the click event to onEditVisualization for modified clicks', async () => {
+    const user = userEvent.setup();
+    const { mockOnEditVisualization } = await mountComponent();
+
+    await user.keyboard('{Control>}');
+    await user.click(screen.getByText('Edit visualization'));
+    await user.keyboard('{/Control}');
+
+    expect(mockOnEditVisualization).toHaveBeenCalledWith(
+      expect.objectContaining({ ctrlKey: true })
+    );
+  });
+
   it('should not render chart if data view is not time based', async () => {
     await mountComponent({ dataView: dataViewMock });
 

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_edit_visualization.test.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_edit_visualization.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
 import { waitFor, renderHook } from '@testing-library/react';
@@ -44,11 +45,41 @@ describe('useEditVisualization', () => {
     );
     await waitFor(() => expect(hook.result.current).toBeDefined());
     hook.result.current!();
-    expect(navigateToPrefilledEditor).toHaveBeenCalledWith({
-      id: '',
-      time_range: relativeTimeRange,
-      attributes: lensAttributes,
-    });
+    expect(navigateToPrefilledEditor).toHaveBeenCalledWith(
+      {
+        id: '',
+        time_range: relativeTimeRange,
+        attributes: lensAttributes,
+      },
+      { openInNewTab: false }
+    );
+  });
+
+  it('should open the editor in a new tab on a modified click', async () => {
+    getTriggerCompatibleActions.mockReturnValue(Promise.resolve([{ id: 'test' }]));
+    const relativeTimeRange = { from: 'now-15m', to: 'now' };
+    const lensAttributes = {
+      visualizationType: 'lnsXY',
+      title: 'test',
+    } as TypedLensByValueInput['attributes'];
+    const hook = renderHook(() =>
+      useEditVisualization({
+        services: unifiedHistogramServicesMock,
+        dataView: dataViewWithTimefieldMock,
+        relativeTimeRange,
+        lensAttributes,
+      })
+    );
+    await waitFor(() => expect(hook.result.current).toBeDefined());
+    hook.result.current!(new MouseEvent('click', { ctrlKey: true }) as unknown as ReactMouseEvent);
+    expect(navigateToPrefilledEditor).toHaveBeenCalledWith(
+      {
+        id: '',
+        time_range: relativeTimeRange,
+        attributes: lensAttributes,
+      },
+      { openInNewTab: true }
+    );
   });
 
   it('should return undefined if the data view has no ID', async () => {

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_edit_visualization.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_edit_visualization.ts
@@ -10,6 +10,8 @@
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { TimeRange } from '@kbn/es-query';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import { hasActiveModifierKey } from '@kbn/shared-ux-utility';
+import type { MouseEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { VISUALIZE_FIELD_TRIGGER } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import type { UnifiedHistogramServices } from '../../..';
@@ -56,12 +58,18 @@ export const useEditVisualization = ({
       return undefined;
     }
 
-    return () => {
-      services.lens.navigateToPrefilledEditor({
-        id: '',
-        time_range: relativeTimeRange,
-        attributes: lensAttributes,
-      });
+    return (event?: MouseEvent) => {
+      services.lens.navigateToPrefilledEditor(
+        {
+          id: '',
+          time_range: relativeTimeRange,
+          attributes: lensAttributes,
+        },
+        {
+          // open the editor in a new tab on modified clicks, keeping the current view intact
+          openInNewTab: !!event && hasActiveModifierKey(event),
+        }
+      );
     };
   }, [canVisualize, lensAttributes, relativeTimeRange, services.lens]);
 

--- a/src/platform/packages/shared/shared-ux/button_toolbar/src/buttons/icon_button_group/icon_button_group.test.tsx
+++ b/src/platform/packages/shared/shared-ux/button_toolbar/src/buttons/icon_button_group/icon_button_group.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithI18n } from '@kbn/test-jest-helpers';
 
@@ -24,6 +24,18 @@ describe('<IconButtonGroup />', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Text' })).toBeInTheDocument();
+  });
+
+  it('invokes onClick with the originating click event', () => {
+    const onClick = jest.fn();
+    renderWithI18n(
+      <IconButtonGroup legend="Legend" buttons={[{ label: 'Text', onClick, iconType: 'text' }]} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Text' }), { metaKey: true });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick.mock.calls[0][0]).toMatchObject({ metaKey: true, ctrlKey: false });
   });
 
   it('does not expose a native browser title when toolTipContent is provided', () => {

--- a/src/platform/packages/shared/shared-ux/button_toolbar/src/buttons/icon_button_group/icon_button_group.tsx
+++ b/src/platform/packages/shared/shared-ux/button_toolbar/src/buttons/icon_button_group/icon_button_group.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import type { EuiButtonGroupOptionProps, IconType, EuiButtonGroupProps } from '@elastic/eui';
 import { EuiButtonGroup, htmlIdGenerator, useEuiTheme } from '@elastic/eui';
 import type { SerializedStyles } from '@emotion/react';
@@ -22,8 +22,8 @@ export interface IconButton {
   label: string;
   /** EUI `IconType` to display. */
   iconType: IconType;
-  /** Handler for button click. */
-  onClick: () => void;
+  /** Handler for button click. Receives the originating mouse event when available. */
+  onClick: (event?: React.MouseEvent) => void;
   /**
    * HTML `title` attribute for the native browser tooltip. Defaults to `label`.
    * Ignored when `toolTipContent` is provided — the native tooltip is suppressed
@@ -62,7 +62,10 @@ export interface Props {
   css?: SerializedStyles;
 }
 
-type Option = EuiButtonGroupOptionProps & Omit<IconButton, 'label' | 'css'>;
+type Option = EuiButtonGroupOptionProps &
+  Omit<IconButton, 'label' | 'css'> & {
+    onClickCapture?: React.MouseEventHandler<HTMLButtonElement>;
+  };
 
 /**
  * A group of buttons each performing an action, represented by an icon.
@@ -77,6 +80,10 @@ export const IconButtonGroup = ({
   const euiTheme = useEuiTheme();
   const iconButtonStyles = getIconButtonStyles(euiTheme);
   const iconButtonGroupStyles = getIconButtonGroupStyles(euiTheme);
+  // EuiButtonGroup replaces each option's onClick with its own onChange handler which
+  // only reports the option id, so the click event is captured here to hand it to the
+  // option's onClick (e.g. for detecting modifier keys)
+  const lastClickEvent = useRef<React.MouseEvent<HTMLButtonElement>>();
 
   const buttonGroupOptions: Option[] = buttons.map((button: IconButton, index) => {
     const { label, title, toolTipContent, css: buttonCss, ...rest } = button;
@@ -85,6 +92,9 @@ export const IconButtonGroup = ({
     // `title: ''`) so the EuiToolTip is the only tooltip shown.
     return {
       ...rest,
+      onClickCapture: (event: React.MouseEvent<HTMLButtonElement>) => {
+        lastClickEvent.current = event;
+      },
       'aria-label': title ?? label,
       id: `${htmlIdGenerator()()}${index}`,
       label,
@@ -98,7 +108,7 @@ export const IconButtonGroup = ({
   });
 
   const onChangeIconsMulti = (optionId: string) => {
-    buttonGroupOptions.find((x) => x.id === optionId)?.onClick();
+    buttonGroupOptions.find((x) => x.id === optionId)?.onClick(lastClickEvent.current);
   };
 
   return (


### PR DESCRIPTION
## Summary

Part of #136043, closes #211770

Allows opening the prefilled Lens editor in a **new browser tab** via cmd/ctrl (or shift/alt) + click on the "Edit visualization" icon in Discover's histogram toolbar.

The button is rendered through the shared `IconButtonGroup`, and `EuiButtonGroup` replaces each option's `onClick` with its own `onChange` handler which only reports the option id — so the click event never reached the handler. `IconButtonGroup` now captures the originating click event (via an option-level `onClickCapture`, which EUI passes through to the underlying button) and forwards it to the option's `onClick`. The `IconButton['onClick']` signature widens to `(event?: React.MouseEvent) => void`, which is backwards compatible for all existing consumers.

The unified histogram edit-visualization handler uses the event to pass `openInNewTab: hasActiveModifierKey(event)` to `lens.navigateToPrefilledEditor`. A plain click behaves exactly as before.

### How to test

1. Open Discover with time-based sample data.
2. Cmd/ctrl+click the "Edit visualization" (Lens icon) button in the histogram toolbar → Lens opens in a new tab with the prefilled chart and time range.
3. Plain click → Lens opens in the current tab as before.

## Release note

Discover: cmd/ctrl + click on "Edit visualization" in the histogram now opens the Lens editor in a new browser tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
