### PR TITLE
[9.3] [Data Views] Confirm data view Save submitted in createIndexPattern FTR helper (#282103)

### DIFF
--- a/src/platform/test/functional/page_objects/settings_page.ts
+++ b/src/platform/test/functional/page_objects/settings_page.ts
@@ -204,16 +204,13 @@ export class SettingsPageObject extends FtrService {
   }
 
   async getSaveDataViewButtonActive() {
+    // EuiButton renders its disabled state as the native `disabled` attribute rather than a
+    // class, and a disabled button never fires its onClick, so the element has to be probed
+    // directly: a click sent to it is dropped without throwing.
     await this.retry.waitFor('active save button', async () => {
-      return (
-        (
-          await this.find.allByCssSelector(
-            '[data-test-subj="saveIndexPatternButton"]:not(.euiButton-isDisabled)'
-          )
-        ).length === 1
-      );
+      return await (await this.getSaveIndexPatternButton()).isEnabled();
     });
-    return await this.testSubjects.find('saveIndexPatternButton');
+    return await this.getSaveIndexPatternButton();
   }
 
   async clickEditIndexButton() {
@@ -480,11 +477,22 @@ export class SettingsPageObject extends FtrService {
     }
   }
 
-  async addCustomDataViewId(value: string) {
+  // `toggleAdvancedSetting` flips the section between shown and hidden, so calling it
+  // unconditionally would collapse the section again when the form is filled a second time.
+  async showAdvancedSettings() {
+    if (await this.testSubjects.exists('advancedSettings')) {
+      return;
+    }
     await this.testSubjects.click('toggleAdvancedSetting');
+    await this.testSubjects.existOrFail('advancedSettings');
+  }
+
+  async addCustomDataViewId(value: string) {
+    await this.showAdvancedSettings();
     const customDataViewIdInput = await (
       await this.testSubjects.find('savedObjectIdField')
     ).findByTagName('input');
+    await customDataViewIdInput.clearValueWithKeyboard();
     await customDataViewIdInput.type(value);
   }
 
@@ -517,9 +525,14 @@ export class SettingsPageObject extends FtrService {
   }
 
   async allowHiddenClick() {
-    await this.testSubjects.click('toggleAdvancedSetting');
+    await this.showAdvancedSettings();
     const allowHiddenField = await this.testSubjects.find('allowHiddenField');
-    await (await allowHiddenField.findByTagName('button')).click();
+    const allowHiddenToggle = await allowHiddenField.findByTagName('button');
+    // The toggle is a switch, so re-clicking it on a second fill would turn allow-hidden back off.
+    if ((await allowHiddenToggle.getAttribute('aria-checked')) === 'true') {
+      return;
+    }
+    await allowHiddenToggle.click();
   }
 
   async createIndexPattern(
@@ -531,7 +544,12 @@ export class SettingsPageObject extends FtrService {
     dataViewName?: string,
     allowHidden?: boolean
   ) {
+    let hasSubmittedTheForm = false;
     await this.retry.try(async () => {
+      if (hasSubmittedTheForm && !(await this.testSubjects.exists('indexPatternEditorFlyout'))) {
+        // The save was accepted and the editor flyout closed: the data view was created.
+        return;
+      }
       await this.header.waitUntilLoadingHasFinished();
       await this.clickKibanaIndexPatterns();
 
@@ -578,8 +596,14 @@ export class SettingsPageObject extends FtrService {
           return validationError === '0';
         }
       );
+      await (await this.getSaveDataViewButtonActive()).click();
+      hasSubmittedTheForm = true;
 
-      await (await this.getSaveIndexPatternButton()).click();
+      // The Save click can be swallowed when it races the async CCS source
+      // resolution re-render, leaving the flyout open with nothing submitted.
+      // Confirm the flyout closed inside this retry.try so a swallowed click
+      // re-runs fill→save, rather than the URL loop below dead-polling forever.
+      await this.testSubjects.missingOrFail('indexPatternEditorFlyout', { timeout: 30000 });
     });
     await this.header.waitUntilLoadingHasFinished();
     await this.retry.try(async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Data Views] Confirm data view Save submitted in createIndexPattern FTR helper (#282103)](https://github.com/elastic/kibana/pull/282103)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kibana Machine","email":"42973632+kibanamachine@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-02T21:46:20Z","message":"[Data Views] Confirm data view Save submitted in createIndexPattern FTR helper (#282103)\n\nFixes #259317\n\n### Summary\n- The CCS data view test times out with `Data view not created` because\nthe `Save data view` click in the `createIndexPattern` FTR helper is\noccasionally swallowed — it races the async CCS source-resolution\nre-render, resolves without submitting, and (since it does not throw)\nthe fill→save block never retries.\n- The click lived in one `retry.try` while success was checked in a\n*separate* `retry.try` that only polls the URL, so a no-op click could\nnever be recovered — the URL loop just dead-polled a URL that never\nchanges until the 120s timeout.\n- This patch folds a submission confirmation into the **same**\n`retry.try` as the Save click: after clicking, it waits for the editor\nflyout to close (`missingOrFail('indexPatternEditorFlyout')`). A\nswallowed click leaves the flyout open, so it re-runs fill→save on a\nsettled flyout; a `hasSubmittedTheForm` guard short-circuits the retry\nonce the save is accepted (mirrors the existing `editIndexPattern`\npattern).\n\n### Context\n- Follows the root cause and proposed fix in the [Failed Test\nInvestigator\ncomment](https://github.com/elastic/kibana/issues/259317#issuecomment-5144892251)\n(2026-07-31): the swallowed Save click leaves the flyout open and the\nURL-only recovery loop dead-polls until timeout. This patch implements\nits primary recommendation (fold the flyout-close confirmation into the\nSave `retry.try`).\n- Supersedes the earlier proposed fix from\n[#263426](https://github.com/elastic/kibana/pull/263426) (merged\n2026-04-16), which added `getSaveDataViewButtonActive` to wait for the\nSave button to be enabled. Waiting for the button to be enabled at one\ninstant was insufficient — it did not confirm the click actually\n*submitted*, which is why that fix did not hold\n(`failure:fix-did-not-hold`).\n- Both recorded failures are rare and on `kibana-on-merge` (`main`):\n[2026-03-24](https://buildkite.com/elastic/kibana-on-merge/builds/91653#019d1f86-0d24-42f8-9d88-e117bb6a93f3)\nand\n[2026-07-31](https://buildkite.com/elastic/kibana-on-merge/builds/104717#019fb8b3-e5cd-4f08-8a55-a38779a9b4f8);\nthe failure screenshot shows the create-data-view flyout still open with\na valid, enabled form and no create request in the server log.\n\n## Corrections from maintainer\n\nEverything above is the original generated description, left as written.\nReviewing the patch turned up the following.\n\n- **`getSaveDataViewButtonActive` never waited for anything.** This\ncorrects the #263426 bullet under Context. Its selector\n`[data-test-subj=\"saveIndexPatternButton\"]:not(.euiButton-isDisabled)`\nstopped matching when `EuiButton` moved to Emotion — the disabled state\nis the native `disabled` attribute in `@elastic/eui@118.0.0` — so\n`:not()` always matched and the helper returned immediately. A no-op\nhelper is a simpler explanation for `failure:fix-did-not-hold` than the\none recorded on the issue.\n- **A natively disabled Save button is a second candidate mechanism**,\nalongside the re-render race in the first Summary bullet.\n`submitDisabled` is `(form.isSubmitted && !form.isValid) ||\nform.isSubmitting`, and a disabled `EuiButton` drops the click without\nthrowing. This is unproven against the recorded failures — the\nscreenshot shows a form that looks enabled — but the retry loop this PR\nadds re-clicks through that same helper, so it now probes `isEnabled()`.\n- **The fill helpers had to be made safe to run twice**, since retry is\nnow the recovery path: `toggleAdvancedSetting` is a flip rather than a\nshow, the allow-hidden switch is a toggle, and the custom data view id\ninput was typed into without being cleared.\n- **This belongs on every open branch, not just `9.5`/`9.4`.** This\nsupersedes the Backporting guidance below; the labels are now\n`backport:all-open`. `config.ccs.ts` is in the FTR manifest on\n[`9.3`](https://github.com/elastic/kibana/blob/668bf142d45844b105328871986bff277ee7b43b/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml#L110)\nand\n[`8.19`](https://github.com/elastic/kibana/blob/25c19045288e71bd578ca54fd1f82c9c60b4a2ae/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml#L106)\ntoo, so the spec runs there and a flake can block a patch release. Those\nbranches are more exposed rather than less: [`createIndexPattern` on\n`8.19`](https://github.com/elastic/kibana/blob/25c19045288e71bd578ca54fd1f82c9c60b4a2ae/src/platform/test/functional/page_objects/settings_page.ts#L568)\nclicks Save with no enabled-wait at all, since #263426 stopped at\n`v9.4.0`. Everything the patch needs is already there on both:\n`isEnabled`, `clearValueWithKeyboard`, `missingOrFail` with a `timeout`\noption, and `toggleAdvancedSetting` / `advancedSettings` /\n`allowHiddenField` / `savedObjectIdField` markup identical to `main`.\nThe one conflicting line is the Save click, and taking\n`getSaveDataViewButtonActive()` there — folding in #263426's one-liner —\nmakes the patch apply cleanly on both.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n`✅ Passed: node scripts/eslint\nsrc/platform/test/functional/page_objects/settings_page.ts`\n`✅ Passed: node scripts/type_check --project\nsrc/platform/test/tsconfig.json`\n\n#### Not verified locally\n\n- The FTR test itself (`_data_views_ccs.ts`) requires a live\nElasticsearch + Kibana with a remote CCS cluster and cannot be run in\nthis environment, so behavior under real CCS latency and CI parallel\nload is unverified.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:version` with `v9.5.0` and `v9.4.5`. The failing test\nexists on all open release branches (`9.5`, `9.4`, `9.3`, `8.19`), and\n`createIndexPattern` on `9.5`/`9.4` is identical to `main` (uses\n`getSaveDataViewButtonActive`), so this patch applies unchanged there.\nOn `9.3` and `8.19`, `createIndexPattern` still calls\n`getSaveIndexPatternButton()` (the #263426 refactor was never\nbackported), so this patch does **not** apply cleanly — I left those\nbranches out; a maintainer would need to adapt the fix if the flake\nsurfaces there.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/30645378865) for\n#259317 · 75.3 AIC · ⌖ 2.73 AIC ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\n---------\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"25529aa8f6ed7df7460fa1caeff1ff8606ca2afe","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0","flaky-test-fixer","flaky-fix-check:passed","v9.6.0","v9.4.5"],"title":"[Data Views] Confirm data view Save submitted in createIndexPattern FTR helper","number":282103,"url":"https://github.com/elastic/kibana/pull/282103","mergeCommit":{"message":"[Data Views] Confirm data view Save submitted in createIndexPattern FTR helper (#282103)\n\nFixes #259317\n\n### Summary\n- The CCS data view test times out with `Data view not created` because\nthe `Save data view` click in the `createIndexPattern` FTR helper is\noccasionally swallowed — it races the async CCS source-resolution\nre-render, resolves without submitting, and (since it does not throw)\nthe fill→save block never retries.\n- The click lived in one `retry.try` while success was checked in a\n*separate* `retry.try` that only polls the URL, so a no-op click could\nnever be recovered — the URL loop just dead-polled a URL that never\nchanges until the 120s timeout.\n- This patch folds a submission confirmation into the **same**\n`retry.try` as the Save click: after clicking, it waits for the editor\nflyout to close (`missingOrFail('indexPatternEditorFlyout')`). A\nswallowed click leaves the flyout open, so it re-runs fill→save on a\nsettled flyout; a `hasSubmittedTheForm` guard short-circuits the retry\nonce the save is accepted (mirrors the existing `editIndexPattern`\npattern).\n\n### Context\n- Follows the root cause and proposed fix in the [Failed Test\nInvestigator\ncomment](https://github.com/elastic/kibana/issues/259317#issuecomment-5144892251)\n(2026-07-31): the swallowed Save click leaves the flyout open and the\nURL-only recovery loop dead-polls until timeout. This patch implements\nits primary recommendation (fold the flyout-close confirmation into the\nSave `retry.try`).\n- Supersedes the earlier proposed fix from\n[#263426](https://github.com/elastic/kibana/pull/263426) (merged\n2026-04-16), which added `getSaveDataViewButtonActive` to wait for the\nSave button to be enabled. Waiting for the button to be enabled at one\ninstant was insufficient — it did not confirm the click actually\n*submitted*, which is why that fix did not hold\n(`failure:fix-did-not-hold`).\n- Both recorded failures are rare and on `kibana-on-merge` (`main`):\n[2026-03-24](https://buildkite.com/elastic/kibana-on-merge/builds/91653#019d1f86-0d24-42f8-9d88-e117bb6a93f3)\nand\n[2026-07-31](https://buildkite.com/elastic/kibana-on-merge/builds/104717#019fb8b3-e5cd-4f08-8a55-a38779a9b4f8);\nthe failure screenshot shows the create-data-view flyout still open with\na valid, enabled form and no create request in the server log.\n\n## Corrections from maintainer\n\nEverything above is the original generated description, left as written.\nReviewing the patch turned up the following.\n\n- **`getSaveDataViewButtonActive` never waited for anything.** This\ncorrects the #263426 bullet under Context. Its selector\n`[data-test-subj=\"saveIndexPatternButton\"]:not(.euiButton-isDisabled)`\nstopped matching when `EuiButton` moved to Emotion — the disabled state\nis the native `disabled` attribute in `@elastic/eui@118.0.0` — so\n`:not()` always matched and the helper returned immediately. A no-op\nhelper is a simpler explanation for `failure:fix-did-not-hold` than the\none recorded on the issue.\n- **A natively disabled Save button is a second candidate mechanism**,\nalongside the re-render race in the first Summary bullet.\n`submitDisabled` is `(form.isSubmitted && !form.isValid) ||\nform.isSubmitting`, and a disabled `EuiButton` drops the click without\nthrowing. This is unproven against the recorded failures — the\nscreenshot shows a form that looks enabled — but the retry loop this PR\nadds re-clicks through that same helper, so it now probes `isEnabled()`.\n- **The fill helpers had to be made safe to run twice**, since retry is\nnow the recovery path: `toggleAdvancedSetting` is a flip rather than a\nshow, the allow-hidden switch is a toggle, and the custom data view id\ninput was typed into without being cleared.\n- **This belongs on every open branch, not just `9.5`/`9.4`.** This\nsupersedes the Backporting guidance below; the labels are now\n`backport:all-open`. `config.ccs.ts` is in the FTR manifest on\n[`9.3`](https://github.com/elastic/kibana/blob/668bf142d45844b105328871986bff277ee7b43b/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml#L110)\nand\n[`8.19`](https://github.com/elastic/kibana/blob/25c19045288e71bd578ca54fd1f82c9c60b4a2ae/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml#L106)\ntoo, so the spec runs there and a flake can block a patch release. Those\nbranches are more exposed rather than less: [`createIndexPattern` on\n`8.19`](https://github.com/elastic/kibana/blob/25c19045288e71bd578ca54fd1f82c9c60b4a2ae/src/platform/test/functional/page_objects/settings_page.ts#L568)\nclicks Save with no enabled-wait at all, since #263426 stopped at\n`v9.4.0`. Everything the patch needs is already there on both:\n`isEnabled`, `clearValueWithKeyboard`, `missingOrFail` with a `timeout`\noption, and `toggleAdvancedSetting` / `advancedSettings` /\n`allowHiddenField` / `savedObjectIdField` markup identical to `main`.\nThe one conflicting line is the Save click, and taking\n`getSaveDataViewButtonActive()` there — folding in #263426's one-liner —\nmakes the patch apply cleanly on both.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n`✅ Passed: node scripts/eslint\nsrc/platform/test/functional/page_objects/settings_page.ts`\n`✅ Passed: node scripts/type_check --project\nsrc/platform/test/tsconfig.json`\n\n#### Not verified locally\n\n- The FTR test itself (`_data_views_ccs.ts`) requires a live\nElasticsearch + Kibana with a remote CCS cluster and cannot be run in\nthis environment, so behavior under real CCS latency and CI parallel\nload is unverified.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:version` with `v9.5.0` and `v9.4.5`. The failing test\nexists on all open release branches (`9.5`, `9.4`, `9.3`, `8.19`), and\n`createIndexPattern` on `9.5`/`9.4` is identical to `main` (uses\n`getSaveDataViewButtonActive`), so this patch applies unchanged there.\nOn `9.3` and `8.19`, `createIndexPattern` still calls\n`getSaveIndexPatternButton()` (the #263426 refactor was never\nbackported), so this patch does **not** apply cleanly — I left those\nbranches out; a maintainer would need to adapt the fix if the flake\nsurfaces there.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/30645378865) for\n#259317 · 75.3 AIC · ⌖ 2.73 AIC ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\n---------\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"25529aa8f6ed7df7460fa1caeff1ff8606ca2afe"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282178","number":282178,"state":"MERGED","mergeCommit":{"sha":"77d7736e05bacb5201599cfeb851dd550e611dc6","message":"[9.5] [Data Views] Confirm data view Save submitted in createIndexPattern FTR helper (#282103) (#282178)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Data Views] Confirm data view Save submitted in createIndexPattern\nFTR helper (#282103)](https://github.com/elastic/kibana/pull/282103)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282103","number":282103,"mergeCommit":{"message":"[Data Views] Confirm data view Save submitted in createIndexPattern FTR helper (#282103)\n\nFixes #259317\n\n### Summary\n- The CCS data view test times out with `Data view not created` because\nthe `Save data view` click in the `createIndexPattern` FTR helper is\noccasionally swallowed — it races the async CCS source-resolution\nre-render, resolves without submitting, and (since it does not throw)\nthe fill→save block never retries.\n- The click lived in one `retry.try` while success was checked in a\n*separate* `retry.try` that only polls the URL, so a no-op click could\nnever be recovered — the URL loop just dead-polled a URL that never\nchanges until the 120s timeout.\n- This patch folds a submission confirmation into the **same**\n`retry.try` as the Save click: after clicking, it waits for the editor\nflyout to close (`missingOrFail('indexPatternEditorFlyout')`). A\nswallowed click leaves the flyout open, so it re-runs fill→save on a\nsettled flyout; a `hasSubmittedTheForm` guard short-circuits the retry\nonce the save is accepted (mirrors the existing `editIndexPattern`\npattern).\n\n### Context\n- Follows the root cause and proposed fix in the [Failed Test\nInvestigator\ncomment](https://github.com/elastic/kibana/issues/259317#issuecomment-5144892251)\n(2026-07-31): the swallowed Save click leaves the flyout open and the\nURL-only recovery loop dead-polls until timeout. This patch implements\nits primary recommendation (fold the flyout-close confirmation into the\nSave `retry.try`).\n- Supersedes the earlier proposed fix from\n[#263426](https://github.com/elastic/kibana/pull/263426) (merged\n2026-04-16), which added `getSaveDataViewButtonActive` to wait for the\nSave button to be enabled. Waiting for the button to be enabled at one\ninstant was insufficient — it did not confirm the click actually\n*submitted*, which is why that fix did not hold\n(`failure:fix-did-not-hold`).\n- Both recorded failures are rare and on `kibana-on-merge` (`main`):\n[2026-03-24](https://buildkite.com/elastic/kibana-on-merge/builds/91653#019d1f86-0d24-42f8-9d88-e117bb6a93f3)\nand\n[2026-07-31](https://buildkite.com/elastic/kibana-on-merge/builds/104717#019fb8b3-e5cd-4f08-8a55-a38779a9b4f8);\nthe failure screenshot shows the create-data-view flyout still open with\na valid, enabled form and no create request in the server log.\n\n## Corrections from maintainer\n\nEverything above is the original generated description, left as written.\nReviewing the patch turned up the following.\n\n- **`getSaveDataViewButtonActive` never waited for anything.** This\ncorrects the #263426 bullet under Context. Its selector\n`[data-test-subj=\"saveIndexPatternButton\"]:not(.euiButton-isDisabled)`\nstopped matching when `EuiButton` moved to Emotion — the disabled state\nis the native `disabled` attribute in `@elastic/eui@118.0.0` — so\n`:not()` always matched and the helper returned immediately. A no-op\nhelper is a simpler explanation for `failure:fix-did-not-hold` than the\none recorded on the issue.\n- **A natively disabled Save button is a second candidate mechanism**,\nalongside the re-render race in the first Summary bullet.\n`submitDisabled` is `(form.isSubmitted && !form.isValid) ||\nform.isSubmitting`, and a disabled `EuiButton` drops the click without\nthrowing. This is unproven against the recorded failures — the\nscreenshot shows a form that looks enabled — but the retry loop this PR\nadds re-clicks through that same helper, so it now probes `isEnabled()`.\n- **The fill helpers had to be made safe to run twice**, since retry is\nnow the recovery path: `toggleAdvancedSetting` is a flip rather than a\nshow, the allow-hidden switch is a toggle, and the custom data view id\ninput was typed into without being cleared.\n- **This belongs on every open branch, not just `9.5`/`9.4`.** This\nsupersedes the Backporting guidance below; the labels are now\n`backport:all-open`. `config.ccs.ts` is in the FTR manifest on\n[`9.3`](https://github.com/elastic/kibana/blob/668bf142d45844b105328871986bff277ee7b43b/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml#L110)\nand\n[`8.19`](https://github.com/elastic/kibana/blob/25c19045288e71bd578ca54fd1f82c9c60b4a2ae/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml#L106)\ntoo, so the spec runs there and a flake can block a patch release. Those\nbranches are more exposed rather than less: [`createIndexPattern` on\n`8.19`](https://github.com/elastic/kibana/blob/25c19045288e71bd578ca54fd1f82c9c60b4a2ae/src/platform/test/functional/page_objects/settings_page.ts#L568)\nclicks Save with no enabled-wait at all, since #263426 stopped at\n`v9.4.0`. Everything the patch needs is already there on both:\n`isEnabled`, `clearValueWithKeyboard`, `missingOrFail` with a `timeout`\noption, and `toggleAdvancedSetting` / `advancedSettings` /\n`allowHiddenField` / `savedObjectIdField` markup identical to `main`.\nThe one conflicting line is the Save click, and taking\n`getSaveDataViewButtonActive()` there — folding in #263426's one-liner —\nmakes the patch apply cleanly on both.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n`✅ Passed: node scripts/eslint\nsrc/platform/test/functional/page_objects/settings_page.ts`\n`✅ Passed: node scripts/type_check --project\nsrc/platform/test/tsconfig.json`\n\n#### Not verified locally\n\n- The FTR test itself (`_data_views_ccs.ts`) requires a live\nElasticsearch + Kibana with a remote CCS cluster and cannot be run in\nthis environment, so behavior under real CCS latency and CI parallel\nload is unverified.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:version` with `v9.5.0` and `v9.4.5`. The failing test\nexists on all open release branches (`9.5`, `9.4`, `9.3`, `8.19`), and\n`createIndexPattern` on `9.5`/`9.4` is identical to `main` (uses\n`getSaveDataViewButtonActive`), so this patch applies unchanged there.\nOn `9.3` and `8.19`, `createIndexPattern` still calls\n`getSaveIndexPatternButton()` (the #263426 refactor was never\nbackported), so this patch does **not** apply cleanly — I left those\nbranches out; a maintainer would need to adapt the fix if the flake\nsurfaces there.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/30645378865) for\n#259317 · 75.3 AIC · ⌖ 2.73 AIC ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\n---------\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"25529aa8f6ed7df7460fa1caeff1ff8606ca2afe"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282177","number":282177,"state":"MERGED","mergeCommit":{"sha":"3e69688be0e80bde90e290c298c6a4acb876d617","message":"[9.4] [Data Views] Confirm data view Save submitted in createIndexPattern FTR helper (#282103) (#282177)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Data Views] Confirm data view Save submitted in createIndexPattern\nFTR helper (#282103)](https://github.com/elastic/kibana/pull/282103)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}}]}] BACKPORT-->