### PR TITLE
docs: warn before deleting linked exception lists

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -20536,7 +20536,7 @@ paths:
           name: product_name
   /api/exception_lists:
     delete:
-      description: |-
+      description: |
         **Spaces method and path for this operation:**
 
         <div><span class="operation-verb delete">delete</span>&nbsp;<span class="operation-path">/s/{space_id}/api/exception_lists</span></div>
@@ -20544,6 +20544,10 @@ paths:
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
         Delete an exception list using the `id` or `list_id` field.
+
+        Before deleting an exception list that is linked to detection rules, remove or unlink the
+        exception list from those rules. Deleting a linked exception list can leave rules referencing
+        an exception list that no longer exists.
       operationId: DeleteExceptionList
       parameters:
         - description: Exception list's identifier. Either `id` or `list_id` must be specified.

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -23866,7 +23866,7 @@ paths:
           name: product_name
   /api/exception_lists:
     delete:
-      description: |-
+      description: |
         **Spaces method and path for this operation:**
 
         <div><span class="operation-verb delete">delete</span>&nbsp;<span class="operation-path">/s/{space_id}/api/exception_lists</span></div>
@@ -23874,6 +23874,10 @@ paths:
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
         Delete an exception list using the `id` or `list_id` field.
+
+        Before deleting an exception list that is linked to detection rules, remove or unlink the
+        exception list from those rules. Deleting a linked exception list can leave rules referencing
+        an exception list that no longer exists.
       operationId: DeleteExceptionList
       parameters:
         - description: Exception list's identifier. Either `id` or `list_id` must be specified.

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list/delete_exception_list.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list/delete_exception_list.schema.yaml
@@ -9,7 +9,12 @@ paths:
       operationId: DeleteExceptionList
       x-codegen-enabled: true
       summary: Delete an exception list
-      description: Delete an exception list using the `id` or `list_id` field.
+      description: |
+        Delete an exception list using the `id` or `list_id` field.
+
+        Before deleting an exception list that is linked to detection rules, remove or unlink the
+        exception list from those rules. Deleting a linked exception list can leave rules referencing
+        an exception list that no longer exists.
       parameters:
         - name: id
           in: query

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/quickstart_client.gen.ts
@@ -170,8 +170,13 @@ export class Client {
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Delete an exception list using the `id` or `list_id` field.
-   */
+    * Delete an exception list using the `id` or `list_id` field.
+
+Before deleting an exception list that is linked to detection rules, remove or unlink the
+exception list from those rules. Deleting a linked exception list can leave rules referencing
+an exception list that no longer exists.
+
+    */
   async deleteExceptionList(props: DeleteExceptionListProps) {
     this.log.info(`${new Date().toISOString()} Calling API DeleteExceptionList`);
     return this.kbnClient

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -188,7 +188,17 @@ paths:
         - Security Exceptions API
   /api/exception_lists:
     delete:
-      description: Delete an exception list using the `id` or `list_id` field.
+      description: >
+        Delete an exception list using the `id` or `list_id` field.
+
+
+        Before deleting an exception list that is linked to detection rules,
+        remove or unlink the
+
+        exception list from those rules. Deleting a linked exception list can
+        leave rules referencing
+
+        an exception list that no longer exists.
       operationId: DeleteExceptionList
       parameters:
         - description: Exception list's identifier. Either `id` or `list_id` must be

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -188,7 +188,17 @@ paths:
         - Security Exceptions API
   /api/exception_lists:
     delete:
-      description: Delete an exception list using the `id` or `list_id` field.
+      description: >
+        Delete an exception list using the `id` or `list_id` field.
+
+
+        Before deleting an exception list that is linked to detection rules,
+        remove or unlink the
+
+        exception list from those rules. Deleting a linked exception list can
+        leave rules referencing
+
+        an exception list that no longer exists.
       operationId: DeleteExceptionList
       parameters:
         - description: Exception list's identifier. Either `id` or `list_id` must be

--- a/x-pack/solutions/security/packages/test-api-clients/supertest/exceptions.gen.ts
+++ b/x-pack/solutions/security/packages/test-api-clients/supertest/exceptions.gen.ts
@@ -112,8 +112,13 @@ const securitySolutionApiServiceFactory = (supertest: SuperTest.Agent) => ({
       .send(props.body as object);
   },
   /**
-   * Delete an exception list using the `id` or `list_id` field.
-   */
+      * Delete an exception list using the `id` or `list_id` field.
+
+Before deleting an exception list that is linked to detection rules, remove or unlink the
+exception list from those rules. Deleting a linked exception list can leave rules referencing
+an exception list that no longer exists.
+
+      */
   deleteExceptionList(props: DeleteExceptionListProps, kibanaSpace: string = 'default') {
     return supertest
       .delete(getRouteUrlForSpace('/api/exception_lists', kibanaSpace))


### PR DESCRIPTION
**Related to: #163122**

## Summary

Adds a warning to the Delete exception list API description.

The warning tells users to remove or unlink an exception list from detection rules before deleting it. Deleting a linked exception list can leave rules referencing an exception list that no longer exists.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

This is a documentation-only change to an OpenAPI description. It does not change runtime behavior, API behavior, configuration, or data handling.

Risk is low. The main risk is wording clarity, which can be addressed during review.

- [x] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->