### PR TITLE
[Security Solution] Improve fallback document fetch for restored indices

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.test.tsx
@@ -128,9 +128,12 @@ describe('useTimelineEventsDetails - broadened index retry (SDH #1666)', () => {
 
     // Two calls: primary (stale) then the broadened pattern.
     expect(search).toHaveBeenCalledTimes(2);
+    // Primary lookup keeps its request unchanged: it must NOT opt into hidden-index expansion.
     expect(search.mock.calls[0][0]).toEqual(expect.objectContaining({ indexName: STALE_INDEX }));
+    expect(search.mock.calls[0][0]).not.toHaveProperty('includeHiddenIndices', true);
+    // Only the fallback retry broadens the index name AND opts into hidden-index expansion.
     expect(search.mock.calls[1][0]).toEqual(
-      expect.objectContaining({ indexName: BROADENED_INDEX })
+      expect.objectContaining({ indexName: BROADENED_INDEX, includeHiddenIndices: true })
     );
     expect(addError).not.toHaveBeenCalled();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.tsx
@@ -120,7 +120,13 @@ export const useTimelineEventsDetails = ({
       const retryWithFallback = () => {
         attemptedFallbackRef.current = true;
         searchSubscription$.current.unsubscribe();
-        timelineDetailsSearch({ ...request, indexName: fallbackIndex as string });
+        // `includeHiddenIndices` is set only here so the server broadens wildcard expansion to hidden
+        // indices for the fallback lookup only, leaving the primary request unchanged.
+        timelineDetailsSearch({
+          ...request,
+          indexName: fallbackIndex as string,
+          includeHiddenIndices: true,
+        });
       };
 
       const asyncSearch = async () => {

--- a/x-pack/solutions/security/plugins/timelines/common/api/search_strategy/timeline/events_details.ts
+++ b/x-pack/solutions/security/plugins/timelines/common/api/search_strategy/timeline/events_details.ts
@@ -16,6 +16,11 @@ export const timelineEventsDetailsSchema = requestPaginated.partial().extend({
   authFilter: z.object({}).optional(),
   runtimeMappings,
   factoryQueryType: z.literal(TimelineEventsQueries.details),
+  /**
+   * When `true`, hidden indices are included in wildcard expansion for the lookup.
+   * Left unset by default. Used for example for the  fallback retry.
+   */
+  includeHiddenIndices: z.boolean().optional(),
 });
 
 export type TimelineEventsDetailsRequestOptionsInput = z.input<typeof timelineEventsDetailsSchema>;

--- a/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/index.ts
+++ b/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/index.ts
@@ -20,24 +20,30 @@ import { buildEcsObjects } from '../../helpers/build_ecs_objects';
 export const timelineEventsDetails: TimelineFactory<TimelineEventsQueries.details> = {
   buildDsl: (parsedRequest) => {
     const { authFilter, ...options } = parsedRequest;
-    const { indexName, eventId, runtimeMappings = {} } = options;
+    const { indexName, eventId, runtimeMappings = {}, includeHiddenIndices } = options;
     return buildTimelineDetailsQuery({
       indexName,
       id: eventId,
       runtimeMappings,
       authFilter,
+      includeHiddenIndices,
     });
   },
   parse: async (
     options,
     response: IEsSearchResponse<EventHit>
   ): Promise<TimelineEventsDetailsStrategyResponse> => {
-    const { indexName, eventId, runtimeMappings = {} } = options;
+    const { indexName, eventId, runtimeMappings = {}, includeHiddenIndices } = options;
 
     const inspect = {
       dsl: [
         inspectStringifyObject(
-          buildTimelineDetailsQuery({ indexName, id: eventId, runtimeMappings })
+          buildTimelineDetailsQuery({
+            indexName,
+            id: eventId,
+            runtimeMappings,
+            includeHiddenIndices,
+          })
         ),
       ],
     };

--- a/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.test.ts
+++ b/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.test.ts
@@ -57,4 +57,29 @@ describe('buildTimelineDetailsQuery', () => {
       }
     `);
   });
+
+  it('does not set expand_wildcards when includeHiddenIndices is omitted (primary lookup)', () => {
+    const query = buildTimelineDetailsQuery({
+      indexName: '.ds-logs-endpoint.events-default-2026.05.17-000001',
+      id: 'some-id',
+      runtimeMappings: {},
+    });
+
+    expect(query).not.toHaveProperty('expand_wildcards');
+  });
+
+  it('includes hidden indices in wildcard expansion when includeHiddenIndices is true (fallback)', () => {
+    const query = buildTimelineDetailsQuery({
+      indexName: '*.ds-logs-endpoint.events-default-2026.05.17-000001',
+      id: 'some-id',
+      runtimeMappings: {},
+      includeHiddenIndices: true,
+    });
+
+    expect(query).toEqual(
+      expect.objectContaining({
+        expand_wildcards: ['open', 'hidden'],
+      })
+    );
+  });
 });

--- a/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
+import type { ExpandWildcards, MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
 import type { JsonObject } from '@kbn/utility-types';
 import type { RunTimeMappings } from '../../../../../../common/api/search_strategy/model/runtime_mappings';
 
@@ -14,11 +14,13 @@ export const buildTimelineDetailsQuery = ({
   id,
   indexName,
   runtimeMappings,
+  includeHiddenIndices = false,
 }: {
   authFilter?: JsonObject;
   id: string;
   indexName: string;
   runtimeMappings: RunTimeMappings;
+  includeHiddenIndices?: boolean;
 }) => {
   const basicFilter = {
     terms: {
@@ -42,6 +44,11 @@ export const buildTimelineDetailsQuery = ({
     allow_no_indices: true,
     index: indexName,
     ignore_unavailable: true,
+    // Only the client-side fallback retry sets `includeHiddenIndices`. It broadens the index name
+    // with a `*` prefix to resolve documents whose backing index was relocated to a searchable-
+    // snapshot tier and remounted as a hidden `restored-`/`partial-` index, and needs hidden indices
+    // included in wildcard expansion to match them.
+    ...(includeHiddenIndices ? { expand_wildcards: ['open', 'hidden'] as ExpandWildcards } : {}),
     query,
     fields: [
       { field: '*', include_unmapped: true },


### PR DESCRIPTION
> [!NOTE]
> The fix merged in https://github.com/elastic/kibana/pull/277703 was not sufficient. This is a server-side follow up that should hopefully solve the issue for good.

## Summary

This PR makes the "Source event" fallback lookup also resolve documents that live in **hidden** `restored-`/`partial-` indices.

### Prior work

In the previous [PR](https://github.com/elastic/kibana/pull/277703), we added a client-side fallback: when opening the `Source event` from an alert's `Highlighted Fields` fails (because the document's backing index was relocated to a searchable-snapshot tier and remounted under a `restored-` prefix), we retry once against a broadened index pattern (`*`-prefixed) so it can match the renamed index.

That fix worked in local testing but **did not resolve the customer's case** (still reproducing after upgrading). The reason: the `restored-` indices produced by ILM's `searchable_snapshot` action — and `.ds-` datastream backing indices in general — are **hidden** indices. A wildcard pattern (`*.ds-...`) only matches hidden indices when the search request sets `expand_wildcards` to include `hidden`. The timeline event-details query never set `expand_wildcards`, so Elasticsearch defaulted to `open` and the broadened retry still returned no hit.

> [!TIP]
> Manual test masked this because it created the `restored-` index with a plain `_reindex`, which produces a **non-hidden** index — so the wildcard matched and the fix appeared to work.

https://github.com/user-attachments/assets/31593ff0-ca97-4d6e-aaf7-77d575a3589b

### Solutions explored

The straightforward option was to always add `expand_wildcards: ['open', 'hidden']` to `buildTimelineDetailsQuery`. But that query is shared by every event-details lookup, including legitimate primary lookups that already pass a broad index *pattern* (e.g. `DocumentFlyoutWrapperFromPattern`, used for notes). Always expanding to hidden indices would silently change behavior for those calls too.

To keep the same additive/no-impact mindset as #277703, the change is scoped to the fallback only:

- A new optional `includeHiddenIndices` flag is added to the `eventsDetails` search-strategy request.
- The **primary** lookup leaves it unset, so its request is byte-for-byte unchanged (no `expand_wildcards` key at all).
- The **client fallback retry** is the only caller that sets `includeHiddenIndices: true`, and only then does `buildTimelineDetailsQuery` add `expand_wildcards: ['open', 'hidden']`.

Since exact index names resolve regardless of hidden status, the only behavioral change is: "when we retry a failed by-id lookup against a broadened pattern, also look inside hidden indices" — which is exactly the intended fix.

https://github.com/user-attachments/assets/ea1120fc-83b7-4269-b195-53caff455948

## How to test

- generate some documents locally (`yarn test:generate`)
- generate some alerts off of those documents (install the `Endpoint Security` rule)

Use Kibana Dev Tools to make one alert's source event only available in a **hidden** `restored-` index (the `index.hidden: true` setting is the important difference vs #277703).

Find one alert with ancestor index/id:
```
GET .alerts-security.alerts-*/_search
{
  "size": 5,
  "_source": ["kibana.alert.ancestors", "kibana.alert.rule.name", "@timestamp"],
  "query": { "exists": { "field": "kibana.alert.ancestors.index" } },
  "sort": [{ "@timestamp": "desc" }]
}
```

Pick one ancestor event entry and note:
```
OLD_INDEX = kibana.alert.ancestors.index
EVENT_ID  = kibana.alert.ancestors.id
```

Create a **hidden** restored-style index and copy only that event:
```
PUT restored-OLD_INDEX
{
  "settings": { "index.hidden": true }
}

POST _reindex
{
  "source": { "index": "OLD_INDEX", "query": { "ids": { "values": ["EVENT_ID"] } } },
  "dest":   { "index": "restored-OLD_INDEX", "op_type": "create" }
}
```

Remove it from the original index so the primary lookup fails (this triggers the fallback):
```
POST OLD_INDEX/_delete_by_query
{
  "query": { "ids": { "values": ["EVENT_ID"] } }
}
```

Then open that alert, expand the details flyout, and click `Source event` in `Highlighted Fields`:
- **Before this PR:** the fallback retries but still errors, because the hidden `restored-` index isn't matched by the wildcard.
- **With this PR:** the source-event preview opens and shows the document.

> Note: the `Source event` link is only rendered in the legacy flyout. If you have the `securitySolution:enableNewFlyout` advanced setting on, turn it off to test this flow.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->