### PR TITLE
[Agent Builder] Remove actor guard blocking dashboard live updates

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/dashboard_integration/agent_live_updates_subscription.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/dashboard_integration/agent_live_updates_subscription.test.ts
@@ -22,14 +22,14 @@ const buildAttachment = (data: Record<string, unknown>) => ({
   versions: [{ version: 1, data }],
 });
 
-const buildRoundCompleteEvent = (actor: 'agent' | 'user' | 'system') => ({
+const buildRoundCompleteEvent = () => ({
   type: ChatEventType.roundComplete,
   data: {
     attachments: [buildAttachment({ panels: [] })],
     round: {
       input: {
         attachment_refs: [
-          { attachment_id: 'attachment-1', version: 1, operation: 'updated', actor },
+          { attachment_id: 'attachment-1', version: 1, operation: 'updated', actor: 'user' },
         ],
       },
     },
@@ -65,30 +65,12 @@ describe('createAgentLiveUpdatesSubscription', () => {
     return { chatEvents$, setState, subscription };
   };
 
-  it('applies the dashboard state when an agent genuinely updated the attachment', () => {
+  it('applies the dashboard state when an attachment is updated', () => {
     const { chatEvents$, setState, subscription } = createHarness();
 
-    chatEvents$.next(buildRoundCompleteEvent('agent'));
+    chatEvents$.next(buildRoundCompleteEvent());
 
     expect(setState).toHaveBeenCalledTimes(1);
-    subscription.unsubscribe();
-  });
-
-  it('does not apply the dashboard state for the ambient self-sync (user-actor) ref', () => {
-    const { chatEvents$, setState, subscription } = createHarness();
-
-    chatEvents$.next(buildRoundCompleteEvent('user'));
-
-    expect(setState).not.toHaveBeenCalled();
-    subscription.unsubscribe();
-  });
-
-  it('does not apply the dashboard state for a system-actor ref', () => {
-    const { chatEvents$, setState, subscription } = createHarness();
-
-    chatEvents$.next(buildRoundCompleteEvent('system'));
-
-    expect(setState).not.toHaveBeenCalled();
     subscription.unsubscribe();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/dashboard_integration/agent_live_updates_subscription.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/dashboard_integration/agent_live_updates_subscription.ts
@@ -7,11 +7,7 @@
 
 import { EMPTY, filter, switchMap, type Subscription } from 'rxjs';
 import { isRoundCompleteEvent } from '@kbn/agent-builder-common';
-import {
-  ATTACHMENT_REF_ACTOR,
-  ATTACHMENT_REF_OPERATION,
-  getLatestVersion,
-} from '@kbn/agent-builder-common/attachments';
+import { ATTACHMENT_REF_OPERATION, getLatestVersion } from '@kbn/agent-builder-common/attachments';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type { DashboardAttachment } from '@kbn/agent-builder-dashboards-common';
 import {
@@ -50,10 +46,7 @@ export const createAgentLiveUpdatesSubscription = ({
             (ref) =>
               ref.attachment_id === attachment.id &&
               (ref.operation === ATTACHMENT_REF_OPERATION.updated ||
-                ref.operation === ATTACHMENT_REF_OPERATION.created) &&
-              // Only reapply agent-driven edits. A `user` ref here is the dashboard's own
-              // ambient self-sync echoing back — reapplying it would revert what just changed.
-              ref.actor === ATTACHMENT_REF_ACTOR.agent
+                ref.operation === ATTACHMENT_REF_OPERATION.created)
           ) === true
         );
       });


### PR DESCRIPTION
## Summary
- Removes the `ref.actor === ATTACHMENT_REF_ACTOR.agent` filter from dashboard live-update application.
- Reverts the actor-specific unit tests that encoded that guard.

Live dashboard updates from chat currently do **not** apply with the agent-actor guard in place. In practice, the attachment refs we need to apply arrive with `actor: user`, so filtering on `ATTACHMENT_REF_ACTOR.agent` drops them and the open dashboard never receives the change.

This restores live updates. The previous guard was meant to ignore ambient self-sync echoes, but as wired today it also blocks real live changes.

cc @rbrtj — can you add any additional context on when these refs are tagged `user` vs `agent`, and whether we should filter differently (e.g. by operation/source) instead of actor? cc @stratoula when you're back let's discuss how we can fix it for your usecase 🙏🏼 

## Test plan
- [ ] Unit: `node scripts/jest x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/dashboard_integration/agent_live_updates_subscription.test.ts`
- [ ] Manually: open a dashboard in chat, ask for a change, confirm the dashboard updates live without refresh
- [ ] Manually: edit the dashboard in the UI while chat is open and confirm we don't get unexpected revert loops (the risk the old guard was trying to address)


Made with [Cursor](https://cursor.com)