### PR TITLE
[9.5] [Synthetics] Show attached maintenance windows in monitor details (#281853)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.test.tsx
@@ -44,6 +44,12 @@ jest.mock('@kbn/observability-shared-plugin/public', () => ({
   ),
 }));
 
+jest.mock('./monitor_maintenance_windows', () => ({
+  MonitorMaintenanceWindows: ({ monitorMWs }: { monitorMWs: string[] }) => (
+    <div data-test-subj="maintenanceWindowsStub">{monitorMWs.join(',')}</div>
+  ),
+}));
+
 const localMonitor = {
   config_id: 'config-1',
   id: 'config-1',
@@ -92,5 +98,30 @@ describe('MonitorDetailsPanel', () => {
     expect(screen.getByText('config-1')).toBeInTheDocument();
     expect(screen.getByTestId('locationsStatusStub')).toBeInTheDocument();
     expect(screen.getByTestId('tagsListStub')).toHaveTextContent('env:prod');
+  });
+
+  it('renders the maintenance windows section when the monitor has attached windows', () => {
+    render(
+      <MonitorDetailsPanel
+        monitor={
+          {
+            ...localMonitor,
+            maintenance_windows: ['mw-1', 'mw-2'],
+          } as EncryptedSyntheticsSavedMonitor
+        }
+        loading={false}
+        configId="config-1"
+      />
+    );
+
+    expect(screen.getByText(/Maintenance windows/i)).toBeInTheDocument();
+    expect(screen.getByTestId('maintenanceWindowsStub')).toHaveTextContent('mw-1,mw-2');
+  });
+
+  it('hides the maintenance windows section when none are attached', () => {
+    render(<MonitorDetailsPanel monitor={localMonitor} loading={false} configId="config-1" />);
+
+    expect(screen.queryByText(/Maintenance windows/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('maintenanceWindowsStub')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
@@ -34,6 +34,7 @@ import type {
 } from '../../../../../../common/runtime_types';
 import { ConfigKey, isRemoteSyntheticsMonitor } from '../../../../../../common/runtime_types';
 import { MonitorTypeBadge } from './monitor_type_badge';
+import { MonitorMaintenanceWindows } from './monitor_maintenance_windows';
 import { useDateFormat } from '../../../../../hooks/use_date_format';
 import { useGetUrlParams } from '../../../hooks';
 
@@ -75,6 +76,7 @@ export const MonitorDetailsPanel = ({
 
   const url = latestPing?.url?.full ?? (savedMonitor as unknown as MonitorFields)?.[ConfigKey.URLS];
   const labels = savedMonitor?.[ConfigKey.LABELS];
+  const maintenanceWindows = savedMonitor?.[ConfigKey.MAINTENANCE_WINDOWS];
 
   return (
     <PanelWithTitle
@@ -185,6 +187,15 @@ export const MonitorDetailsPanel = ({
           <TagsList tags={monitor[ConfigKey.TAGS]} />
         </EuiDescriptionListDescription>
 
+        {!isEmpty(maintenanceWindows) ? (
+          <>
+            <EuiDescriptionListTitle>{MAINTENANCE_WINDOWS_LABEL}</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              <MonitorMaintenanceWindows monitorMWs={maintenanceWindows!} />
+            </EuiDescriptionListDescription>
+          </>
+        ) : null}
+
         {!isEmpty(labels) ? (
           <>
             <EuiDescriptionListTitle>{LABELS_LABEL}</EuiDescriptionListTitle>
@@ -280,6 +291,13 @@ const TAGS_LABEL = i18n.translate('xpack.synthetics.management.monitorList.tags'
 const LABELS_LABEL = i18n.translate('xpack.synthetics.management.monitorList.labels', {
   defaultMessage: 'Labels',
 });
+
+const MAINTENANCE_WINDOWS_LABEL = i18n.translate(
+  'xpack.synthetics.management.monitorList.maintenanceWindows',
+  {
+    defaultMessage: 'Maintenance windows',
+  }
+);
 
 const ENABLED_LABEL = i18n.translate('xpack.synthetics.detailsPanel.monitorDetails.enabled', {
   defaultMessage: 'Enabled (all locations)',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_maintenance_windows.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_maintenance_windows.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MonitorMaintenanceWindows } from './monitor_maintenance_windows';
+
+const mockUseMaintenanceWindows = jest.fn();
+
+jest.mock('../../monitor_add_edit/fields/maintenance_windows/use_maintenance_windows', () => ({
+  useMaintenanceWindows: () => mockUseMaintenanceWindows(),
+}));
+
+jest.mock(
+  '../../monitor_add_edit/fields/maintenance_windows/create_maintenance_windows_btn',
+  () => ({
+    MaintenanceWindowsLink: ({ id, label }: { id?: string; label?: string }) => (
+      <a data-test-subj={`mwLink-${id}`}>{label}</a>
+    ),
+  })
+);
+
+describe('MonitorMaintenanceWindows', () => {
+  beforeEach(() => {
+    mockUseMaintenanceWindows.mockReset();
+  });
+
+  it('resolves maintenance window ids to their titles', () => {
+    mockUseMaintenanceWindows.mockReturnValue({
+      isLoading: false,
+      data: {
+        data: [
+          { id: 'mw-1', title: 'Weekend window' },
+          { id: 'mw-2', title: 'Nightly window' },
+        ],
+      },
+    });
+
+    render(<MonitorMaintenanceWindows monitorMWs={['mw-1', 'mw-2']} />);
+
+    expect(screen.getByTestId('mwLink-mw-1')).toHaveTextContent('Weekend window');
+    expect(screen.getByTestId('mwLink-mw-2')).toHaveTextContent('Nightly window');
+  });
+
+  it('falls back to the id when the window title cannot be resolved', () => {
+    mockUseMaintenanceWindows.mockReturnValue({
+      isLoading: false,
+      data: { data: [] },
+    });
+
+    render(<MonitorMaintenanceWindows monitorMWs={['mw-missing']} />);
+
+    expect(screen.getByTestId('mwLink-mw-missing')).toHaveTextContent('mw-missing');
+  });
+
+  it('shows a loading skeleton while windows are loading', () => {
+    mockUseMaintenanceWindows.mockReturnValue({ isLoading: true, data: undefined });
+
+    const { container } = render(<MonitorMaintenanceWindows monitorMWs={['mw-1']} />);
+
+    expect(container.querySelector('.euiSkeletonText')).toBeInTheDocument();
+    expect(screen.queryByTestId('mwLink-mw-1')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_maintenance_windows.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_maintenance_windows.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiSkeletonText } from '@elastic/eui';
+import { MaintenanceWindowsLink } from '../../monitor_add_edit/fields/maintenance_windows/create_maintenance_windows_btn';
+import { useMaintenanceWindows } from '../../monitor_add_edit/fields/maintenance_windows/use_maintenance_windows';
+
+export const MonitorMaintenanceWindows = ({ monitorMWs }: { monitorMWs: string[] }) => {
+  const { isLoading, data } = useMaintenanceWindows();
+
+  const titleById = useMemo(() => {
+    const map = new Map<string, string>();
+    data?.data?.forEach((mw) => map.set(mw.id, mw.title));
+    return map;
+  }, [data]);
+
+  if (isLoading && !data) {
+    return <EuiSkeletonText lines={1} />;
+  }
+
+  return (
+    <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+      {monitorMWs.map((id) => (
+        <EuiFlexItem grow={false} key={id}>
+          <MaintenanceWindowsLink id={id} label={titleById.get(id) ?? id} />
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/maintenance_windows/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/maintenance_windows/api.ts
@@ -14,6 +14,10 @@ export const getMaintenanceWindows = async (): Promise<FindMaintenanceWindowsRes
     '/internal/alerting/rules/maintenance_window/_find',
     {
       version: INITIAL_REST_VERSION,
+      // Request the route's max page size so monitors attached to windows beyond
+      // the default first page (10) still resolve their titles in the details panel
+      // and the add/edit picker, instead of falling back to the raw window ID.
+      per_page: 100,
     }
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- [[Synthetics] Show attached maintenance windows in monitor details (#281853)](https://github.com/elastic/kibana/pull/281853)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":281853,"url":"https://github.com/elastic/kibana/pull/281853","title":"[Synthetics] Show attached maintenance windows in monitor details"},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"sourceCommit":{"sha":"2f4ecebae916edf0e05dd859873369c75d5025f9"}}] BACKPORT-->

Made with [Cursor](https://cursor.com)