### PR TITLE
[Alerting v2] Add dedicated rule template saved object type and client

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.test.ts
@@ -6,50 +6,53 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { createRuleDataBaseSchema } from './rule_data_schema';
+import { createRuleDataBaseSchema, createRuleDataSchema } from './rule_data_schema';
 import { ruleTemplateDataSchema } from './rule_template_schema';
 
 const exampleTemplateAttributes = {
-  kind: 'alert' as const,
   engine: 'v2' as const,
-  metadata: {
-    name: '[Kubernetes OTel] Pod CrashLoopBackOff',
-    description: 'Alerts when containers have a high restart count, indicating CrashLoopBackOff.',
-    tags: ['Kubernetes'],
-  },
-  schedule: {
-    every: '1m',
-    lookback: '15m',
-  },
-  state_transition: {
-    pending_count: 3,
-  },
-  recovery_strategy: 'no_breach' as const,
-  artifacts: [
-    {
-      id: 'kubernetes_otel-pod-crashloopbackoff-v2-runbook',
-      type: 'runbook',
-      value: '## Pod CrashLoopBackOff\n\n### Triage Steps\n1. Identify the affected pod(s).',
+  rule: {
+    kind: 'alert' as const,
+    metadata: {
+      name: '[Kubernetes OTel] Pod CrashLoopBackOff',
+      description: 'Alerts when containers have a high restart count, indicating CrashLoopBackOff.',
+      tags: ['Kubernetes'],
     },
-  ],
-  query: {
-    format: 'composed' as const,
-    base: 'TS metrics-k8sclusterreceiver.otel-*\n| STATS restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name',
-    breach: {
-      segment:
-        'WHERE restarts > 0\n| SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, restarts\n| LIMIT 50',
+    schedule: {
+      every: '1m',
+      lookback: '15m',
     },
+    state_transition: {
+      pending_count: 3,
+    },
+    recovery_strategy: 'no_breach' as const,
+    artifacts: [
+      {
+        id: 'kubernetes_otel-pod-crashloopbackoff-v2-runbook',
+        type: 'runbook',
+        value: '## Pod CrashLoopBackOff\n\n### Triage Steps\n1. Identify the affected pod(s).',
+      },
+    ],
+    query: {
+      format: 'composed' as const,
+      base: 'TS metrics-k8sclusterreceiver.otel-*\n| STATS restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name',
+      breach: {
+        segment:
+          'WHERE restarts > 0\n| SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, restarts\n| LIMIT 50',
+      },
+    },
+    grouping: {
+      fields: ['k8s.pod.name', 'k8s.container.name', 'k8s.namespace.name'],
+    },
+    time_field: '@timestamp',
   },
-  grouping: {
-    fields: ['k8s.pod.name', 'k8s.container.name', 'k8s.namespace.name'],
-  },
-  time_field: '@timestamp',
 };
 
 describe('ruleTemplateDataSchema', () => {
   it('parses valid template attributes', () => {
     const result = ruleTemplateDataSchema.parse(exampleTemplateAttributes);
     expect(result.engine).toBe('v2');
+    expect(result.rule.kind).toBe('alert');
   });
 
   it('rejects a v1 rule template', () => {
@@ -83,11 +86,39 @@ describe('ruleTemplateDataSchema', () => {
 
     expect(() => ruleTemplateDataSchema.parse(v1RuleTemplate)).toThrow();
   });
+
+  it('rejects flat v2 create-rule attributes without a rule envelope', () => {
+    expect(() =>
+      ruleTemplateDataSchema.parse({
+        engine: 'v2',
+        ...exampleTemplateAttributes.rule,
+      })
+    ).toThrow();
+  });
+
+  it('applies create-rule refines under rule', () => {
+    const { state_transition: _stateTransition, ...ruleWithoutStateTransition } =
+      exampleTemplateAttributes.rule;
+
+    expect(() =>
+      ruleTemplateDataSchema.parse({
+        engine: 'v2',
+        rule: {
+          ...ruleWithoutStateTransition,
+          kind: 'signal',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM logs-* | KEEP @timestamp | LIMIT 1' },
+          },
+          recovery_strategy: 'no_breach',
+        },
+      })
+    ).toThrow(/Signal rules cannot set recovery_strategy/);
+  });
 });
 
 /**
- * Tripwire: the template schema must stay derived from the create-rule base
- * (same Zod object per field), not a forked copy.
+ * Tripwire: the template `rule` field must stay coupled to createRuleDataSchema.
  */
 describe('rule template create-rule schema coupling', () => {
   const toStableJsonSchema = (schema: z.ZodType) => {
@@ -98,55 +129,26 @@ describe('rule template create-rule schema coupling', () => {
     return rest;
   };
 
-  it('template keys match create-rule keys plus engine', () => {
-    const createRuleKeys = new Set(Object.keys(createRuleDataBaseSchema.shape));
-    const templateKeys = Object.keys(ruleTemplateDataSchema.shape);
-
-    const templateRuleKeys = templateKeys.filter((key) => key !== 'engine').sort();
-    const createKeysSorted = [...createRuleKeys].sort();
-
-    expect({
-      hint: 'Rule template top-level fields drifted from create-rule. Keep ruleTemplateDataSchema = createRuleDataBaseSchema.extend({ engine }).',
-      templateRuleKeys,
-      createKeysSorted,
-    }).toEqual({
-      hint: 'Rule template top-level fields drifted from create-rule. Keep ruleTemplateDataSchema = createRuleDataBaseSchema.extend({ engine }).',
-      templateRuleKeys: createKeysSorted,
-      createKeysSorted,
-    });
-
-    if (!templateKeys.includes('engine')) {
-      throw new Error('Rule template schema is missing required field "engine".');
-    }
+  it('top-level keys are engine and rule', () => {
+    expect(Object.keys(ruleTemplateDataSchema.shape).sort()).toEqual(['engine', 'rule']);
   });
 
-  it('reuses create-rule field schemas by reference (not a forked copy)', () => {
-    const createShape = createRuleDataBaseSchema.shape;
-    const templateShape = ruleTemplateDataSchema.shape;
-
-    for (const key of Object.keys(createShape) as Array<keyof typeof createShape>) {
-      if (templateShape[key] !== createShape[key]) {
-        throw new Error(
-          `Rule template field "${String(key)}" is not the same Zod schema as create-rule. ` +
-            `Keep ruleTemplateDataSchema = createRuleDataBaseSchema.extend({ engine }).`
-        );
-      }
-    }
+  it('reuses createRuleDataSchema for the nested rule field by reference', () => {
+    expect(ruleTemplateDataSchema.shape.rule).toBe(createRuleDataSchema);
   });
 
   /**
    * Full structural snapshot of the create-rule base schema.
    * When create-rule changes, update this snapshot and confirm the template
-   * schema still extends the same base. If a new model version was added
-   * for create rule, a new model version is needed for the template.
+   * schema still nests createRuleDataSchema under `rule`.
    */
   it('matches the snapshot of the full create-rule JSON schema', () => {
     expect({
-      hint: 'Create-rule schema changed. Update this snapshot and confirm ruleTemplateDataSchema still extends createRuleDataBaseSchema.',
+      hint: 'Create-rule schema changed. Update this snapshot and confirm ruleTemplateDataSchema.rule still uses createRuleDataSchema.',
       schema: toStableJsonSchema(createRuleDataBaseSchema),
     }).toMatchInlineSnapshot(`
       Object {
-        "hint": "Create-rule schema changed. Update this snapshot and confirm ruleTemplateDataSchema still extends createRuleDataBaseSchema.",
+        "hint": "Create-rule schema changed. Update this snapshot and confirm ruleTemplateDataSchema.rule still uses createRuleDataSchema.",
         "schema": Object {
           "additionalProperties": false,
           "properties": Object {
@@ -481,52 +483,5 @@ describe('rule template create-rule schema coupling', () => {
         },
       }
     `);
-  });
-
-  it('template JSON schema is create-rule plus engine', () => {
-    const createJson = toStableJsonSchema(createRuleDataBaseSchema) as {
-      properties?: Record<string, unknown>;
-      required?: string[];
-    };
-    const templateJson = toStableJsonSchema(ruleTemplateDataSchema) as {
-      properties?: Record<string, unknown>;
-      required?: string[];
-    };
-
-    const { engine, ...templateRuleProperties } = templateJson.properties ?? {};
-    expect({
-      hint: 'Rule template must add engine:"v2" on top of create-rule properties.',
-      engine,
-    }).toEqual({
-      hint: 'Rule template must add engine:"v2" on top of create-rule properties.',
-      engine: {
-        type: 'string',
-        const: 'v2',
-        description: 'The alerting engine this template targets. Always "v2" for v2 templates.',
-      },
-    });
-
-    expect({
-      hint: 'Rule template create-rule properties drifted from createRuleDataBaseSchema. Keep ruleTemplateDataSchema = createRuleDataBaseSchema.extend({ engine }).',
-      templateRuleProperties,
-      createRuleProperties: createJson.properties,
-    }).toEqual({
-      hint: 'Rule template create-rule properties drifted from createRuleDataBaseSchema. Keep ruleTemplateDataSchema = createRuleDataBaseSchema.extend({ engine }).',
-      templateRuleProperties: createJson.properties,
-      createRuleProperties: createJson.properties,
-    });
-
-    const templateRequiredWithoutEngine = (templateJson.required ?? [])
-      .filter((key) => key !== 'engine')
-      .sort();
-    expect({
-      hint: 'Rule template required fields (excluding engine) must match create-rule required fields.',
-      templateRequiredWithoutEngine,
-      createRequired: [...(createJson.required ?? [])].sort(),
-    }).toEqual({
-      hint: 'Rule template required fields (excluding engine) must match create-rule required fields.',
-      templateRequiredWithoutEngine: [...(createJson.required ?? [])].sort(),
-      createRequired: [...(createJson.required ?? [])].sort(),
-    });
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.ts
@@ -6,15 +6,23 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { createRuleDataBaseSchema } from './rule_data_schema';
+import { createRuleDataSchema } from './rule_data_schema';
 
 const engineField = z
   .literal('v2')
   .describe('The alerting engine this template targets. Always "v2" for v2 templates.');
 
-export const ruleTemplateDataSchema = createRuleDataBaseSchema
-  .extend({
+/**
+ * Alerting v2 rule template attributes.
+ *
+ * Create-rule fields are nested under `rule` so template storage can evolve
+ * independently of top-level SO metadata (`engine`). Uses the full create-rule
+ * schema (including cross-field refines), not only the base object shape.
+ */
+export const ruleTemplateDataSchema = z
+  .object({
     engine: engineField,
+    rule: createRuleDataSchema,
   })
   .strict()
   .describe('Alerting v2 rule template attributes.');

--- a/x-pack/platform/plugins/shared/alerting_v2/common/create_rule_data_from_template.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/create_rule_data_from_template.test.ts
@@ -12,44 +12,46 @@ import { createRuleDataFromTemplate } from './create_rule_data_from_template';
  * Mirrors attributes in repo-root `rule_template_v2.example.json`.
  */
 const exampleTemplateAttributes = {
-  kind: 'alert' as const,
   engine: 'v2' as const,
-  metadata: {
-    name: '[Kubernetes OTel] Pod CrashLoopBackOff',
-    description: 'Alerts when containers have a high restart count, indicating CrashLoopBackOff.',
-    tags: ['Kubernetes'],
-  },
-  schedule: {
-    every: '1m',
-    lookback: '15m',
-  },
-  state_transition: {
-    pending_count: 3,
-  },
-  recovery_strategy: 'no_breach' as const,
-  artifacts: [
-    {
-      id: 'kubernetes_otel-pod-crashloopbackoff-v2-runbook',
-      type: 'runbook',
-      value: '## Pod CrashLoopBackOff\n\n### Triage Steps\n1. Identify the affected pod(s).',
+  rule: {
+    kind: 'alert' as const,
+    metadata: {
+      name: '[Kubernetes OTel] Pod CrashLoopBackOff',
+      description: 'Alerts when containers have a high restart count, indicating CrashLoopBackOff.',
+      tags: ['Kubernetes'],
     },
-  ],
-  query: {
-    format: 'composed' as const,
-    base: 'TS metrics-k8sclusterreceiver.otel-*\n| STATS restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name',
-    breach: {
-      segment:
-        'WHERE restarts > 0\n| SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, restarts\n| LIMIT 50',
+    schedule: {
+      every: '1m',
+      lookback: '15m',
     },
+    state_transition: {
+      pending_count: 3,
+    },
+    recovery_strategy: 'no_breach' as const,
+    artifacts: [
+      {
+        id: 'kubernetes_otel-pod-crashloopbackoff-v2-runbook',
+        type: 'runbook',
+        value: '## Pod CrashLoopBackOff\n\n### Triage Steps\n1. Identify the affected pod(s).',
+      },
+    ],
+    query: {
+      format: 'composed' as const,
+      base: 'TS metrics-k8sclusterreceiver.otel-*\n| STATS restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name',
+      breach: {
+        segment:
+          'WHERE restarts > 0\n| SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, restarts\n| LIMIT 50',
+      },
+    },
+    grouping: {
+      fields: ['k8s.pod.name', 'k8s.container.name', 'k8s.namespace.name'],
+    },
+    time_field: '@timestamp',
   },
-  grouping: {
-    fields: ['k8s.pod.name', 'k8s.container.name', 'k8s.namespace.name'],
-  },
-  time_field: '@timestamp',
 };
 
 describe('createRuleDataFromTemplate', () => {
-  it('strips engine and passes createRuleDataSchema', () => {
+  it('returns create-rule data from the nested rule field', () => {
     const template = ruleTemplateDataSchema.parse(exampleTemplateAttributes);
     const createData = createRuleDataFromTemplate(template);
 

--- a/x-pack/platform/plugins/shared/alerting_v2/common/create_rule_data_from_template.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/create_rule_data_from_template.ts
@@ -11,7 +11,13 @@ import {
   type RuleTemplateData,
 } from '@kbn/alerting-v2-schemas';
 
+/**
+ * Convert a v2 rule template into create-rule data.
+ *
+ * Re-parses `template.rule` even though {@link RuleTemplateData} already types it:
+ * Fleet/SO storage only keeps an opaque bag, so runtime Zod validation here is the
+ * safety boundary before rule creation.
+ */
 export const createRuleDataFromTemplate = (template: RuleTemplateData): CreateRuleData => {
-  const { engine: _engine, ...ruleFields } = template;
-  return createRuleDataSchema.parse(ruleFields);
+  return createRuleDataSchema.parse(template.rule);
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
@@ -10,7 +10,11 @@ import type {
   SubFeatureConfig,
   SubFeaturePrivilegeConfig,
 } from '@kbn/features-plugin/common';
-import { ACTION_POLICY_SAVED_OBJECT_TYPE, RULE_SAVED_OBJECT_TYPE } from './saved_object_types';
+import {
+  ACTION_POLICY_SAVED_OBJECT_TYPE,
+  RULE_SAVED_OBJECT_TYPE,
+  RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+} from './saved_object_types';
 import {
   ALERTING_V2_ACTION_POLICIES_APP_ID,
   ALERTING_V2_EPISODES_APP_ID,
@@ -143,7 +147,7 @@ export const ALERTING_V2_FEATURES = {
         api: [ALERTING_V2_API_PRIVILEGES.rules.read, ALERTING_V2_API_PRIVILEGES.rules.write],
         ui: [ALERTING_V2_UI_CAPABILITIES.rules.all, ALERTING_V2_UI_CAPABILITIES.rules.read],
         savedObject: {
-          all: [RULE_SAVED_OBJECT_TYPE],
+          all: [RULE_SAVED_OBJECT_TYPE, RULE_TEMPLATE_SAVED_OBJECT_TYPE],
           read: [],
         },
       },
@@ -152,7 +156,7 @@ export const ALERTING_V2_FEATURES = {
         ui: [ALERTING_V2_UI_CAPABILITIES.rules.read],
         savedObject: {
           all: [],
-          read: [RULE_SAVED_OBJECT_TYPE],
+          read: [RULE_SAVED_OBJECT_TYPE, RULE_TEMPLATE_SAVED_OBJECT_TYPE],
         },
       },
     },

--- a/x-pack/platform/plugins/shared/alerting_v2/common/saved_object_types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/saved_object_types.ts
@@ -6,5 +6,6 @@
  */
 
 export const RULE_SAVED_OBJECT_TYPE = 'alerting_rule';
+export const RULE_TEMPLATE_SAVED_OBJECT_TYPE = 'alerting_v2_rule_template';
 export const ACTION_POLICY_SAVED_OBJECT_TYPE = 'alerting_action_policy';
 export const API_KEY_PENDING_INVALIDATION_TYPE = 'alerting_api_key_pending_invalidation';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_templates_client/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_templates_client/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { RuleTemplatesClient } from './rule_templates_client';
+export type { CreateRuleTemplateParams, RuleTemplateResponse } from './rule_templates_client';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_templates_client/rule_templates_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_templates_client/rule_templates_client.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import {
+  RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+  type RuleTemplateSavedObjectAttributes,
+} from '../../saved_objects';
+import { RuleTemplatesClient } from './rule_templates_client';
+
+const validTemplateAttributes = {
+  engine: 'v2' as const,
+  rule: {
+    kind: 'alert' as const,
+    metadata: {
+      name: 'Template rule',
+      tags: ['test'],
+    },
+    schedule: {
+      every: '1m',
+    },
+    query: {
+      format: 'standalone' as const,
+      breach: {
+        query: 'FROM logs-* | KEEP @timestamp | LIMIT 1',
+      },
+    },
+    time_field: '@timestamp',
+  },
+};
+
+describe('RuleTemplatesClient', () => {
+  const savedObjectsClient = savedObjectsClientMock.create();
+  let client: RuleTemplatesClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new RuleTemplatesClient(savedObjectsClient);
+  });
+
+  describe('create', () => {
+    it('validates with Zod and creates the saved object', async () => {
+      savedObjectsClient.create.mockResolvedValue({
+        id: 'template-1',
+        type: RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+        attributes: validTemplateAttributes as RuleTemplateSavedObjectAttributes,
+        references: [],
+        version: 'WzEsMV0=',
+      });
+
+      const result = await client.create({ attributes: validTemplateAttributes, id: 'template-1' });
+
+      expect(savedObjectsClient.create).toHaveBeenCalledWith(
+        RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+        {
+          engine: 'v2',
+          rule: expect.objectContaining({
+            kind: 'alert',
+            metadata: expect.objectContaining({ name: 'Template rule' }),
+          }),
+        },
+        { id: 'template-1' }
+      );
+      expect(result).toEqual({
+        id: 'template-1',
+        attributes: expect.objectContaining({
+          engine: 'v2',
+          rule: expect.objectContaining({ kind: 'alert' }),
+        }),
+        version: 'WzEsMV0=',
+      });
+    });
+
+    it('rejects invalid attributes before calling saved objects', async () => {
+      await expect(
+        client.create({
+          attributes: {
+            engine: 'v2',
+            ...validTemplateAttributes.rule,
+          },
+        })
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 400 },
+      });
+
+      expect(savedObjectsClient.create).not.toHaveBeenCalled();
+    });
+
+    it('maps saved-object conflicts to 409', async () => {
+      savedObjectsClient.create.mockRejectedValue(
+        SavedObjectsErrorHelpers.createConflictError(RULE_TEMPLATE_SAVED_OBJECT_TYPE, 'template-1')
+      );
+
+      await expect(
+        client.create({ attributes: validTemplateAttributes, id: 'template-1' })
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 409 },
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('returns a parsed template', async () => {
+      savedObjectsClient.get.mockResolvedValue({
+        id: 'template-1',
+        type: RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+        attributes: validTemplateAttributes as RuleTemplateSavedObjectAttributes,
+        references: [],
+        version: 'WzEsMV0=',
+      });
+
+      const result = await client.get('template-1');
+
+      expect(savedObjectsClient.get).toHaveBeenCalledWith(
+        RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+        'template-1'
+      );
+      expect(result.id).toBe('template-1');
+      expect(result.attributes.engine).toBe('v2');
+      expect(result.attributes.rule.metadata.name).toBe('Template rule');
+    });
+
+    it('maps missing templates to 404', async () => {
+      savedObjectsClient.get.mockRejectedValue(
+        SavedObjectsErrorHelpers.createGenericNotFoundError(
+          RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+          'missing'
+        )
+      );
+
+      await expect(client.get('missing')).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 404 },
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_templates_client/rule_templates_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_templates_client/rule_templates_client.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import { ruleTemplateDataSchema, type RuleTemplateData } from '@kbn/alerting-v2-schemas';
+import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { stringifyZodError } from '@kbn/zod-helpers/v4';
+import { treeifyError } from '@kbn/zod/v4';
+import {
+  RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+  type RuleTemplateSavedObjectAttributes,
+} from '../../saved_objects';
+import { ALERTING_V2_ERROR_CODES } from '../errors/error_codes';
+
+export interface CreateRuleTemplateParams {
+  attributes: unknown;
+  id?: string;
+}
+
+export interface RuleTemplateResponse {
+  id: string;
+  attributes: RuleTemplateData;
+  version?: string;
+}
+
+/**
+ * Minimal create/get client for `alerting_v2_rule_template` saved objects.
+ * Zod owns create-rule validation; the SO create schema keeps `rule` opaque.
+ */
+export class RuleTemplatesClient {
+  constructor(private readonly savedObjectsClient: SavedObjectsClientContract) {}
+
+  public async create(params: CreateRuleTemplateParams): Promise<RuleTemplateResponse> {
+    const parsed = ruleTemplateDataSchema.safeParse(params.attributes);
+    if (!parsed.success) {
+      throw Boom.badRequest(`Invalid rule template data: ${stringifyZodError(parsed.error)}`, {
+        code: ALERTING_V2_ERROR_CODES.INVALID_RULE_DATA,
+        details: { errors: treeifyError(parsed.error) },
+      });
+    }
+
+    const attributes: RuleTemplateSavedObjectAttributes = {
+      engine: parsed.data.engine,
+      rule: parsed.data.rule,
+    };
+
+    try {
+      const created = await this.savedObjectsClient.create<RuleTemplateSavedObjectAttributes>(
+        RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+        attributes,
+        params.id !== undefined ? { id: params.id } : undefined
+      );
+
+      return {
+        id: created.id,
+        attributes: parsed.data,
+        version: created.version,
+      };
+    } catch (e) {
+      if (SavedObjectsErrorHelpers.isConflictError(e)) {
+        const conflictId = params.id ?? 'unknown';
+        throw Boom.conflict(`Rule template "${conflictId}" already exists`, {
+          code: ALERTING_V2_ERROR_CODES.RULE_ALREADY_EXISTS,
+          details: { rule_template_id: conflictId },
+        });
+      }
+      throw e;
+    }
+  }
+
+  public async get(id: string): Promise<RuleTemplateResponse> {
+    try {
+      const doc = await this.savedObjectsClient.get<RuleTemplateSavedObjectAttributes>(
+        RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+        id
+      );
+
+      const parsed = ruleTemplateDataSchema.safeParse(doc.attributes);
+      if (!parsed.success) {
+        throw Boom.badData(
+          `Stored rule template "${id}" failed schema validation: ${stringifyZodError(
+            parsed.error
+          )}`,
+          {
+            code: ALERTING_V2_ERROR_CODES.INVALID_RULE_DATA,
+            details: { rule_template_id: id, errors: treeifyError(parsed.error) },
+          }
+        );
+      }
+
+      return {
+        id: doc.id,
+        attributes: parsed.data,
+        version: doc.version,
+      };
+    } catch (e) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
+        throw Boom.notFound(`Rule template "${id}" not found`, {
+          code: ALERTING_V2_ERROR_CODES.RULE_NOT_FOUND,
+          details: { rule_template_id: id },
+        });
+      }
+      throw e;
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/reset_resources_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/reset_resources_route.ts
@@ -35,6 +35,7 @@ import {
   API_KEY_PENDING_INVALIDATION_TYPE,
   ACTION_POLICY_SAVED_OBJECT_TYPE,
   RULE_SAVED_OBJECT_TYPE,
+  RULE_TEMPLATE_SAVED_OBJECT_TYPE,
 } from '../saved_objects';
 import { AlertingRouteContext } from './alerting_route_context';
 import { BaseAlertingRoute } from './base_alerting_route';
@@ -44,6 +45,7 @@ const RESET_RESOURCES_API_PATH = '/internal/alerting/v2/_reset_resources';
 // Keep in sync with `registerSavedObjects` in `server/saved_objects/index.ts`.
 const ALERTING_V2_SAVED_OBJECT_TYPES = [
   RULE_SAVED_OBJECT_TYPE,
+  RULE_TEMPLATE_SAVED_OBJECT_TYPE,
   ACTION_POLICY_SAVED_OBJECT_TYPE,
   API_KEY_PENDING_INVALIDATION_TYPE,
 ];

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/index.ts
@@ -12,20 +12,25 @@ import {
   actionPolicyModelVersions,
   apiKeyPendingInvalidationModelVersions,
   ruleModelVersions,
+  ruleTemplateModelVersions,
 } from './model_versions';
 import { apiKeyPendingInvalidationMappings } from './api_key_pending_invalidation_mappings';
 import { actionPolicyMappings } from './action_policy_mappings';
 import { ruleMappings } from './rule_mappings';
+import { ruleTemplateMappings } from './rule_template_mappings';
 import type { ActionPolicySavedObjectAttributes } from './schemas/action_policy_saved_object_attributes';
 import type { RuleSavedObjectAttributes } from './schemas/rule_saved_object_attributes';
+import type { RuleTemplateSavedObjectAttributes } from './schemas/rule_template_saved_object_attributes';
 import {
   ACTION_POLICY_SAVED_OBJECT_TYPE,
   API_KEY_PENDING_INVALIDATION_TYPE,
   RULE_SAVED_OBJECT_TYPE,
+  RULE_TEMPLATE_SAVED_OBJECT_TYPE,
 } from '../../common/saved_object_types';
 
 export {
   RULE_SAVED_OBJECT_TYPE,
+  RULE_TEMPLATE_SAVED_OBJECT_TYPE,
   ACTION_POLICY_SAVED_OBJECT_TYPE,
   API_KEY_PENDING_INVALIDATION_TYPE,
 };
@@ -56,6 +61,22 @@ export function registerSavedObjects({
       },
     },
     modelVersions: ruleModelVersions,
+  });
+
+  savedObjects.registerType({
+    name: RULE_TEMPLATE_SAVED_OBJECT_TYPE,
+    indexPattern: ALERTING_CASES_SAVED_OBJECT_INDEX,
+    hidden: true,
+    namespaceType: 'multiple-isolated',
+    mappings: ruleTemplateMappings,
+    management: {
+      importableAndExportable: false,
+      getTitle(so: SavedObject<RuleTemplateSavedObjectAttributes>) {
+        const rule = so.attributes.rule as { metadata?: { name?: string } };
+        return `Rule Template: [${rule.metadata?.name ?? so.id}]`;
+      },
+    },
+    modelVersions: ruleTemplateModelVersions,
   });
 
   savedObjects.registerType({
@@ -92,3 +113,4 @@ export function registerSavedObjects({
 
 export type { ActionPolicySavedObjectAttributes } from './schemas/action_policy_saved_object_attributes';
 export type { RuleSavedObjectAttributes } from './schemas/rule_saved_object_attributes';
+export type { RuleTemplateSavedObjectAttributes } from './schemas/rule_template_saved_object_attributes';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/model_versions/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/model_versions/index.ts
@@ -6,5 +6,6 @@
  */
 
 export { ruleModelVersions } from './rule_model_versions';
+export { ruleTemplateModelVersions } from './rule_template_model_versions';
 export { actionPolicyModelVersions } from './action_policy_model_versions';
 export { apiKeyPendingInvalidationModelVersions } from './api_key_pending_invalidation_model_versions';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/model_versions/rule_template_model_versions.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/model_versions/rule_template_model_versions.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsModelVersionMap } from '@kbn/core-saved-objects-server';
+import { ruleTemplateSavedObjectAttributesSchemaV1 } from '../schemas/rule_template_saved_object_attributes';
+
+export const ruleTemplateModelVersions: SavedObjectsModelVersionMap = {
+  '1': {
+    changes: [],
+    schemas: {
+      forwardCompatibility: ruleTemplateSavedObjectAttributesSchemaV1.extends(
+        {},
+        { unknowns: 'ignore' }
+      ),
+      create: ruleTemplateSavedObjectAttributesSchemaV1,
+    },
+  },
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/rule_template_mappings.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/rule_template_mappings.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsTypeMappingDefinition } from '@kbn/core-saved-objects-server';
+
+/**
+ * Mappings for the alerting v2 rule template saved object.
+ * Only searchable fields that are declared on the create schema are mapped;
+ * create-rule fields under `rule` stay opaque (Zod owns their validation).
+ */
+export const ruleTemplateMappings: SavedObjectsTypeMappingDefinition = {
+  dynamic: false,
+  properties: {
+    engine: { type: 'keyword', ignore_above: 1024 },
+  },
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/schemas/rule_template_saved_object_attributes/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/schemas/rule_template_saved_object_attributes/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TypeOf } from '@kbn/config-schema';
+import { ruleTemplateSavedObjectAttributesSchema } from './v1';
+
+export type RuleTemplateSavedObjectAttributes = TypeOf<
+  typeof ruleTemplateSavedObjectAttributesSchema
+>;
+
+export { ruleTemplateSavedObjectAttributesSchema as ruleTemplateSavedObjectAttributesSchemaV1 };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/schemas/rule_template_saved_object_attributes/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/schemas/rule_template_saved_object_attributes/v1.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+/**
+ * Saved object attributes for an alerting v2 rule template.
+ *
+ * Intentionally separate from `@kbn/alerting-v2-schemas` Zod API schemas.
+ * Create-rule fields live under `rule` as an opaque bag so the SO schema does
+ * not duplicate create-rule validation; Zod owns full validation of `rule`.
+ */
+export const ruleTemplateSavedObjectAttributesSchema = schema.object({
+  engine: schema.literal('v2'),
+  rule: schema.object({}, { unknowns: 'allow' }),
+});


### PR DESCRIPTION
## Summary

Alternative approach to [#281861](https://github.com/elastic/kibana/pull/281861): instead of teaching the v1 `alerting_rule_template` saved object to also store alerting-v2 templates via a new model version, this gives alerting v2 its own saved object type so template storage can evolve without coupling to the v1 Fleet/legacy shape.

- Register a new hidden, `multiple-isolated` saved object type `alerting_v2_rule_template` in the `alerting_v2` plugin (`ALERTING_CASES_SAVED_OBJECT_INDEX`), with model version `1`.
- Keep the SO schema deliberately thin: `engine: 'v2'` plus `rule` as an opaque bag (`unknowns: 'allow'`). Zod (`@kbn/alerting-v2-schemas`) stays the single owner of create-rule validation, including cross-field refinements. Mappings are `dynamic: false` and only map `engine`.
- Nest create-rule fields under `rule` in `ruleTemplateDataSchema` (previously the template schema spread create-rule fields at the top level alongside `engine`). The nested field reuses `createRuleDataSchema` by reference so refinements apply, and `createRuleDataFromTemplate` now re-parses `template.rule`.
- Add `RuleTemplatesClient` with `create` / `get`, mapping saved-object errors to Boom responses (400 invalid data, 409 conflict, 404 not found, 422 for stored docs that fail schema validation).
- Grant the existing alerting v2 rules sub-feature privileges access to the new SO type (`all` for write, `read` for read), and include it in `_reset_resources`.

## Notes for reviewers

- No HTTP routes are wired up yet; this PR only adds the storage layer and client.
- The schema tripwire tests in `rule_template_schema.test.ts` were reworked: they now assert the top-level shape is exactly `engine` + `rule` and that `ruleTemplateDataSchema.shape.rule` is `createRuleDataSchema` by reference, keeping the inline snapshot of the create-rule JSON schema as the drift detector.
- `get` fully re-parses stored attributes with Zod, so a stored template that drifts from the current schema fails with 422 rather than being returned as-is.

## Tests

- [x] Unit tests for `RuleTemplatesClient` create/get, including validation failure, conflict, and not-found mapping
- [x] Unit tests for the nested `rule` template schema and create-rule coupling tripwires
- [x] Unit tests for `createRuleDataFromTemplate`
- [ ] API integration tests (pending routes)

## Manual (smoke) testing

- [ ] Confirm the new saved object type registers cleanly on startup and shows up in the SO index mappings
- [ ] Create and read a template through `RuleTemplatesClient` and confirm error codes for invalid/duplicate/missing templates

Made with [Cursor](https://cursor.com)