### PR TITLE
Disallow code gen from strings when FTR/Scout runs Kibana from source

### DIFF
--- a/src/platform/packages/shared/kbn-test-kibana-server/src/run_kibana_server.test.ts
+++ b/src/platform/packages/shared/kbn-test-kibana-server/src/run_kibana_server.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ProcRunner } from '@kbn/dev-proc-runner';
+import { runKibanaServer } from './run_kibana_server';
+import type { KibanaTestServerLaunchConfig } from './kibana_test_server_launch_config';
+
+const CODE_GEN_FLAG = '--disallow-code-generation-from-strings';
+
+const createConfig = (
+  env: Record<string, string | undefined> = {}
+): KibanaTestServerLaunchConfig => ({
+  get: (path: string) => {
+    switch (path) {
+      case 'kbnTestServer.runOptions':
+        return {};
+      case 'kbnTestServer.env':
+        return env;
+      case 'kbnTestServer.useDedicatedTaskRunner':
+        return false;
+      case 'kbnTestServer.buildArgs':
+      case 'kbnTestServer.sourceArgs':
+        return [];
+      case 'kbnTestServer.serverArgs':
+        return ['--server.port=5620'];
+      default:
+        return undefined;
+    }
+  },
+});
+
+const createProcs = () => ({ run: jest.fn() } as unknown as ProcRunner);
+
+const getArgs = (procs: ProcRunner) => (procs.run as jest.Mock).mock.calls[0][1].args as string[];
+
+describe('runKibanaServer()', () => {
+  const originalEnvValue = process.env.KBN_DISALLOW_CODE_GEN_FROM_STRINGS;
+
+  afterEach(() => {
+    if (originalEnvValue === undefined) {
+      delete process.env.KBN_DISALLOW_CODE_GEN_FROM_STRINGS;
+    } else {
+      process.env.KBN_DISALLOW_CODE_GEN_FROM_STRINGS = originalEnvValue;
+    }
+  });
+
+  it('passes --disallow-code-generation-from-strings by default when running from source', async () => {
+    const procs = createProcs();
+    delete process.env.KBN_DISALLOW_CODE_GEN_FROM_STRINGS;
+
+    await runKibanaServer({ procs, config: createConfig() });
+
+    const args = getArgs(procs);
+    expect(args[0]).toBe(CODE_GEN_FLAG);
+    expect(args[1]).toMatch(/scripts[\\/]kibana$/);
+  });
+
+  it('omits the flag when opted out via the environment', async () => {
+    const procs = createProcs();
+    process.env.KBN_DISALLOW_CODE_GEN_FROM_STRINGS = 'false';
+
+    await runKibanaServer({ procs, config: createConfig() });
+
+    expect(getArgs(procs)).not.toContain(CODE_GEN_FLAG);
+  });
+
+  it('reads the opt-out from the config so a test config can disable it', async () => {
+    const procs = createProcs();
+    delete process.env.KBN_DISALLOW_CODE_GEN_FROM_STRINGS;
+
+    await runKibanaServer({
+      procs,
+      config: createConfig({ KBN_DISALLOW_CODE_GEN_FROM_STRINGS: 'false' }),
+    });
+
+    expect(getArgs(procs)).not.toContain(CODE_GEN_FLAG);
+  });
+
+  it('does not pass the flag when running from a build, where bin/kibana handles it', async () => {
+    const procs = createProcs();
+    delete process.env.KBN_DISALLOW_CODE_GEN_FROM_STRINGS;
+
+    await runKibanaServer({ procs, config: createConfig(), installDir: '/tmp/kibana-build' });
+
+    expect(getArgs(procs)).not.toContain(CODE_GEN_FLAG);
+  });
+});

--- a/src/platform/packages/shared/kbn-test-kibana-server/src/run_kibana_server.ts
+++ b/src/platform/packages/shared/kbn-test-kibana-server/src/run_kibana_server.ts
@@ -79,6 +79,15 @@ export async function runKibanaServer(options: RunKibanaServerOptions) {
     prefixArgs.unshift('--inspect');
   }
 
+  // Code generation from strings (eval / new Function) is disallowed by default, matching the
+  // distributable `bin/kibana` that running from source bypasses. Opt out by setting
+  // KBN_DISALLOW_CODE_GEN_FROM_STRINGS=false. Passed as a node exec arg rather than via NODE_OPTIONS
+  // so it reaches the dev CLI's server child process (which forwards `process.execArgv`) without
+  // leaking into the optimizer's webpack workers.
+  if (devMode && env.KBN_DISALLOW_CODE_GEN_FROM_STRINGS !== 'false') {
+    prefixArgs.unshift('--disallow-code-generation-from-strings');
+  }
+
   const buildArgs: string[] = (config.get('kbnTestServer.buildArgs') as string[] | undefined) || [];
   const sourceArgs: string[] =
     (config.get('kbnTestServer.sourceArgs') as string[] | undefined) || [];


### PR DESCRIPTION
## Summary

Ensures that Kibana starts with `--disallow-code-generation-from-strings` when FTR or Scout spins up a Kibana instance from local source.

This flag is already managed via the distributable when running in CI. No changes here.