### PR TITLE
[Alerting] Return a clear 400 when an organization-level UIAM API key is used for rule operations

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/moon.yml
+++ b/x-pack/platform/plugins/shared/alerting/moon.yml
@@ -89,6 +89,7 @@ dependsOn:
   - '@kbn/core-elasticsearch-server-mocks'
   - '@kbn/core-saved-objects-server-mocks'
   - '@kbn/scout'
+  - '@kbn/mock-idp-utils'
   - '@kbn/encrypted-saved-objects-shared'
   - '@kbn/core-analytics-server-mocks'
   - '@kbn/cps-server-utils'

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client_factory.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client_factory.test.ts
@@ -843,6 +843,68 @@ describe('RulesClientFactory', () => {
     );
   });
 
+  test('getAuthenticationAPIKey() throws a 400 when the request is authenticated with a raw organization-level UIAM API key', async () => {
+    const factory = new RulesClientFactory();
+    factory.initialize({
+      ...rulesClientFactoryParams,
+      securityService,
+      securityPluginSetup,
+      securityPluginStart,
+      shouldGrantUiam: true,
+    });
+
+    // Organization-level keys are presented as the raw `essu_` secret, not `base64(id:key)`
+    const request = mockRouter.createKibanaRequest({
+      headers: {
+        authorization: `ApiKey essu_raw_org_level_key`,
+      },
+    });
+
+    await factory.create(request, savedObjectsService);
+    const constructorCall = jest.requireMock('./rules_client').RulesClient.mock.calls[0][0];
+
+    let thrownError;
+    try {
+      constructorCall.getAuthenticationAPIKey('test');
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError.isBoom).toBe(true);
+    expect(thrownError.output.statusCode).toBe(400);
+    expect(thrownError.message).toMatchInlineSnapshot(
+      `"Cannot use an organization-level API key to create or enable rule \\"test\\". Organization-level API keys are not supported for rule operations; use a project-scoped Elasticsearch API key instead."`
+    );
+  });
+
+  test('getAuthenticationAPIKey() returns uiamResult for a framework-granted UIAM API key encoded as base64(id:key)', async () => {
+    const factory = new RulesClientFactory();
+    factory.initialize({
+      ...rulesClientFactoryParams,
+      securityService,
+      securityPluginSetup,
+      securityPluginStart,
+      shouldGrantUiam: true,
+    });
+
+    const request = mockRouter.createKibanaRequest({
+      headers: {
+        authorization: `ApiKey ${Buffer.from('uiam-key-id:essu_granted_key').toString('base64')}`,
+      },
+    });
+
+    await factory.create(request, savedObjectsService);
+    const constructorCall = jest.requireMock('./rules_client').RulesClient.mock.calls[0][0];
+
+    expect(constructorCall.getAuthenticationAPIKey('test')).toEqual({
+      apiKeysEnabled: true,
+      uiamResult: {
+        name: 'uiam-test',
+        id: 'uiam-key-id',
+        api_key: 'essu_granted_key',
+      },
+    });
+  });
+
   test('cloneAPIKey is always defined on the context', async () => {
     const factory = new RulesClientFactory();
     factory.initialize({

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client_factory.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client_factory.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
 import type {
   KibanaRequest,
   Logger,
@@ -487,6 +488,18 @@ export class RulesClientFactory {
       getAuthenticationAPIKey(name: string) {
         const authorizationHeader = HTTPAuthorizationHeader.parseFromRequest(request);
         if (authorizationHeader && authorizationHeader.credentials) {
+          // A raw UIAM credential (`essu_...`) means the request was authenticated with a
+          // user-created organization-level API key. Unlike framework-granted UIAM keys
+          // (encoded as `base64(id:key)`), it carries no key id, so it cannot be persisted on
+          // the rule for execution and invalidation bookkeeping.
+          if (isUiamCredential(authorizationHeader)) {
+            throw Boom.badRequest(
+              `Cannot use an organization-level API key to create or enable rule "${name}". ` +
+                `Organization-level API keys are not supported for rule operations; ` +
+                `use a project-scoped Elasticsearch API key instead.`
+            );
+          }
+
           const [apiKeyId, apiKey] = Buffer.from(authorizationHeader.credentials, 'base64')
             .toString()
             .split(':');

--- a/x-pack/platform/plugins/shared/alerting/test/scout_uiam_local/api/parallel.playwright.config.ts
+++ b/x-pack/platform/plugins/shared/alerting/test/scout_uiam_local/api/parallel.playwright.config.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './parallel_tests',
+  workers: 2,
+});

--- a/x-pack/platform/plugins/shared/alerting/test/scout_uiam_local/api/parallel_tests/global.setup.ts
+++ b/x-pack/platform/plugins/shared/alerting/test/scout_uiam_local/api/parallel_tests/global.setup.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { globalSetupHook } from '@kbn/scout';
+
+globalSetupHook('To make ESLint happy', async () => {});

--- a/x-pack/platform/plugins/shared/alerting/test/scout_uiam_local/api/parallel_tests/org_level_uiam_api_key.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting/test/scout_uiam_local/api/parallel_tests/org_level_uiam_api_key.spec.ts
@@ -8,10 +8,11 @@
 import { MOCK_IDP_UIAM_ORG_ADMIN_API_KEY } from '@kbn/mock-idp-utils';
 import { apiTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
+import { COMMON_HEADERS, ES_QUERY_RULE_PARAMS } from '../../../scout/api/fixtures/constants';
 
-const COMMON_HEADERS = {
-  'Content-Type': 'application/json;charset=UTF-8',
-  'kbn-xsrf': 'some-xsrf-token',
+const ORG_KEY_HEADERS = {
+  ...COMMON_HEADERS,
+  Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
 };
 
 const getRuleBody = (name: string, enabled: boolean) => ({
@@ -21,17 +22,7 @@ const getRuleBody = (name: string, enabled: boolean) => ({
   enabled,
   schedule: { interval: '1m' },
   actions: [],
-  params: {
-    searchType: 'esQuery',
-    esQuery: '{"query":{"match_all":{}}}',
-    index: ['alerting-test-index'],
-    timeField: '@timestamp',
-    threshold: [0],
-    thresholdComparator: '>',
-    size: 10,
-    timeWindowSize: 5,
-    timeWindowUnit: 'm',
-  },
+  params: ES_QUERY_RULE_PARAMS,
 });
 
 // These tests cannot be run on MKI because they rely on the Mock IdP UIAM setup.
@@ -39,6 +30,15 @@ apiTest.describe(
   '[NON-MKI] Rule operations with an organization-level UIAM API key',
   { tag: tags.serverless.all },
   () => {
+    let createdRuleId: string | undefined;
+
+    apiTest.afterAll(async ({ apiClient }) => {
+      if (!createdRuleId) return;
+      await apiClient.delete(`api/alerting/rule/${createdRuleId}`, {
+        headers: ORG_KEY_HEADERS,
+      });
+    });
+
     apiTest(
       'creating an enabled rule fails with a clear 400 instead of a parse error',
       async ({ apiClient }) => {
@@ -46,10 +46,7 @@ apiTest.describe(
         // so the "reuse the caller's key" path cannot persist it on the rule and must reject it
         // with an actionable message.
         const response = await apiClient.post('api/alerting/rule', {
-          headers: {
-            ...COMMON_HEADERS,
-            Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
-          },
+          headers: ORG_KEY_HEADERS,
           responseType: 'json',
           body: getRuleBody('org-level-key-enabled-rule', true),
         });
@@ -65,23 +62,17 @@ apiTest.describe(
       'creating a disabled rule succeeds (no rule API key is resolved for disabled rules)',
       async ({ apiClient }) => {
         const createResponse = await apiClient.post('api/alerting/rule', {
-          headers: {
-            ...COMMON_HEADERS,
-            Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
-          },
+          headers: ORG_KEY_HEADERS,
           responseType: 'json',
           body: getRuleBody('org-level-key-disabled-rule', false),
         });
 
         expect(createResponse).toHaveStatusCode(200);
-        const ruleId = createResponse.body.id;
+        createdRuleId = createResponse.body.id;
 
         // Enabling the rule afterwards resolves an API key and must fail with the same clear 400.
-        const enableResponse = await apiClient.post(`api/alerting/rule/${ruleId}/_enable`, {
-          headers: {
-            ...COMMON_HEADERS,
-            Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
-          },
+        const enableResponse = await apiClient.post(`api/alerting/rule/${createdRuleId}/_enable`, {
+          headers: ORG_KEY_HEADERS,
           responseType: 'json',
         });
 
@@ -89,15 +80,6 @@ apiTest.describe(
         expect(enableResponse.body.message).toContain(
           'Organization-level API keys are not supported for rule operations'
         );
-
-        // Cleanup — deleting a disabled rule does not touch the API key path.
-        const deleteResponse = await apiClient.delete(`api/alerting/rule/${ruleId}`, {
-          headers: {
-            ...COMMON_HEADERS,
-            Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
-          },
-        });
-        expect(deleteResponse).toHaveStatusCode(204);
       }
     );
   }

--- a/x-pack/platform/plugins/shared/alerting/test/scout_uiam_local/api/parallel_tests/org_level_uiam_api_key.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting/test/scout_uiam_local/api/parallel_tests/org_level_uiam_api_key.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MOCK_IDP_UIAM_ORG_ADMIN_API_KEY } from '@kbn/mock-idp-utils';
+import { apiTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+
+const COMMON_HEADERS = {
+  'Content-Type': 'application/json;charset=UTF-8',
+  'kbn-xsrf': 'some-xsrf-token',
+};
+
+const getRuleBody = (name: string, enabled: boolean) => ({
+  name,
+  rule_type_id: '.es-query',
+  consumer: 'alerts',
+  enabled,
+  schedule: { interval: '1m' },
+  actions: [],
+  params: {
+    searchType: 'esQuery',
+    esQuery: '{"query":{"match_all":{}}}',
+    index: ['alerting-test-index'],
+    timeField: '@timestamp',
+    threshold: [0],
+    thresholdComparator: '>',
+    size: 10,
+    timeWindowSize: 5,
+    timeWindowUnit: 'm',
+  },
+});
+
+// These tests cannot be run on MKI because they rely on the Mock IdP UIAM setup.
+apiTest.describe(
+  '[NON-MKI] Rule operations with an organization-level UIAM API key',
+  { tag: tags.serverless.all },
+  () => {
+    apiTest(
+      'creating an enabled rule fails with a clear 400 instead of a parse error',
+      async ({ apiClient }) => {
+        // An organization-level key is presented as the raw `essu_` secret. It carries no key id,
+        // so the "reuse the caller's key" path cannot persist it on the rule and must reject it
+        // with an actionable message.
+        const response = await apiClient.post('api/alerting/rule', {
+          headers: {
+            ...COMMON_HEADERS,
+            Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
+          },
+          responseType: 'json',
+          body: getRuleBody('org-level-key-enabled-rule', true),
+        });
+
+        expect(response).toHaveStatusCode(400);
+        expect(response.body.message).toContain(
+          'Organization-level API keys are not supported for rule operations'
+        );
+      }
+    );
+
+    apiTest(
+      'creating a disabled rule succeeds (no rule API key is resolved for disabled rules)',
+      async ({ apiClient }) => {
+        const createResponse = await apiClient.post('api/alerting/rule', {
+          headers: {
+            ...COMMON_HEADERS,
+            Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
+          },
+          responseType: 'json',
+          body: getRuleBody('org-level-key-disabled-rule', false),
+        });
+
+        expect(createResponse).toHaveStatusCode(200);
+        const ruleId = createResponse.body.id;
+
+        // Enabling the rule afterwards resolves an API key and must fail with the same clear 400.
+        const enableResponse = await apiClient.post(`api/alerting/rule/${ruleId}/_enable`, {
+          headers: {
+            ...COMMON_HEADERS,
+            Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
+          },
+          responseType: 'json',
+        });
+
+        expect(enableResponse).toHaveStatusCode(400);
+        expect(enableResponse.body.message).toContain(
+          'Organization-level API keys are not supported for rule operations'
+        );
+
+        // Cleanup — deleting a disabled rule does not touch the API key path.
+        const deleteResponse = await apiClient.delete(`api/alerting/rule/${ruleId}`, {
+          headers: {
+            ...COMMON_HEADERS,
+            Authorization: `ApiKey ${MOCK_IDP_UIAM_ORG_ADMIN_API_KEY}`,
+          },
+        });
+        expect(deleteResponse).toHaveStatusCode(204);
+      }
+    );
+  }
+);

--- a/x-pack/platform/plugins/shared/alerting/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting/tsconfig.json
@@ -84,6 +84,7 @@
     "@kbn/core-elasticsearch-server-mocks",
     "@kbn/core-saved-objects-server-mocks",
     "@kbn/scout",
+    "@kbn/mock-idp-utils",
     "@kbn/encrypted-saved-objects-shared",
     "@kbn/core-analytics-server-mocks",
     "@kbn/cps-server-utils",


### PR DESCRIPTION
## Summary

When a rule is created enabled (or enabled) and the request is authenticated with an API key, the alerting framework reuses the caller's key (`resolveRuleAPIKey` → `getAuthenticationAPIKey`) and persists it on the rule as an `(id, key)` pair for execution and invalidation bookkeeping.

A user-created **organization-level UIAM API key** is presented as the raw `essu_...` secret — unlike framework-granted UIAM keys, which are encoded as `base64(id:key)`, it carries **no key id on the wire**, so this path cannot support it. Until now the base64 decode produced garbage and the request failed with a confusing generic error:

```
Failed to parse API key credentials from authorization header for alerting rule : <name>
```

surfacing as an opaque failure to users trying to manage rules from automation (e.g. CI) with an org-level key.

### Fix

Detect the raw UIAM credential shape **before** decoding and throw `Boom.badRequest` with an actionable message:

```
Cannot use an organization-level API key to create or enable rule "<name>".
Organization-level API keys are not supported for rule operations;
use a project-scoped Elasticsearch API key instead.
```

- The suggested workaround works today: the org-level key can be used once as a bootstrap credential to mint a project-scoped ES API key (`POST /_security/api_key`), which is fully supported on this path.
- Framework-granted UIAM keys (`base64(id:essu_key)`) are unaffected — a regression test locks that in.
- The check lives in `getAuthenticationAPIKey`, so create, enable, bulk enable, update, and bulk edit all get the clear error through the same code path.

This is the "fail cleanly" step; actual support for user-created org-level UIAM keys (pending broader availability of user-created UIAM keys) is tracked separately and would require key-id resolution via UIAM plus owner-identity work.

### Testing

- [x] `node scripts/jest x-pack/platform/plugins/shared/alerting/server/rules_client_factory.test.ts` (38 passing; 2 new: raw org-level key → Boom 400 with message, encoded framework UIAM key → unchanged `uiamResult`)

## Release note

Creating or enabling an alerting rule with an organization-level API key now returns a clear 400 error explaining that organization-level API keys are not supported for rule operations, instead of a generic parse failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)