### PR TITLE
[Alerting v2] Add missing OAS examples for rules, action policies, and alert events

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/create_alert_event_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/create_alert_event_data_schema.ts
@@ -122,7 +122,6 @@ export const createAlertEventSourceParamsSchema = z.object({
   ),
 });
 
-
 export const createAlertEventResponseSchema = z.object({
   group_hash: z.string(),
   episode_id: z.string(),

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/create_alert_event_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/create_alert_event_data_schema.ts
@@ -117,8 +117,11 @@ export const createAlertEventDataSchema = createAlertEventBodyBaseObjectSchema
 
 /** Path params for POST /api/alerting/v2/alerts/:source */
 export const createAlertEventSourceParamsSchema = z.object({
-  source: sourceSchema,
+  source: sourceSchema.describe(
+    'The external source system that produced the alert event (for example, "datadog"). Cannot start with "elastic".'
+  ),
 });
+
 
 export const createAlertEventResponseSchema = z.object({
   group_hash: z.string(),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/delete_action_policy_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/delete_action_policy_oas_example.ts
@@ -6,12 +6,16 @@
  */
 
 import type { AlertingOasOperationObject } from '../oas_types';
-import { ACTION_POLICY_NOT_FOUND_RESPONSE } from './action_policy_oas_shared_examples';
+import {
+  ACTION_POLICY_NOT_FOUND_RESPONSE,
+  INVALID_QUERY_PARAMETERS_RESPONSE,
+} from './action_policy_oas_shared_examples';
 import { buildOasOperation } from '../oas_utils';
 
 export const deleteActionPolicyOasExamples = (): AlertingOasOperationObject =>
   buildOasOperation({
     responses: {
+      400: INVALID_QUERY_PARAMETERS_RESPONSE,
       404: ACTION_POLICY_NOT_FOUND_RESPONSE,
     },
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/disable_action_policy_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/disable_action_policy_oas_example.ts
@@ -9,6 +9,7 @@ import type { AlertingOasOperationObject } from '../oas_types';
 import {
   ACTION_POLICY_NOT_FOUND_RESPONSE,
   ACTION_POLICY_VERSION_CONFLICT_RESPONSE,
+  INVALID_QUERY_PARAMETERS_RESPONSE,
   actionPolicyResponseExample,
 } from './action_policy_oas_shared_examples';
 import { buildOasOperation } from '../oas_utils';
@@ -19,6 +20,7 @@ export const disableActionPolicyOasExamples = (): AlertingOasOperationObject =>
       200: actionPolicyResponseExample('disableActionPolicyResponse', 'Disabled action policy', {
         enabled: false,
       }),
+      400: INVALID_QUERY_PARAMETERS_RESPONSE,
       404: ACTION_POLICY_NOT_FOUND_RESPONSE,
       409: ACTION_POLICY_VERSION_CONFLICT_RESPONSE,
     },

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/enable_action_policy_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/enable_action_policy_oas_example.ts
@@ -9,6 +9,7 @@ import type { AlertingOasOperationObject } from '../oas_types';
 import {
   ACTION_POLICY_NOT_FOUND_RESPONSE,
   ACTION_POLICY_VERSION_CONFLICT_RESPONSE,
+  INVALID_QUERY_PARAMETERS_RESPONSE,
   actionPolicyResponseExample,
 } from './action_policy_oas_shared_examples';
 import { buildOasOperation } from '../oas_utils';
@@ -19,6 +20,7 @@ export const enableActionPolicyOasExamples = (): AlertingOasOperationObject =>
       200: actionPolicyResponseExample('enableActionPolicyResponse', 'Enabled action policy', {
         enabled: true,
       }),
+      400: INVALID_QUERY_PARAMETERS_RESPONSE,
       404: ACTION_POLICY_NOT_FOUND_RESPONSE,
       409: ACTION_POLICY_VERSION_CONFLICT_RESPONSE,
     },

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/unsnooze_action_policy_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/unsnooze_action_policy_oas_example.ts
@@ -9,6 +9,7 @@ import type { AlertingOasOperationObject } from '../oas_types';
 import {
   ACTION_POLICY_NOT_FOUND_RESPONSE,
   ACTION_POLICY_VERSION_CONFLICT_RESPONSE,
+  INVALID_QUERY_PARAMETERS_RESPONSE,
   actionPolicyResponseExample,
 } from './action_policy_oas_shared_examples';
 import { buildOasOperation } from '../oas_utils';
@@ -19,6 +20,7 @@ export const unsnoozeActionPolicyOasExamples = (): AlertingOasOperationObject =>
       200: actionPolicyResponseExample('unsnoozeActionPolicyResponse', 'Unsnoozed action policy', {
         snoozedUntil: null,
       }),
+      400: INVALID_QUERY_PARAMETERS_RESPONSE,
       404: ACTION_POLICY_NOT_FOUND_RESPONSE,
       409: ACTION_POLICY_VERSION_CONFLICT_RESPONSE,
     },

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/update_action_policy_api_key_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/action_policies/update_action_policy_api_key_oas_example.ts
@@ -9,12 +9,14 @@ import type { AlertingOasOperationObject } from '../oas_types';
 import {
   ACTION_POLICY_NOT_FOUND_RESPONSE,
   ACTION_POLICY_VERSION_CONFLICT_RESPONSE,
+  INVALID_QUERY_PARAMETERS_RESPONSE,
 } from './action_policy_oas_shared_examples';
 import { buildOasOperation } from '../oas_utils';
 
 export const updateActionPolicyApiKeyOasExamples = (): AlertingOasOperationObject =>
   buildOasOperation({
     responses: {
+      400: INVALID_QUERY_PARAMETERS_RESPONSE,
       404: ACTION_POLICY_NOT_FOUND_RESPONSE,
       409: ACTION_POLICY_VERSION_CONFLICT_RESPONSE,
     },

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_by_source_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_by_source_route.ts
@@ -23,6 +23,7 @@ import {
   createAlertEventRouteSchemas,
   createAlertEventRouteSecurity,
 } from './create_alert_event_route_shared';
+import { createAlertEventBySourceOasExamples } from './create_alert_event_oas_example';
 
 /** POST /api/alerting/v2/alerts/:source — source in URL path */
 @injectable()
@@ -30,7 +31,10 @@ export class CreateAlertEventBySourceRoute extends BaseAlertingRoute {
   static method = 'post' as const;
   static path = `${ALERTING_V2_ALERT_API_PATH}/{source}`;
   static security = createAlertEventRouteSecurity;
-  static routeOptions = createAlertEventRouteOptions;
+  static routeOptions = {
+    ...createAlertEventRouteOptions,
+    oasOperationObject: createAlertEventBySourceOasExamples,
+  } as const;
   static schemas = {
     request: {
       params: createAlertEventSourceParamsSchema,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_oas_example.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_oas_example.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  createAlertEventDataSchema,
+  createAlertEventPathBodySchema,
+  createAlertEventResponseSchema,
+} from '@kbn/alerting-v2-schemas';
+import {
+  CREATE_ALERT_EVENT_BY_SOURCE_REQUEST,
+  CREATE_ALERT_EVENT_REQUEST,
+  CREATE_ALERT_EVENT_RESPONSE,
+} from './create_alert_event_oas_example';
+
+describe('create alert event OAS example payloads', () => {
+  it('keeps create request example valid against createAlertEventDataSchema', () => {
+    expect(createAlertEventDataSchema.safeParse(CREATE_ALERT_EVENT_REQUEST).success).toBe(true);
+  });
+
+  it('keeps by-source request example valid against createAlertEventPathBodySchema', () => {
+    expect(
+      createAlertEventPathBodySchema.safeParse(CREATE_ALERT_EVENT_BY_SOURCE_REQUEST).success
+    ).toBe(true);
+  });
+
+  it('keeps response example valid against createAlertEventResponseSchema', () => {
+    expect(createAlertEventResponseSchema.safeParse(CREATE_ALERT_EVENT_RESPONSE).success).toBe(
+      true
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_oas_example.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import type {
-  CreateAlertEventData,
-  CreateAlertEventResponse,
-} from '@kbn/alerting-v2-schemas';
+import type { CreateAlertEventData, CreateAlertEventResponse } from '@kbn/alerting-v2-schemas';
 import type { AlertingOasOperationObject } from '../oas_types';
 import { buildOasOperation, invalidResponseExample } from '../oas_utils';
 import { INVALID_SCHEMA_OR_PARAMETERS_DESCRIPTION } from '../route_descriptions';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_oas_example.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CreateAlertEventData,
+  CreateAlertEventResponse,
+} from '@kbn/alerting-v2-schemas';
+import type { AlertingOasOperationObject } from '../oas_types';
+import { buildOasOperation, invalidResponseExample } from '../oas_utils';
+import { INVALID_SCHEMA_OR_PARAMETERS_DESCRIPTION } from '../route_descriptions';
+
+export const SAMPLE_ALERT_EVENT_SOURCE = 'datadog';
+
+export const CREATE_ALERT_EVENT_REQUEST: CreateAlertEventData = {
+  source: SAMPLE_ALERT_EVENT_SOURCE,
+  fingerprint: 'fp-1',
+  timestamp: '2026-07-29T12:00:00.000Z',
+  severity: 'high',
+  data: { rule_name: 'CPU high', monitor_id: 'mon-1' },
+};
+
+/** Path-body request omits `source` — it comes from the URL. */
+export const CREATE_ALERT_EVENT_BY_SOURCE_REQUEST = {
+  fingerprint: CREATE_ALERT_EVENT_REQUEST.fingerprint,
+  timestamp: CREATE_ALERT_EVENT_REQUEST.timestamp,
+  severity: CREATE_ALERT_EVENT_REQUEST.severity,
+  data: CREATE_ALERT_EVENT_REQUEST.data,
+};
+
+export const CREATE_ALERT_EVENT_RESPONSE: CreateAlertEventResponse = {
+  group_hash: 'group-hash-1',
+  episode_id: 'episode-1',
+};
+
+const INVALID_CREATE_ALERT_EVENT_RESPONSE = invalidResponseExample({
+  summary: INVALID_SCHEMA_OR_PARAMETERS_DESCRIPTION,
+  message:
+    'fingerprint: one of fingerprint, fingerprint_fields, or rule_id is required to establish a stable series identity',
+  details: {
+    errors: {
+      errors: [],
+      properties: {
+        fingerprint: {
+          errors: [
+            'one of fingerprint, fingerprint_fields, or rule_id is required to establish a stable series identity',
+          ],
+        },
+      },
+    },
+  },
+});
+
+export const createAlertEventOasExamples = (): AlertingOasOperationObject =>
+  buildOasOperation({
+    requestBody: {
+      name: 'createAlertEventRequest',
+      summary: 'Create an alert event from Datadog',
+      value: CREATE_ALERT_EVENT_REQUEST,
+    },
+    responses: {
+      201: {
+        name: 'createAlertEventResponse',
+        summary: 'Created alert event identifiers',
+        value: CREATE_ALERT_EVENT_RESPONSE,
+      },
+      400: INVALID_CREATE_ALERT_EVENT_RESPONSE,
+    },
+  });
+
+export const createAlertEventBySourceOasExamples = (): AlertingOasOperationObject =>
+  buildOasOperation({
+    requestBody: {
+      name: 'createAlertEventBySourceRequest',
+      summary: 'Create an alert event with source in the path',
+      value: CREATE_ALERT_EVENT_BY_SOURCE_REQUEST,
+    },
+    responses: {
+      201: {
+        name: 'createAlertEventBySourceResponse',
+        summary: 'Created alert event identifiers',
+        value: CREATE_ALERT_EVENT_RESPONSE,
+      },
+      400: INVALID_CREATE_ALERT_EVENT_RESPONSE,
+    },
+  });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_route.ts
@@ -18,6 +18,7 @@ import {
   createAlertEventRouteSchemas,
   createAlertEventRouteSecurity,
 } from './create_alert_event_route_shared';
+import { createAlertEventOasExamples } from './create_alert_event_oas_example';
 
 /** POST /api/alerting/v2/alerts — source in body */
 @injectable()
@@ -25,7 +26,10 @@ export class CreateAlertEventRoute extends BaseAlertingRoute {
   static method = 'post' as const;
   static path = `${ALERTING_V2_ALERT_API_PATH}`;
   static security = createAlertEventRouteSecurity;
-  static routeOptions = createAlertEventRouteOptions;
+  static routeOptions = {
+    ...createAlertEventRouteOptions,
+    oasOperationObject: createAlertEventOasExamples,
+  } as const;
   static schemas = createAlertEventRouteSchemas;
 
   protected readonly routeName = 'create alert event';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/delete_rule_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/delete_rule_oas_example.ts
@@ -7,11 +7,15 @@
 
 import type { AlertingOasOperationObject } from '../oas_types';
 import { buildOasOperation } from '../oas_utils';
-import { RULE_NOT_FOUND_RESPONSE } from './rule_oas_shared_examples';
+import {
+  INVALID_QUERY_PARAMETERS_RESPONSE,
+  RULE_NOT_FOUND_RESPONSE,
+} from './rule_oas_shared_examples';
 
 export const deleteRuleOasExamples = (): AlertingOasOperationObject =>
   buildOasOperation({
     responses: {
+      400: INVALID_QUERY_PARAMETERS_RESPONSE,
       404: RULE_NOT_FOUND_RESPONSE,
     },
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/disable_rule_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/disable_rule_oas_example.ts
@@ -6,18 +6,22 @@
  */
 
 import type { AlertingOasOperationObject } from '../oas_types';
-import {
-  ACTION_POLICY_NOT_FOUND_RESPONSE,
-  INVALID_QUERY_PARAMETERS_RESPONSE,
-  actionPolicyResponseExample,
-} from './action_policy_oas_shared_examples';
 import { buildOasOperation } from '../oas_utils';
+import {
+  INVALID_QUERY_PARAMETERS_RESPONSE,
+  RULE_NOT_FOUND_RESPONSE,
+  RULE_VERSION_CONFLICT_RESPONSE,
+  ruleResponseExample,
+} from './rule_oas_shared_examples';
 
-export const getActionPolicyOasExamples = (): AlertingOasOperationObject =>
+export const disableRuleOasExamples = (): AlertingOasOperationObject =>
   buildOasOperation({
     responses: {
-      200: actionPolicyResponseExample('getActionPolicyResponse', 'An action policy'),
+      200: ruleResponseExample('disableRuleResponse', 'Disabled host CPU threshold rule', {
+        enabled: false,
+      }),
       400: INVALID_QUERY_PARAMETERS_RESPONSE,
-      404: ACTION_POLICY_NOT_FOUND_RESPONSE,
+      404: RULE_NOT_FOUND_RESPONSE,
+      409: RULE_VERSION_CONFLICT_RESPONSE,
     },
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/disable_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/disable_rule_route.ts
@@ -17,6 +17,7 @@ import { ALERTING_V2_RULE_API_PATH } from '../constants';
 import { BaseAlertingRoute } from '../base_alerting_route';
 import { AlertingRouteContext } from '../alerting_route_context';
 import { ruleIdParamsSchema } from './route_schemas';
+import { disableRuleOasExamples } from './disable_rule_oas_example';
 
 @injectable()
 export class DisableRuleRoute extends BaseAlertingRoute {
@@ -30,6 +31,7 @@ export class DisableRuleRoute extends BaseAlertingRoute {
   static routeOptions = {
     summary: 'Disable a rule',
     description: 'Disable a rule by identifier.',
+    oasOperationObject: disableRuleOasExamples,
   } as const;
   static schemas = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/enable_rule_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/enable_rule_oas_example.ts
@@ -8,16 +8,20 @@
 import type { AlertingOasOperationObject } from '../oas_types';
 import { buildOasOperation } from '../oas_utils';
 import {
-  INVALID_QUERY_PARAMETERS_RESPONSE,
+  MAX_SCHEDULES_PER_MINUTE_EXCEEDED_RESPONSE,
   RULE_NOT_FOUND_RESPONSE,
+  RULE_VERSION_CONFLICT_RESPONSE,
   ruleResponseExample,
 } from './rule_oas_shared_examples';
 
-export const getRuleOasExamples = (): AlertingOasOperationObject =>
+export const enableRuleOasExamples = (): AlertingOasOperationObject =>
   buildOasOperation({
     responses: {
-      200: ruleResponseExample('getRuleResponse', 'Retrieved host CPU threshold rule'),
-      400: INVALID_QUERY_PARAMETERS_RESPONSE,
+      200: ruleResponseExample('enableRuleResponse', 'Enabled host CPU threshold rule', {
+        enabled: true,
+      }),
+      400: MAX_SCHEDULES_PER_MINUTE_EXCEEDED_RESPONSE,
       404: RULE_NOT_FOUND_RESPONSE,
+      409: RULE_VERSION_CONFLICT_RESPONSE,
     },
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/enable_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/enable_rule_route.ts
@@ -17,6 +17,7 @@ import { ALERTING_V2_RULE_API_PATH } from '../constants';
 import { BaseAlertingRoute } from '../base_alerting_route';
 import { AlertingRouteContext } from '../alerting_route_context';
 import { ruleIdParamsSchema } from './route_schemas';
+import { enableRuleOasExamples } from './enable_rule_oas_example';
 
 @injectable()
 export class EnableRuleRoute extends BaseAlertingRoute {
@@ -30,6 +31,7 @@ export class EnableRuleRoute extends BaseAlertingRoute {
   static routeOptions = {
     summary: 'Enable a rule',
     description: 'Enable a rule by identifier.',
+    oasOperationObject: enableRuleOasExamples,
   } as const;
   static schemas = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/list_rules_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/list_rules_oas_example.ts
@@ -8,10 +8,7 @@
 import type { FindRulesResponse } from '@kbn/alerting-v2-schemas';
 import { buildOasOperation } from '../oas_utils';
 import type { AlertingOasOperationObject } from '../oas_types';
-import {
-  INVALID_QUERY_PARAMETERS_RESPONSE,
-  RULE_RESPONSE,
-} from './rule_oas_shared_examples';
+import { INVALID_QUERY_PARAMETERS_RESPONSE, RULE_RESPONSE } from './rule_oas_shared_examples';
 
 export const LIST_RULES_RESPONSE: FindRulesResponse = {
   items: [RULE_RESPONSE],

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/list_rules_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/list_rules_oas_example.ts
@@ -6,9 +6,12 @@
  */
 
 import type { FindRulesResponse } from '@kbn/alerting-v2-schemas';
-import { buildOasOperation, invalidResponseExample } from '../oas_utils';
+import { buildOasOperation } from '../oas_utils';
 import type { AlertingOasOperationObject } from '../oas_types';
-import { RULE_RESPONSE } from './rule_oas_shared_examples';
+import {
+  INVALID_QUERY_PARAMETERS_RESPONSE,
+  RULE_RESPONSE,
+} from './rule_oas_shared_examples';
 
 export const LIST_RULES_RESPONSE: FindRulesResponse = {
   items: [RULE_RESPONSE],
@@ -16,12 +19,6 @@ export const LIST_RULES_RESPONSE: FindRulesResponse = {
   page: 1,
   perPage: 20,
 };
-
-const INVALID_LIST_RULES_RESPONSE = invalidResponseExample({
-  summary: 'List query uses an invalid page number',
-  message: 'page: Number must be greater than or equal to 1',
-  details: { errors: { page: ['Number must be greater than or equal to 1'] } },
-});
 
 export const listRulesOasExamples = (): AlertingOasOperationObject =>
   buildOasOperation({
@@ -31,6 +28,6 @@ export const listRulesOasExamples = (): AlertingOasOperationObject =>
         summary: 'Paginated list containing one matching rule',
         value: LIST_RULES_RESPONSE,
       },
-      400: INVALID_LIST_RULES_RESPONSE,
+      400: INVALID_QUERY_PARAMETERS_RESPONSE,
     },
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/rule_oas_shared_examples.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/rule_oas_shared_examples.ts
@@ -15,9 +15,14 @@ import type {
   RuleResponse,
 } from '@kbn/alerting-v2-schemas';
 import { ALERTING_V2_ERROR_CODES } from '../../lib/errors/error_codes';
-import { getRuleNotFoundMessage } from '../../lib/errors/rule_error_messages';
+import {
+  getRuleNotFoundMessage,
+  getRuleVersionConflictMessage,
+} from '../../lib/errors/rule_error_messages';
+import { INVALID_SCHEMA_OR_PARAMETERS_DESCRIPTION } from '../route_descriptions';
 import { invalidResponseExample } from '../oas_utils';
 import type { OasExampleEntry } from '../oas_types';
+import { RULE_VERSION_CONFLICT_DESCRIPTION } from './rule_response_descriptions';
 
 const SAMPLE_RULE_DATA = {
   kind: 'alert' as const,
@@ -93,6 +98,20 @@ export const INVALID_BULK_BY_QUERY_RESPONSE = invalidResponseExample({
   },
 });
 
+/** Shared 400 body for invalid path/query parameters. */
+export const INVALID_QUERY_PARAMETERS_RESPONSE: OasExampleEntry = invalidResponseExample({
+  summary: INVALID_SCHEMA_OR_PARAMETERS_DESCRIPTION,
+  message: 'page: Too small: expected number to be >=1',
+  details: {
+    errors: {
+      errors: [],
+      properties: {
+        page: { errors: ['Too small: expected number to be >=1'] },
+      },
+    },
+  },
+});
+
 /** Shared 404 body for single-rule routes (get/update/delete/upsert). */
 export const RULE_NOT_FOUND_RESPONSE: OasExampleEntry = {
   name: 'ruleNotFound',
@@ -101,6 +120,55 @@ export const RULE_NOT_FOUND_RESPONSE: OasExampleEntry = {
     code: ALERTING_V2_ERROR_CODES.RULE_NOT_FOUND,
     error: 'Not Found',
     message: getRuleNotFoundMessage(RULE_RESPONSE.id),
+    details: { rule_id: RULE_RESPONSE.id },
+  } satisfies ErrorResponse,
+};
+
+/** Shared 409 body for single-rule mutate routes. */
+export const RULE_VERSION_CONFLICT_RESPONSE: OasExampleEntry = {
+  name: 'ruleVersionConflict',
+  summary: RULE_VERSION_CONFLICT_DESCRIPTION,
+  value: {
+    code: ALERTING_V2_ERROR_CODES.RULE_VERSION_CONFLICT,
+    error: 'Conflict',
+    message: getRuleVersionConflictMessage(RULE_RESPONSE.id),
+    details: { rule_id: RULE_RESPONSE.id },
+  } satisfies ErrorResponse,
+};
+
+/** Shared 400 body when enabling a rule would exceed the schedule limit. */
+export const MAX_SCHEDULES_PER_MINUTE_EXCEEDED_RESPONSE: OasExampleEntry = {
+  name: 'maxSchedulesPerMinuteExceeded',
+  summary:
+    'Indicates the request is invalid, for example enabling the rule would exceed the configured schedule limit.',
+  value: {
+    code: ALERTING_V2_ERROR_CODES.MAX_SCHEDULES_PER_MINUTE_EXCEEDED,
+    error: 'Bad Request',
+    message: `Rule schedule of "1m" would exceed the limit of 400 rule runs per minute`,
+    details: { interval: '1m', maxScheduledPerMinute: 400 },
+  } satisfies ErrorResponse,
+};
+
+/** Shared 400 body when running a disabled rule. */
+export const RULE_DISABLED_RESPONSE: OasExampleEntry = {
+  name: 'ruleDisabled',
+  summary: 'Indicates the rule is disabled and cannot be run.',
+  value: {
+    code: ALERTING_V2_ERROR_CODES.RULE_DISABLED,
+    error: 'Bad Request',
+    message: `Rule with id "${RULE_RESPONSE.id}" is disabled and cannot be run`,
+    details: { rule_id: RULE_RESPONSE.id },
+  } satisfies ErrorResponse,
+};
+
+/** Shared 409 body when a rule is already running. */
+export const RULE_ALREADY_RUNNING_RESPONSE: OasExampleEntry = {
+  name: 'ruleAlreadyRunning',
+  summary: 'Indicates the rule is already running or the run request conflicted.',
+  value: {
+    code: ALERTING_V2_ERROR_CODES.RULE_ALREADY_RUNNING,
+    error: 'Conflict',
+    message: `Rule with id "${RULE_RESPONSE.id}" is already running`,
     details: { rule_id: RULE_RESPONSE.id },
   } satisfies ErrorResponse,
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/run_rule_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/run_rule_oas_example.ts
@@ -6,18 +6,18 @@
  */
 
 import type { AlertingOasOperationObject } from '../oas_types';
-import {
-  ACTION_POLICY_NOT_FOUND_RESPONSE,
-  INVALID_QUERY_PARAMETERS_RESPONSE,
-  actionPolicyResponseExample,
-} from './action_policy_oas_shared_examples';
 import { buildOasOperation } from '../oas_utils';
+import {
+  RULE_ALREADY_RUNNING_RESPONSE,
+  RULE_DISABLED_RESPONSE,
+  RULE_NOT_FOUND_RESPONSE,
+} from './rule_oas_shared_examples';
 
-export const getActionPolicyOasExamples = (): AlertingOasOperationObject =>
+export const runRuleOasExamples = (): AlertingOasOperationObject =>
   buildOasOperation({
     responses: {
-      200: actionPolicyResponseExample('getActionPolicyResponse', 'An action policy'),
-      400: INVALID_QUERY_PARAMETERS_RESPONSE,
-      404: ACTION_POLICY_NOT_FOUND_RESPONSE,
+      400: RULE_DISABLED_RESPONSE,
+      404: RULE_NOT_FOUND_RESPONSE,
+      409: RULE_ALREADY_RUNNING_RESPONSE,
     },
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/run_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/run_rule_route.ts
@@ -17,6 +17,7 @@ import { ALERTING_V2_RULE_API_PATH } from '../constants';
 import { BaseAlertingRoute } from '../base_alerting_route';
 import { AlertingRouteContext } from '../alerting_route_context';
 import { ruleIdParamsSchema } from './route_schemas';
+import { runRuleOasExamples } from './run_rule_oas_example';
 
 @injectable()
 export class RunRuleRoute extends BaseAlertingRoute {
@@ -29,6 +30,7 @@ export class RunRuleRoute extends BaseAlertingRoute {
   };
   static routeOptions = {
     summary: 'Run a rule now',
+    oasOperationObject: runRuleOasExamples,
   } as const;
   static schemas = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/update_rule_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/update_rule_oas_example.ts
@@ -6,13 +6,12 @@
  */
 
 import type { UpdateRuleBody } from '@kbn/alerting-v2-schemas';
-import { ALERTING_V2_ERROR_CODES } from '../../lib/errors/error_codes';
-import { getRuleVersionConflictMessage } from '../../lib/errors/rule_error_messages';
 import { buildOasOperation, invalidResponseExample } from '../oas_utils';
 import type { AlertingOasOperationObject } from '../oas_types';
 import {
   RULE_NOT_FOUND_RESPONSE,
   RULE_RESPONSE,
+  RULE_VERSION_CONFLICT_RESPONSE,
   ruleResponseExample,
 } from './rule_oas_shared_examples';
 
@@ -32,17 +31,6 @@ const INVALID_UPDATE_RULE_RESPONSE = invalidResponseExample({
   message: "Unrecognized key(s) in object: 'unknownField'",
   details: { errors: { unknownField: ['Unrecognized key'] } },
 });
-
-const RULE_VERSION_CONFLICT_RESPONSE = {
-  name: 'ruleVersionConflict',
-  summary: 'Rule was updated by another caller',
-  value: {
-    code: ALERTING_V2_ERROR_CODES.RULE_VERSION_CONFLICT,
-    error: 'Conflict',
-    message: getRuleVersionConflictMessage(RULE_RESPONSE.id),
-    details: { rule_id: RULE_RESPONSE.id },
-  },
-};
 
 export const updateRuleOasExamples = (): AlertingOasOperationObject =>
   buildOasOperation({


### PR DESCRIPTION
## Summary
- Add missing OAS `examples` for action-policy routes that only had path-param validation 400s (`get`/`delete`/`enable`/`disable`/`unsnooze`/`update_api_key`).
- Add OAS examples for single-rule `enable`/`disable`/`run`, plus shared 400/409 examples reused by get/delete/list/update.
- Add OAS examples for `POST /api/alerting/v2/alerts` and `POST /api/alerting/v2/alerts/{source}`, and document the `{source}` path param.

These fill the Kibana OAS media-type `examples` requirement that was increasing the CI baseline error count for the new alerting v2 surface.

## Test plan
- [ ] `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/rule_oas_examples.test.ts --config x-pack/platform/plugins/shared/alerting_v2/jest.config.js`
- [ ] `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_oas_example.test.ts --config x-pack/platform/plugins/shared/alerting_v2/jest.config.js`
- [ ] Capture OAS for `/api/alerting/v2/` and run `node ./scripts/validate_oas_docs.js --only traditional --path /api/alerting/v2/` (expect no new errors vs baseline)
- [ ] Confirm CI `capture_oas_snapshot` / OAS validation no longer reports an error-count increase from these routes


Made with [Cursor](https://cursor.com)