### PR TITLE
[Discover] Support cmd/ctrl click on the Visualize field button

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_visualize_button/field_visualize_button.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_visualize_button/field_visualize_button.test.tsx
@@ -17,7 +17,7 @@ import {
   VISUALIZE_FIELD_TRIGGER,
   VISUALIZE_GEO_FIELD_TRIGGER,
 } from '@kbn/ui-actions-plugin/common/trigger_ids';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const ORIGINATING_APP = 'test';
@@ -42,6 +42,10 @@ jest
   .mockResolvedValue([visualizeAction as ActionInternal<object>]);
 
 describe('UnifiedFieldList <FieldVisualizeButton />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render correctly', async () => {
     const user = userEvent.setup();
     const FIELD_NAME = 'extension';
@@ -122,6 +126,69 @@ describe('UnifiedFieldList <FieldVisualizeButton />', () => {
       dataViewSpec: dataView.toSpec(false),
       fieldName: FIELD_NAME,
       originatingApp: ORIGINATING_APP,
+    });
+  });
+
+  it('should let the browser handle modified clicks when the button has a href', async () => {
+    const FIELD_NAME = 'bytes';
+    const field = dataView.fields.find((f) => f.name === FIELD_NAME)!;
+
+    jest.spyOn(field, 'visualizable', 'get').mockImplementationOnce(() => true);
+
+    const visualizeButton = await getFieldVisualizeButton({
+      field,
+      dataView,
+      originatingApp: ORIGINATING_APP,
+      uiActions,
+    });
+
+    renderWithI18n(visualizeButton);
+
+    const visualizeLink = screen.getByText('Visualize');
+    expect(visualizeLink.closest('a')).toHaveAttribute('href', '/app/test');
+
+    fireEvent.click(visualizeLink, { metaKey: true });
+
+    expect(uiActions.executeTriggerActions).not.toHaveBeenCalled();
+  });
+
+  it('should request opening in a new tab on modified clicks without a href', async () => {
+    const FIELD_NAME = 'bytes';
+    const field = dataView.fields.find((f) => f.name === FIELD_NAME)!;
+
+    jest.spyOn(field, 'visualizable', 'get').mockImplementationOnce(() => true);
+
+    const actionWithoutHref = new ActionInternal({
+      type: ACTION_VISUALIZE_LENS_FIELD,
+      id: ACTION_VISUALIZE_LENS_FIELD,
+      getDisplayName: () => 'test',
+      isCompatible: async () => true,
+      execute: async () => {},
+    });
+    jest
+      .spyOn(uiActions, 'getTriggerCompatibleActions')
+      .mockResolvedValue([actionWithoutHref as ActionInternal<object>]);
+
+    const visualizeButton = await getFieldVisualizeButton({
+      field,
+      dataView,
+      originatingApp: ORIGINATING_APP,
+      uiActions,
+    });
+
+    renderWithI18n(visualizeButton);
+
+    const visualizeLink = screen.getByText('Visualize');
+    expect(visualizeLink.closest('a')).toBeNull();
+
+    fireEvent.click(visualizeLink, { metaKey: true });
+
+    expect(uiActions.executeTriggerActions).toHaveBeenCalledWith(VISUALIZE_FIELD_TRIGGER, {
+      contextualFields: [],
+      dataViewSpec: dataView.toSpec(false),
+      fieldName: FIELD_NAME,
+      originatingApp: ORIGINATING_APP,
+      openInNewTab: true,
     });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_visualize_button/field_visualize_button.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_visualize_button/field_visualize_button.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import type { EuiButtonProps } from '@elastic/eui';
 import type { UiCounterMetricType } from '@kbn/analytics';
 import { METRIC_TYPE } from '@kbn/analytics';
+import { hasActiveModifierKey } from '@kbn/shared-ux-utility';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import { FieldVisualizeButtonInner } from './field_visualize_button_inner';
@@ -50,8 +51,17 @@ export const FieldVisualizeButton: React.FC<FieldVisualizeButtonProps> = React.m
     const handleVisualizeLinkClick = async (
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
     ) => {
+      if (
+        visualizeInfo.href &&
+        (event.defaultPrevented || event.button !== 0 || hasActiveModifierKey(event))
+      ) {
+        // let the browser handle the modified click on the link natively (e.g. open in a new tab)
+        return;
+      }
+
       // regular link click. let the uiActions code handle the navigation and show popup if needed
       event.preventDefault();
+      const openInNewTab = hasActiveModifierKey(event);
 
       const triggerVisualization = (updatedDataView: DataView) => {
         trackUiMetric?.(METRIC_TYPE.CLICK, 'visualize_link_click');
@@ -60,7 +70,8 @@ export const FieldVisualizeButton: React.FC<FieldVisualizeButtonProps> = React.m
           visualizeInfo.field,
           contextualFields,
           originatingApp,
-          updatedDataView
+          updatedDataView,
+          { openInNewTab }
         );
       };
       triggerVisualization(dataView);

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_visualize_button/visualize_trigger_utils.test.ts
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_visualize_button/visualize_trigger_utils.test.ts
@@ -9,7 +9,7 @@
 
 import type { DataViewField, DataView } from '@kbn/data-views-plugin/public';
 import type { Action, UiActionsStart } from '@kbn/ui-actions-plugin/public';
-import { getVisualizeInformation } from './visualize_trigger_utils';
+import { getVisualizeInformation, triggerVisualizeActions } from './visualize_trigger_utils';
 
 const field = {
   name: 'fieldName',
@@ -127,6 +127,39 @@ describe('visualize_trigger_utils', () => {
       );
       expect(information).not.toBeUndefined();
       expect(information?.field).toHaveProperty('name', 'multi2');
+    });
+  });
+
+  describe('triggerVisualizeActions', () => {
+    it('should not include openInNewTab in the context by default', () => {
+      const executeTriggerActions = jest.fn();
+      const uiActionsStart = { executeTriggerActions } as unknown as UiActionsStart;
+
+      triggerVisualizeActions(uiActionsStart, field, ['bytes'], 'testApp', dataViewMock);
+
+      expect(executeTriggerActions).toHaveBeenCalledWith('VISUALIZE_FIELD_TRIGGER', {
+        dataViewSpec: {},
+        fieldName: 'fieldName',
+        contextualFields: ['bytes'],
+        originatingApp: 'testApp',
+      });
+    });
+
+    it('should include openInNewTab in the context when requested', () => {
+      const executeTriggerActions = jest.fn();
+      const uiActionsStart = { executeTriggerActions } as unknown as UiActionsStart;
+
+      triggerVisualizeActions(uiActionsStart, field, ['bytes'], 'testApp', dataViewMock, {
+        openInNewTab: true,
+      });
+
+      expect(executeTriggerActions).toHaveBeenCalledWith('VISUALIZE_FIELD_TRIGGER', {
+        dataViewSpec: {},
+        fieldName: 'fieldName',
+        contextualFields: ['bytes'],
+        originatingApp: 'testApp',
+        openInNewTab: true,
+      });
     });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_visualize_button/visualize_trigger_utils.ts
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_visualize_button/visualize_trigger_utils.ts
@@ -50,7 +50,8 @@ export function triggerVisualizeActions(
   field: DataViewField,
   contextualFields: string[] = [],
   originatingApp: string,
-  dataView?: DataView
+  dataView?: DataView,
+  options?: { openInNewTab?: boolean }
 ) {
   if (!dataView) return;
   const trigger = getTriggerConstant(field.type);
@@ -59,6 +60,7 @@ export function triggerVisualizeActions(
     fieldName: field.name,
     contextualFields,
     originatingApp,
+    ...(options?.openInNewTab ? { openInNewTab: true } : {}),
   };
   uiActions.executeTriggerActions(trigger, triggerOptions);
 }

--- a/src/platform/plugins/shared/ui_actions/public/types.ts
+++ b/src/platform/plugins/shared/ui_actions/public/types.ts
@@ -24,6 +24,11 @@ export interface VisualizeFieldContext {
   textBasedColumns?: DatatableColumn[];
   originatingApp?: string;
   query?: AggregateQuery;
+  /**
+   * Set when the user requested opening the visualization in a new browser tab
+   * (e.g. via cmd/ctrl + click), so actions can navigate accordingly.
+   */
+  openInNewTab?: boolean;
 }
 
 export const ACTION_VISUALIZE_FIELD = 'ACTION_VISUALIZE_FIELD';

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/mounter.tsx
@@ -52,6 +52,7 @@ import { getPreloadedState } from '../state_management/lens_slice';
 import { getLensInspectorService } from '../lens_inspector_service';
 import { LensDocumentService } from '../persistence';
 import { EditorFrameServiceProvider } from '../editor_frame_service/editor_frame_service_context';
+import { takeStoredVisualizeFieldContext } from '../trigger_actions/visualize_field_context_transfer';
 
 function getInitialContext(history: AppMountParameters['history']) {
   const historyLocationState = history.location.state as
@@ -74,6 +75,17 @@ function getInitialContext(history: AppMountParameters['history']) {
         originatingApp: historyLocationState.originatingApp,
       };
     }
+  }
+
+  // history state does not survive window.open, so the visualize-field action stores
+  // the context in sessionStorage when it opens Lens in a new tab
+  const storedContext = takeStoredVisualizeFieldContext();
+  if (storedContext) {
+    return {
+      contextType: ACTION_VISUALIZE_LENS_FIELD,
+      initialContext: storedContext.payload,
+      originatingApp: storedContext.originatingApp,
+    };
   }
 }
 

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -654,7 +654,7 @@ export class LensPlugin {
       ACTION_VISUALIZE_LENS_FIELD,
       async () => {
         const { visualizeFieldAction } = await import('./async_services');
-        return visualizeFieldAction(core.application);
+        return visualizeFieldAction(core.application, startDependencies.data);
       }
     );
 

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/visualize_field_actions.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/visualize_field_actions.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ApplicationStart } from '@kbn/core/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { ActionExecutionContext, VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
+import { ACTION_VISUALIZE_LENS_FIELD } from '@kbn/ui-actions-plugin/public';
+import { VISUALIZE_FIELD_TRIGGER } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import { visualizeFieldAction } from './visualize_field_actions';
+import { takeStoredVisualizeFieldContext } from './visualize_field_context_transfer';
+
+const getServicesMock = () => {
+  const navigateToApp = jest.fn().mockResolvedValue(undefined);
+  const application = {
+    navigateToApp,
+    capabilities: { visualize_v2: { show: true } },
+  } as unknown as ApplicationStart;
+  const data = {
+    query: {
+      timefilter: { timefilter: { getTime: () => ({ from: 'now-15m', to: 'now' }) } },
+      filterManager: { getGlobalFilters: () => [] },
+    },
+  } as unknown as DataPublicPluginStart;
+  return { application, data, navigateToApp };
+};
+
+const context: VisualizeFieldContext = {
+  fieldName: 'bytes',
+  dataViewSpec: { id: 'test-data-view-id' },
+  contextualFields: ['extension'],
+  originatingApp: 'discover',
+};
+
+const executionContext = (
+  extra: Partial<VisualizeFieldContext> = {}
+): ActionExecutionContext<VisualizeFieldContext> => ({
+  ...context,
+  ...extra,
+  trigger: { id: VISUALIZE_FIELD_TRIGGER },
+});
+
+describe('visualizeFieldAction', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('navigates in the current tab passing the context via history state', async () => {
+    const { application, data, navigateToApp } = getServicesMock();
+
+    await visualizeFieldAction(application, data).execute(executionContext());
+
+    expect(navigateToApp).toHaveBeenCalledWith('lens', {
+      state: { type: ACTION_VISUALIZE_LENS_FIELD, payload: executionContext() },
+    });
+    expect(takeStoredVisualizeFieldContext()).toBeUndefined();
+  });
+
+  it('navigates to a new tab passing the context via session storage', async () => {
+    const { application, data, navigateToApp } = getServicesMock();
+    let storedContextDuringNavigation: string | null = null;
+    navigateToApp.mockImplementation(async () => {
+      // window.open clones sessionStorage at this point, so the context must be stored
+      storedContextDuringNavigation = window.sessionStorage.getItem('lens-visualize-field-context');
+    });
+
+    await visualizeFieldAction(application, data).execute(executionContext({ openInNewTab: true }));
+
+    expect(navigateToApp).toHaveBeenCalledWith('lens', {
+      path: `#/?_g=(filters:!(),time:(from:now-15m,to:now))`,
+      openInNewTab: true,
+      skipAppLeave: true,
+    });
+    expect(storedContextDuringNavigation).toBeDefined();
+    expect(JSON.parse(storedContextDuringNavigation!)).toEqual({
+      payload: executionContext({ openInNewTab: true }),
+      originatingApp: 'discover',
+    });
+    // cleaned up after the new tab has been opened
+    expect(window.sessionStorage.getItem('lens-visualize-field-context')).toBeNull();
+  });
+});
+
+describe('takeStoredVisualizeFieldContext', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('reads the stored context only once', async () => {
+    const { application, data, navigateToApp } = getServicesMock();
+    navigateToApp.mockImplementation(async () => {
+      // keep the stored context around, simulating the cloned session storage of a new tab
+      expect(window.sessionStorage.getItem('lens-visualize-field-context')).toBeDefined();
+      throw new Error('stop before cleanup');
+    });
+
+    await expect(
+      visualizeFieldAction(application, data).execute(executionContext({ openInNewTab: true }))
+    ).rejects.toThrow('stop before cleanup');
+
+    expect(takeStoredVisualizeFieldContext()?.payload).toMatchObject({ fieldName: 'bytes' });
+    expect(takeStoredVisualizeFieldContext()).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/visualize_field_actions.ts
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/visualize_field_actions.ts
@@ -9,8 +9,14 @@ import { i18n } from '@kbn/i18n';
 import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import { createAction, ACTION_VISUALIZE_LENS_FIELD } from '@kbn/ui-actions-plugin/public';
 import type { ApplicationStart } from '@kbn/core/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import rison from '@kbn/rison';
+import {
+  storeVisualizeFieldContext,
+  removeStoredVisualizeFieldContext,
+} from './visualize_field_context_transfer';
 
-export const visualizeFieldAction = (application: ApplicationStart) =>
+export const visualizeFieldAction = (application: ApplicationStart, data: DataPublicPluginStart) =>
   createAction<VisualizeFieldContext>({
     type: ACTION_VISUALIZE_LENS_FIELD,
     id: ACTION_VISUALIZE_LENS_FIELD,
@@ -20,6 +26,24 @@ export const visualizeFieldAction = (application: ApplicationStart) =>
       }),
     isCompatible: async () => !!application.capabilities.visualize_v2.show,
     execute: async (context: VisualizeFieldContext) => {
+      if (context.openInNewTab) {
+        // history state does not survive window.open, so the context travels via
+        // sessionStorage while time and global filters travel in the URL, since
+        // the new tab cannot rely on the shared timefilter of the current one
+        const globalState = {
+          time: data.query.timefilter.timefilter.getTime(),
+          filters: data.query.filterManager.getGlobalFilters(),
+        };
+        storeVisualizeFieldContext(context);
+        await application.navigateToApp('lens', {
+          path: `#/?_g=${rison.encode(globalState)}`,
+          openInNewTab: true,
+          skipAppLeave: true,
+        });
+        // window.open has already cloned sessionStorage into the new tab
+        removeStoredVisualizeFieldContext();
+        return;
+      }
       application.navigateToApp('lens', {
         state: { type: ACTION_VISUALIZE_LENS_FIELD, payload: context },
       });

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/visualize_field_context_transfer.ts
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/visualize_field_context_transfer.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
+import { Storage } from '@kbn/kibana-utils-plugin/public';
+
+/**
+ * A `VisualizeFieldContext` is too large to travel in a URL (it contains a full
+ * data view spec, which may describe an ad-hoc data view that cannot be resolved
+ * by id in a fresh tab). When the visualize-field action opens Lens in a new tab,
+ * the context is passed through sessionStorage instead, which `window.open`
+ * clones into the new same-origin tab.
+ */
+const VISUALIZE_FIELD_CONTEXT_STORAGE_KEY = 'lens-visualize-field-context';
+
+export interface StoredVisualizeFieldContext {
+  payload: VisualizeFieldContext;
+  originatingApp?: string;
+}
+
+export const storeVisualizeFieldContext = (
+  context: VisualizeFieldContext,
+  storage: Storage = new Storage(window.sessionStorage)
+): void => {
+  const stored: StoredVisualizeFieldContext = {
+    payload: context,
+    originatingApp: context.originatingApp,
+  };
+  storage.set(VISUALIZE_FIELD_CONTEXT_STORAGE_KEY, stored);
+};
+
+export const removeStoredVisualizeFieldContext = (
+  storage: Storage = new Storage(window.sessionStorage)
+): void => {
+  storage.remove(VISUALIZE_FIELD_CONTEXT_STORAGE_KEY);
+};
+
+/**
+ * Reads and removes the stored context, so it is only consumed once and cannot
+ * be picked up by a later navigation to Lens in the same tab.
+ */
+export const takeStoredVisualizeFieldContext = (
+  storage: Storage = new Storage(window.sessionStorage)
+): StoredVisualizeFieldContext | undefined => {
+  const stored: StoredVisualizeFieldContext | null = storage.get(
+    VISUALIZE_FIELD_CONTEXT_STORAGE_KEY
+  );
+  if (!stored) {
+    return undefined;
+  }
+  storage.remove(VISUALIZE_FIELD_CONTEXT_STORAGE_KEY);
+  return stored;
+};


### PR DESCRIPTION
## Summary

Part of #136043, closes #112471

Allows opening Lens (or Maps for geo fields) in a **new browser tab** via cmd/ctrl (or shift/alt) + click on the "Visualize" button in the field popover of the unified field list (Discover sidebar and Lens field list).

Two changes:

1. **Click guard (unified field list):** the button already renders a `href` when the visualize action provides one (the Maps geo-field action implements `getHref`), but the click handler called `event.preventDefault()` unconditionally, swallowing modified clicks. Modified/non-left clicks on a link now fall through to the browser, so for geo fields cmd/ctrl+click, middle-click, and right-click → "Open in new tab" work natively.
2. **Lens visualize-field action:** the Lens action cannot provide a `href` because its `VisualizeFieldContext` does not fit in a URL (it contains a full data view spec, which may describe an ad-hoc data view that cannot be re-resolved by id in a fresh tab). Instead, an `openInNewTab` flag travels through the trigger context, and the action hands the context to the new tab via sessionStorage — which `window.open` clones into a same-origin tab, the same mechanism `navigateToPrefilledEditor({ openInNewTab: true })` relies on. Time and global filters travel in the `_g` URL param, since history state does not survive `window.open`. The Lens mounter reads (and removes) the stored context when no history state is present.

A plain click behaves exactly as before (in-tab navigation via history state).

### How to test

1. Open Discover with time-based sample data.
2. In the sidebar, open a field popover and cmd/ctrl+click **Visualize** → Lens opens in a new tab with the prefilled chart, same time range and pinned filters. Plain click → in-tab as before.
3. With sample web logs, open the `geo.coordinates` field popover: cmd/ctrl+click and middle-click **Visualize** → Maps opens in a new tab.

## Release note

Discover: cmd/ctrl + click on the "Visualize" button in the field popover now opens Lens (or Maps for geo fields) in a new browser tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
