### PR TITLE
Reassign langchain dependency updates to Agent Builder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2140,9 +2140,9 @@
         "@aws-sdk/credential-provider-node",
         "google-auth-library"
       ],
-      "reviewers": ["team:security-generative-ai"],
+      "reviewers": ["team:workchat-eng", "team:appex-ai-infra"],
       "matchBaseBranches": ["main"],
-      "addLabels": ["Team:Security Generative AI"],
+      "addLabels": ["Team:agent-builder", "Team:AI Infra"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },

--- a/renovate.json
+++ b/renovate.json
@@ -2140,9 +2140,9 @@
         "@aws-sdk/credential-provider-node",
         "google-auth-library"
       ],
-      "reviewers": ["team:workchat-eng", "team:appex-ai-infra"],
+      "reviewers": ["team:workchat-eng"],
       "matchBaseBranches": ["main"],
-      "addLabels": ["Team:agent-builder", "Team:AI Infra"],
+      "addLabels": ["Team:agent-builder"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },


### PR DESCRIPTION
## Summary

Moves the renovate `langchain` dependency group from `security-generative-ai` to `workchat-eng` (Agent Builder). Security's langchain use cases (assistant and the old graph-based attack discovery) are deprecated, and Security Generative AI isn't a functioning team anymore, so those teams shouldn't keep owning the upgrades.

Agent Builder is the sole active owner going forward. It's the only team with direct, heavy langchain/langgraph usage (`StateGraph`, `Annotation`, `Command`, etc. across `agent_builder`, `agent-builder-server`, `agent-builder-genai-utils`, `agent-builder-workflow-gen`). AI Infra's only touch point was `kbn-inference-cli` importing the `InferenceChatModel` type from `@kbn/inference-langchain` (itself owned by search-kibana), which is thin and type-only, so they aren't included as a reviewer here.

This is motivated by the long-running renovate PR [#259302](https://github.com/elastic/kibana/pull/259302), which still routes to Security Generative AI / Threat Hunting.

`@kbn/langchain` and the `langsmith` renovate group stay with Threat Hunting for now. Their real consumers (`security_solution`, `elastic_assistant`, `automatic_import`, `search_playground`) are unchanged, and Agent Builder uses `@kbn/inference-langchain` instead.

## To test

No runtime behavior change. Confirm the renovate group in `renovate.json` now has:
1. `reviewers`: `team:workchat-eng`
2. `addLabels`: `Team:agent-builder`

_PR developed with Cursor + GPT-5.2_