### PR TITLE
[9.4] Fix APM agent detection leaking across environments (#282067)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/context/apm_service/apm_service_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/context/apm_service/apm_service_context.tsx
@@ -49,7 +49,7 @@ export function ApmServiceContextProvider({ children }: { children: ReactNode })
   const {
     path: { serviceName },
     query,
-    query: { kuery, rangeFrom, rangeTo },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useAnyOfApmParams('/services/{serviceName}', '/mobile-services/{serviceName}');
 
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
@@ -64,6 +64,7 @@ export function ApmServiceContextProvider({ children }: { children: ReactNode })
     status: serviceAgentStatus,
   } = useServiceAgentFetcher({
     serviceName,
+    environment,
     start,
     end,
   });

--- a/x-pack/solutions/observability/plugins/apm/public/context/apm_service/use_service_agent_fetcher.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/context/apm_service/use_service_agent_fetcher.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { Environment } from '../../../common/environment_rt';
 import { useFetcher } from '../../hooks/use_fetcher';
 
 const INITIAL_STATE = {
@@ -18,10 +19,12 @@ const INITIAL_STATE = {
 
 export function useServiceAgentFetcher({
   serviceName,
+  environment,
   start,
   end,
 }: {
   serviceName?: string;
+  environment: Environment;
   start: string;
   end: string;
 }) {
@@ -35,12 +38,12 @@ export function useServiceAgentFetcher({
         return callApmApi('GET /internal/apm/services/{serviceName}/agent', {
           params: {
             path: { serviceName },
-            query: { start, end },
+            query: { environment, start, end },
           },
         });
       }
     },
-    [serviceName, start, end]
+    [serviceName, environment, start, end]
   );
 
   return { ...data, status, error };

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/alerting/use_alerting_props.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/alerting/use_alerting_props.tsx
@@ -17,6 +17,7 @@ import { getAggsTypeFromRule } from '../../components/alerting/ui_components/ale
 import { getTimeZone } from '../../components/shared/charts/helper/timezone';
 import { ApmDocumentType } from '../../../common/document_type';
 import type { LatencyAggregationType } from '../../../common/latency_aggregation_types';
+import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
 
 export function useAlertingProps({
   rule,
@@ -55,6 +56,7 @@ export function useAlertingProps({
   });
   const { agentName } = useServiceAgentFetcher({
     serviceName,
+    environment: ENVIRONMENT_ALL.value,
     start,
     end,
   });

--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/get_service_agent.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/get_service_agent.ts
@@ -24,6 +24,7 @@ import type { APMEventClient } from '../../lib/helpers/create_es_client/create_a
 import type { ServerlessType } from '../../../common/serverless';
 import { getServerlessTypeFromCloudData } from '../../../common/serverless';
 import { maybe } from '../../../common/utils/maybe';
+import { environmentQuery } from '../../../common/utils/environment_query';
 
 export interface ServiceAgentResponse {
   agentName?: string;
@@ -36,11 +37,13 @@ export interface ServiceAgentResponse {
 
 export async function getServiceAgent({
   serviceName,
+  environment,
   apmEventClient,
   start,
   end,
 }: {
   serviceName: string;
+  environment: string;
   apmEventClient: APMEventClient;
   start: number;
   end: number;
@@ -74,6 +77,7 @@ export async function getServiceAgent({
         filter: [
           { term: { [SERVICE_NAME]: serviceName } },
           ...rangeQuery(start, end),
+          ...environmentQuery(environment),
           {
             exists: {
               field: AGENT_NAME,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/route.ts
@@ -286,17 +286,18 @@ const serviceAgentRoute = createApmServerRoute({
     path: t.type({
       serviceName: t.string,
     }),
-    query: rangeRt,
+    query: t.intersection([rangeRt, environmentRt]),
   }),
   security: { authz: { requiredPrivileges: ['apm'] } },
   handler: async (resources): Promise<ServiceAgentResponse> => {
     const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName } = params.path;
-    const { start, end } = params.query;
+    const { environment, start, end } = params.query;
 
     const apmServiceAgent = await getServiceAgent({
       serviceName,
+      environment,
       apmEventClient,
       start,
       end,

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/services/agent.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/services/agent.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from '@kbn/expect';
+import { ENVIRONMENT_ALL_VALUE } from '@kbn/apm-plugin/common/environment_filter_values';
 import archives_metadata from '../../../../apm_api_integration/common/fixtures/es_archiver/archives_metadata';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { ARCHIVER_ROUTES } from '../constants/archiver';
@@ -25,6 +26,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           params: {
             path: { serviceName: 'opbeans-node' },
             query: {
+              environment: ENVIRONMENT_ALL_VALUE,
               start,
               end,
             },
@@ -50,6 +52,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           params: {
             path: { serviceName: 'opbeans-node' },
             query: {
+              environment: ENVIRONMENT_ALL_VALUE,
               start,
               end,
             },

--- a/x-pack/solutions/observability/test/apm_api_integration/tests/feature_controls.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/feature_controls.spec.ts
@@ -111,7 +111,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     },
     {
       req: {
-        url: `/internal/apm/services/foo/agent?start=${start}&end=${end}`,
+        url: `/internal/apm/services/foo/agent?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix APM agent detection leaking across environments (#282067)](https://github.com/elastic/kibana/pull/282067)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miłosz Marcinkowski","email":"38698566+miloszmarcinkowski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-04T08:00:22Z","message":"Fix APM agent detection leaking across environments (#282067)\n\nCloses #282062\n## Summary\n\nThe getServiceAgent query did not filter by environment, so when a\nservice existed in multiple environments with different instrumentation\ntypes, the most recent agent document across all environments determined\nwhich dashboard the Metrics tab showed. This caused the wrong dashboard\nvariant to appear, for example, a service using OTel in dev would show\nthe classic APM dashboard if production had a more recent classic\ndocument.\n\nThis fix scopes the query to the selected environment. The alerting\nembeddable passes ENVIRONMENT_ALL to preserve its existing\ncross-environment behavior.\n\n## How to reproduce\n\nUse the `apm_service_multi_env_otel_migration` synthtrace scenario\n(`--from now-1w --to now`), then view the `staging` environment in a\ntime window where `staging` is still in its classic phase (~now-5d to\nnow-2d) but `production` has already migrated to OTel. Without the fix\nthe Metrics tab shows the OTel dashboard for `staging`, with the fix it\nshows the correct classic dashboard.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/2ad0cf28-34e8-4814-8b13-f87e6aacaa19\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/0d60b65a-9f9c-4470-a363-e7fa8505ae5f\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"a74af22e25fadbd6aaa7ef65f6e343b365ea2cd2","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:all-open","ci:project-deploy-observability","Team:obs-presentation","v9.6.0","Team:obs-signals-traces"],"title":"Fix APM agent detection leaking across environments","number":282067,"url":"https://github.com/elastic/kibana/pull/282067","mergeCommit":{"message":"Fix APM agent detection leaking across environments (#282067)\n\nCloses #282062\n## Summary\n\nThe getServiceAgent query did not filter by environment, so when a\nservice existed in multiple environments with different instrumentation\ntypes, the most recent agent document across all environments determined\nwhich dashboard the Metrics tab showed. This caused the wrong dashboard\nvariant to appear, for example, a service using OTel in dev would show\nthe classic APM dashboard if production had a more recent classic\ndocument.\n\nThis fix scopes the query to the selected environment. The alerting\nembeddable passes ENVIRONMENT_ALL to preserve its existing\ncross-environment behavior.\n\n## How to reproduce\n\nUse the `apm_service_multi_env_otel_migration` synthtrace scenario\n(`--from now-1w --to now`), then view the `staging` environment in a\ntime window where `staging` is still in its classic phase (~now-5d to\nnow-2d) but `production` has already migrated to OTel. Without the fix\nthe Metrics tab shows the OTel dashboard for `staging`, with the fix it\nshows the correct classic dashboard.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/2ad0cf28-34e8-4814-8b13-f87e6aacaa19\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/0d60b65a-9f9c-4470-a363-e7fa8505ae5f\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"a74af22e25fadbd6aaa7ef65f6e343b365ea2cd2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282067","number":282067,"mergeCommit":{"message":"Fix APM agent detection leaking across environments (#282067)\n\nCloses #282062\n## Summary\n\nThe getServiceAgent query did not filter by environment, so when a\nservice existed in multiple environments with different instrumentation\ntypes, the most recent agent document across all environments determined\nwhich dashboard the Metrics tab showed. This caused the wrong dashboard\nvariant to appear, for example, a service using OTel in dev would show\nthe classic APM dashboard if production had a more recent classic\ndocument.\n\nThis fix scopes the query to the selected environment. The alerting\nembeddable passes ENVIRONMENT_ALL to preserve its existing\ncross-environment behavior.\n\n## How to reproduce\n\nUse the `apm_service_multi_env_otel_migration` synthtrace scenario\n(`--from now-1w --to now`), then view the `staging` environment in a\ntime window where `staging` is still in its classic phase (~now-5d to\nnow-2d) but `production` has already migrated to OTel. Without the fix\nthe Metrics tab shows the OTel dashboard for `staging`, with the fix it\nshows the correct classic dashboard.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/2ad0cf28-34e8-4814-8b13-f87e6aacaa19\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/0d60b65a-9f9c-4470-a363-e7fa8505ae5f\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"a74af22e25fadbd6aaa7ef65f6e343b365ea2cd2"}}]}] BACKPORT-->