### PR TITLE
[One Workflow] Label connector spec changes

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -13,6 +13,8 @@
     - 'src/platform/packages/shared/kbn-connector-specs/src/specs/shodan/**/*.*'
     - 'src/platform/packages/shared/kbn-connector-specs/src/specs/urlvoid/**/*.*'
     - 'src/platform/packages/shared/kbn-connector-specs/src/specs/virustotal/**/*.*'
+- 'connectors-v2':
+    - 'src/platform/packages/shared/kbn-connector-specs/**/*.*'
 - 'Feature:Embedding':
     - 'src/platform/plugins/shared/embeddable/**/*.*'
     - 'src/plugins/dashboard_embeddable_container/**/*.*'


### PR DESCRIPTION
## Summary

- Automatically apply the `connectors-v2` label when a PR changes files in `src/platform/packages/shared/kbn-connector-specs`
- Allow connector-spec PR activity to be routed to subscribed channels

Made with [Cursor](https://cursor.com)