### PR TITLE
[Agent Builder][Visualizations] Prefer validated ES|QL for known indices

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_visualizations/server/skills/visualization_creation_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_visualizations/server/skills/visualization_creation_skill.ts
@@ -68,6 +68,7 @@ Do **not** use this skill when:
    }, optionally validate the shape with ${platformCoreTools.executeEsql}, then hand the query to ${
     platformCoreTools.createVisualization
   } via \`esql\`.
+   - When the correct index and field names are already known from prior tool calls or conversation context (for example, a previous ES|QL query ran successfully against a specific index), always pass the validated ES|QL explicitly via the \`esql\` parameter. Do **not** rely on the tool to infer the index from natural language in this case — the tool may silently substitute a different index pattern.
 
 3. **Call ${platformCoreTools.createVisualization}**
    - Provide:
@@ -163,6 +164,8 @@ For every new Lens visualization, choose and pass \`chartType\`; it is required.
 \`\`\`
 
 ## Create using pre-generated ES|QL
+
+Preferred when the target index and fields are already known from context, such as after a successful ES|QL validation against the same index.
 
 \`\`\`json
 {


### PR DESCRIPTION
## Summary

Updates the visualization creation skill guidance to prefer passing validated ES|QL when the target index and fields are already known from prior context.

This avoids relying on natural-language query generation in cases where the tool may infer or substitute a different index pattern than the grounded one.

## Test plan

- [x] Checked IDE lints for `x-pack/platform/plugins/shared/agent_builder_visualizations/server/skills/visualization_creation_skill.ts`

Extra context: https://elastic.slack.com/archives/C08LX7YSHU2/p1785726546281939

Made with [Cursor](https://cursor.com)