### PR TITLE
Update 8.19.19 release notes with security update

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -131,6 +131,12 @@ include::upgrade-notes.asciidoc[]
 
 The 8.19.19 release includes the following enhancements and fixes.
 
+[IMPORTANT]
+====
+The 8.19.19 release contains fixes for potential security vulnerabilities.
+For details, go to the https://discuss.elastic.co/c/announcements/security-announcements/31[security announcements].
+====
+
 [float]
 [[enhancement-v8.19.19]]
 === Enhancements


### PR DESCRIPTION
## Summary

Adds security update link to Kibana 8.19.19 release notes.

Related to https://github.com/elastic/docs-content-internal/issues/1544.


