### PR TITLE
[Inference] Add workflow anonymization steps and provider

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
@@ -73,6 +73,15 @@ const configSchema = schema.object({
   hitlExternalResume: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
   }),
+  syncExecution: schema.object({
+    /**
+     * Maximum wall-clock time allowed for a single synchronous workflow execution.
+     * When the deadline is reached the internal AbortController is aborted, which
+     * propagates cancellation through the execution loop to any in-flight step.
+     * Callers may impose a shorter deadline via ExecuteWorkflowOptions.abortSignal.
+     */
+    maxDurationMs: schema.number({ defaultValue: 60_000, min: 1_000 }),
+  }),
 });
 
 export type EventTriggersConfig = TypeOf<typeof EventTriggersConfigSchema>;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
@@ -75,6 +75,12 @@ const configSchema = schema.object({
   }),
   syncExecution: schema.object({
     /**
+     * Master switch for the synchronous execution path. Must be set to true alongside
+     * `xpack.inference.anonymization.workflow_driven: true` to enable workflow-driven
+     * PII anonymization. Defaults to false so the path is inert until explicitly activated.
+     */
+    enabled: schema.boolean({ defaultValue: false }),
+    /**
      * Maximum wall-clock time allowed for a single synchronous workflow execution.
      * When the deadline is reached the internal AbortController is aborted, which
      * propagates cancellation through the execution loop to any in-flight step.

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
@@ -32,6 +32,6 @@ export const mockContextDependencies = () => ({
     },
     collectQueueMetrics: false,
     hitlExternalResume: { enabled: true },
-    syncExecution: { maxDurationMs: 60_000 },
+    syncExecution: { enabled: true, maxDurationMs: 60_000 },
   },
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
@@ -32,5 +32,6 @@ export const mockContextDependencies = () => ({
     },
     collectQueueMetrics: false,
     hitlExternalResume: { enabled: true },
+    syncExecution: { maxDurationMs: 60_000 },
   },
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import { ExecutionStatus } from '@kbn/workflows';
+import type { EsWorkflowExecution, WorkflowExecutionEngineModel } from '@kbn/workflows';
+import { mockContextDependencies } from './__mock__/context_dependencies';
+import { executeWorkflowSync } from './execute_workflow_sync';
+import { runWorkflowSync } from './run_workflow_sync';
+import { buildWorkflowExecutionDocument } from '../lib/build_workflow_execution_document';
+import { getAuthenticatedUser } from '../lib/get_user';
+import { validateWorkflowInputs } from '../lib/validate_workflow_inputs';
+
+jest.mock('./run_workflow_sync');
+jest.mock('../lib/build_workflow_execution_document');
+jest.mock('../lib/get_user');
+jest.mock('../lib/validate_workflow_inputs');
+jest.mock('../repositories/execution_persistence', () => ({
+  InMemoryExecutionPersistence: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockRunWorkflowSync = runWorkflowSync as jest.MockedFunction<typeof runWorkflowSync>;
+const mockBuildWorkflowExecutionDocument = buildWorkflowExecutionDocument as jest.MockedFunction<
+  typeof buildWorkflowExecutionDocument
+>;
+const mockValidateWorkflowInputs = validateWorkflowInputs as jest.MockedFunction<
+  typeof validateWorkflowInputs
+>;
+const mockGetAuthenticatedUser = getAuthenticatedUser as jest.MockedFunction<
+  typeof getAuthenticatedUser
+>;
+
+const baseWorkflowExecution = {
+  id: 'exec-1',
+  workflowId: 'wf-1',
+  spaceId: 'default',
+  triggeredBy: 'manual',
+  workflowDefinition: { version: '1', name: 'Test', enabled: true, triggers: [], steps: [] },
+  isTestRun: false,
+  status: ExecutionStatus.PENDING,
+  context: {},
+  yaml: '',
+  scopeStack: [],
+  error: null,
+  startedAt: '2026-01-01T00:00:00.000Z',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  finishedAt: '',
+  cancelRequested: false,
+  duration: 0,
+};
+
+const completedExecution: EsWorkflowExecution = {
+  ...baseWorkflowExecution,
+  status: ExecutionStatus.COMPLETED,
+  context: { output: { answer: 42 } },
+};
+
+describe('executeWorkflowSync', () => {
+  const workflow = { id: 'wf-1', yaml: '', isEphemeral: false } as WorkflowExecutionEngineModel;
+  const request = {} as KibanaRequest;
+  const logger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any;
+  const getWorkflowsExecutionEngine = jest.fn().mockResolvedValue({});
+
+  let dependencies: ReturnType<typeof mockContextDependencies> & {
+    workflowRepository?: { isWorkflowEnabled: jest.Mock };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dependencies = mockContextDependencies();
+    mockGetAuthenticatedUser.mockResolvedValue({ username: 'test-user' } as any);
+    mockBuildWorkflowExecutionDocument.mockReturnValue(baseWorkflowExecution as any);
+    mockValidateWorkflowInputs.mockResolvedValue(true);
+    mockRunWorkflowSync.mockResolvedValue(completedExecution);
+  });
+
+  const invoke = (overrides?: Partial<Parameters<typeof executeWorkflowSync>[0]>) =>
+    executeWorkflowSync({
+      workflow,
+      context: {},
+      request,
+      options: {},
+      logger,
+      dependencies: dependencies as any,
+      getWorkflowsExecutionEngine,
+      ...overrides,
+    });
+
+  describe('disabled workflow guard', () => {
+    let isWorkflowEnabled: jest.Mock;
+
+    beforeEach(() => {
+      isWorkflowEnabled = jest.fn().mockResolvedValue(true);
+      dependencies = { ...dependencies, workflowRepository: { isWorkflowEnabled } } as any;
+    });
+
+    it('throws when a non-ephemeral workflow is disabled', async () => {
+      isWorkflowEnabled.mockResolvedValue(false);
+      await expect(invoke()).rejects.toThrow('Workflow is disabled: wf-1');
+      expect(mockRunWorkflowSync).not.toHaveBeenCalled();
+    });
+
+    it('skips the check when workflow.isEphemeral is true', async () => {
+      const ephemeral = { ...workflow, isEphemeral: true } as WorkflowExecutionEngineModel;
+      await invoke({ workflow: ephemeral });
+      expect(isWorkflowEnabled).not.toHaveBeenCalled();
+    });
+
+    it('skips the check when workflowRepository is absent', async () => {
+      delete dependencies.workflowRepository;
+      await expect(invoke()).resolves.toBeDefined();
+    });
+  });
+
+  describe('workflowDefinition guard', () => {
+    it('throws when buildWorkflowExecutionDocument returns no workflowDefinition', async () => {
+      mockBuildWorkflowExecutionDocument.mockReturnValue({
+        ...baseWorkflowExecution,
+        workflowDefinition: undefined,
+      } as any);
+      await expect(invoke()).rejects.toThrow(
+        'Synchronous workflow execution requires a workflow definition'
+      );
+      expect(mockRunWorkflowSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateWorkflowInputs guard', () => {
+    it('returns FAILED and does not call runWorkflowSync when inputs are invalid', async () => {
+      mockValidateWorkflowInputs.mockResolvedValue(false);
+      const result = await invoke();
+      expect(result).toEqual({
+        workflowExecutionId: 'exec-1',
+        result: { status: ExecutionStatus.FAILED },
+      });
+      expect(mockRunWorkflowSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('output extraction', () => {
+    it('returns no output field when context.output is undefined', async () => {
+      mockRunWorkflowSync.mockResolvedValue({ ...completedExecution, context: {} });
+      const result = await invoke();
+      expect(result.result).not.toHaveProperty('output');
+    });
+
+    it('returns no output field when context.output is null', async () => {
+      mockRunWorkflowSync.mockResolvedValue({
+        ...completedExecution,
+        context: { output: null },
+      });
+      const result = await invoke();
+      expect(result.result).not.toHaveProperty('output');
+    });
+
+    it('returns output field when context.output is an object', async () => {
+      const output = { answer: 42 };
+      mockRunWorkflowSync.mockResolvedValue({
+        ...completedExecution,
+        context: { output },
+      });
+      const result = await invoke();
+      expect(result.result?.output).toEqual(output);
+    });
+
+    it('throws when context.output is a non-object scalar', async () => {
+      mockRunWorkflowSync.mockResolvedValue({
+        ...completedExecution,
+        context: { output: 'not-an-object' },
+      });
+      await expect(invoke()).rejects.toThrow('Synchronous workflow output must be an object');
+    });
+  });
+
+  describe('abort signal', () => {
+    it('removes abort listener after successful execution', async () => {
+      const controller = new AbortController();
+      const removeEventListener = jest.spyOn(controller.signal, 'removeEventListener');
+      await invoke({ options: { abortSignal: controller.signal } });
+      expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    });
+
+    it('removes abort listener even when runWorkflowSync throws', async () => {
+      const controller = new AbortController();
+      const removeEventListener = jest.spyOn(controller.signal, 'removeEventListener');
+      mockRunWorkflowSync.mockRejectedValue(new Error('execution failed'));
+      await expect(invoke({ options: { abortSignal: controller.signal } })).rejects.toThrow(
+        'execution failed'
+      );
+      expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    });
+
+    it('aborts the internal controller immediately when signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort('pre-aborted');
+      mockRunWorkflowSync.mockImplementation(async ({ abortController: ctrl }) => {
+        expect(ctrl.signal.aborted).toBe(true);
+        return completedExecution;
+      });
+      await invoke({ options: { abortSignal: controller.signal } });
+      expect(mockRunWorkflowSync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('happy path', () => {
+    it('returns workflowExecutionId and status from runWorkflowSync', async () => {
+      const result = await invoke();
+      expect(result).toEqual({
+        workflowExecutionId: 'exec-1',
+        result: { status: ExecutionStatus.COMPLETED, output: { answer: 42 } },
+      });
+    });
+
+    it('calls getWorkflowsExecutionEngine and forwards the result to runWorkflowSync', async () => {
+      const fakeEngine = { supportsSynchronousExecution: true as const };
+      getWorkflowsExecutionEngine.mockResolvedValue(fakeEngine);
+      await invoke();
+      expect(getWorkflowsExecutionEngine).toHaveBeenCalledTimes(1);
+      expect(mockRunWorkflowSync).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowsExecutionEngine: fakeEngine })
+      );
+    });
+
+    it('overrides execution id when options.executionId is set', async () => {
+      await invoke({ options: { executionId: 'custom-id' } });
+      expect(mockRunWorkflowSync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowExecution: expect.objectContaining({ id: 'custom-id' }),
+        })
+      );
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
@@ -21,8 +21,11 @@ jest.mock('./run_workflow_sync');
 jest.mock('../lib/build_workflow_execution_document');
 jest.mock('../lib/get_user');
 jest.mock('../lib/validate_workflow_inputs');
+const mockGetWorkflowExecutionById = jest.fn().mockResolvedValue(null);
 jest.mock('../repositories/execution_persistence', () => ({
-  InMemoryExecutionPersistence: jest.fn().mockImplementation(() => ({})),
+  InMemoryExecutionPersistence: jest.fn().mockImplementation(() => ({
+    getWorkflowExecutionById: mockGetWorkflowExecutionById,
+  })),
 }));
 
 const mockRunWorkflowSync = runWorkflowSync as jest.MockedFunction<typeof runWorkflowSync>;
@@ -78,6 +81,7 @@ describe('executeWorkflowSync', () => {
     mockBuildWorkflowExecutionDocument.mockReturnValue(baseWorkflowExecution as any);
     mockValidateWorkflowInputs.mockResolvedValue(true);
     mockRunWorkflowSync.mockResolvedValue(completedExecution);
+    mockGetWorkflowExecutionById.mockResolvedValue(null);
   });
 
   const invoke = (overrides?: Partial<Parameters<typeof executeWorkflowSync>[0]>) =>
@@ -140,6 +144,20 @@ describe('executeWorkflowSync', () => {
         result: { status: ExecutionStatus.FAILED },
       });
       expect(mockRunWorkflowSync).not.toHaveBeenCalled();
+    });
+
+    it('includes error from in-memory persistence when validation fails', async () => {
+      mockValidateWorkflowInputs.mockResolvedValue(false);
+      mockGetWorkflowExecutionById.mockResolvedValueOnce({
+        ...baseWorkflowExecution,
+        status: ExecutionStatus.FAILED,
+        error: { type: 'InputValidationError', message: 'inputs: required field missing' },
+      });
+      const result = await invoke();
+      expect(result.result?.error).toEqual({
+        type: 'InputValidationError',
+        message: 'inputs: required field missing',
+      });
     });
   });
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.test.ts
@@ -58,11 +58,11 @@ const baseWorkflowExecution = {
   duration: 0,
 };
 
-const completedExecution: EsWorkflowExecution = {
+const completedExecution = {
   ...baseWorkflowExecution,
   status: ExecutionStatus.COMPLETED,
   context: { output: { answer: 42 } },
-};
+} as unknown as EsWorkflowExecution;
 
 describe('executeWorkflowSync', () => {
   const workflow = { id: 'wf-1', yaml: '', isEphemeral: false } as WorkflowExecutionEngineModel;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
@@ -71,14 +71,9 @@ export const executeWorkflowSync = async ({
     coreStart.elasticsearch.client
   );
 
-  const syncContext = {
-    ...context,
-    ...(options.metadata ? { metadata: options.metadata } : {}),
-  };
-
   const workflowExecution = await buildWorkflowExecutionDocument({
     workflow,
-    context: syncContext,
+    context,
     defaultTriggeredBy: 'manual',
     authenticatedUser,
     now: new Date(),

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
@@ -118,9 +118,16 @@ export const executeWorkflowSync = async ({
     { ...dependencies, capabilities: options.capabilities }
   );
   if (!inputsValid) {
+    const failedExecution = await syncExecutionPersistence.getWorkflowExecutionById(
+      syncWorkflowExecution.id,
+      spaceId
+    );
     return {
       workflowExecutionId: syncWorkflowExecution.id,
-      result: { status: ExecutionStatus.FAILED },
+      result: {
+        status: ExecutionStatus.FAILED,
+        ...(failedExecution?.error ? { error: failedExecution.error } : {}),
+      },
     };
   }
 
@@ -130,6 +137,15 @@ export const executeWorkflowSync = async ({
   if (options.abortSignal?.aborted) {
     abort();
   }
+
+  const maxDurationMs = config.syncExecution.maxDurationMs;
+  const timeoutId = setTimeout(
+    () =>
+      abortController.abort(
+        new Error(`Synchronous workflow execution timed out after ${maxDurationMs}ms`)
+      ),
+    maxDurationMs
+  );
 
   try {
     const workflowsExecutionEngine = await getWorkflowsExecutionEngine();
@@ -154,6 +170,7 @@ export const executeWorkflowSync = async ({
       },
     };
   } finally {
+    clearTimeout(timeoutId);
     options.abortSignal?.removeEventListener('abort', abort);
   }
 };

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import { ExecutionStatus } from '@kbn/workflows';
+import type { EsWorkflowExecution, WorkflowExecutionEngineModel } from '@kbn/workflows';
+import { runWorkflowSync } from './run_workflow_sync';
+import { buildWorkflowExecutionDocument } from '../lib/build_workflow_execution_document';
+import { getAuthenticatedUser } from '../lib/get_user';
+import { validateWorkflowInputs } from '../lib/validate_workflow_inputs';
+import { InMemoryExecutionPersistence } from '../repositories/execution_persistence';
+import type {
+  ExecuteWorkflowOptions,
+  ExecuteWorkflowResponse,
+  WorkflowsExecutionEnginePluginStart,
+} from '../types';
+import type { ContextDependencies } from '../workflow_context_manager/types';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getSynchronousWorkflowOutput = (output: unknown): Record<string, unknown> | undefined => {
+  if (output === undefined || output === null) {
+    return undefined;
+  }
+  if (isRecord(output)) {
+    return output;
+  }
+  throw new Error('Synchronous workflow output must be an object');
+};
+
+export const executeWorkflowSync = async ({
+  workflow,
+  context,
+  request,
+  options,
+  logger,
+  dependencies,
+  getWorkflowsExecutionEngine,
+}: {
+  workflow: WorkflowExecutionEngineModel;
+  context: Record<string, unknown>;
+  request: KibanaRequest;
+  options: ExecuteWorkflowOptions;
+  logger: Logger;
+  dependencies: ContextDependencies;
+  getWorkflowsExecutionEngine: () => Promise<WorkflowsExecutionEnginePluginStart>;
+}): Promise<ExecuteWorkflowResponse> => {
+  const { coreStart, workflowRepository, config } = dependencies;
+
+  const spaceId = typeof context.spaceId === 'string' ? context.spaceId : 'default';
+
+  if (!workflow.isEphemeral && workflowRepository) {
+    const stillEnabled = await workflowRepository.isWorkflowEnabled(workflow.id, spaceId, {
+      includeGlobal: true,
+    });
+    if (!stillEnabled) {
+      throw new Error(`Workflow is disabled: ${workflow.id}. Enable the workflow to run it.`);
+    }
+  }
+
+  const authenticatedUser = await getAuthenticatedUser(
+    request,
+    coreStart.security,
+    coreStart.elasticsearch.client
+  );
+
+  const syncContext = {
+    ...context,
+    ...(options.metadata ? { metadata: options.metadata } : {}),
+  };
+
+  const workflowExecution = await buildWorkflowExecutionDocument({
+    workflow,
+    context: syncContext,
+    defaultTriggeredBy: 'manual',
+    authenticatedUser,
+    now: new Date(),
+    maxEventChainDepth: config.eventDriven.maxChainDepth,
+    getConcurrencyGroupKey: () => null,
+  });
+
+  if (options.executionId) {
+    workflowExecution.id = options.executionId;
+  }
+
+  if (!workflowExecution.workflowDefinition) {
+    throw new Error('Synchronous workflow execution requires a workflow definition');
+  }
+
+  const syncWorkflowExecution: EsWorkflowExecution = {
+    ...workflowExecution,
+    isTestRun: workflowExecution.isTestRun ?? false,
+    status: workflowExecution.status ?? ExecutionStatus.PENDING,
+    context: workflowExecution.context ?? syncContext,
+    workflowDefinition: workflowExecution.workflowDefinition,
+    yaml: workflowExecution.yaml ?? workflow.yaml,
+    scopeStack: workflowExecution.scopeStack ?? [],
+    error: workflowExecution.error ?? null,
+    startedAt: workflowExecution.startedAt ?? workflowExecution.createdAt,
+    finishedAt: workflowExecution.finishedAt ?? '',
+    cancelRequested: workflowExecution.cancelRequested ?? false,
+    duration: workflowExecution.duration ?? 0,
+  };
+
+  const syncExecutionPersistence = new InMemoryExecutionPersistence(syncWorkflowExecution);
+  const inputsValid = await validateWorkflowInputs(
+    syncWorkflowExecution,
+    syncExecutionPersistence,
+    logger,
+    coreStart,
+    { ...dependencies, capabilities: options.capabilities }
+  );
+  if (!inputsValid) {
+    return {
+      workflowExecutionId: syncWorkflowExecution.id,
+      result: { status: ExecutionStatus.FAILED },
+    };
+  }
+
+  const abortController = new AbortController();
+  const abort = () => abortController.abort(options.abortSignal?.reason);
+  options.abortSignal?.addEventListener('abort', abort, { once: true });
+  if (options.abortSignal?.aborted) {
+    abort();
+  }
+
+  try {
+    const workflowsExecutionEngine = await getWorkflowsExecutionEngine();
+    const result = await runWorkflowSync({
+      workflowExecution: syncWorkflowExecution,
+      request,
+      abortController,
+      logger,
+      config,
+      dependencies: { ...dependencies, capabilities: options.capabilities },
+      workflowsExecutionEngine,
+      workflowExecutionRepository: syncExecutionPersistence,
+      stepExecutionRepository: syncExecutionPersistence,
+    });
+
+    const output = getSynchronousWorkflowOutput(result.context?.output);
+    return {
+      workflowExecutionId: result.id,
+      result: {
+        status: result.status,
+        ...(output ? { output } : {}),
+      },
+    };
+  } finally {
+    options.abortSignal?.removeEventListener('abort', abort);
+  }
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execute_workflow_sync.ts
@@ -93,7 +93,7 @@ export const executeWorkflowSync = async ({
     ...workflowExecution,
     isTestRun: workflowExecution.isTestRun ?? false,
     status: workflowExecution.status ?? ExecutionStatus.PENDING,
-    context: workflowExecution.context ?? syncContext,
+    context: workflowExecution.context ?? context,
     workflowDefinition: workflowExecution.workflowDefinition,
     yaml: workflowExecution.yaml ?? workflow.yaml,
     scopeStack: workflowExecution.scopeStack ?? [],

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execution_functions_test_utils.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/execution_functions_test_utils.ts
@@ -28,6 +28,7 @@ export const createMockWorkflowExecutionEngineConfig = (): WorkflowsExecutionEng
   eviction: { minPayloadSize: new ByteSizeValue(10 * 1024) },
   collectQueueMetrics: false,
   hitlExternalResume: { enabled: true },
+  syncExecution: { enabled: false, maxDurationMs: 60_000 },
 });
 
 export const createMockLogger = (): Logger =>

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/index.ts
@@ -10,6 +10,7 @@
 export { setupDependencies } from './setup_dependencies';
 export { runWorkflow } from './run_workflow';
 export { runWorkflowSync } from './run_workflow_sync';
+export { executeWorkflowSync } from './execute_workflow_sync';
 export { resumeWorkflow } from './resume_workflow';
 export { cancelWorkflow } from './cancel_workflow';
 export {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/index.ts
@@ -9,6 +9,7 @@
 
 export { setupDependencies } from './setup_dependencies';
 export { runWorkflow } from './run_workflow';
+export { runWorkflowSync } from './run_workflow_sync';
 export { resumeWorkflow } from './resume_workflow';
 export { cancelWorkflow } from './cancel_workflow';
 export {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/resume_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/resume_workflow.ts
@@ -87,6 +87,10 @@ export async function resumeWorkflow({
     workflowExecutionCursor,
   } = setupResult;
 
+  if (!workflowExecutionRepository) {
+    throw new Error('Persistent workflow execution repository is unavailable');
+  }
+
   const loadedExecution = workflowExecutionState.getWorkflowExecution();
   if (isTerminalStatus(loadedExecution.status)) {
     logger.info(

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
@@ -56,6 +56,7 @@ export async function runWorkflow({
   meteringService?: WorkflowsMeteringService;
   internalResumeWorkflowExecution?: InternalResumeWorkflowExecution;
 }): Promise<RunWorkflowResult | void> {
+  apm.currentTransaction?.setLabel('execution_mode', 'async');
   // Span for setup/initialization phase
   const setupSpan = apm.startSpan('workflow setup', 'workflow', 'setup');
   let setupResult: Awaited<ReturnType<typeof setupDependencies>>;
@@ -99,6 +100,10 @@ export async function runWorkflow({
     telemetryClient,
     workflowExecutionCursor,
   } = setupResult;
+
+  if (!workflowExecutionRepository) {
+    throw new Error('Persistent workflow execution repository is unavailable');
+  }
 
   const execution = workflowExecutionState.getWorkflowExecution();
   if (isTerminalStatus(execution.status)) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
@@ -96,7 +96,7 @@ describe('runWorkflowSync', () => {
     expect(workflowExecutionLoop).toHaveBeenCalledWith(
       expect.objectContaining({
         executionMode: 'sync',
-        taskAbortController: abortController,
+        signal: abortController.signal,
         fakeRequest: request,
         workflowExecutionRepository: setup.workflowExecutionPersistence,
       })

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { type EsWorkflowExecution, ExecutionStatus } from '@kbn/workflows';
+import { runWorkflowSync } from './run_workflow_sync';
+import { setupDependencies } from './setup_dependencies';
+import { validateSyncWorkflow } from './validate_sync_workflow';
+import { workflowExecutionLoop } from '../workflow_execution_loop';
+
+jest.mock('./setup_dependencies', () => ({ setupDependencies: jest.fn() }));
+jest.mock('./validate_sync_workflow', () => ({ validateSyncWorkflow: jest.fn() }));
+jest.mock('../workflow_execution_loop', () => ({ workflowExecutionLoop: jest.fn() }));
+
+describe('runWorkflowSync', () => {
+  it('runs the canonical workflow loop with in-memory dependencies and sync mode', async () => {
+    const completedExecution = {
+      id: 'execution-1',
+      spaceId: 'default',
+      workflowId: 'workflow-1',
+      isTestRun: false,
+      status: ExecutionStatus.COMPLETED,
+      context: {},
+      workflowDefinition: {
+        version: '1',
+        name: 'Test workflow',
+        enabled: true,
+        triggers: [],
+        steps: [],
+      },
+      yaml: '',
+      scopeStack: [],
+      createdAt: '2026-07-21T00:00:00.000Z',
+      error: null,
+      startedAt: '2026-07-21T00:00:00.000Z',
+      finishedAt: '2026-07-21T00:00:01.000Z',
+      cancelRequested: false,
+      duration: 1000,
+    } satisfies EsWorkflowExecution;
+    const workflowExecutionGraph = { topologicalOrder: [] };
+    const workflowRuntime = { start: jest.fn().mockResolvedValue(undefined) };
+    const workflowExecutionState = {
+      getWorkflowExecution: jest.fn().mockReturnValue(completedExecution),
+    };
+    const setup = {
+      workflowExecutionGraph,
+      workflowRuntime,
+      workflowExecutionState,
+      stepExecutionRuntimeFactory: {},
+      stepIoService: {},
+      workflowLogger: {},
+      workflowTaskManager: {},
+      nodesFactory: {},
+      workflowExecutionPersistence: {},
+      workflowExecutionRepository: undefined,
+      esClient: {},
+    };
+    (setupDependencies as jest.Mock).mockResolvedValue(setup);
+    (workflowExecutionLoop as jest.Mock).mockResolvedValue(undefined);
+
+    const abortController = new AbortController();
+    const request = {} as Parameters<typeof runWorkflowSync>[0]['request'];
+    const dependencies = {
+      coreStart: {},
+    } as Parameters<typeof runWorkflowSync>[0]['dependencies'];
+    const workflowExecutionRepository = {} as Parameters<
+      typeof runWorkflowSync
+    >[0]['workflowExecutionRepository'];
+    const stepExecutionRepository = {} as Parameters<
+      typeof runWorkflowSync
+    >[0]['stepExecutionRepository'];
+
+    await expect(
+      runWorkflowSync({
+        workflowExecution: completedExecution,
+        request,
+        abortController,
+        logger: {} as Parameters<typeof runWorkflowSync>[0]['logger'],
+        config: {} as Parameters<typeof runWorkflowSync>[0]['config'],
+        dependencies,
+        workflowsExecutionEngine: {} as Parameters<
+          typeof runWorkflowSync
+        >[0]['workflowsExecutionEngine'],
+        workflowExecutionRepository,
+        stepExecutionRepository,
+      })
+    ).resolves.toBe(completedExecution);
+
+    expect(validateSyncWorkflow).toHaveBeenCalledWith(workflowExecutionGraph);
+    expect(workflowRuntime.start).toHaveBeenCalledTimes(1);
+    expect(workflowExecutionLoop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: 'sync',
+        taskAbortController: abortController,
+        fakeRequest: request,
+        workflowExecutionRepository: setup.workflowExecutionPersistence,
+      })
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.ts
@@ -61,7 +61,7 @@ export const runWorkflowSync = async ({
     workflowExecutionRepository: setup.workflowExecutionPersistence,
     fakeRequest: request,
     coreStart: dependencies.coreStart,
-    taskAbortController: abortController,
+    signal: abortController.signal,
     executionMode: 'sync',
   });
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow_sync.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import apm from 'elastic-apm-node';
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { EsWorkflowExecution } from '@kbn/workflows';
+import { setupDependencies } from './setup_dependencies';
+import { validateSyncWorkflow } from './validate_sync_workflow';
+import type { WorkflowsExecutionEngineConfig } from '../config';
+import type {
+  StepExecutionPersistence,
+  WorkflowExecutionPersistence,
+} from '../repositories/execution_persistence';
+import type { WorkflowsExecutionEnginePluginStart } from '../types';
+import type { ContextDependencies } from '../workflow_context_manager/types';
+import { workflowExecutionLoop } from '../workflow_execution_loop';
+
+export const runWorkflowSync = async ({
+  workflowExecution,
+  request,
+  abortController,
+  logger,
+  config,
+  dependencies,
+  workflowsExecutionEngine,
+  workflowExecutionRepository,
+  stepExecutionRepository,
+}: {
+  workflowExecution: EsWorkflowExecution;
+  request: KibanaRequest;
+  abortController: AbortController;
+  logger: Logger;
+  config: WorkflowsExecutionEngineConfig;
+  dependencies: ContextDependencies;
+  workflowsExecutionEngine: WorkflowsExecutionEnginePluginStart;
+  workflowExecutionRepository: WorkflowExecutionPersistence;
+  stepExecutionRepository: StepExecutionPersistence;
+}): Promise<EsWorkflowExecution> => {
+  apm.currentTransaction?.setLabel('execution_mode', 'sync');
+  const setup = await setupDependencies(
+    workflowExecution.id,
+    workflowExecution.spaceId,
+    logger,
+    config,
+    dependencies,
+    request,
+    workflowsExecutionEngine,
+    { workflowExecution, workflowExecutionRepository, stepExecutionRepository }
+  );
+
+  validateSyncWorkflow(setup.workflowExecutionGraph);
+  await setup.workflowRuntime.start();
+  await workflowExecutionLoop({
+    ...setup,
+    workflowExecutionRepository: setup.workflowExecutionPersistence,
+    fakeRequest: request,
+    coreStart: dependencies.coreStart,
+    taskAbortController: abortController,
+    executionMode: 'sync',
+  });
+
+  return setup.workflowExecutionState.getWorkflowExecution();
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
@@ -65,6 +65,7 @@ describe('setupDependencies', () => {
     },
     collectQueueMetrics: false,
     hitlExternalResume: { enabled: true },
+    syncExecution: { enabled: false, maxDurationMs: 60_000 },
   };
 
   let mockDependencies: ReturnType<typeof mockContextDependencies>;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
@@ -23,6 +23,10 @@ import {
   mergeEmitterWorkflowIntoEventChainVisited,
 } from '../lib/telemetry/utils/extract_execution_metadata';
 import { WorkflowExecutionTelemetryClient } from '../lib/telemetry/workflow_execution_telemetry_client';
+import type {
+  StepExecutionPersistence,
+  WorkflowExecutionPersistence,
+} from '../repositories/execution_persistence';
 import { StepExecutionRepository } from '../repositories/step_execution_repository';
 import { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
 import { NodesFactory } from '../step/nodes_factory';
@@ -44,7 +48,12 @@ export async function setupDependencies(
   config: WorkflowsExecutionEngineConfig,
   dependencies: ContextDependencies,
   fakeRequest?: KibanaRequest,
-  workflowsExecutionEngine?: WorkflowsExecutionEnginePluginStart
+  workflowsExecutionEngine?: WorkflowsExecutionEnginePluginStart,
+  options: {
+    workflowExecution?: EsWorkflowExecution;
+    workflowExecutionRepository?: WorkflowExecutionPersistence;
+    stepExecutionRepository?: StepExecutionPersistence;
+  } = {}
 ) {
   const { coreStart, actions, taskManager, workflowsExtensions } = dependencies;
 
@@ -53,17 +62,18 @@ export async function setupDependencies(
   // Get ES client from core services (guaranteed to be available at task execution time)
   const internalEsClient = coreStart.elasticsearch.client.asInternalUser;
 
-  const workflowExecutionRepository = new WorkflowExecutionRepository(internalEsClient, logger);
-  const stepExecutionRepository = new StepExecutionRepository(internalEsClient, logger);
+  const workflowExecutionPersistence =
+    options.workflowExecutionRepository ?? new WorkflowExecutionRepository(internalEsClient, logger);
+  const stepExecutionPersistence =
+    options.stepExecutionRepository ?? new StepExecutionRepository(internalEsClient, logger);
   const workflowRepository = new WorkflowRepository({
     esClient: internalEsClient,
     logger,
   });
 
-  const workflowExecution = await workflowExecutionRepository.getWorkflowExecutionById(
-    workflowRunId,
-    spaceId
-  );
+  const workflowExecution =
+    options.workflowExecution ??
+    (await workflowExecutionPersistence.getWorkflowExecutionById(workflowRunId, spaceId));
 
   if (!workflowExecution) {
     throw new Error(`Workflow execution with ID ${workflowRunId} not found`);
@@ -113,7 +123,7 @@ export async function setupDependencies(
   } catch (error) {
     if (isGraphBuildError(error)) {
       const finishedAt = new Date();
-      await workflowExecutionRepository.updateWorkflowExecution({
+      await workflowExecutionPersistence.updateWorkflowExecution({
         id: workflowRunId,
         status: ExecutionStatus.FAILED,
         error: { type: 'GraphBuildError', message: error.message },
@@ -150,12 +160,12 @@ export async function setupDependencies(
   });
 
   const workflowExecutionState = new WorkflowExecutionState(
-    workflowExecution as EsWorkflowExecution,
-    workflowExecutionRepository
+    workflowExecution,
+    workflowExecutionPersistence
   );
 
   const stepIoService = new StepIoService({
-    stepRepository: stepExecutionRepository,
+    stepRepository: stepExecutionPersistence,
     state: workflowExecutionState,
     evictionMinBytes: config.eviction.minPayloadSize.getValueInBytes(),
     logger,
@@ -172,7 +182,7 @@ export async function setupDependencies(
 
   // Create workflow runtime first (simpler, fewer dependencies)
   const workflowRuntime = new WorkflowExecutionRuntimeManager({
-    workflowExecution: workflowExecution as EsWorkflowExecution,
+    workflowExecution,
     workflowExecutionGraph,
     workflowExecutionCursor,
     workflowLogger,
@@ -187,6 +197,15 @@ export async function setupDependencies(
     coreStart.elasticsearch.client.asScoped(fakeRequest).asCurrentUser;
 
   const workflowTaskManager = new WorkflowTaskManager(taskManager);
+
+  const workflowExecutionRepository =
+    workflowExecutionPersistence instanceof WorkflowExecutionRepository
+      ? workflowExecutionPersistence
+      : undefined;
+  const stepExecutionRepository =
+    stepExecutionPersistence instanceof StepExecutionRepository
+      ? stepExecutionPersistence
+      : undefined;
 
   const enhancedDependencies: ContextDependencies = {
     ...dependencies,
@@ -228,6 +247,7 @@ export async function setupDependencies(
     workflowLogger,
     workflowTaskManager,
     nodesFactory,
+    workflowExecutionPersistence,
     workflowExecutionRepository,
     esClient,
     telemetryClient,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
@@ -28,7 +28,7 @@ describe('validateSyncWorkflow', () => {
     }
   );
 
-  it('accepts ordinary and capability-backed atomic steps', () => {
-    expect(() => validateSyncWorkflow(createGraph('ai.pii'))).not.toThrow();
+  it('accepts steps that are not in the async-only set', () => {
+    expect(() => validateSyncWorkflow(createGraph('data.set'))).not.toThrow();
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { validateSyncWorkflow } from './validate_sync_workflow';
+
+const createGraph = (stepType: string) => ({
+  topologicalOrder: ['node-1'],
+  getNode: jest.fn().mockReturnValue({
+    id: 'node-1',
+    stepId: 'step-1',
+    stepType,
+  }),
+});
+
+describe('validateSyncWorkflow', () => {
+  it.each(['wait', 'waitForInput', 'waitForApproval', 'workflow.execute', 'workflow.executeAsync'])(
+    'rejects async-only step %s',
+    (stepType) => {
+      expect(() => validateSyncWorkflow(createGraph(stepType))).toThrow(
+        'is not supported in synchronous workflows'
+      );
+    }
+  );
+
+  it('accepts ordinary and capability-backed atomic steps', () => {
+    expect(() => validateSyncWorkflow(createGraph('ai.pii'))).not.toThrow();
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.ts
@@ -11,6 +11,11 @@ import type { WorkflowGraph } from '@kbn/workflows/graph';
 
 type SyncWorkflowGraph = Pick<WorkflowGraph, 'getNode' | 'topologicalOrder'>;
 
+// Known step types that require durable execution (timers, HITL pauses, child workflows).
+// This is a pre-execution check. A runtime check in handle_execution_delay.ts provides a
+// second layer by catching any waiting status that makes it through — e.g. from extension
+// step types added after this list. Both layers use the same error message format so
+// diagnostics are consistent.
 const ASYNC_ONLY_STEP_TYPES = new Set([
   'wait',
   'waitForInput',
@@ -19,13 +24,13 @@ const ASYNC_ONLY_STEP_TYPES = new Set([
   'workflow.executeAsync',
 ]);
 
+export const SYNC_WORKFLOW_UNSUPPORTED_MSG = 'is not supported in synchronous workflows';
+
 export const validateSyncWorkflow = (workflowGraph: SyncWorkflowGraph): void => {
   for (const nodeId of workflowGraph.topologicalOrder) {
     const node = workflowGraph.getNode(nodeId);
     if (node?.stepType && ASYNC_ONLY_STEP_TYPES.has(node.stepType)) {
-      throw new Error(
-        `Step "${node.stepId}" (${node.stepType}) is not supported in synchronous workflows`
-      );
+      throw new Error(`Step "${node.stepId}" (${node.stepType}) ${SYNC_WORKFLOW_UNSUPPORTED_MSG}`);
     }
   }
 };

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/validate_sync_workflow.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowGraph } from '@kbn/workflows/graph';
+
+type SyncWorkflowGraph = Pick<WorkflowGraph, 'getNode' | 'topologicalOrder'>;
+
+const ASYNC_ONLY_STEP_TYPES = new Set([
+  'wait',
+  'waitForInput',
+  'waitForApproval',
+  'workflow.execute',
+  'workflow.executeAsync',
+]);
+
+export const validateSyncWorkflow = (workflowGraph: SyncWorkflowGraph): void => {
+  for (const nodeId of workflowGraph.topologicalOrder) {
+    const node = workflowGraph.getNode(nodeId);
+    if (node?.stepType && ASYNC_ONLY_STEP_TYPES.has(node.stepType)) {
+      throw new Error(
+        `Step "${node.stepId}" (${node.stepType}) is not supported in synchronous workflows`
+      );
+    }
+  }
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/index.ts
@@ -23,6 +23,7 @@ export type {
   WorkflowsExecutionEnginePluginSetup,
   WorkflowsExecutionEnginePluginStart,
   ExecuteWorkflowOptions,
+  ExecuteWorkflowResponse,
   WorkflowExecutionMode,
 } from './types';
 
@@ -36,6 +37,10 @@ export type {
 export type { IWorkflowEventLoggerService } from './workflow_event_logger';
 
 export { resolveWorkflowEventsModeFromOn } from './trigger_events/lib/resolve_workflow_events_mode_from_on';
+export {
+  classifyWorkflowTriggerMatch,
+  type WorkflowTriggerMatchOutcome,
+} from './trigger_events/filter_workflows_by_trigger_condition';
 
 export type {
   SearchTriggerEventLogHit,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/index.ts
@@ -22,6 +22,8 @@ export type {
   TriggerEventsContract,
   WorkflowsExecutionEnginePluginSetup,
   WorkflowsExecutionEnginePluginStart,
+  ExecuteWorkflowOptions,
+  WorkflowExecutionMode,
 } from './types';
 
 export type {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
@@ -15,7 +15,7 @@ import {
   applyInputDefaults,
   getInputsFromDefinition,
 } from '@kbn/workflows/spec/lib/field_conversion';
-import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { WorkflowExecutionPersistence } from '../repositories/execution_persistence';
 import { WorkflowTemplatingEngine } from '../templating_engine';
 import {
   buildInputDefaultRenderContext,
@@ -36,7 +36,7 @@ const hasInputChanges = (
  */
 export const validateWorkflowInputs = async (
   workflowExecution: WorkflowExecutionForInputRendering,
-  workflowExecutionRepository: WorkflowExecutionRepository,
+  workflowExecutionRepository: WorkflowExecutionPersistence,
   logger: Logger,
   coreStart?: CoreStart,
   dependencies?: ContextDependencies

--- a/src/platform/plugins/shared/workflows_execution_engine/server/mocks.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/mocks.ts
@@ -16,6 +16,7 @@ import { createMockWorkflowEventLoggerService } from './workflow_event_logger/mo
 export const workflowsExecutionEngineMock = {
   createSetup: jest.fn().mockReturnValue({} as jest.Mocked<WorkflowsExecutionEnginePluginSetup>),
   createStart: jest.fn().mockReturnValue({
+    supportsSynchronousExecution: true,
     workflowEventLoggerService: createMockWorkflowEventLoggerService(),
     executeWorkflow: jest.fn(),
     executeWorkflowStep: jest.fn(),

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -772,7 +772,6 @@ export class WorkflowsExecutionEnginePlugin
       options: {
         refresh: boolean | 'wait_for';
         executionId?: string;
-        metadata?: Record<string, string>;
       } = { refresh: false }
     ): Promise<{
       workflowExecution: WorkflowExecutionForInputRendering;
@@ -788,12 +787,9 @@ export class WorkflowsExecutionEnginePlugin
         coreStart.elasticsearch.client
       );
 
-      const executionContext = options.metadata
-        ? { ...context, metadata: options.metadata }
-        : context;
       const workflowExecution = await buildExecutionDocument({
         workflow,
-        context: executionContext,
+        context,
         defaultTriggeredBy,
         authenticatedUser,
         now: new Date(),
@@ -910,7 +906,6 @@ export class WorkflowsExecutionEnginePlugin
         {
           refresh: true,
           executionId: options.executionId,
-          metadata: options.metadata,
         }
       );
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -40,6 +40,7 @@ import {
   checkAndSkipIfExistingScheduledExecution,
   resumeWorkflow,
   runWorkflow,
+  runWorkflowSync,
 } from './execution_functions';
 import { handlePostExecutionLoop } from './execution_functions/handle_post_execution_loop';
 import { buildWorkflowExecutionDocument } from './lib/build_workflow_execution_document';
@@ -55,6 +56,7 @@ import {
 import { WorkflowExecutionTelemetryClient } from './lib/telemetry/workflow_execution_telemetry_client';
 import { validateWorkflowInputs } from './lib/validate_workflow_inputs';
 import { WorkflowsMeteringService } from './metering/metering_service';
+import { InMemoryExecutionPersistence } from './repositories/execution_persistence';
 import { initializeLogsRepositoryDataStream } from './repositories/logs_repository/data_stream';
 import { StepExecutionRepository } from './repositories/step_execution_repository';
 import { WorkflowExecutionRepository } from './repositories/workflow_execution_repository';
@@ -109,6 +111,19 @@ import { createIndexes } from '../common';
  *   it is not meant as extra user workflow retries after successful interrupt recovery.
  */
 const WORKFLOW_RUN_TASK_MAX_ATTEMPTS = 3;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getSynchronousWorkflowOutput = (output: unknown): Record<string, unknown> | undefined => {
+  if (output === undefined || output === null) {
+    return undefined;
+  }
+  if (isRecord(output)) {
+    return output;
+  }
+  throw new Error('Synchronous workflow output must be an object');
+};
 
 /**
  * Max Task Manager attempts for `workflow:resume`.
@@ -693,7 +708,10 @@ export class WorkflowsExecutionEnginePlugin
     return {};
   }
 
-  public start(coreStart: CoreStart, plugins: WorkflowsExecutionEnginePluginStartDeps) {
+  public start(
+    coreStart: CoreStart,
+    plugins: WorkflowsExecutionEnginePluginStartDeps
+  ): WorkflowsExecutionEnginePluginStart {
     this.logger.debug('workflows-execution-engine: Start');
 
     if (!this.setupDependencies) {
@@ -765,7 +783,11 @@ export class WorkflowsExecutionEnginePlugin
       context: Record<string, unknown>,
       defaultTriggeredBy: string,
       request: KibanaRequest,
-      options: { refresh: boolean | 'wait_for' } = { refresh: false }
+      options: {
+        refresh: boolean | 'wait_for';
+        executionId?: string;
+        metadata?: Record<string, string>;
+      } = { refresh: false }
     ): Promise<{
       workflowExecution: WorkflowExecutionForInputRendering;
       repository: WorkflowExecutionRepository;
@@ -780,13 +802,19 @@ export class WorkflowsExecutionEnginePlugin
         coreStart.elasticsearch.client
       );
 
+      const executionContext = options.metadata
+        ? { ...context, metadata: options.metadata }
+        : context;
       const workflowExecution = await buildExecutionDocument({
         workflow,
-        context,
+        context: executionContext,
         defaultTriggeredBy,
         authenticatedUser,
         now: new Date(),
       });
+      if (options.executionId) {
+        workflowExecution.id = options.executionId;
+      }
 
       await maybeDrainConcurrencyQueueBeforeEnqueue({
         workflowExecution,
@@ -830,8 +858,110 @@ export class WorkflowsExecutionEnginePlugin
       };
     };
 
-    const executeWorkflow: ExecuteWorkflow = async (workflow, context, request) => {
+    const executeWorkflow: ExecuteWorkflow = async (workflow, context, request, options = {}) => {
       await checkLicense(plugins.licensing);
+
+      if (
+        options.executionMode !== 'sync' &&
+        (options.capabilities !== undefined || options.abortSignal !== undefined)
+      ) {
+        throw new Error('Request-local capabilities and abort signals require sync execution');
+      }
+
+      if (options.executionMode === 'sync') {
+        if (!request) {
+          throw new Error('Synchronous workflows cannot be executed without the user context');
+        }
+
+        const spaceId = typeof context.spaceId === 'string' ? context.spaceId : 'default';
+        await ensureWorkflowEnabled(workflow, spaceId);
+        const authenticatedUser = await getAuthenticatedUser(
+          request,
+          coreStart.security,
+          coreStart.elasticsearch.client
+        );
+        const syncContext = {
+          ...context,
+          ...(options.metadata ? { metadata: options.metadata } : {}),
+        };
+        const workflowExecution = await buildExecutionDocument({
+          workflow,
+          context: syncContext,
+          defaultTriggeredBy: 'manual',
+          authenticatedUser,
+          now: new Date(),
+        });
+        if (options.executionId) {
+          workflowExecution.id = options.executionId;
+        }
+        if (!workflowExecution.workflowDefinition) {
+          throw new Error('Synchronous workflow execution requires a workflow definition');
+        }
+        const syncWorkflowExecution: EsWorkflowExecution = {
+          ...workflowExecution,
+          isTestRun: workflowExecution.isTestRun ?? false,
+          status: workflowExecution.status ?? ExecutionStatus.PENDING,
+          context: workflowExecution.context ?? syncContext,
+          workflowDefinition: workflowExecution.workflowDefinition,
+          yaml: workflowExecution.yaml ?? workflow.yaml,
+          scopeStack: workflowExecution.scopeStack ?? [],
+          error: workflowExecution.error ?? null,
+          startedAt: workflowExecution.startedAt ?? workflowExecution.createdAt,
+          finishedAt: workflowExecution.finishedAt ?? '',
+          cancelRequested: workflowExecution.cancelRequested ?? false,
+          duration: workflowExecution.duration ?? 0,
+        };
+
+        const syncExecutionPersistence = new InMemoryExecutionPersistence(syncWorkflowExecution);
+        const inputsValid = await validateWorkflowInputs(
+          syncWorkflowExecution,
+          syncExecutionPersistence,
+          this.logger,
+          coreStart,
+          { ...dependencies, capabilities: options.capabilities }
+        );
+        if (!inputsValid) {
+          return {
+            workflowExecutionId: syncWorkflowExecution.id,
+            result: { status: ExecutionStatus.FAILED },
+          };
+        }
+        const abortController = new AbortController();
+        const abort = () => abortController.abort(options.abortSignal?.reason);
+        options.abortSignal?.addEventListener('abort', abort, { once: true });
+        if (options.abortSignal?.aborted) {
+          abort();
+        }
+
+        try {
+          if (!this.coreSetup) {
+            throw new Error('Core setup not available');
+          }
+          const [, , workflowsExecutionEngine] = await this.coreSetup.getStartServices();
+          const result = await runWorkflowSync({
+            workflowExecution: syncWorkflowExecution,
+            request,
+            abortController,
+            logger: this.logger,
+            config: this.config,
+            dependencies: { ...dependencies, capabilities: options.capabilities },
+            workflowsExecutionEngine,
+            workflowExecutionRepository: syncExecutionPersistence,
+            stepExecutionRepository: syncExecutionPersistence,
+          });
+
+          const output = getSynchronousWorkflowOutput(result.context?.output);
+          return {
+            workflowExecutionId: result.id,
+            result: {
+              status: result.status,
+              ...(output ? { output } : {}),
+            },
+          };
+        } finally {
+          options.abortSignal?.removeEventListener('abort', abort);
+        }
+      }
 
       // AUTO-DETECT: Check if we're already running in a Task Manager context
       const isRunningInTaskManager =
@@ -864,7 +994,11 @@ export class WorkflowsExecutionEnginePlugin
         context,
         'manual',
         request,
-        { refresh: true }
+        {
+          refresh: true,
+          executionId: options.executionId,
+          metadata: options.metadata,
+        }
       );
 
       const inputsValid = await validateWorkflowInputs(
@@ -1426,6 +1560,7 @@ export class WorkflowsExecutionEnginePlugin
     };
 
     return {
+      supportsSynchronousExecution: true,
       workflowEventLoggerService,
       executeWorkflow,
       executeWorkflowStep,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -854,14 +854,7 @@ export class WorkflowsExecutionEnginePlugin
         throw new Error('Request-local capabilities and abort signals require sync execution');
       }
 
-      if (options.executionMode === 'sync') {
-        if (!this.config.syncExecution.enabled) {
-          throw new Error(
-            'Synchronous workflow execution is disabled. ' +
-              'Set xpack.workflowsExecutionEngine.syncExecution.enabled: true alongside ' +
-              'xpack.inference.anonymization.workflow_driven: true to enable it.'
-          );
-        }
+      if (options.executionMode === 'sync' && this.config.syncExecution.enabled) {
         if (!request) {
           throw new Error('Synchronous workflows cannot be executed without the user context');
         }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -855,6 +855,13 @@ export class WorkflowsExecutionEnginePlugin
       }
 
       if (options.executionMode === 'sync') {
+        if (!this.config.syncExecution.enabled) {
+          throw new Error(
+            'Synchronous workflow execution is disabled. ' +
+              'Set xpack.workflowsExecutionEngine.syncExecution.enabled: true alongside ' +
+              'xpack.inference.anonymization.workflow_driven: true to enable it.'
+          );
+        }
         if (!request) {
           throw new Error('Synchronous workflows cannot be executed without the user context');
         }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -40,8 +40,8 @@ import {
   checkAndSkipIfExistingScheduledExecution,
   resumeWorkflow,
   runWorkflow,
-  runWorkflowSync,
 } from './execution_functions';
+import { executeWorkflowSync } from './execution_functions/execute_workflow_sync';
 import { handlePostExecutionLoop } from './execution_functions/handle_post_execution_loop';
 import { buildWorkflowExecutionDocument } from './lib/build_workflow_execution_document';
 import { checkLicense } from './lib/check_license';
@@ -56,7 +56,6 @@ import {
 import { WorkflowExecutionTelemetryClient } from './lib/telemetry/workflow_execution_telemetry_client';
 import { validateWorkflowInputs } from './lib/validate_workflow_inputs';
 import { WorkflowsMeteringService } from './metering/metering_service';
-import { InMemoryExecutionPersistence } from './repositories/execution_persistence';
 import { initializeLogsRepositoryDataStream } from './repositories/logs_repository/data_stream';
 import { StepExecutionRepository } from './repositories/step_execution_repository';
 import { WorkflowExecutionRepository } from './repositories/workflow_execution_repository';
@@ -111,19 +110,6 @@ import { createIndexes } from '../common';
  *   it is not meant as extra user workflow retries after successful interrupt recovery.
  */
 const WORKFLOW_RUN_TASK_MAX_ATTEMPTS = 3;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const getSynchronousWorkflowOutput = (output: unknown): Record<string, unknown> | undefined => {
-  if (output === undefined || output === null) {
-    return undefined;
-  }
-  if (isRecord(output)) {
-    return output;
-  }
-  throw new Error('Synchronous workflow output must be an object');
-};
 
 /**
  * Max Task Manager attempts for `workflow:resume`.
@@ -872,95 +858,22 @@ export class WorkflowsExecutionEnginePlugin
         if (!request) {
           throw new Error('Synchronous workflows cannot be executed without the user context');
         }
-
-        const spaceId = typeof context.spaceId === 'string' ? context.spaceId : 'default';
-        await ensureWorkflowEnabled(workflow, spaceId);
-        const authenticatedUser = await getAuthenticatedUser(
-          request,
-          coreStart.security,
-          coreStart.elasticsearch.client
-        );
-        const syncContext = {
-          ...context,
-          ...(options.metadata ? { metadata: options.metadata } : {}),
-        };
-        const workflowExecution = await buildExecutionDocument({
+        if (!this.coreSetup) {
+          throw new Error('Core setup not available');
+        }
+        const coreSetup = this.coreSetup;
+        return executeWorkflowSync({
           workflow,
-          context: syncContext,
-          defaultTriggeredBy: 'manual',
-          authenticatedUser,
-          now: new Date(),
+          context,
+          request,
+          options,
+          logger: this.logger,
+          dependencies,
+          getWorkflowsExecutionEngine: async () => {
+            const [, , workflowsExecutionEngine] = await coreSetup.getStartServices();
+            return workflowsExecutionEngine;
+          },
         });
-        if (options.executionId) {
-          workflowExecution.id = options.executionId;
-        }
-        if (!workflowExecution.workflowDefinition) {
-          throw new Error('Synchronous workflow execution requires a workflow definition');
-        }
-        const syncWorkflowExecution: EsWorkflowExecution = {
-          ...workflowExecution,
-          isTestRun: workflowExecution.isTestRun ?? false,
-          status: workflowExecution.status ?? ExecutionStatus.PENDING,
-          context: workflowExecution.context ?? syncContext,
-          workflowDefinition: workflowExecution.workflowDefinition,
-          yaml: workflowExecution.yaml ?? workflow.yaml,
-          scopeStack: workflowExecution.scopeStack ?? [],
-          error: workflowExecution.error ?? null,
-          startedAt: workflowExecution.startedAt ?? workflowExecution.createdAt,
-          finishedAt: workflowExecution.finishedAt ?? '',
-          cancelRequested: workflowExecution.cancelRequested ?? false,
-          duration: workflowExecution.duration ?? 0,
-        };
-
-        const syncExecutionPersistence = new InMemoryExecutionPersistence(syncWorkflowExecution);
-        const inputsValid = await validateWorkflowInputs(
-          syncWorkflowExecution,
-          syncExecutionPersistence,
-          this.logger,
-          coreStart,
-          { ...dependencies, capabilities: options.capabilities }
-        );
-        if (!inputsValid) {
-          return {
-            workflowExecutionId: syncWorkflowExecution.id,
-            result: { status: ExecutionStatus.FAILED },
-          };
-        }
-        const abortController = new AbortController();
-        const abort = () => abortController.abort(options.abortSignal?.reason);
-        options.abortSignal?.addEventListener('abort', abort, { once: true });
-        if (options.abortSignal?.aborted) {
-          abort();
-        }
-
-        try {
-          if (!this.coreSetup) {
-            throw new Error('Core setup not available');
-          }
-          const [, , workflowsExecutionEngine] = await this.coreSetup.getStartServices();
-          const result = await runWorkflowSync({
-            workflowExecution: syncWorkflowExecution,
-            request,
-            abortController,
-            logger: this.logger,
-            config: this.config,
-            dependencies: { ...dependencies, capabilities: options.capabilities },
-            workflowsExecutionEngine,
-            workflowExecutionRepository: syncExecutionPersistence,
-            stepExecutionRepository: syncExecutionPersistence,
-          });
-
-          const output = getSynchronousWorkflowOutput(result.context?.output);
-          return {
-            workflowExecutionId: result.id,
-            result: {
-              status: result.status,
-              ...(output ? { output } : {}),
-            },
-          };
-        } finally {
-          options.abortSignal?.removeEventListener('abort', abort);
-        }
       }
 
       // AUTO-DETECT: Check if we're already running in a Task Manager context

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { type EsWorkflowExecution, ExecutionStatus } from '@kbn/workflows';
+import { InMemoryExecutionPersistence } from './execution_persistence';
+
+describe('InMemoryExecutionPersistence', () => {
+  const execution = {
+    id: 'execution-1',
+    spaceId: 'space-1',
+    workflowId: 'workflow-1',
+    isTestRun: false,
+    status: ExecutionStatus.PENDING,
+    context: {},
+    workflowDefinition: {
+      version: '1',
+      name: 'Test workflow',
+      enabled: true,
+      triggers: [],
+      steps: [],
+    },
+    yaml: '',
+    scopeStack: [],
+    createdAt: '2026-07-21T00:00:00.000Z',
+    error: null,
+    startedAt: '2026-07-21T00:00:00.000Z',
+    finishedAt: '',
+    cancelRequested: false,
+    duration: 0,
+  } satisfies EsWorkflowExecution;
+
+  it('keeps workflow updates process-local', async () => {
+    const persistence = new InMemoryExecutionPersistence(execution);
+    await persistence.updateWorkflowExecution({
+      id: execution.id,
+      status: ExecutionStatus.RUNNING,
+    });
+
+    await expect(
+      persistence.getWorkflowExecutionById(execution.id, execution.spaceId)
+    ).resolves.toEqual(expect.objectContaining({ status: ExecutionStatus.RUNNING }));
+    await expect(
+      persistence.getWorkflowExecutionById(execution.id, 'another-space')
+    ).resolves.toBeNull();
+  });
+
+  it('merges step lifecycle and IO updates without an external repository', async () => {
+    const persistence = new InMemoryExecutionPersistence(execution);
+    await persistence.bulkUpsert([
+      {
+        id: 'step-1',
+        spaceId: 'space-1',
+        stepId: 'step-1',
+        scopeStack: [],
+        workflowRunId: execution.id,
+        workflowId: execution.workflowId,
+        status: ExecutionStatus.RUNNING,
+        startedAt: '2026-07-21T00:00:00.000Z',
+        topologicalIndex: 0,
+        globalExecutionIndex: 0,
+        stepExecutionIndex: 0,
+      },
+      { id: 'step-1', output: { content: 'result' } },
+    ]);
+
+    await expect(persistence.getStepExecutionsByIds(['step-1'])).resolves.toEqual([
+      expect.objectContaining({
+        id: 'step-1',
+        status: ExecutionStatus.RUNNING,
+        output: { content: 'result' },
+      }),
+    ]);
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EsWorkflowExecution, EsWorkflowStepExecution } from '@kbn/workflows';
+import type { StepExecutionField } from './step_execution_repository';
+
+export interface WorkflowExecutionPersistence {
+  getWorkflowExecutionById(
+    workflowExecutionId: string,
+    spaceId: string
+  ): Promise<EsWorkflowExecution | null>;
+  updateWorkflowExecution(
+    workflowExecution: Partial<EsWorkflowExecution>,
+    options?: { refresh?: boolean | 'wait_for' }
+  ): Promise<void>;
+}
+
+export interface StepExecutionPersistence {
+  getStepExecutionsByIds(
+    stepExecutionIds: string[],
+    sourceIncludes?: StepExecutionField[],
+    sourceExcludes?: StepExecutionField[]
+  ): Promise<EsWorkflowStepExecution[]>;
+  bulkUpsert(stepExecutions: Array<Partial<EsWorkflowStepExecution>>): Promise<void>;
+}
+
+export class InMemoryExecutionPersistence
+  implements WorkflowExecutionPersistence, StepExecutionPersistence
+{
+  private readonly stepExecutions = new Map<string, Partial<EsWorkflowStepExecution>>();
+
+  constructor(private execution: EsWorkflowExecution) {}
+
+  public async getWorkflowExecutionById(
+    workflowExecutionId: string,
+    spaceId: string
+  ): Promise<EsWorkflowExecution | null> {
+    if (this.execution.id !== workflowExecutionId || this.execution.spaceId !== spaceId) {
+      return null;
+    }
+    return this.execution;
+  }
+
+  public async updateWorkflowExecution(
+    workflowExecution: Partial<EsWorkflowExecution>
+  ): Promise<void> {
+    this.execution = { ...this.execution, ...workflowExecution };
+  }
+  public async getStepExecutionsByIds(ids: string[]): Promise<EsWorkflowStepExecution[]> {
+    return ids.flatMap((id) => {
+      const execution = this.stepExecutions.get(id);
+      if (!execution) {
+        return [];
+      }
+      if (!isCompleteStepExecution(execution)) {
+        throw new Error(
+          `Step execution ${id} was read before its required fields were initialized`
+        );
+      }
+      return [execution];
+    });
+  }
+
+  public async bulkUpsert(executions: Array<Partial<EsWorkflowStepExecution>>): Promise<void> {
+    for (const update of executions) {
+      if (!update.id) {
+        throw new Error('Step execution ID is required for in-memory upsert');
+      }
+      this.stepExecutions.set(update.id, {
+        ...this.stepExecutions.get(update.id),
+        ...update,
+      });
+    }
+  }
+}
+
+const isCompleteStepExecution = (
+  execution: Partial<EsWorkflowStepExecution>
+): execution is EsWorkflowStepExecution =>
+  typeof execution.spaceId === 'string' &&
+  typeof execution.id === 'string' &&
+  typeof execution.stepId === 'string' &&
+  Array.isArray(execution.scopeStack) &&
+  typeof execution.workflowRunId === 'string' &&
+  typeof execution.workflowId === 'string' &&
+  execution.status !== undefined &&
+  typeof execution.startedAt === 'string' &&
+  typeof execution.topologicalIndex === 'number' &&
+  typeof execution.globalExecutionIndex === 'number' &&
+  typeof execution.stepExecutionIndex === 'number';

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/execution_persistence.ts
@@ -48,7 +48,8 @@ export class InMemoryExecutionPersistence
   }
 
   public async updateWorkflowExecution(
-    workflowExecution: Partial<EsWorkflowExecution>
+    workflowExecution: Partial<EsWorkflowExecution>,
+    _options?: { refresh?: boolean | 'wait_for' }
   ): Promise<void> {
     this.execution = { ...this.execution, ...workflowExecution };
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/create_base_handler_context.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/create_base_handler_context.ts
@@ -12,13 +12,31 @@ import type { StepHandlerContext } from '@kbn/workflows-extensions/server';
 import type { StepExecutionRuntime } from '../../../workflow_context_manager/step_execution_runtime';
 import type { IWorkflowEventLogger } from '../../../workflow_event_logger';
 
+export type BaseHandlerNode = Pick<AtomicGraphNode, 'stepId' | 'stepType'>;
+export interface BaseHandlerStepExecutionRuntime {
+  abortController: StepExecutionRuntime['abortController'];
+  contextManager: Pick<
+    StepExecutionRuntime['contextManager'],
+    | 'callKibanaApi'
+    | 'getContext'
+    | 'getEsClientAsUser'
+    | 'getExecutionCapabilities'
+    | 'getFakeRequest'
+    | 'renderValueAccordingToContext'
+  >;
+}
+export type BaseHandlerWorkflowLogger = Pick<
+  IWorkflowEventLogger,
+  'logDebug' | 'logError' | 'logInfo' | 'logWarn'
+>;
+
 export function createBaseHandlerContext(
   input: unknown,
   rawInput: unknown,
   config: Record<string, unknown>,
-  node: AtomicGraphNode,
-  stepExecutionRuntime: StepExecutionRuntime,
-  workflowLogger: IWorkflowEventLogger
+  node: BaseHandlerNode,
+  stepExecutionRuntime: BaseHandlerStepExecutionRuntime,
+  workflowLogger: BaseHandlerWorkflowLogger
 ): StepHandlerContext {
   return {
     input,
@@ -56,5 +74,6 @@ export function createBaseHandlerContext(
     abortSignal: stepExecutionRuntime.abortController.signal,
     stepId: node.stepId,
     stepType: node.stepType,
+    capabilities: stepExecutionRuntime.contextManager.getExecutionCapabilities(),
   };
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/tests/create_base_handler_context.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/tests/create_base_handler_context.test.ts
@@ -21,9 +21,9 @@ describe('createBaseHandlerContext', () => {
       input,
       rawInput,
       config,
-      defaultTestNode as any,
-      mocks.stepExecutionRuntime as any,
-      mocks.workflowLogger as any
+      defaultTestNode,
+      mocks.stepExecutionRuntime,
+      mocks.workflowLogger
     );
 
     expect(context.input).toBe(input);
@@ -40,9 +40,7 @@ describe('createBaseHandlerContext', () => {
     expect(mocks.stepExecutionRuntime.contextManager.getEsClientAsUser).toHaveBeenCalled();
 
     context.contextManager.renderInputTemplate({ x: 1 });
-    expect(
-      mocks.stepExecutionRuntime.contextManager.renderValueAccordingToContext
-    ).toHaveBeenCalledWith({ x: 1 }, undefined);
+    expect(mocks.renderValueAccordingToContext).toHaveBeenCalledWith({ x: 1 }, undefined);
 
     context.logger.info('hello', { meta: true });
     expect(mocks.workflowLogger.logInfo).toHaveBeenCalledWith('hello', { meta: true });
@@ -55,13 +53,36 @@ describe('createBaseHandlerContext', () => {
       {},
       undefined as unknown as Record<string, unknown>,
       undefined as unknown as Record<string, unknown>,
-      defaultTestNode as any,
-      mocks.stepExecutionRuntime as any,
-      mocks.workflowLogger as any
+      defaultTestNode,
+      mocks.stepExecutionRuntime,
+      mocks.workflowLogger
     );
 
     expect(context.rawInput).toEqual({});
     expect(context.config).toEqual({});
+  });
+
+  it('exposes request-local capabilities directly to the handler', () => {
+    const mocks = createHandlerTestMocks();
+    const capabilities = {
+      id: 'proceed',
+      value: { invoke: jest.fn() },
+    };
+    (
+      mocks.stepExecutionRuntime.contextManager.getExecutionCapabilities as jest.Mock
+    ).mockReturnValue([capabilities]);
+
+    const context = createBaseHandlerContext(
+      {},
+      {},
+      {},
+      defaultTestNode,
+      mocks.stepExecutionRuntime,
+      mocks.workflowLogger
+    );
+
+    expect(context.capabilities).toEqual([capabilities]);
+    expect(context.contextManager.getContext()).not.toHaveProperty('capabilities');
   });
 
   it('forwards callKibanaApi to the execution runtime with abort signal', async () => {
@@ -76,9 +97,9 @@ describe('createBaseHandlerContext', () => {
       {},
       {},
       {},
-      defaultTestNode as any,
-      mocks.stepExecutionRuntime as any,
-      mocks.workflowLogger as any
+      defaultTestNode,
+      mocks.stepExecutionRuntime,
+      mocks.workflowLogger
     );
 
     const result = await context.contextManager.callKibanaApi({

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/tests/test_helpers.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl/step_definition_handlers/tests/test_helpers.ts
@@ -7,6 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { elasticsearchServiceMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { StepContext } from '@kbn/workflows';
+import type {
+  BaseHandlerNode,
+  BaseHandlerStepExecutionRuntime,
+  BaseHandlerWorkflowLogger,
+} from '../create_base_handler_context';
 import { DURABLE_STEP_STATE_KEY, type DurableStepState } from '../durable_step_state';
 
 export { DURABLE_STEP_STATE_KEY, type DurableStepState };
@@ -14,35 +21,57 @@ export { DURABLE_STEP_STATE_KEY, type DurableStepState };
 export const getDurableState = (persisted: Record<string, unknown> | undefined): DurableStepState =>
   (persisted?.[DURABLE_STEP_STATE_KEY] ?? {}) as DurableStepState;
 
-export interface TestNode {
-  stepId: string;
-  stepType: string;
+export interface TestNode extends BaseHandlerNode {
   configuration: {
     with?: Record<string, unknown>;
     'max-step-size'?: undefined;
   };
 }
 
-export const defaultTestNode: TestNode = {
+export const defaultTestNode = {
   stepId: 'custom-step',
   stepType: 'my-custom-type',
   configuration: { with: { key: 'value' }, 'max-step-size': undefined },
-};
+} satisfies TestNode;
 
 export const createHandlerTestMocks = (initialPersistedState?: Record<string, unknown>) => {
   const persistedState: { value: Record<string, unknown> | undefined } = {
     value: initialPersistedState,
   };
 
-  const stepExecutionRuntime = {
+  const renderValueAccordingToContext = jest.fn();
+  const stepContext: StepContext = {
+    execution: {
+      id: 'workflow-execution-1',
+      isTestRun: false,
+      startedAt: new Date(0),
+      url: '',
+    },
+    workflow: {
+      id: 'workflow-1',
+      name: 'Test workflow',
+      enabled: true,
+      spaceId: 'default',
+    },
+    kibanaUrl: '',
+    steps: {},
+  };
+  const baseHandlerStepExecutionRuntime = {
     contextManager: {
-      renderValueAccordingToContext: jest.fn((v: unknown) => v),
-      getContext: jest.fn(() => ({})),
-      getEsClientAsUser: jest.fn(() => ({})),
-      getFakeRequest: jest.fn(() => null),
+      renderValueAccordingToContext: <T>(value: T, additionalContext?: Record<string, unknown>) => {
+        renderValueAccordingToContext(value, additionalContext);
+        return value;
+      },
+      getContext: jest.fn(() => stepContext),
+      getEsClientAsUser: jest.fn(() => elasticsearchServiceMock.createElasticsearchClient()),
+      getFakeRequest: jest.fn(() => httpServerMock.createKibanaRequest()),
+      getExecutionCapabilities: jest.fn(() => undefined),
       callKibanaApi: jest.fn(),
     },
     abortController: new AbortController(),
+  } satisfies BaseHandlerStepExecutionRuntime;
+  const stepExecutionRuntime = {
+    ...baseHandlerStepExecutionRuntime,
     node: { configuration: { with: { key: 'value' } } },
     startStep: jest.fn(),
     flushEventLogs: jest.fn().mockResolvedValue(undefined),
@@ -63,11 +92,12 @@ export const createHandlerTestMocks = (initialPersistedState?: Record<string, un
     logError: jest.fn(),
     logDebug: jest.fn(),
     logWarn: jest.fn(),
-  };
+  } satisfies BaseHandlerWorkflowLogger;
 
   return {
     stepExecutionRuntime,
     workflowLogger,
     persistedState,
+    renderValueAccordingToContext,
   };
 };

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -48,7 +48,6 @@ export type WorkflowExecutionMode = 'async' | 'sync';
 export interface ExecuteWorkflowOptions {
   executionMode?: WorkflowExecutionMode;
   executionId?: string;
-  metadata?: Record<string, string>;
   capabilities?: WorkflowExecutionCapabilities;
   abortSignal?: AbortSignal;
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -39,6 +39,7 @@ export interface ExecuteWorkflowResponse {
   result?: {
     status: ExecutionStatus;
     output?: Record<string, unknown>;
+    error?: { type: string; message: string; details?: Record<string, unknown> };
   };
 }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -77,6 +77,10 @@ export interface TriggerEventsContract {
 }
 
 export interface WorkflowsExecutionEnginePluginStart {
+  /**
+   * Type-level discriminant: callers (e.g. inference plugin) narrow on this
+   * before calling executeWorkflow with executionMode: 'sync'.
+   */
   readonly supportsSynchronousExecution: true;
   executeWorkflow: ExecuteWorkflow;
   executeWorkflowStep: ExecuteWorkflowStep;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -17,8 +17,13 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { UsageApiSetup } from '@kbn/usage-api-plugin/server';
-import type { BulkScheduleWorkflowResult, WorkflowExecutionEngineModel } from '@kbn/workflows';
 import type {
+  BulkScheduleWorkflowResult,
+  ExecutionStatus,
+  WorkflowExecutionEngineModel,
+} from '@kbn/workflows';
+import type {
+  WorkflowExecutionCapabilities,
   WorkflowsExtensionsServerPluginSetup,
   WorkflowsExtensionsServerPluginStart,
 } from '@kbn/workflows-extensions/server';
@@ -31,6 +36,20 @@ import type { IWorkflowEventLoggerService } from './workflow_event_logger';
 
 export interface ExecuteWorkflowResponse {
   workflowExecutionId: string;
+  result?: {
+    status: ExecutionStatus;
+    output?: Record<string, unknown>;
+  };
+}
+
+export type WorkflowExecutionMode = 'async' | 'sync';
+
+export interface ExecuteWorkflowOptions {
+  executionMode?: WorkflowExecutionMode;
+  executionId?: string;
+  metadata?: Record<string, string>;
+  capabilities?: WorkflowExecutionCapabilities;
+  abortSignal?: AbortSignal;
 }
 
 export interface ExecuteWorkflowStepResponse {
@@ -58,6 +77,7 @@ export interface TriggerEventsContract {
 }
 
 export interface WorkflowsExecutionEnginePluginStart {
+  readonly supportsSynchronousExecution: true;
   executeWorkflow: ExecuteWorkflow;
   executeWorkflowStep: ExecuteWorkflowStep;
   cancelWorkflowExecution: CancelWorkflowExecution;
@@ -88,7 +108,8 @@ export interface WorkflowsExecutionEnginePluginStartDeps {
 export type ExecuteWorkflow = (
   workflow: WorkflowExecutionEngineModel,
   context: Record<string, unknown>,
-  request: KibanaRequest
+  request: KibanaRequest,
+  options?: ExecuteWorkflowOptions
 ) => Promise<ExecuteWorkflowResponse>;
 
 export type ExecuteWorkflowStep = (

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_io_service.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_io_service.ts
@@ -21,7 +21,7 @@ import { EVICTION_EXEMPT_STEP_TYPES, LOOP_STEP_TYPES } from './step_io_pinned_ty
 import type { StepExecutionMetadata, StepIoStateAccessor } from './workflow_execution_state';
 import { WorkflowScopeStack } from './workflow_scope_stack';
 import type { OutputSizeStats } from '../lib/telemetry/events/workflows_execution/types';
-import type { StepExecutionRepository } from '../repositories/step_execution_repository';
+import type { StepExecutionPersistence } from '../repositories/execution_persistence';
 import { formatBytes, safeOutputSize } from '../step/errors';
 import { buildStepExecutionId } from '../utils';
 
@@ -32,7 +32,7 @@ import { buildStepExecutionId } from '../utils';
 export type PredecessorsResolver = (node: GraphNodeUnion) => ReadonlyArray<GraphNodeUnion>;
 
 export interface StepIoServiceInit {
-  stepRepository: StepExecutionRepository;
+  stepRepository: StepExecutionPersistence;
   state: StepIoStateAccessor;
   pinnedStepTypes?: ReadonlySet<string>;
   /**
@@ -141,7 +141,7 @@ export interface StepIoLifecycle {
  * stepExecutionRepository.
  */
 export class StepIoService implements StepIoWriter, StepIoLifecycle {
-  private readonly stepRepository: StepExecutionRepository;
+  private readonly stepRepository: StepExecutionPersistence;
   private readonly state: StepIoStateAccessor;
   private readonly pinnedStepTypes: ReadonlySet<string>;
   private readonly evictionMinBytes: number;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/types.ts
@@ -12,7 +12,10 @@ import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { CoreStart, KibanaRequest } from '@kbn/core/server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { WorkflowRepository } from '@kbn/workflows';
-import type { WorkflowsExtensionsServerPluginStart } from '@kbn/workflows-extensions/server';
+import type {
+  WorkflowExecutionCapabilities,
+  WorkflowsExtensionsServerPluginStart,
+} from '@kbn/workflows-extensions/server';
 import type { WorkflowsExecutionEngineConfig } from '../config';
 import type { WorkflowLogEvent } from '../repositories/logs_repository';
 import type { StepExecutionRepository } from '../repositories/step_execution_repository';
@@ -32,6 +35,8 @@ export interface ContextDependencies {
   workflowsExecutionEngine?: WorkflowsExecutionEnginePluginStart;
   spaceId?: string;
   request?: KibanaRequest;
+  /** Request-local privileged behavior; never serialize this value. */
+  capabilities?: WorkflowExecutionCapabilities;
 }
 
 /**

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -19,6 +19,7 @@ import {
   type WorkflowContext,
 } from '@kbn/workflows';
 import type { GraphNodeUnion, WorkflowGraph } from '@kbn/workflows/graph';
+import type { WorkflowExecutionCapabilities } from '@kbn/workflows-extensions/server';
 import { buildWorkflowContext } from './build_workflow_context';
 import type { StepIoService } from './step_io_service';
 import type { ContextDependencies } from './types';
@@ -120,6 +121,10 @@ export class WorkflowContextManager {
     this.stackFrames = init.stackFrames;
     this.templateEngine = init.templateEngine;
     this.dependencies = init.dependencies;
+  }
+
+  public getExecutionCapabilities(): WorkflowExecutionCapabilities | undefined {
+    return this.dependencies.capabilities;
   }
 
   /**

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
@@ -14,7 +14,7 @@ import type {
   WorkflowTokenUsage,
 } from '@kbn/workflows';
 import { isTerminalStatus } from '@kbn/workflows';
-import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { WorkflowExecutionPersistence } from '../repositories/execution_persistence';
 import { sumTokenUsage } from '../utils';
 
 /** Context for the step that failed during this run; used to build workflow_execution_failed event. */
@@ -100,7 +100,7 @@ export class WorkflowExecutionState {
 
   constructor(
     initialWorkflowExecution: EsWorkflowExecution,
-    private workflowExecutionRepository: WorkflowExecutionRepository
+    private workflowExecutionRepository: WorkflowExecutionPersistence
   ) {
     this.workflowExecution = initialWorkflowExecution;
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/cancel_workflow_if_requested.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/cancel_workflow_if_requested.ts
@@ -8,7 +8,7 @@
  */
 
 import { ExecutionStatus } from '@kbn/workflows';
-import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { WorkflowExecutionPersistence } from '../repositories/execution_persistence';
 import { buildStepExecutionId } from '../utils';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
 import type { WorkflowExecutionCursorApi } from '../workflow_context_manager/workflow_execution_cursor';
@@ -26,7 +26,7 @@ import type { IWorkflowEventLogger } from '../workflow_event_logger';
  * issues from causing step execution failures.
  */
 export async function cancelWorkflowIfRequested(
-  workflowExecutionRepository: WorkflowExecutionRepository,
+  workflowExecutionRepository: WorkflowExecutionPersistence,
   workflowExecutionState: WorkflowExecutionState,
   monitoredStepExecutionRuntime: StepExecutionRuntime,
   workflowLogger: IWorkflowEventLogger,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
@@ -71,6 +71,27 @@ const makeStepRuntime = (
   } as unknown as jest.Mocked<StepExecutionRuntime>);
 
 describe('handleExecutionDelay', () => {
+  it.each([
+    ExecutionStatus.WAITING,
+    ExecutionStatus.WAITING_FOR_INPUT,
+    ExecutionStatus.WAITING_FOR_CHILD,
+  ])('rejects asynchronous resume status %s in sync mode', async (status) => {
+    const params = makeParams();
+    params.executionMode = 'sync';
+    const stepRuntime = makeStepRuntime({
+      node: { stepId: 'blocking-step', stepType: 'wait' } as any,
+      stepExecution: { status } as any,
+    });
+
+    await expect(handleExecutionDelay(params, stepRuntime)).rejects.toThrow(
+      'is not supported in synchronous workflows'
+    );
+    expect(params.workflowTaskManager.scheduleResumeTask).not.toHaveBeenCalled();
+    expect(
+      params.workflowTaskManager.scheduleWorkflowGlobalTimeoutResumeTask
+    ).not.toHaveBeenCalled();
+  });
+
   describe('WAITING_FOR_INPUT step (HITL)', () => {
     it('should set workflow status to WAITING_FOR_INPUT', async () => {
       const params = makeParams();

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
@@ -87,7 +87,7 @@ async function scheduleWorkflowGlobalTimeoutResumeTask(
 
   await params.workflowTaskManager
     .scheduleWorkflowGlobalTimeoutResumeTask({
-      workflowExecution: workflowExecution as EsWorkflowExecution,
+      workflowExecution,
       resumeAt: new Date(resumeAtMs),
       fakeRequest: params.fakeRequest,
     })
@@ -153,7 +153,7 @@ export async function ensureWorkflowIdleTimeoutResumeAfterLoop(
 
   await params.workflowTaskManager
     .scheduleWorkflowGlobalTimeoutResumeTask({
-      workflowExecution: workflowExecution as EsWorkflowExecution,
+      workflowExecution,
       resumeAt,
       fakeRequest: params.fakeRequest,
     })
@@ -173,6 +173,16 @@ export async function handleExecutionDelay(
   const workflowExecution = params.workflowRuntime.getWorkflowExecution();
 
   const stepStatus = stepExecutionRuntime.stepExecution?.status;
+  if (
+    params.executionMode === 'sync' &&
+    (stepStatus === ExecutionStatus.WAITING_FOR_INPUT ||
+      stepStatus === ExecutionStatus.WAITING_FOR_CHILD ||
+      stepStatus === ExecutionStatus.WAITING)
+  ) {
+    throw new Error(
+      `Step "${stepExecutionRuntime.node.stepId}" is not supported in synchronous workflows`
+    );
+  }
   if (
     stepStatus === ExecutionStatus.WAITING_FOR_INPUT ||
     stepStatus === ExecutionStatus.WAITING_FOR_CHILD

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
@@ -13,6 +13,7 @@ import type { GraphNodeUnion } from '@kbn/workflows/graph';
 import { isEnterStepTimeoutZone } from '@kbn/workflows/graph';
 import { flushState } from './persistence_loop';
 import type { WorkflowExecutionLoopParams } from './types';
+import { SYNC_WORKFLOW_UNSUPPORTED_MSG } from '../execution_functions/validate_sync_workflow';
 import {
   getHitlIdleDeadlineMsForNode,
   getHitlIdleDeadlineMsForStep,
@@ -179,9 +180,7 @@ export async function handleExecutionDelay(
       stepStatus === ExecutionStatus.WAITING_FOR_CHILD ||
       stepStatus === ExecutionStatus.WAITING)
   ) {
-    throw new Error(
-      `Step "${stepExecutionRuntime.node.stepId}" is not supported in synchronous workflows`
-    );
+    throw new Error(`Step "${stepExecutionRuntime.node.stepId}" ${SYNC_WORKFLOW_UNSUPPORTED_MSG}`);
   }
   if (
     stepStatus === ExecutionStatus.WAITING_FOR_INPUT ||

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_stack_monitor/process_node_stack_monitoring.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_stack_monitor/process_node_stack_monitoring.ts
@@ -50,12 +50,14 @@ export async function processNodeStackMonitoring(
     }
   }
 
-  await cancelWorkflowIfRequested(
-    params.workflowExecutionRepository,
-    params.workflowExecutionState,
-    monitoredStepExecutionRuntime,
-    params.workflowLogger,
-    params.workflowExecutionCursor,
-    monitoredStepExecutionRuntime.abortController
-  );
+  if (params.executionMode !== 'sync') {
+    await cancelWorkflowIfRequested(
+      params.workflowExecutionRepository,
+      params.workflowExecutionState,
+      monitoredStepExecutionRuntime,
+      params.workflowLogger,
+      params.workflowExecutionCursor,
+      monitoredStepExecutionRuntime.abortController
+    );
+  }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/types.ts
@@ -9,8 +9,9 @@
 
 import type { CoreStart, ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
 import type { WorkflowGraph } from '@kbn/workflows/graph';
-import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { WorkflowExecutionPersistence } from '../repositories/execution_persistence';
 import type { NodesFactory } from '../step/nodes_factory';
+import type { WorkflowExecutionMode } from '../types';
 import type { StepExecutionRuntimeFactory } from '../workflow_context_manager/step_execution_runtime_factory';
 import type { StepIoService } from '../workflow_context_manager/step_io_service';
 import type { WorkflowExecutionCursorApi } from '../workflow_context_manager/workflow_execution_cursor';
@@ -27,11 +28,12 @@ export interface WorkflowExecutionLoopParams {
   workflowExecutionState: WorkflowExecutionState;
   stepIoService: StepIoService;
   workflowLogger: IWorkflowEventLogger;
-  workflowExecutionRepository: WorkflowExecutionRepository;
+  workflowExecutionRepository: WorkflowExecutionPersistence;
   nodesFactory: NodesFactory;
   esClient: ElasticsearchClient;
   fakeRequest: KibanaRequest<unknown, unknown, unknown>;
   coreStart: CoreStart;
   signal: AbortSignal;
   workflowTaskManager: WorkflowTaskManager;
+  executionMode?: WorkflowExecutionMode;
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.test.ts
@@ -58,10 +58,13 @@ describe('workflowExecutionLoop', () => {
     const params = createParams();
     await workflowExecutionLoop(params as any);
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { executionFlowLoop } = require('./execution_flow_loop');
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { persistenceLoop, flushState } = require('./persistence_loop');
+    const { executionFlowLoop } = jest.requireMock('./execution_flow_loop') as {
+      executionFlowLoop: jest.Mock;
+    };
+    const { persistenceLoop, flushState } = jest.requireMock('./persistence_loop') as {
+      persistenceLoop: jest.Mock;
+      flushState: jest.Mock;
+    };
 
     expect(executionFlowLoop).toHaveBeenCalledWith(params);
     expect(persistenceLoop).toHaveBeenCalled();
@@ -74,12 +77,32 @@ describe('workflowExecutionLoop', () => {
     expect(params.workflowLogger.flushEvents).toHaveBeenCalled();
   });
 
+  it('uses the shared execution loop without periodic persistence in sync mode', async () => {
+    const params = { ...createParams(), executionMode: 'sync' as const };
+    await workflowExecutionLoop(params as any);
+
+    const { executionFlowLoop } = jest.requireMock('./execution_flow_loop') as {
+      executionFlowLoop: jest.Mock;
+    };
+    const { persistenceLoop, flushState } = jest.requireMock('./persistence_loop') as {
+      persistenceLoop: jest.Mock;
+      flushState: jest.Mock;
+    };
+
+    expect(executionFlowLoop).toHaveBeenCalledWith(params);
+    expect(persistenceLoop).not.toHaveBeenCalled();
+    expect(flushState).not.toHaveBeenCalled();
+    expect(params.workflowRuntime.saveState).toHaveBeenCalled();
+    expect(params.stepIoService.flush).toHaveBeenCalled();
+  });
+
   it('sets workflow error when execution loop throws', async () => {
     const params = createParams();
     const testError = new Error('execution failed');
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { executionFlowLoop } = require('./execution_flow_loop');
+    const { executionFlowLoop } = jest.requireMock('./execution_flow_loop') as {
+      executionFlowLoop: jest.Mock;
+    };
     (executionFlowLoop as jest.Mock).mockRejectedValueOnce(testError);
 
     await workflowExecutionLoop(params as any);
@@ -108,8 +131,7 @@ describe('workflowExecutionLoop', () => {
   it('marks Task Manager abort as system cancellation and suppresses workflow log errors', async () => {
     const params = createParams();
     const abortController = new AbortController();
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { flushState } = require('./persistence_loop');
+    const { flushState } = jest.requireMock('./persistence_loop') as { flushState: jest.Mock };
     const loopPromise = workflowExecutionLoop({ ...params, signal: abortController.signal } as any);
     abortController.abort(new WorkflowTaskManagerAbortError());
     await loopPromise;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/workflow_execution_loop.ts
@@ -76,20 +76,26 @@ export async function workflowExecutionLoop(params: WorkflowExecutionLoopParams)
     workflowExecutionCursor.start();
     // Run execution and persistence loops in parallel
     // When execution finishes, signal persistence loop to exit immediately
-    await Promise.all([
-      executionFlowLoop(params).finally(() => {
-        // Signal persistence loop to stop waiting and exit
-        persistenceAbortController.abort();
-      }),
-      persistenceLoop(params, persistenceAbortController.signal),
-    ]);
+    if (params.executionMode === 'sync') {
+      await executionFlowLoop(params);
+    } else {
+      await Promise.all([
+        executionFlowLoop(params).finally(() => {
+          // Signal persistence loop to stop waiting and exit
+          persistenceAbortController.abort();
+        }),
+        persistenceLoop(params, persistenceAbortController.signal),
+      ]);
+    }
   } catch (error) {
     workflowExecutionCursor.captureError(error);
   } finally {
     const finalFlushSpan = apm.startSpan('final flush state', 'workflow', 'persistence');
-    await flushState(params, {
-      workflowLogFlushSignal: params.signal,
-    });
+    if (params.executionMode !== 'sync') {
+      await flushState(params, {
+        workflowLogFlushSignal: params.signal,
+      });
+    }
     finalFlushSpan?.end();
   }
 

--- a/src/platform/plugins/shared/workflows_extensions/server/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/index.ts
@@ -50,6 +50,8 @@ export type {
   StepHandler,
   StepHandlerContext,
   StepHandlerResult,
+  WorkflowExecutionCapability,
+  WorkflowExecutionCapabilities,
   OnCancelHandler,
   StartWithHandoffHandler,
   PollHandler,

--- a/src/platform/plugins/shared/workflows_extensions/server/step_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/step_registry/types.ts
@@ -13,6 +13,14 @@ import type { StepContext } from '@kbn/workflows';
 import type { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../common';
 
+/** A named request-local capability transported opaquely by the workflow engine. */
+export interface WorkflowExecutionCapability {
+  readonly id: string;
+  readonly value: object;
+}
+
+export type WorkflowExecutionCapabilities = readonly WorkflowExecutionCapability[];
+
 // -----------------------------------------------------------------------------
 // Poll step types
 // -----------------------------------------------------------------------------
@@ -383,6 +391,13 @@ export interface StepHandlerContext<TInput = z.ZodType, TConfig = z.ZodObject> {
    * Current step's type
    */
   stepType: string;
+
+  /**
+   * Trusted, request-local capabilities supplied by the execution caller.
+   * They are passed directly to handlers and are never added to workflow
+   * context, template variables, step input/output, or persisted state.
+   */
+  capabilities?: WorkflowExecutionCapabilities;
 }
 
 /**

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
@@ -176,6 +176,67 @@ describe('WorkflowsManagementApi', () => {
         }
       );
     });
+
+    it('skips the ES re-fetch when a pre-fetched workflow DTO is provided', async () => {
+      const workflow = createTriggeredWorkflow({ id: 'workflow-1' });
+      mockWorkflowsExecutionEngine.executeWorkflow.mockResolvedValue({
+        workflowExecutionId: 'execution-1',
+        result: { status: ExecutionStatus.COMPLETED, output: { content: 'restored' } },
+      });
+
+      await api.executeWorkflowSynchronously({
+        workflowId: workflow.id,
+        workflow,
+        context: { event: { messages: [] }, spaceId: 'space-a' },
+        spaceId: 'space-a',
+        request: mockRequest,
+      });
+
+      expect(mockWorkflowsService.getWorkflow).not.toHaveBeenCalled();
+      expect(mockWorkflowsExecutionEngine.executeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ id: workflow.id }),
+        expect.any(Object),
+        mockRequest,
+        expect.objectContaining({ executionMode: 'sync' })
+      );
+    });
+
+    it('validates the pre-fetched DTO and throws without an ES fetch when the workflow is disabled, invalid, or missing a definition', async () => {
+      const base = createTriggeredWorkflow({ id: 'wf-guard' });
+
+      await expect(
+        api.executeWorkflowSynchronously({
+          workflowId: base.id,
+          workflow: { ...base, enabled: false },
+          context: {},
+          spaceId: 'space-a',
+          request: mockRequest,
+        })
+      ).rejects.toThrow('disabled');
+
+      await expect(
+        api.executeWorkflowSynchronously({
+          workflowId: base.id,
+          workflow: { ...base, valid: false },
+          context: {},
+          spaceId: 'space-a',
+          request: mockRequest,
+        })
+      ).rejects.toThrow('validation errors');
+
+      await expect(
+        api.executeWorkflowSynchronously({
+          workflowId: base.id,
+          workflow: { ...base, definition: null },
+          context: {},
+          spaceId: 'space-a',
+          request: mockRequest,
+        })
+      ).rejects.toThrow('no definition');
+
+      // All three guard paths use the supplied DTO — no ES re-fetch
+      expect(mockWorkflowsService.getWorkflow).not.toHaveBeenCalled();
+    });
   });
 
   describe('cloneWorkflow', () => {

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
@@ -9,7 +9,12 @@
 
 import type { KibanaRequest, Logger } from '@kbn/core/server';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
-import { type WorkflowDetailDto, WorkflowsManagementApiActions } from '@kbn/workflows';
+import {
+  ExecutionStatus,
+  type WorkflowDetailDto,
+  WorkflowsManagementApiActions,
+  type WorkflowYaml,
+} from '@kbn/workflows';
 import { WORKFLOW_SML_TYPE } from '@kbn/workflows/common/constants';
 import {
   WorkflowExecutionInvalidStatusError,
@@ -42,6 +47,7 @@ describe('WorkflowsManagementApi', () => {
 
     mockWorkflowsService = {
       getWorkflow: jest.fn(),
+      getWorkflowsSubscribedToTrigger: jest.fn(),
       getWorkflowsByIds: jest.fn(),
       getWorkflowZodSchema: jest.fn(),
       createWorkflow: jest.fn(),
@@ -74,6 +80,103 @@ describe('WorkflowsManagementApi', () => {
       steps: z.array(z.any()).optional(),
     });
   };
+
+  describe('workflow-trigger synchronous execution', () => {
+    const createAroundCompletionTrigger = (
+      condition?: string
+    ): WorkflowYaml['triggers'][number] => {
+      // The static WorkflowYaml type models built-ins only; registered triggers are added dynamically.
+      const trigger: WorkflowYaml['triggers'][number] = { type: 'manual' };
+      Reflect.set(trigger, 'type', 'inference.aroundCompletion');
+      if (condition) {
+        Reflect.set(trigger, 'on', { condition });
+      }
+      return trigger;
+    };
+
+    const createTriggeredWorkflow = ({
+      id,
+      condition,
+    }: {
+      id: string;
+      condition?: string;
+    }): WorkflowDetailDto => ({
+      id,
+      name: id,
+      enabled: true,
+      yaml: `name: ${id}`,
+      valid: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      createdBy: 'system',
+      lastUpdatedAt: '2026-01-01T00:00:00.000Z',
+      lastUpdatedBy: 'system',
+      definition: {
+        version: '1',
+        name: id,
+        enabled: true,
+        triggers: [createAroundCompletionTrigger(condition)],
+        steps: [{ name: 'proceed', type: 'call_site.proceed', with: {} }],
+      },
+    });
+
+    it('resolves matching workflows and reports invalid trigger conditions separately', async () => {
+      mockWorkflowsService.getWorkflowsSubscribedToTrigger.mockResolvedValue([
+        createTriggeredWorkflow({ id: 'unconditional' }),
+        createTriggeredWorkflow({ id: 'matching', condition: 'event.agentId: "agent-a"' }),
+        createTriggeredWorkflow({ id: 'not-matching', condition: 'event.agentId: "agent-b"' }),
+        createTriggeredWorkflow({ id: 'invalid', condition: '(' }),
+      ]);
+
+      await expect(
+        api.resolveWorkflowTriggerMatches(
+          'inference.aroundCompletion',
+          { agentId: 'agent-a' },
+          'space-a'
+        )
+      ).resolves.toEqual({
+        matched: [
+          expect.objectContaining({ id: 'unconditional' }),
+          expect.objectContaining({ id: 'matching' }),
+        ],
+        invalidConditionWorkflowIds: ['invalid'],
+      });
+      expect(mockWorkflowsService.getWorkflowsSubscribedToTrigger).toHaveBeenCalledWith(
+        'inference.aroundCompletion',
+        'space-a'
+      );
+    });
+
+    it('executes a saved workflow synchronously with request-local options', async () => {
+      const workflow = createTriggeredWorkflow({ id: 'workflow-1' });
+      const abortSignal = new AbortController().signal;
+      const capabilities = [{ id: 'test-capability', value: { invoke: jest.fn() } }];
+      mockWorkflowsService.getWorkflow.mockResolvedValue(workflow);
+      mockWorkflowsExecutionEngine.executeWorkflow.mockResolvedValue({
+        workflowExecutionId: 'execution-1',
+        result: { status: ExecutionStatus.COMPLETED, output: { content: 'restored' } },
+      });
+
+      await api.executeWorkflowSynchronously({
+        workflowId: workflow.id,
+        context: { event: { messages: [] }, spaceId: 'space-a' },
+        spaceId: 'space-a',
+        request: mockRequest,
+        capabilities,
+        abortSignal,
+      });
+
+      expect(mockWorkflowsExecutionEngine.executeWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ id: workflow.id }),
+        { event: { messages: [] }, spaceId: 'space-a' },
+        mockRequest,
+        {
+          executionMode: 'sync',
+          capabilities,
+          abortSignal,
+        }
+      );
+    });
+  });
 
   describe('cloneWorkflow', () => {
     const createMockWorkflow = (overrides: Partial<WorkflowDetailDto> = {}): WorkflowDetailDto => ({

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -132,6 +132,12 @@ export interface ResolveWorkflowTriggerMatchesResult {
 
 export interface ExecuteWorkflowSynchronouslyParams {
   workflowId: string;
+  /**
+   * Pre-fetched workflow DTO (e.g. from trigger resolution). When supplied, the ES re-fetch
+   * inside `executeWorkflowSynchronously` is skipped — eliminates a redundant read on the
+   * inference hot path. The DTO is still validated (enabled, valid, definition) before execution.
+   */
+  workflow?: WorkflowDetailDto;
   context: Record<string, unknown>;
   spaceId: string;
   request: KibanaRequest;
@@ -350,15 +356,18 @@ export class WorkflowsManagementApi {
 
   public async executeWorkflowSynchronously({
     workflowId,
+    workflow: prefetchedWorkflow,
     context,
     spaceId,
     request,
     capabilities,
     abortSignal,
   }: ExecuteWorkflowSynchronouslyParams): Promise<ExecuteWorkflowResponse> {
-    const workflow = await this.getSavedWorkflowExecutionModel(workflowId, spaceId);
+    const model = prefetchedWorkflow
+      ? this.validateAndBuildWorkflowModel(prefetchedWorkflow)
+      : await this.getSavedWorkflowExecutionModel(workflowId, spaceId);
     const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
-    return workflowsExecutionEngine.executeWorkflow(workflow, context, request, {
+    return workflowsExecutionEngine.executeWorkflow(model, context, request, {
       executionMode: 'sync',
       capabilities,
       abortSignal,
@@ -627,26 +636,33 @@ export class WorkflowsManagementApi {
     };
   }
 
+  /**
+   * Validates an already-fetched workflow DTO and converts it to an execution model.
+   * Used by `executeWorkflowSynchronously` when the caller passes a pre-fetched workflow,
+   * and by `getSavedWorkflowExecutionModel` after the ES fetch.
+   */
+  private validateAndBuildWorkflowModel(workflow: WorkflowDetailDto): WorkflowExecutionEngineModel {
+    if (!workflow.enabled) {
+      throw new Error(`Workflow '${workflow.id}' is disabled and cannot be executed.`);
+    }
+    if (!workflow.valid) {
+      throw new Error(`Workflow '${workflow.id}' has validation errors and cannot be executed.`);
+    }
+    if (!workflow.definition) {
+      throw new Error(`Workflow '${workflow.id}' has no definition and cannot be executed.`);
+    }
+    return toWorkflowExecutionEngineModel(workflow);
+  }
+
   private async getSavedWorkflowExecutionModel(
     workflowId: string,
     spaceId: string
   ): Promise<WorkflowExecutionEngineModel> {
     const workflow = await this.getWorkflow(workflowId, spaceId);
-
     if (!workflow) {
       throw new WorkflowNotFoundError(workflowId);
     }
-    if (!workflow.enabled) {
-      throw new Error(`Workflow '${workflowId}' is disabled and cannot be executed.`);
-    }
-    if (!workflow.valid) {
-      throw new Error(`Workflow '${workflowId}' has validation errors and cannot be executed.`);
-    }
-    if (!workflow.definition) {
-      throw new Error(`Workflow '${workflowId}' has no definition and cannot be executed.`);
-    }
-
-    return toWorkflowExecutionEngineModel(workflow);
+    return this.validateAndBuildWorkflowModel(workflow);
   }
 
   private async waitForWorkflowExecution({

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -49,13 +49,20 @@ import type {
   WorkflowPartialDetailDto,
   WorkflowSortField,
 } from '@kbn/workflows/types/v1';
-import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
+import type {
+  ExecuteWorkflowResponse,
+  WorkflowsExecutionEnginePluginStart,
+} from '@kbn/workflows-execution-engine/server';
+import { classifyWorkflowTriggerMatch } from '@kbn/workflows-execution-engine/server';
 import type { LogSearchResult } from '@kbn/workflows-execution-engine/server/repositories/logs_repository';
 import type {
   ExecutionLogsParams,
   StepLogsParams,
 } from '@kbn/workflows-execution-engine/server/workflow_event_logger/types';
-import type { ServerTriggerDefinition } from '@kbn/workflows-extensions/server';
+import type {
+  ServerTriggerDefinition,
+  WorkflowExecutionCapabilities,
+} from '@kbn/workflows-extensions/server';
 import {
   parseWorkflowYamlToJSON,
   parseYamlToJSONWithoutValidation,
@@ -116,6 +123,20 @@ export interface GetWorkflowsParams {
 
 export interface GetWorkflowAggsOptions {
   managedFilter?: GetWorkflowsParams['managedFilter'];
+}
+
+export interface ResolveWorkflowTriggerMatchesResult {
+  matched: WorkflowDetailDto[];
+  invalidConditionWorkflowIds: string[];
+}
+
+export interface ExecuteWorkflowSynchronouslyParams {
+  workflowId: string;
+  context: Record<string, unknown>;
+  spaceId: string;
+  request: KibanaRequest;
+  capabilities?: WorkflowExecutionCapabilities;
+  abortSignal?: AbortSignal;
 }
 
 export interface DeleteWorkflowsResponse {
@@ -304,6 +325,44 @@ export class WorkflowsManagementApi {
     spaceId: string
   ): Promise<WorkflowDetailDto[]> {
     return this.workflowsService.getWorkflowsSubscribedToTrigger(triggerId, spaceId);
+  }
+
+  public async resolveWorkflowTriggerMatches(
+    triggerId: string,
+    event: Record<string, unknown>,
+    spaceId: string
+  ): Promise<ResolveWorkflowTriggerMatchesResult> {
+    const subscribed = await this.getWorkflowsSubscribedToTrigger(triggerId, spaceId);
+    const matched: WorkflowDetailDto[] = [];
+    const invalidConditionWorkflowIds: string[] = [];
+
+    subscribed.forEach((workflow) => {
+      const outcome = classifyWorkflowTriggerMatch(workflow, triggerId, event);
+      if (outcome === 'matched') {
+        matched.push(workflow);
+      } else if (outcome === 'kql_error') {
+        invalidConditionWorkflowIds.push(workflow.id);
+      }
+    });
+
+    return { matched, invalidConditionWorkflowIds };
+  }
+
+  public async executeWorkflowSynchronously({
+    workflowId,
+    context,
+    spaceId,
+    request,
+    capabilities,
+    abortSignal,
+  }: ExecuteWorkflowSynchronouslyParams): Promise<ExecuteWorkflowResponse> {
+    const workflow = await this.getSavedWorkflowExecutionModel(workflowId, spaceId);
+    const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
+    return workflowsExecutionEngine.executeWorkflow(workflow, context, request, {
+      executionMode: 'sync',
+      capabilities,
+      abortSignal,
+    });
   }
 
   public async getWorkflow(id: string, spaceId: string): Promise<WorkflowDetailDto | null> {

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_search_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_search_service.ts
@@ -105,6 +105,15 @@ export class WorkflowSearchService {
       'valid',
       'created_at',
       'updated_at',
+      // Required for executeWorkflowSynchronously when the DTO is reused directly:
+      // 'version' is surfaced to Liquid templates as {{ workflow.version }} in sync mode;
+      // the managed fields feed execution telemetry.
+      'version',
+      'managed',
+      'managedBy',
+      'billable',
+      'originManagedWorkflowId',
+      'managedVersion',
     ];
 
     const pitResponse = await esClient.openPointInTime({

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/metadata.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/metadata.ts
@@ -36,6 +36,10 @@ export interface ChatCompleteAnonymizationTarget {
  * field-based policy for a target.
  */
 export interface ChatCompleteAnonymizationMetadata {
+  /** Stable conversation scope used by workflow-driven anonymization. */
+  sessionId?: string;
+  /** Active agent identity used only for workflow policy selection. */
+  agentId?: string;
   profileId?: string;
   replacementsId?: string;
   target?: ChatCompleteAnonymizationTarget;

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_detection_context.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_detection_context.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegexWorkerService } from './regex_worker_service';
+import { createPiiDetectionContext } from './create_pii_detection_context';
+
+describe('createPiiDetectionContext', () => {
+  it('delegates enabled regex detection to the worker and maps record IDs', async () => {
+    const run = jest.fn().mockResolvedValue([
+      {
+        recordIndex: 0,
+        recordKey: 'message-1',
+        start: 8,
+        end: 24,
+        matchValue: 'user@example.com',
+        class_name: 'EMAIL',
+        ruleIndex: 0,
+      },
+    ]);
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+
+    await expect(
+      context.detectEntities({
+        records: [{ id: 'message-1', text: 'Contact user@example.com' }],
+        rules: [
+          { type: 'RegExp', enabled: true, pattern: '[^ ]+@[^ ]+', entityClass: 'EMAIL' },
+          { type: 'RegExp', enabled: false, pattern: 'ignored', entityClass: 'MISC' },
+          { type: 'NER', enabled: false },
+        ],
+      })
+    ).resolves.toEqual([
+      {
+        recordId: 'message-1',
+        start: 8,
+        end: 24,
+        value: 'user@example.com',
+        entityClass: 'EMAIL',
+      },
+    ]);
+
+    expect(run).toHaveBeenCalledWith({
+      rules: [{ type: 'RegExp', enabled: true, pattern: '[^ ]+@[^ ]+', entityClass: 'EMAIL' }],
+      records: [{ 'message-1': 'Contact user@example.com' }],
+    });
+  });
+
+  it('does not invoke the worker when there are no enabled regex rules', async () => {
+    const run = jest.fn();
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+
+    await expect(
+      context.detectEntities({
+        records: [{ id: 'message-1', text: 'some text' }],
+        rules: [{ type: 'NER', enabled: false }],
+      })
+    ).resolves.toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('rejects enabled NER rules instead of silently ignoring them', async () => {
+    const run = jest.fn();
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+
+    await expect(
+      context.detectEntities({
+        records: [{ id: 'message-1', text: 'some text' }],
+        rules: [{ type: 'NER', enabled: true }],
+      })
+    ).rejects.toThrow('NER detection is not supported by workflow-driven anonymization');
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('honors cancellation before dispatching worker work', async () => {
+    const run = jest.fn();
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      context.detectEntities({
+        records: [{ id: 'message-1', text: 'some text' }],
+        rules: [{ type: 'RegExp', enabled: true, pattern: 'text', entityClass: 'MISC' }],
+        abortSignal: abortController.signal,
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('honors cancellation while worker work is in flight', async () => {
+    let resolveRun: ((matches: []) => void) | undefined;
+    const run = jest.fn(
+      () =>
+        new Promise<[]>((resolve) => {
+          resolveRun = resolve;
+        })
+    );
+    const context = createPiiDetectionContext({
+      regexWorker: { run } as unknown as RegexWorkerService,
+    });
+    const abortController = new AbortController();
+
+    const detection = context.detectEntities({
+      records: [{ id: 'message-1', text: 'some text' }],
+      rules: [{ type: 'RegExp', enabled: true, pattern: 'text', entityClass: 'MISC' }],
+      abortSignal: abortController.signal,
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    abortController.abort();
+    if (!resolveRun) {
+      throw new Error('Expected regex worker invocation');
+    }
+    resolveRun([]);
+
+    await expect(detection).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_detection_context.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_detection_context.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnonymizationRule, RegexAnonymizationRule } from '@kbn/inference-common';
+import type {
+  DetectedPiiEntity,
+  PiiDetectionContext,
+  PiiTextRecord,
+} from './pii_detection_context';
+import type { RegexWorkerService } from './regex_worker_service';
+
+export const createPiiDetectionContext = ({
+  regexWorker,
+}: {
+  regexWorker: RegexWorkerService;
+}): PiiDetectionContext => ({
+  detectEntities: async ({ records, rules, abortSignal }) => {
+    abortSignal?.throwIfAborted();
+
+    if (hasEnabledNerRule(rules)) {
+      throw new Error('NER detection is not supported by workflow-driven anonymization');
+    }
+
+    const regexRules = rules.filter(
+      (rule): rule is RegexAnonymizationRule => rule.enabled && rule.type === 'RegExp'
+    );
+    if (regexRules.length === 0 || records.length === 0) {
+      return [];
+    }
+
+    const workerRecords = records.map(({ id, text }) => ({ [id]: text }));
+    const matches = await regexWorker.run({ rules: regexRules, records: workerRecords });
+    abortSignal?.throwIfAborted();
+
+    return matches.map<DetectedPiiEntity>((match) => ({
+      recordId: getRecordId(records, match.recordIndex),
+      start: match.start,
+      end: match.end,
+      value: match.matchValue,
+      entityClass: match.class_name,
+    }));
+  },
+});
+
+const hasEnabledNerRule = (rules: readonly AnonymizationRule[]): boolean =>
+  rules.some((rule) => rule.enabled && rule.type === 'NER');
+
+const getRecordId = (records: readonly PiiTextRecord[], recordIndex: number): string => {
+  const record = records[recordIndex];
+  if (!record) {
+    throw new Error(`PII detector returned an invalid record index: ${recordIndex}`);
+  }
+  return record.id;
+};

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_tokenization_context.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_tokenization_context.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PiiDetectionContext } from './pii_detection_context';
+import { createPiiTokenizationContext } from './create_pii_tokenization_context';
+
+const detectionContext: PiiDetectionContext = {
+  detectEntities: jest.fn().mockResolvedValue([]),
+};
+
+describe('createPiiTokenizationContext', () => {
+  it('derives stable tokens for the same session without exposing scope or key material', () => {
+    const first = createPiiTokenizationContext({
+      detectionContext,
+      serverSalt: 'stable-high-entropy-test-secret',
+      sessionId: 'conversation-1',
+    });
+    const second = createPiiTokenizationContext({
+      detectionContext,
+      serverSalt: 'stable-high-entropy-test-secret',
+      sessionId: 'conversation-1',
+    });
+
+    expect(first.tokenize('EMAIL', 'person@example.com')).toBe(
+      second.tokenize('EMAIL', 'person@example.com')
+    );
+    expect(Object.keys(first).sort()).toEqual(['detectEntities', 'tokenize']);
+    expect(JSON.stringify(first)).not.toContain('stable-high-entropy-test-secret');
+    expect(JSON.stringify(first)).not.toContain('conversation-1');
+  });
+
+  it('isolates deterministic tokens by session', () => {
+    const first = createPiiTokenizationContext({
+      detectionContext,
+      serverSalt: 'stable-high-entropy-test-secret',
+      sessionId: 'conversation-1',
+    });
+    const second = createPiiTokenizationContext({
+      detectionContext,
+      serverSalt: 'stable-high-entropy-test-secret',
+      sessionId: 'conversation-2',
+    });
+
+    expect(first.tokenize('EMAIL', 'person@example.com')).not.toBe(
+      second.tokenize('EMAIL', 'person@example.com')
+    );
+  });
+
+  it('uses an independent random scope for each call without a session', () => {
+    const first = createPiiTokenizationContext({
+      detectionContext,
+      serverSalt: 'stable-high-entropy-test-secret',
+    });
+    const second = createPiiTokenizationContext({
+      detectionContext,
+      serverSalt: 'stable-high-entropy-test-secret',
+    });
+
+    expect(first.tokenize('EMAIL', 'person@example.com')).not.toBe(
+      second.tokenize('EMAIL', 'person@example.com')
+    );
+  });
+
+  it('delegates detection without exposing the detector implementation', async () => {
+    const detectEntities = jest.fn().mockResolvedValue([]);
+    const context = createPiiTokenizationContext({
+      detectionContext: { detectEntities },
+      serverSalt: 'stable-high-entropy-test-secret',
+      sessionId: 'conversation-1',
+    });
+    const options = { records: [{ id: 'record', text: 'hello' }], rules: [] };
+
+    await context.detectEntities(options);
+
+    expect(detectEntities).toHaveBeenCalledWith(options);
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_tokenization_context.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/create_pii_tokenization_context.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createHmac, randomBytes } from 'crypto';
+import type { PiiTokenizationContext } from '../../workflow_anonymization_capabilities';
+import type { PiiDetectionContext } from './pii_detection_context';
+import { getEntityMask } from './get_entity_mask';
+
+const deriveExecutionScope = ({
+  serverSalt,
+  sessionId,
+}: {
+  serverSalt: string;
+  sessionId?: string;
+}): string => {
+  if (!sessionId) {
+    return randomBytes(32).toString('hex');
+  }
+
+  return createHmac('sha256', serverSalt).update(`session:${sessionId}`).digest('hex');
+};
+
+export const createPiiTokenizationContext = ({
+  detectionContext,
+  serverSalt,
+  sessionId,
+}: {
+  detectionContext: PiiDetectionContext;
+  serverSalt: string;
+  sessionId?: string;
+}): PiiTokenizationContext => {
+  const executionScope = deriveExecutionScope({ serverSalt, sessionId });
+
+  return {
+    detectEntities: (options) => detectionContext.detectEntities(options),
+    tokenize: (entityClass, value) =>
+      getEntityMask({ class_name: entityClass, value }, executionScope),
+  };
+};

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/pii_detection_context.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/pii_detection_context.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnonymizationRule } from '@kbn/inference-common';
+
+export interface PiiTextRecord {
+  id: string;
+  text: string;
+}
+
+export interface DetectedPiiEntity {
+  recordId: string;
+  start: number;
+  end: number;
+  value: string;
+  entityClass: string;
+}
+
+export interface PiiDetectionContext {
+  detectEntities(options: {
+    records: readonly PiiTextRecord[];
+    rules: readonly AnonymizationRule[];
+    abortSignal?: AbortSignal;
+  }): Promise<readonly DetectedPiiEntity[]>;
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/pii_detection_context.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/pii_detection_context.ts
@@ -6,19 +6,9 @@
  */
 
 import type { AnonymizationRule } from '@kbn/inference-common';
+import type { DetectedPiiEntity, PiiTextRecord } from '../../workflow_anonymization_capabilities';
 
-export interface PiiTextRecord {
-  id: string;
-  text: string;
-}
-
-export interface DetectedPiiEntity {
-  recordId: string;
-  start: number;
-  end: number;
-  value: string;
-  entityClass: string;
-}
+export type { DetectedPiiEntity, PiiTextRecord };
 
 export interface PiiDetectionContext {
   detectEntities(options: {

--- a/x-pack/platform/plugins/shared/inference/server/index.ts
+++ b/x-pack/platform/plugins/shared/inference/server/index.ts
@@ -21,6 +21,16 @@ import type {
 
 export type { InferenceServerSetup, InferenceServerStart };
 export type { InferenceEndpoint } from './util/get_inference_endpoints';
+export {
+  INFERENCE_PROCEED_CAPABILITY_ID,
+  PII_TOKENIZATION_CAPABILITY_ID,
+  type DetectedPiiEntity,
+  type InferenceProceedCapability,
+  type InferenceProceedInput,
+  type InferenceTokenMapEntry,
+  type PiiTextRecord,
+  type PiiTokenizationContext,
+} from './workflow_anonymization_capabilities';
 
 export {
   naturalLanguageToEsql,

--- a/x-pack/platform/plugins/shared/inference/server/index.ts
+++ b/x-pack/platform/plugins/shared/inference/server/index.ts
@@ -21,6 +21,11 @@ import type {
 
 export type { InferenceServerSetup, InferenceServerStart };
 export type { InferenceEndpoint } from './util/get_inference_endpoints';
+export type {
+  AroundCompletionEvent,
+  WorkflowAnonymizationProvider,
+  WorkflowAroundCompletionResult,
+} from './workflow_anonymization_provider';
 export {
   INFERENCE_PROCEED_CAPABILITY_ID,
   PII_TOKENIZATION_CAPABILITY_ID,

--- a/x-pack/platform/plugins/shared/inference/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference/server/plugin.ts
@@ -44,6 +44,7 @@ import { getInferenceEndpointById } from './util/get_inference_endpoint_by_id';
 import { InferenceEndpointIdCache } from './util/inference_endpoint_id_cache';
 import { TokenUsageLogger } from './token_usage';
 import { installTokenUsageDashboard } from './dashboard';
+import type { WorkflowAnonymizationProvider } from './workflow_anonymization_provider';
 
 const parseLegacyAnonymizationRules = (value: unknown): AnonymizationRule[] => {
   let parsed: unknown = value;
@@ -101,6 +102,7 @@ export class InferencePlugin
   private regexWorker?: RegexWorkerService;
   private endpointIdCache: InferenceEndpointIdCache;
   private tokenUsageLogger: TokenUsageLogger;
+  private workflowAnonymizationProvider?: WorkflowAnonymizationProvider;
 
   constructor(context: PluginInitializerContext<InferenceConfig>) {
     this.logger = context.logger.get();
@@ -121,7 +123,14 @@ export class InferencePlugin
       logger: this.logger,
     });
 
-    return {};
+    return {
+      registerWorkflowAnonymizationProvider: (provider) => {
+        if (this.workflowAnonymizationProvider) {
+          throw new Error('A workflow anonymization provider is already registered');
+        }
+        this.workflowAnonymizationProvider = provider;
+      },
+    };
   }
 
   start(core: CoreStart, pluginsStart: InferenceStartDependencies): InferenceServerStart {

--- a/x-pack/platform/plugins/shared/inference/server/types.ts
+++ b/x-pack/platform/plugins/shared/inference/server/types.ts
@@ -36,8 +36,7 @@ import type {
   AnonymizationPluginSetup,
 } from '@kbn/anonymization-plugin/server';
 import type { InferenceEndpoint } from './util/get_inference_endpoints';
-
-/* eslint-disable @typescript-eslint/no-empty-interface*/
+import type { WorkflowAnonymizationProvider } from './workflow_anonymization_provider';
 
 export interface InferenceSetupDependencies {
   actions: ActionsPluginSetup;
@@ -52,7 +51,9 @@ export interface InferenceStartDependencies {
 /**
  * Setup contract of the inference plugin.
  */
-export interface InferenceServerSetup {}
+export interface InferenceServerSetup {
+  registerWorkflowAnonymizationProvider(provider: WorkflowAnonymizationProvider): void;
+}
 
 /**
  * Options to create an inference client using the {@link InferenceServerStart.getClient} API.

--- a/x-pack/platform/plugins/shared/inference/server/workflow_anonymization_capabilities.ts
+++ b/x-pack/platform/plugins/shared/inference/server/workflow_anonymization_capabilities.ts
@@ -30,6 +30,15 @@ export interface PiiTokenizationContext {
     abortSignal?: AbortSignal;
   }): Promise<readonly DetectedPiiEntity[]>;
 
+  /**
+   * Generates a replacement token for the given entity class and original value.
+   *
+   * **MUST be deterministic**: calling `tokenize` with the same `(entityClass, value)` pair
+   * within a single call MUST return the same token. The PII-application logic uses this
+   * guarantee to deduplicate repeated occurrences into a single token-map entry and to detect
+   * collisions. A non-deterministic implementation would silently corrupt the token map and
+   * break PII restoration.
+   */
   tokenize(entityClass: string, value: string): string;
 }
 

--- a/x-pack/platform/plugins/shared/inference/server/workflow_anonymization_capabilities.ts
+++ b/x-pack/platform/plugins/shared/inference/server/workflow_anonymization_capabilities.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnonymizationRule, Message } from '@kbn/inference-common';
+
+export const PII_TOKENIZATION_CAPABILITY_ID = 'inference.pii_tokenization';
+export const INFERENCE_PROCEED_CAPABILITY_ID = 'inference.proceed';
+
+export interface PiiTextRecord {
+  readonly id: string;
+  readonly text: string;
+}
+
+export interface DetectedPiiEntity {
+  readonly recordId: string;
+  readonly start: number;
+  readonly end: number;
+  readonly value: string;
+  readonly entityClass: string;
+}
+
+export interface PiiTokenizationContext {
+  detectEntities(options: {
+    records: readonly PiiTextRecord[];
+    rules: readonly AnonymizationRule[];
+    abortSignal?: AbortSignal;
+  }): Promise<readonly DetectedPiiEntity[]>;
+
+  tokenize(entityClass: string, value: string): string;
+}
+
+export interface InferenceTokenMapEntry {
+  readonly original: string;
+  readonly entityClass: string;
+}
+
+export interface InferenceProceedInput {
+  readonly system?: string;
+  readonly messages: readonly Message[];
+  readonly tokenMap: Readonly<Record<string, InferenceTokenMapEntry>>;
+  readonly abortSignal?: AbortSignal;
+}
+
+export interface InferenceProceedCapability {
+  invoke(input: InferenceProceedInput): Promise<{ rawContent: string }>;
+}

--- a/x-pack/platform/plugins/shared/inference/server/workflow_anonymization_provider.ts
+++ b/x-pack/platform/plugins/shared/inference/server/workflow_anonymization_provider.ts
@@ -24,8 +24,12 @@ export type WorkflowAroundCompletionResult =
   | { matched: true; content: string };
 
 export interface WorkflowAnonymizationProvider {
-  /** Compatibility marker aligned with the workflow engine's synchronous execution support. */
-  readonly supportsSynchronousExecution: true;
+  /**
+   * Whether this provider supports synchronous (within-request) workflow execution.
+   * Checked at runtime before the hook path is entered; must be `true` for
+   * providers that implement the around-completion flow.
+   */
+  readonly supportsSynchronousExecution: boolean;
   execute(options: {
     event: AroundCompletionEvent;
     namespace: string;

--- a/x-pack/platform/plugins/shared/inference/server/workflow_anonymization_provider.ts
+++ b/x-pack/platform/plugins/shared/inference/server/workflow_anonymization_provider.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { Message } from '@kbn/inference-common';
+import type {
+  InferenceProceedCapability,
+  PiiTokenizationContext,
+} from './workflow_anonymization_capabilities';
+
+export interface AroundCompletionEvent {
+  readonly system?: string;
+  readonly messages: readonly Message[];
+  readonly sessionId?: string;
+  readonly agentId?: string;
+}
+
+export type WorkflowAroundCompletionResult =
+  | { matched: false }
+  | { matched: true; content: string };
+
+export interface WorkflowAnonymizationProvider {
+  /** Compatibility marker aligned with the workflow engine's synchronous execution support. */
+  readonly supportsSynchronousExecution: true;
+  execute(options: {
+    event: AroundCompletionEvent;
+    namespace: string;
+    request: KibanaRequest;
+    pii: PiiTokenizationContext;
+    proceed: InferenceProceedCapability;
+    abortSignal?: AbortSignal;
+  }): Promise<WorkflowAroundCompletionResult>;
+}

--- a/x-pack/platform/plugins/shared/inference_workflows/common/workflow_anonymization.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/common/workflow_anonymization.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MessageRole, type Message } from '@kbn/inference-common';
+import {
+  aiPiiInputSchema,
+  anonymizationRuleSchema,
+  tokenMapSchema,
+  workflowChatMessageSchema,
+} from './workflow_anonymization';
+
+describe('workflow anonymization schemas', () => {
+  const supportedEntityClasses = [
+    'PER',
+    'ORG',
+    'LOC',
+    'MISC',
+    'HOST_NAME',
+    'USER_NAME',
+    'IP',
+    'URL',
+    'EMAIL',
+    'CLOUD_ACCOUNT',
+    'ENTITY_NAME',
+    'RESOURCE_NAME',
+    'RESOURCE_ID',
+  ] as const;
+  const messages: Message[] = [
+    {
+      role: MessageRole.User,
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'image', source: { data: 'base64', mimeType: 'image/png' } },
+      ],
+    },
+    {
+      role: MessageRole.Assistant,
+      content: null,
+      refusal: null,
+      toolCalls: [
+        {
+          toolCallId: 'call-1',
+          function: { name: 'lookup', arguments: { email: 'person@example.com' } },
+        },
+      ],
+    },
+    {
+      role: MessageRole.Tool,
+      name: 'lookup',
+      toolCallId: 'call-1',
+      response: { nested: ['value'] },
+      data: { source: 'test' },
+    },
+  ];
+
+  it.each(messages)('accepts a valid inference Message %#', (message) => {
+    expect(workflowChatMessageSchema.parse(message)).toEqual(message);
+  });
+
+  it('rejects unknown message, rule, and token-map fields', () => {
+    expect(() =>
+      workflowChatMessageSchema.parse({
+        role: MessageRole.User,
+        content: 'hello',
+        unexpected: 'value',
+      })
+    ).toThrow();
+    expect(() =>
+      anonymizationRuleSchema.parse({
+        type: 'RegExp',
+        enabled: true,
+        pattern: 'secret',
+        entityClass: 'ENTITY_NAME',
+        unexpected: 'value',
+      })
+    ).toThrow();
+    expect(() =>
+      tokenMapSchema.parse({
+        TOKEN: { original: 'secret', entityClass: 'ENTITY_NAME', unexpected: 'value' },
+      })
+    ).toThrow();
+  });
+
+  it.each(supportedEntityClasses)('accepts the supported %s entity class', (entityClass) => {
+    expect(
+      anonymizationRuleSchema.parse({
+        type: 'RegExp',
+        enabled: true,
+        pattern: 'value',
+        entityClass,
+      })
+    ).toEqual({ type: 'RegExp', enabled: true, pattern: 'value', entityClass });
+  });
+
+  it('rejects an unsupported message role through the PII input boundary', () => {
+    expect(() =>
+      aiPiiInputSchema.parse({
+        messages: [{ role: 'system', content: 'not a Message role' }],
+        rules: [],
+      })
+    ).toThrow();
+  });
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/common/workflow_anonymization.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/common/workflow_anonymization.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { MessageRole, type AnonymizationEntityClass, type Message } from '@kbn/inference-common';
+import { StepCategory } from '@kbn/workflows';
+import type {
+  CommonStepDefinition,
+  CommonTriggerDefinition,
+} from '@kbn/workflows-extensions/common';
+import { z } from '@kbn/zod/v4';
+
+export const INFERENCE_AROUND_COMPLETION_TRIGGER_ID = 'inference.aroundCompletion';
+export const AI_PII_STEP_ID = 'ai.pii';
+export const CALL_SITE_PROCEED_STEP_ID = 'call_site.proceed';
+export const TRANSFORM_PII_RESTORE_STEP_ID = 'transform.pii_restore';
+
+const textContentSchema = z.object({ type: z.literal('text'), text: z.string() }).strict();
+const imageContentSchema = z
+  .object({
+    type: z.literal('image'),
+    source: z.object({ data: z.string(), mimeType: z.string() }).strict(),
+  })
+  .strict();
+
+const userMessageSchema = z
+  .object({
+    role: z.literal(MessageRole.User),
+    content: z.union([z.string(), z.array(z.union([textContentSchema, imageContentSchema]))]),
+  })
+  .strict();
+
+const toolCallSchema = z
+  .object({
+    toolCallId: z.string(),
+    function: z
+      .object({
+        name: z.string(),
+        arguments: z.record(z.string(), z.unknown()),
+      })
+      .strict(),
+  })
+  .strict();
+
+const assistantMessageSchema = z
+  .object({
+    role: z.literal(MessageRole.Assistant),
+    content: z.string().nullable(),
+    refusal: z.string().nullable().optional(),
+    toolCalls: z.array(toolCallSchema).optional(),
+  })
+  .strict();
+
+const toolMessageSchema = z
+  .object({
+    role: z.literal(MessageRole.Tool),
+    name: z.string(),
+    toolCallId: z.string(),
+    response: z.union([z.string(), z.record(z.string(), z.unknown())]),
+    data: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export const workflowChatMessageSchema = z.discriminatedUnion('role', [
+  userMessageSchema,
+  assistantMessageSchema,
+  toolMessageSchema,
+]) satisfies z.ZodType<Message>;
+
+export const tokenMapEntrySchema = z
+  .object({
+    original: z.string(),
+    entityClass: z.string(),
+  })
+  .strict();
+
+export const tokenMapSchema = z.record(z.string(), tokenMapEntrySchema);
+
+const ANONYMIZATION_ENTITY_CLASSES = {
+  PER: 'PER',
+  ORG: 'ORG',
+  LOC: 'LOC',
+  MISC: 'MISC',
+  HOST_NAME: 'HOST_NAME',
+  USER_NAME: 'USER_NAME',
+  IP: 'IP',
+  URL: 'URL',
+  EMAIL: 'EMAIL',
+  CLOUD_ACCOUNT: 'CLOUD_ACCOUNT',
+  ENTITY_NAME: 'ENTITY_NAME',
+  RESOURCE_NAME: 'RESOURCE_NAME',
+  RESOURCE_ID: 'RESOURCE_ID',
+} as const satisfies Record<AnonymizationEntityClass, AnonymizationEntityClass>;
+
+const regexRuleSchema = z
+  .object({
+    type: z.literal('RegExp'),
+    enabled: z.boolean(),
+    pattern: z.string(),
+    entityClass: z.enum(ANONYMIZATION_ENTITY_CLASSES),
+  })
+  .strict();
+
+const nerRuleSchema = z
+  .object({
+    type: z.literal('NER'),
+    enabled: z.boolean(),
+    modelId: z.string().optional(),
+    timeoutSeconds: z.number().positive().optional(),
+    allowedEntityClasses: z.array(z.enum(['PER', 'ORG', 'LOC', 'MISC'])).optional(),
+  })
+  .strict();
+
+export const anonymizationRuleSchema = z.discriminatedUnion('type', [
+  regexRuleSchema,
+  nerRuleSchema,
+]);
+
+export const aroundCompletionEventSchema = z
+  .object({
+    system: z.string().optional(),
+    messages: z.array(workflowChatMessageSchema),
+    sessionId: z.string().optional(),
+    agentId: z.string().optional(),
+  })
+  .strict();
+
+export const aiPiiInputSchema = z
+  .object({
+    system: z.string().optional(),
+    messages: z.array(workflowChatMessageSchema),
+    rules: z.array(anonymizationRuleSchema),
+    tokenMap: tokenMapSchema.optional(),
+  })
+  .strict();
+
+export const anonymizedCompletionSchema = z
+  .object({
+    system: z.string().optional(),
+    messages: z.array(workflowChatMessageSchema),
+    tokenMap: tokenMapSchema,
+  })
+  .strict();
+
+export const callSiteProceedInputSchema = anonymizedCompletionSchema;
+export const callSiteProceedOutputSchema = z.object({ rawContent: z.string() }).strict();
+
+export const piiRestoreInputSchema = z
+  .object({ rawContent: z.string(), tokenMap: tokenMapSchema })
+  .strict();
+export const piiRestoreOutputSchema = z.object({ content: z.string() }).strict();
+
+const emptyConfigSchema = z.object({}).strict();
+
+export const aroundCompletionTriggerDefinition: CommonTriggerDefinition<
+  typeof aroundCompletionEventSchema
+> = {
+  id: INFERENCE_AROUND_COMPLETION_TRIGGER_ID,
+  eventSchema: aroundCompletionEventSchema,
+  title: i18n.translate('xpack.inferenceWorkflows.aroundCompletionTrigger.title', {
+    defaultMessage: 'Around inference completion',
+  }),
+  description: i18n.translate('xpack.inferenceWorkflows.aroundCompletionTrigger.description', {
+    defaultMessage: 'Runs a workflow around an inference completion call.',
+  }),
+  stability: 'tech_preview',
+};
+
+export const aiPiiCommonDefinition: CommonStepDefinition<
+  typeof aiPiiInputSchema,
+  typeof anonymizedCompletionSchema,
+  typeof emptyConfigSchema
+> = {
+  id: AI_PII_STEP_ID,
+  category: StepCategory.Ai,
+  label: i18n.translate('xpack.inferenceWorkflows.aiPiiStep.label', {
+    defaultMessage: 'Protect PII',
+  }),
+  description: i18n.translate('xpack.inferenceWorkflows.aiPiiStep.description', {
+    defaultMessage: 'Detects and replaces sensitive values for the current inference call.',
+  }),
+  inputSchema: aiPiiInputSchema,
+  outputSchema: anonymizedCompletionSchema,
+  configSchema: emptyConfigSchema,
+  stability: 'tech_preview',
+};
+
+export const callSiteProceedCommonDefinition: CommonStepDefinition<
+  typeof callSiteProceedInputSchema,
+  typeof callSiteProceedOutputSchema,
+  typeof emptyConfigSchema
+> = {
+  id: CALL_SITE_PROCEED_STEP_ID,
+  category: StepCategory.Ai,
+  label: i18n.translate('xpack.inferenceWorkflows.callSiteProceedStep.label', {
+    defaultMessage: 'Call inference model',
+  }),
+  description: i18n.translate('xpack.inferenceWorkflows.callSiteProceedStep.description', {
+    defaultMessage: 'Calls the inference model once with workflow-transformed input.',
+  }),
+  inputSchema: callSiteProceedInputSchema,
+  outputSchema: callSiteProceedOutputSchema,
+  configSchema: emptyConfigSchema,
+  stability: 'tech_preview',
+};
+
+export const piiRestoreCommonDefinition: CommonStepDefinition<
+  typeof piiRestoreInputSchema,
+  typeof piiRestoreOutputSchema,
+  typeof emptyConfigSchema
+> = {
+  id: TRANSFORM_PII_RESTORE_STEP_ID,
+  category: StepCategory.Ai,
+  label: i18n.translate('xpack.inferenceWorkflows.piiRestoreStep.label', {
+    defaultMessage: 'Restore PII',
+  }),
+  description: i18n.translate('xpack.inferenceWorkflows.piiRestoreStep.description', {
+    defaultMessage: 'Restores protected values in the final inference response.',
+  }),
+  inputSchema: piiRestoreInputSchema,
+  outputSchema: piiRestoreOutputSchema,
+  configSchema: emptyConfigSchema,
+  stability: 'tech_preview',
+};
+
+export type TokenMap = z.infer<typeof tokenMapSchema>;
+export type AiPiiInput = z.infer<typeof aiPiiInputSchema>;
+export type AnonymizedCompletion = z.infer<typeof anonymizedCompletionSchema>;

--- a/x-pack/platform/plugins/shared/inference_workflows/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/inference_workflows/kibana.jsonc
@@ -10,7 +10,7 @@
     "server": true,
     "browser": true,
     "configPath": ["xpack", "inferenceWorkflows"],
-    "requiredPlugins": ["inference", "workflowsExtensions"],
+    "requiredPlugins": ["inference", "workflowsExtensions", "workflowsManagement"],
     "optionalPlugins": ["searchInferenceEndpoints"]
   }
 }

--- a/x-pack/platform/plugins/shared/inference_workflows/moon.yml
+++ b/x-pack/platform/plugins/shared/inference_workflows/moon.yml
@@ -22,6 +22,7 @@ dependsOn:
   - '@kbn/zod'
   - '@kbn/workflows'
   - '@kbn/workflows-extensions'
+  - '@kbn/workflows-management-plugin'
   - '@kbn/inference-plugin'
   - '@kbn/inference-common'
   - '@kbn/search-inference-endpoints'

--- a/x-pack/platform/plugins/shared/inference_workflows/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/public/plugin.ts
@@ -25,6 +25,20 @@ export class InferenceWorkflowsPublicPlugin
     deps.workflowsExtensions.registerStepDefinition(() =>
       import('./steps/ai/ai_classify_step').then((m) => m.AiClassifyStepDefinition)
     );
+    deps.workflowsExtensions.registerStepDefinition(() =>
+      import('./workflow_anonymization').then((module) => module.aiPiiStepDefinition)
+    );
+    deps.workflowsExtensions.registerStepDefinition(() =>
+      import('./workflow_anonymization').then((module) => module.callSiteProceedStepDefinition)
+    );
+    deps.workflowsExtensions.registerStepDefinition(() =>
+      import('./workflow_anonymization').then((module) => module.piiRestoreStepDefinition)
+    );
+    deps.workflowsExtensions.registerTriggerDefinition(() =>
+      import('./workflow_anonymization').then(
+        (module) => module.aroundCompletionPublicTriggerDefinition
+      )
+    );
     return {};
   }
 

--- a/x-pack/platform/plugins/shared/inference_workflows/public/workflow_anonymization.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/public/workflow_anonymization.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  createPublicStepDefinition,
+  type PublicTriggerDefinition,
+} from '@kbn/workflows-extensions/public';
+import {
+  aiPiiCommonDefinition,
+  aroundCompletionTriggerDefinition,
+  callSiteProceedCommonDefinition,
+  piiRestoreCommonDefinition,
+} from '../common/workflow_anonymization';
+
+const loadAgentIcon = () =>
+  import('@elastic/eui/es/components/icon/assets/product_agent').then(({ icon }) => ({
+    default: icon,
+  }));
+
+const AgentIcon = React.lazy(loadAgentIcon);
+
+export const aiPiiStepDefinition = createPublicStepDefinition({
+  ...aiPiiCommonDefinition,
+  icon: AgentIcon,
+});
+
+export const callSiteProceedStepDefinition = createPublicStepDefinition({
+  ...callSiteProceedCommonDefinition,
+  icon: AgentIcon,
+});
+
+export const piiRestoreStepDefinition = createPublicStepDefinition({
+  ...piiRestoreCommonDefinition,
+  icon: AgentIcon,
+});
+
+export const aroundCompletionPublicTriggerDefinition: PublicTriggerDefinition<
+  typeof aroundCompletionTriggerDefinition.eventSchema
+> = {
+  ...aroundCompletionTriggerDefinition,
+  icon: AgentIcon,
+};

--- a/x-pack/platform/plugins/shared/inference_workflows/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/plugin.ts
@@ -11,6 +11,10 @@ import { aiPromptStepDefinition } from './steps/ai/ai_prompt_step/step';
 import { aiSummarizeStepDefinition } from './steps/ai/ai_summarize_step/step';
 import { aiClassifyStepDefinition } from './steps/ai/ai_classify_step/step';
 import { registerInferenceFeatures } from './steps/ai/register_inference_features';
+import { aroundCompletionTriggerDefinition } from '../common/workflow_anonymization';
+import { aiPiiStepDefinition } from './workflow_anonymization/ai_pii_step';
+import { callSiteProceedStepDefinition } from './workflow_anonymization/call_site_proceed_step';
+import { piiRestoreStepDefinition } from './workflow_anonymization/pii_restore_step';
 
 export class InferenceWorkflowsPlugin
   implements Plugin<{}, {}, InferenceWorkflowsSetupDeps, InferenceWorkflowsStartDeps>
@@ -19,6 +23,10 @@ export class InferenceWorkflowsPlugin
     deps.workflowsExtensions.registerStepDefinition(aiPromptStepDefinition(core));
     deps.workflowsExtensions.registerStepDefinition(aiSummarizeStepDefinition(core));
     deps.workflowsExtensions.registerStepDefinition(aiClassifyStepDefinition(core));
+    deps.workflowsExtensions.registerStepDefinition(aiPiiStepDefinition);
+    deps.workflowsExtensions.registerStepDefinition(callSiteProceedStepDefinition);
+    deps.workflowsExtensions.registerStepDefinition(piiRestoreStepDefinition);
+    deps.workflowsExtensions.registerTriggerDefinition(aroundCompletionTriggerDefinition);
 
     if (deps.searchInferenceEndpoints) {
       registerInferenceFeatures(deps.searchInferenceEndpoints);

--- a/x-pack/platform/plugins/shared/inference_workflows/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/plugin.ts
@@ -15,6 +15,7 @@ import { aroundCompletionTriggerDefinition } from '../common/workflow_anonymizat
 import { aiPiiStepDefinition } from './workflow_anonymization/ai_pii_step';
 import { callSiteProceedStepDefinition } from './workflow_anonymization/call_site_proceed_step';
 import { piiRestoreStepDefinition } from './workflow_anonymization/pii_restore_step';
+import { createWorkflowAnonymizationProvider } from './workflow_anonymization/create_workflow_anonymization_provider';
 
 export class InferenceWorkflowsPlugin
   implements Plugin<{}, {}, InferenceWorkflowsSetupDeps, InferenceWorkflowsStartDeps>
@@ -27,6 +28,9 @@ export class InferenceWorkflowsPlugin
     deps.workflowsExtensions.registerStepDefinition(callSiteProceedStepDefinition);
     deps.workflowsExtensions.registerStepDefinition(piiRestoreStepDefinition);
     deps.workflowsExtensions.registerTriggerDefinition(aroundCompletionTriggerDefinition);
+    deps.inference.registerWorkflowAnonymizationProvider(
+      createWorkflowAnonymizationProvider({ management: deps.workflowsManagement.management })
+    );
 
     if (deps.searchInferenceEndpoints) {
       registerInferenceFeatures(deps.searchInferenceEndpoints);

--- a/x-pack/platform/plugins/shared/inference_workflows/server/types.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/types.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { InferenceServerSetup, InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
 import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
 import type {
   SearchInferenceEndpointsPluginSetup,
@@ -13,7 +14,9 @@ import type {
 } from '@kbn/search-inference-endpoints/server';
 
 export interface InferenceWorkflowsSetupDeps {
+  inference: InferenceServerSetup;
   workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
+  workflowsManagement: WorkflowsServerPluginSetup;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginSetup;
 }
 

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.test.ts
@@ -150,7 +150,7 @@ describe('executePiiProtection', () => {
     ).rejects.toThrow('PII detector returned an invalid range');
   });
 
-  it('honors cancellation that occurs while detection is running', async () => {
+  it('honors abort signal that fires during detection and before entity application', async () => {
     const abortController = new AbortController();
     const capabilities = createCapabilities({
       detectEntities: jest.fn().mockImplementation(async () => {
@@ -168,6 +168,44 @@ describe('executePiiProtection', () => {
         logger: createLogger(),
       })
     ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('deduplicates the same detected value into a single token-map entry', async () => {
+    // Regression guard for the tokenize-determinism contract on PiiTokenizationContext.
+    // If tokenize() were non-deterministic, repeated occurrences would produce different tokens,
+    // triggering a false collision error or leaving orphaned token-map entries.
+    const detectEntities = jest.fn(({ records }) => Promise.resolve(detectEmailEntities(records)));
+    const capabilities = createCapabilities({
+      detectEntities,
+      tokenize: () => 'EMAIL_TOKEN',
+    });
+
+    const output = await executePiiProtection({
+      input: {
+        messages: [
+          { role: MessageRole.User, content: 'First person@example.com mention' },
+          { role: MessageRole.User, content: 'Second person@example.com mention' },
+        ],
+        rules: [rule],
+      },
+      capabilities,
+      abortSignal: new AbortController().signal,
+      logger: createLogger(),
+    });
+
+    expect(output.messages[0]).toEqual({
+      role: MessageRole.User,
+      content: 'First EMAIL_TOKEN mention',
+    });
+    expect(output.messages[1]).toEqual({
+      role: MessageRole.User,
+      content: 'Second EMAIL_TOKEN mention',
+    });
+    // Both occurrences share one entry — not two separate entries
+    expect(Object.keys(output.tokenMap)).toHaveLength(1);
+    expect(output.tokenMap).toEqual({
+      EMAIL_TOKEN: { original: 'person@example.com', entityClass: 'EMAIL' },
+    });
   });
 
   it('requires a valid request-local PII capability', async () => {

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.test.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MessageRole } from '@kbn/inference-common';
+import {
+  PII_TOKENIZATION_CAPABILITY_ID,
+  type DetectedPiiEntity,
+  type PiiTextRecord,
+  type PiiTokenizationContext,
+} from '@kbn/inference-plugin/server';
+import type { WorkflowExecutionCapabilities } from '@kbn/workflows-extensions/server';
+import type { AiPiiInput } from '../../common/workflow_anonymization';
+import { executePiiProtection } from './ai_pii_step';
+
+const rule = {
+  type: 'RegExp',
+  enabled: true,
+  pattern: '[^\\s]+@[^\\s]+',
+  entityClass: 'EMAIL',
+} as const;
+
+const createCapabilities = (pii: PiiTokenizationContext): WorkflowExecutionCapabilities => [
+  { id: PII_TOKENIZATION_CAPABILITY_ID, value: pii },
+];
+
+const createLogger = () => ({ warn: jest.fn() });
+
+const input: AiPiiInput = {
+  system: 'Contact person@example.com',
+  messages: [
+    { role: MessageRole.User, content: 'Email person@example.com' },
+    {
+      role: MessageRole.Assistant,
+      content: null,
+      toolCalls: [
+        {
+          toolCallId: 'call-1',
+          function: { name: 'lookup', arguments: { email: 'person@example.com' } },
+        },
+      ],
+    },
+  ],
+  rules: [rule],
+};
+
+const detectEmailEntities = (records: readonly PiiTextRecord[]): DetectedPiiEntity[] =>
+  records.flatMap((record) => {
+    const value = 'person@example.com';
+    const start = record.text.indexOf(value);
+    return start === -1
+      ? []
+      : [
+          {
+            recordId: record.id,
+            start,
+            end: start + value.length,
+            value,
+            entityClass: 'EMAIL',
+          },
+        ];
+  });
+
+describe('executePiiProtection', () => {
+  it('protects system, message content, and structured tool arguments with one call-local map', async () => {
+    const detectEntities = jest.fn(({ records }) => Promise.resolve(detectEmailEntities(records)));
+    const capabilities = createCapabilities({
+      detectEntities,
+      tokenize: () => 'EMAIL_TOKEN',
+    });
+
+    const output = await executePiiProtection({
+      input,
+      capabilities,
+      abortSignal: new AbortController().signal,
+      logger: createLogger(),
+    });
+
+    expect(output.system).toBe('Contact EMAIL_TOKEN');
+    expect(output.messages[0]).toEqual({ role: MessageRole.User, content: 'Email EMAIL_TOKEN' });
+    expect(output.messages[1]).toEqual({
+      role: MessageRole.Assistant,
+      content: null,
+      toolCalls: [
+        {
+          toolCallId: 'call-1',
+          function: { name: 'lookup', arguments: { email: 'EMAIL_TOKEN' } },
+        },
+      ],
+    });
+    expect(output.tokenMap).toEqual({
+      EMAIL_TOKEN: { original: 'person@example.com', entityClass: 'EMAIL' },
+    });
+    expect(detectEntities).toHaveBeenCalledWith({
+      records: expect.any(Array),
+      rules: [rule],
+      abortSignal: expect.any(AbortSignal),
+    });
+    const detectedRecords = detectEntities.mock.calls[0][0].records;
+    expect(detectedRecords).not.toContainEqual(
+      expect.objectContaining({ id: expect.stringContaining('/function/name') })
+    );
+  });
+
+  it('uses a previous map only within the supplied execution input without mutating it', async () => {
+    const tokenMap = {
+      EXISTING_TOKEN: { original: 'known secret', entityClass: 'ENTITY_NAME' },
+    };
+    const capabilities = createCapabilities({
+      detectEntities: jest.fn().mockResolvedValue([]),
+      tokenize: jest.fn(),
+    });
+
+    const output = await executePiiProtection({
+      input: {
+        messages: [{ role: MessageRole.User, content: 'repeat known secret' }],
+        rules: [],
+        tokenMap,
+      },
+      capabilities,
+      abortSignal: new AbortController().signal,
+      logger: createLogger(),
+    });
+
+    expect(output.messages).toEqual([{ role: MessageRole.User, content: 'repeat EXISTING_TOKEN' }]);
+    expect(output.tokenMap).toEqual(tokenMap);
+    expect(output.tokenMap).not.toBe(tokenMap);
+  });
+
+  it('fails closed when the detector returns an invalid range', async () => {
+    const capabilities = createCapabilities({
+      detectEntities: jest
+        .fn()
+        .mockResolvedValue([
+          { recordId: '/system', start: 0, end: 999, value: 'Contact', entityClass: 'EMAIL' },
+        ]),
+      tokenize: jest.fn(),
+    });
+
+    await expect(
+      executePiiProtection({
+        input,
+        capabilities,
+        abortSignal: new AbortController().signal,
+        logger: createLogger(),
+      })
+    ).rejects.toThrow('PII detector returned an invalid range');
+  });
+
+  it('honors cancellation that occurs while detection is running', async () => {
+    const abortController = new AbortController();
+    const capabilities = createCapabilities({
+      detectEntities: jest.fn().mockImplementation(async () => {
+        abortController.abort();
+        return [];
+      }),
+      tokenize: jest.fn(),
+    });
+
+    await expect(
+      executePiiProtection({
+        input,
+        capabilities,
+        abortSignal: abortController.signal,
+        logger: createLogger(),
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('requires a valid request-local PII capability', async () => {
+    await expect(
+      executePiiProtection({
+        input,
+        capabilities: [],
+        abortSignal: new AbortController().signal,
+        logger: createLogger(),
+      })
+    ).rejects.toThrow(PII_TOKENIZATION_CAPABILITY_ID);
+  });
+
+  it('warns when a later detected entity overlaps an earlier protected range', async () => {
+    const logger = createLogger();
+    const capabilities = createCapabilities({
+      detectEntities: jest.fn().mockResolvedValue([
+        { recordId: '/system', start: 0, end: 7, value: 'Contact', entityClass: 'ENTITY_NAME' },
+        { recordId: '/system', start: 4, end: 10, value: 'act pe', entityClass: 'ENTITY_NAME' },
+      ]),
+      tokenize: () => 'ENTITY_TOKEN',
+    });
+
+    await executePiiProtection({
+      input,
+      capabilities,
+      abortSignal: new AbortController().signal,
+      logger,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'PII detector returned overlapping entities; ignoring the later match',
+      { recordId: '/system', entityClass: 'ENTITY_NAME', start: 4, end: 10 }
+    );
+  });
+
+  it('logs token collisions without recording sensitive values and then fails closed', async () => {
+    const logger = createLogger();
+    const capabilities = createCapabilities({
+      detectEntities: jest.fn(({ records }) => Promise.resolve(detectEmailEntities(records))),
+      tokenize: () => 'EXISTING_TOKEN',
+    });
+
+    await expect(
+      executePiiProtection({
+        input: {
+          ...input,
+          tokenMap: {
+            EXISTING_TOKEN: { original: 'different secret', entityClass: 'ENTITY_NAME' },
+          },
+        },
+        capabilities,
+        abortSignal: new AbortController().signal,
+        logger,
+      })
+    ).rejects.toThrow('PII token collision detected');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'PII token collision detected; failing workflow protection',
+      { existingEntityClass: 'ENTITY_NAME', detectedEntityClass: 'EMAIL' }
+    );
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain('person@example.com');
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain('different secret');
+  });
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.ts
@@ -6,7 +6,10 @@
  */
 
 import type { DetectedPiiEntity, PiiTextRecord } from '@kbn/inference-plugin/server';
-import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import {
+  createServerStepDefinition,
+  type WorkflowExecutionCapabilities,
+} from '@kbn/workflows-extensions/server';
 import {
   aiPiiCommonDefinition,
   type AiPiiInput,
@@ -121,7 +124,7 @@ export const executePiiProtection = async ({
   logger,
 }: {
   input: AiPiiInput;
-  capabilities: Parameters<typeof getPiiTokenizationContext>[0];
+  capabilities: WorkflowExecutionCapabilities | undefined;
   abortSignal: AbortSignal;
   logger: PiiProtectionLogger;
 }): Promise<AnonymizedCompletion> => {

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/ai_pii_step.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DetectedPiiEntity, PiiTextRecord } from '@kbn/inference-plugin/server';
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import {
+  aiPiiCommonDefinition,
+  type AiPiiInput,
+  type AnonymizedCompletion,
+  type TokenMap,
+} from '../../common/workflow_anonymization';
+import { getPiiTokenizationContext } from './capabilities';
+import { createCompletionTextRecords } from './message_records';
+import { replaceKnownOriginals } from './token_map';
+
+interface IndexedEntity extends DetectedPiiEntity {
+  readonly detectionIndex: number;
+}
+
+interface PiiProtectionLogger {
+  warn(message: string, meta?: object): void;
+}
+
+const validateEntity = (entity: DetectedPiiEntity, record: PiiTextRecord | undefined): void => {
+  if (!record) {
+    throw new Error(`PII detector returned unknown record "${entity.recordId}"`);
+  }
+  if (
+    !Number.isInteger(entity.start) ||
+    !Number.isInteger(entity.end) ||
+    entity.start < 0 ||
+    entity.end <= entity.start ||
+    entity.end > record.text.length ||
+    record.text.slice(entity.start, entity.end) !== entity.value
+  ) {
+    throw new Error(`PII detector returned an invalid range for record "${entity.recordId}"`);
+  }
+};
+
+const applyDetectedEntities = ({
+  records,
+  entities,
+  tokenMap,
+  tokenize,
+  logger,
+}: {
+  records: readonly PiiTextRecord[];
+  entities: readonly DetectedPiiEntity[];
+  tokenMap: TokenMap;
+  tokenize: (entityClass: string, value: string) => string;
+  logger: PiiProtectionLogger;
+}): { values: ReadonlyMap<string, string>; tokenMap: TokenMap } => {
+  const recordsById = new Map(records.map((record) => [record.id, record]));
+  const entitiesByRecord = new Map<string, IndexedEntity[]>();
+
+  entities.forEach((entity, detectionIndex) => {
+    validateEntity(entity, recordsById.get(entity.recordId));
+    const recordEntities = entitiesByRecord.get(entity.recordId) ?? [];
+    recordEntities.push({ ...entity, detectionIndex });
+    entitiesByRecord.set(entity.recordId, recordEntities);
+  });
+
+  const nextTokenMap: TokenMap = { ...tokenMap };
+  const values = new Map<string, string>();
+
+  records.forEach((record) => {
+    const sortedEntities = [...(entitiesByRecord.get(record.id) ?? [])].sort(
+      (left, right) => left.start - right.start || left.detectionIndex - right.detectionIndex
+    );
+    let cursor = 0;
+    let output = '';
+
+    sortedEntities.forEach((entity) => {
+      if (entity.start < cursor) {
+        logger.warn('PII detector returned overlapping entities; ignoring the later match', {
+          recordId: entity.recordId,
+          entityClass: entity.entityClass,
+          start: entity.start,
+          end: entity.end,
+        });
+        return;
+      }
+
+      const token = tokenize(entity.entityClass, entity.value);
+      const existing = nextTokenMap[token];
+      if (
+        existing &&
+        (existing.original !== entity.value || existing.entityClass !== entity.entityClass)
+      ) {
+        logger.warn('PII token collision detected; failing workflow protection', {
+          existingEntityClass: existing.entityClass,
+          detectedEntityClass: entity.entityClass,
+        });
+        throw new Error('PII token collision detected');
+      }
+
+      output += record.text.slice(cursor, entity.start);
+      output += token;
+      cursor = entity.end;
+      nextTokenMap[token] = {
+        original: entity.value,
+        entityClass: entity.entityClass,
+      };
+    });
+
+    output += record.text.slice(cursor);
+    values.set(record.id, output);
+  });
+
+  return { values, tokenMap: nextTokenMap };
+};
+
+export const executePiiProtection = async ({
+  input,
+  capabilities,
+  abortSignal,
+  logger,
+}: {
+  input: AiPiiInput;
+  capabilities: Parameters<typeof getPiiTokenizationContext>[0];
+  abortSignal: AbortSignal;
+  logger: PiiProtectionLogger;
+}): Promise<AnonymizedCompletion> => {
+  const pii = getPiiTokenizationContext(capabilities);
+  const previousTokenMap = input.tokenMap ?? {};
+  const initialRecords = createCompletionTextRecords(input);
+  const knownReplacementValues = new Map(
+    initialRecords.records.map((record) => [
+      record.id,
+      replaceKnownOriginals(record.text, previousTokenMap),
+    ])
+  );
+  const protectedInput = initialRecords.replace(knownReplacementValues);
+  const detectionRecords = createCompletionTextRecords(protectedInput);
+  const entities = await pii.detectEntities({
+    records: detectionRecords.records,
+    rules: input.rules,
+    abortSignal,
+  });
+  abortSignal.throwIfAborted();
+
+  const protectedRecords = applyDetectedEntities({
+    records: detectionRecords.records,
+    entities,
+    tokenMap: previousTokenMap,
+    tokenize: pii.tokenize,
+    logger,
+  });
+
+  return {
+    ...detectionRecords.replace(protectedRecords.values),
+    tokenMap: protectedRecords.tokenMap,
+  };
+};
+
+export const aiPiiStepDefinition = createServerStepDefinition({
+  ...aiPiiCommonDefinition,
+  handler: async ({ input, capabilities, abortSignal, logger }) => {
+    return {
+      output: await executePiiProtection({ input, capabilities, abortSignal, logger }),
+    };
+  },
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/call_site_proceed_step.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/call_site_proceed_step.test.ts
@@ -10,7 +10,30 @@ import {
   INFERENCE_PROCEED_CAPABILITY_ID,
   type InferenceProceedInput,
 } from '@kbn/inference-plugin/server';
+import { callSiteProceedStepDefinition } from './call_site_proceed_step';
 import { getInferenceProceedCapability } from './capabilities';
+
+describe('callSiteProceedStepDefinition handler', () => {
+  it('forwards combined input and abortSignal to the proceed capability and returns rawContent', async () => {
+    const invoke = jest.fn().mockResolvedValue({ rawContent: 'RESULT' });
+    const abortSignal = new AbortController().signal;
+    const input: Omit<InferenceProceedInput, 'abortSignal'> = {
+      system: 'protected system',
+      messages: [{ role: MessageRole.User, content: 'text TOKEN' }],
+      tokenMap: { TOKEN: { original: 'secret', entityClass: 'ENTITY_NAME' } },
+    };
+    const capabilities = [{ id: INFERENCE_PROCEED_CAPABILITY_ID, value: { invoke } }];
+
+    const result = await callSiteProceedStepDefinition.handler({
+      input,
+      capabilities,
+      abortSignal,
+    });
+
+    expect(invoke).toHaveBeenCalledWith({ ...input, abortSignal });
+    expect(result).toEqual({ output: { rawContent: 'RESULT' } });
+  });
+});
 
 describe('inference proceed capability', () => {
   it('receives workflow-transformed input and its call-local token map', async () => {

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/call_site_proceed_step.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/call_site_proceed_step.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MessageRole } from '@kbn/inference-common';
+import {
+  INFERENCE_PROCEED_CAPABILITY_ID,
+  type InferenceProceedInput,
+} from '@kbn/inference-plugin/server';
+import { getInferenceProceedCapability } from './capabilities';
+
+describe('inference proceed capability', () => {
+  it('receives workflow-transformed input and its call-local token map', async () => {
+    const invoke = jest.fn().mockResolvedValue({ rawContent: 'TOKEN' });
+    const proceed = getInferenceProceedCapability([
+      { id: INFERENCE_PROCEED_CAPABILITY_ID, value: { invoke } },
+    ]);
+    const abortSignal = new AbortController().signal;
+    const input: InferenceProceedInput = {
+      system: 'protected system',
+      messages: [{ role: MessageRole.User, content: 'protected TOKEN' }],
+      tokenMap: { TOKEN: { original: 'secret', entityClass: 'ENTITY_NAME' } },
+      abortSignal,
+    };
+
+    await expect(proceed.invoke(input)).resolves.toEqual({ rawContent: 'TOKEN' });
+    expect(invoke).toHaveBeenCalledWith(input);
+  });
+
+  it('rejects a malformed capability', () => {
+    expect(() =>
+      getInferenceProceedCapability([
+        { id: INFERENCE_PROCEED_CAPABILITY_ID, value: { invoke: 'not-a-function' } },
+      ])
+    ).toThrow(`Workflow capability "${INFERENCE_PROCEED_CAPABILITY_ID}" is invalid`);
+  });
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/call_site_proceed_step.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/call_site_proceed_step.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { callSiteProceedCommonDefinition } from '../../common/workflow_anonymization';
+import { getInferenceProceedCapability } from './capabilities';
+
+export const callSiteProceedStepDefinition = createServerStepDefinition({
+  ...callSiteProceedCommonDefinition,
+  handler: async ({ input, capabilities, abortSignal }) => {
+    const proceed = getInferenceProceedCapability(capabilities);
+    const output = await proceed.invoke({ ...input, abortSignal });
+    return { output };
+  },
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/capabilities.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/capabilities.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  INFERENCE_PROCEED_CAPABILITY_ID,
+  PII_TOKENIZATION_CAPABILITY_ID,
+  type InferenceProceedCapability,
+  type PiiTokenizationContext,
+} from '@kbn/inference-plugin/server';
+import type { WorkflowExecutionCapabilities } from '@kbn/workflows-extensions/server';
+
+const getCapabilityValue = (
+  capabilities: WorkflowExecutionCapabilities | undefined,
+  id: string
+): object => {
+  const capability = capabilities?.find((entry) => entry.id === id);
+  if (!capability) {
+    throw new Error(`Workflow step requires the request-local "${id}" capability`);
+  }
+  return capability.value;
+};
+
+const isPiiTokenizationContext = (value: object): value is PiiTokenizationContext =>
+  'detectEntities' in value &&
+  typeof value.detectEntities === 'function' &&
+  'tokenize' in value &&
+  typeof value.tokenize === 'function';
+
+const isInferenceProceedCapability = (value: object): value is InferenceProceedCapability =>
+  'invoke' in value && typeof value.invoke === 'function';
+
+export const getPiiTokenizationContext = (
+  capabilities: WorkflowExecutionCapabilities | undefined
+): PiiTokenizationContext => {
+  const value = getCapabilityValue(capabilities, PII_TOKENIZATION_CAPABILITY_ID);
+  if (!isPiiTokenizationContext(value)) {
+    throw new Error(`Workflow capability "${PII_TOKENIZATION_CAPABILITY_ID}" is invalid`);
+  }
+  return value;
+};
+
+export const getInferenceProceedCapability = (
+  capabilities: WorkflowExecutionCapabilities | undefined
+): InferenceProceedCapability => {
+  const value = getCapabilityValue(capabilities, INFERENCE_PROCEED_CAPABILITY_ID);
+  if (!isInferenceProceedCapability(value)) {
+    throw new Error(`Workflow capability "${INFERENCE_PROCEED_CAPABILITY_ID}" is invalid`);
+  }
+  return value;
+};

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/create_workflow_anonymization_provider.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/create_workflow_anonymization_provider.test.ts
@@ -1,0 +1,227 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { MessageRole } from '@kbn/inference-common';
+import type {
+  AroundCompletionEvent,
+  InferenceProceedCapability,
+  PiiTokenizationContext,
+} from '@kbn/inference-plugin/server';
+import { ExecutionStatus, type WorkflowDetailDto, type WorkflowYaml } from '@kbn/workflows';
+import type { WorkflowsManagementApi } from '@kbn/workflows-management-plugin/server';
+import {
+  INFERENCE_PROCEED_CAPABILITY_ID,
+  PII_TOKENIZATION_CAPABILITY_ID,
+} from '@kbn/inference-plugin/server';
+import { aroundCompletionEventSchema } from '../../common/workflow_anonymization';
+import {
+  countWorkflowStepType,
+  createWorkflowAnonymizationProvider,
+} from './create_workflow_anonymization_provider';
+
+type Management = Pick<
+  WorkflowsManagementApi,
+  'resolveWorkflowTriggerMatches' | 'executeWorkflowSynchronously'
+>;
+
+const createManagement = (): jest.Mocked<Management> => ({
+  resolveWorkflowTriggerMatches: jest.fn(),
+  executeWorkflowSynchronously: jest.fn(),
+});
+
+const createAroundCompletionTrigger = (): WorkflowYaml['triggers'][number] => {
+  // The static WorkflowYaml type models built-ins only; registered triggers are added dynamically.
+  const trigger: WorkflowYaml['triggers'][number] = { type: 'manual' };
+  Reflect.set(trigger, 'type', 'inference.aroundCompletion');
+  return trigger;
+};
+
+const createWorkflow = (steps: WorkflowYaml['steps']): WorkflowDetailDto => ({
+  id: 'workflow-1',
+  name: 'Inference protection',
+  enabled: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  createdBy: 'system',
+  lastUpdatedAt: '2026-01-01T00:00:00.000Z',
+  lastUpdatedBy: 'system',
+  yaml: 'name: Inference protection',
+  valid: true,
+  definition: {
+    version: '1',
+    name: 'Inference protection',
+    enabled: true,
+    triggers: [createAroundCompletionTrigger()],
+    steps,
+  },
+});
+
+const proceedStep: WorkflowYaml['steps'][number] = {
+  name: 'proceed',
+  type: 'call_site.proceed',
+  with: {},
+};
+
+const event: AroundCompletionEvent = {
+  messages: [{ role: MessageRole.User, content: 'hello' }],
+};
+const pii: PiiTokenizationContext = {
+  detectEntities: jest.fn().mockResolvedValue([]),
+  tokenize: jest.fn(),
+};
+const proceed: InferenceProceedCapability = {
+  invoke: jest.fn().mockResolvedValue({ rawContent: 'protected' }),
+};
+
+describe('countWorkflowStepType', () => {
+  it('counts nested workflow steps without inspecting step configuration', () => {
+    const configuredStep: WorkflowYaml['steps'][number] = {
+      name: 'configured',
+      type: 'test.step',
+      with: { type: 'call_site.proceed' },
+    };
+    const conditionalStep: WorkflowYaml['steps'][number] = {
+      name: 'conditional',
+      type: 'if',
+      condition: 'true',
+      steps: [proceedStep],
+    };
+
+    expect(countWorkflowStepType([configuredStep, conditionalStep], 'call_site.proceed')).toBe(1);
+  });
+});
+
+describe('createWorkflowAnonymizationProvider', () => {
+  it('returns without execution when no workflow matches', async () => {
+    const management = createManagement();
+    management.resolveWorkflowTriggerMatches.mockResolvedValue({
+      matched: [],
+      invalidConditionWorkflowIds: [],
+    });
+    const provider = createWorkflowAnonymizationProvider({ management });
+
+    await expect(
+      provider.execute({
+        event,
+        namespace: 'space-a',
+        request: httpServerMock.createKibanaRequest(),
+        pii,
+        proceed,
+      })
+    ).resolves.toEqual({ matched: false });
+    expect(management.executeWorkflowSynchronously).not.toHaveBeenCalled();
+  });
+
+  it('executes one matching workflow synchronously with request-local capabilities', async () => {
+    const management = createManagement();
+    management.resolveWorkflowTriggerMatches.mockResolvedValue({
+      matched: [createWorkflow([proceedStep])],
+      invalidConditionWorkflowIds: [],
+    });
+    management.executeWorkflowSynchronously.mockResolvedValue({
+      workflowExecutionId: 'execution-1',
+      result: { status: ExecutionStatus.COMPLETED, output: { content: 'restored content' } },
+    });
+    const provider = createWorkflowAnonymizationProvider({ management });
+    const request = httpServerMock.createKibanaRequest();
+    const abortSignal = new AbortController().signal;
+    const parsedEvent = aroundCompletionEventSchema.parse(event);
+
+    await expect(
+      provider.execute({ event, namespace: 'space-a', request, pii, proceed, abortSignal })
+    ).resolves.toEqual({ matched: true, content: 'restored content' });
+    expect(management.executeWorkflowSynchronously).toHaveBeenCalledWith({
+      workflowId: 'workflow-1',
+      context: {
+        event: parsedEvent,
+        spaceId: 'space-a',
+        triggeredBy: 'inference.aroundCompletion',
+      },
+      spaceId: 'space-a',
+      request,
+      capabilities: [
+        { id: PII_TOKENIZATION_CAPABILITY_ID, value: pii },
+        { id: INFERENCE_PROCEED_CAPABILITY_ID, value: proceed },
+      ],
+      abortSignal,
+    });
+    const [{ context }] = management.executeWorkflowSynchronously.mock.calls[0];
+    expect(context.event).not.toBe(event);
+  });
+
+  it('rejects invalid trigger conditions and overlapping workflow matches before execution', async () => {
+    const management = createManagement();
+    const provider = createWorkflowAnonymizationProvider({ management });
+
+    management.resolveWorkflowTriggerMatches.mockResolvedValue({
+      matched: [createWorkflow([proceedStep])],
+      invalidConditionWorkflowIds: ['invalid-workflow'],
+    });
+    await expect(
+      provider.execute({
+        event,
+        namespace: 'space-a',
+        request: httpServerMock.createKibanaRequest(),
+        pii,
+        proceed,
+      })
+    ).rejects.toThrow('invalid-workflow');
+    expect(management.executeWorkflowSynchronously).not.toHaveBeenCalled();
+
+    management.resolveWorkflowTriggerMatches.mockResolvedValue({
+      matched: [createWorkflow([proceedStep]), createWorkflow([proceedStep])],
+      invalidConditionWorkflowIds: [],
+    });
+    await expect(
+      provider.execute({
+        event,
+        namespace: 'space-a',
+        request: httpServerMock.createKibanaRequest(),
+        pii,
+        proceed,
+      })
+    ).rejects.toThrow('Multiple workflows matched');
+    expect(management.executeWorkflowSynchronously).not.toHaveBeenCalled();
+  });
+
+  it('requires exactly one proceed step and a string workflow output', async () => {
+    const management = createManagement();
+    const provider = createWorkflowAnonymizationProvider({ management });
+
+    management.resolveWorkflowTriggerMatches.mockResolvedValue({
+      matched: [createWorkflow([])],
+      invalidConditionWorkflowIds: [],
+    });
+    await expect(
+      provider.execute({
+        event,
+        namespace: 'space-a',
+        request: httpServerMock.createKibanaRequest(),
+        pii,
+        proceed,
+      })
+    ).rejects.toThrow('must contain exactly one');
+
+    management.resolveWorkflowTriggerMatches.mockResolvedValue({
+      matched: [createWorkflow([proceedStep])],
+      invalidConditionWorkflowIds: [],
+    });
+    management.executeWorkflowSynchronously.mockResolvedValue({
+      workflowExecutionId: 'execution-1',
+      result: { status: ExecutionStatus.COMPLETED, output: {} },
+    });
+    await expect(
+      provider.execute({
+        event,
+        namespace: 'space-a',
+        request: httpServerMock.createKibanaRequest(),
+        pii,
+        proceed,
+      })
+    ).rejects.toThrow('did not return string content');
+  });
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/create_workflow_anonymization_provider.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/create_workflow_anonymization_provider.test.ts
@@ -19,10 +19,7 @@ import {
   PII_TOKENIZATION_CAPABILITY_ID,
 } from '@kbn/inference-plugin/server';
 import { aroundCompletionEventSchema } from '../../common/workflow_anonymization';
-import {
-  countWorkflowStepType,
-  createWorkflowAnonymizationProvider,
-} from './create_workflow_anonymization_provider';
+import { createWorkflowAnonymizationProvider } from './create_workflow_anonymization_provider';
 
 type Management = Pick<
   WorkflowsManagementApi,
@@ -77,24 +74,6 @@ const proceed: InferenceProceedCapability = {
   invoke: jest.fn().mockResolvedValue({ rawContent: 'protected' }),
 };
 
-describe('countWorkflowStepType', () => {
-  it('counts nested workflow steps without inspecting step configuration', () => {
-    const configuredStep: WorkflowYaml['steps'][number] = {
-      name: 'configured',
-      type: 'test.step',
-      with: { type: 'call_site.proceed' },
-    };
-    const conditionalStep: WorkflowYaml['steps'][number] = {
-      name: 'conditional',
-      type: 'if',
-      condition: 'true',
-      steps: [proceedStep],
-    };
-
-    expect(countWorkflowStepType([configuredStep, conditionalStep], 'call_site.proceed')).toBe(1);
-  });
-});
-
 describe('createWorkflowAnonymizationProvider', () => {
   it('returns without execution when no workflow matches', async () => {
     const management = createManagement();
@@ -136,6 +115,7 @@ describe('createWorkflowAnonymizationProvider', () => {
     ).resolves.toEqual({ matched: true, content: 'restored content' });
     expect(management.executeWorkflowSynchronously).toHaveBeenCalledWith({
       workflowId: 'workflow-1',
+      workflow: expect.objectContaining({ id: 'workflow-1' }),
       context: {
         event: parsedEvent,
         spaceId: 'space-a',

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/create_workflow_anonymization_provider.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/create_workflow_anonymization_provider.ts
@@ -23,7 +23,7 @@ type WorkflowAnonymizationManagement = Pick<
   'resolveWorkflowTriggerMatches' | 'executeWorkflowSynchronously'
 >;
 
-export const countWorkflowStepType = (steps: WorkflowYaml['steps'], stepType: string): number => {
+const countWorkflowStepType = (steps: WorkflowYaml['steps'], stepType: string): number => {
   let count = 0;
   visitNestedSteps(steps, ({ step }) => {
     if (step.type === stepType) {
@@ -41,6 +41,9 @@ export const createWorkflowAnonymizationProvider = ({
   supportsSynchronousExecution: true,
   execute: async ({ event, namespace, request, pii, proceed, abortSignal }) => {
     const parsedEvent = aroundCompletionEventSchema.parse(event);
+    // NOTE: getWorkflowsSubscribedToTrigger is unbounded (PIT + search_after), but for the
+    // around-completion trigger the effective matched set is enforced by the >1 throw below.
+    // Do not add a hard cap to the shared method — it also serves the event-driven execution path.
     const resolution = await management.resolveWorkflowTriggerMatches(
       INFERENCE_AROUND_COMPLETION_TRIGGER_ID,
       parsedEvent,
@@ -76,6 +79,9 @@ export const createWorkflowAnonymizationProvider = ({
 
     const response = await management.executeWorkflowSynchronously({
       workflowId: workflow.id,
+      // Pass the already-fetched DTO to avoid a second ES read on the inference hot path.
+      // executeWorkflowSynchronously validates the DTO (enabled/valid/definition) before executing.
+      workflow,
       context: {
         event: parsedEvent,
         spaceId: namespace,

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/create_workflow_anonymization_provider.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/create_workflow_anonymization_provider.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ExecutionStatus, visitNestedSteps, type WorkflowYaml } from '@kbn/workflows';
+import type { WorkflowAnonymizationProvider } from '@kbn/inference-plugin/server';
+import type { WorkflowsManagementApi } from '@kbn/workflows-management-plugin/server';
+import {
+  INFERENCE_PROCEED_CAPABILITY_ID,
+  PII_TOKENIZATION_CAPABILITY_ID,
+} from '@kbn/inference-plugin/server';
+import {
+  aroundCompletionEventSchema,
+  CALL_SITE_PROCEED_STEP_ID,
+  INFERENCE_AROUND_COMPLETION_TRIGGER_ID,
+} from '../../common/workflow_anonymization';
+
+type WorkflowAnonymizationManagement = Pick<
+  WorkflowsManagementApi,
+  'resolveWorkflowTriggerMatches' | 'executeWorkflowSynchronously'
+>;
+
+export const countWorkflowStepType = (steps: WorkflowYaml['steps'], stepType: string): number => {
+  let count = 0;
+  visitNestedSteps(steps, ({ step }) => {
+    if (step.type === stepType) {
+      count += 1;
+    }
+  });
+  return count;
+};
+
+export const createWorkflowAnonymizationProvider = ({
+  management,
+}: {
+  management: WorkflowAnonymizationManagement;
+}): WorkflowAnonymizationProvider => ({
+  supportsSynchronousExecution: true,
+  execute: async ({ event, namespace, request, pii, proceed, abortSignal }) => {
+    const parsedEvent = aroundCompletionEventSchema.parse(event);
+    const resolution = await management.resolveWorkflowTriggerMatches(
+      INFERENCE_AROUND_COMPLETION_TRIGGER_ID,
+      parsedEvent,
+      namespace
+    );
+
+    if (resolution.invalidConditionWorkflowIds.length > 0) {
+      // Fail closed across the space. Ignoring a malformed subscribed policy could allow an
+      // unprotected connector call when the workflow author intended that policy to match.
+      throw new Error(
+        `Invalid around-completion trigger condition in workflow(s): ${resolution.invalidConditionWorkflowIds.join(
+          ', '
+        )}`
+      );
+    }
+    if (resolution.matched.length === 0) {
+      return { matched: false };
+    }
+    if (resolution.matched.length > 1) {
+      throw new Error('Multiple workflows matched the around-completion inference event');
+    }
+
+    const [workflow] = resolution.matched;
+    const proceedCount = countWorkflowStepType(
+      workflow.definition?.steps ?? [],
+      CALL_SITE_PROCEED_STEP_ID
+    );
+    if (proceedCount !== 1) {
+      throw new Error(
+        `Workflow "${workflow.id}" must contain exactly one ${CALL_SITE_PROCEED_STEP_ID} step`
+      );
+    }
+
+    const response = await management.executeWorkflowSynchronously({
+      workflowId: workflow.id,
+      context: {
+        event: parsedEvent,
+        spaceId: namespace,
+        triggeredBy: INFERENCE_AROUND_COMPLETION_TRIGGER_ID,
+      },
+      spaceId: namespace,
+      request,
+      capabilities: [
+        { id: PII_TOKENIZATION_CAPABILITY_ID, value: pii },
+        { id: INFERENCE_PROCEED_CAPABILITY_ID, value: proceed },
+      ],
+      abortSignal,
+    });
+
+    if (response.result?.status !== ExecutionStatus.COMPLETED) {
+      throw new Error(`Workflow "${workflow.id}" did not complete successfully`);
+    }
+    const content = response.result.output?.content;
+    if (typeof content !== 'string') {
+      throw new Error(`Workflow "${workflow.id}" did not return string content`);
+    }
+
+    return { matched: true, content };
+  },
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/message_records.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/message_records.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MessageRole } from '@kbn/inference-common';
+import { createCompletionTextRecords } from './message_records';
+
+describe('createCompletionTextRecords', () => {
+  it('throws when tool-call arguments exceed the maximum nesting depth', () => {
+    // Build a structure that is 101 levels deep — one beyond MAX_STRUCTURED_DEPTH (100).
+    // Tool-call arguments are user-influenced and could be arbitrarily nested; the guard
+    // ensures we fail closed rather than recurse until OOM.
+    const deeplyNestedArgs: Record<string, unknown> = {};
+    let level: Record<string, unknown> = deeplyNestedArgs;
+    for (let i = 0; i < 101; i++) {
+      const next: Record<string, unknown> = {};
+      level.nested = next;
+      level = next;
+    }
+    level.value = 'secret';
+
+    expect(() =>
+      createCompletionTextRecords({
+        messages: [
+          {
+            role: MessageRole.Assistant,
+            content: null,
+            toolCalls: [
+              {
+                toolCallId: 'call-1',
+                function: { name: 'test', arguments: deeplyNestedArgs },
+              },
+            ],
+          },
+        ],
+      })
+    ).toThrow('maximum nesting depth');
+  });
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/message_records.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/message_records.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MessageRole, type Message } from '@kbn/inference-common';
+import type { PiiTextRecord } from '@kbn/inference-plugin/server';
+
+type RecordValues = ReadonlyMap<string, string>;
+
+const collectStructuredStrings = (value: unknown, path: string, records: PiiTextRecord[]): void => {
+  if (typeof value === 'string') {
+    records.push({ id: path, text: value });
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectStructuredStrings(item, `${path}/${index}`, records));
+    return;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  if (objectValue.type === 'image') {
+    return;
+  }
+
+  Object.entries(objectValue).forEach(([key, entry]) =>
+    collectStructuredStrings(entry, `${path}/${key}`, records)
+  );
+};
+
+const replaceStructuredStrings = <T>(value: T, path: string, values: RecordValues): T => {
+  if (typeof value === 'string') {
+    return (values.get(path) ?? value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      replaceStructuredStrings(item, `${path}/${index}`, values)
+    ) as T;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  if (objectValue.type === 'image') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(objectValue).map(([key, entry]) => [
+      key,
+      replaceStructuredStrings(entry, `${path}/${key}`, values),
+    ])
+  ) as T;
+};
+
+const collectMessageStrings = (message: Message, index: number, records: PiiTextRecord[]): void => {
+  const path = `/messages/${index}`;
+
+  if (message.role === MessageRole.User) {
+    if (typeof message.content === 'string') {
+      records.push({ id: `${path}/content`, text: message.content });
+      return;
+    }
+
+    message.content.forEach((content, contentIndex) => {
+      if (content.type === 'text') {
+        records.push({ id: `${path}/content/${contentIndex}/text`, text: content.text });
+      }
+    });
+    return;
+  }
+
+  if (message.role === MessageRole.Assistant) {
+    if (typeof message.content === 'string') {
+      records.push({ id: `${path}/content`, text: message.content });
+    }
+    message.toolCalls?.forEach((toolCall, toolCallIndex) =>
+      collectStructuredStrings(
+        toolCall.function.arguments,
+        `${path}/toolCalls/${toolCallIndex}/function/arguments`,
+        records
+      )
+    );
+    return;
+  }
+
+  collectStructuredStrings(message.response, `${path}/response`, records);
+  if (message.data !== undefined) {
+    collectStructuredStrings(message.data, `${path}/data`, records);
+  }
+};
+
+const replaceMessageStrings = (message: Message, index: number, values: RecordValues): Message => {
+  const path = `/messages/${index}`;
+
+  if (message.role === MessageRole.User) {
+    return {
+      ...message,
+      content:
+        typeof message.content === 'string'
+          ? values.get(`${path}/content`) ?? message.content
+          : message.content.map((content, contentIndex) =>
+              content.type === 'text'
+                ? {
+                    ...content,
+                    text: values.get(`${path}/content/${contentIndex}/text`) ?? content.text,
+                  }
+                : content
+            ),
+    };
+  }
+
+  if (message.role === MessageRole.Assistant) {
+    return {
+      ...message,
+      content:
+        typeof message.content === 'string'
+          ? values.get(`${path}/content`) ?? message.content
+          : message.content,
+      toolCalls: message.toolCalls?.map((toolCall, toolCallIndex) => ({
+        ...toolCall,
+        function: {
+          ...toolCall.function,
+          arguments: replaceStructuredStrings(
+            toolCall.function.arguments,
+            `${path}/toolCalls/${toolCallIndex}/function/arguments`,
+            values
+          ),
+        },
+      })),
+    };
+  }
+
+  return {
+    ...message,
+    response: replaceStructuredStrings(message.response, `${path}/response`, values),
+    ...(message.data !== undefined
+      ? { data: replaceStructuredStrings(message.data, `${path}/data`, values) }
+      : {}),
+  };
+};
+
+export const createCompletionTextRecords = ({
+  system,
+  messages,
+}: {
+  system?: string;
+  messages: readonly Message[];
+}): {
+  records: readonly PiiTextRecord[];
+  replace(values: RecordValues): { system?: string; messages: Message[] };
+} => {
+  const records: PiiTextRecord[] = [];
+  if (system !== undefined) {
+    records.push({ id: '/system', text: system });
+  }
+  messages.forEach((message, index) => collectMessageStrings(message, index, records));
+
+  return {
+    records,
+    replace: (values) => ({
+      ...(system !== undefined ? { system: values.get('/system') ?? system } : {}),
+      messages: messages.map((message, index) => replaceMessageStrings(message, index, values)),
+    }),
+  };
+};

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/message_records.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/message_records.ts
@@ -10,14 +10,31 @@ import type { PiiTextRecord } from '@kbn/inference-plugin/server';
 
 type RecordValues = ReadonlyMap<string, string>;
 
-const collectStructuredStrings = (value: unknown, path: string, records: PiiTextRecord[]): void => {
+// Fail-closed guard: tool-call arguments are user-influenced and could be arbitrarily nested.
+// Exceeding this depth throws rather than silently truncating or OOM-ing.
+const MAX_STRUCTURED_DEPTH = 100;
+
+const collectStructuredStrings = (
+  value: unknown,
+  path: string,
+  records: PiiTextRecord[],
+  depth = 0
+): void => {
+  if (depth > MAX_STRUCTURED_DEPTH) {
+    throw new Error(
+      `PII scanner exceeded maximum nesting depth (${MAX_STRUCTURED_DEPTH}) at path "${path}"`
+    );
+  }
+
   if (typeof value === 'string') {
     records.push({ id: path, text: value });
     return;
   }
 
   if (Array.isArray(value)) {
-    value.forEach((item, index) => collectStructuredStrings(item, `${path}/${index}`, records));
+    value.forEach((item, index) =>
+      collectStructuredStrings(item, `${path}/${index}`, records, depth + 1)
+    );
     return;
   }
 
@@ -31,18 +48,29 @@ const collectStructuredStrings = (value: unknown, path: string, records: PiiText
   }
 
   Object.entries(objectValue).forEach(([key, entry]) =>
-    collectStructuredStrings(entry, `${path}/${key}`, records)
+    collectStructuredStrings(entry, `${path}/${key}`, records, depth + 1)
   );
 };
 
-const replaceStructuredStrings = <T>(value: T, path: string, values: RecordValues): T => {
+const replaceStructuredStrings = <T>(
+  value: T,
+  path: string,
+  values: RecordValues,
+  depth = 0
+): T => {
+  if (depth > MAX_STRUCTURED_DEPTH) {
+    throw new Error(
+      `PII scanner exceeded maximum nesting depth (${MAX_STRUCTURED_DEPTH}) at path "${path}"`
+    );
+  }
+
   if (typeof value === 'string') {
     return (values.get(path) ?? value) as T;
   }
 
   if (Array.isArray(value)) {
     return value.map((item, index) =>
-      replaceStructuredStrings(item, `${path}/${index}`, values)
+      replaceStructuredStrings(item, `${path}/${index}`, values, depth + 1)
     ) as T;
   }
 
@@ -58,7 +86,7 @@ const replaceStructuredStrings = <T>(value: T, path: string, values: RecordValue
   return Object.fromEntries(
     Object.entries(objectValue).map(([key, entry]) => [
       key,
-      replaceStructuredStrings(entry, `${path}/${key}`, values),
+      replaceStructuredStrings(entry, `${path}/${key}`, values, depth + 1),
     ])
   ) as T;
 };

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/pii_restore_step.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/pii_restore_step.test.ts
@@ -5,15 +5,19 @@
  * 2.0.
  */
 
-import {
-  executePiiRestore,
-  piiRestoreStepDefinition,
-  piiRestoreStepHandler,
-} from './pii_restore_step';
+import { executePiiRestore, piiRestoreStepDefinition } from './pii_restore_step';
 
 describe('piiRestoreStepDefinition', () => {
-  it('wires the tested restoration handler into the step definition', () => {
-    expect(piiRestoreStepDefinition.handler).toBe(piiRestoreStepHandler);
+  it('restores protected values through the step definition handler', async () => {
+    const result = await piiRestoreStepDefinition.handler({
+      input: {
+        rawContent: 'Contact EMAIL_TOKEN',
+        tokenMap: {
+          EMAIL_TOKEN: { original: 'person@example.com', entityClass: 'EMAIL' },
+        },
+      },
+    });
+    expect(result).toEqual({ output: { content: 'Contact person@example.com' } });
   });
 
   it('restores protected values in final response content', () => {

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/pii_restore_step.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/pii_restore_step.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  executePiiRestore,
+  piiRestoreStepDefinition,
+  piiRestoreStepHandler,
+} from './pii_restore_step';
+
+describe('piiRestoreStepDefinition', () => {
+  it('wires the tested restoration handler into the step definition', () => {
+    expect(piiRestoreStepDefinition.handler).toBe(piiRestoreStepHandler);
+  });
+
+  it('restores protected values in final response content', () => {
+    expect(
+      executePiiRestore({
+        rawContent: 'Contact EMAIL_TOKEN',
+        tokenMap: {
+          EMAIL_TOKEN: { original: 'person@example.com', entityClass: 'EMAIL' },
+        },
+      })
+    ).toEqual({ content: 'Contact person@example.com' });
+  });
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/pii_restore_step.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/pii_restore_step.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { piiRestoreCommonDefinition } from '../../common/workflow_anonymization';
+import { restoreTokens } from './token_map';
+
+export const executePiiRestore = ({
+  rawContent,
+  tokenMap,
+}: {
+  rawContent: string;
+  tokenMap: Parameters<typeof restoreTokens>[1];
+}): { content: string } => ({ content: restoreTokens(rawContent, tokenMap) });
+
+export const piiRestoreStepHandler = async ({
+  input,
+}: {
+  input: Parameters<typeof executePiiRestore>[0];
+}) => ({
+  output: executePiiRestore(input),
+});
+
+export const piiRestoreStepDefinition = createServerStepDefinition({
+  ...piiRestoreCommonDefinition,
+  handler: piiRestoreStepHandler,
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/token_map.test.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/token_map.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { replaceKnownOriginals, restoreTokens } from './token_map';
+
+describe('token map transformations', () => {
+  const tokenMap = {
+    SHORT_TOKEN: { original: 'secret', entityClass: 'ENTITY_NAME' },
+    LONG_TOKEN: { original: 'secret value', entityClass: 'ENTITY_NAME' },
+  };
+
+  it('replaces longer originals first', () => {
+    expect(replaceKnownOriginals('a secret value and secret', tokenMap)).toBe(
+      'a LONG_TOKEN and SHORT_TOKEN'
+    );
+  });
+
+  it('restores every occurrence of call-local tokens', () => {
+    expect(restoreTokens('LONG_TOKEN then SHORT_TOKEN and SHORT_TOKEN', tokenMap)).toBe(
+      'secret value then secret and secret'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/token_map.ts
+++ b/x-pack/platform/plugins/shared/inference_workflows/server/workflow_anonymization/token_map.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TokenMap } from '../../common/workflow_anonymization';
+
+export const replaceKnownOriginals = (value: string, tokenMap: TokenMap): string =>
+  Object.entries(tokenMap)
+    .sort(([, left], [, right]) => right.original.length - left.original.length)
+    .reduce(
+      (current, [token, entry]) =>
+        entry.original ? current.split(entry.original).join(token) : current,
+      value
+    );
+
+export const restoreTokens = (value: string, tokenMap: TokenMap): string =>
+  Object.entries(tokenMap)
+    .sort(([left], [right]) => right.length - left.length)
+    .reduce(
+      (current, [token, entry]) => (token ? current.split(token).join(entry.original) : current),
+      value
+    );

--- a/x-pack/platform/plugins/shared/inference_workflows/tsconfig.json
+++ b/x-pack/platform/plugins/shared/inference_workflows/tsconfig.json
@@ -11,6 +11,7 @@
     "@kbn/zod",
     "@kbn/workflows",
     "@kbn/workflows-extensions",
+    "@kbn/workflows-management-plugin",
     "@kbn/inference-plugin",
     "@kbn/inference-common",
     "@kbn/search-inference-endpoints"


### PR DESCRIPTION
## About the stacked PRs

### Stack — workflow-driven inference anonymization

| # | PR | What |
|---|---|---|
| 1 | [#282476](https://github.com/elastic/kibana/pull/282476) | Synchronous execution + type foundation |
| 2 | [#282477](https://github.com/elastic/kibana/pull/282477) ← **this PR** | Anonymization step implementations + provider |
| 3 | [#282478](https://github.com/elastic/kibana/pull/282478) | Pipeline integration (wires anonymization to `inference.aroundCompletion`) |
| 4 | [#282479](https://github.com/elastic/kibana/pull/282479) | Metadata propagation (agentId + sessionId) |
| 5 | [#282480](https://github.com/elastic/kibana/pull/282480) | Sync log drain (removes inline ES writes from the hot path) |



> [!TIP]
> This PR is stacked on [PR 1 — Synchronous execution + type foundation](https://github.com/elastic/kibana/pull/282476), to review only the changes introduced in this pr see: [Incremental diff vs PR 1](https://github.com/jonwalstedt/kibana/compare/pr1/workflows-sync-execution-mode...pr2/inference-anonymization-building-blocks) or see the full final state in [PR5](https://github.com/elastic/kibana/pull/282480).

## Summary

**The goal of the stack** is to let the inference plugin intercept every LLM completion call and run a PII anonymization workflow synchronously — before tokens reach the model and again after the model responds — all within the lifetime of a single HTTP request, with no background tasks and no persisted execution state.

PR 1 built a synchronous execution engine that can run a workflow in-process and inject request-scoped objects into steps — but had nothing to run. This PR fills that gap: the three steps that implement the anonymization logic, the capability contracts those steps depend on, and the provider that sits between the inference hook and the workflow engine. None of it fires until PR 3 wires the `inference.aroundCompletion` hook.

> [!IMPORTANT]
> **"Synchronous" is a call-site contract, not an absence of Promises.** The HTTP request blocks until the workflow completes and the result is returned directly, rather than handing off to a background Task Manager task. Steps are still `async` functions; the execution loop is still `await`-ed. The only difference from the async path is that no concurrent `persistenceLoop` flushes state to Elasticsearch — because there is no state to flush. See [PR 1](https://github.com/elastic/kibana/pull/282476) for the full execution model.

---

## The three-step pipeline

The pipeline could have been a single function, but a three-step workflow structure makes one guarantee explicit: the LLM is called **exactly once**. The provider verifies step count before execution — a workflow with zero `call_site.proceed` steps would anonymize and discard the request; two would call the LLM twice. The structure makes both misconfiguration cases immediately visible.

The three steps are:

1. **`ai.pii`** — scan messages for PII entities, replace them with opaque tokens, accumulate the token map
2. **`call_site.proceed`** — invoke the LLM with the anonymized messages; return the raw response with tokens still in place
3. **`transform.pii_restore`** — replace tokens with original values in the model response

```mermaid
sequenceDiagram
    participant Provider as WorkflowAnonymizationProvider
    participant Engine as workflowExecutionLoop (sync)
    participant S1 as ai.pii step
    participant S2 as call_site.proceed step
    participant S3 as transform.pii_restore step
    participant Pii as PiiTokenizationContext (capability)
    participant Proceed as InferenceProceedCapability (capability)

    Provider->>Engine: executeWorkflowSynchronously(capabilities=[pii, proceed])
    Engine->>S1: handler({ input: { messages, rules }, capabilities })
    S1->>Pii: detectEntities(records, rules)
    Pii-->>S1: DetectedPiiEntity[]
    S1-->>Engine: { messages (anonymized), tokenMap }

    Engine->>S2: handler({ input: { messages (anonymized), tokenMap }, capabilities })
    S2->>Proceed: invoke({ messages, tokenMap })
    Note over Proceed: Calls LLM connector — streaming resolved internally (built in PR 3)
    Proceed-->>S2: { rawContent }
    S2-->>Engine: { rawContent }

    Engine->>S3: handler({ input: { rawContent, tokenMap } })
    S3-->>Engine: { content (PII restored) }

    Engine-->>Provider: ExecutionStatus.COMPLETED, output.content
    Provider-->>Caller: { matched: true, content }
```

---

## Request-local capabilities

The two objects the steps depend on cannot be serialized into workflow state, so they arrive as **capabilities** — opaque, request-scoped values passed through the injection mechanism introduced in PR 1.

**`PiiTokenizationContext`** holds a closure over an HMAC-derived execution scope:

```typescript
createHmac('sha256', serverSalt).update(`session:${sessionId}`).digest('hex')
```

`serverSalt` comes from `xpack.inference.anonymization.encryptionKey` — an operator-configured secret that must stay server-side. With it, tokens are opaque even to someone who knows the session ID; without it, tokens are session-stable but predictable. Serializing this context would expose the derived scope and break that guarantee.

**`InferenceProceedCapability`** holds a live relay into the caller's streaming observable. The `call_site.proceed` step must invoke the LLM, stream chunks to the caller in real time, and return the terminal response — all as a single synchronous step from the workflow's perspective. PR 3 implements this via a `Subject` created in the `aroundCompletion` handler and injected as a capability. It cannot be reconstructed from serialized state because the subscription it feeds belongs to a specific live request.

Both capability interfaces (`PiiTokenizationContext`, `InferenceProceedCapability`) are defined in the `inference` plugin rather than `inference_workflows` so that the dependency direction flows correctly: `inference_workflows` depends on `inference`, not the other way around. The provider itself (`createWorkflowAnonymizationProvider`) is implemented in `inference_workflows` and injected into `inference` during `setup()`.

---

## Provider behavior

The provider resolves which workflows in the current space are subscribed to the `inference.aroundCompletion` trigger, then executes the matched workflow synchronously. A few intentional constraints:

- **Fail-closed on invalid conditions.** If any subscribed workflow has an unparseable trigger condition, the call throws rather than skipping the broken workflow. Silently skipping would mean a space with a misconfigured PII policy passes all LLM calls through unprotected — worse than an error.
- **Exactly one match required.** Zero matches returns `{ matched: false }` and inference proceeds normally. More than one match throws; overlapping policies are a configuration error, not a tie-break situation.
- **Single proceed step enforced.** Checked before execution, as above.

```mermaid
flowchart TD
    A["provider.execute(event, pii, proceed)"] --> B["resolveWorkflowTriggerMatches"]
    B --> L{invalidConditionWorkflows?}
    L -->|non-empty| M["throw — fail closed"]
    L -->|empty| C{matched.length}
    C -->|0| D["return { matched: false }"]
    C -->|>1| E["throw: multiple workflows matched"]
    C -->|1| F{exactly one proceed step?}
    F -->|no| G["throw: invalid workflow structure"]
    F -->|yes| H["executeWorkflowSynchronously\n(capabilities=[pii, proceed])"]
    H --> I{status === COMPLETED?}
    I -->|no| J["throw: workflow did not complete"]
    I -->|yes| K["return { matched: true, content }"]
```

---

## What comes next (PR 3)

This PR registers the provider with `inference` during `setup()` but leaves two seams open for PR 3:

- **No `proceed` capability implementation yet.** The `InferenceProceedCapability` interface is defined here; the implementation — the relay `Subject`, real-time chunk restoration, and tool-call argument de-anonymization — is built in PR 3 as part of the `aroundCompletion` hook.
- **No managed workflow YAML yet.** The `inference_pii_anonymization` workflow that subscribes to `inference.aroundCompletion` and the per-space installer are added in PR 3.

`inference` won't use the registered provider in `chatComplete` until PR 3 enables `xpack.inference.anonymization.workflow_driven` (default `false`).

---

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

**Low risk overall.** Steps only execute when a matching workflow runs in sync mode, which requires `xpack.inference.anonymization.workflow_driven: true` (introduced in PR 3, default `false`). No call site exists until PR 3.

**Capability validation** — typed accessors validate shape at resolution time and throw diagnostic errors rather than allowing confusing failures inside step handlers.

### Release note

> No user-facing changes — internal anonymization workflow step implementations and provider.

**Suggested label:** `release_note:skip`

