### PR TITLE
[Security Solution] Add missing source event link in new flyout Highlighted Fields section

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.test.tsx
@@ -19,6 +19,8 @@ import { useExpandSection } from '../../../shared/hooks/use_expand_section';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import { HighlightedFields } from './highlighted_fields';
+import { HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID } from './test_ids';
+import { EVENT_SOURCE_FIELD_DESCRIPTOR } from '../../../../common/components/event_details/translations';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
 import {
@@ -288,6 +290,83 @@ describe('InvestigationSection', () => {
     // No UUID on the hit → no OpenFlyoutLink, just the passthrough children.
     expect(element.props.value).toBeUndefined();
     expect(element.props.children).toBeDefined();
+  });
+
+  it('renders a Source event link that opens the ancestor document in a new flyout', () => {
+    mockUseExpandSection.mockReturnValue(true);
+    const sourceEventHit = createMockHit({
+      'event.kind': 'signal',
+      'signal.ancestors.index': '.internal.alerts-security.alerts-default',
+    });
+
+    render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>
+            <InvestigationSection hit={sourceEventHit} renderCellActions={mockRenderCellActions} />
+          </Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    const renderFlyoutLink = mockHighlightedFields.mock.calls[0][0].renderFlyoutLink;
+    const element = renderFlyoutLink!({
+      field: EVENT_SOURCE_FIELD_DESCRIPTOR,
+      value: 'ancestor-id-1',
+      children: <span data-test-subj="sourceEventChild" />,
+    }) as React.ReactElement;
+
+    const { getByTestId } = render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>{element}</Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    act(() => getByTestId(HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID).click());
+
+    // The Source event opens the ancestor document as a new top-level flyout (session start),
+    // consistent with the sibling host/user/rule links in the same table.
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ session: 'start' })
+    );
+  });
+
+  it('falls back to plain children for a Source event when the ancestors index is unavailable', () => {
+    mockUseExpandSection.mockReturnValue(true);
+
+    render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>
+            <InvestigationSection hit={mockHit} renderCellActions={mockRenderCellActions} />
+          </Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    const renderFlyoutLink = mockHighlightedFields.mock.calls[0][0].renderFlyoutLink;
+    const element = renderFlyoutLink!({
+      field: EVENT_SOURCE_FIELD_DESCRIPTOR,
+      value: 'ancestor-id-1',
+      children: <span data-test-subj="sourceEventChild" />,
+    }) as React.ReactElement;
+
+    // mockHit has no signal.ancestors.index → passthrough children, no link.
+    expect(element.type).toBe(React.Fragment);
+
+    const { queryByTestId } = render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>{element}</Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    expect(queryByTestId(HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID)).not.toBeInTheDocument();
+    expect(queryByTestId('sourceEventChild')).toBeInTheDocument();
   });
 
   it('keeps non-rule entity fields (host) as direct flyout links', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { memo, useCallback, useMemo } from 'react';
+import { EuiLink } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { isNonLocalIndexName } from '@kbn/es-query';
@@ -19,6 +20,8 @@ import { ExpandableSection } from '../../../shared/components/expandable_section
 import { PREFIX } from '../../../../flyout/shared/test_ids';
 import { InvestigationGuide } from './investigation_guide';
 import { HighlightedFields } from './highlighted_fields';
+import { HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID } from './test_ids';
+import { EVENT_SOURCE_FIELD_DESCRIPTOR } from '../../../../common/components/event_details/translations';
 import { useRuleWithFallback } from '../../../../detection_engine/rule_management/logic/use_rule_with_fallback';
 import type { OpenFlyoutLinkProps } from '../../../shared/components/open_flyout_link';
 import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
@@ -51,7 +54,7 @@ export interface InvestigationSectionProps {
  */
 export const InvestigationSection = memo(
   ({ hit, renderCellActions }: InvestigationSectionProps) => {
-    const { openDocumentInvestigationGuide } = useFlyoutApi();
+    const { openDocumentInvestigationGuide, openDocumentFlyoutFromIndex } = useFlyoutApi();
 
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
@@ -90,6 +93,29 @@ export const InvestigationSection = memo(
 
     const renderFlyoutLink = useCallback(
       (props: OpenFlyoutLinkProps) => {
+        // Source event: open the ancestor document in a new flyout. The value is the ancestor
+        // document id and the index comes from `signal.ancestors.index`. Uses the same open method
+        // as the sibling host/user/rule links in this table so the navigation behaves consistently.
+        // Render plain text when either piece is missing.
+        if (props.field === EVENT_SOURCE_FIELD_DESCRIPTOR) {
+          if (!props.value || !ancestorsIndexName) {
+            return <>{props.children}</>;
+          }
+          return (
+            <EuiLink
+              onClick={() =>
+                openDocumentFlyoutFromIndex({
+                  documentId: props.value,
+                  indexName: ancestorsIndexName,
+                  origin: FLYOUT_ORIGIN.FLYOUT_FIELD_LINK,
+                })
+              }
+              data-test-subj={HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID}
+            >
+              {props.children}
+            </EuiLink>
+          );
+        }
         // Rule name fields: substitute the rule UUID as the link target (the flyout is keyed by
         // UUID) while keeping the rule name as the displayed text. When no UUID is available,
         // render plain text to avoid opening the rule flyout with an invalid id.
@@ -104,7 +130,7 @@ export const InvestigationSection = memo(
         }
         return <OpenFlyoutLink {...props} />;
       },
-      [ruleId]
+      [ruleId, ancestorsIndexName, openDocumentFlyoutFromIndex]
     );
 
     return (


### PR DESCRIPTION
## Summary

This PR makes a small fix to the new document flyout Highlighted Fields section. In the legacy flyout, we were able to open a preview of the document source event flyout:

https://github.com/user-attachments/assets/464cf3be-b4b3-4dca-beed-a1dbddef370e

This was lost when we moved to the new flyout system

https://github.com/user-attachments/assets/073719bd-8d5b-4b4e-8cd8-196633ed7957

This PR fixes that

https://github.com/user-attachments/assets/48d04732-b8c5-4d71-8567-05d2a2dd62f7

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->