### PR TITLE
[9.5] [Discover] Wait for the "Traces in Discover" alert link href before clicking (#282172)

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/explore_from_alerts.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/explore_from_alerts.spec.ts
@@ -163,7 +163,13 @@ spaceTest.describe(
               ).toBeVisible();
             }).toPass({ timeout: 60_000, intervals: [2_000] });
 
-            await page.testSubj.locator('apmAlertDetailsTracesOpenInDiscoverAction').click();
+            const tracesInDiscover = page.testSubj.locator(
+              'apmAlertDetailsTracesOpenInDiscoverAction'
+            );
+            // The item's href is populated only after the APM index-settings fetch resolves;
+            // clicking before then lands on a disabled, href-less item and navigation never happens.
+            await expect(tracesInDiscover).toHaveAttribute('href', /\S/, { timeout: 30_000 });
+            await tracesInDiscover.click();
           }
         );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- [[Discover] Wait for the "Traces in Discover" alert link href before clicking (#282172)](https://github.com/elastic/kibana/pull/282172)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":282172,"url":"https://github.com/elastic/kibana/pull/282172","title":"[Discover] Wait for the \"Traces in Discover\" alert link href before clicking"},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"sourceCommit":{"sha":"21980925e6aa7e6ef8a9b32ba68eaf751082c6e7"}}] BACKPORT-->