### PR TITLE
[Chrome Next] Fix external links and native title attribute for context switcher

### DIFF
--- a/src/platform/packages/shared/context-switcher-components/src/components/footer.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/footer.tsx
@@ -29,7 +29,9 @@ export const Footer = ({ action }: FooterProps) => {
         href={action.href}
         onClick={action.onClick}
         external={action.external}
+        target={action.external ? '_blank' : undefined}
         isDisabled={action.disabled}
+        wrapText
         color="text"
         data-test-subj={action['data-test-subj']}
       />

--- a/src/platform/packages/shared/context-switcher-components/src/components/links_list.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/links_list.tsx
@@ -29,8 +29,10 @@ export const LinksList = ({ items }: LinksListProps) => {
           href={item.href}
           onClick={item.onClick}
           external={item.external}
+          target={item.external ? '_blank' : undefined}
           isDisabled={item.disabled}
           iconType={item.iconType}
+          wrapText
           color="text"
           data-test-subj={item['data-test-subj']}
         />

--- a/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_footer_links.test.ts
+++ b/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_footer_links.test.ts
@@ -62,10 +62,12 @@ describe('useFooterLinks', () => {
     );
   });
 
-  it('returns "Connection details" link for serverless cloud', () => {
+  it('returns "Connection details" link when cloud is enabled', () => {
     const application = createApplication();
 
-    const { result } = renderHook(() => useFooterLinks({ application, cloud, isServerless: true }));
+    const { result } = renderHook(() =>
+      useFooterLinks({ application, cloud, isServerless: false, activeSpaceSolution: 'es' })
+    );
 
     expect(result.current).toEqual(
       expect.arrayContaining([
@@ -77,11 +79,12 @@ describe('useFooterLinks', () => {
     );
   });
 
-  it('does not return "Connection details" when not serverless', () => {
+  it('does not return "Connection details" when cloud is disabled', () => {
     const application = createApplication();
+    const cloudMock = createCloud({ isCloudEnabled: false });
 
     const { result } = renderHook(() =>
-      useFooterLinks({ application, cloud, isServerless: false, activeSpaceSolution: 'es' })
+      useFooterLinks({ application, cloud: cloudMock, activeSpaceSolution: 'es' })
     );
 
     const ids = result.current.map((item) => item.id);

--- a/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_footer_links.ts
+++ b/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_footer_links.ts
@@ -121,7 +121,7 @@ export const useFooterLinks = ({
     }
 
     // "Connection details" link
-    if (isServerless === true && cloud?.isCloudEnabled === true) {
+    if (cloud?.isCloudEnabled === true) {
       items.push({
         id: 'connectionDetails',
         label: i18n.translate('xpack.spaces.contextSwitcher.footerLinks.connectionDetailsLabel', {


### PR DESCRIPTION
## Summary

This PR makes `external` links in `ContextSwitcher` open in new tab and it fixes the native `title` tooltip always showing on links even when they don't need truncation by setting `wrapText` property to true. It also removes unnecessary `isServerless` check for `Connection details` link.


