### PR TITLE
[Cases] Fall back to email for the reporter name in the case view header

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.test.ts
@@ -174,6 +174,38 @@ describe('useCaseViewHeader', () => {
     );
   });
 
+  it('falls back to the reporter email when the full name is missing', () => {
+    const caseWithoutFullName: CaseUI = {
+      ...basicCase,
+      createdBy: { username: 'lknope', fullName: null, email: 'leslie.knope@elastic.co' },
+    };
+    const { result } = renderHook(
+      () => useCaseViewHeader({ ...defaultArgs, caseData: caseWithoutFullName }),
+      { wrapper }
+    );
+
+    const reportedBy = result.current.metadata.find(
+      (m) => m?.['data-test-subj'] === 'case-view-reported-by'
+    );
+    expect(reportedBy?.label).toBe('Reported by: leslie.knope@elastic.co');
+  });
+
+  it('falls back to the reporter username when full name and email are missing', () => {
+    const caseWithUsernameOnly: CaseUI = {
+      ...basicCase,
+      createdBy: { username: 'lknope', fullName: null, email: null },
+    };
+    const { result } = renderHook(
+      () => useCaseViewHeader({ ...defaultArgs, caseData: caseWithUsernameOnly }),
+      { wrapper }
+    );
+
+    const reportedBy = result.current.metadata.find(
+      (m) => m?.['data-test-subj'] === 'case-view-reported-by'
+    );
+    expect(reportedBy?.label).toBe('Reported by: lknope');
+  });
+
   it('returns a backHref', () => {
     const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
       wrapper,

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.tsx
@@ -86,8 +86,14 @@ export const useCaseViewHeader = ({
 
   // Metadata
   const metadata = useMemo((): AppHeaderMetadataItems => {
+    // Same precedence as `getUserDisplayName` (used for the participant avatars next to this
+    // header) so both surfaces show the same name — e.g. serverless operator users have an email
+    // but no full name.
     const reporterName =
-      caseData.createdBy.fullName || caseData.createdBy.username || UNKNOWN_REPORTER;
+      caseData.createdBy.fullName ||
+      caseData.createdBy.email ||
+      caseData.createdBy.username ||
+      UNKNOWN_REPORTER;
     const formattedDate = moment.tz(caseData.createdAt, timeZone).format(dateFormat);
 
     const reportedByItem = {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_case.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_case.ts
@@ -79,7 +79,9 @@ export const attachTimeline = (newCase: TestCase) => {
         }
       });
     },
-    { interval: 500, timeout: 12000 }
+    // The timeline is created via the API right before this and can take a while to show up in
+    // the selector's search on slower environments (serverless MKI).
+    { interval: 500, timeout: 30000 }
   );
   cy.get(TIMELINE).first().click();
 };


### PR DESCRIPTION
## Summary

Fixes the flaky-on-MKI Cypress spec **"Cases – Creates a new case with timeline and opens the timeline"** (`x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/cases/creation.cy.ts`), which https://github.com/elastic/kibana/pull/282196 did not fully resolve.

## What was wrong

The redesigned case view header builds the "Reported by" text from the case creator's full name, and if that's missing, their username. Everywhere else in Cases — including the participant avatars right next to the header — display names come from `getUserDisplayName`, which prefers the email over the username when there's no full name.

On serverless (MKI), the automated test users have an email but no full name. So the header showed the username while the test (and the avatars) expected the email, and the assertion failed every time. This was a real UI inconsistency, not just a test problem: the header and the avatar beside it could show two different names for the same person.

## What this PR changes

- The case view header now resolves the reporter's name the same way as the rest of Cases: full name, then email, then username.
- Added unit tests covering both fallbacks (email when there's no full name, username when there's neither).
- The retry execution of the same spec died earlier, waiting for the timeline picker to populate — the 12 second cap is too tight for MKI, so it's now 30 seconds.

## How to verify

- `node scripts/jest --config x-pack/platform/plugins/shared/cases/jest.config.js x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.test.ts` — 24/24 passing.
- The real confirmation is the serverless MKI run of the Cypress spec, since the failure only reproduces with users that have no full name.