### PR TITLE
[One Workflow] Classify missing workflow connector errors as user errors

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/errors/errors.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/errors/errors.test.ts
@@ -44,4 +44,11 @@ describe('workflow error classes', () => {
       expect(error.message).toBe(expectedMessage);
     }
   );
+
+  it.each([new WorkflowDisabledError('wf-123'), new WorkflowNotFoundError('wf-123')])(
+    '%s is marked as a user error',
+    (error) => {
+      expect(error).toHaveProperty('isUserError', true);
+    }
+  );
 });

--- a/src/platform/packages/shared/kbn-workflows/common/errors/workflow_not_found_error.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/errors/workflow_not_found_error.ts
@@ -8,6 +8,8 @@
  */
 
 export class WorkflowNotFoundError extends Error {
+  readonly isUserError = true as const;
+
   constructor(workflowId: string) {
     super(`Workflow with id "${workflowId}" not found.`);
     this.name = 'WorkflowNotFoundError';

--- a/src/platform/packages/shared/kbn-workflows/server/lib/validate_workflow_for_execution.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/server/lib/validate_workflow_for_execution.test.ts
@@ -9,7 +9,7 @@
 
 import { validateWorkflowForExecution } from './validate_workflow_for_execution';
 import type { WorkflowDetailDto } from '../..';
-import { WorkflowDisabledError } from '../../common/errors';
+import { WorkflowDisabledError, WorkflowNotFoundError } from '../../common/errors';
 
 const createMockWorkflow = (overrides: Partial<WorkflowDetailDto> = {}): WorkflowDetailDto => ({
   id: 'test-workflow-id',
@@ -37,9 +37,20 @@ describe('validateWorkflowForExecution', () => {
   });
 
   it('should throw when workflow is null (not found)', () => {
-    expect(() => validateWorkflowForExecution(null, 'missing-id')).toThrow(
-      'Workflow not found: missing-id'
-    );
+    // caught like this to assert on the error properties, since it's a custom error class
+    const error = (() => {
+      try {
+        validateWorkflowForExecution(null, 'missing-id');
+      } catch (caughtError) {
+        return caughtError;
+      }
+      return undefined;
+    })();
+
+    expect(error).toBeDefined();
+    expect(error).toBeInstanceOf(WorkflowNotFoundError);
+    expect(error).toHaveProperty('isUserError', true);
+    expect((error as Error).message).toBe('Workflow with id "missing-id" not found.');
   });
 
   it('should throw when workflow definition is missing', () => {
@@ -80,7 +91,9 @@ describe('validateWorkflowForExecution', () => {
 
   it('should check conditions in order: not found > no definition > not valid > disabled', () => {
     // A null workflow should throw "not found", not any other error
-    expect(() => validateWorkflowForExecution(null, 'wf-1')).toThrow('Workflow not found: wf-1');
+    expect(() => validateWorkflowForExecution(null, 'wf-1')).toThrow(
+      'Workflow with id "wf-1" not found.'
+    );
 
     // A workflow with no definition should throw "definition not found" even if also invalid and disabled
     const noDefAndInvalidAndDisabled = createMockWorkflow({

--- a/src/platform/packages/shared/kbn-workflows/server/lib/validate_workflow_for_execution.ts
+++ b/src/platform/packages/shared/kbn-workflows/server/lib/validate_workflow_for_execution.ts
@@ -8,7 +8,7 @@
  */
 
 import type { WorkflowDetailDto } from '../..';
-import { WorkflowDisabledError } from '../../common/errors';
+import { WorkflowDisabledError, WorkflowNotFoundError } from '../../common/errors';
 
 /**
  * Validates that a workflow is in a runnable state before execution.
@@ -25,7 +25,7 @@ export function validateWorkflowForExecution(
   definition: NonNullable<WorkflowDetailDto['definition']>;
 } {
   if (!workflow) {
-    throw new Error(`Workflow not found: ${workflowId}`);
+    throw new WorkflowNotFoundError(workflowId);
   }
 
   if (!workflow.definition) {

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/service.test.ts
@@ -11,7 +11,7 @@ import { actionsConfigMock } from '@kbn/actions-plugin/server/actions_config.moc
 import type { KibanaRequest, Logger } from '@kbn/core/server';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { getErrorSource, TaskErrorSource } from '@kbn/task-manager-plugin/server/task_running';
-import { WorkflowDisabledError } from '@kbn/workflows/common/errors';
+import { WorkflowDisabledError, WorkflowNotFoundError } from '@kbn/workflows/common/errors';
 import {
   createExternalService,
   type ScheduleWorkflowServiceFunction,
@@ -223,6 +223,45 @@ describe('Workflows Service', () => {
       const mockWorkflowService: WorkflowsServiceFunction = jest
         .fn()
         .mockRejectedValue(new WorkflowDisabledError('test-workflow-id'));
+
+      const service = createExternalService(
+        actionId,
+        mockLogger,
+        mockConfigurationUtilities,
+        mockConnectorUsageCollector,
+        mockRequest,
+        mockWorkflowService
+      );
+
+      const params = {
+        workflowId: 'test-workflow-id',
+        spaceId: 'default',
+        inputs: {
+          event: {
+            alerts: [],
+            rule: {
+              id: 'rule-1',
+              name: 'Test Rule',
+              tags: [],
+              consumer: 'test',
+              producer: 'test',
+              ruleTypeId: 'test',
+            },
+            spaceId: 'default',
+          },
+        },
+      };
+
+      const error = await service.runWorkflow(params).catch((err) => err);
+
+      expect(getErrorSource(error)).toBe(TaskErrorSource.USER);
+      expect(error.message).toContain('Unable to run workflow');
+    });
+
+    it('runWorkflow classifies missing workflow error as user error', async () => {
+      const mockWorkflowService: WorkflowsServiceFunction = jest
+        .fn()
+        .mockRejectedValue(new WorkflowNotFoundError('test-workflow-id'));
 
       const service = createExternalService(
         actionId,
@@ -501,6 +540,46 @@ describe('Workflows Service', () => {
       const mockScheduleWorkflowService: ScheduleWorkflowServiceFunction = jest
         .fn()
         .mockRejectedValue(new WorkflowDisabledError('new-workflow'));
+
+      const service = createExternalService(
+        actionId,
+        mockLogger,
+        mockConfigurationUtilities,
+        mockConnectorUsageCollector,
+        mockRequest,
+        undefined,
+        mockScheduleWorkflowService
+      );
+
+      const params = {
+        workflowId: 'test-workflow-id',
+        spaceId: 'default',
+        inputs: {
+          event: {
+            alerts: [{ _id: 'alert-1', _index: 'test-index' }] as any,
+            rule: {
+              id: 'rule-1',
+              name: 'Test Rule',
+              tags: [],
+              consumer: 'test',
+              producer: 'test',
+              ruleTypeId: 'test',
+            },
+            spaceId: 'default',
+          },
+        },
+      };
+
+      const error = await service.scheduleWorkflow(params).catch((err) => err);
+
+      expect(getErrorSource(error)).toBe(TaskErrorSource.USER);
+      expect(error.message).toContain('Unable to schedule workflow');
+    });
+
+    it('scheduleWorkflow classifies missing workflow error as user error', async () => {
+      const mockScheduleWorkflowService: ScheduleWorkflowServiceFunction = jest
+        .fn()
+        .mockRejectedValue(new WorkflowNotFoundError('test-workflow-id'));
 
       const service = createExternalService(
         actionId,


### PR DESCRIPTION
## Summary

- Marks `WorkflowNotFoundError` as a user error, matching the existing disabled-workflow behavior.
- Throws `WorkflowNotFoundError` when execution validation cannot find the target workflow, so `.workflows` connector run/schedule failures are classified with `TaskErrorSource.USER` instead of framework errors.
- Adds coverage for the error class, validation path, and connector run/schedule classification.

## References

Closes elastic/kibana#274635

More context: https://elastic.slack.com/archives/C05MZ28B0BA/p1783446095373479

Made with [Cursor](https://cursor.com)