### PR TITLE
[Core] Bound non-app page-load transaction names to first path segment

### DIFF
--- a/src/core/packages/root/browser-internal/src/get_page_load_transaction_name.test.ts
+++ b/src/core/packages/root/browser-internal/src/get_page_load_transaction_name.test.ts
@@ -26,6 +26,16 @@ describe('getPageLoadTransactionName', () => {
     expect(getPageLoadTransactionName('/login')).toBe('/login');
     expect(getPageLoadTransactionName('/status')).toBe('/status');
   });
+
+  it('bounds non-app routes to their first segment so dynamic tails cannot inflate cardinality', () => {
+    // /goto/{id} is a chromeless redirect app; the id must not leak into the name
+    expect(getPageLoadTransactionName('/goto/abcdef123456')).toBe('/goto');
+    expect(getPageLoadTransactionName('/spaces/space_selector')).toBe('/spaces');
+  });
+
+  it('returns the root pathname unchanged', () => {
+    expect(getPageLoadTransactionName('/')).toBe('/');
+  });
 });
 
 describe('isAppPath', () => {

--- a/src/core/packages/root/browser-internal/src/get_page_load_transaction_name.ts
+++ b/src/core/packages/root/browser-internal/src/get_page_load_transaction_name.ts
@@ -29,7 +29,9 @@ const stripBasePath = (pathname: string, basePath: string): string => {
  * Derives a low-cardinality page-load transaction name from a URL pathname.
  *
  * - App routes resolve to `/app/{appId}` regardless of deeper path segments.
- * - Non-app routes (e.g. `/login`) keep their pathname as-is.
+ * - Non-app routes resolve to their first path segment only (e.g. `/login`),
+ *   so dynamic tails on chromeless non-app routes (such as the short-URL id in
+ *   `/goto/{id}`) cannot leak into the name and inflate transaction cardinality.
  */
 export const getPageLoadTransactionName = (pathname: string, basePath = ''): string => {
   const path = stripBasePath(pathname, basePath);
@@ -39,7 +41,8 @@ export const getPageLoadTransactionName = (pathname: string, basePath = ''): str
     return `/app/${appMatch[1]}`;
   }
 
-  return path;
+  const [, firstSegment] = path.split('/');
+  return firstSegment ? `/${firstSegment}` : path;
 };
 
 export const isAppPath = (pathname: string, basePath = ''): boolean => {


### PR DESCRIPTION
## Summary

Follow-up to #277199 (merged, main-only). That PR closes the page-load transaction on non-app pages using a name derived from `window.location.pathname`, but the non-app fallback returned the **raw** pathname.

For chromeless redirect apps whose URL carries a dynamic tail, the raw pathname includes a unique id, so the id leaked into `transaction.name` and re-introduced the high cardinality that #256044 set out to remove. The clearest case is the short-URL redirect app (`appRoute: '/goto'`), where every opened short URL (`/goto/{shortUrlId}`) produced a distinct transaction name.

This bounds non-app fallback names to their **first path segment**, so a dynamic tail can no longer leak in:

- `/goto/abcdef123456` -> `/goto`
- `/login` -> `/login` (unchanged)
- `/app/apm/services/x` -> `/app/apm` (app routes unchanged)

App-route naming is untouched.

## Test plan

```
node scripts/jest src/core/packages/root/browser-internal/src/get_page_load_transaction_name.test.ts
```

Addresses elastic/kibana#256044

## Risks

Low. Only affects the `transaction.name` of `kibana-frontend` page-load transactions on non-app routes, and only makes them lower cardinality. App-route, route-change, app-change, and http-request naming are unchanged.
