### PR TITLE
[Security Solution] remove dead setSelectedDataView sourcerer dispatches

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.test.tsx
@@ -13,8 +13,6 @@ import { useKibana } from '../../../../../common/lib/kibana';
 import { TestProviders } from '../../../../../common/mock';
 import { useSignalIndex } from '../../../../../detections/containers/detection_engine/alerts/use_signal_index';
 
-const mockDispatch = jest.fn();
-
 jest.mock('../../../../../common/lib/kibana');
 jest.mock('../../../../../detections/containers/detection_engine/alerts/use_signal_index');
 jest.mock('react-router-dom', () => ({
@@ -23,10 +21,6 @@ jest.mock('react-router-dom', () => ({
     search: '',
   }),
   withRouter: jest.fn(),
-}));
-jest.mock('react-redux-v7', () => ({
-  ...jest.requireActual('react-redux-v7'),
-  useDispatch: () => mockDispatch,
 }));
 
 const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
@@ -158,24 +152,6 @@ describe('PreviewTab', () => {
     );
 
     expect(container.firstChild).toBeNull();
-  });
-
-  it('limits the fields in the StackByComboBox to the fields in the signal index', () => {
-    render(
-      <TestProviders>
-        <PreviewTab {...defaultProps} />
-      </TestProviders>
-    );
-
-    expect(mockDispatch).toHaveBeenCalledWith({
-      payload: {
-        id: 'alerts',
-        selectedDataViewId: 'mock-signal-index',
-        selectedPatterns: ['mock-signal-index'],
-        shouldValidateSelectedPatterns: false,
-      },
-      type: 'x-pack/security_solution/local/sourcerer/SET_SELECTED_DATA_VIEW',
-    });
   });
 
   it('passes esqlQuery to getPreviewEsqlQuery when provided', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.tsx
@@ -17,16 +17,13 @@ import {
 import { css } from '@emotion/react';
 import type { Filter, Query, TimeRange } from '@kbn/es-query';
 import { isEmpty } from 'lodash/fp';
-import React, { useCallback, useEffect, useMemo } from 'react';
-import { useDispatch } from 'react-redux-v7';
+import React, { useCallback, useMemo } from 'react';
 
-import { PageScope } from '../../../../../data_view_manager/constants';
 import { useEuiComboBoxReset } from '../../../../../common/components/use_combo_box_reset';
 import { StackByComboBox } from '../../../../../detections/components/alerts_kpis/common/components';
 import { useSignalIndex } from '../../../../../detections/containers/detection_engine/alerts/use_signal_index';
 import type { LensAttributes } from '../../../../../common/components/visualization_actions/types';
 import { useKibana } from '../../../../../common/lib/kibana';
-import { sourcererActions } from '../../../../../sourcerer/store';
 import * as i18n from '../translations';
 import type { Sorting } from '../types';
 
@@ -98,7 +95,6 @@ const PreviewTabComponent = ({
   const {
     euiTheme: { font },
   } = useEuiTheme();
-  const dispatch = useDispatch();
 
   const { signalIndexName } = useSignalIndex();
 
@@ -178,23 +174,6 @@ const PreviewTabComponent = ({
       ) : null,
     [actions, body, tableStackBy0]
   );
-
-  useEffect(() => {
-    if (signalIndexName != null) {
-      // Limit the fields in the StackByComboBox to the fields in the signal index.
-      // NOTE: The page containing this component must also be a member of
-      // `detectionsPaths` in `sourcerer/containers/sourcerer_paths.ts` for this
-      // action to have any effect.
-      dispatch(
-        sourcererActions.setSelectedDataView({
-          id: PageScope.alerts,
-          selectedDataViewId: signalIndexName,
-          selectedPatterns: [signalIndexName],
-          shouldValidateSelectedPatterns: false,
-        })
-      );
-    }
-  }, [dispatch, signalIndexName]);
 
   if (signalIndexName == null) {
     return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
@@ -7,7 +7,6 @@
 
 import { isEmpty } from 'lodash/fp';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux-v7';
 import { i18n } from '@kbn/i18n';
 import type { EqlOptions } from '@kbn/timelines-plugin/common';
 import { PageScope } from '../../data_view_manager/constants';
@@ -17,7 +16,6 @@ import { convertKueryToElasticSearchQuery } from '../../common/lib/kuery';
 import { useAppToasts } from '../../common/hooks/use_app_toasts';
 import type { TimelineModel } from '../..';
 import type { FieldValueQueryBar } from '../../detection_engine/rule_creation_ui/components/query_bar_field';
-import { sourcererActions } from '../../sourcerer/store';
 import { useQueryTimelineById } from '../../timelines/components/open_timeline/helpers';
 import { useGetInitialUrlParamValue } from '../../common/utils/global_query_string/helpers';
 import { buildGlobalQuery } from '../../timelines/components/timeline/helpers';
@@ -44,7 +42,6 @@ export type SetRuleQuery = ({
 }) => void;
 
 export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimeline => {
-  const dispatch = useDispatch();
   const { addError } = useAppToasts();
 
   const getInitialUrlParamValue = useGetInitialUrlParamValue<string>(RULE_FROM_TIMELINE_URL_PARAM);
@@ -86,16 +83,7 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
       setSelectedTimeline(timeline);
 
       if (timeline.dataViewId !== dataViewId && !isEmpty(timeline.indexNames)) {
-        // let sourcerer manage the selected browser fields by setting timeline scope to the selected timeline data view
-        // sourcerer handles the logic of if the fields have been fetched or need to be fetched
-        dispatch(
-          sourcererActions.setSelectedDataView({
-            id: PageScope.timeline,
-            selectedDataViewId: timeline.dataViewId,
-            selectedPatterns: timeline.indexNames,
-          })
-        );
-
+        // let the data view manager handle the selected browser fields by setting timeline scope to the selected timeline data view
         selectDataView({
           scope: PageScope.timeline,
           id: timeline.dataViewId,
@@ -103,7 +91,7 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
         });
       }
     },
-    [dataViewId, dispatch, selectDataView]
+    [dataViewId, selectDataView]
   );
 
   const getTimelineById = useCallback(
@@ -181,14 +169,6 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
     isEql.current = false;
     // reset timeline data view once complete
     if (originalDataView.dataViewId !== dataViewId) {
-      dispatch(
-        sourcererActions.setSelectedDataView({
-          id: PageScope.timeline,
-          selectedDataViewId: originalDataView.dataViewId,
-          selectedPatterns: originalDataView.selectedPatterns,
-        })
-      );
-
       selectDataView({
         scope: PageScope.timeline,
         id: originalDataView.dataViewId,
@@ -198,7 +178,6 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
   }, [
     addError,
     dataViewId,
-    dispatch,
     originalDataView.dataViewId,
     originalDataView.selectedPatterns,
     selectDataView,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
@@ -13,13 +13,13 @@ import { TimelineId } from '../../../common/types';
 import { useDiscoverInTimelineContext } from '../../common/components/discover_in_timeline/use_discover_in_timeline_context';
 import { timelineActions } from '../store';
 import { inputsActions } from '../../common/store/inputs';
-import { sourcererActions } from '../../sourcerer/store';
 import { appActions } from '../../common/store/app';
 import { InputsModelId } from '../../common/store/inputs/constants';
 import { mockGlobalState, TestProviders } from '../../common/mock';
 import { defaultUdtHeaders } from '../components/timeline/body/column_headers/default_headers';
 import { PageScope } from '../../data_view_manager/constants';
 import { useSecurityDefaultPatterns } from '../../data_view_manager/hooks/use_security_default_patterns';
+import { useSelectDataView } from '../../data_view_manager/hooks/use_select_data_view';
 
 jest.mock('../../common/components/discover_in_timeline/use_discover_in_timeline_context');
 jest.mock('../../common/containers/use_global_time', () => {
@@ -34,13 +34,16 @@ jest.mock('../../common/containers/use_global_time', () => {
 });
 jest.mock('../../common/lib/kibana');
 jest.mock('../../data_view_manager/hooks/use_security_default_patterns');
+jest.mock('../../data_view_manager/hooks/use_select_data_view');
 
 describe('useCreateTimeline', () => {
   const resetDiscoverAppState = jest.fn().mockResolvedValue({});
+  const selectDataView = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useDiscoverInTimelineContext as jest.Mock).mockReturnValue({ resetDiscoverAppState });
+    (useSelectDataView as jest.Mock).mockReturnValue(selectDataView);
     (useSecurityDefaultPatterns as jest.Mock).mockReturnValue({
       id: 'security-solution',
       indexPatterns: [
@@ -74,7 +77,6 @@ describe('useCreateTimeline', () => {
 
   it('should dispatch correct actions when calling the returned function', async () => {
     const createTimeline = jest.spyOn(timelineActions, 'createTimeline');
-    const setSelectedDataView = jest.spyOn(sourcererActions, 'setSelectedDataView');
     const addLinkTo = jest.spyOn(inputsActions, 'addLinkTo');
     const addNotes = jest.spyOn(appActions, 'addNotes');
 
@@ -105,11 +107,11 @@ describe('useCreateTimeline', () => {
     expect(createTimeline.mock.calls[0][0].show).toEqual(true);
     expect(createTimeline.mock.calls[0][0].updated).toEqual(undefined);
     expect(createTimeline.mock.calls[0][0].excludedRowRendererIds).toHaveLength(RowRendererCount);
-    expect(setSelectedDataView.mock.calls[0][0].id).toEqual(PageScope.timeline);
-    expect(setSelectedDataView.mock.calls[0][0].selectedDataViewId).toEqual(
+    expect(selectDataView.mock.calls[0][0].scope).toEqual(PageScope.timeline);
+    expect(selectDataView.mock.calls[0][0].id).toEqual(
       mockGlobalState.sourcerer.defaultDataView.id
     );
-    expect(setSelectedDataView.mock.calls[0][0].selectedPatterns).toEqual(
+    expect(selectDataView.mock.calls[0][0].fallbackPatterns).toEqual(
       expect.arrayContaining(
         mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline].selectedPatterns
       )

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
@@ -21,7 +21,6 @@ import { defaultUdtHeaders } from '../components/timeline/body/column_headers/de
 import { timelineDefaults } from '../store/defaults';
 import { useSelectDataView } from '../../data_view_manager/hooks/use_select_data_view';
 import { PageScope } from '../../data_view_manager/constants';
-import { sourcererActions } from '../../sourcerer/store';
 import { useSecurityDefaultPatterns } from '../../data_view_manager/hooks/use_security_default_patterns';
 
 export interface UseCreateTimelineParams {
@@ -82,14 +81,6 @@ export const useCreateTimeline = ({
         fallbackPatterns: selectedPatterns,
         scope: PageScope.timeline,
       });
-
-      dispatch(
-        sourcererActions.setSelectedDataView({
-          id: PageScope.timeline,
-          selectedDataViewId: dataViewId,
-          selectedPatterns,
-        })
-      );
 
       dispatch(
         timelineActions.createTimeline({


### PR DESCRIPTION
> [!NOTE]
> This PR is the fourth of a few aiming at removing all dependencies on the legacy sourcerer code. We officially switched to using the data_view_manager code [a couple of months ago](https://github.com/elastic/kibana/pull/238549).

## Summary

The sourcerer store scope state is now write-only: after removing the sourcerer selectors, nothing reads state.sourcerer, and the data view manager reads its own slice via `sourcererAdapterSelector`. The remaining `sourcererActions.setSelectedDataView` dispatches in these consumers were therefore dead writes.

> [!TIP]
> This PR does not introduce any visual or functional change. All the code removed was dead and unused.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
