### PR TITLE
[Console] Keep console definitions sync cron green

### DIFF
--- a/.buildkite/scripts/steps/console_definitions_sync.sh
+++ b/.buildkite/scripts/steps/console_definitions_sync.sh
@@ -39,6 +39,9 @@ main() {
     --emptyDest \
     --skipOverrideAudit
 
+  # Generated definitions need human review before merge.
+  local auto_merge=false
+
   create_sync_pr \
     "$GIT_SCOPE" \
     "[Console] Update console definitions (${BUILDKITE_BRANCH})" \
@@ -46,7 +49,7 @@ main() {
     "console_definitions_sync" \
     "Update console definitions" \
     "console_defs_existing_pr" \
-    true \
+    "$auto_merge" \
     'backport:skip' 'release_note:skip' 'Feature:Console' 'Team:Kibana Management'
 }
 

--- a/.buildkite/scripts/steps/console_definitions_sync.sh
+++ b/.buildkite/scripts/steps/console_definitions_sync.sh
@@ -8,6 +8,17 @@ source "$(dirname "${BASH_SOURCE[0]}")/console_definitions/sync_pr_lib.sh"
 # whose output lives under kibana_api_doc_links/ in the same parent directory.
 GIT_SCOPE="src/platform/plugins/shared/console/server/lib/spec_definitions/json"
 
+CONSOLE_DEFINITIONS_SYNC_PR_BODY=$'This PR updates the console definitions to match the latest ones from the @elastic/elasticsearch-specification repo.
+
+## If override conflict CI fails
+
+PR CI runs the override conflict contract test in `@kbn/generate-console-definitions`. If `kibana-ci` fails on that test, a curated override is masking changed generated rules.
+
+1. Review each reported conflict in the Jest log.
+2. Keep the override only if it is still intentional; otherwise update or remove it.
+3. Run `node scripts/audit_console_definition_overrides.js --updateOverrideAudit`.
+4. Commit the updated `packages/kbn-generate-console-definitions/src/override_conflict_baseline.json`.'
+
 main() {
   cd "$PARENT_DIR"
 
@@ -28,36 +39,15 @@ main() {
     --emptyDest \
     --skipOverrideAudit
 
-  echo "--- Auditing curated override conflicts"
-  local audit_output
-  local audit_status
-  set +e
-  audit_output=$(node scripts/audit_console_definition_overrides.js 2>&1)
-  audit_status=$?
-  set -e
-  echo "$audit_output"
-
-  local auto_merge=true
-  local pr_body='This PR updates the console definitions to match the latest ones from the @elastic/elasticsearch-specification repo.'
-  if [ $audit_status -ne 0 ]; then
-    echo "Override conflict audit requires human review; creating a PR without auto-merge."
-    auto_merge=false
-    pr_body+=$'\n\n## Override conflict audit\n\nThis specification update changes generated body rules that curated overrides replace. Review each conflict, fix stale overrides, and update the approved conflict baseline only when the remaining replacements are intentional.\n\n```\n'
-    pr_body+="$audit_output"
-    pr_body+=$'\n```'
-  fi
-
   create_sync_pr \
     "$GIT_SCOPE" \
     "[Console] Update console definitions (${BUILDKITE_BRANCH})" \
-    "$pr_body" \
+    "$CONSOLE_DEFINITIONS_SYNC_PR_BODY" \
     "console_definitions_sync" \
     "Update console definitions" \
     "console_defs_existing_pr" \
-    "$auto_merge" \
+    true \
     'backport:skip' 'release_note:skip' 'Feature:Console' 'Team:Kibana Management'
-
-  return $audit_status
 }
 
 main

--- a/.buildkite/scripts/steps/console_definitions_sync.test.ts
+++ b/.buildkite/scripts/steps/console_definitions_sync.test.ts
@@ -114,14 +114,14 @@ printf '%s\\n' "$*" > "\${TEST_ROOT}/buildkite-agent-args"
 };
 
 describe('WHEN Console definitions are synchronized', () => {
-  it('SHOULD open a PR with override conflict runbook and enable auto-merge', () => {
+  it('SHOULD open a PR with override-conflict instructions in the body and without auto-merge', () => {
     const result = runSync();
     try {
       expect(result.status).toBe(0);
       expect(result.prCreateArgs).toContain('If override conflict CI fails');
       expect(result.prCreateArgs).toContain('--updateOverrideAudit');
       expect(result.prCreateArgs).toContain('override_conflict_baseline.json');
-      expect(result.autoMergeCalled).toBe(true);
+      expect(result.autoMergeCalled).toBe(false);
       expect(result.prCreateArgs).toContain('--label backport:skip');
     } finally {
       result.cleanup();
@@ -136,7 +136,7 @@ describe('WHEN Console definitions are synchronized', () => {
     try {
       expect(result.status).toBe(0);
       expect(result.prCreateArgs).toContain('[Console] Update console definitions (main)');
-      expect(result.autoMergeCalled).toBe(true);
+      expect(result.autoMergeCalled).toBe(false);
     } finally {
       result.cleanup();
     }

--- a/.buildkite/scripts/steps/console_definitions_sync.test.ts
+++ b/.buildkite/scripts/steps/console_definitions_sync.test.ts
@@ -23,16 +23,14 @@ const writeExecutable = (file: string, content: string) => {
 };
 
 const runSync = ({
-  auditStatus,
   existingPr = false,
   script = SYNC_SCRIPT,
   statusOutput = ' M src/platform/plugins/shared/console/server/lib/spec_definitions/json/generated/search.json',
 }: {
-  auditStatus: number;
   existingPr?: boolean;
   script?: string;
   statusOutput?: string;
-}) => {
+} = {}) => {
   const root = fs.mkdtempSync(Path.join(os.tmpdir(), 'console-definitions-sync-'));
   const fakeBin = Path.resolve(root, 'bin');
   const kibanaDir = Path.resolve(root, 'kibana');
@@ -55,17 +53,7 @@ fi
 exit 0
 `
   );
-  writeExecutable(
-    Path.resolve(fakeBin, 'node'),
-    `#!/usr/bin/env bash
-if [[ "$*" == *"audit_console_definition_overrides.js"* ]]; then
-  echo "Changed conflicts:"
-  echo "  - watcher.put_watch::throttle_period"
-  exit "\${TEST_AUDIT_STATUS}"
-fi
-exit 0
-`
-  );
+  writeExecutable(Path.resolve(fakeBin, 'node'), '#!/usr/bin/env bash\nexit 0\n');
   writeExecutable(
     Path.resolve(fakeBin, 'gh'),
     `#!/usr/bin/env bash
@@ -105,7 +93,6 @@ printf '%s\\n' "$*" > "\${TEST_ROOT}/buildkite-agent-args"
       BUILDKITE_BRANCH: 'main',
       KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true',
       TEST_ROOT: root,
-      TEST_AUDIT_STATUS: String(auditStatus),
       TEST_EXISTING_PR: String(existingPr),
       TEST_PR_TITLE: PR_TITLE,
       TEST_STATUS_OUTPUT: statusOutput,
@@ -127,23 +114,13 @@ printf '%s\\n' "$*" > "\${TEST_ROOT}/buildkite-agent-args"
 };
 
 describe('WHEN Console definitions are synchronized', () => {
-  it('SHOULD open an audit-report PR without auto-merge and fail the build', () => {
-    const result = runSync({ auditStatus: 1 });
-    try {
-      expect(result.status).toBe(1);
-      expect(result.prCreateArgs).toContain('Override conflict audit');
-      expect(result.prCreateArgs).toContain('watcher.put_watch::throttle_period');
-      expect(result.autoMergeCalled).toBe(false);
-    } finally {
-      result.cleanup();
-    }
-  });
-
-  it('SHOULD keep auto-merge enabled when the audit passes', () => {
-    const result = runSync({ auditStatus: 0 });
+  it('SHOULD open a PR with override conflict runbook and enable auto-merge', () => {
+    const result = runSync();
     try {
       expect(result.status).toBe(0);
-      expect(result.prCreateArgs).not.toContain('Override conflict audit');
+      expect(result.prCreateArgs).toContain('If override conflict CI fails');
+      expect(result.prCreateArgs).toContain('--updateOverrideAudit');
+      expect(result.prCreateArgs).toContain('override_conflict_baseline.json');
       expect(result.autoMergeCalled).toBe(true);
       expect(result.prCreateArgs).toContain('--label backport:skip');
     } finally {
@@ -153,7 +130,6 @@ describe('WHEN Console definitions are synchronized', () => {
 
   it('SHOULD open a PR when generation only adds new scoped files', () => {
     const result = runSync({
-      auditStatus: 0,
       statusOutput:
         '?? src/platform/plugins/shared/console/server/lib/spec_definitions/json/generated/new_endpoint.json',
     });
@@ -166,10 +142,10 @@ describe('WHEN Console definitions are synchronized', () => {
     }
   });
 
-  it('SHOULD remind the team instead of opening a duplicate unsafe PR', () => {
-    const result = runSync({ auditStatus: 1, existingPr: true });
+  it('SHOULD remind the team instead of opening a duplicate PR', () => {
+    const result = runSync({ existingPr: true });
     try {
-      expect(result.status).toBe(1);
+      expect(result.status).toBe(0);
       expect(result.prCreateArgs).toBeUndefined();
       expect(result.autoMergeCalled).toBe(false);
       expect(result.buildkiteAgentArgs).toContain('slack:console_defs_existing_pr:body');
@@ -179,7 +155,7 @@ describe('WHEN Console definitions are synchronized', () => {
   });
 
   it('SHOULD preserve API doc-links PR labels and auto-merge behavior', () => {
-    const result = runSync({ auditStatus: 0, script: DOC_LINKS_SYNC_SCRIPT });
+    const result = runSync({ script: DOC_LINKS_SYNC_SCRIPT });
     try {
       expect(result.status).toBe(0);
       expect(result.prCreateArgs).toContain('[Console] Update Kibana API doc links (main)');

--- a/packages/kbn-generate-console-definitions/README.md
+++ b/packages/kbn-generate-console-definitions/README.md
@@ -15,7 +15,7 @@ The audit can also be run without regenerating definitions:
 node scripts/audit_console_definition_overrides.js
 ```
 
-The weekly definitions sync only regenerates definitions and opens a PR with generic override-resolution instructions. Override conflicts are enforced in PR CI by the committed-definitions test in [`audit_overrides.test.ts`](./src/audit_overrides.test.ts), which fails until the reviewed baseline is committed. A later weekly run does not update or duplicate an open sync PR; it sends the existing-PR Slack reminder instead.
+The weekly definitions sync only regenerates definitions and opens a PR with generic override-resolution instructions. Sync PRs do not auto-merge; a human reviews the generated definitions before merge. Override conflicts are enforced in PR CI by the committed-definitions test in [`audit_overrides.test.ts`](./src/audit_overrides.test.ts), which fails until the reviewed baseline is committed. A later weekly run does not update or duplicate an open sync PR; it sends the existing-PR Slack reminder instead.
 
 ## Functionality
 This script generates definitions for all endpoints defined in the ES specification at once. 

--- a/packages/kbn-generate-console-definitions/README.md
+++ b/packages/kbn-generate-console-definitions/README.md
@@ -15,7 +15,7 @@ The audit can also be run without regenerating definitions:
 node scripts/audit_console_definition_overrides.js
 ```
 
-The weekly definitions sync separates generation from this audit. If generation succeeds but the audit fails, it includes the audit report in one sync PR, disables auto-merge, and leaves the scheduled build failing for human review. A later weekly run does not update or duplicate that PR while it remains open; it sends the existing-PR Slack reminder instead.
+The weekly definitions sync only regenerates definitions and opens a PR with generic override-resolution instructions. Override conflicts are enforced in PR CI by the committed-definitions test in [`audit_overrides.test.ts`](./src/audit_overrides.test.ts), which fails until the reviewed baseline is committed. A later weekly run does not update or duplicate an open sync PR; it sends the existing-PR Slack reminder instead.
 
 ## Functionality
 This script generates definitions for all endpoints defined in the ES specification at once. 


### PR DESCRIPTION
## Summary

- Stop failing the weekly `kibana-console-definitions-sync` Buildkite job when override conflicts need review.
- The cron now only regenerates definitions and opens a sync PR with a generic override-resolution runbook.
- Override conflicts stay enforced in PR CI via the committed-definitions contract test in `packages/kbn-generate-console-definitions`.

## Why

A red cron build reads as "automation failed" even when the sync succeeded and opened the right PR. The mechanical merge gate already lives on the sync PR itself: `kibana-ci` stays red until someone reviews conflicts and commits an updated `override_conflict_baseline.json`.

## Test plan

- [x] `npx --prefix .buildkite jest --config .buildkite/jest.config.js --rootDir .buildkite scripts/steps/console_definitions_sync.test.ts`

Assisted with Cursor using Composer

Made with [Cursor](https://cursor.com)