### PR TITLE
[Fleet] Fix incoming-data detection for agentless OTel integrations (Supabase)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.test.ts
@@ -14,7 +14,9 @@ import { appContextService } from '../../services';
 import {
   getAgentStatusForAgentPolicy,
   getIncomingDataByAgentsId,
+  getIncomingDataByDataStreams,
 } from '../../services/agents/status';
+import { agentPolicyService } from '../../services/agent_policy';
 import { fetchAndAssignAgentMetrics } from '../../services/agents/agent_metrics';
 import { getPackageInfo } from '../../services/epm/packages';
 
@@ -38,6 +40,7 @@ jest.mock('../../services/app_context', () => {
     appContextService: {
       getLogger: () => loggerMock.create(),
       getInternalUserESClient: jest.fn(),
+      getExperimentalFeatures: jest.fn(),
     },
   };
 });
@@ -49,6 +52,13 @@ jest.mock('../../services/spaces/helpers', () => ({
 jest.mock('../../services/agents/status', () => ({
   getAgentStatusForAgentPolicy: jest.fn(),
   getIncomingDataByAgentsId: jest.fn(),
+  getIncomingDataByDataStreams: jest.fn(),
+}));
+
+jest.mock('../../services/agent_policy', () => ({
+  agentPolicyService: {
+    getByIds: jest.fn(),
+  },
 }));
 
 jest.mock('../../services/agents/agent_metrics', () => ({
@@ -436,14 +446,23 @@ describe('Handlers', () => {
   describe('getAgentDataHandler', () => {
     let mockResponse: any;
     let mockContext: any;
+    let mockGetByIds: jest.Mock;
 
     beforeEach(() => {
       (getIncomingDataByAgentsId as jest.Mock).mockResolvedValue({ items: [], dataPreview: [] });
+      (getIncomingDataByDataStreams as jest.Mock).mockResolvedValue({ items: [], dataPreview: [] });
+      // Not found by default, so the identity-free gate falls back unless a test opts an agent in.
+      mockGetByIds = jest.fn().mockResolvedValue([]);
+      (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([]);
       mockResponse = httpServerMock.createResponseFactory();
       mockContext = {
         core: Promise.resolve({
           elasticsearch: { client: { asCurrentUser: {} } },
           savedObjects: { client: { getCurrentNamespace: jest.fn().mockReturnValue('default') } },
+        }),
+        fleet: Promise.resolve({
+          agentClient: { asCurrentUser: { getByIds: mockGetByIds } },
+          internalSoClient: {},
         }),
       };
     });
@@ -515,6 +534,452 @@ describe('Handlers', () => {
       const [[{ dataStreamPattern }]] = (getIncomingDataByAgentsId as jest.Mock).mock.calls;
       expect(dataStreamPattern).toBeDefined();
       expect(dataStreamPattern).not.toBe('');
+    });
+
+    it('appends the .otel dataset suffix only for data streams on the OTel input', async () => {
+      (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+        enableOtelIntegrations: true,
+      });
+      (getPackageInfo as jest.Mock).mockResolvedValue({
+        policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+        data_streams: [
+          {
+            type: 'metrics',
+            dataset: 'supabase.metrics',
+            path: 'metrics',
+            streams: [{ input: 'otelcol' }],
+          },
+          {
+            type: 'logs',
+            dataset: 'supabase.logs',
+            path: 'logs',
+            streams: [{ input: 'logfile' }],
+          },
+        ],
+      });
+
+      await getAgentDataHandler(
+        mockContext,
+        {
+          query: {
+            agentsIds: ['agent-1'],
+            pkgName: 'supabase',
+            pkgVersion: '1.0.0',
+            previewData: false,
+          },
+        } as any,
+        mockResponse
+      );
+
+      const [[{ dataStreamPattern }]] = (getIncomingDataByAgentsId as jest.Mock).mock.calls;
+      expect(dataStreamPattern).toBe('metrics-supabase.metrics.otel-*,logs-supabase.logs-*');
+    });
+
+    describe('identity-free gate for agentless OTel', () => {
+      const otelPackageInfo = {
+        policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+        data_streams: [
+          {
+            type: 'metrics',
+            dataset: 'supabase.metrics',
+            path: 'metrics',
+            streams: [{ input: 'otelcol' }],
+          },
+        ],
+      };
+
+      beforeEach(() => {
+        (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+          enableOtelIntegrations: true,
+        });
+      });
+
+      it('uses getIncomingDataByDataStreams with a namespace-scoped pattern for one agentless agent', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'production' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByAgentsId).not.toHaveBeenCalled();
+        expect(getIncomingDataByDataStreams).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentId: 'agent-1',
+            dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+          })
+        );
+      });
+
+      it('falls back to getIncomingDataByAgentsId for a non-agentless agent', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { id: 'policy-1', namespace: 'default', supports_agentless: false },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for a regular (non-OTel) package even with an agentless agent', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue({
+          data_streams: [{ type: 'logs', dataset: 'aws.cloudwatch', path: 'logs' }],
+        });
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { id: 'policy-1', namespace: 'default', supports_agentless: true },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'aws',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(mockGetByIds).not.toHaveBeenCalled();
+      });
+
+      it('falls back and skips agent/policy lookups when no pkgName or pkgVersion is given', async () => {
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(mockGetByIds).not.toHaveBeenCalled();
+        expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for more than one requested id, even with an OTel package and agentless agents', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1', 'agent-2'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(mockGetByIds).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for an agent that is notFound', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for an agent whose policy cannot be resolved', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('scopes the pattern to the namespace of the agent whose policy is silent, so a healthy sibling does not mask it', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-2', policy_id: 'policy-2' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-2',
+            namespace: 'staging',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'staging' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-2'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        const [[{ dataStreamPattern }]] = (getIncomingDataByDataStreams as jest.Mock).mock.calls;
+        expect(dataStreamPattern).toBe('metrics-supabase.metrics.otel-staging');
+        expect(dataStreamPattern).not.toContain('*');
+      });
+
+      it('falls back for an agentless agent whose policy has no package policy matching pkgName', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            // Attached package policy is for a different integration, so a caller-supplied
+            // pkgName cannot be used to attribute this policy's data to it.
+            package_policies: [{ package: { name: 'other-package' }, namespace: 'production' }],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for an agentless agent whose attached package policy runs a different version', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            // Attached package policy runs version 2.0.0, but the request asks about
+            // version 1.0.0's OTel streams. Those manifests can differ, so a name-only
+            // match would attribute this policy's data to a version it does not run.
+            package_policies: [
+              { package: { name: 'supabase', version: '2.0.0' }, namespace: 'production' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('passes ignoreMissing so a deleted agent policy falls back instead of throwing', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(agentPolicyService.getByIds).toHaveBeenCalledWith(
+          expect.anything(),
+          ['policy-1'],
+          expect.objectContaining({ ignoreMissing: true })
+        );
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('combines the identity-free OTel answer with the identity answer for a mixed package', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue({
+          policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+          data_streams: [
+            {
+              type: 'metrics',
+              dataset: 'supabase.metrics',
+              path: 'metrics',
+              streams: [{ input: 'otelcol' }],
+            },
+            {
+              type: 'logs',
+              dataset: 'supabase.logs',
+              path: 'logs',
+              streams: [{ input: 'logfile' }],
+            },
+          ],
+        });
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'production' },
+            ],
+          },
+        ]);
+        (getIncomingDataByDataStreams as jest.Mock).mockResolvedValue({
+          items: [{ 'agent-1': { data: false } }],
+          dataPreview: [{ _index: 'otel-preview' }],
+        });
+        (getIncomingDataByAgentsId as jest.Mock).mockResolvedValue({
+          items: [{ 'agent-1': { data: true } }],
+          dataPreview: [{ _index: 'regular-preview' }],
+        });
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: true,
+            },
+          } as any,
+          mockResponse
+        );
+
+        // Only the non-OTel stream is queried through the identity path, not the OTel one.
+        expect(getIncomingDataByAgentsId).toHaveBeenCalledWith(
+          expect.objectContaining({ dataStreamPattern: 'logs-supabase.logs-*' })
+        );
+        expect(mockResponse.ok).toHaveBeenCalledWith({
+          body: {
+            items: [{ 'agent-1': { data: true } }],
+            dataPreview: [{ _index: 'otel-preview' }, { _index: 'regular-preview' }],
+          },
+        });
+      });
+
+      it('allows an ordinary Fleet reader through the agent client, not the raw ES client', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'default' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        // The agent lookup went through fleetContext.agentClient, which runs its own authz
+        // preflight, rather than a direct query against the hidden .fleet-agents index.
+        expect(mockGetByIds).toHaveBeenCalledWith(['agent-1'], { ignoreMissing: true });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.test.ts
@@ -803,8 +803,6 @@ describe('Handlers', () => {
             id: 'policy-1',
             namespace: 'default',
             supports_agentless: true,
-            // Attached package policy is for a different integration, so a caller-supplied
-            // pkgName cannot be used to attribute this policy's data to it.
             package_policies: [{ package: { name: 'other-package' }, namespace: 'production' }],
           },
         ]);
