### PR TITLE
[Metrics Experience] Capture user interactions via PublishesInteractions interface

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
@@ -336,6 +336,7 @@ type LensRendererPrivateProps = ComponentSerializedProps & ComponentProps;
 export type LensRendererProps = Omit<LensRendererPrivateProps, 'hide_title' | 'time_range'> & {
   hidePanelTitles?: boolean;
   timeRange?: TimeRange;
+  onInteraction?: () => void;
 };
 
 /**

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/index.tsx
@@ -44,6 +44,7 @@ export type ChartProps = Pick<UnifiedMetricsGridProps, 'fetchParams'> &
     profileId: string;
     id: string;
     isSelected: boolean;
+    onInteraction?: () => void;
   };
 
 const LensWrapperMemo = React.memo(LensWrapper);
@@ -73,6 +74,7 @@ export const Chart = ({
   profileId,
   id,
   isSelected,
+  onInteraction,
 }: ChartProps) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const { euiTheme } = useEuiTheme();
@@ -124,6 +126,7 @@ export const Chart = ({
             syncTooltips={syncTooltips}
             extraDisabledActions={extraDisabledActions}
             quickActionIds={quickActionIds}
+            onInteraction={onInteraction}
           />
           {isSaveModalVisible && (
             <SaveModalComponent

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.tsx
@@ -34,6 +34,7 @@ export type LensWrapperProps = {
   disabledActions?: string[];
   extraDisabledActions?: string[];
   quickActionIds?: QuickActionIds;
+  onInteraction?: () => void;
 } & Pick<UnifiedMetricsGridProps, 'services' | 'onBrushEnd' | 'onFilter'>;
 
 const DEFAULT_DISABLED_ACTIONS = ['ACTION_CUSTOMIZE_PANEL', 'ACTION_EXPORT_CSV', 'alertRule'];
@@ -51,6 +52,7 @@ export function LensWrapper({
   syncCursor,
   extraDisabledActions = [],
   quickActionIds,
+  onInteraction,
 }: LensWrapperProps) {
   const { euiTheme } = useEuiTheme();
 
@@ -141,6 +143,7 @@ export function LensWrapper({
           onFilter={onFilter}
           syncTooltips={syncTooltips}
           syncCursor={syncCursor}
+          onInteraction={onInteraction}
         />
       </EmbeddableRendererContext.Provider>
     </div>

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_grid.tsx
@@ -328,21 +328,6 @@ const ChartItem = React.memo(
       [euiTheme.colors.vis]
     );
 
-    const recordExploredMetric = useCallback<React.MouseEventHandler<HTMLDivElement>>(
-      (event) => {
-        // Only count clicks on panel action controls (Inspect, View details, Explore in
-        // Discover, Copy to dashboard, and the overflow menu that hosts Cases), not clicks
-        // on the chart body, legend, or time series selection.
-        const isActionClick = (event.target as HTMLElement).closest(
-          '[data-test-subj^="embeddablePanelAction-"], [data-test-subj="embeddablePanelToggleMenuIcon"]'
-        );
-        if (isActionClick) {
-          onMetricExplored?.(getMetricUniqueKey(metricItem));
-        }
-      },
-      [onMetricExplored, metricItem]
-    );
-
     const applicableDimensions = useStableApplicableDimensions(
       dimensions,
       metricItem.dimensionFields
@@ -374,6 +359,11 @@ const ChartItem = React.memo(
       [index, esqlQuery, metricItem, onViewDetails]
     );
 
+    const handleMetricExplored = useCallback(
+      () => onMetricExplored?.(getMetricUniqueKey(metricItem)),
+      [onMetricExplored, metricItem]
+    );
+
     const titleHighlight = useMemo(() => {
       if (!searchTerm?.trim()) {
         return undefined;
@@ -390,7 +380,6 @@ const ChartItem = React.memo(
         isFocused={isFocused}
         isSelected={isSelected}
         onFocus={onFocusCell}
-        onClickCapture={recordExploredMetric}
       >
         <Chart
           id={metricItem.metricName}
@@ -414,6 +403,7 @@ const ChartItem = React.memo(
           quickActionIds={METRICS_QUICK_ACTION_IDS}
           userMessages={userMessages}
           profileId={profileId}
+          onInteraction={handleMetricExplored}
         />
       </A11yGridCell>
     );

--- a/src/platform/packages/shared/presentation/presentation_publishing/index.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/index.ts
@@ -203,6 +203,7 @@ export {
 export { SAVED_OBJECT_REF_NAME } from './constants';
 export { convertCamelCasedKeysToSnakeCase } from './utils/snake_case';
 export type { PublishesSearchSession } from './interfaces/fetch/publishes_search_session';
+export type { PublishesInteractions } from './interfaces/publishes_interactions';
 
 // =============================================
 // Container interfaces (merged from removed @kbn/presentation-containers package, to avoid circular dependencies between packages)

--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_interactions.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_interactions.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Observable } from "rxjs";
+
+export interface PublishesInteractions {
+  interaction$: Observable<void>;
+}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
@@ -590,6 +590,9 @@ export function initializeLayoutManager(
         layout$.next(layout);
       },
       registerChildApi: (api: DefaultEmbeddableApi) => {
+        api.interaction$.subscribe(() => {
+          console.log(`[${api.uuid}] interaction$ emit`);
+        });
         children$.next({
           ...children$.value,
           [api.uuid]: api,

--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/build_embeddable.tsx
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/build_embeddable.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { v4 as generateId } from 'uuid';
 import type { HasPanelCapabilities, HasSerializedChildState } from '@kbn/presentation-publishing';
 import { i18n } from '@kbn/i18n';
@@ -37,6 +37,8 @@ export async function buildEmbeddable<
   type: string;
 }) {
   const uuid = maybeId ?? generateId();
+  const interaction$ = new Subject<void>();
+  const onInteraction = () => interaction$.next();
 
   const finalizeApi = (apiRegistration: EmbeddableApiRegistration<SerializedState, Api>) => {
     const hasLockedHoverActions$ = new BehaviorSubject(false);
@@ -52,6 +54,7 @@ export async function buildEmbeddable<
       ...panelCapabilitiesDefaults,
       ...apiRegistration,
       uuid,
+      interaction$,
       phase$: phaseTracker.getPhase$(),
       parentApi,
       hasLockedHoverActions$,
@@ -79,7 +82,11 @@ export async function buildEmbeddable<
       parentApi,
       initializeDrilldownsManager,
     });
-    return { componentApi: api, Component };
+    return {
+      componentApi: api,
+      Component,
+      onInteraction
+    };
   } catch (e) {
     /**
      * critical error encountered when trying to build the api / embeddable;
@@ -88,8 +95,10 @@ export async function buildEmbeddable<
     return {
       componentApi: finalizeApi({
         blockingError$: new BehaviorSubject(e),
+        interaction$,
       } as unknown as EmbeddableApiRegistration<SerializedState, Api>),
       Component: () => <span />,
+      onInteraction
     };
   }
 }

--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/panel_header/presentation_panel_hover_actions_wrapper.tsx
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/panel_header/presentation_panel_hover_actions_wrapper.tsx
@@ -33,7 +33,9 @@ const customActionsStyles = css({
 });
 
 export const PresentationPanelHoverActionsWrapper = (
-  props: PropsWithChildren<PresentationPanelHoverActionsProps>
+  props: PropsWithChildren<PresentationPanelHoverActionsProps> & {
+    onInteraction: () => void;
+  }
 ) => {
   const [defaultTitle, title, hasLockedHoverActions, overrideHoverActions] =
     useBatchedPublishingSubjects(
@@ -62,6 +64,7 @@ export const PresentationPanelHoverActionsWrapper = (
         ''
       )}`}
       css={containerStyles}
+      onClick={props.onInteraction}
     >
       {OverriddenHoverActionsComponent && (
         <div className="embPanel__hoverActions" css={customActionsStyles}>

--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/presentation_panel.tsx
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/presentation_panel.tsx
@@ -43,6 +43,7 @@ const PresentationPanelChrome = <
   titleHighlight,
   setDragHandle,
   componentApi,
+  onInteraction,
 }: React.PropsWithChildren<
   Omit<
     PresentationPanelProps<ApiType, ComponentPropsType>,
@@ -110,6 +111,7 @@ const PresentationPanelChrome = <
         showBorder,
       }}
       setDragHandle={setDragHandle}
+      onInteraction={onInteraction}
     >
       <EuiPanel
         role="figure"

--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/types.ts
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/types.ts
@@ -67,6 +67,8 @@ export interface PresentationPanelProps<
    * Optional search term to highlight in the panel title
    */
   titleHighlight?: string;
