### PR TITLE
[Renovate] Fix version designation for advanced-security/dismiss-alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Dismiss alerts
       id: dismiss-alerts
       continue-on-error: true
-      uses: advanced-security/dismiss-alerts@a18f986bdb40edba0dd7a74382c15d4a3d50a1c8 # 2.0.3
+      uses: advanced-security/dismiss-alerts@a18f986bdb40edba0dd7a74382c15d4a3d50a1c8 # v2.0.3
       env:
         GITHUB_TOKEN: ${{secrets.KIBANAMACHINE_TOKEN}}
       with:


### PR DESCRIPTION
## Summary

Fixes the version designation for `advanced-security/dismiss-alerts` in order to resolve the Renovate configuration error in #271772:

<img width="947" height="219" alt="Larry Gregory 2026-08-03 at 17 51 42" src="https://github.com/user-attachments/assets/0557b5e8-a6c2-4717-aa6a-97d383c716fb" />


Resolves https://github.com/elastic/kibana/issues/282378


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->