@@ -834,9 +832,6 @@ describe('Handlers', () => {
             id: 'policy-1',
             namespace: 'default',
             supports_agentless: true,
-            // Attached package policy runs version 2.0.0, but the request asks about
-            // version 1.0.0's OTel streams. Those manifests can differ, so a name-only
-            // match would attribute this policy's data to a version it does not run.
             package_policies: [
               { package: { name: 'supabase', version: '2.0.0' }, namespace: 'production' },
             ],
@@ -858,6 +853,78 @@ describe('Handlers', () => {
 
         expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
         expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for an agentless agent whose policy has more than one package policy matching pkgName and pkgVersion', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            // Same name+version attached under two namespaces; the match is ambiguous.
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'production' },
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'staging' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back and skips agent/policy lookups when enableOtelIntegrations is disabled, even for an otherwise-eligible agentless setup', async () => {
+        (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+          enableOtelIntegrations: false,
+        });
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'production' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        // With the flag off, otelDataStreams stays empty, so the gate never looks up the agent.
+        expect(mockGetByIds).not.toHaveBeenCalled();
+        expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalledWith(
+          expect.objectContaining({ dataStreamPattern: 'metrics-supabase.metrics-*' })
+        );
       });
 
       it('passes ignoreMissing so a deleted agent policy falls back instead of throwing', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
@@ -7,6 +7,7 @@
 
 import { omit, uniq } from 'lodash';
 import { type RequestHandler, SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 
 import type { Script } from '@elastic/elasticsearch/lib/api/types';
@@ -47,10 +48,16 @@ import { getAgentStatusForAgentPolicy } from '../../services/agents';
 import { isAgentInNamespace } from '../../services/spaces/agent_namespaces';
 import { getCurrentNamespace } from '../../services/spaces/get_current_namespace';
 import { getPackageInfo } from '../../services/epm/packages';
-import { generateTemplateIndexPattern } from '../../services/epm/elasticsearch/template/template';
+import {
+  generateTemplateIndexPattern,
+  generateNamespaceTemplateIndexPattern,
+} from '../../services/epm/elasticsearch/template/template';
+import { isOtelDataStream } from '../../services/epm/packages/namespace_template_utils';
 import { buildAgentStatusRuntimeField } from '../../services/agents/build_status_runtime_field';
-import { appContextService } from '../../services';
+import { appContextService, agentPolicyService } from '../../services';
 import { AGENTS_INDEX } from '../../constants';
+import type { AgentClient } from '../../services';
+import type { RegistryDataStream } from '../../types';
 
 async function verifyNamespace(agent: Agent, namespace?: string) {
   if (!(await isAgentInNamespace(agent, namespace))) {
@@ -369,7 +376,68 @@ export const getAgentStatusForAgentPolicyHandler: FleetRequestHandler<
   return response.ok({ body });
 };
 
-export const getAgentDataHandler: RequestHandler<
+/**
+ * Resolves the namespace-scoped OTel pattern for the identity-free incoming-data path,
+ * or undefined if any condition of the gate does not hold. Every unresolved step falls back
+ * to the identity path unchanged: a `notFound` agent, a missing or unresolved policy, a policy
+ * that is not agentless, or a namespace that cannot be determined.
+ *
+ * The pattern is scoped to one namespace, never a wildcard: an unscoped pattern would report
+ * success for any document from any deployment of the same package, since there is no
+ * `agent.id` left to narrow the match once the identity filter is dropped.
+ */
+async function resolveAgentlessOtelDataStreamPattern({
+  agentClient,
+  soClient,
+  agentId,
+  pkgName,
+  pkgVersion,
+  otelDataStreams,
+}: {
+  agentClient: AgentClient;
+  soClient: SavedObjectsClientContract;
+  agentId: string;
+  pkgName: string;
+  pkgVersion: string;
+  otelDataStreams: RegistryDataStream[];
+}): Promise<string | undefined> {
+  const [agent] = await agentClient.getByIds([agentId], { ignoreMissing: true });
+  if (!agent?.policy_id) {
+    return undefined;
+  }
+
+  const [agentPolicy] = await agentPolicyService.getByIds(soClient, [agent.policy_id], {
+    withPackagePolicies: true,
+    ignoreMissing: true,
+  });
+  if (!agentPolicy?.supports_agentless) {
+    return undefined;
+  }
+
+  // The identity-free path answers "did this policy's data streams receive data", so the
+  // requested package and version must actually be attached to the policy. `otelDataStreams`
+  // was resolved from the requested pkgVersion's manifest, which can differ from the version
+  // actually deployed. Matching name only would let a caller whose policy runs version A
+  // attribute data to a query for version B's (possibly different) OTel streams.
+  const matchingPackagePolicy = agentPolicy.package_policies?.find(
+    (packagePolicy) =>
+      packagePolicy.package?.name === pkgName && packagePolicy.package?.version === pkgVersion
+  );
+  if (!matchingPackagePolicy) {
+    return undefined;
+  }
+
+  const namespace = matchingPackagePolicy.namespace || agentPolicy.namespace;
+  if (!namespace) {
+    return undefined;
+  }
+
+  return otelDataStreams
+    .map((ds) => generateNamespaceTemplateIndexPattern(ds, namespace, true))
+    .join(',');
+}
+
+export const getAgentDataHandler: FleetRequestHandler<
   undefined,
   TypeOf<typeof GetAgentDataRequestSchema.query>
 > = async (context, request, response) => {
@@ -383,6 +451,8 @@ export const getAgentDataHandler: RequestHandler<
   // If a package is specified, get data stream patterns for that package
   // and scope incoming data query to that pattern
   let dataStreamPattern: string | undefined;
+  let otelDataStreams: RegistryDataStream[] = [];
+  let nonOtelDataStreams: RegistryDataStream[] = [];
   if (pkgName && pkgVersion) {
     const packageInfo = await getPackageInfo({
       savedObjectsClient: coreContext.savedObjects.client,
@@ -390,9 +460,62 @@ export const getAgentDataHandler: RequestHandler<
       pkgName,
       pkgVersion,
     });
+    // Input-only OTel packages (e.g. `aws_cloudwatch_input_otel`, `verifier_otel`) declare no
+    // manifest data streams, so `dataStreams` is empty and the gate below falls through to the
+    // unchanged identity path. That's a known, tracked gap, not an oversight: see
+    // https://github.com/elastic/ingest-dev/issues/8988.
+    const dataStreams = packageInfo.data_streams || [];
+    otelDataStreams = dataStreams.filter((ds) => isOtelDataStream(ds, packageInfo));
+    nonOtelDataStreams = dataStreams.filter((ds) => !isOtelDataStream(ds, packageInfo));
     dataStreamPattern =
-      (packageInfo.data_streams || []).map((ds) => generateTemplateIndexPattern(ds)).join(',') ||
-      undefined;
+      dataStreams
+        .map((ds) => generateTemplateIndexPattern(ds, isOtelDataStream(ds, packageInfo)))
+        .join(',') || undefined;
+
+    // Native OTel documents carry no queryable agent identity, so the identity path can never
+    // succeed for them. Reachable only for a single agentless agent, so a namespace-scoped
+    // "this policy received data" answer cannot be attributed to the wrong agent.
+    if (otelDataStreams.length > 0 && agentsIds.length === 1) {
+      const fleetContext = await context.fleet;
+      const namespacedPattern = await resolveAgentlessOtelDataStreamPattern({
+        agentClient: fleetContext.agentClient.asCurrentUser,
+        soClient: fleetContext.internalSoClient,
+        agentId: agentsIds[0],
+        pkgName,
+        pkgVersion,
+        otelDataStreams,
+      });
+
+      if (namespacedPattern) {
+        const identityFreeResult = await AgentService.getIncomingDataByDataStreams({
+          esClient,
+          agentId: agentsIds[0],
+          dataStreamPattern: namespacedPattern,
+          returnDataPreview,
+        });
+
+        // A mixed package can still have non-OTel streams that the identity path can answer
+        // for. Returning only the identity-free answer here would silently ignore data that
+        // arrived on those streams, so combine both answers instead of returning early.
+        if (nonOtelDataStreams.length === 0) {
+          return response.ok({ body: identityFreeResult });
+        }
+
+        const nonOtelPattern = nonOtelDataStreams
+          .map((ds) => generateTemplateIndexPattern(ds, false))
+          .join(',');
+        const identityResult = await AgentService.getIncomingDataByAgentsId({
+          esClient,
+          agentsIds,
+          dataStreamPattern: nonOtelPattern,
+          returnDataPreview,
+        });
+
+        return response.ok({
+          body: combineIncomingDataResults(agentsIds[0], identityFreeResult, identityResult),
+        });
+      }
+    }
   }
 
   const { items, dataPreview } = await AgentService.getIncomingDataByAgentsId({
@@ -406,6 +529,34 @@ export const getAgentDataHandler: RequestHandler<
 
   return response.ok({ body });
 };
+
+interface IncomingDataResult {
+  items: Array<Record<string, { data: boolean }>>;
+  dataPreview: unknown[];
+}
+
+/**
+ * Combines the identity-free OTel answer with the identity-based answer for a mixed
+ * package's non-OTel streams. Either source reporting data is enough to report data overall,
+ * since a mixed package can deliver a healthy signal through only one of its stream groups.
+ */
+function combineIncomingDataResults(
+  agentId: string,
+  identityFreeResult: IncomingDataResult,
+  identityResult: IncomingDataResult
+): IncomingDataResult {
+  const hasData =
+    (identityFreeResult.items[0]?.[agentId]?.data ?? false) ||
+    (identityResult.items[0]?.[agentId]?.data ?? false);
+
+  return {
+    items: [{ [agentId]: { data: hasData } }],
+    dataPreview: [...identityFreeResult.dataPreview, ...identityResult.dataPreview].slice(
+      0,
+      AgentService.MAX_AGENT_DATA_PREVIEW_SIZE
+    ),
+  };
+}
 
 function isStringArray(arr: unknown | string[]): arr is string[] {
   return Array.isArray(arr) && arr.every((p) => typeof p === 'string');

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
@@ -377,14 +377,10 @@ export const getAgentStatusForAgentPolicyHandler: FleetRequestHandler<
 };
 
 /**
- * Resolves the namespace-scoped OTel pattern for the identity-free incoming-data path,
- * or undefined if any condition of the gate does not hold. Every unresolved step falls back
- * to the identity path unchanged: a `notFound` agent, a missing or unresolved policy, a policy
- * that is not agentless, or a namespace that cannot be determined.
- *
- * The pattern is scoped to one namespace, never a wildcard: an unscoped pattern would report
- * success for any document from any deployment of the same package, since there is no
- * `agent.id` left to narrow the match once the identity filter is dropped.
+ * Resolves the namespace-scoped OTel pattern for the identity-free incoming-data path, or
+ * undefined if any condition of the gate (agent, policy, namespace) does not hold. The pattern
+ * is scoped to a single namespace, never a wildcard, since there is no `agent.id` left to
+ * narrow the match once the identity filter is dropped.
  */
 async function resolveAgentlessOtelDataStreamPattern({
   agentClient,
@@ -414,18 +410,17 @@ async function resolveAgentlessOtelDataStreamPattern({
     return undefined;
   }
 
-  // The identity-free path answers "did this policy's data streams receive data", so the
-  // requested package and version must actually be attached to the policy. `otelDataStreams`
-  // was resolved from the requested pkgVersion's manifest, which can differ from the version
-  // actually deployed. Matching name only would let a caller whose policy runs version A
-  // attribute data to a query for version B's (possibly different) OTel streams.
-  const matchingPackagePolicy = agentPolicy.package_policies?.find(
+  // Require exactly one attached package policy matching pkgName and pkgVersion; zero or more
+  // than one (e.g. attached in multiple namespaces) is ambiguous, so fall back to the identity
+  // path instead of guessing.
+  const matchingPackagePolicies = (agentPolicy.package_policies ?? []).filter(
     (packagePolicy) =>
       packagePolicy.package?.name === pkgName && packagePolicy.package?.version === pkgVersion
   );
-  if (!matchingPackagePolicy) {
+  if (matchingPackagePolicies.length !== 1) {
     return undefined;
   }
+  const [matchingPackagePolicy] = matchingPackagePolicies;
 
   const namespace = matchingPackagePolicy.namespace || agentPolicy.namespace;
   if (!namespace) {
@@ -460,10 +455,8 @@ export const getAgentDataHandler: FleetRequestHandler<
       pkgName,
       pkgVersion,
     });
-    // Input-only OTel packages (e.g. `aws_cloudwatch_input_otel`, `verifier_otel`) declare no
-    // manifest data streams, so `dataStreams` is empty and the gate below falls through to the
-    // unchanged identity path. That's a known, tracked gap, not an oversight: see
-    // https://github.com/elastic/ingest-dev/issues/8988.
+    // Input-only OTel packages declare no manifest data streams, so this falls through to the
+    // identity path. Known gap: https://github.com/elastic/ingest-dev/issues/8988.
     const dataStreams = packageInfo.data_streams || [];
     otelDataStreams = dataStreams.filter((ds) => isOtelDataStream(ds, packageInfo));
     nonOtelDataStreams = dataStreams.filter((ds) => !isOtelDataStream(ds, packageInfo));
@@ -472,11 +465,12 @@ export const getAgentDataHandler: FleetRequestHandler<
         .map((ds) => generateTemplateIndexPattern(ds, isOtelDataStream(ds, packageInfo)))
         .join(',') || undefined;
 
-    // Native OTel documents carry no queryable agent identity, so the identity path can never
-    // succeed for them. Reachable only for a single agentless agent, so a namespace-scoped
-    // "this policy received data" answer cannot be attributed to the wrong agent.
+    // Native OTel data has no queryable agent identity, so only a single-agent, namespace-scoped
+    // lookup can answer for it.
     if (otelDataStreams.length > 0 && agentsIds.length === 1) {
       const fleetContext = await context.fleet;
+      // internalSoClient reads only policy metadata for the gate below; the route still requires
+      // agents:read, and ES data is queried with asCurrentUser.
       const namespacedPattern = await resolveAgentlessOtelDataStreamPattern({
         agentClient: fleetContext.agentClient.asCurrentUser,
         soClient: fleetContext.internalSoClient,
@@ -494,9 +488,8 @@ export const getAgentDataHandler: FleetRequestHandler<
           returnDataPreview,
         });
 
-        // A mixed package can still have non-OTel streams that the identity path can answer
-        // for. Returning only the identity-free answer here would silently ignore data that
-        // arrived on those streams, so combine both answers instead of returning early.
+        // Combine with the identity path's answer so non-OTel streams in a mixed package
+        // aren't silently ignored.
         if (nonOtelDataStreams.length === 0) {
           return response.ok({ body: identityFreeResult });
         }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.test.ts
@@ -14,7 +14,11 @@ import { createAppContextStartContractMock } from '../../mocks';
 
 import { appContextService } from '../app_context';
 
-import { getAgentStatusForAgentPolicy, getIncomingDataByAgentsId } from './status';
+import {
+  getAgentStatusForAgentPolicy,
+  getIncomingDataByAgentsId,
+  getIncomingDataByDataStreams,
+} from './status';
 
 describe('getAgentStatusForAgentPolicy', () => {
   beforeEach(async () => {
@@ -337,5 +341,113 @@ describe('getIncomingDataByAgentsId', () => {
     const searchArgs = esClient.search.mock.calls[0][0] as any;
     const rangeFilter = searchArgs.query.bool.filter.find((f: any) => f.range);
     expect(Object.keys(rangeFilter.range)).toEqual(['event.ingested']);
+  });
+});
+
+describe('getIncomingDataByDataStreams', () => {
+  beforeEach(() => {
+    appContextService.start(createAppContextStartContractMock());
+  });
+
+  afterEach(() => {
+    appContextService.stop();
+  });
+
+  it('queries only the given pattern with the event.ingested recency filter, no agent.id filter or aggregation', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    esClient.search.mockReturnValueOnce({ hits: { total: { value: 0 } } } as any);
+
+    await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+    });
+
+    const searchArgs = esClient.search.mock.calls[0][0] as any;
+    expect(searchArgs.index).toBe('metrics-supabase.metrics.otel-production');
+    expect(searchArgs.aggs).toBeUndefined();
+    expect(searchArgs.query.bool.filter).toEqual([
+      { range: { 'event.ingested': { gte: 'now-5m', lte: 'now' } } },
+    ]);
+  });
+
+  it('sets ignore_unavailable so a not-yet-created namespace-scoped data stream reports zero hits instead of throwing', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    esClient.search.mockReturnValueOnce({ hits: { total: { value: 0 } } } as any);
+
+    await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+    });
+
+    const searchArgs = esClient.search.mock.calls[0][0] as any;
+    expect(searchArgs.ignore_unavailable).toBe(true);
+  });
+
+  it('reports data: true for the requested agent when the search reports a hit', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    esClient.search.mockReturnValueOnce({ hits: { total: { value: 1 } } } as any);
+
+    const result = await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+    });
+
+    expect(result).toEqual({ items: [{ 'agent-1': { data: true } }], dataPreview: [] });
+  });
+
+  it('reports data: false for the requested agent when the search reports no hits', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    esClient.search.mockReturnValueOnce({ hits: { total: { value: 0 } } } as any);
+
+    const result = await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+    });
+
+    expect(result).toEqual({ items: [{ 'agent-1': { data: false } }], dataPreview: [] });
+  });
+
+  it('returnDataPreview controls _source and size, and dataPreview carries the hits through unchanged', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    const previewHits = [{ _index: 'metrics-supabase.metrics.otel-production', _source: {} }];
+    esClient.search.mockReturnValueOnce({
+      hits: { total: { value: 1 }, hits: previewHits },
+    } as any);
+
+    const result = await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+      returnDataPreview: true,
+    });
+
+    const searchArgs = esClient.search.mock.calls[0][0] as any;
+    expect(searchArgs._source).toBe(true);
+    expect(searchArgs.size).toBeGreaterThan(0);
+    expect(result.dataPreview).toEqual(previewHits);
+  });
+
+  it('surfaces missing read access the same way getIncomingDataByAgentsId does', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: false } as any);
+
+    await expect(
+      getIncomingDataByDataStreams({
+        esClient,
+        agentId: 'agent-1',
+        dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+      })
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Unable to retrieve incoming data'),
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
@@ -275,12 +275,8 @@ export async function getIncomingDataByAgentsId({
 
 /**
  * Identity-free incoming-data check for a single agentless agent whose data streams carry no
- * queryable agent identity (native OTel documents). `dataStreamPattern` must be scoped to the
- * requesting agent's own namespace by the caller: an unscoped wildcard would report success for
- * any document from any deployment of the same package, since there is no `agent.id` left to
- * narrow the match. `agentId` is deliberately singular so a single hit can never be fanned out
- * across agents that were not measured. See `getAgentDataHandler` for the gate that gives both
- * guarantees before calling this function.
+ * queryable agent identity (native OTel documents). The caller must scope `dataStreamPattern` to
+ * the agent's own namespace; see `getAgentDataHandler` for the gate that guarantees this.
  */
 export async function getIncomingDataByDataStreams({
   esClient,
@@ -313,10 +309,8 @@ export async function getIncomingDataByDataStreams({
       () =>
         esClient.search({
           index: dataStreamPattern,
-          // The pattern names concrete, non-wildcarded data stream names (see the doc
-          // comment above), which do not exist until the first document is ingested.
-          // Without this, Elasticsearch rejects the request with index_not_found_exception
-          // instead of returning zero hits, which would otherwise stop the polling caller.
+          // The pattern names concrete data streams that may not exist yet; without this,
+          // Elasticsearch throws index_not_found_exception instead of returning zero hits.
           ignore_unavailable: true,
           allow_partial_search_results: true,
           _source: returnDataPreview,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
@@ -13,6 +13,7 @@ import type {
   AggregationsTermsAggregateBase,
   AggregationsTermsBucketBase,
   QueryDslQueryContainer,
+  SearchTotalHits,
 } from '@elastic/elasticsearch/lib/api/types';
 
 import { ALL_SPACES_ID } from '../../../common/constants';
@@ -39,7 +40,7 @@ interface AggregationsStatusTermsBucketKeys extends AggregationsTermsBucketBase 
 }
 
 const DATA_STREAM_INDEX_PATTERN = 'logs-*-*,metrics-*-*,traces-*-*,synthetics-*-*';
-const MAX_AGENT_DATA_PREVIEW_SIZE = 20;
+export const MAX_AGENT_DATA_PREVIEW_SIZE = 20;
 export async function getAgentStatusById(
   esClient: ElasticsearchClient,
   soClient: SavedObjectsClientContract,
@@ -209,7 +210,7 @@ export async function getIncomingDataByAgentsId({
 
     const searchResult = await retryTransientEsErrors(
       () =>
-        esClient.search({
+        esClient.search<unknown, Record<'agent_ids', { buckets: Array<{ key: string }> }>>({
           index: dataStreamPattern,
           allow_partial_search_results: true,
           _source: returnDataPreview,
@@ -255,9 +256,9 @@ export async function getIncomingDataByAgentsId({
 
     const dataPreview = searchResult.hits?.hits || [];
 
-    const agentIdsWithData: string[] =
-      // @ts-expect-error aggregation type is not specified
-      searchResult.aggregations.agent_ids.buckets.map((bucket: any) => bucket.key as string) ?? [];
+    const agentIdsWithData: string[] = searchResult.aggregations.agent_ids.buckets.map(
+      (bucket) => bucket.key
+    );
 
     const items = agentsIds.map((id) =>
       agentIdsWithData.includes(id) ? { [id]: { data: true } } : { [id]: { data: false } }
@@ -266,6 +267,87 @@ export async function getIncomingDataByAgentsId({
     return { items, dataPreview };
   } catch (error) {
     logger.debug(`Error getting incoming data for agents: ${error}`);
+    throw new FleetError(
+      `Unable to retrieve incoming data for agents due to error: ${error.message}`
+    );
+  }
+}
+
+/**
+ * Identity-free incoming-data check for a single agentless agent whose data streams carry no
+ * queryable agent identity (native OTel documents). `dataStreamPattern` must be scoped to the
+ * requesting agent's own namespace by the caller: an unscoped wildcard would report success for
+ * any document from any deployment of the same package, since there is no `agent.id` left to
+ * narrow the match. `agentId` is deliberately singular so a single hit can never be fanned out
+ * across agents that were not measured. See `getAgentDataHandler` for the gate that gives both
+ * guarantees before calling this function.
+ */
+export async function getIncomingDataByDataStreams({
+  esClient,
+  agentId,
+  dataStreamPattern,
+  returnDataPreview = false,
+}: {
+  esClient: ElasticsearchClient;
+  agentId: string;
+  dataStreamPattern: string;
+  returnDataPreview?: boolean;
+}) {
+  const logger = appContextService.getLogger();
+
+  try {
+    const { has_all_requested: hasAllPrivileges } = await esClient.security.hasPrivileges({
+      index: [
+        {
+          names: dataStreamPattern.split(','),
+          privileges: ['read'],
+        },
+      ],
+    });
+
+    if (!hasAllPrivileges) {
+      throw new FleetUnauthorizedError('Missing permissions to read data streams indices');
+    }
+
+    const searchResult = await retryTransientEsErrors(
+      () =>
+        esClient.search({
+          index: dataStreamPattern,
+          // The pattern names concrete, non-wildcarded data stream names (see the doc
+          // comment above), which do not exist until the first document is ingested.
+          // Without this, Elasticsearch rejects the request with index_not_found_exception
+          // instead of returning zero hits, which would otherwise stop the polling caller.
+          ignore_unavailable: true,
+          allow_partial_search_results: true,
+          _source: returnDataPreview,
+          timeout: '5s',
+          size: returnDataPreview ? MAX_AGENT_DATA_PREVIEW_SIZE : 0,
+          terminate_after: returnDataPreview ? undefined : 1,
+          query: {
+            bool: {
+              filter: [
+                {
+                  range: {
+                    'event.ingested': {
+                      gte: 'now-5m',
+                      lte: 'now',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        }),
+      { logger }
+    );
+
+    const dataPreview = searchResult.hits?.hits || [];
+    const total = searchResult.hits.total as SearchTotalHits | undefined;
+    const hasData = (total?.value ?? 0) > 0;
+
+    return { items: [{ [agentId]: { data: hasData } }], dataPreview };
+  } catch (error) {
+    logger.debug(`Error getting incoming data for data streams: ${error}`);
     throw new FleetError(
       `Unable to retrieve incoming data for agents due to error: ${error.message}`
     );

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -31,7 +31,8 @@ import {
 
 import { createAppContextStartContractMock } from '../../../../mocks';
 import { appContextService } from '../../..';
-import type { RegistryDataStream } from '../../../../types';
+import type { PackageInfo, RegistryDataStream } from '../../../../types';
+import type { ExperimentalFeatures } from '../../../../../common/experimental_features';
 import { processFields } from '../../fields/field';
 import type { Field } from '../../fields/field';
 import {
@@ -2970,26 +2971,81 @@ describe('EPM template', () => {
       });
     });
 
-    // TODO: generateESIndexPatterns does not accept an isOtelInputType flag and therefore
-    // never appends the '.otel' suffix for OTel input packages. The pattern is stored in
-    // the Fleet installation saved object (es_index_patterns) and used by get.ts to match
-    // active data streams for the Fleet UI — it does not affect ES index template routing.
-    // With the missing suffix, the UI will fail to match data streams named
-    // 'logs-generic.otel-<namespace>' against the stored pattern 'logs-generic-*'.
-    // The test below locks in the current (incorrect) behavior so any future fix is explicit.
-    it('does not append .otel suffix for OTel input data streams (current behavior — see TODO above)', () => {
-      const otelDataStream = {
+    describe('with package context', () => {
+      const regularDataStream = {
         type: 'logs',
-        dataset: 'generic',
-        title: 'Generic OTel logs',
+        dataset: 'nginx.access',
+        title: 'Nginx access logs',
         release: 'ga',
-        package: 'otel',
-        path: 'generic',
+        package: 'nginx',
+        path: 'access',
         ingest_pipeline: 'default',
+        streams: [{ input: 'logfile' }],
       } as RegistryDataStream;
 
-      expect(generateESIndexPatterns([otelDataStream])).toEqual({
-        generic: 'logs-generic-*',
+      const otelDataStream = {
+        type: 'metrics',
+        dataset: 'supabase.metrics',
+        title: 'Supabase OTel metrics',
+        release: 'ga',
+        package: 'supabase',
+        path: 'metrics',
+        ingest_pipeline: 'default',
+        streams: [{ input: 'otelcol' }],
+      } as RegistryDataStream;
+
+      const packageInfo = {
+        policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+      } as PackageInfo;
+
+      beforeEach(() => {
+        appContextService.start(
+          createAppContextStartContractMock({}, undefined, undefined, {
+            enableOtelIntegrations: true,
+          } as ExperimentalFeatures)
+        );
+      });
+
+      it('appends the .otel suffix only for data streams on the OTel input', () => {
+        expect(generateESIndexPatterns([regularDataStream, otelDataStream], packageInfo)).toEqual({
+          access: 'logs-nginx.access-*',
+          metrics: 'metrics-supabase.metrics.otel-*',
+        });
+      });
+
+      it('resolves an input referenced by name', () => {
+        const namedInputDataStream = {
+          ...otelDataStream,
+          streams: [{ input: 'otel_metrics' }],
+        } as RegistryDataStream;
+
+        expect(
+          generateESIndexPatterns([namedInputDataStream], {
+            policy_templates: [
+              { name: 'supabase', inputs: [{ type: 'otelcol', name: 'otel_metrics' }] },
+            ],
+          } as PackageInfo)
+        ).toEqual({
+          metrics: 'metrics-supabase.metrics.otel-*',
+        });
+      });
+
+      it('leaves patterns unsuffixed when no package context is given', () => {
+        expect(generateESIndexPatterns([otelDataStream])).toEqual({
+          metrics: 'metrics-supabase.metrics-*',
+        });
+      });
+
+      it('leaves patterns unsuffixed when OTel integrations are disabled', () => {
+        appContextService.start(
+          createAppContextStartContractMock({}, undefined, undefined, {
+            enableOtelIntegrations: false,
+          } as ExperimentalFeatures)
+        );
+
+        expect(generateESIndexPatterns([otelDataStream], packageInfo)).toEqual({
+          metrics: 'metrics-supabase.metrics-*',
+        });
       });
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -30,8 +30,10 @@ import type {
   IndexTemplateEntry,
   IndexTemplate,
   IndexTemplateMappings,
+  PackageInfo,
   RegistryElasticsearch,
 } from '../../../../types';
+import { isOtelDataStream } from '../../packages/namespace_template_utils';
 import { appContextService } from '../../..';
 import { getRegistryDataStreamAssetBaseName } from '../../../../../common/services';
 import {
@@ -305,9 +307,12 @@ export function getNamespaceFromTemplateId(id: string): string | undefined {
 /**
  * Returns a map of the data stream path fields to elasticsearch index pattern.
  * @param dataStreams an array of RegistryDataStream objects
+ * @param packageInfo package context used to detect OTel input data streams, which carry a
+ * `.otel` dataset suffix. Callers that omit it get unsuffixed patterns.
  */
 export function generateESIndexPatterns(
-  dataStreams: RegistryDataStream[] | undefined
+  dataStreams: RegistryDataStream[] | undefined,
+  packageInfo?: Pick<PackageInfo, 'policy_templates'>
 ): Record<string, string> {
   if (!dataStreams) {
     return {};
@@ -315,7 +320,10 @@ export function generateESIndexPatterns(
 
   const patterns: Record<string, string> = {};
   for (const dataStream of dataStreams) {
-    patterns[dataStream.path] = generateTemplateIndexPattern(dataStream);
+    patterns[dataStream.path] = generateTemplateIndexPattern(
+      dataStream,
+      packageInfo ? isOtelDataStream(dataStream, packageInfo) : undefined
+    );
   }
   return patterns;
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
@@ -167,6 +167,44 @@ describe('createInstallation', () => {
       });
     });
   });
+
+  describe('es_index_patterns', () => {
+    beforeEach(() => {
+      (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+        enableOtelIntegrations: true,
+      });
+      soClient.create.mockClear();
+    });
+
+    it('stores an .otel pattern for an OTel data stream', async () => {
+      const otelPackageInfo: InstallablePackage = {
+        ...packageInfo,
+        policy_templates: [{ name: 'test-package', inputs: [{ type: 'otelcol' }] } as any],
+        data_streams: [
+          {
+            type: 'metrics',
+            dataset: 'test-package.metrics',
+            path: 'metrics',
+            title: 'metrics',
+            release: 'ga',
+            streams: [{ input: 'otelcol' } as any],
+          } as any,
+        ],
+      };
+
+      await createInstallation({
+        savedObjectsClient: soClient,
+        packageInfo: otelPackageInfo,
+        installSource: 'registry',
+        spaceId: DEFAULT_SPACE_ID,
+      });
+
+      const [, savedObject] = soClient.create.mock.calls[0];
+      expect((savedObject as Installation).es_index_patterns).toEqual({
+        metrics: 'metrics-test-package.metrics.otel-*',
+      });
+    });
+  });
 });
 
 describe('install', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -1326,7 +1326,7 @@ export async function createInstallation(options: {
   const typedStreams = getNormalizedDataStreams(packageInfo, GENERIC_DATASET_NAME).filter(
     (ds): ds is RegistryDataStream => !!ds.type
   );
-  const toSaveESIndexPatterns = generateESIndexPatterns(typedStreams);
+  const toSaveESIndexPatterns = generateESIndexPatterns(typedStreams, packageInfo);
 
   // For "stack-aligned" packages, default the `keep_policies_up_to_date` setting to true. For all other
   // packages, default it to undefined. Use undefined rather than false to allow us to differentiate

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_index_template_pipelines.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_index_template_pipelines.test.ts
@@ -797,9 +797,8 @@ describe('stepInstallIndexTemplatePipelines', () => {
         esReferences: [],
       });
 
-      // Without packageInfo, isOtelDataStream (invoked inside the real generateESIndexPatterns)
-      // can never fire, so an OTel-derived custom dataset would silently keep the unsuffixed
-      // pattern that the manifest-driven recompute in stepSaveSystemObject cannot repair.
+      // Without packageInfo, this pattern would keep an unsuffixed dataset that
+      // stepSaveSystemObject's manifest-driven recompute can't repair later.
       expect(mockedGenerateESIndexPatterns).toHaveBeenCalledWith(
         [expect.objectContaining({ dataset: 'my_custom_access', path: 'my_custom_access' })],
         packageInstallContext.packageInfo

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_index_template_pipelines.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_index_template_pipelines.test.ts
@@ -22,6 +22,7 @@ import { createAppContextStartContractMock } from '../../../../../mocks';
 import { installIndexTemplatesAndPipelines } from '../../install_index_template_pipeline';
 import { optimisticallyAddEsAssetReferences } from '../../es_assets_reference';
 import { deletePrerequisiteAssets, cleanupComponentTemplate } from '../../remove';
+import { generateESIndexPatterns } from '../../../elasticsearch/template/template';
 
 jest.mock('../../install_index_template_pipeline');
 jest.mock('../../es_assets_reference');
@@ -46,6 +47,9 @@ const mockCleanupComponentTemplate = cleanupComponentTemplate as jest.MockedFunc
 >;
 const mockDeletePrerequisiteAssets = deletePrerequisiteAssets as jest.MockedFunction<
   typeof deletePrerequisiteAssets
+>;
+const mockedGenerateESIndexPatterns = generateESIndexPatterns as jest.MockedFunction<
+  typeof generateESIndexPatterns
 >;
 
 import { createArchiveIteratorFromMap } from '../../../archive/archive_iterator';
@@ -91,6 +95,7 @@ describe('stepInstallIndexTemplatePipelines', () => {
   afterEach(async () => {
     jest.mocked(mockedInstallIndexTemplatesAndPipelines).mockReset();
     jest.mocked(optimisticallyAddEsAssetReferences).mockReset();
+    mockedGenerateESIndexPatterns.mockClear();
   });
 
   it('Should call installIndexTemplatesAndPipelines if packageInfo type is integration', async () => {
@@ -756,6 +761,49 @@ describe('stepInstallIndexTemplatePipelines', () => {
       );
 
       expect(result?.esReferences).toEqual(updatedRefsWithCustom);
+    });
+
+    it('passes packageInfo when generating the index pattern for a custom dataset, so an OTel-derived custom dataset can be detected as OTel', async () => {
+      const dataStreams = [{ dataset: 'test-package.access', type: 'logs', path: 'access' }];
+
+      mockedInstallIndexTemplatesAndPipelines.mockResolvedValue({
+        installedTemplates: [],
+        esReferences: [],
+      });
+      jest.mocked(optimisticallyAddEsAssetReferences).mockResolvedValue([]);
+
+      const mockInstalledPackageSo = getMockInstalledPackageSo([
+        {
+          id: 'logs-my_custom_access',
+          type: ElasticsearchAssetType.indexTemplate,
+          customDataStreamOriginDataset: 'test-package.access',
+          customDataStreamOriginType: 'logs',
+        },
+      ]);
+
+      const packageInstallContext = makeIntegrationContext(dataStreams);
+
+      await stepInstallIndexTemplatePipelines({
+        savedObjectsClient: soClient,
+        // @ts-ignore
+        savedObjectsImporter: jest.fn(),
+        esClient,
+        logger: loggerMock.create(),
+        packageInstallContext,
+        installedPkg: mockInstalledPackageSo,
+        installType: 'update',
+        installSource: 'registry',
+        spaceId: DEFAULT_SPACE_ID,
+        esReferences: [],
+      });
+
+      // Without packageInfo, isOtelDataStream (invoked inside the real generateESIndexPatterns)
+      // can never fire, so an OTel-derived custom dataset would silently keep the unsuffixed
+      // pattern that the manifest-driven recompute in stepSaveSystemObject cannot repair.
+      expect(mockedGenerateESIndexPatterns).toHaveBeenCalledWith(
+        [expect.objectContaining({ dataset: 'my_custom_access', path: 'my_custom_access' })],
+        packageInstallContext.packageInfo
+      );
     });
 
     it('should skip if no custom dataset refs exist in installed_es', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_index_template_pipelines.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_index_template_pipelines.ts
@@ -162,11 +162,15 @@ async function reinstallCustomDatasetTemplates({
         customDataStreamOriginType: originInfo.type,
       });
 
+      // Pass packageInfo so an OTel-derived custom dataset gets the same `.otel` suffix as its
+      // manifest counterpart. Custom datasets have no manifest entry of their own, so the
+      // install/upgrade recompute in stepSaveSystemObject (which only recomputes manifest
+      // entries) can never repair a pattern stored without it.
       currentRefs = await optimisticallyAddEsAssetReferences(
         savedObjectsClient,
         packageInfo.name,
         [],
-        generateESIndexPatterns([{ ...dataStream, path: dataStream.dataset }])
+        generateESIndexPatterns([{ ...dataStream, path: dataStream.dataset }], packageInfo)
       );
     } catch (error) {
       logger.warn(

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_index_template_pipelines.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_index_template_pipelines.ts
@@ -162,10 +162,8 @@ async function reinstallCustomDatasetTemplates({
         customDataStreamOriginType: originInfo.type,
       });
 
-      // Pass packageInfo so an OTel-derived custom dataset gets the same `.otel` suffix as its
-      // manifest counterpart. Custom datasets have no manifest entry of their own, so the
-      // install/upgrade recompute in stepSaveSystemObject (which only recomputes manifest
-      // entries) can never repair a pattern stored without it.
+      // Pass packageInfo so an OTel-derived custom dataset gets the `.otel` suffix too; it has
+      // no manifest entry for stepSaveSystemObject's recompute to repair later.
       currentRefs = await optimisticallyAddEsAssetReferences(
         savedObjectsClient,
         packageInfo.name,

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.test.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SavedObjectsClientContract, ElasticsearchClient } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import {
   savedObjectsClientMock,
   elasticsearchServiceMock,
@@ -100,6 +101,7 @@ describe('updateLatestExecutedState', () => {
           version: '1.0.0',
         },
       ],
+      ['epm-packages', 'test-integration', { es_index_patterns: {} }, { version: undefined }],
     ]);
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
@@ -168,6 +170,7 @@ describe('updateLatestExecutedState', () => {
           version: '1.0.0',
         },
       ],
+      ['epm-packages', 'test-integration', { es_index_patterns: {} }, { version: undefined }],
     ]);
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
@@ -246,6 +249,322 @@ describe('updateLatestExecutedState', () => {
           version: '1.0.0',
         },
       ],
+      ['epm-packages', 'test-integration', { es_index_patterns: {} }, { version: undefined }],
     ]);
+  });
+
+  describe('es_index_patterns recompute', () => {
+    const baseArgs = {
+      installType: 'install' as const,
+      installSource: 'registry' as const,
+      spaceId: DEFAULT_SPACE_ID,
+    };
+
+    beforeEach(() => {
+      appContextService.start(
+        createAppContextStartContractMock({}, undefined, undefined, {
+          enableOtelIntegrations: true,
+        } as any)
+      );
+    });
+
+    it('produces an .otel pattern for an OTel data stream in the package manifest', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'supabase',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'supabase',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: {},
+        },
+      } as any);
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'supabase',
+            version: '1.0.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+            policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] } as any],
+            data_streams: [
+              {
+                type: 'metrics',
+                dataset: 'supabase.metrics',
+                path: 'metrics',
+                title: 'metrics',
+                release: 'ga',
+                streams: [{ input: 'otelcol' } as any],
+              } as any,
+            ],
+          },
+        },
+      });
+
+      const [, , esIndexPatternsUpdate] = soClient.update.mock.calls[1];
+      expect(esIndexPatternsUpdate).toEqual({
+        es_index_patterns: { metrics: 'metrics-supabase.metrics.otel-*' },
+      });
+    });
+
+    it('keeps a stored entry for a dataset absent from the manifest', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'test-integration',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'test-integration',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: { custom_dataset: 'logs-test-integration.custom_dataset-*' },
+        },
+      } as any);
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'test-integration',
+            version: '1.0.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+          },
+        },
+      });
+
+      const [, , esIndexPatternsUpdate] = soClient.update.mock.calls[1];
+      expect(esIndexPatternsUpdate).toEqual({
+        es_index_patterns: { custom_dataset: 'logs-test-integration.custom_dataset-*' },
+      });
+    });
+
+    it('adds a manifest data stream missing from the stored map, with no OTel stream in the package', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'all_assets',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'all_assets',
+          version: '0.2.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: { test_logs: 'logs-all_assets.test_logs-*' },
+        },
+      } as any);
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'all_assets',
+            version: '0.2.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+            data_streams: [
+              {
+                type: 'logs',
+                dataset: 'all_assets.test_logs',
+                path: 'test_logs',
+                title: 'test_logs',
+                release: 'ga',
+                streams: [{ input: 'logfile' } as any],
+              } as any,
+              {
+                type: 'logs',
+                dataset: 'all_assets.test_logs2',
+                path: 'test_logs2',
+                title: 'test_logs2',
+                release: 'ga',
+                streams: [{ input: 'logfile' } as any],
+              } as any,
+            ],
+          },
+        },
+      });
+
+      const [, , esIndexPatternsUpdate] = soClient.update.mock.calls[1];
+      expect(esIndexPatternsUpdate).toEqual({
+        es_index_patterns: {
+          test_logs: 'logs-all_assets.test_logs-*',
+          test_logs2: 'logs-all_assets.test_logs2-*',
+        },
+      });
+    });
+
+    it('carries the version returned by the read inside the retry', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'test-integration',
+        version: 'WzUsNV0=',
+        attributes: {
+          title: 'title',
+          name: 'test-integration',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: {},
+        },
+      } as any);
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'test-integration',
+            version: '1.0.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+          },
+        },
+      });
+
+      const [, , , esIndexPatternsOptions] = soClient.update.mock.calls[1];
+      expect(esIndexPatternsOptions).toEqual({ version: 'WzUsNV0=' });
+    });
+
+    it('retries once on a conflict and succeeds', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'test-integration',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'test-integration',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: {},
+        },
+      } as any);
+      soClient.update
+        .mockResolvedValueOnce({} as any) // install-status update
+        .mockRejectedValueOnce(
+          SavedObjectsErrorHelpers.createConflictError('epm-packages', 'test-integration')
+        )
+        .mockResolvedValueOnce({} as any); // es_index_patterns update, second attempt
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'test-integration',
+            version: '1.0.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+          },
+        },
+      });
+
+      expect(soClient.update).toHaveBeenCalledTimes(3);
+    });
+
+    it('rethrows a non-conflict error without retrying', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'test-integration',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'test-integration',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: {},
+        },
+      } as any);
+      soClient.update
+        .mockResolvedValueOnce({} as any) // install-status update
+        .mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        stepSaveSystemObject({
+          ...baseArgs,
+          savedObjectsClient: soClient,
+          esClient,
+          logger,
+          packageInstallContext: {
+            archiveIterator: createArchiveIteratorFromMap(new Map()),
+            paths: [],
+            packageInfo: {
+              title: 'title',
+              name: 'test-integration',
+              version: '1.0.0',
+              description: 'test',
+              type: 'integration',
+              categories: ['cloud', 'custom'],
+              format_version: 'string',
+              release: 'experimental',
+              conditions: { kibana: { version: 'x.y.z' } },
+              owner: { github: 'elastic/fleet' },
+            },
+          },
+        })
+      ).rejects.toThrow('boom');
+
+      expect(soClient.update).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 import semverLt from 'semver/functions/lt';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import pRetry from 'p-retry';
 
 import {
   PACKAGES_SAVED_OBJECT_TYPE,
@@ -12,8 +14,10 @@ import {
   SO_SEARCH_LIMIT,
   FLEET_INSTALL_FORMAT_VERSION,
 } from '../../../../../constants';
+import { GENERIC_DATASET_NAME } from '../../../../../../common/constants';
 import { handleNamespaceTemplateRestoreAfterPackageInstall } from '../..';
-import type { Installation } from '../../../../../types';
+import type { Installation, RegistryDataStream } from '../../../../../types';
+import { getNormalizedDataStreams } from '../../../../../../common/services';
 
 import { packagePolicyService } from '../../../../package_policy';
 
@@ -22,8 +26,15 @@ import { auditLoggingService } from '../../../../audit_logging';
 import { withPackageSpan } from '../../utils';
 
 import { clearLatestFailedAttempts } from '../../install_errors_helpers';
+import { generateESIndexPatterns } from '../../../elasticsearch/template/template';
 
 import type { InstallContext } from '../_state_machine_package_install';
+
+const onlyRetryConflictErrors = (err: Error) => {
+  if (!SavedObjectsErrorHelpers.isConflictError(err)) {
+    throw err;
+  }
+};
 
 export async function stepSaveSystemObject(context: InstallContext) {
   const {
@@ -66,6 +77,42 @@ export async function stepSaveSystemObject(context: InstallContext) {
     pkgName
   );
   logger.debug(`Package install - Install status ${updatedPackage?.attributes?.install_status}`);
+
+  // Recompute es_index_patterns from the manifest and merge over the stored map, so that an
+  // install or upgrade repairs stale or missing entries (including, but not limited to, OTel
+  // '.otel' suffixes). The merge base is re-read on every attempt, matching the retry precedent
+  // in es_assets_reference.ts, since custom-dataset and input-package flows can concurrently
+  // add entries through optimisticallyAddEsAssetReferences that this recompute must not drop.
+  const recomputedEsIndexPatterns = generateESIndexPatterns(
+    getNormalizedDataStreams(packageInfo, GENERIC_DATASET_NAME).filter(
+      (ds): ds is RegistryDataStream => !!ds.type
+    ),
+    packageInfo
+  );
+
+  const updateEsIndexPatterns = async () => {
+    const latest = await savedObjectsClient.get<Installation>(PACKAGES_SAVED_OBJECT_TYPE, pkgName);
+
+    auditLoggingService.writeCustomSoAuditLog({
+      action: 'update',
+      id: pkgName,
+      name: pkgName,
+      savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
+    });
+
+    return savedObjectsClient.update<Installation>(
+      PACKAGES_SAVED_OBJECT_TYPE,
+      pkgName,
+      {
+        es_index_patterns: { ...latest.attributes.es_index_patterns, ...recomputedEsIndexPatterns },
+      },
+      { version: latest.version }
+    );
+  };
+
+  await withPackageSpan('Update es_index_patterns', () =>
+    pRetry(updateEsIndexPatterns, { retries: 5, onFailedAttempt: onlyRetryConflictErrors })
+  );
   // Recreate namespace-scoped index templates for every namespace opted in on this
   // package's Installation SO. On first install this is a no-op (opt-in list is empty).
   if (packageInfo.type === 'integration') {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.ts
@@ -78,11 +78,9 @@ export async function stepSaveSystemObject(context: InstallContext) {
   );
   logger.debug(`Package install - Install status ${updatedPackage?.attributes?.install_status}`);
 
-  // Recompute es_index_patterns from the manifest and merge over the stored map, so that an
-  // install or upgrade repairs stale or missing entries (including, but not limited to, OTel
-  // '.otel' suffixes). The merge base is re-read on every attempt, matching the retry precedent
-  // in es_assets_reference.ts, since custom-dataset and input-package flows can concurrently
-  // add entries through optimisticallyAddEsAssetReferences that this recompute must not drop.
+  // Recompute es_index_patterns from the manifest and merge over the stored map so install/
+  // upgrade repairs stale entries (e.g. missing '.otel' suffixes). The merge base is re-read on
+  // every retry attempt so this doesn't clobber entries other install flows add concurrently.
   const recomputedEsIndexPatterns = generateESIndexPatterns(
     getNormalizedDataStreams(packageInfo, GENERIC_DATASET_NAME).filter(
       (ds): ds is RegistryDataStream => !!ds.type

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -487,6 +487,7 @@ export default function (providerContext: FtrProviderContext) {
           ),
           es_index_patterns: {
             test_logs: 'logs-all_assets.test_logs-*',
+            test_logs2: 'logs-all_assets.test_logs2-*',
             test_metrics: 'metrics-all_assets.test_metrics-*',
           },
           package_assets: [


### PR DESCRIPTION
closes: https://github.com/elastic/ingest-dev/issues/9005

## Summary

Addresses https://github.com/elastic/ingest-dev/issues/8988. Root cause 1 (missing `.otel` suffix) is fixed for all three OTel packages that own manifest data streams — `supabase`, `claude_code`, and `claude_cowork` — since the fix keys off `packageInfo.data_streams`, not a package name; both `claude_code` and `claude_cowork` self-heal their stored patterns on their next install or upgrade. Root cause 2 (unqueryable `agent.id`) is fixed generically for any single-agent agentless policy, but today that only changes observable behavior for `supabase`: `claude_code` and `claude_cowork` don't have agentless enabled in their manifests (`deployment_modes: null`), so that branch is unreachable for them right now. `aws_cloudwatch_input_otel` and `verifier_otel` remain unfixed by both root causes (see Scope below) and are tracked separately in https://github.com/elastic/ingest-dev/issues/9012; please keep #8988 open until that follow-up is resolved. Separately, this PR fully fixes https://github.com/elastic/ingest-dev/issues/9005 (the same missing-`.otel`-suffix root cause, reported independently), so that one can close on merge.

Fleet's "Confirming Incoming Data" step falsely reports no data for agentless OTel integrations, even while their data streams are actively receiving documents. Two independent bugs combine to cause this:

1. **Wrong index patterns.** Fleet's live incoming-data check and its stored `es_index_patterns` are missing the `.otel` dataset suffix that OTel-backed data streams actually use, so the query and the stored record both point at index patterns that don't exist.
2. **Unqueryable identity field.** Once pointed at the right pattern, the query still filters and aggregates on `agent.id`. Native OTel documents never carry that field: the collector doesn't write it, and the OTel index templates (`dynamic: false`, no `ecs@mappings`) don't map it, so the filter matches nothing even when fresh data is present. This was reproduced against a live Elasticsearch 9.6.0 snapshot, including confirming that writing the field from a Fleet ingest pipeline is not a viable alternative: that pipeline isn't even composed on serverless Observability, where this bug was reported, there's no evidence the agentless OTel exporter authenticates with API-key metadata a pipeline could read, and writing it under `resource.attributes` would add a permanent TSDS dimension to every OTel metrics series.

## What changed

**Index patterns (root cause 1).** Pattern generation now reuses the existing `isOtelDataStream` helper instead of a second, inconsistent way of asking the same question. `generateESIndexPatterns` takes the OTel flag per data stream, the live incoming-data handler builds its pattern the same way, and the install/upgrade save step recomputes `es_index_patterns` on install, upgrade, and reinstall so previously-broken stored records repair themselves without a schema bump. This recompute also fixes a pre-existing, non-OTel bug: an upgrade that adds a data stream never added its pattern to the stored map for any package.

**Identity-free detection (root cause 2).** For an agentless policy there is exactly one agent, so "this policy's data streams received a document recently" is equivalent to "this agent has incoming data", and no identity field is needed. `getIncomingDataByDataStreams` answers that question directly: same privilege check and `event.ingested` recency window as the existing path, but no `agent.id` filter or aggregation. The route only takes this path when all three hold, otherwise it falls back unchanged to the existing identity-based query:

- the package's data streams use the OTel input (`isOtelDataStream`),
- exactly one agent id was requested, and
- that agent's policy is agentless, **and** the requested `pkgName`/`pkgVersion` actually match a package policy attached to that agent's policy.

The query itself is scoped to the requesting agent's own namespace (via `generateNamespaceTemplateIndexPattern`, pinning the namespace segment rather than a `-*` wildcard) so one healthy deployment can't report success for a different, broken deployment of the same integration.

The policy lookup behind this gate uses `internalSoClient`, even though the route only requires `agents:read`; that's safe because the response never exposes policy contents (just `data: boolean`, plus previews that are already gated by the current user's own Elasticsearch read privileges), matching existing precedent elsewhere in Fleet's handlers.

**Scope.** Root cause 1's fix reaches `supabase`, `claude_code`, and `claude_cowork` on their next install or upgrade. Root cause 2's fix is generic (any single-agent agentless policy with OTel data streams) but is currently observable only for `supabase`, since neither Claude package has agentless enabled today. `aws_cloudwatch_input_otel` and `verifier_otel` are `type: input` packages with no manifest `data_streams`. Both mechanisms above key off `packageInfo.data_streams`, so those two are unaffected and remain exactly as broken as they are today — and this is not a theoretical gap: agentless is enabled for both, and is the *default* deployment mode for every `aws_cloudwatch_input_otel` policy template (`aws.ec2`, `aws.lambda`, `aws.rds`, `aws.sqs`, `aws.elb*`, `aws.ecs`). Deriving their concrete data streams means resolving them from the attached package policy's own inputs instead of the manifest, which is a separate, reviewed change and not a follow-on edit to this one. That work is tracked in https://github.com/elastic/ingest-dev/issues/9012.

**Accepted limitation.** Two agentless deployments of the same integration in the same namespace are indistinguishable by the namespace-scoped fallback: data from one can report success for the other. There's no identity left in the document to disambiguate them, and the collision requires a second independent agentless deployment of the same integration in the same namespace writing within the same 5-minute window, so this is accepted rather than solved.

**Not fixed by this PR.** Any OTel integration enrolled on a regular, non-agentless policy still fails incoming-data confirmation today. `agent.id` is unmapped on OTel index templates regardless of agentless-ness — that's inherent to the templates, not something this PR touches — and the identity-free path only applies when there's exactly one agent on an agentless policy, since a policy-scoped answer would be wrong by construction for a policy multiple agents can write to. This PR doesn't attempt that case; it's a real, currently-unaddressed scenario for any OTel package run outside agentless (including `claude_code` and `claude_cowork` today, since neither has agentless enabled), not just a deliberately-excluded edge case.

## Verification

Verified end to end in a QA serverless Observability project using deployed PR revision `0112d46c64bf3214161805b0ed06fa58479ca037`. Because Supabase's Metrics API requires a paid plan, the real Supabase agentless integration was configured with an unreachable placeholder endpoint. Its real agentless OTel Collector still emitted Prometheus scrape-health documents, exercising the Fleet path without using customer data:

- documents landed in `metrics-supabase.metrics.otel-<namespace>`, while the old `metrics-supabase.metrics-*` pattern did not resolve them;
- the installed package reported the stored `metrics-supabase.metrics.otel-*` pattern;
- `event.ingested` was mapped and populated by the ingest pipeline, while `agent.id` was absent;
- the incoming-data API returned `data: true`; and
- the enrollment flyout showed both deployment and incoming-data checks as successful.

This verifies Fleet's agentless policy gate, namespace resolution, `.otel` pattern, ingest pipeline, API, and UI. It does not verify real Supabase business metrics or endpoint health. The QA image predates the current head (`d889c3eda2107defb00e681aba145aff5e0b1967`); the only behavioral difference is the separately unit-tested exact-one-package-policy ambiguity guard, which is not exercised by this single-policy scenario.

## Release note

Fixes a bug where Fleet reported no incoming data for the Supabase agentless integration even while its OpenTelemetry data streams were actively receiving documents.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->