### PR TITLE
[8.19] [ResponseOps][Connectors] Prefix email subjects for Elastic Cloud trial deployments (#276705)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/stack_connectors/kibana.jsonc
@@ -18,8 +18,10 @@
       "actions",
       "esUiShared",
       "kibanaReact",
-      "triggersActionsUi"
+      "triggersActionsUi",
+      "licensing"
     ],
+    "optionalPlugins": ["cloud"],
     "extraPublicDirs": [
       "public/common"
     ]

--- a/x-pack/platform/plugins/shared/stack_connectors/moon.yml
+++ b/x-pack/platform/plugins/shared/stack_connectors/moon.yml
@@ -50,6 +50,8 @@ dependsOn:
   - '@kbn/alerts-ui-shared'
   - '@kbn/inference-endpoint-ui-common'
   - '@kbn/deeplinks-analytics'
+  - '@kbn/cloud-plugin'
+  - '@kbn/licensing-plugin'
   - '@kbn/react-query'
 tags:
   - plugin

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
@@ -32,7 +32,7 @@ import type {
   ConnectorTypeConfigType,
   ConnectorTypeSecretsType,
 } from '.';
-import { getConnectorType } from '.';
+import { getConnectorType, ELASTIC_CLOUD_TRIAL_SUBJECT_PREFIX } from '.';
 import type { ValidateEmailAddressesOptions } from '@kbn/actions-plugin/common';
 import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/types';
 import { AdditionalEmailServices } from '../../../common';
