### PR TITLE
[Chrome Next] Reduce app-menu-components dependencies

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/moon.yml
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/moon.yml
@@ -18,7 +18,6 @@ project:
   sourceRoot: src/core/packages/chrome/app-menu/core-chrome-app-menu-components
 dependsOn:
   - '@kbn/i18n'
-  - '@kbn/router-utils'
   - '@kbn/core-chrome-layout-utils'
 tags:
   - shared-browser

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.tsx
@@ -11,8 +11,13 @@ import React, { useRef, type MouseEvent } from 'react';
 import { upperFirst } from 'lodash';
 import { EuiButton, EuiHideFor, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { getRouterLinkProps } from '@kbn/router-utils';
-import { createReturnFocus, getIsSelectedColor, getTooltip, isDisabled } from '../utils';
+import {
+  createReturnFocus,
+  getIsSelectedColor,
+  getLinkProps,
+  getTooltip,
+  isDisabled,
+} from '../utils';
 import { AppMenuPopover } from './app_menu_popover';
 import { SplitButtonWithNotification } from './split_button_with_notification';
 import type { AppMenuPrimaryActionItem, AppMenuSplitButtonProps } from '../types';
@@ -101,11 +106,11 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
     });
   };
 
-  const routerLinkProps =
-    href && run ? getRouterLinkProps({ href, onClick: handleClick }) : { onClick: handleClick };
+  const linkProps =
+    href && run ? getLinkProps({ href, onClick: handleClick }) : { onClick: handleClick };
 
   const commonProps = {
-    ...routerLinkProps,
+    ...linkProps,
     id: htmlId,
     'data-test-subj': testId || getAppMenuActionButtonTestSubj(id),
     iconType,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_item.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_item.tsx
@@ -11,8 +11,13 @@ import React, { useRef, type MouseEvent } from 'react';
 import { EuiHeaderLink, EuiHideFor, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { upperFirst } from 'lodash';
 import { css } from '@emotion/react';
-import { getRouterLinkProps } from '@kbn/router-utils';
-import { createReturnFocus, getIsSelectedColor, getTooltip, isDisabled } from '../utils';
+import {
+  createReturnFocus,
+  getIsSelectedColor,
+  getLinkProps,
+  getTooltip,
+  isDisabled,
+} from '../utils';
 import { AppMenuPopover } from './app_menu_popover';
 import type { AppMenuItemType } from '../types';
 import { getAppMenuItemTestSubj } from '../test_subjects';
@@ -69,8 +74,8 @@ export const AppMenuItem = ({
     });
   };
 
-  const routerLinkProps =
-    href && run ? getRouterLinkProps({ href, onClick: handleClick }) : { onClick: handleClick };
+  const linkProps =
+    href && run ? getLinkProps({ href, onClick: handleClick }) : { onClick: handleClick };
 
   const showAsSelected = hasItems ? isPopoverOpen : Boolean(isSelected);
 
@@ -101,7 +106,7 @@ export const AppMenuItem = ({
         aria-haspopup={hasItems ? 'menu' : undefined}
         isSelected={showAsSelected}
         css={buttonCss}
-        {...routerLinkProps}
+        {...linkProps}
       >
         {itemText}
       </EuiHeaderLink>

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -22,7 +22,6 @@ import {
   EuiSwitch,
   EuiToolTip,
 } from '@elastic/eui';
-import { getRouterLinkProps } from '@kbn/router-utils';
 import { AppMenuBadge } from './components/app_menu_badge';
 import { AppMenuPopoverActionButtons } from './components/app_menu_popover_action_buttons';
 import type {
@@ -35,6 +34,41 @@ import type {
 } from './types';
 import { APP_MENU_ITEM_LIMIT, DEFAULT_POPOVER_WIDTH } from './constants';
 import { APP_MENU_TEST_SUBJECTS, getAppMenuItemTestSubj } from './test_subjects';
+
+const isModifiedEvent = (event: MouseEvent) =>
+  !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+
+const isLeftClickEvent = (event: MouseEvent) => event.button === 0;
+
+/**
+ * Returns href/onClick props that let elements behave as in-app links:
+ * left-click without modifiers runs onClick (and preventDefault);
+ * modified/middle clicks keep native browser link behavior.
+ */
+export const getLinkProps = <E extends Element = Element>({
+  href,
+  onClick,
+}: {
+  href?: string;
+  onClick: (event: MouseEvent<E>) => void;
+}) => {
+  const guardedClickHandler = (event: MouseEvent<E>) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (isModifiedEvent(event) || !isLeftClickEvent(event)) {
+      return;
+    }
+
+    // Prevent regular link behavior, which causes a browser refresh.
+    event.preventDefault();
+
+    onClick(event);
+  };
+
+  return { href, onClick: guardedClickHandler };
+};
 
 const sortByOrder = <T extends { order?: number }>(items: T[]): T[] =>
   [...items].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
@@ -208,9 +242,9 @@ export const mapAppMenuItemToPanelItem = (
   };
 
   const hasClickHandler = childPanelId === undefined;
-  const routerLinkProps =
+  const linkProps =
     item?.href && item?.run && hasClickHandler
-      ? getRouterLinkProps({ href: item.href, onClick: handleClick })
+      ? getLinkProps({ href: item.href, onClick: handleClick })
       : { onClick: hasClickHandler ? handleClick : undefined };
 
   const itemTestSubj = item.testId ?? getAppMenuItemTestSubj(item.id);
@@ -236,7 +270,7 @@ export const mapAppMenuItemToPanelItem = (
     ) : (
       item?.iconType
     ),
-    ...routerLinkProps,
+    ...linkProps,
     href: item?.href,
     target: item?.href ? item?.target : undefined,
     disabled: isDisabled(item?.disableButton) || loading,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/tsconfig.json
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/tsconfig.json
@@ -18,7 +18,6 @@
   ],
   "kbn_references": [
     "@kbn/i18n",
-    "@kbn/router-utils",
     "@kbn/core-chrome-layout-utils"
   ]
 }


### PR DESCRIPTION
## Summary

This PR removes the dependency on `@kbn/router-utils` in `@kbn/core-chrome-app-menu-components` by simply copying the helper function to app menu utils.



