### PR TITLE
Restore 10 skipped accessibility snapshots with strict WCAG 2.2 AA profile

### DIFF
--- a/src/platform/test/accessibility/services/a11y/a11y.ts
+++ b/src/platform/test/accessibility/services/a11y/a11y.ts
@@ -21,7 +21,10 @@ interface AxeContext {
   exclude?: string[][];
 }
 
-interface TestOptions {
+export type AccessibilitySnapshotProfile = 'default' | 'strictWcag22aa';
+
+export interface AccessibilitySnapshotOptions {
+  profile?: AccessibilitySnapshotProfile;
   excludeTestSubj?: string | string[];
 }
 
@@ -35,6 +38,21 @@ export const normalizeResult = (report: any) => {
   return report.result as false | AxeReport;
 };
 
+const STRICT_AXE_CONFIG = {
+  rules: [],
+};
+
+const STRICT_AXE_OPTIONS = {
+  reporter: 'v2' as const,
+  runOnly: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'],
+  rules: {
+    'color-contrast': { enabled: true },
+    bypass: { enabled: true },
+    'nested-interactive': { enabled: true },
+    'target-size': { enabled: true },
+  },
+};
+
 /**
  * Accessibility testing service using the Axe (https://www.deque.com/axe/)
  * toolset to validate a11y rules similar to ESLint. In order to test against
@@ -44,16 +62,34 @@ export class AccessibilityService extends FtrService {
   private readonly browser = this.ctx.getService('browser');
   private readonly Wd = this.ctx.getService('__webdriver__');
 
-  public async testAppSnapshot(options: TestOptions = {}) {
-    const context = this.getAxeContext(true, options.excludeTestSubj);
-    const report = await this.captureAxeReport(context);
-    this.assertValidAxeReport(report);
+  public async testAppSnapshot(options: AccessibilitySnapshotOptions = {}) {
+    if (options.profile === 'strictWcag22aa') {
+      const context = this.getStrictAxeContext();
+      const report = await this.captureAxeReport(context, STRICT_AXE_CONFIG, STRICT_AXE_OPTIONS);
+      this.assertValidAxeReportStrict(report);
+    } else {
+      const context = this.getAxeContext(true, options.excludeTestSubj);
+      const report = await this.captureAxeReport(context, AXE_CONFIG, AXE_OPTIONS);
+      this.assertValidAxeReport(report);
+    }
   }
 
-  public async testGlobalSnapshot(options: TestOptions = {}) {
-    const context = this.getAxeContext(false, options.excludeTestSubj);
-    const report = await this.captureAxeReport(context);
-    this.assertValidAxeReport(report);
+  public async testGlobalSnapshot(options: AccessibilitySnapshotOptions = {}) {
+    if (options.profile === 'strictWcag22aa') {
+      const context = this.getStrictAxeContext();
+      const report = await this.captureAxeReport(context, STRICT_AXE_CONFIG, STRICT_AXE_OPTIONS);
+      this.assertValidAxeReportStrict(report);
+    } else {
+      const context = this.getAxeContext(false, options.excludeTestSubj);
+      const report = await this.captureAxeReport(context, AXE_CONFIG, AXE_OPTIONS);
+      this.assertValidAxeReport(report);
+    }
+  }
+
+  private getStrictAxeContext(): AxeContext {
+    return {
+      include: [testSubjectToCss('appA11yRoot')],
+    };
   }
 
   private getAxeContext(global: boolean, excludeTestSubj?: string | string[]): AxeContext {
@@ -78,14 +114,37 @@ export class AccessibilityService extends FtrService {
     }
   }
 
-  private async captureAxeReport(context: AxeContext): Promise<AxeReport> {
+  private assertValidAxeReportStrict(report: AxeReport) {
+    if (!report.violations.length) return;
+
+    const lines: string[] = [];
+    for (const violation of report.violations) {
+      for (const node of violation.nodes) {
+        lines.push(
+          [
+            `rule: ${violation.id}`,
+            `impact: ${violation.impact}`,
+            `html: ${node.html}`,
+            `target: ${node.target?.join(', ')}`,
+          ].join(' | ')
+        );
+      }
+    }
+    throw new Error(`strict a11y violations:\n${lines.join('\n')}`);
+  }
+
+  private async captureAxeReport(
+    context: AxeContext,
+    axeConfig: typeof AXE_CONFIG,
+    axeOptions: typeof AXE_OPTIONS
+  ): Promise<AxeReport> {
     await this.Wd.driver.manage().setTimeouts({
       ...(await this.Wd.driver.manage().getTimeouts()),
       script: 600000,
     });
 
     const report = normalizeResult(
-      await this.browser.executeAsync(analyzeWithAxe, context, AXE_CONFIG, AXE_OPTIONS)
+      await this.browser.executeAsync(analyzeWithAxe, context, axeConfig, axeOptions)
     );
 
     if (report !== false) {
@@ -93,7 +152,7 @@ export class AccessibilityService extends FtrService {
     }
 
     const withClientReport = normalizeResult(
-      await this.browser.executeAsync(analyzeWithAxeWithClient, context, AXE_CONFIG, AXE_OPTIONS)
+      await this.browser.executeAsync(analyzeWithAxeWithClient, context, axeConfig, axeOptions)
     );
 
     if (withClientReport === false) {

--- a/x-pack/platform/test/accessibility/apps/group3/rules_connectors.ts
+++ b/x-pack/platform/test/accessibility/apps/group3/rules_connectors.ts
@@ -7,86 +7,192 @@
 
 // a11y tests for rules, logs and connectors page
 
+import { v4 as uuidv4 } from 'uuid';
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['settings', 'common']);
+  const PageObjects = getPageObjects(['settings', 'common', 'header']);
   const a11y = getService('a11y');
   const testSubjects = getService('testSubjects');
   const kibanaServer = getService('kibanaServer');
   const toasts = getService('toasts');
+  const find = getService('find');
+  const comboBox = getService('comboBox');
+  const retry = getService('retry');
+  const es = getService('es');
 
-  // Failing: See https://github.com/elastic/kibana/issues/145452
-  describe.skip('Kibana Alerts - rules tab accessibility tests', () => {
+  const ruleId = uuidv4().slice(0, 8);
+  const ruleName = `a11y-test-rule-${ruleId}`;
+  const indexName = `a11y-test-index-${ruleId}`;
+
+  describe('Kibana Alerts - rules tab accessibility tests', () => {
     before(async () => {
-      await PageObjects.settings.navigateTo();
-      await testSubjects.click('triggersActions');
+      await es.indices.create({
+        index: indexName,
+        mappings: {
+          properties: {
+            '@timestamp': { type: 'date' },
+            value: { type: 'long' },
+          },
+        },
+      });
+      await es.index({
+        index: indexName,
+        refresh: 'wait_for',
+        body: {
+          '@timestamp': new Date().toISOString(),
+          value: 1,
+        },
+      });
+
+      await PageObjects.common.navigateToApp('management', {
+        path: 'insightsAndAlerting/triggersActions',
+      });
+      await testSubjects.click('rulesTab');
+      await PageObjects.header.waitUntilLoadingHasFinished();
     });
+
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      const errors: Error[] = [];
+      try {
+        await kibanaServer.savedObjects.cleanStandardList();
+      } catch (e) {
+        errors.push(e);
+      }
+      try {
+        await es.indices.delete({ index: indexName, ignore_unavailable: true } as any);
+      } catch (e) {
+        errors.push(e);
+      }
+      if (errors.length > 0) throw errors[0];
     });
 
     it('a11y test on rules and connectors main page', async () => {
-      await a11y.testAppSnapshot();
+      await retry.waitForWithTimeout('rules list ready', 10000, async () => {
+        const loading = await testSubjects.exists('centerJustifiedSpinner', { timeout: 500 });
+        return !loading;
+      });
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
     });
 
     it('a11y test on create rules panel', async () => {
-      await testSubjects.click('createFirstRuleButton');
-      await a11y.testAppSnapshot();
-    });
-    // https://github.com/elastic/kibana/issues/144953
-    it.skip('a11y test on inputs on rules panel', async () => {
-      await testSubjects.click('ruleNameInput');
-      await testSubjects.setValue('ruleNameInput', 'testRule');
-      await testSubjects.click('tagsComboBox');
-      await testSubjects.setValue('tagsComboBox', 'ruleTag');
-      await testSubjects.click('intervalFormRow');
-      await testSubjects.click('notifyWhenSelect');
-      await testSubjects.click('onActiveAlert');
-      await testSubjects.click('solutionsFilterButton');
-      await a11y.testAppSnapshot();
-      await testSubjects.click('solutionapmFilterOption');
-      await testSubjects.setValue('solutionsFilterButton', 'solutionapmFilterOption');
-      await testSubjects.click('apm.anomaly-SelectOption');
-      await a11y.testAppSnapshot();
-    });
-    // https://github.com/elastic/kibana/issues/144953
-    it.skip('a11y test on save rule without connectors panel', async () => {
-      await toasts.dismissAll();
-      await testSubjects.click('saveRuleButton');
-      await a11y.testAppSnapshot();
-    });
-    // https://github.com/elastic/kibana/issues/144953
-    it.skip('a11y test on alerts and logs page with one rule populated', async () => {
-      await testSubjects.click('confirmModalConfirmButton');
-      await a11y.testAppSnapshot();
-      await testSubjects.click('checkboxSelectAll');
-      await testSubjects.click('deleteActionHoverButton');
-      await testSubjects.click('confirmModalConfirmButton');
+      await retry.try(async () => {
+        const firstRuleBtn = await testSubjects.exists('createFirstRuleButton', { timeout: 500 });
+        if (firstRuleBtn) {
+          await testSubjects.click('createFirstRuleButton');
+        } else {
+          await testSubjects.click('createRuleButton');
+        }
+      });
+
+      await retry.waitForWithTimeout('rule type modal cards', 10000, async () => {
+        return await testSubjects.exists('.index-threshold-SelectOption', { timeout: 500 });
+      });
+
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
+
+      await retry.try(async () => {
+        await testSubjects.click('apm-LeftSidebarSelectOption');
+      });
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
+
+      await testSubjects.click('allRuleTypesButton');
+      await testSubjects.click('.index-threshold-SelectOption');
     });
 
-    // uncomment after rules tests a11y violations get fixed
-    it.skip('a11y test on logs tab', async () => {
+    it('a11y test on inputs on rules panel', async () => {
+      await testSubjects.scrollIntoView('ruleDetailsNameInput');
+      await testSubjects.setValue('ruleDetailsNameInput', ruleName);
+
+      await testSubjects.scrollIntoView('selectIndexExpression');
+      await testSubjects.click('selectIndexExpression');
+      await comboBox.set('thresholdIndexesComboBox', indexName);
+
+      await testSubjects.click('thresholdAlertTimeFieldSelect');
+      await retry.try(async () => {
+        const fieldOptions = await find.allByCssSelector('#thresholdTimeField option');
+        if (fieldOptions.length < 2) throw new Error('no time field options');
+        await fieldOptions[1].click();
+      });
+      await testSubjects.click('closePopover');
+
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
+    });
+
+    it('a11y test on save rule without connectors panel', async () => {
+      await toasts.dismissIfExists();
+      await testSubjects.click('rulePageFooterSaveButton');
+      await testSubjects.existOrFail('confirmCreateRuleModal');
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
+    });
+
+    it('a11y test on alerts and logs page with one rule populated', async () => {
+      await testSubjects.click('confirmCreateRuleModal > confirmModalConfirmButton');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+
+      await PageObjects.common.navigateToApp('management', {
+        path: 'insightsAndAlerting/triggersActions',
+      });
+      await testSubjects.click('rulesTab');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+
+      await retry.waitForWithTimeout('created rule in list', 15000, async () => {
+        const rows = await find.allByCssSelector('[data-test-subj="rulesTableCell-name"]');
+        for (const row of rows) {
+          const text = await row.getVisibleText();
+          if (text.includes(ruleName)) return true;
+        }
+        return false;
+      });
+
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
+
+      await retry.try(async () => {
+        await testSubjects.click('collapsedItemActions');
+      });
+      await testSubjects.click('deleteRule');
+      await testSubjects.click('confirmModalConfirmButton');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+    });
+
+    it('a11y test on logs tab', async () => {
       await testSubjects.click('logsTab');
-      await a11y.testAppSnapshot();
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
     });
 
     it('a11y test on connectors tab with create first connector message screen', async () => {
-      await PageObjects.settings.navigateTo();
-      await testSubjects.click('triggersActionsConnectors');
-      await a11y.testAppSnapshot();
+      await PageObjects.common.navigateToApp('triggersActionsConnectors');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
     });
 
     it('a11y test on create connector panel', async () => {
-      await testSubjects.click('createFirstActionButton');
-      await a11y.testAppSnapshot();
+      await retry.try(async () => {
+        const firstBtn = await testSubjects.exists('createFirstActionButton', { timeout: 500 });
+        if (firstBtn) {
+          await testSubjects.click('createFirstActionButton');
+        } else {
+          await testSubjects.click('createActionButton');
+        }
+      });
+      await retry.waitForWithTimeout('connector type modal cards', 10000, async () => {
+        return await testSubjects.exists('.email-card', { timeout: 500 });
+      });
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
     });
 
-    // Adding a11y test for one connector
     it('a11y test on email connectors', async () => {
       await testSubjects.click('.email-card');
-      await a11y.testAppSnapshot();
+      await retry.waitForWithTimeout('email connector form', 10000, async () => {
+        return await testSubjects.exists('create-connector-flyout-back-btn', { timeout: 500 });
+      });
+      await a11y.testAppSnapshot({ profile: 'strictWcag22aa' });
       await testSubjects.click('create-connector-flyout-back-btn');
+      await retry.waitForWithTimeout('connector chooser restored', 5000, async () => {
+        return await testSubjects.exists('.email-card', { timeout: 500 });
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR restores 10 accessibility snapshots that were skipped in the rules/connectors test suite and introduces an opt-in strict WCAG 2.2 AA profile for enhanced accessibility validation. The changes enable comprehensive accessibility testing while maintaining backward compatibility with existing test suites.

The accessibility suite previously used a 2022 ordered journey and the shared default axe profile, which could not establish strict WCAG 2.2 AA coverage. This implementation provides an isolated strict profile that applies all available WCAG tags and explicitly enables critical checks including color contrast, bypass, nested-interactive, and target-size rules.

## What Changed

### Phase 4: Restore strict rules/connectors accessibility coverage

- **Accessibility Service Enhancement**: Added opt-in `strictWcag22aa` profile to `src/platform/test/accessibility/services/a11y/a11y.ts`
  - Introduced `AccessibilitySnapshotProfile` type and `AccessibilitySnapshotOptions` interface
  - Implemented strict WCAG 2.2 AA configuration with tags: `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa`  
  - Enabled critical accessibility checks: color contrast, bypass, nested-interactive, and target-size
  - Added detailed violation reporting with rule, impact, HTML, and target selector information
  - Preserved existing default profile behavior for all other test suites

- **Rules/Connectors Test Restoration**: Unskipped and enhanced `x-pack/platform/test/accessibility/apps/group3/rules_connectors.ts`
  - Removed suite skip and all four nested test skips, restoring 10 accessibility snapshots
  - Implemented proper test data lifecycle with unique rule/index names using UUID generation
  - Added Elasticsearch index creation with `@timestamp` date field and document seeding
  - Enhanced navigation flow using current UI contracts: rule type modal, producer facets, form validation
  - Implemented deterministic rule creation workflow with proper form population and confirmation modal handling
  - Added robust cleanup for both Kibana saved objects and Elasticsearch indices with failure-safe error propagation
  - Applied strict WCAG 2.2 AA profile to all ten snapshots while maintaining original test assertions

### Test Infrastructure Changes

- Created owned test fixtures with unique naming to prevent cross-test interference
- Implemented failure-safe cleanup ensuring both rule and index removal attempts complete
- Added proper loading state detection and UI readiness polling
- Enhanced connector workflow testing with flyout state validation and navigation confirmation

## Test Plan

### Automated Tests Written
- All 10 accessibility snapshots now execute with strict WCAG 2.2 AA validation
- Enhanced test lifecycle management with proper setup/teardown for Elasticsearch indices
- Robust error handling and cleanup validation

### Manual Verification Steps
- Verified focused suite execution with evidence-producing strict baseline
- Confirmed unrelated accessibility suites maintain unchanged default profile behavior  
- Validated proper UI navigation flow through rules creation, connector selection, and cleanup
- Tested failure scenarios to ensure cleanup robustness and error propagation

### Validation Commands
- `node scripts/functional_tests --config x-pack/platform/test/accessibility/apps/group3/config.ts --grep 'Kibana Alerts - rules tab accessibility tests'` (evidence-producing baseline)
- Full group config execution with ESLint validation
- Normal CI and x30 flaky verification on final head commit

The implementation stops immediately on any strict-profile violation and records detailed evidence including rule, impact, HTML, selector, UI state, and FTR output for proper debugging without weakening the strict validation requirements.

Closes #282546