### PR TITLE
Add package-level connector spec contract tests

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec_contract.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec_contract.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as authTypeSpecs from './all_auth_types';
+import * as connectorsSpecs from './all_specs';
+import type { AuthTypeDef, ConnectorSpec, NormalizedAuthType } from './connector_spec';
+import { ConnectorIconsMap } from './connector_icons_map';
+import { getSchemaForAuthType } from './lib';
+
+const CONNECTOR_ID_PATTERN = /^\.[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$/;
+const MAX_CONNECTOR_ID_LENGTH = 64;
+const allSpecs = Object.entries(connectorsSpecs) as Array<[string, ConnectorSpec]>;
+const registeredAuthTypes = Object.values(authTypeSpecs) as NormalizedAuthType[];
+
+const getAuthTypeId = (authType: string | AuthTypeDef): string =>
+  typeof authType === 'string' ? authType : authType.type;
+
+describe('connector spec contracts', () => {
+  it('uses unique connector IDs', () => {
+    const connectorIds = allSpecs.map(([, spec]) => spec.metadata.id);
+    const duplicateConnectorIds = connectorIds.filter(
+      (connectorId, index) => connectorIds.indexOf(connectorId) !== index
+    );
+
+    expect(duplicateConnectorIds).toEqual([]);
+  });
+
+  it.each(allSpecs)('%s has valid metadata', (_exportName, spec) => {
+    const { metadata } = spec;
+
+    expect(metadata.id).toMatch(CONNECTOR_ID_PATTERN);
+    expect(metadata.id.length).toBeLessThanOrEqual(MAX_CONNECTOR_ID_LENGTH);
+    expect(metadata.displayName.trim()).not.toHaveLength(0);
+    expect(metadata.description.trim()).not.toHaveLength(0);
+    // supportedFeatureIds may be [] for support-only connectors (not yet feature-enabled).
+    // Non-empty entries must be valid feature ID strings.
+    if (metadata.supportedFeatureIds.length > 0) {
+      expect(metadata.supportedFeatureIds.every((id) => typeof id === 'string')).toBe(true);
+    }
+  });
+
+  it.each(allSpecs)('%s has valid authentication configuration', (_exportName, spec) => {
+    const authTypes = spec.auth?.types ?? [];
+    const authTypeIds = authTypes.map(getAuthTypeId);
+    const violations: string[] = [];
+
+    if (new Set(authTypeIds).size !== authTypeIds.length) {
+      violations.push('auth type IDs must be unique');
+    }
+
+    for (const authType of authTypes) {
+      getSchemaForAuthType(authType);
+
+      if (typeof authType === 'string') {
+        continue;
+      }
+
+      const registeredAuthType = registeredAuthTypes.find(({ id }) => id === authType.type);
+      for (const defaultField of Object.keys(authType.defaults)) {
+        if (!registeredAuthType || !(defaultField in registeredAuthType.schema.shape)) {
+          violations.push(`${authType.type}.${defaultField} is not defined by the auth type`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps exported connector IDs and icon IDs in sync', () => {
+    const connectorIdsRequiringMappedIcons = allSpecs
+      .map(([, spec]) => spec)
+      .filter(({ metadata }) => metadata.icon === undefined)
+      .map(({ metadata }) => metadata.id)
+      .sort();
+    const mappedIconIds = [...ConnectorIconsMap.keys()].sort();
+
+    expect(mappedIconIds).toEqual(connectorIdsRequiringMappedIcons);
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/no_sensitive_in_config.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/no_sensitive_in_config.test.ts
@@ -7,12 +7,72 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { z } from '@kbn/zod/v4';
 import * as connectorsSpecs from './all_specs';
 import type { ConnectorSpec } from './connector_spec';
 import { getMeta } from './connector_spec_ui';
 
+type JsonSchema = Record<string, unknown>;
+const SENSITIVE_CONFIG_FIX = 'Move the field to an auth type so it is stored as encrypted secrets.';
+
+const isJsonSchema = (value: unknown): value is JsonSchema =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getSensitiveConfigViolations = (schema: JsonSchema, path = 'config'): string[] => {
+  const violations: string[] = [];
+
+  if (schema.sensitive === true) {
+    violations.push(`${path} has sensitive: true. ${SENSITIVE_CONFIG_FIX}`);
+  }
+  if (schema.widget === 'password') {
+    violations.push(`${path} has widget: 'password'. ${SENSITIVE_CONFIG_FIX}`);
+  }
+
+  if (isJsonSchema(schema.properties)) {
+    for (const [propertyName, propertySchema] of Object.entries(schema.properties)) {
+      if (isJsonSchema(propertySchema)) {
+        violations.push(...getSensitiveConfigViolations(propertySchema, `${path}.${propertyName}`));
+      }
+    }
+  }
+
+  if (isJsonSchema(schema.items)) {
+    violations.push(...getSensitiveConfigViolations(schema.items, `${path}[]`));
+  }
+
+  for (const branchName of ['allOf', 'anyOf', 'oneOf'] as const) {
+    const branches = schema[branchName];
+    if (!Array.isArray(branches)) {
+      continue;
+    }
+    branches.forEach((branch, index) => {
+      if (isJsonSchema(branch)) {
+        violations.push(...getSensitiveConfigViolations(branch, `${path}.${branchName}[${index}]`));
+      }
+    });
+  }
+
+  return violations;
+};
+
 describe('connector spec config schemas', () => {
   const allSpecs = Object.entries(connectorsSpecs) as Array<[string, ConnectorSpec]>;
+
+  it.each(allSpecs)('%s config schema fields have labels', (_exportName, spec) => {
+    const { schema } = spec;
+    if (!schema) {
+      return;
+    }
+
+    const fieldsWithoutLabels = Object.entries(schema.shape)
+      .filter(([, fieldSchema]) => {
+        const meta = getMeta(fieldSchema);
+        return meta.hidden !== true && (!meta.label || meta.label.trim().length === 0);
+      })
+      .map(([fieldKey]) => fieldKey);
+
+    expect(fieldsWithoutLabels).toEqual([]);
+  });
 
   it.each(allSpecs)(
     '%s config schema must not contain sensitive or password-widget fields',
@@ -22,28 +82,27 @@ describe('connector spec config schemas', () => {
         return;
       }
 
-      const violations: string[] = [];
+      const violations = getSensitiveConfigViolations(z.toJSONSchema(schema) as JsonSchema);
 
-      for (const fieldKey of Object.keys(schema.shape)) {
-        const fieldSchema = schema.shape[fieldKey];
-        const meta = getMeta(fieldSchema);
-        if (meta.sensitive === true) {
-          violations.push(`${fieldKey} has meta.sensitive: true`);
-        }
-        if (meta.widget === 'password') {
-          violations.push(`${fieldKey} has meta.widget: 'password'`);
-        }
-      }
-
-      expect({
-        violations,
-        reason:
-          'Connector configuration is stored unencrypted. Use auth types and encrypted secrets for credentials.',
-      }).toEqual({
-        violations: [],
-        reason:
-          'Connector configuration is stored unencrypted. Use auth types and encrypted secrets for credentials.',
-      });
+      expect(violations).toEqual([]);
     }
   );
+
+  it('detects nested sensitive and password-widget fields in the serialized schema', () => {
+    const schema = z.object({
+      nested: z.object({
+        apiKey: z.string().optional().meta({ sensitive: true }),
+      }),
+      connections: z.array(
+        z.object({
+          password: z.string().default('password').meta({ widget: 'password' }),
+        })
+      ),
+    });
+
+    expect(getSensitiveConfigViolations(z.toJSONSchema(schema) as JsonSchema)).toEqual([
+      `config.nested.apiKey has sensitive: true. ${SENSITIVE_CONFIG_FIX}`,
+      `config.connections[].password has widget: 'password'. ${SENSITIVE_CONFIG_FIX}`,
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
Add package-level connector spec contracts for metadata, auth defaults, config UI safety, exports, and icons

Addresses #279174