### PR TITLE
[Context Engine] Add workflow preview button

### DIFF
--- a/x-pack/platform/plugins/shared/context_engine/moon.yml
+++ b/x-pack/platform/plugins/shared/context_engine/moon.yml
@@ -42,6 +42,8 @@ dependsOn:
   - '@kbn/workflows-ui'
   - '@kbn/deeplinks-workflows'
   - '@kbn/deeplinks-management'
+  - '@kbn/code-editor'
+  - '@kbn/ui-callout'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/automation_row.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/automation_row.test.tsx
@@ -12,6 +12,26 @@ import React from 'react';
 import type { AiIndexAutomation } from '../../../../common/http_api/ai_indices';
 import { AutomationRow } from './automation_row';
 
+jest.mock('./workflow_yaml_preview_flyout', () => ({
+  WorkflowYamlPreviewFlyout: ({
+    workflowId,
+    workflowName,
+    onClose,
+  }: {
+    workflowId: string;
+    workflowName: string;
+    onClose: () => void;
+  }) => (
+    <div data-test-subj="contextWorkflowYamlPreviewFlyout">
+      <span>{workflowName}</span>
+      <span>{workflowId}</span>
+      <button type="button" onClick={onClose}>
+        Close preview
+      </button>
+    </div>
+  ),
+}));
+
 const renderWithProviders = (ui: React.ReactElement) =>
   render(
     <I18nProvider>
@@ -92,11 +112,12 @@ describe('AutomationRow', () => {
     expect(link).not.toHaveAttribute('target');
   });
 
-  it('renders no actions when isEditing is false', () => {
+  it('renders no edit actions when isEditing is false', () => {
     renderAutomationRow({ isEditing: false });
 
     expect(screen.queryByTestId('contextOpenWorkflowButton')).not.toBeInTheDocument();
     expect(screen.queryByTestId('contextRemoveAutomationButton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('contextPreviewWorkflowButton')).toBeInTheDocument();
   });
 
   it('renders the actions when isEditing is true', () => {
@@ -134,5 +155,24 @@ describe('AutomationRow', () => {
     expect(
       screen.getByRole('button', { name: 'Remove automation My Workflow' })
     ).toBeInTheDocument();
+  });
+
+  it('opens the workflow yaml preview flyout when the eye button is clicked', () => {
+    renderAutomationRow({ name: 'My Workflow', isEditing: false });
+
+    fireEvent.click(screen.getByTestId('contextPreviewWorkflowButton'));
+
+    const flyout = screen.getByTestId('contextWorkflowYamlPreviewFlyout');
+    expect(flyout).toBeInTheDocument();
+    expect(flyout).toHaveTextContent('workflow-value-id');
+  });
+
+  it('closes the workflow yaml preview flyout', () => {
+    renderAutomationRow({ isEditing: false });
+
+    fireEvent.click(screen.getByTestId('contextPreviewWorkflowButton'));
+    fireEvent.click(screen.getByRole('button', { name: 'Close preview' }));
+
+    expect(screen.queryByTestId('contextWorkflowYamlPreviewFlyout')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/automation_row.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/automation_row.tsx
@@ -17,8 +17,9 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+import React, { useState } from 'react';
 import type { AiIndexAutomation } from '../../../../common/http_api/ai_indices';
+import { WorkflowYamlPreviewFlyout } from './workflow_yaml_preview_flyout';
 
 interface AutomationRowProps {
   automation: AiIndexAutomation;
@@ -39,7 +40,12 @@ export const AutomationRow = ({
   isRemoveDisabled,
   onRemove,
 }: AutomationRowProps) => {
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const displayName = name ?? automation.value;
+  const previewLabel = i18n.translate(
+    'xpack.contextEngine.aiIndexDetail.automations.previewWorkflowAriaLabel',
+    { defaultMessage: 'Preview workflow YAML for {name}', values: { name: displayName } }
+  );
   const removeLabel = i18n.translate(
     'xpack.contextEngine.aiIndexDetail.automations.removeButtonAriaLabel',
     { defaultMessage: 'Remove automation {name}', values: { name: displayName } }
@@ -70,6 +76,16 @@ export const AutomationRow = ({
             </EuiBadge>
           </EuiFlexItem>
         )}
+        <EuiFlexItem grow={false}>
+          <EuiToolTip content={previewLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              iconType="eye"
+              aria-label={previewLabel}
+              onClick={() => setIsPreviewOpen(true)}
+              data-test-subj="contextPreviewWorkflowButton"
+            />
+          </EuiToolTip>
+        </EuiFlexItem>
         {isEditing && (
           <>
             <EuiFlexItem grow={false}>
@@ -109,6 +125,13 @@ export const AutomationRow = ({
           </>
         )}
       </EuiFlexGroup>
+      {isPreviewOpen ? (
+        <WorkflowYamlPreviewFlyout
+          workflowId={automation.value}
+          workflowName={displayName}
+          onClose={() => setIsPreviewOpen(false)}
+        />
+      ) : null}
     </EuiPanel>
   );
 };

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/workflow_yaml_preview_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/workflow_yaml_preview_flyout.test.tsx
@@ -76,7 +76,7 @@ describe('WorkflowYamlPreviewFlyout', () => {
     expect(screen.getByTestId('contextWorkflowYamlPreviewFlyout')).toBeInTheDocument();
     expect(screen.getByText('Workflow preview: My workflow')).toBeInTheDocument();
     expect(screen.getByTestId('contextWorkflowYamlPreview')).toHaveTextContent('name: preview');
-    expect(mockUseWorkflow).toHaveBeenCalledWith('wf-1', true);
+    expect(mockUseWorkflow).toHaveBeenCalledWith('wf-1');
   });
 
   it('shows an error when loading fails', () => {
@@ -89,6 +89,20 @@ describe('WorkflowYamlPreviewFlyout', () => {
     renderFlyout();
 
     expect(screen.getByTestId('contextWorkflowYamlPreviewError')).toBeInTheDocument();
-    expect(screen.getByText('Forbidden')).toBeInTheDocument();
+    expect(screen.getByText('Try again later.')).toBeInTheDocument();
+    expect(screen.queryByText('Forbidden')).not.toBeInTheDocument();
+  });
+
+  it('shows a message when the workflow has no yaml content', () => {
+    mockUseWorkflow.mockReturnValue({
+      data: { id: 'wf-1' },
+      isLoading: false,
+      error: null,
+    });
+
+    renderFlyout();
+
+    expect(screen.getByTestId('contextWorkflowYamlPreviewEmpty')).toBeInTheDocument();
+    expect(screen.queryByTestId('contextWorkflowYamlPreview')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/workflow_yaml_preview_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/workflow_yaml_preview_flyout.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { WorkflowYamlPreviewFlyout } from './workflow_yaml_preview_flyout';
+
+const mockUseWorkflow = jest.fn();
+
+jest.mock('../../hooks/use_workflow', () => ({
+  useWorkflow: (...args: unknown[]) => mockUseWorkflow(...args),
+}));
+
+jest.mock('@kbn/code-editor', () => ({
+  CodeEditor: ({
+    value,
+    'data-test-subj': dataTestSubj,
+  }: {
+    value: string;
+    'data-test-subj'?: string;
+  }) => <pre data-test-subj={dataTestSubj}>{value}</pre>,
+}));
+
+const renderFlyout = (onClose = jest.fn()) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <I18nProvider>
+      <EuiProvider>
+        <QueryClientProvider client={queryClient}>
+          <WorkflowYamlPreviewFlyout
+            workflowId="wf-1"
+            workflowName="My workflow"
+            onClose={onClose}
+          />
+        </QueryClientProvider>
+      </EuiProvider>
+    </I18nProvider>
+  );
+};
+
+describe('WorkflowYamlPreviewFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseWorkflow.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+  });
+
+  it('renders the loading spinner while the workflow loads', () => {
+    renderFlyout();
+
+    expect(screen.getByTestId('contextWorkflowYamlPreviewLoading')).toBeInTheDocument();
+  });
+
+  it('loads and renders the workflow yaml preview', () => {
+    mockUseWorkflow.mockReturnValue({
+      data: { id: 'wf-1', yaml: 'name: preview\nsteps: []' },
+      isLoading: false,
+      error: null,
+    });
+
+    renderFlyout();
+
+    expect(screen.getByTestId('contextWorkflowYamlPreviewFlyout')).toBeInTheDocument();
+    expect(screen.getByText('Workflow preview: My workflow')).toBeInTheDocument();
+    expect(screen.getByTestId('contextWorkflowYamlPreview')).toHaveTextContent('name: preview');
+    expect(mockUseWorkflow).toHaveBeenCalledWith('wf-1', true);
+  });
+
+  it('shows an error when loading fails', () => {
+    mockUseWorkflow.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Forbidden'),
+    });
+
+    renderFlyout();
+
+    expect(screen.getByTestId('contextWorkflowYamlPreviewError')).toBeInTheDocument();
+    expect(screen.getByText('Forbidden')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/workflow_yaml_preview_flyout.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/workflow_yaml_preview_flyout.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiLoadingSpinner,
+  EuiTitle,
+} from '@elastic/eui';
+import { CodeEditor } from '@kbn/code-editor';
+import { i18n } from '@kbn/i18n';
+import { KbnDangerCallout } from '@kbn/ui-callout';
+import React from 'react';
+import { useWorkflow } from '../../hooks/use_workflow';
+
+const READ_ONLY_OPTIONS = {
+  readOnly: true,
+  domReadOnly: true,
+  minimap: { enabled: false },
+  lineNumbers: 'on',
+  scrollBeyondLastLine: false,
+  wordWrap: 'on',
+  fontSize: 14,
+} as const;
+
+export interface WorkflowYamlPreviewFlyoutProps {
+  workflowId: string;
+  workflowName: string;
+  onClose: () => void;
+}
+
+export const WorkflowYamlPreviewFlyout = ({
+  workflowId,
+  workflowName,
+  onClose,
+}: WorkflowYamlPreviewFlyoutProps) => {
+  const { data: workflow, isLoading, error } = useWorkflow(workflowId, true);
+
+  return (
+    <EuiFlyout
+      onClose={onClose}
+      size="m"
+      aria-labelledby="contextWorkflowYamlPreviewFlyoutTitle"
+      data-test-subj="contextWorkflowYamlPreviewFlyout"
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="s" id="contextWorkflowYamlPreviewFlyoutTitle">
+          <h2>
+            {i18n.translate('xpack.contextEngine.aiIndexDetail.automations.previewFlyoutTitle', {
+              defaultMessage: 'Workflow preview: {name}',
+              values: { name: workflowName },
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        {isLoading ? (
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiLoadingSpinner size="m" data-test-subj="contextWorkflowYamlPreviewLoading" />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ) : null}
+        {error ? (
+          <KbnDangerCallout
+            announceOnMount
+            title={i18n.translate(
+              'xpack.contextEngine.aiIndexDetail.automations.previewFlyoutErrorTitle',
+              { defaultMessage: 'Unable to load workflow' }
+            )}
+            data-test-subj="contextWorkflowYamlPreviewError"
+          >
+            {error instanceof Error
+              ? error.message
+              : i18n.translate(
+                  'xpack.contextEngine.aiIndexDetail.automations.previewFlyoutErrorBody',
+                  { defaultMessage: 'Try again later.' }
+                )}
+          </KbnDangerCallout>
+        ) : null}
+        {workflow?.yaml ? (
+          <div style={{ height: '60vh' }}>
+            <CodeEditor
+              languageId="yaml"
+              value={workflow.yaml}
+              height="100%"
+              options={READ_ONLY_OPTIONS}
+              isCopyable
+              allowFullScreen
+              data-test-subj="contextWorkflowYamlPreview"
+            />
+          </div>
+        ) : null}
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/workflow_yaml_preview_flyout.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_detail/workflow_yaml_preview_flyout.tsx
@@ -6,8 +6,6 @@
  */
 
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
@@ -16,7 +14,7 @@ import {
 } from '@elastic/eui';
 import { CodeEditor } from '@kbn/code-editor';
 import { i18n } from '@kbn/i18n';
-import { KbnDangerCallout } from '@kbn/ui-callout';
+import { KbnDangerCallout, KbnWarningCallout } from '@kbn/ui-callout';
 import React from 'react';
 import { useWorkflow } from '../../hooks/use_workflow';
 
@@ -41,7 +39,8 @@ export const WorkflowYamlPreviewFlyout = ({
   workflowName,
   onClose,
 }: WorkflowYamlPreviewFlyoutProps) => {
-  const { data: workflow, isLoading, error } = useWorkflow(workflowId, true);
+  const { data: workflow, isLoading, error } = useWorkflow(workflowId);
+  const workflowYaml = workflow?.yaml;
 
   return (
     <EuiFlyout
@@ -62,11 +61,7 @@ export const WorkflowYamlPreviewFlyout = ({
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         {isLoading ? (
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <EuiLoadingSpinner size="m" data-test-subj="contextWorkflowYamlPreviewLoading" />
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          <EuiLoadingSpinner size="m" data-test-subj="contextWorkflowYamlPreviewLoading" />
         ) : null}
         {error ? (
           <KbnDangerCallout
@@ -77,19 +72,32 @@ export const WorkflowYamlPreviewFlyout = ({
             )}
             data-test-subj="contextWorkflowYamlPreviewError"
           >
-            {error instanceof Error
-              ? error.message
-              : i18n.translate(
-                  'xpack.contextEngine.aiIndexDetail.automations.previewFlyoutErrorBody',
-                  { defaultMessage: 'Try again later.' }
-                )}
+            {i18n.translate(
+              'xpack.contextEngine.aiIndexDetail.automations.previewFlyoutErrorBody',
+              { defaultMessage: 'Try again later.' }
+            )}
           </KbnDangerCallout>
         ) : null}
-        {workflow?.yaml ? (
-          <div style={{ height: '60vh' }}>
+        {!isLoading && !error && workflow && !workflowYaml ? (
+          <KbnWarningCallout
+            announceOnMount
+            title={i18n.translate(
+              'xpack.contextEngine.aiIndexDetail.automations.previewFlyoutEmptyTitle',
+              { defaultMessage: 'No workflow YAML available' }
+            )}
+            data-test-subj="contextWorkflowYamlPreviewEmpty"
+          >
+            {i18n.translate(
+              'xpack.contextEngine.aiIndexDetail.automations.previewFlyoutEmptyBody',
+              { defaultMessage: 'This workflow does not have YAML content to preview.' }
+            )}
+          </KbnWarningCallout>
+        ) : null}
+        {workflowYaml ? (
+          <div css={{ height: '60vh' }}>
             <CodeEditor
               languageId="yaml"
-              value={workflow.yaml}
+              value={workflowYaml}
               height="100%"
               options={READ_ONLY_OPTIONS}
               isCopyable

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_workflow.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_workflow.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useWorkflow } from './use_workflow';
+
+const mockGetWorkflow = jest.fn();
+
+jest.mock('@kbn/workflows-ui', () => ({
+  useWorkflowsApi: () => ({ getWorkflow: mockGetWorkflow }),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('useWorkflow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetWorkflow.mockResolvedValue({
+      id: 'wf-1',
+      name: 'My workflow',
+      yaml: 'name: test\nsteps: []',
+    });
+  });
+
+  it('fetches the workflow when enabled', async () => {
+    const { result } = renderHook(() => useWorkflow('wf-1', true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGetWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(result.current.data).toEqual({
+      id: 'wf-1',
+      name: 'My workflow',
+      yaml: 'name: test\nsteps: []',
+    });
+  });
+
+  it('does not fetch when disabled', () => {
+    renderHook(() => useWorkflow('wf-1', false), { wrapper: createWrapper() });
+
+    expect(mockGetWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_workflow.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_workflow.test.tsx
@@ -38,8 +38,8 @@ describe('useWorkflow', () => {
     });
   });
 
-  it('fetches the workflow when enabled', async () => {
-    const { result } = renderHook(() => useWorkflow('wf-1', true), {
+  it('fetches the workflow', async () => {
+    const { result } = renderHook(() => useWorkflow('wf-1'), {
       wrapper: createWrapper(),
     });
 
@@ -51,11 +51,5 @@ describe('useWorkflow', () => {
       name: 'My workflow',
       yaml: 'name: test\nsteps: []',
     });
-  });
-
-  it('does not fetch when disabled', () => {
-    renderHook(() => useWorkflow('wf-1', false), { wrapper: createWrapper() });
-
-    expect(mockGetWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_workflow.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_workflow.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { useWorkflowsApi } from '@kbn/workflows-ui';
+
+export const useWorkflow = (workflowId: string | undefined, enabled: boolean) => {
+  const api = useWorkflowsApi();
+
+  return useQuery({
+    queryKey: ['context_engine', 'workflow', workflowId],
+    queryFn: () => api.getWorkflow(workflowId!),
+    enabled: enabled && Boolean(workflowId),
+  });
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_workflow.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_workflow.ts
@@ -8,12 +8,11 @@
 import { useQuery } from '@kbn/react-query';
 import { useWorkflowsApi } from '@kbn/workflows-ui';
 
-export const useWorkflow = (workflowId: string | undefined, enabled: boolean) => {
+export const useWorkflow = (workflowId: string) => {
   const api = useWorkflowsApi();
 
   return useQuery({
     queryKey: ['context_engine', 'workflow', workflowId],
-    queryFn: () => api.getWorkflow(workflowId!),
-    enabled: enabled && Boolean(workflowId),
+    queryFn: () => api.getWorkflow(workflowId),
   });
 };

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -36,6 +36,8 @@
     "@kbn/core-security-server",
     "@kbn/workflows-ui",
     "@kbn/deeplinks-workflows",
-    "@kbn/deeplinks-management"
+    "@kbn/deeplinks-management",
+    "@kbn/code-editor",
+    "@kbn/ui-callout"
   ]
 }


### PR DESCRIPTION

## Summary

Adds a preview action on Context Engine automation rows so users can inspect a linked workflow's YAML without leaving the AI index detail page.

The eye icon opens a flyout that loads the workflow via the existing Workflows API and renders it in a read-only YAML editor, with loading and error states.

### Visuals

<img width="1220" height="391" alt="Screenshot 2026-08-03 at 11 21 52" src="https://github.com/user-attachments/assets/8efc3e29-d15f-4d78-bb15-d0e78e81e769" />
<img width="1703" height="1016" alt="Screenshot 2026-08-03 at 11 22 04" src="https://github.com/user-attachments/assets/124ba870-8b78-4aa9-9cc2-f823f24c65b2" />


### How to test

1. Open Context Engine → an AI index with at least one automation linked to a workflow.
2. On the automations list, click the eye icon on a row.
3. Confirm the flyout opens, shows the workflow YAML, and closes on dismiss.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [x] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Low — preview fetches workflow YAML on demand; mitigated by loading only when the flyout opens and showing an error if the user lacks access.

### Release notes

Added a workflow YAML preview on Context Engine automation rows.

### Backport

`backport:skip` — new UI feature, not a bug fix.