@@ -1793,6 +1793,116 @@ describe('execute()', () => {
 
     const expectedMessage = `connector "some-id" email parameter messageHTML length 1000 exceeds xpack.actions.email.maximum_body_length bytes (0) and has been trimmed`;
     expect(mockedLogger.warn).toBeCalledWith(expectedMessage);
+  });
+});
+
+describe('execute() Elastic Cloud trial subject prefix', () => {
+  const secrets: ConnectorTypeSecretsType = {
+    user: 'bob',
+    password: 'supersecret',
+    clientSecret: null,
+  };
+  const params: ActionParamsType = {
+    to: ['jim@example.com'],
+    cc: [],
+    bcc: [],
+    subject: 'the subject',
+    message: 'a message to you',
+    messageHTML: null,
+    kibanaFooterLink: {
+      path: '/',
+      text: 'Go to Elastic',
+    },
+  };
+  const connectorUsageCollector = new ConnectorUsageCollector({
+    logger: mockedLogger,
+    connectorId: 'test-connector-id',
+  });
+
+  const buildExecutorOptions = (
+    config: ConnectorTypeConfigType
+  ): EmailConnectorTypeExecutorOptions => ({
+    actionId: 'some-id',
+    config,
+    params,
+    secrets,
+    services,
+    configurationUtilities: actionsConfigMock.create(),
+    logger: mockedLogger,
+    connectorUsageCollector,
+  });
+
+  const elasticCloudConfig: ConnectorTypeConfigType = {
+    service: AdditionalEmailServices.ELASTIC_CLOUD,
+    host: null,
+    port: null,
+    secure: null,
+    from: 'bob@example.com',
+    hasAuth: true,
+    clientId: null,
+    tenantId: null,
+    oauthTokenUrl: null,
+  };
+
+  beforeEach(() => {
+    sendEmailMock.mockReset();
+  });
+
+  test('prefixes the subject when the deployment is a trial and service is elastic_cloud', async () => {
+    const trialConnectorType = getConnectorType({
+      isElasticCloudTrial: () => Promise.resolve(true),
+    });
+
+    await trialConnectorType.executor(buildExecutorOptions(elasticCloudConfig));
+
+    expect(sendEmailMock.mock.calls[0][1].content.subject).toBe(
+      `${ELASTIC_CLOUD_TRIAL_SUBJECT_PREFIX} the subject`
+    );
+  });
+
+  test('does not prefix the subject when the deployment is not a trial', async () => {
+    const nonTrialConnectorType = getConnectorType({
+      isElasticCloudTrial: () => Promise.resolve(false),
+    });
+
+    await nonTrialConnectorType.executor(buildExecutorOptions(elasticCloudConfig));
+
+    expect(sendEmailMock.mock.calls[0][1].content.subject).toBe('the subject');
+  });
+
+  test('does not prefix the subject for non elastic_cloud services even on a trial', async () => {
+    const trialConnectorType = getConnectorType({
+      isElasticCloudTrial: () => Promise.resolve(true),
+    });
+
+    await trialConnectorType.executor(
+      buildExecutorOptions({ ...elasticCloudConfig, service: '__json' })
+    );
+
+    expect(sendEmailMock.mock.calls[0][1].content.subject).toBe('the subject');
+  });
+
+  test('does not prefix the subject when trial detection is unavailable (self-managed)', async () => {
+    const selfManagedConnectorType = getConnectorType({});
+
+    await selfManagedConnectorType.executor(buildExecutorOptions(elasticCloudConfig));
+
+    expect(sendEmailMock.mock.calls[0][1].content.subject).toBe('the subject');
+  });
+
+  test('does not add a duplicate prefix when the subject already carries it', async () => {
+    const trialConnectorType = getConnectorType({
+      isElasticCloudTrial: () => Promise.resolve(true),
+    });
+
+    await trialConnectorType.executor({
+      ...buildExecutorOptions(elasticCloudConfig),
+      params: { ...params, subject: `${ELASTIC_CLOUD_TRIAL_SUBJECT_PREFIX} the subject` },
+    });
+
+    expect(sendEmailMock.mock.calls[0][1].content.subject).toBe(
+      `${ELASTIC_CLOUD_TRIAL_SUBJECT_PREFIX} the subject`
+    );
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.ts
@@ -63,6 +63,11 @@ export const ELASTIC_CLOUD_SERVICE: SMTPConnection.Options = {
 
 const EMAIL_FOOTER_DIVIDER = '\n\n---\n\n';
 
+// Emails sent from Elastic Cloud trial deployments (ECH and Serverless) go through the shared
+// Elastic SMTP relay (the `elastic_cloud` service). Their subjects are prefixed so trial traffic
+// can be identified and, if abused, filtered at the SMTP gateway.
+export const ELASTIC_CLOUD_TRIAL_SUBJECT_PREFIX = '[Elastic Cloud Trial]';
+
 const ConfigSchemaProps = {
   service: schema.string({ defaultValue: 'other' }),
   host: schema.nullable(schema.string()),
@@ -259,6 +264,7 @@ function validateParams(paramsObject: unknown, validatorServices: ValidatorServi
 
 interface GetConnectorTypeParams {
   publicBaseUrl?: string;
+  isElasticCloudTrial?: () => Promise<boolean>;
 }
 
 function validateConnector(
@@ -283,7 +289,7 @@ function validateConnector(
 // connector type definition
 export const ConnectorTypeId = '.email';
 export function getConnectorType(params: GetConnectorTypeParams): EmailConnectorType {
-  const { publicBaseUrl } = params;
+  const { publicBaseUrl, isElasticCloudTrial } = params;
   return {
     id: ConnectorTypeId,
     minimumLicenseRequired: 'gold',
@@ -310,7 +316,7 @@ export function getConnectorType(params: GetConnectorTypeParams): EmailConnector
       connector: validateConnector,
     },
     renderParameterTemplates,
-    executor: curry(executor)({ publicBaseUrl }),
+    executor: curry(executor)({ publicBaseUrl, isElasticCloudTrial }),
   };
 }
 
@@ -332,8 +338,10 @@ function renderParameterTemplates(
 async function executor(
   {
     publicBaseUrl,
+    isElasticCloudTrial,
   }: {
     publicBaseUrl: GetConnectorTypeParams['publicBaseUrl'];
+    isElasticCloudTrial: GetConnectorTypeParams['isElasticCloudTrial'];
   },
   execOptions: EmailConnectorTypeExecutorOptions
 ): Promise<ConnectorTypeExecutorResult<unknown>> {
@@ -447,6 +455,14 @@ async function executor(
     actualMessage = `${actualMessage}${EMAIL_FOOTER_DIVIDER}${footerMessage}`;
   }
 
+  // Trial deployments (ECH and Serverless) route through the shared Elastic SMTP relay
+  // (the `elastic_cloud` service), so their subjects are prefixed to identify trial traffic.
+  // `&&` short-circuits, so the trial lookup only runs for the `elastic_cloud` service.
+  const subject =
+    config.service === AdditionalEmailServices.ELASTIC_CLOUD && (await isElasticCloudTrial?.())
+      ? prefixTrialSubject(params.subject)
+      : params.subject;
+
   const sendEmailOptions: SendEmailOptions = {
     connectorId: actionId,
     transport,
@@ -457,7 +473,7 @@ async function executor(
       bcc: params.bcc,
     },
     content: {
-      subject: params.subject,
+      subject,
       message: actualMessage || 'no message set',
       messageHTML: actualHTMLMessage,
     },
@@ -502,6 +518,15 @@ async function executor(
 }
 
 // utilities
+
+// Prepend the trial marker unless the subject already carries it, so re-rendered or
+// user-authored subjects don't accumulate duplicate prefixes.
+function prefixTrialSubject(subject: string): string {
+  if (subject.startsWith(ELASTIC_CLOUD_TRIAL_SUBJECT_PREFIX)) {
+    return subject;
+  }
+  return `${ELASTIC_CLOUD_TRIAL_SUBJECT_PREFIX} ${subject}`;
+}
 
 function trimMessageIfRequired(
   connectorId: string,

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
@@ -85,12 +85,14 @@ export function registerConnectorTypes({
   actions,
   publicBaseUrl,
   experimentalFeatures,
+  isElasticCloudTrial,
 }: {
   actions: ActionsPluginSetupContract;
   publicBaseUrl?: string;
   experimentalFeatures: ExperimentalFeatures;
+  isElasticCloudTrial?: () => Promise<boolean>;
 }) {
-  actions.registerType(getEmailConnectorType({ publicBaseUrl }));
+  actions.registerType(getEmailConnectorType({ publicBaseUrl, isElasticCloudTrial }));
   actions.registerType(getIndexConnectorType());
   actions.registerType(getPagerDutyConnectorType());
   actions.registerType(getSwimlaneConnectorType());

--- a/x-pack/platform/plugins/shared/stack_connectors/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/plugin.test.ts
@@ -5,9 +5,16 @@
  * 2.0.
  */
 
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import type { PluginInitializerContext } from '@kbn/core/server';
 import { coreMock } from '@kbn/core/server/mocks';
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import { cloudMock } from '@kbn/cloud-plugin/server/mocks';
+import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
+import type { ILicense, LicenseType } from '@kbn/licensing-plugin/server';
 import { StackConnectorsPlugin } from './plugin';
+import type { ConnectorsPluginsStart } from './plugin';
 import { actionsMock } from '@kbn/actions-plugin/server/mocks';
 
 describe('Stack Connectors Plugin', () => {
@@ -209,6 +216,100 @@ describe('Stack Connectors Plugin', () => {
           name: 'CrowdStrike',
         })
       );
+    });
+  });
+
+  describe('Elastic Cloud trial detection (isElasticCloudTrial)', () => {
+    const setupPlugin = (cloud?: CloudSetup) => {
+      const context = coreMock.createPluginInitializerContext();
+      mockParseExperimentalConfigValue.mockReturnValue({ ...experimentalFeaturesMock });
+      const plugin = new StackConnectorsPlugin(context);
+
+      const actionsSetup = actionsMock.createSetup();
+      (
+        actionsSetup.getActionsConfigurationUtilities().getWebhookSettings as jest.Mock
+      ).mockReturnValue({ ssl: { pfx: { enabled: true } } });
+
+      plugin.setup(coreMock.createSetup(), { actions: actionsSetup, cloud });
+      return plugin;
+    };
+
+    // `getLicense()` resolves the current value of the license observable (as the real
+    // licensing plugin does), so pushing onto `license$` simulates a live license change.
+    const startWithLicense = (
+      plugin: StackConnectorsPlugin,
+      license$: BehaviorSubject<ILicense>
+    ) => {
+      const licensing = {
+        ...licensingMock.createStart(),
+        license$,
+        getLicense: jest.fn(() => firstValueFrom(license$)),
+      } as unknown as LicensingPluginStart;
+      plugin.start(coreMock.createStart(), { licensing } as unknown as ConnectorsPluginsStart);
+    };
+
+    const createLicense$ = (type: LicenseType) =>
+      new BehaviorSubject<ILicense>(licensingMock.createLicense({ license: { type } }));
+
+    // Access the private detection method for focused unit coverage.
+    const isElasticCloudTrial = (plugin: StackConnectorsPlugin) =>
+      (plugin as unknown as { isElasticCloudTrial: () => Promise<boolean> }).isElasticCloudTrial();
+
+    const createServerlessCloud = (organizationInTrial: boolean): CloudSetup => {
+      const cloud = cloudMock.createSetup();
+      return {
+        ...cloud,
+        isServerlessEnabled: true,
+        serverless: { ...cloud.serverless, organizationInTrial },
+      };
+    };
+
+    it('returns true on a Serverless deployment whose organization is in trial', async () => {
+      const plugin = setupPlugin(createServerlessCloud(true));
+      startWithLicense(plugin, createLicense$('enterprise'));
+
+      await expect(isElasticCloudTrial(plugin)).resolves.toBe(true);
+    });
+
+    it('returns false on a Serverless deployment that is not in trial', async () => {
+      const plugin = setupPlugin(createServerlessCloud(false));
+      startWithLicense(plugin, createLicense$('enterprise'));
+
+      await expect(isElasticCloudTrial(plugin)).resolves.toBe(false);
+    });
+
+    it('returns true on ECH when the current license type is trial', async () => {
+      const plugin = setupPlugin(cloudMock.createSetup());
+      startWithLicense(plugin, createLicense$('trial'));
+
+      await expect(isElasticCloudTrial(plugin)).resolves.toBe(true);
+    });
+
+    it('returns false on ECH when the current license type is not trial', async () => {
+      const plugin = setupPlugin(cloudMock.createSetup());
+      startWithLicense(plugin, createLicense$('gold'));
+
+      await expect(isElasticCloudTrial(plugin)).resolves.toBe(false);
+    });
+
+    it('reacts to a live ECH trial -> paid license change without a restart', async () => {
+      const plugin = setupPlugin(cloudMock.createSetup());
+      const license$ = createLicense$('trial');
+      startWithLicense(plugin, license$);
+
+      await expect(isElasticCloudTrial(plugin)).resolves.toBe(true);
+
+      // Simulate the license being refreshed to a converted, paid license.
+      license$.next(licensingMock.createLicense({ license: { type: 'platinum' } }));
+
+      await expect(isElasticCloudTrial(plugin)).resolves.toBe(false);
+    });
+
+    it('returns false on a self-managed deployment (no cloud, no trial license)', async () => {
+      const plugin = setupPlugin(undefined);
+      startWithLicense(plugin, createLicense$('basic'));
+
+      await expect(isElasticCloudTrial(plugin)).resolves.toBe(false);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/plugin.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import type { PluginInitializerContext, Plugin, CoreSetup, Logger } from '@kbn/core/server';
+import type { PluginInitializerContext, Plugin, CoreSetup, CoreStart, Logger } from '@kbn/core/server';
 import type { PluginSetupContract as ActionsPluginSetupContract } from '@kbn/actions-plugin/server';
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import { registerConnectorTypes } from './connector_types';
 import { validSlackApiChannelsRoute, getWellKnownEmailServiceRoute } from './routes';
 import type { ExperimentalFeatures } from '../common/experimental_features';
@@ -14,10 +16,12 @@ import { parseExperimentalConfigValue } from '../common/experimental_features';
 import type { ConfigSchema as StackConnectorsConfigType } from './config';
 export interface ConnectorsPluginsSetup {
   actions: ActionsPluginSetupContract;
+  cloud?: CloudSetup;
 }
 
 export interface ConnectorsPluginsStart {
   actions: ActionsPluginSetupContract;
+  licensing: LicensingPluginStart;
 }
 
 export class StackConnectorsPlugin
@@ -27,15 +31,39 @@ export class StackConnectorsPlugin
   private config: StackConnectorsConfigType;
   readonly experimentalFeatures: ExperimentalFeatures;
 
+  // Whether this is a Serverless deployment, and — if so — whether its organization is in trial.
+  // Serverless projects always report an `enterprise` ES license, so their trial status can only
+  // come from Cloud config (which is static for the process lifetime).
+  private isServerless = false;
+  private isServerlessTrial = false;
+  private licensing?: LicensingPluginStart;
+
   constructor(context: PluginInitializerContext) {
     this.logger = context.logger.get();
     this.config = context.config.get();
     this.experimentalFeatures = parseExperimentalConfigValue(this.config.enableExperimental || []);
   }
 
+  // Trial detection for the Elastic-managed email SMTP relay (the `elastic_cloud` service).
+  private isElasticCloudTrial = async (): Promise<boolean> => {
+    if (this.isServerless) {
+      return this.isServerlessTrial;
+    }
+    // On ECH the ES license tier reflects the current subscription. `getLicense()` reads the
+    // licensing plugin's cached license (no ES round-trip), so a trial -> paid conversion is
+    // picked up without a Kibana restart.
+    const license = await this.licensing?.getLicense();
+    return license?.type === 'trial';
+  };
+
   public setup(core: CoreSetup<ConnectorsPluginsStart>, plugins: ConnectorsPluginsSetup) {
     const router = core.http.createRouter();
     const { actions } = plugins;
+
+    // Serverless trial status is only available on the Cloud setup contract and is static config,
+    // so capture it here. The live ECH license is tracked from the licensing observable in start().
+    this.isServerless = plugins.cloud?.isServerlessEnabled ?? false;
+    this.isServerlessTrial = plugins.cloud?.serverless.organizationInTrial ?? false;
 
     const awsSesConfig = actions.getActionsConfigurationUtilities().getAwsSesConfig();
     getWellKnownEmailServiceRoute(router, awsSesConfig);
@@ -45,9 +73,13 @@ export class StackConnectorsPlugin
       actions,
       publicBaseUrl: core.http.basePath.publicBaseUrl,
       experimentalFeatures: this.experimentalFeatures,
+      isElasticCloudTrial: this.isElasticCloudTrial,
     });
   }
 
-  public start() {}
+  public start(core: CoreStart, plugins: ConnectorsPluginsStart) {
+    this.licensing = plugins.licensing;
+  }
+
   public stop() {}
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/plugin.ts
@@ -5,7 +5,13 @@
  * 2.0.
  */
 
-import type { PluginInitializerContext, Plugin, CoreSetup, CoreStart, Logger } from '@kbn/core/server';
+import type {
+  PluginInitializerContext,
+  Plugin,
+  CoreSetup,
+  CoreStart,
+  Logger,
+} from '@kbn/core/server';
 import type { PluginSetupContract as ActionsPluginSetupContract } from '@kbn/actions-plugin/server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';

--- a/x-pack/platform/plugins/shared/stack_connectors/tsconfig.json
+++ b/x-pack/platform/plugins/shared/stack_connectors/tsconfig.json
@@ -45,6 +45,8 @@
     "@kbn/alerts-ui-shared",
     "@kbn/inference-endpoint-ui-common",
     "@kbn/deeplinks-analytics",
+    "@kbn/cloud-plugin",
+    "@kbn/licensing-plugin",
     "@kbn/react-query",
   ],
   "exclude": [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
- [[ResponseOps][Connectors] Prefix email subjects for Elastic Cloud trial deployments (#276705)](https://github.com/elastic/kibana/pull/276705)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":276705,"url":"https://github.com/elastic/kibana/pull/276705","title":"[ResponseOps][Connectors] Prefix email subjects for Elastic Cloud trial deployments"},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"sourceCommit":{"sha":"9c44b79a293dd8e4da12cec736eda3ee7bd342c3"}}] BACKPORT-->