### PR TITLE
[One Workflow] Mark workflow execution query params as 9.5+

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -67989,6 +67989,7 @@ paths:
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Whether to exclude step-level execution data.
           in: query
           name: omitStepRuns
@@ -68001,12 +68002,14 @@ paths:
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Datemath upper bound for filtering executions by finishedAt (inclusive when parsed with roundUp).
           in: query
           name: finishedBefore
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Field to collapse execution results by.
           in: query
           name: collapse
@@ -68018,6 +68021,7 @@ paths:
               - executedBy
               - triggeredBy
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Field to sort executions by.
           in: query
           name: sortField
@@ -68027,6 +68031,7 @@ paths:
               - createdAt
               - finishedAt
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Sort order.
           in: query
           name: sortOrder
@@ -68036,6 +68041,7 @@ paths:
               - asc
               - desc
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Page number.
           in: query
           name: page
@@ -68057,12 +68063,14 @@ paths:
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Datemath upper bound for filtering executions by startedAt (inclusive when parsed with roundUp).
           in: query
           name: startedBefore
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
       responses:
         '200':
           content:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -75786,6 +75786,7 @@ paths:
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Whether to exclude step-level execution data.
           in: query
           name: omitStepRuns
@@ -75798,12 +75799,14 @@ paths:
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Datemath upper bound for filtering executions by finishedAt (inclusive when parsed with roundUp).
           in: query
           name: finishedBefore
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Field to collapse execution results by.
           in: query
           name: collapse
@@ -75815,6 +75818,7 @@ paths:
               - executedBy
               - triggeredBy
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Field to sort executions by.
           in: query
           name: sortField
@@ -75824,6 +75828,7 @@ paths:
               - createdAt
               - finishedAt
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Sort order.
           in: query
           name: sortOrder
@@ -75833,6 +75838,7 @@ paths:
               - asc
               - desc
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Page number.
           in: query
           name: page
@@ -75854,12 +75860,14 @@ paths:
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
         - description: Datemath upper bound for filtering executions by startedAt (inclusive when parsed with roundUp).
           in: query
           name: startedBefore
           required: false
           schema:
             type: string
+            x-state: Generally available; added in 9.5.0
       responses:
         '200':
           content:

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_workflow_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_workflow_executions.ts
@@ -39,6 +39,9 @@ const executionStatusSchema = schema.oneOf(
 const executionTypeSchema = schema.oneOf(
   ExecutionTypeValues.map((type) => schema.literal(type)) as [Type<ExecutionType>]
 );
+
+const EXECUTION_QUERY_PARAM_AVAILABILITY = { stability: 'stable', since: '9.5.0' } as const;
+
 export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
     .get({
@@ -97,7 +100,10 @@ export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: Rout
               ),
               concurrencyGroupKey: schema.maybe(
                 schema.string({
-                  meta: { description: 'Filter by evaluated concurrency group key.' },
+                  meta: {
+                    description: 'Filter by evaluated concurrency group key.',
+                    availability: EXECUTION_QUERY_PARAM_AVAILABILITY,
+                  },
                 })
               ),
               omitStepRuns: schema.maybe(
@@ -110,6 +116,7 @@ export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: Rout
                   meta: {
                     description:
                       'Datemath lower bound for filtering executions by finishedAt (inclusive when parsed).',
+                    availability: EXECUTION_QUERY_PARAM_AVAILABILITY,
                   },
                 })
               ),
@@ -118,6 +125,7 @@ export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: Rout
                   meta: {
                     description:
                       'Datemath upper bound for filtering executions by finishedAt (inclusive when parsed with roundUp).',
+                    availability: EXECUTION_QUERY_PARAM_AVAILABILITY,
                   },
                 })
               ),
@@ -127,7 +135,10 @@ export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: Rout
                     Type<WorkflowExecutionCollapseField>
                   ],
                   {
-                    meta: { description: 'Field to collapse execution results by.' },
+                    meta: {
+                      description: 'Field to collapse execution results by.',
+                      availability: EXECUTION_QUERY_PARAM_AVAILABILITY,
+                    },
                   }
                 )
               ),
@@ -137,13 +148,19 @@ export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: Rout
                     Type<WorkflowExecutionSortField>
                   ],
                   {
-                    meta: { description: 'Field to sort executions by.' },
+                    meta: {
+                      description: 'Field to sort executions by.',
+                      availability: EXECUTION_QUERY_PARAM_AVAILABILITY,
+                    },
                   }
                 )
               ),
               sortOrder: schema.maybe(
                 schema.oneOf([schema.literal('asc'), schema.literal('desc')], {
-                  meta: { description: 'Sort order.' },
+                  meta: {
+                    description: 'Sort order.',
+                    availability: EXECUTION_QUERY_PARAM_AVAILABILITY,
+                  },
                 })
               ),
               page: schema.maybe(schema.number({ min: 1, meta: { description: 'Page number.' } })),
@@ -159,6 +176,7 @@ export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: Rout
                   meta: {
                     description:
                       'Datemath lower bound for filtering executions by startedAt (inclusive when parsed).',
+                    availability: EXECUTION_QUERY_PARAM_AVAILABILITY,
                   },
                 })
               ),
@@ -167,6 +185,7 @@ export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: Rout
                   meta: {
                     description:
                       'Datemath upper bound for filtering executions by startedAt (inclusive when parsed with roundUp).',
+                    availability: EXECUTION_QUERY_PARAM_AVAILABILITY,
                   },
                 })
               ),


### PR DESCRIPTION
## Summary

Small docs metadata fix for the workflow executions API.

Some query params were added in 9.5, but the generated API docs didn't say that. This marks those params as added in 9.5.0 so the docs don't imply they work in 9.4.

## Test plan

- `node scripts/check`
- `node scripts/eslint src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_workflow_executions.ts`
- `node scripts/type_check --project src/platform/plugins/shared/workflows_management/tsconfig.json`


Made with [Cursor](https://cursor.com)