### PR TITLE
[9.3] [Security Solution] Improve fallback document fetch for restored indices (#282272)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.test.tsx
@@ -128,9 +128,12 @@ describe('useTimelineEventsDetails - broadened index retry (SDH #1666)', () => {
 
     // Two calls: primary (stale) then the broadened pattern.
     expect(search).toHaveBeenCalledTimes(2);
+    // Primary lookup keeps its request unchanged: it must NOT opt into hidden-index expansion.
     expect(search.mock.calls[0][0]).toEqual(expect.objectContaining({ indexName: STALE_INDEX }));
+    expect(search.mock.calls[0][0]).not.toHaveProperty('includeHiddenIndices', true);
+    // Only the fallback retry broadens the index name AND opts into hidden-index expansion.
     expect(search.mock.calls[1][0]).toEqual(
-      expect.objectContaining({ indexName: BROADENED_INDEX })
+      expect.objectContaining({ indexName: BROADENED_INDEX, includeHiddenIndices: true })
     );
     expect(addError).not.toHaveBeenCalled();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.tsx
@@ -120,7 +120,13 @@ export const useTimelineEventsDetails = ({
       const retryWithFallback = () => {
         attemptedFallbackRef.current = true;
         searchSubscription$.current.unsubscribe();
-        timelineDetailsSearch({ ...request, indexName: fallbackIndex as string });
+        // `includeHiddenIndices` is set only here so the server broadens wildcard expansion to hidden
+        // indices for the fallback lookup only, leaving the primary request unchanged.
+        timelineDetailsSearch({
+          ...request,
+          indexName: fallbackIndex as string,
+          includeHiddenIndices: true,
+        });
       };
 
       const asyncSearch = async () => {

--- a/x-pack/solutions/security/plugins/timelines/common/api/search_strategy/timeline/events_details.ts
+++ b/x-pack/solutions/security/plugins/timelines/common/api/search_strategy/timeline/events_details.ts
@@ -16,6 +16,11 @@ export const timelineEventsDetailsSchema = requestPaginated.partial().extend({
   authFilter: z.object({}).optional(),
   runtimeMappings,
   factoryQueryType: z.literal(TimelineEventsQueries.details),
+  /**
+   * When `true`, hidden indices are included in wildcard expansion for the lookup.
+   * Left unset by default. Used for example for the  fallback retry.
+   */
+  includeHiddenIndices: z.boolean().optional(),
 });
 
 export type TimelineEventsDetailsRequestOptionsInput = z.input<typeof timelineEventsDetailsSchema>;

--- a/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/index.ts
+++ b/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/index.ts
@@ -22,26 +22,32 @@ import { buildEcsObjects } from '../../helpers/build_ecs_objects';
 export const timelineEventsDetails: TimelineFactory<TimelineEventsQueries.details> = {
   buildDsl: (parsedRequest) => {
     const { authFilter, ...options } = parsedRequest;
-    const { indexName, eventId, runtimeMappings = {} } = options;
+    const { indexName, eventId, runtimeMappings = {}, includeHiddenIndices } = options;
     return buildTimelineDetailsQuery({
       indexName,
       id: eventId,
       runtimeMappings,
       authFilter,
+      includeHiddenIndices,
     });
   },
   parse: async (
     options,
     response: IEsSearchResponse<EventHit>
   ): Promise<TimelineEventsDetailsStrategyResponse> => {
-    const { indexName, eventId, runtimeMappings = {} } = options;
+    const { indexName, eventId, runtimeMappings = {}, includeHiddenIndices } = options;
     // _source is removed here as it's only needed in the rawEventData below
     const { fields, _source, ...hitsData } = response.rawResponse.hits.hits[0] ?? {};
 
     const inspect = {
       dsl: [
         inspectStringifyObject(
-          buildTimelineDetailsQuery({ indexName, id: eventId, runtimeMappings })
+          buildTimelineDetailsQuery({
+            indexName,
+            id: eventId,
+            runtimeMappings,
+            includeHiddenIndices,
+          })
         ),
       ],
     };

--- a/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.test.ts
+++ b/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.test.ts
@@ -57,4 +57,29 @@ describe('buildTimelineDetailsQuery', () => {
       }
     `);
   });
+
+  it('does not set expand_wildcards when includeHiddenIndices is omitted (primary lookup)', () => {
+    const query = buildTimelineDetailsQuery({
+      indexName: '.ds-logs-endpoint.events-default-2026.05.17-000001',
+      id: 'some-id',
+      runtimeMappings: {},
+    });
+
+    expect(query).not.toHaveProperty('expand_wildcards');
+  });
+
+  it('includes hidden indices in wildcard expansion when includeHiddenIndices is true (fallback)', () => {
+    const query = buildTimelineDetailsQuery({
+      indexName: '*.ds-logs-endpoint.events-default-2026.05.17-000001',
+      id: 'some-id',
+      runtimeMappings: {},
+      includeHiddenIndices: true,
+    });
+
+    expect(query).toEqual(
+      expect.objectContaining({
+        expand_wildcards: ['open', 'hidden'],
+      })
+    );
+  });
 });

--- a/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { ExpandWildcards } from '@elastic/elasticsearch/lib/api/types';
 import type { JsonObject } from '@kbn/utility-types';
 import type { RunTimeMappings } from '../../../../../../common/api/search_strategy/model/runtime_mappings';
 
@@ -13,11 +14,13 @@ export const buildTimelineDetailsQuery = ({
   id,
   indexName,
   runtimeMappings,
+  includeHiddenIndices = false,
 }: {
   authFilter?: JsonObject;
   id: string;
   indexName: string;
   runtimeMappings: RunTimeMappings;
+  includeHiddenIndices?: boolean;
 }) => {
   const basicFilter = {
     terms: {
@@ -41,6 +44,11 @@ export const buildTimelineDetailsQuery = ({
     allow_no_indices: true,
     index: indexName,
     ignore_unavailable: true,
+    // Only the client-side fallback retry sets `includeHiddenIndices`. It broadens the index name
+    // with a `*` prefix to resolve documents whose backing index was relocated to a searchable-
+    // snapshot tier and remounted as a hidden `restored-`/`partial-` index, and needs hidden indices
+    // included in wildcard expansion to match them.
+    ...(includeHiddenIndices ? { expand_wildcards: ['open', 'hidden'] as ExpandWildcards } : {}),
     query,
     fields: [
       { field: '*', include_unmapped: true },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Security Solution] Improve fallback document fetch for restored indices (#282272)](https://github.com/elastic/kibana/pull/282272)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-08-03T14:03:51Z","message":"[Security Solution] Improve fallback document fetch for restored indices (#282272)\n\n> [!NOTE]\n> The fix merged in https://github.com/elastic/kibana/pull/277703 was\nnot sufficient. This is a server-side follow up that should hopefully\nsolve the issue for good.\n\n## Summary\n\nThis PR makes the \"Source event\" fallback lookup also resolve documents\nthat live in **hidden** `restored-`/`partial-` indices.\n\n### Prior work\n\nIn the previous [PR](https://github.com/elastic/kibana/pull/277703), we\nadded a client-side fallback: when opening the `Source event` from an\nalert's `Highlighted Fields` fails (because the document's backing index\nwas relocated to a searchable-snapshot tier and remounted under a\n`restored-` prefix), we retry once against a broadened index pattern\n(`*`-prefixed) so it can match the renamed index.\n\nThat fix worked in local testing but **did not resolve the customer's\ncase** (still reproducing after upgrading). The reason: the `restored-`\nindices produced by ILM's `searchable_snapshot` action — and `.ds-`\ndatastream backing indices in general — are **hidden** indices. A\nwildcard pattern (`*.ds-...`) only matches hidden indices when the\nsearch request sets `expand_wildcards` to include `hidden`. The timeline\nevent-details query never set `expand_wildcards`, so Elasticsearch\ndefaulted to `open` and the broadened retry still returned no hit.\n\n> [!TIP]\n> Manual test masked this because it created the `restored-` index with\na plain `_reindex`, which produces a **non-hidden** index — so the\nwildcard matched and the fix appeared to work.\n\n\nhttps://github.com/user-attachments/assets/31593ff0-ca97-4d6e-aaf7-77d575a3589b\n\n### Solutions explored\n\nThe straightforward option was to always add `expand_wildcards: ['open',\n'hidden']` to `buildTimelineDetailsQuery`. But that query is shared by\nevery event-details lookup, including legitimate primary lookups that\nalready pass a broad index *pattern* (e.g.\n`DocumentFlyoutWrapperFromPattern`, used for notes). Always expanding to\nhidden indices would silently change behavior for those calls too.\n\nTo keep the same additive/no-impact mindset as #277703, the change is\nscoped to the fallback only:\n\n- A new optional `includeHiddenIndices` flag is added to the\n`eventsDetails` search-strategy request.\n- The **primary** lookup leaves it unset, so its request is\nbyte-for-byte unchanged (no `expand_wildcards` key at all).\n- The **client fallback retry** is the only caller that sets\n`includeHiddenIndices: true`, and only then does\n`buildTimelineDetailsQuery` add `expand_wildcards: ['open', 'hidden']`.\n\nSince exact index names resolve regardless of hidden status, the only\nbehavioral change is: \"when we retry a failed by-id lookup against a\nbroadened pattern, also look inside hidden indices\" — which is exactly\nthe intended fix.\n\n\nhttps://github.com/user-attachments/assets/ea1120fc-83b7-4269-b195-53caff455948\n\n## How to test\n\n- generate some documents locally (`yarn test:generate`)\n- generate some alerts off of those documents (install the `Endpoint\nSecurity` rule)\n\nUse Kibana Dev Tools to make one alert's source event only available in\na **hidden** `restored-` index (the `index.hidden: true` setting is the\nimportant difference vs #277703).\n\nFind one alert with ancestor index/id:\n```\nGET .alerts-security.alerts-*/_search\n{\n  \"size\": 5,\n  \"_source\": [\"kibana.alert.ancestors\", \"kibana.alert.rule.name\", \"@timestamp\"],\n  \"query\": { \"exists\": { \"field\": \"kibana.alert.ancestors.index\" } },\n  \"sort\": [{ \"@timestamp\": \"desc\" }]\n}\n```\n\nPick one ancestor event entry and note:\n```\nOLD_INDEX = kibana.alert.ancestors.index\nEVENT_ID  = kibana.alert.ancestors.id\n```\n\nCreate a **hidden** restored-style index and copy only that event:\n```\nPUT restored-OLD_INDEX\n{\n  \"settings\": { \"index.hidden\": true }\n}\n\nPOST _reindex\n{\n  \"source\": { \"index\": \"OLD_INDEX\", \"query\": { \"ids\": { \"values\": [\"EVENT_ID\"] } } },\n  \"dest\":   { \"index\": \"restored-OLD_INDEX\", \"op_type\": \"create\" }\n}\n```\n\nRemove it from the original index so the primary lookup fails (this\ntriggers the fallback):\n```\nPOST OLD_INDEX/_delete_by_query\n{\n  \"query\": { \"ids\": { \"values\": [\"EVENT_ID\"] } }\n}\n```\n\nThen open that alert, expand the details flyout, and click `Source\nevent` in `Highlighted Fields`:\n- **Before this PR:** the fallback retries but still errors, because the\nhidden `restored-` index isn't matched by the wildcard.\n- **With this PR:** the source-event preview opens and shows the\ndocument.\n\n> Note: the `Source event` link is only rendered in the legacy flyout.\nIf you have the `securitySolution:enableNewFlyout` advanced setting on,\nturn it off to test this flow.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2c3998d939335d5db1240a7876cfa57ad00c2493","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","backport:version","v9.6.0","v9.4.5","v8.19.20","v9.5.1","v9.3.9"],"title":"[Security Solution] Improve fallback document fetch for restored indices","number":282272,"url":"https://github.com/elastic/kibana/pull/282272","mergeCommit":{"message":"[Security Solution] Improve fallback document fetch for restored indices (#282272)\n\n> [!NOTE]\n> The fix merged in https://github.com/elastic/kibana/pull/277703 was\nnot sufficient. This is a server-side follow up that should hopefully\nsolve the issue for good.\n\n## Summary\n\nThis PR makes the \"Source event\" fallback lookup also resolve documents\nthat live in **hidden** `restored-`/`partial-` indices.\n\n### Prior work\n\nIn the previous [PR](https://github.com/elastic/kibana/pull/277703), we\nadded a client-side fallback: when opening the `Source event` from an\nalert's `Highlighted Fields` fails (because the document's backing index\nwas relocated to a searchable-snapshot tier and remounted under a\n`restored-` prefix), we retry once against a broadened index pattern\n(`*`-prefixed) so it can match the renamed index.\n\nThat fix worked in local testing but **did not resolve the customer's\ncase** (still reproducing after upgrading). The reason: the `restored-`\nindices produced by ILM's `searchable_snapshot` action — and `.ds-`\ndatastream backing indices in general — are **hidden** indices. A\nwildcard pattern (`*.ds-...`) only matches hidden indices when the\nsearch request sets `expand_wildcards` to include `hidden`. The timeline\nevent-details query never set `expand_wildcards`, so Elasticsearch\ndefaulted to `open` and the broadened retry still returned no hit.\n\n> [!TIP]\n> Manual test masked this because it created the `restored-` index with\na plain `_reindex`, which produces a **non-hidden** index — so the\nwildcard matched and the fix appeared to work.\n\n\nhttps://github.com/user-attachments/assets/31593ff0-ca97-4d6e-aaf7-77d575a3589b\n\n### Solutions explored\n\nThe straightforward option was to always add `expand_wildcards: ['open',\n'hidden']` to `buildTimelineDetailsQuery`. But that query is shared by\nevery event-details lookup, including legitimate primary lookups that\nalready pass a broad index *pattern* (e.g.\n`DocumentFlyoutWrapperFromPattern`, used for notes). Always expanding to\nhidden indices would silently change behavior for those calls too.\n\nTo keep the same additive/no-impact mindset as #277703, the change is\nscoped to the fallback only:\n\n- A new optional `includeHiddenIndices` flag is added to the\n`eventsDetails` search-strategy request.\n- The **primary** lookup leaves it unset, so its request is\nbyte-for-byte unchanged (no `expand_wildcards` key at all).\n- The **client fallback retry** is the only caller that sets\n`includeHiddenIndices: true`, and only then does\n`buildTimelineDetailsQuery` add `expand_wildcards: ['open', 'hidden']`.\n\nSince exact index names resolve regardless of hidden status, the only\nbehavioral change is: \"when we retry a failed by-id lookup against a\nbroadened pattern, also look inside hidden indices\" — which is exactly\nthe intended fix.\n\n\nhttps://github.com/user-attachments/assets/ea1120fc-83b7-4269-b195-53caff455948\n\n## How to test\n\n- generate some documents locally (`yarn test:generate`)\n- generate some alerts off of those documents (install the `Endpoint\nSecurity` rule)\n\nUse Kibana Dev Tools to make one alert's source event only available in\na **hidden** `restored-` index (the `index.hidden: true` setting is the\nimportant difference vs #277703).\n\nFind one alert with ancestor index/id:\n```\nGET .alerts-security.alerts-*/_search\n{\n  \"size\": 5,\n  \"_source\": [\"kibana.alert.ancestors\", \"kibana.alert.rule.name\", \"@timestamp\"],\n  \"query\": { \"exists\": { \"field\": \"kibana.alert.ancestors.index\" } },\n  \"sort\": [{ \"@timestamp\": \"desc\" }]\n}\n```\n\nPick one ancestor event entry and note:\n```\nOLD_INDEX = kibana.alert.ancestors.index\nEVENT_ID  = kibana.alert.ancestors.id\n```\n\nCreate a **hidden** restored-style index and copy only that event:\n```\nPUT restored-OLD_INDEX\n{\n  \"settings\": { \"index.hidden\": true }\n}\n\nPOST _reindex\n{\n  \"source\": { \"index\": \"OLD_INDEX\", \"query\": { \"ids\": { \"values\": [\"EVENT_ID\"] } } },\n  \"dest\":   { \"index\": \"restored-OLD_INDEX\", \"op_type\": \"create\" }\n}\n```\n\nRemove it from the original index so the primary lookup fails (this\ntriggers the fallback):\n```\nPOST OLD_INDEX/_delete_by_query\n{\n  \"query\": { \"ids\": { \"values\": [\"EVENT_ID\"] } }\n}\n```\n\nThen open that alert, expand the details flyout, and click `Source\nevent` in `Highlighted Fields`:\n- **Before this PR:** the fallback retries but still errors, because the\nhidden `restored-` index isn't matched by the wildcard.\n- **With this PR:** the source-event preview opens and shows the\ndocument.\n\n> Note: the `Source event` link is only rendered in the legacy flyout.\nIf you have the `securitySolution:enableNewFlyout` advanced setting on,\nturn it off to test this flow.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2c3998d939335d5db1240a7876cfa57ad00c2493"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282272","number":282272,"mergeCommit":{"message":"[Security Solution] Improve fallback document fetch for restored indices (#282272)\n\n> [!NOTE]\n> The fix merged in https://github.com/elastic/kibana/pull/277703 was\nnot sufficient. This is a server-side follow up that should hopefully\nsolve the issue for good.\n\n## Summary\n\nThis PR makes the \"Source event\" fallback lookup also resolve documents\nthat live in **hidden** `restored-`/`partial-` indices.\n\n### Prior work\n\nIn the previous [PR](https://github.com/elastic/kibana/pull/277703), we\nadded a client-side fallback: when opening the `Source event` from an\nalert's `Highlighted Fields` fails (because the document's backing index\nwas relocated to a searchable-snapshot tier and remounted under a\n`restored-` prefix), we retry once against a broadened index pattern\n(`*`-prefixed) so it can match the renamed index.\n\nThat fix worked in local testing but **did not resolve the customer's\ncase** (still reproducing after upgrading). The reason: the `restored-`\nindices produced by ILM's `searchable_snapshot` action — and `.ds-`\ndatastream backing indices in general — are **hidden** indices. A\nwildcard pattern (`*.ds-...`) only matches hidden indices when the\nsearch request sets `expand_wildcards` to include `hidden`. The timeline\nevent-details query never set `expand_wildcards`, so Elasticsearch\ndefaulted to `open` and the broadened retry still returned no hit.\n\n> [!TIP]\n> Manual test masked this because it created the `restored-` index with\na plain `_reindex`, which produces a **non-hidden** index — so the\nwildcard matched and the fix appeared to work.\n\n\nhttps://github.com/user-attachments/assets/31593ff0-ca97-4d6e-aaf7-77d575a3589b\n\n### Solutions explored\n\nThe straightforward option was to always add `expand_wildcards: ['open',\n'hidden']` to `buildTimelineDetailsQuery`. But that query is shared by\nevery event-details lookup, including legitimate primary lookups that\nalready pass a broad index *pattern* (e.g.\n`DocumentFlyoutWrapperFromPattern`, used for notes). Always expanding to\nhidden indices would silently change behavior for those calls too.\n\nTo keep the same additive/no-impact mindset as #277703, the change is\nscoped to the fallback only:\n\n- A new optional `includeHiddenIndices` flag is added to the\n`eventsDetails` search-strategy request.\n- The **primary** lookup leaves it unset, so its request is\nbyte-for-byte unchanged (no `expand_wildcards` key at all).\n- The **client fallback retry** is the only caller that sets\n`includeHiddenIndices: true`, and only then does\n`buildTimelineDetailsQuery` add `expand_wildcards: ['open', 'hidden']`.\n\nSince exact index names resolve regardless of hidden status, the only\nbehavioral change is: \"when we retry a failed by-id lookup against a\nbroadened pattern, also look inside hidden indices\" — which is exactly\nthe intended fix.\n\n\nhttps://github.com/user-attachments/assets/ea1120fc-83b7-4269-b195-53caff455948\n\n## How to test\n\n- generate some documents locally (`yarn test:generate`)\n- generate some alerts off of those documents (install the `Endpoint\nSecurity` rule)\n\nUse Kibana Dev Tools to make one alert's source event only available in\na **hidden** `restored-` index (the `index.hidden: true` setting is the\nimportant difference vs #277703).\n\nFind one alert with ancestor index/id:\n```\nGET .alerts-security.alerts-*/_search\n{\n  \"size\": 5,\n  \"_source\": [\"kibana.alert.ancestors\", \"kibana.alert.rule.name\", \"@timestamp\"],\n  \"query\": { \"exists\": { \"field\": \"kibana.alert.ancestors.index\" } },\n  \"sort\": [{ \"@timestamp\": \"desc\" }]\n}\n```\n\nPick one ancestor event entry and note:\n```\nOLD_INDEX = kibana.alert.ancestors.index\nEVENT_ID  = kibana.alert.ancestors.id\n```\n\nCreate a **hidden** restored-style index and copy only that event:\n```\nPUT restored-OLD_INDEX\n{\n  \"settings\": { \"index.hidden\": true }\n}\n\nPOST _reindex\n{\n  \"source\": { \"index\": \"OLD_INDEX\", \"query\": { \"ids\": { \"values\": [\"EVENT_ID\"] } } },\n  \"dest\":   { \"index\": \"restored-OLD_INDEX\", \"op_type\": \"create\" }\n}\n```\n\nRemove it from the original index so the primary lookup fails (this\ntriggers the fallback):\n```\nPOST OLD_INDEX/_delete_by_query\n{\n  \"query\": { \"ids\": { \"values\": [\"EVENT_ID\"] } }\n}\n```\n\nThen open that alert, expand the details flyout, and click `Source\nevent` in `Highlighted Fields`:\n- **Before this PR:** the fallback retries but still errors, because the\nhidden `restored-` index isn't matched by the wildcard.\n- **With this PR:** the source-event preview opens and shows the\ndocument.\n\n> Note: the `Source event` link is only rendered in the legacy flyout.\nIf you have the `securitySolution:enableNewFlyout` advanced setting on,\nturn it off to test this flow.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2c3998d939335d5db1240a7876cfa57ad00c2493"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282325","number":282325,"state":"OPEN"},{"branch":"8.19","label":"v8.19.20","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282326","number":282326,"state":"OPEN"},{"branch":"9.3","label":"v9.3.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->