### PR TITLE
[One Workflow] Preserve inline query parameters in HTTP connector paths

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.test.ts
@@ -1616,9 +1616,7 @@ describe('execute()', () => {
       connectorUsageCollector,
     });
 
-    expect(requestMock.mock.calls[0][0].url).toBe(
-      'https://abc.def/api/users.info?user=U123'
-    );
+    expect(requestMock.mock.calls[0][0].url).toBe('https://abc.def/api/users.info?user=U123');
   });
 
   test('execute preserves query strings in both the base URL and path', async () => {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.test.ts
@@ -1597,6 +1597,54 @@ describe('execute()', () => {
     expect(requestMock.mock.calls[0][0].url).toContain('key2=value2');
   });
 
+  test('execute preserves a query string embedded in path', async () => {
+    const config: ConnectorTypeConfigType = {
+      ...emptyConfig,
+      url: 'https://abc.def',
+    };
+    await connectorType.executor?.({
+      actionId: 'some-id',
+      services,
+      config,
+      secrets: { ...emptySecrets, user: 'abc', password: '123' },
+      params: {
+        method: 'GET',
+        path: '/api/users.info?user=U123',
+      },
+      configurationUtilities,
+      logger: mockedLogger,
+      connectorUsageCollector,
+    });
+
+    expect(requestMock.mock.calls[0][0].url).toBe(
+      'https://abc.def/api/users.info?user=U123'
+    );
+  });
+
+  test('execute preserves query strings in both the base URL and path', async () => {
+    const config: ConnectorTypeConfigType = {
+      ...emptyConfig,
+      url: 'https://abc.def?tenant=1',
+    };
+    await connectorType.executor?.({
+      actionId: 'some-id',
+      services,
+      config,
+      secrets: { ...emptySecrets, user: 'abc', password: '123' },
+      params: {
+        method: 'GET',
+        path: '/api/users.info?user=U123',
+      },
+      configurationUtilities,
+      logger: mockedLogger,
+      connectorUsageCollector,
+    });
+
+    expect(requestMock.mock.calls[0][0].url).toBe(
+      'https://abc.def/api/users.info?tenant=1&user=U123'
+    );
+  });
+
   test('execute injects secretQueryParams from connector secrets into URL', async () => {
     const config: ConnectorTypeConfigType = {
       ...emptyConfig,

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.test.ts
@@ -1645,6 +1645,59 @@ describe('execute()', () => {
     );
   });
 
+  test('execute preserves the raw encoding of a query string embedded in path', async () => {
+    const config: ConnectorTypeConfigType = {
+      ...emptyConfig,
+      url: 'https://abc.def',
+    };
+    await connectorType.executor?.({
+      actionId: 'some-id',
+      services,
+      config,
+      secrets: { ...emptySecrets, user: 'abc', password: '123' },
+      params: {
+        method: 'GET',
+        path: '/api/search?q=a%20b&flag&symbol=~',
+      },
+      configurationUtilities,
+      logger: mockedLogger,
+      connectorUsageCollector,
+    });
+
+    expect(requestMock.mock.calls[0][0].url).toBe(
+      'https://abc.def/api/search?q=a%20b&flag&symbol=~'
+    );
+  });
+
+  test('execute combines inline, explicit, and secret query parameters', async () => {
+    const config: ConnectorTypeConfigType = {
+      ...emptyConfig,
+      url: 'https://abc.def',
+      hasAuth: false,
+    };
+    await connectorType.executor?.({
+      actionId: 'some-id',
+      services,
+      config,
+      secrets: {
+        ...emptySecrets,
+        secretQueryParams: { apiKey: 'secret-api-key' },
+      },
+      params: {
+        method: 'GET',
+        path: '/api/search?q=a%20b&flag&symbol=~',
+        query: { page: '1' },
+      },
+      configurationUtilities,
+      logger: mockedLogger,
+      connectorUsageCollector,
+    });
+
+    expect(requestMock.mock.calls[0][0].url).toBe(
+      'https://abc.def/api/search?q=a%20b&flag&symbol=~&apiKey=secret-api-key&page=1'
+    );
+  });
+
   test('execute injects secretQueryParams from connector secrets into URL', async () => {
     const config: ConnectorTypeConfigType = {
       ...emptyConfig,

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.ts
@@ -188,17 +188,31 @@ function combineUrl(basePath: string, path?: string): string {
   if (!path) return basePath;
   const url = new URL(basePath);
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  const parsedPath = new URL(`http://placeholder${normalizedPath}`);
+  const hashIndex = normalizedPath.indexOf('#');
+  const pathWithoutHash =
+    hashIndex === -1 ? normalizedPath : normalizedPath.slice(0, hashIndex);
+  const queryIndex = pathWithoutHash.indexOf('?');
+  const pathname = queryIndex === -1 ? pathWithoutHash : pathWithoutHash.slice(0, queryIndex);
+  const pathQuery = queryIndex === -1 ? undefined : pathWithoutHash.slice(queryIndex + 1);
   const baseQueryKeys = new Set(url.searchParams.keys());
 
-  url.pathname = url.pathname.replace(/\/$/, '') + parsedPath.pathname;
-  for (const [key, value] of parsedPath.searchParams) {
-    if (!baseQueryKeys.has(key)) {
-      url.searchParams.append(key, value);
+  url.pathname = url.pathname.replace(/\/$/, '') + pathname;
+  if (pathQuery) {
+    const filteredPathQuery = pathQuery
+      .split('&')
+      .filter((queryPart) => {
+        const [key] = new URLSearchParams(queryPart).keys();
+        return key === undefined || !baseQueryKeys.has(key);
+      })
+      .join('&');
+
+    if (filteredPathQuery) {
+      const baseQuery = url.search.slice(1);
+      url.search = baseQuery ? `?${baseQuery}&${filteredPathQuery}` : `?${filteredPathQuery}`;
     }
   }
-  if (parsedPath.hash) {
-    url.hash = parsedPath.hash;
+  if (hashIndex !== -1) {
+    url.hash = normalizedPath.slice(hashIndex);
   }
 
   return url.toString();
@@ -209,11 +223,23 @@ function appendQueryString(baseUrl: string, query?: Record<string, string>): str
     return baseUrl;
   }
   const url = new URL(baseUrl);
+  const existingQueryKeys = new Set(url.searchParams.keys());
+  const appendedQuery = new URLSearchParams();
+
   for (const [key, value] of Object.entries(query)) {
-    if (!url.searchParams.has(key)) {
-      url.searchParams.set(key, value);
+    if (!existingQueryKeys.has(key)) {
+      appendedQuery.set(key, value);
     }
   }
+
+  const appendedQueryString = appendedQuery.toString();
+  if (appendedQueryString) {
+    const existingQuery = url.search.slice(1);
+    url.search = existingQuery
+      ? `?${existingQuery}&${appendedQueryString}`
+      : `?${appendedQueryString}`;
+  }
+
   return url.toString();
 }
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.ts
@@ -188,7 +188,19 @@ function combineUrl(basePath: string, path?: string): string {
   if (!path) return basePath;
   const url = new URL(basePath);
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  url.pathname = url.pathname.replace(/\/$/, '') + normalizedPath;
+  const parsedPath = new URL(`http://placeholder${normalizedPath}`);
+  const baseQueryKeys = new Set(url.searchParams.keys());
+
+  url.pathname = url.pathname.replace(/\/$/, '') + parsedPath.pathname;
+  for (const [key, value] of parsedPath.searchParams) {
+    if (!baseQueryKeys.has(key)) {
+      url.searchParams.append(key, value);
+    }
+  }
+  if (parsedPath.hash) {
+    url.hash = parsedPath.hash;
+  }
+
   return url.toString();
 }
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.ts
@@ -188,14 +188,12 @@ function combineUrl(basePath: string, path?: string): string {
   if (!path) return basePath;
   const url = new URL(basePath);
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  const hashIndex = normalizedPath.indexOf('#');
-  const pathWithoutHash =
-    hashIndex === -1 ? normalizedPath : normalizedPath.slice(0, hashIndex);
-  const queryIndex = pathWithoutHash.indexOf('?');
-  const pathname = queryIndex === -1 ? pathWithoutHash : pathWithoutHash.slice(0, queryIndex);
-  const pathQuery = queryIndex === -1 ? undefined : pathWithoutHash.slice(queryIndex + 1);
+  const queryIndex = normalizedPath.indexOf('?');
+  const pathname = queryIndex === -1 ? normalizedPath : normalizedPath.slice(0, queryIndex);
+  const pathQuery = queryIndex === -1 ? undefined : normalizedPath.slice(queryIndex + 1);
   const baseQueryKeys = new Set(url.searchParams.keys());
 
+  // Keep the query out of URL.pathname, which would encode its `?` delimiter as `%3F`.
   url.pathname = url.pathname.replace(/\/$/, '') + pathname;
   if (pathQuery) {
     const filteredPathQuery = pathQuery
@@ -210,9 +208,6 @@ function combineUrl(basePath: string, path?: string): string {
       const baseQuery = url.search.slice(1);
       url.search = baseQuery ? `?${baseQuery}&${filteredPathQuery}` : `?${filteredPathQuery}`;
     }
-  }
-  if (hashIndex !== -1) {
-    url.hash = normalizedPath.slice(hashIndex);
   }
 
   return url.toString();
@@ -234,6 +229,7 @@ function appendQueryString(baseUrl: string, query?: Record<string, string>): str
 
   const appendedQueryString = appendedQuery.toString();
   if (appendedQueryString) {
+    // Avoid reserializing existing parameters, which would normalize their raw encoding.
     const existingQuery = url.search.slice(1);
     url.search = existingQuery
       ? `?${existingQuery}&${appendedQueryString}`


### PR DESCRIPTION
## Summary

- parse query parameters embedded in an HTTP connector `path` instead of encoding the `?` delimiter into the pathname
- preserve the raw encoding of existing base/path query strings while appending explicit and secret query parameters
- preserve query parameters already configured on the connector base URL
- add regression coverage for inline path queries, raw encoding, and `secretQueryParams` interaction

## References

Closes elastic/security-team#18692

- [Production report in Slack](https://elastic.slack.com/archives/C08U04SUN49/p1785521078766519)
- Regression introduced by #258291

## Test plan

- [x] `node scripts/jest x-pack/platform/plugins/shared/stack_connectors/server/connector_types/http/http_connector.test.ts`
- [x] All 128 HTTP connector tests pass
- [x] No lint diagnostics in the changed files

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->