### PR TITLE
[One Workflow] Authenticate Kibana action steps with UIAM

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/call_kibana_api.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/call_kibana_api.ts
@@ -8,13 +8,17 @@
  */
 
 import type { CoreStart, KibanaRequest } from '@kbn/core/server';
-import { HTTPAuthorizationHeader, isUiamCredential } from '@kbn/core-security-server';
+import {
+  HTTPAuthorizationHeader,
+  UIAM_INTERNAL_CALLER_ATTESTATION_HEADER,
+} from '@kbn/core-security-server';
 import { applySpacePrefix } from '@kbn/workflows';
 import {
   getOutboundEventChainHeaders,
   KibanaApiCallError,
   X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
 } from '@kbn/workflows-extensions/server';
+import { getInternalUiamCallerAttestationHeaders } from './get_internal_uiam_caller_attestation_headers';
 import { isTextContentType, readResponseStream } from '../utils/http_response';
 
 export { KibanaApiCallError } from '@kbn/workflows-extensions/server';
@@ -104,6 +108,7 @@ const RESERVED_HEADER_NAMES = new Set([
   'authorization',
   'content-type',
   'kbn-xsrf',
+  UIAM_INTERNAL_CALLER_ATTESTATION_HEADER,
   X_ELASTIC_INTERNAL_ORIGIN_REQUEST.toLowerCase(),
   'x-kibana-event-chain-depth',
   'x-kibana-event-chain-source-execution-id',
@@ -197,9 +202,8 @@ const stringifyErrorBodyForMessage = (body: unknown): string => {
  * and it additionally exposes the parsed `status`, `headers`, and `body` so callers can recover
  * a structured partial-success response via `try/catch` + `instanceof KibanaApiCallError`.
  *
- * This helper backs both the `kibana.request` YAML step (for its JSON-body / connector-definition
- * branches) and the `callKibanaApi` tool exposed to custom step handlers. Behavior is intentionally
- * kept narrow (no multipart, no fetcher options, no streaming).
+ * This helper backs the `callKibanaApi` tool exposed to custom step handlers. Behavior is
+ * intentionally kept narrow (no multipart, no fetcher options, no streaming).
  *
  * Transport is Core's HTTP self client (`coreStart.http.selfClient`): it owns URL resolution,
  * forwarding the scoped request's `authorization`, and stamping `x-elastic-internal-origin` /
@@ -225,24 +229,8 @@ export async function callKibanaApi<T = unknown>(
   const outboundHeaders: Record<string, string> = {
     ...stripReservedHeaders(params.headers),
     ...getOutboundEventChainHeaders(fakeRequest, workflowRunId),
+    ...getInternalUiamCallerAttestationHeaders(coreStart, fakeRequest),
   };
-
-  // Internal UIAM (essu_) keys need the shared secret attached once this loopback request re-enters
-  // Kibana. We must never hold the secret here, so instead we present a non-reversible attestation
-  // of it, bound to this very credential, fetched right before the call and never stored, to
-  // authorize Kibana to attach the secret on our behalf. Spread last, so a step author cannot
-  // override it.
-  // Stamping for any essu_ credential is safe because the workflow identity is always an internal
-  // granted key. If the engine ever proxies an *external* UIAM key over a loopback, gate this on an
-  // explicit internal flag: Elasticsearch rejects an external key presented with the shared secret.
-  if (isUiamCredential(authorizationHeader)) {
-    Object.assign(
-      outboundHeaders,
-      coreStart.security.authc.apiKeys.uiam?.getInternalCallerAttestationHeaders(
-        authorizationHeader
-      )
-    );
-  }
 
   // The workflow's fake request carries no space, so the space has to be encoded in the path.
   const path = applySpacePrefix(params.path, spaceId);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/get_internal_uiam_caller_attestation_headers.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/get_internal_uiam_caller_attestation_headers.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CoreStart, KibanaRequest } from '@kbn/core/server';
+import { HTTPAuthorizationHeader, isUiamCredential } from '@kbn/core-security-server';
+
+export const getInternalUiamCallerAttestationHeaders = (
+  coreStart: CoreStart,
+  request: KibanaRequest
+): Record<string, string> => {
+  const authorizationHeader = HTTPAuthorizationHeader.parseFromRequest(request);
+  if (!authorizationHeader || !isUiamCredential(authorizationHeader)) {
+    return {};
+  }
+
+  return (
+    coreStart.security.authc.apiKeys.uiam?.getInternalCallerAttestationHeaders(
+      authorizationHeader
+    ) ?? {}
+  );
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.test.ts
@@ -7,10 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { KibanaRequest } from '@kbn/core/server';
+import { UIAM_INTERNAL_CALLER_ATTESTATION_HEADER } from '@kbn/core-security-server';
 import type { KibanaGraphNode } from '@kbn/workflows/graph/types';
 
 import { KibanaActionStepImpl } from './kibana_action_step';
 import type { RunStepResult } from './node_implementation';
+import { EVENT_CHAIN_DEPTH_HEADER } from '../trigger_events/event_context/event_chain_context';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
 import type { WorkflowContextManager } from '../workflow_context_manager/workflow_context_manager';
 import type { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
@@ -19,6 +22,7 @@ import type { IWorkflowEventLogger } from '../workflow_event_logger';
 // Mock fetch globally
 global.fetch = jest.fn();
 const mockedFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+const mockGetInternalCallerAttestationHeaders = jest.fn();
 
 const runStep = (
   step: KibanaActionStepImpl,
@@ -100,6 +104,15 @@ describe('KibanaActionStepImpl - Fetcher Configuration', () => {
         http: {
           basePath: { publicBaseUrl: 'https://localhost:5601' },
         },
+        security: {
+          authc: {
+            apiKeys: {
+              uiam: {
+                getInternalCallerAttestationHeaders: mockGetInternalCallerAttestationHeaders,
+              },
+            },
+          },
+        },
       }),
       getFakeRequest: jest.fn().mockReturnValue({
         headers: { authorization: 'ApiKey test-key' },
@@ -135,6 +148,72 @@ describe('KibanaActionStepImpl - Fetcher Configuration', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+  });
+
+  it('attaches the UIAM internal-caller attestation to loopback requests', async () => {
+    mockGetInternalCallerAttestationHeaders.mockReturnValue({
+      [UIAM_INTERNAL_CALLER_ATTESTATION_HEADER]: 'valid-attestation',
+    });
+    mockContextManager.getFakeRequest.mockReturnValue({
+      headers: { authorization: 'ApiKey essu_internal_key' },
+    } as unknown as KibanaRequest);
+
+    const stepWith = {
+      request: {
+        method: 'GET',
+        path: '/api/status',
+        headers: {
+          Authorization: 'ApiKey another_key',
+          'X-Kbn-Uiam-Internal-Caller-Attestation': 'forged-attestation',
+          'X-Kibana-Event-Chain-Depth': '999',
+        },
+      },
+    };
+    const step = {
+      id: 'test_step',
+      type: 'kibana.request',
+      stepId: 'test_step',
+      stepType: 'kibana.request',
+      configuration: { name: 'test_step', type: 'kibana.request', with: stepWith },
+    } as unknown as KibanaGraphNode;
+
+    await runStep(
+      new KibanaActionStepImpl(
+        step,
+        mockStepExecutionRuntime,
+        mockWorkflowRuntime,
+        mockWorkflowLogger
+      ),
+      stepWith
+    );
+
+    const fetchOptions = mockedFetch.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(fetchOptions.headers);
+    expect(headers.get('authorization')).toBe('ApiKey essu_internal_key');
+    expect(headers.get(UIAM_INTERNAL_CALLER_ATTESTATION_HEADER)).toBe('valid-attestation');
+    expect(headers.get(EVENT_CHAIN_DEPTH_HEADER)).toBeNull();
+    expect(mockGetInternalCallerAttestationHeaders).toHaveBeenCalledTimes(1);
+
+    mockedFetch.mockClear();
+    mockGetInternalCallerAttestationHeaders.mockClear();
+    mockContextManager.getFakeRequest.mockReturnValue({
+      headers: { authorization: 'ApiKey regular_key' },
+    } as unknown as KibanaRequest);
+
+    await runStep(
+      new KibanaActionStepImpl(
+        step,
+        mockStepExecutionRuntime,
+        mockWorkflowRuntime,
+        mockWorkflowLogger
+      ),
+      stepWith
+    );
+
+    const unattestedFetchOptions = mockedFetch.mock.calls[0][1] as RequestInit;
+    const unattestedHeaders = new Headers(unattestedFetchOptions.headers);
+    expect(unattestedHeaders.get(UIAM_INTERNAL_CALLER_ATTESTATION_HEADER)).toBeNull();
+    expect(mockGetInternalCallerAttestationHeaders).not.toHaveBeenCalled();
   });
 
   describe('fetcher options extraction', () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.ts
@@ -10,6 +10,7 @@
 // TODO: Remove eslint exceptions comments and fix the issues
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { UIAM_INTERNAL_CALLER_ATTESTATION_HEADER } from '@kbn/core-security-server';
 import type { FetcherConfigSchema } from '@kbn/workflows';
 import { buildKibanaRequest, KibanaHttpMethods } from '@kbn/workflows';
 import type { KibanaGraphNode } from '@kbn/workflows/graph/types';
@@ -17,7 +18,12 @@ import type { z } from '@kbn/zod/v4';
 import { ResponseSizeLimitError } from './errors';
 import type { BaseStep, RunStepResult } from './node_implementation';
 import { BaseAtomicNodeImplementation } from './node_implementation';
+import { getInternalUiamCallerAttestationHeaders } from '../lib/get_internal_uiam_caller_attestation_headers';
 import {
+  EVENT_CHAIN_DEPTH_HEADER,
+  EVENT_CHAIN_EMITTER_EXECUTION_ID_HEADER,
+  EVENT_CHAIN_SOURCE_EXECUTION_HEADER,
+  EVENT_CHAIN_VISITED_WORKFLOW_IDS_HEADER,
   getOutboundEventChainHeaders,
   X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
 } from '../trigger_events/event_context/event_chain_context';
@@ -190,7 +196,6 @@ export class KibanaActionStepImpl extends BaseAtomicNodeImplementation<BaseStep>
       );
     }
 
-    const authHeaders = this.getAuthHeaders();
     const jsonContentType = { 'Content-Type': 'application/json' };
 
     if (cleanParams.request) {
@@ -201,7 +206,7 @@ export class KibanaActionStepImpl extends BaseAtomicNodeImplementation<BaseStep>
         path,
         body,
         query,
-        headers: { ...authHeaders, ...jsonContentType, ...customHeaders },
+        headers: { ...jsonContentType, ...customHeaders },
       };
     } else if (cleanParams.form_data) {
       // form_data mode: POST multipart/form-data (e.g. saved objects import).
@@ -212,7 +217,7 @@ export class KibanaActionStepImpl extends BaseAtomicNodeImplementation<BaseStep>
         path,
         formData: form_data as Record<string, FormDataFieldSpec>,
         query,
-        headers: { ...authHeaders, ...(customHeaders as Record<string, string> | undefined) },
+        headers: customHeaders as Record<string, string> | undefined,
       };
     } else {
       // Use generated connector definitions to determine method and path (covers all 454+ Kibana APIs)
@@ -228,7 +233,7 @@ export class KibanaActionStepImpl extends BaseAtomicNodeImplementation<BaseStep>
         path,
         body,
         query,
-        headers: { ...authHeaders, ...jsonContentType, ...connectorHeaders },
+        headers: { ...jsonContentType, ...connectorHeaders },
       };
     }
 
@@ -321,10 +326,32 @@ export class KibanaActionStepImpl extends BaseAtomicNodeImplementation<BaseStep>
     // HTTP caller, so it gates naive spoofing but is not a hard trust boundary.
     const fakeRequest = this.stepExecutionRuntime.contextManager.getFakeRequest();
     const workflowRunId = this.stepExecutionRuntime.workflowExecution?.id;
+    const authenticationHeaders = this.getAuthHeaders();
+    const eventChainHeaders = getOutboundEventChainHeaders(fakeRequest, workflowRunId);
+    const attestationHeaders = getInternalUiamCallerAttestationHeaders(
+      this.stepExecutionRuntime.contextManager.getCoreStart(),
+      fakeRequest
+    );
+    const managedHeaderNames = new Set(
+      [
+        ...Object.keys(authenticationHeaders),
+        X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
+        EVENT_CHAIN_DEPTH_HEADER,
+        EVENT_CHAIN_EMITTER_EXECUTION_ID_HEADER,
+        EVENT_CHAIN_SOURCE_EXECUTION_HEADER,
+        EVENT_CHAIN_VISITED_WORKFLOW_IDS_HEADER,
+        UIAM_INTERNAL_CALLER_ATTESTATION_HEADER,
+        ...Object.keys(attestationHeaders),
+      ].map((name) => name.toLowerCase())
+    );
     const outboundHeaders = {
-      ...headers,
+      ...Object.fromEntries(
+        Object.entries(headers).filter(([name]) => !managedHeaderNames.has(name.toLowerCase()))
+      ),
+      ...authenticationHeaders,
       [X_ELASTIC_INTERNAL_ORIGIN_REQUEST]: 'Kibana',
-      ...getOutboundEventChainHeaders(fakeRequest, workflowRunId),
+      ...eventChainHeaders,
+      ...attestationHeaders,
     };
 
     // Build full URL with query parameters


### PR DESCRIPTION
## Summary

- Share UIAM internal-caller attestation generation between custom API calls and Kibana action steps.
- Attach the credential-bound attestation to `kibana.request` and generated `kibana.*` loopback requests while preserving their existing fetch, multipart, and response behavior.
- Protect authentication, attestation, internal-origin, and event-chain headers from case-insensitive caller overrides.

## Test plan

- [x] `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.test.ts src/platform/plugins/shared/workflows_execution_engine/server/lib/call_kibana_api.test.ts`
- [x] `node scripts/type_check --project src/platform/plugins/shared/workflows_execution_engine/tsconfig.json`
- [x] ESLint on all changed files

## References

Follow-up to https://github.com/elastic/kibana/pull/279283.

Made with [Cursor](https://cursor.com)