+
+  onInteraction: () => void;
 }
 
 /**

--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
@@ -53,7 +53,7 @@ export const EmbeddableRenderer = <
 
     const phaseTracker = new PhaseTracker(startTime);
 
-    const { Component, componentApi } = await buildEmbeddable<SerializedState, Api>({
+    const { Component, componentApi, onInteraction } = await buildEmbeddable<SerializedState, Api>({
       factory,
       maybeId,
       parentApi: getParentApi(),
@@ -67,6 +67,7 @@ export const EmbeddableRenderer = <
     return {
       Component,
       componentApi,
+      onInteraction,
       Panel: PresentationPanel,
       phaseTracker,
     };
@@ -100,6 +101,7 @@ export const EmbeddableRenderer = <
     <value.Panel<Api, {}>
       Component={value.Component}
       componentApi={value.componentApi}
+      onInteraction={value.onInteraction}
       hidePanelChrome={hidePanelChrome}
       {...panelProps}
     />

--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/types.ts
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/types.ts
@@ -11,6 +11,7 @@ import type {
   CanLockHoverActions,
   HasSerializableState,
   HasType,
+  PublishesInteractions,
   PublishesPhaseEvents,
 } from '@kbn/presentation-publishing';
 import type React from 'react';
@@ -28,6 +29,7 @@ import type { PlacementStrategy } from './constants';
 export interface DefaultEmbeddableApi<SerializedState extends object = object>
   extends DefaultPresentationPanelApi,
     HasType,
+    PublishesInteractions,
     PublishesPhaseEvents,
     HasSerializableState<SerializedState> {}
 

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_custom_renderer_component.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_custom_renderer_component.tsx
@@ -46,6 +46,7 @@ type PanelProps = Pick<
   | 'hideInspector'
   | 'getActions'
   | 'titleHighlight'
+  | 'onInteraction'
 >;
 
 /**
@@ -73,6 +74,7 @@ export function LensRenderer({
   hidePanelTitles,
   lastReloadRequestTime,
   titleHighlight,
+  onInteraction,
   ...props
 }: LensRendererProps) {
   // Use the settings interface to store panel settings
@@ -165,8 +167,9 @@ export function LensRenderer({
 
         return (extraActions ?? []).concat(actions || []);
       },
+      onInteraction: () => onInteraction?.(),
     };
-  }, [showInspector, withDefaultActions, extraActions, lensApi, titleHighlight]);
+  }, [showInspector, withDefaultActions, extraActions, lensApi, titleHighlight, onInteraction]);
 
   return (
     <EmbeddableRenderer<LensWireAPIConfig, LensApi>


### PR DESCRIPTION
## Summary

Capture users interactions with embeddable actions via newly exposed PublishesInteractions interface. Draft PR based on POC in https://github.com/elastic/kibana/pull/281851.



