### PR TITLE
fix(evals): harden Correctness Analysis judge against summary enum mix-ups

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/index.ts
@@ -16,6 +16,7 @@ import {
   calculateProceduralFidelityScore,
 } from './scoring';
 import type { CorrectnessAnalysis } from './types';
+import { normalizeCorrectnessAnalysis } from './normalize';
 import { parseSelectedEvaluators } from '../filter';
 
 const QUALITATIVE_EVALUATOR_NAME = 'Correctness Analysis';
@@ -78,7 +79,7 @@ export function createCorrectnessAnalysisEvaluator({
           throw new Error('No tool call found in LLM response');
         }
 
-        return toolCall.function.arguments;
+        return normalizeCorrectnessAnalysis(toolCall.function.arguments);
       }
 
       const correctnessAnalysisResult = await pRetry(runCorrectnessAnalysis, {

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/normalize.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/normalize.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { normalizeCorrectnessAnalysis } from './normalize';
+import type { CorrectnessAnalysis } from './types';
+
+const baseClaim = {
+  claim: 'c',
+  centrality: 'central' as const,
+  centrality_reason: 'r',
+  verdict: 'NOT_IN_GROUND_TRUTH' as const,
+  sequence_match: 'NOT_APPLICABLE' as const,
+  justification_snippet: undefined,
+  explanation: 'e',
+};
+
+const defaultArgs: CorrectnessAnalysis = {
+  summary: {
+    factual_accuracy_summary: 'NOT_IN_GROUND_TRUTH',
+    relevance_summary: 'PARTIALLY_RELEVANT',
+    sequence_accuracy_summary: 'NOT_APPLICABLE',
+  },
+  analysis: [baseClaim],
+};
+
+describe('normalizeCorrectnessAnalysis', () => {
+  it('returns MAJOR_INACCURACIES when factual_accuracy_summary uses a claim verdict', () => {
+    const result = normalizeCorrectnessAnalysis(defaultArgs);
+    expect(result.summary.factual_accuracy_summary).toBe('MAJOR_INACCURACIES');
+  });
+
+  it('returns the original factual_accuracy_summary when already valid', () => {
+    const result = normalizeCorrectnessAnalysis({
+      ...defaultArgs,
+      summary: {
+        ...defaultArgs.summary,
+        factual_accuracy_summary: 'ACCURATE',
+      },
+      analysis: [{ ...baseClaim, verdict: 'FULLY_SUPPORTED' }],
+    });
+    expect(result.summary.factual_accuracy_summary).toBe('ACCURATE');
+  });
+
+  it('returns NOT_APPLICABLE when sequence_accuracy_summary is invalid and claims are not sequenced', () => {
+    const result = normalizeCorrectnessAnalysis({
+      ...defaultArgs,
+      summary: {
+        ...defaultArgs.summary,
+        factual_accuracy_summary: 'MAJOR_INACCURACIES',
+        sequence_accuracy_summary: 'FULLY_SUPPORTED',
+      },
+    });
+    expect(result.summary.sequence_accuracy_summary).toBe('NOT_APPLICABLE');
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/normalize.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/normalize.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CorrectnessAnalysis } from './types';
+
+const FACTUAL_ACCURACY_SUMMARIES = new Set([
+  'ACCURATE',
+  'MINOR_INACCURACIES',
+  'MAJOR_INACCURACIES',
+]);
+
+const RELEVANCE_SUMMARIES = new Set(['RELEVANT', 'PARTIALLY_RELEVANT', 'IRRELEVANT']);
+
+const SEQUENCE_ACCURACY_SUMMARIES = new Set(['MATCH', 'MISMATCH', 'NOT_APPLICABLE']);
+
+const isBadVerdict = (verdict: string): boolean =>
+  verdict === 'CONTRADICTED' || verdict === 'NOT_IN_GROUND_TRUTH';
+
+/**
+ * Judges sometimes copy claim-level verdict enums into summary fields
+ * (e.g. factual_accuracy_summary=NOT_IN_GROUND_TRUTH). Quantitative scoring
+ * already prefers claim analysis, so derive a valid summary when needed.
+ */
+export function normalizeCorrectnessAnalysis(
+  analysisResult: CorrectnessAnalysis
+): CorrectnessAnalysis {
+  const analysis = Array.isArray(analysisResult.analysis) ? analysisResult.analysis : [];
+  const summary = analysisResult.summary ?? {
+    factual_accuracy_summary: '',
+    relevance_summary: '',
+    sequence_accuracy_summary: '',
+  };
+
+  return {
+    ...analysisResult,
+    analysis,
+    summary: {
+      factual_accuracy_summary: FACTUAL_ACCURACY_SUMMARIES.has(summary.factual_accuracy_summary)
+        ? summary.factual_accuracy_summary
+        : deriveFactualAccuracySummary(analysis),
+      relevance_summary: RELEVANCE_SUMMARIES.has(summary.relevance_summary)
+        ? summary.relevance_summary
+        : deriveRelevanceSummary(analysis),
+      sequence_accuracy_summary: SEQUENCE_ACCURACY_SUMMARIES.has(summary.sequence_accuracy_summary)
+        ? summary.sequence_accuracy_summary
+        : deriveSequenceAccuracySummary(analysis),
+    },
+  };
+}
+
+function deriveFactualAccuracySummary(analysis: CorrectnessAnalysis['analysis']): string {
+  if (analysis.some((claim) => claim.centrality === 'central' && isBadVerdict(claim.verdict))) {
+    return 'MAJOR_INACCURACIES';
+  }
+  if (analysis.some((claim) => claim.centrality === 'peripheral' && isBadVerdict(claim.verdict))) {
+    return 'MINOR_INACCURACIES';
+  }
+  return 'ACCURATE';
+}
+
+function deriveRelevanceSummary(analysis: CorrectnessAnalysis['analysis']): string {
+  if (analysis.length === 0) {
+    return 'IRRELEVANT';
+  }
+  const centralCount = analysis.filter((claim) => claim.centrality === 'central').length;
+  if (centralCount === analysis.length) {
+    return 'RELEVANT';
+  }
+  if (centralCount === 0) {
+    return 'IRRELEVANT';
+  }
+  return 'PARTIALLY_RELEVANT';
+}
+
+function deriveSequenceAccuracySummary(analysis: CorrectnessAnalysis['analysis']): string {
+  const centralClaims = analysis.filter((claim) => claim.centrality === 'central');
+  if (
+    centralClaims.length === 0 ||
+    centralClaims.every((claim) => claim.sequence_match === 'NOT_APPLICABLE')
+  ) {
+    return 'NOT_APPLICABLE';
+  }
+  if (centralClaims.some((claim) => claim.sequence_match === 'MISMATCH')) {
+    return 'MISMATCH';
+  }
+  return 'MATCH';
+}

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/prompt.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/prompt.ts
@@ -39,20 +39,23 @@ export const LlmCorrectnessEvaluationPrompt = createPrompt({
             summary: {
               type: 'object',
               properties: {
+                // Keep as free-form strings (allowed values documented below). Strict enums
+                // caused hard toolValidationError failures when judges copied claim-level
+                // verdicts (e.g. NOT_IN_GROUND_TRUTH) into summary fields.
                 factual_accuracy_summary: {
                   type: 'string',
-                  description: 'Overall factual accuracy assessment.',
-                  enum: ['ACCURATE', 'MINOR_INACCURACIES', 'MAJOR_INACCURACIES'],
+                  description:
+                    'Overall factual accuracy assessment. Must be exactly one of: ACCURATE, MINOR_INACCURACIES, MAJOR_INACCURACIES. Do not use claim verdict values.',
                 },
                 relevance_summary: {
                   type: 'string',
-                  description: 'Overall relevance assessment of the response.',
-                  enum: ['RELEVANT', 'PARTIALLY_RELEVANT', 'IRRELEVANT'],
+                  description:
+                    'Overall relevance assessment of the response. Must be exactly one of: RELEVANT, PARTIALLY_RELEVANT, IRRELEVANT.',
                 },
                 sequence_accuracy_summary: {
                   type: 'string',
-                  description: 'Overall sequence accuracy assessment for procedural queries.',
-                  enum: ['MATCH', 'MISMATCH', 'NOT_APPLICABLE'],
+                  description:
+                    'Overall sequence accuracy assessment for procedural queries. Must be exactly one of: MATCH, MISMATCH, NOT_APPLICABLE.',
                 },
               },
               required: [

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/system_prompt.text
@@ -43,12 +43,14 @@ Follow these steps rigorously:
 
 5.  Provide Justification: For every claim, you MUST provide a `justification_snippet` from the `[Ground Truth Response]` that supports your verdict. If the verdict is `NOT_IN_GROUND_TRUTH`, this field should be `null`.
 
-6.  Final Summary: After analyzing all claims, provide a final summary with two categorical verdicts:
+6.  Final Summary: After analyzing all claims, provide a final summary with two categorical verdicts.
 
-      * `factual_accuracy_summary`:
+      CRITICAL: Summary fields use a DIFFERENT vocabulary from claim-level `verdict`. Never copy claim verdicts (`FULLY_SUPPORTED`, `PARTIALLY_SUPPORTED`, `CONTRADICTED`, `NOT_IN_GROUND_TRUTH`) into `factual_accuracy_summary` or any other summary field.
+
+      * `factual_accuracy_summary` (exactly one of these three strings):
           * `ACCURATE`: All claims are `FULLY_SUPPORTED` or `PARTIALLY_SUPPORTED`.
           * `MINOR_INACCURACIES`: Contains `CONTRADICTED` or `NOT_IN_GROUND_TRUTH` claims that are `peripheral`.
-          * `MAJOR_INACCURACIES`: Contains `CONTRADICTED` or `NOT_IN_GROUND_TRUTH` claims that are `central` to the user's query.
+          * `MAJOR_INACCURACIES`: Contains `CONTRADICTED` or `NOT_IN_GROUND_TRUTH` claims that are `central` to the user's query. (Use this when central claims are `NOT_IN_GROUND_TRUTH`.)
       * `relevance_summary`:
           * `RELEVANT`: The response contains only `central` claims.
           * `PARTIALLY_RELEVANT`: The response answers the core query but also contains one or more `peripheral` claims.


### PR DESCRIPTION
## Summary
The Correctness Analysis LLM judge sometimes puts claim-level verdicts like `NOT_IN_GROUND_TRUTH` into `summary.factual_accuracy_summary`, which only allows `ACCURATE | MINOR_INACCURACIES | MAJOR_INACCURACIES`. That fails tool schema validation on `/internal/inference/prompt` and hard-fails the suite after retries.

This showed up on main (alerts RAG `temporal_query`) with current LangChain, so it is harness flakiness, not an upgrade regression. Soften the summary field schemas, normalize invalid summaries from claim analysis, and clarify the prompt so summary vocab stays distinct from claim verdicts.

## To test
- Unit: `node scripts/jest x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness`
- Local alerts RAG (unmodified stack otherwise):
  - `node scripts/evals run --suite security-alerts-rag-regression --model ".anthropic-claude-4.6-sonnet-chat_completion" --judge ".anthropic-claude-4.6-sonnet-chat_completion"`
  - Expect no hard fail from `toolValidationError` on `analyze` for Correctness Analysis (judge may still score low)

## Screenshots
n/a, eval harness only

_PR developed with Cursor + Composer_


Made with [Cursor](https://cursor.com)