### PR TITLE
[9.3] Require Fleet authz on connector agentless_policy routes (#280824)

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/server/routes/connectors.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/routes/connectors.ts
@@ -6,7 +6,6 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { SavedObjectsClient } from '@kbn/core/server';
 import type { ElasticsearchErrorDetails } from '@kbn/es-errors';
 
 import { i18n } from '@kbn/i18n';
@@ -64,6 +63,9 @@ import { ErrorCode } from '../../common/types/error_codes';
 import { AgentlessConnectorsInfraService } from '../services';
 import { fetchIndex } from '../lib/indices/fetch_index';
 import { createIndex } from '../lib/indices/create_index';
+
+const FLEET_AGENT_POLICIES_READ = 'fleet-agent-policies-read';
+const FLEET_AGENTS_READ = 'fleet-agents-read';
 
 export function registerConnectorRoutes({
   router,
@@ -1068,14 +1070,18 @@ export function registerConnectorRoutes({
       },
       security: {
         authz: {
-          enabled: false,
-          reason: 'This route delegates authorization to the scoped ES client',
+          requiredPrivileges: [
+            {
+              anyRequired: [FLEET_AGENT_POLICIES_READ, FLEET_AGENTS_READ],
+            },
+          ],
         },
       },
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {
       const { connectorId } = request.params;
       const { client } = (await context.core).elasticsearch;
+      const soClient = (await context.core).savedObjects.client;
 
       try {
         const connector = await fetchConnectorById(client.asCurrentUser, connectorId);
@@ -1110,26 +1116,24 @@ export function registerConnectorRoutes({
           });
         }
 
-        const [_core, start] = await getStartServices();
-
-        const savedObjects = _core.savedObjects;
+        const [, start] = await getStartServices();
 
         const agentlessPolicyService = start.fleet!.agentlessPoliciesService;
         const packagePolicyService = start.fleet!.packagePolicyService;
         const agentService = start.fleet!.agentService;
-
-        const soClient = new SavedObjectsClient(savedObjects.createInternalRepository());
 
         const service = new AgentlessConnectorsInfraService(
           soClient,
           client.asCurrentUser,
           packagePolicyService,
           agentlessPolicyService,
-          agentService,
           log
         );
 
-        const policy = await service.getAgentPolicyForConnectorId({ connectorId });
+        const policy = await service.getAgentPolicyForConnectorId({
+          connectorId,
+          agentClient: agentService.asScoped(request),
+        });
 
         if (!policy) {
           return response.ok({

--- a/x-pack/platform/plugins/shared/content_connectors/server/services/index.test.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/index.test.ts
@@ -15,14 +15,15 @@ import type { MockedLogger } from '@kbn/logging-mocks';
 import { loggerMock } from '@kbn/logging-mocks';
 import {
   createPackagePolicyServiceMock,
-  createMockAgentService,
+  createMockAgentClient,
   createMockAgentlessPoliciesService,
 } from '@kbn/fleet-plugin/server/mocks';
 import type {
+  AgentClient,
   AgentlessPoliciesService,
-  AgentService,
   PackagePolicyClient,
 } from '@kbn/fleet-plugin/server';
+import { FleetUnauthorizedError } from '@kbn/fleet-plugin/server';
 import type { AgentPolicy, PackagePolicy, PackagePolicyInput } from '@kbn/fleet-plugin/common';
 import { createAgentPolicyMock, createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
 
@@ -73,7 +74,7 @@ describe('AgentlessConnectorsInfraService', () => {
   let esClient: ElasticsearchClientMock;
   let packagePolicyService: jest.Mocked<PackagePolicyClient>;
   let agentlessPoliciesService: jest.Mocked<AgentlessPoliciesService>;
-  let agentService: jest.Mocked<AgentService>;
+  let agentClient: jest.Mocked<AgentClient>;
   let logger: MockedLogger;
   let service: AgentlessConnectorsInfraService;
 
@@ -82,7 +83,7 @@ describe('AgentlessConnectorsInfraService', () => {
     esClient = elasticsearchClientMock.createClusterClient().asInternalUser;
     packagePolicyService = createPackagePolicyServiceMock();
     agentlessPoliciesService = createMockAgentlessPoliciesService();
-    agentService = createMockAgentService();
+    agentClient = createMockAgentClient();
     logger = loggerMock.create();
 
     service = new AgentlessConnectorsInfraService(
@@ -90,7 +91,6 @@ describe('AgentlessConnectorsInfraService', () => {
       esClient,
       packagePolicyService,
       agentlessPoliciesService,
-      agentService,
       logger
     );
 
@@ -349,6 +349,91 @@ describe('AgentlessConnectorsInfraService', () => {
       const policies = await service.getConnectorPackagePolicies();
 
       expect(policies.length).toBe(2);
+    });
+  });
+  describe('getAgentPolicyForConnectorId', () => {
+    const getMockPolicyFetchAllItems = (pages: PackagePolicy[][]) => {
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const page of pages) {
+            yield page;
+          }
+        },
+      } as AsyncIterable<PackagePolicy[]>;
+    };
+
+    test('queries agents with a kuery for the agent policy id', async () => {
+      const packagePolicy = createPackagePolicyMock();
+      packagePolicy.policy_ids = ['this-is-agent-policy-id'];
+      packagePolicy.supports_agentless = true;
+      packagePolicy.inputs = [
+        {
+          type: 'connectors-py',
+          compiled_input: {
+            connector_id: 'connector-1',
+            connector_name: 'Connector One',
+            service_type: 'sharepoint_online',
+          },
+        } as PackagePolicyInput,
+      ];
+
+      packagePolicyService.fetchAllItems.mockResolvedValue(
+        getMockPolicyFetchAllItems([[packagePolicy]])
+      );
+      (agentClient.listAgents as jest.Mock).mockResolvedValue({
+        agents: [],
+        total: 0,
+      });
+
+      await service.getAgentPolicyForConnectorId({
+        connectorId: 'connector-1',
+        agentClient,
+      });
+
+      expect(agentClient.listAgents as jest.Mock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kuery: 'fleet-agents.policy_id:this-is-agent-policy-id',
+        })
+      );
+    });
+
+    test('returns policy without agent metadata when user lacks Fleet agent privileges', async () => {
+      const packagePolicy = createPackagePolicyMock();
+      packagePolicy.policy_ids = ['this-is-agent-policy-id'];
+      packagePolicy.name = 'Connector Package Policy';
+      packagePolicy.supports_agentless = true;
+      packagePolicy.inputs = [
+        {
+          type: 'connectors-py',
+          compiled_input: {
+            connector_id: 'connector-1',
+            connector_name: 'Connector One',
+            service_type: 'sharepoint_online',
+          },
+        } as PackagePolicyInput,
+      ];
+
+      packagePolicyService.fetchAllItems.mockResolvedValue(
+        getMockPolicyFetchAllItems([[packagePolicy]])
+      );
+      (agentClient.listAgents as jest.Mock).mockRejectedValue(
+        new FleetUnauthorizedError(
+          'User does not have adequate permissions to access Fleet agents.'
+        )
+      );
+
+      const result = await service.getAgentPolicyForConnectorId({
+        connectorId: 'connector-1',
+        agentClient,
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          package_policy_name: 'Connector Package Policy',
+          agent_policy_ids: ['this-is-agent-policy-id'],
+        })
+      );
+      expect(result?.agent_metadata).toBeUndefined();
     });
   });
   describe('deployConnector', () => {

--- a/x-pack/platform/plugins/shared/content_connectors/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/index.ts
@@ -9,10 +9,11 @@ import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Agent, AgentPolicy } from '@kbn/fleet-plugin/common';
 import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
 import type {
+  AgentClient,
   AgentlessPoliciesService,
-  AgentService,
   PackagePolicyClient,
 } from '@kbn/fleet-plugin/server';
+import { FleetUnauthorizedError } from '@kbn/fleet-plugin/server';
 import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import { NATIVE_CONNECTOR_DEFINITIONS, fetchConnectors } from '@kbn/search-connectors';
 import { getPackageInfo } from '@kbn/fleet-plugin/server/services/epm/packages';
@@ -55,21 +56,18 @@ export class AgentlessConnectorsInfraService {
   private esClient: ElasticsearchClient;
   private packagePolicyService: PackagePolicyClient;
   private agentlessPolicyService: AgentlessPoliciesService;
-  private agentService: AgentService;
 
   constructor(
     soClient: SavedObjectsClientContract,
     esClient: ElasticsearchClient,
     packagePolicyService: PackagePolicyClient,
     agentlessPolicyService: AgentlessPoliciesService,
-    agentService: AgentService,
     logger: Logger
   ) {
     this.logger = logger;
     this.soClient = soClient;
     this.esClient = esClient;
     this.packagePolicyService = packagePolicyService;
-    this.agentService = agentService;
     this.agentlessPolicyService = agentlessPolicyService;
   }
 
@@ -240,8 +238,10 @@ export class AgentlessConnectorsInfraService {
 
   public getAgentPolicyForConnectorId = async ({
     connectorId,
+    agentClient,
   }: {
     connectorId: string;
+    agentClient: AgentClient;
   }): Promise<PackagePolicyAndAgentMetadata | null> => {
     const allPolicies = await this.getConnectorPackagePolicies();
 
@@ -256,10 +256,21 @@ export class AgentlessConnectorsInfraService {
     if (policy && policy.agent_policy_ids.length > 0) {
       const policyId = policy!.agent_policy_ids[0];
 
-      const listAgentsResponse = await this.agentService.asInternalUser.listAgents({
-        kuery: `fleet-agents.policy_id:${policyId}`,
-        showInactive: false,
-      });
+      let listAgentsResponse;
+      try {
+        listAgentsResponse = await agentClient.listAgents({
+          kuery: `fleet-agents.policy_id:${policyId}`,
+          showInactive: false,
+        });
+      } catch (error) {
+        if (error instanceof FleetUnauthorizedError) {
+          this.logger.debug(
+            `Skipping agent metadata for connector ${connectorId}: user lacks Fleet agent privileges`
+          );
+          return policy;
+        }
+        throw error;
+      }
 
       if (!listAgentsResponse || listAgentsResponse.agents.length === 0) {
         // If no agents assigned to policy, just return the policy

--- a/x-pack/platform/plugins/shared/content_connectors/server/services/infra_service_factory.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/infra_service_factory.ts
@@ -32,7 +32,6 @@ export class AgentlessConnectorsInfraServiceFactory {
 
     const agentlessPolicyService = plugins.fleet.agentlessPoliciesService;
     const packagePolicyService = plugins.fleet.packagePolicyService;
-    const agentService = plugins.fleet.agentService;
 
     const soClient = new SavedObjectsClient(savedObjects.createInternalRepository());
 
@@ -41,7 +40,6 @@ export class AgentlessConnectorsInfraServiceFactory {
       esClient,
       packagePolicyService,
       agentlessPolicyService,
-      agentService,
       logger
     );
   }

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -7,7 +7,6 @@
 
 import { schema } from '@kbn/config-schema';
 import { AgentlessConnectorsInfraService } from '@kbn/content-connectors-plugin/server/services';
-import { SavedObjectsClient } from '@kbn/core/server';
 import type { ElasticsearchErrorDetails } from '@kbn/es-errors';
 
 import { i18n } from '@kbn/i18n';
@@ -59,6 +58,9 @@ import {
   isExpensiveQueriesNotAllowedException,
   isIndexNotFoundException,
 } from '../../utils/identify_exceptions';
+
+const FLEET_AGENT_POLICIES_READ = 'fleet-agent-policies-read';
+const FLEET_AGENTS_READ = 'fleet-agents-read';
 
 export function registerConnectorRoutes({ router, log, getStartServices }: RouteDependencies) {
   router.post(
@@ -1030,8 +1032,11 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       path: '/internal/enterprise_search/{connectorId}/agentless_policy',
       security: {
         authz: {
-          enabled: false,
-          reason: 'This route delegates authorization to the scoped ES client',
+          requiredPrivileges: [
+            {
+              anyRequired: [FLEET_AGENT_POLICIES_READ, FLEET_AGENTS_READ],
+            },
+          ],
         },
       },
       validate: {
@@ -1043,6 +1048,7 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
     elasticsearchErrorHandler(log, async (context, request, response) => {
       const { connectorId } = request.params;
       const { client } = (await context.core).elasticsearch;
+      const soClient = (await context.core).savedObjects.client;
 
       try {
         const connector = await fetchConnectorById(client.asCurrentUser, connectorId);
@@ -1077,26 +1083,24 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
           });
         }
 
-        const [_core, start] = await getStartServices();
-
-        const savedObjects = _core.savedObjects;
+        const [, start] = await getStartServices();
 
         const agentlessPoliciesService = start.fleet!.agentlessPoliciesService;
         const packagePolicyService = start.fleet!.packagePolicyService;
         const agentService = start.fleet!.agentService;
-
-        const soClient = new SavedObjectsClient(savedObjects.createInternalRepository());
 
         const service = new AgentlessConnectorsInfraService(
           soClient,
           client.asCurrentUser,
           packagePolicyService,
           agentlessPoliciesService,
-          agentService,
           log
         );
 
-        const policy = await service.getAgentPolicyForConnectorId({ connectorId });
+        const policy = await service.getAgentPolicyForConnectorId({
+          connectorId,
+          agentClient: agentService.asScoped(request),
+        });
 
         if (!policy) {
           return response.ok({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Require Fleet authz on connector agentless_policy routes (#280824)](https://github.com/elastic/kibana/pull/280824)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Meghan Murphy","email":"meghan.murphy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-31T19:12:06Z","message":"Require Fleet authz on connector agentless_policy routes (#280824)\n\n## Summary\n\nThis PR: \n- Require Fleet read privileges on the content connectors and enterprise\nsearch agentless_policy routes\n- Use the request-scoped Saved Objects client and a scoped Fleet agent\nclient instead of internal/unscoped access\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"594be5afd76479e55281afb3d6595b1fe9da159d","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.6.0","v9.4.5","v9.5.1","v9.3.9"],"title":"Require Fleet authz on connector agentless_policy routes","number":280824,"url":"https://github.com/elastic/kibana/pull/280824","mergeCommit":{"message":"Require Fleet authz on connector agentless_policy routes (#280824)\n\n## Summary\n\nThis PR: \n- Require Fleet read privileges on the content connectors and enterprise\nsearch agentless_policy routes\n- Use the request-scoped Saved Objects client and a scoped Fleet agent\nclient instead of internal/unscoped access\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"594be5afd76479e55281afb3d6595b1fe9da159d"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282124","number":282124,"state":"MERGED","mergeCommit":{"sha":"2f6ce0a54eff33cc52aba24c0b8c0cc3d6207048","message":"[9.5] Require Fleet authz on connector agentless_policy routes (#280824) (#282124)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [Require Fleet authz on connector agentless_policy routes\n(#280824)](https://github.com/elastic/kibana/pull/280824)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Meghan Murphy <meghan.murphy@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280824","number":280824,"mergeCommit":{"message":"Require Fleet authz on connector agentless_policy routes (#280824)\n\n## Summary\n\nThis PR: \n- Require Fleet read privileges on the content connectors and enterprise\nsearch agentless_policy routes\n- Use the request-scoped Saved Objects client and a scoped Fleet agent\nclient instead of internal/unscoped access\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"594be5afd76479e55281afb3d6595b1fe9da159d"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->