### PR TITLE
Enforce explicit registered-team ownership for every connector spec directory

### DIFF
--- a/.buildkite/scripts/steps/checks/verify_codeowners_teams.test.ts
+++ b/.buildkite/scripts/steps/checks/verify_codeowners_teams.test.ts
@@ -15,6 +15,7 @@ jest.mock('@kbn/code-owners', () => ({
 import type { CodeOwnersEntry, Team } from '@kbn/code-owners';
 import { getCodeOwnersEntries, getTeams } from '@kbn/code-owners';
 import {
+  findConnectorSpecsOwnershipIssues,
   findUnrecognizedTeams,
   getCodeownersTeams,
   getRegistryGithubTeams,
@@ -26,7 +27,8 @@ const mockGetCodeOwnersEntries = jest.mocked(getCodeOwnersEntries);
 const team = (id: string, githubTeam?: string): Team =>
   ({ id, name: id, github: { team: githubTeam } } as Team);
 
-const entry = (teams: string[]): CodeOwnersEntry => ({ teams } as CodeOwnersEntry);
+const entry = (teams: string[], pattern = '*'): CodeOwnersEntry =>
+  ({ pattern, teams } as CodeOwnersEntry);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -90,6 +92,71 @@ describe('findUnrecognizedTeams', () => {
     expect(findUnrecognizedTeams(codeowners, registry)).toEqual([
       'elastic/alpha-team',
       'elastic/zeta-team',
+    ]);
+  });
+});
+
+describe('findConnectorSpecsOwnershipIssues', () => {
+  it('accepts connector directories with explicit Elastic team owners', () => {
+    const rootEntries = [
+      { name: 'github', isDirectory: true },
+      { name: 'atlassian', isDirectory: true },
+    ];
+    const codeownersEntries = [
+      entry(
+        ['elastic/workchat-eng'],
+        'src/platform/packages/shared/kbn-connector-specs/src/specs/github/**'
+      ),
+      entry(
+        ['elastic/workchat-eng'],
+        'src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/**'
+      ),
+    ];
+
+    expect(findConnectorSpecsOwnershipIssues(rootEntries, codeownersEntries)).toEqual([]);
+  });
+
+  it('reports missing owners, non-Elastic owners, and files at the specs root', () => {
+    const rootEntries = [
+      { name: 'github', isDirectory: true },
+      { name: 'unowned_connector', isDirectory: true },
+      { name: 'unexpected.ts', isDirectory: false },
+    ];
+    const codeownersEntries = [
+      entry(['someuser'], 'src/platform/packages/shared/kbn-connector-specs/src/specs/github/**'),
+    ];
+
+    expect(findConnectorSpecsOwnershipIssues(rootEntries, codeownersEntries)).toEqual([
+      'src/platform/packages/shared/kbn-connector-specs/src/specs/github/** must explicitly assign an @elastic team',
+      'src/platform/packages/shared/kbn-connector-specs/src/specs/unexpected.ts must be inside a connector directory, not at the specs root',
+      'src/platform/packages/shared/kbn-connector-specs/src/specs/unowned_connector/** must explicitly assign an @elastic team',
+    ]);
+  });
+
+  it('does not accept a broad specs owner in place of an exact connector entry', () => {
+    const rootEntries = [{ name: 'github', isDirectory: true }];
+    const codeownersEntries = [
+      entry(
+        ['elastic/workchat-eng'],
+        'src/platform/packages/shared/kbn-connector-specs/src/specs/**'
+      ),
+    ];
+
+    expect(findConnectorSpecsOwnershipIssues(rootEntries, codeownersEntries)).toEqual([
+      'src/platform/packages/shared/kbn-connector-specs/src/specs/github/** must explicitly assign an @elastic team',
+    ]);
+  });
+
+  it('uses the first matching entry from the reversed CODEOWNERS list', () => {
+    const rootEntries = [{ name: 'github', isDirectory: true }];
+    const pattern = 'src/platform/packages/shared/kbn-connector-specs/src/specs/github/**';
+    mockGetCodeOwnersEntries.mockReturnValue([
+      entry(['someuser'], pattern),
+      entry(['elastic/workchat-eng'], pattern),
+    ]);
+
+    expect(findConnectorSpecsOwnershipIssues(rootEntries, mockGetCodeOwnersEntries())).toEqual([
+      'src/platform/packages/shared/kbn-connector-specs/src/specs/github/** must explicitly assign an @elastic team',
     ]);
   });
 });

--- a/.buildkite/scripts/steps/checks/verify_codeowners_teams.ts
+++ b/.buildkite/scripts/steps/checks/verify_codeowners_teams.ts
@@ -7,7 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { CodeOwnersEntry } from '@kbn/code-owners';
 import { getCodeOwnersEntries, getTeams } from '@kbn/code-owners';
+
+const CONNECTOR_SPECS_ROOT_PATTERN = 'src/platform/packages/shared/kbn-connector-specs/src/specs';
+const CONNECTOR_SPECS_ROOT = resolve(__dirname, '../../../..', CONNECTOR_SPECS_ROOT_PATTERN);
+
+export interface ConnectorSpecsRootEntry {
+  name: string;
+  isDirectory: boolean;
+}
 
 /**
  * Collect the GitHub team handles tracked in the public team registry.
@@ -59,18 +70,47 @@ export function findUnrecognizedTeams(
   return [...codeownersTeams].filter((team) => !registryTeams.has(team)).sort();
 }
 
+export function findConnectorSpecsOwnershipIssues(
+  rootEntries: ConnectorSpecsRootEntry[],
+  codeownersEntries: CodeOwnersEntry[]
+): string[] {
+  const issues: string[] = [];
+
+  for (const rootEntry of rootEntries) {
+    const entryPath = `${CONNECTOR_SPECS_ROOT_PATTERN}/${rootEntry.name}`;
+
+    if (!rootEntry.isDirectory) {
+      issues.push(`${entryPath} must be inside a connector directory, not at the specs root`);
+      continue;
+    }
+
+    const expectedPattern = `${entryPath}/**`;
+    const codeownersEntry = codeownersEntries.find(({ pattern }) => pattern === expectedPattern);
+    const elasticTeams = codeownersEntry?.teams.filter((team) => team.startsWith('elastic/')) ?? [];
+
+    if (elasticTeams.length === 0) {
+      issues.push(`${expectedPattern} must explicitly assign an @elastic team`);
+    }
+  }
+
+  return issues.sort();
+}
+
 function main(): void {
   console.log('Loading teams from the @kbn/code-owners registry...');
   const registryTeams = getRegistryGithubTeams();
   console.log(`Found ${registryTeams.size} teams in teams.jsonc`);
 
   console.log('Extracting teams from CODEOWNERS...');
+  const codeownersEntries = getCodeOwnersEntries();
   const codeownersTeams = getCodeownersTeams();
   console.log(`Found ${codeownersTeams.size} unique teams in CODEOWNERS`);
 
   const invalidTeams = findUnrecognizedTeams(codeownersTeams, registryTeams);
+  let hasErrors = false;
 
   if (invalidTeams.length > 0) {
+    hasErrors = true;
     console.error('\nERROR: The following teams in CODEOWNERS are not recognized:');
     console.error('They are not present in the @kbn/code-owners registry (teams.jsonc).\n');
     for (const team of invalidTeams) {
@@ -81,6 +121,32 @@ function main(): void {
         'src/platform/packages/private/kbn-code-owners,\n' +
         'or remove the invalid owner from CODEOWNERS.\n'
     );
+  }
+
+  const connectorSpecsRootEntries = readdirSync(CONNECTOR_SPECS_ROOT, {
+    withFileTypes: true,
+  }).map((rootEntry) => ({
+    name: rootEntry.name,
+    isDirectory: rootEntry.isDirectory(),
+  }));
+  const connectorOwnershipIssues = findConnectorSpecsOwnershipIssues(
+    connectorSpecsRootEntries,
+    codeownersEntries
+  );
+
+  if (connectorOwnershipIssues.length > 0) {
+    hasErrors = true;
+    console.error('\nERROR: Connector specs ownership is incomplete:');
+    for (const issue of connectorOwnershipIssues) {
+      console.error(`  - ${issue}`);
+    }
+    console.error(
+      '\nAssign every connector directory to an @elastic team in .github/CODEOWNERS.\n' +
+        'Ask @elastic/response-ops to review unexpected entries.\n'
+    );
+  }
+
+  if (hasErrors) {
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- Extend the existing `verify_codeowners` quick check so every connector directory under `kbn-connector-specs/src/specs` must have an exact `@elastic/...` CODEOWNERS entry (not a broad specs-root pattern).
- Same idea as `test_files_missing_owner` (`.buildkite/scripts/steps/checks/test_files_missing_owner.sh` → `node scripts/check_test_code_owners`), which already fails CI when test files lack a code owner — this applies that completeness rule to connector spec directories instead of adding a separate job.