### PR TITLE
[Observability Onboarding] Gate vendor endpoints behind a feature flag

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/common/feature_flags.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/common/feature_flags.ts
@@ -10,3 +10,4 @@ export const IS_MANAGED_OTLP_GA = 'observability.managedOtlpGa';
 export const IS_ADD_DATA_PAGE_V2_ENABLED = 'observability.addDataPageV2Enabled';
 export const IS_MANAGED_OTLP_SERVICE_PRW_ENDPOINT_ENABLED =
   'observability.managedOtlpPrwEndpointEnabled';
+export const IS_VENDOR_ENDPOINTS_ENABLED = 'observability.vendorEndpointsEnabled';

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/endpoints_config.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/endpoints_config.test.ts
@@ -27,6 +27,7 @@ const createContext = (overrides: Partial<ApiEndpointContext> = {}): ApiEndpoint
   isManagedOtlpServiceAvailable: false,
   isServerless: false,
   managedOtlpPrwEndpointEnabled: false,
+  vendorEndpointsEnabled: true,
   ...overrides,
 });
 
@@ -340,6 +341,18 @@ describe('vendor endpoints', () => {
 
       expect(endpoints[0].url).toBe('https://otlp.example.com:443/supabase/v1/logs');
     });
+
+    it('returns an empty list when the vendor endpoints flag is disabled', () => {
+      expect(
+        getPopoverVendorEndpoints(
+          createContext({
+            isManagedOtlpServiceAvailable: true,
+            managedOtlpServiceUrl: 'https://otlp.example.com:443',
+            vendorEndpointsEnabled: false,
+          })
+        )
+      ).toEqual([]);
+    });
   });
 
   describe('getVendorEndpointsForTab', () => {
@@ -359,6 +372,19 @@ describe('vendor endpoints', () => {
         getVendorEndpointsForTab(
           ApiEndpointId.OpenTelemetry,
           createContext({ managedOtlpServiceUrl: 'https://otlp.example.com:443' })
+        )
+      ).toEqual([]);
+    });
+
+    it('returns an empty list when the vendor endpoints flag is disabled', () => {
+      expect(
+        getVendorEndpointsForTab(
+          ApiEndpointId.OpenTelemetry,
+          createContext({
+            isManagedOtlpServiceAvailable: true,
+            managedOtlpServiceUrl: 'https://otlp.example.com:443',
+            vendorEndpointsEnabled: false,
+          })
         )
       ).toEqual([]);
     });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/endpoints_config.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/endpoints_config.ts
@@ -16,6 +16,7 @@ export interface ApiEndpointContext {
   isManagedOtlpServiceAvailable: boolean;
   isServerless: boolean;
   managedOtlpPrwEndpointEnabled: boolean;
+  vendorEndpointsEnabled: boolean;
 }
 
 export interface ApiEndpointDefinition {
@@ -195,7 +196,7 @@ export const getVendorEndpointsForTab = (
   context: ApiEndpointContext
 ): ResolvedVendorEndpoint[] => {
   const placement = TAB_PLACEMENTS[tabId];
-  if (!placement) {
+  if (!placement || !context.vendorEndpointsEnabled) {
     return [];
   }
   return resolveVendorEndpoints(
@@ -204,8 +205,14 @@ export const getVendorEndpointsForTab = (
   );
 };
 
-export const getPopoverVendorEndpoints = (context: ApiEndpointContext): ResolvedVendorEndpoint[] =>
-  resolveVendorEndpoints(
+export const getPopoverVendorEndpoints = (
+  context: ApiEndpointContext
+): ResolvedVendorEndpoint[] => {
+  if (!context.vendorEndpointsEnabled) {
+    return [];
+  }
+  return resolveVendorEndpoints(
     VENDOR_ENDPOINTS.filter((definition) => definition.placements.includes('morePopover')),
     context
   );
+};

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/use_api_endpoints.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/use_api_endpoints.test.ts
@@ -9,6 +9,10 @@ import { renderHook } from '@testing-library/react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { FETCH_STATUS, useFetcher } from '../../hooks/use_fetcher';
 import { useManagedOtlpServiceAvailability } from '../shared/use_managed_otlp_service_availability';
+import {
+  IS_MANAGED_OTLP_SERVICE_PRW_ENDPOINT_ENABLED,
+  IS_VENDOR_ENDPOINTS_ENABLED,
+} from '../../../common/feature_flags';
 import { useApiEndpoints } from './use_api_endpoints';
 
 jest.mock('../../hooks/use_fetcher', () => {
@@ -38,6 +42,7 @@ interface Options {
   isManagedOtlpServiceAvailable?: boolean;
   isServerless?: boolean;
   managedOtlpPrwEndpointEnabled?: boolean;
+  vendorEndpointsEnabled?: boolean;
   elasticsearchUrl?: string;
   managedOtlpServiceUrl?: string;
   status?: FETCH_STATUS;
@@ -47,6 +52,7 @@ const setup = ({
   isManagedOtlpServiceAvailable = false,
   isServerless = false,
   managedOtlpPrwEndpointEnabled = false,
+  vendorEndpointsEnabled = true,
   elasticsearchUrl = 'https://es.example.com',
   managedOtlpServiceUrl = '',
   status = FETCH_STATUS.SUCCESS,
@@ -56,7 +62,15 @@ const setup = ({
     services: {
       context: { isServerless },
       featureFlags: {
-        getBooleanValue: jest.fn().mockReturnValue(managedOtlpPrwEndpointEnabled),
+        getBooleanValue: jest.fn().mockImplementation((key: string) => {
+          if (key === IS_VENDOR_ENDPOINTS_ENABLED) {
+            return vendorEndpointsEnabled;
+          }
+          if (key === IS_MANAGED_OTLP_SERVICE_PRW_ENDPOINT_ENABLED) {
+            return managedOtlpPrwEndpointEnabled;
+          }
+          return false;
+        }),
       },
     },
   } as unknown as ReturnType<typeof useKibana>);
@@ -280,5 +294,16 @@ describe('useApiEndpoints', () => {
 
     expect(findEndpoint(result, 'prometheus')?.additionalEndpoints).toEqual([]);
     expect(findEndpoint(result, 'elasticsearch')?.additionalEndpoints).toEqual([]);
+  });
+
+  it('hides vendor endpoints when the vendor endpoints flag is disabled', () => {
+    const { result } = setup({
+      isManagedOtlpServiceAvailable: true,
+      managedOtlpServiceUrl: 'https://otlp.example.com:443',
+      vendorEndpointsEnabled: false,
+    });
+
+    expect(findEndpoint(result, 'opentelemetry')?.additionalEndpoints).toEqual([]);
+    expect(result.current.popoverEndpoints).toEqual([]);
   });
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/use_api_endpoints.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/api_endpoints/use_api_endpoints.ts
@@ -8,7 +8,10 @@
 import type { EuiIconType } from '@elastic/eui/src/components/icon/icon';
 import { useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { IS_MANAGED_OTLP_SERVICE_PRW_ENDPOINT_ENABLED } from '../../../common/feature_flags';
+import {
+  IS_MANAGED_OTLP_SERVICE_PRW_ENDPOINT_ENABLED,
+  IS_VENDOR_ENDPOINTS_ENABLED,
+} from '../../../common/feature_flags';
 import { FETCH_STATUS, isPending, useFetcher } from '../../hooks/use_fetcher';
 import { useManagedOtlpServiceAvailability } from '../shared/use_managed_otlp_service_availability';
 import type { SupportedLogo } from '../shared/logo_icon';
@@ -49,6 +52,7 @@ export function useApiEndpoints(): {
     IS_MANAGED_OTLP_SERVICE_PRW_ENDPOINT_ENABLED,
     false
   );
+  const vendorEndpointsEnabled = featureFlags.getBooleanValue(IS_VENDOR_ENDPOINTS_ENABLED, false);
 
   const { data, status } = useFetcher(
     (callApi) => callApi('GET /internal/observability_onboarding/api_endpoints'),
@@ -63,6 +67,7 @@ export function useApiEndpoints(): {
       isManagedOtlpServiceAvailable,
       isServerless,
       managedOtlpPrwEndpointEnabled,
+      vendorEndpointsEnabled,
     };
 
     return {
@@ -83,6 +88,7 @@ export function useApiEndpoints(): {
     isManagedOtlpServiceAvailable,
     isServerless,
     managedOtlpPrwEndpointEnabled,
+    vendorEndpointsEnabled,
   ]);
 
   return {

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/api_endpoints/route.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/api_endpoints/route.test.ts
@@ -17,6 +17,7 @@ import { hasApiKeyPrivileges } from '../../lib/api_key/has_api_key_privileges';
 import { APM_EVENT_WRITE_APPLICATION } from '../../lib/api_key/privileges';
 import { resolveApiKeyFactory } from '../../lib/api_key/resolve_api_key_factory';
 import { getManagedOtlpServiceUrl } from '../../lib/get_managed_otlp_service_url';
+import { IS_VENDOR_ENDPOINTS_ENABLED } from '../../../common/feature_flags';
 
 jest.mock('../../lib/get_managed_otlp_service_url', () => ({
   getManagedOtlpServiceUrl: jest.fn().mockReturnValue('https://otlp.example.com:443'),
@@ -46,19 +47,45 @@ describe('hasManagedElasticsearchBulkEndpoint', () => {
 });
 
 describe('ensureVendorEndpointAvailable', () => {
+  const available = { isManagedOtlpServiceAvailable: true, vendorEndpointsEnabled: true };
+
   it('throws for vendor endpoints when the managed OTLP service is unavailable', () => {
-    expect(() => ensureVendorEndpointAvailable(ApiEndpointId.Supabase, false)).toThrow(
-      /managed OTLP service/
-    );
-    expect(() => ensureVendorEndpointAvailable(ApiEndpointId.Vercel, false)).toThrow(
-      /managed OTLP service/
-    );
+    expect(() =>
+      ensureVendorEndpointAvailable(ApiEndpointId.Supabase, {
+        ...available,
+        isManagedOtlpServiceAvailable: false,
+      })
+    ).toThrow(/managed OTLP service/);
+    expect(() =>
+      ensureVendorEndpointAvailable(ApiEndpointId.Vercel, {
+        ...available,
+        isManagedOtlpServiceAvailable: false,
+      })
+    ).toThrow(/managed OTLP service/);
+  });
+
+  it('throws for vendor endpoints when the vendor endpoints flag is disabled', () => {
+    expect(() =>
+      ensureVendorEndpointAvailable(ApiEndpointId.Supabase, {
+        ...available,
+        vendorEndpointsEnabled: false,
+      })
+    ).toThrow(/not enabled/);
+    expect(() =>
+      ensureVendorEndpointAvailable(ApiEndpointId.Vercel, {
+        ...available,
+        vendorEndpointsEnabled: false,
+      })
+    ).toThrow(/not enabled/);
   });
 
   it('marks the failure as a 400 bad request', () => {
     let error: unknown;
     try {
-      ensureVendorEndpointAvailable(ApiEndpointId.Supabase, false);
+      ensureVendorEndpointAvailable(ApiEndpointId.Supabase, {
+        ...available,
+        vendorEndpointsEnabled: false,
+      });
     } catch (caught) {
       error = caught;
     }
@@ -66,14 +93,19 @@ describe('ensureVendorEndpointAvailable', () => {
     expect((error as Boom.Boom).output.statusCode).toBe(400);
   });
 
-  it('passes vendor endpoints when the managed OTLP service is available', () => {
-    expect(() => ensureVendorEndpointAvailable(ApiEndpointId.Supabase, true)).not.toThrow();
-    expect(() => ensureVendorEndpointAvailable(ApiEndpointId.Vercel, true)).not.toThrow();
+  it('passes vendor endpoints when the service is available and the flag is enabled', () => {
+    expect(() => ensureVendorEndpointAvailable(ApiEndpointId.Supabase, available)).not.toThrow();
+    expect(() => ensureVendorEndpointAvailable(ApiEndpointId.Vercel, available)).not.toThrow();
   });
 
   it('ignores non-vendor endpoints regardless of availability', () => {
-    expect(() => ensureVendorEndpointAvailable(ApiEndpointId.OpenTelemetry, false)).not.toThrow();
-    expect(() => ensureVendorEndpointAvailable(ApiEndpointId.Prometheus, false)).not.toThrow();
+    const unavailable = { isManagedOtlpServiceAvailable: false, vendorEndpointsEnabled: false };
+    expect(() =>
+      ensureVendorEndpointAvailable(ApiEndpointId.OpenTelemetry, unavailable)
+    ).not.toThrow();
+    expect(() =>
+      ensureVendorEndpointAvailable(ApiEndpointId.Prometheus, unavailable)
+    ).not.toThrow();
   });
 });
 
@@ -101,15 +133,25 @@ describe('create_key handler', () => {
   const createResources = ({
     id,
     isServerless = true,
+    vendorEndpointsEnabled = true,
   }: {
     id: ApiEndpointId;
     isServerless?: boolean;
+    vendorEndpointsEnabled?: boolean;
   }) =>
     ({
       context: {
         core: Promise.resolve({
           elasticsearch: { client: { asCurrentUser: {} } },
-          featureFlags: { getBooleanValue: jest.fn().mockResolvedValue(false) },
+          featureFlags: {
+            getBooleanValue: jest
+              .fn()
+              .mockImplementation((key: string) =>
+                Promise.resolve(
+                  key === IS_VENDOR_ENDPOINTS_ENABLED ? vendorEndpointsEnabled : false
+                )
+              ),
+          },
         }),
       },
       config: { serverless: { enabled: isServerless } },
@@ -157,4 +199,16 @@ describe('create_key handler', () => {
     expect(hasApiKeyPrivileges).not.toHaveBeenCalled();
     expect(resolveApiKeyFactory).not.toHaveBeenCalled();
   });
+
+  it.each([ApiEndpointId.Supabase, ApiEndpointId.Vercel])(
+    'rejects %s key creation with 400 before any privilege check when the vendor endpoints flag is disabled',
+    async (id) => {
+      await expect(
+        handler(createResources({ id, vendorEndpointsEnabled: false }))
+      ).rejects.toMatchObject({ output: { statusCode: 400 } });
+
+      expect(hasApiKeyPrivileges).not.toHaveBeenCalled();
+      expect(resolveApiKeyFactory).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/api_endpoints/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/api_endpoints/route.ts
@@ -26,6 +26,7 @@ import { ApiEndpointId } from '../../../common/api_endpoints';
 import {
   IS_MANAGED_OTLP_SERVICE_ENABLED,
   IS_MANAGED_OTLP_SERVICE_PRW_ENDPOINT_ENABLED,
+  IS_VENDOR_ENDPOINTS_ENABLED,
 } from '../../../common/feature_flags';
 
 export interface ApiEndpointsRouteResponse {
@@ -46,12 +47,25 @@ const VENDOR_ENDPOINT_IDS: readonly ApiEndpointId[] = [
   ApiEndpointId.Vercel,
 ];
 
-// Vendor paths exist only on the managed OTLP collector. Reject key creation when it is unavailable.
+export interface VendorEndpointAvailability {
+  isManagedOtlpServiceAvailable: boolean;
+  vendorEndpointsEnabled: boolean;
+}
+
+// Vendor paths only exist on the managed OTLP collector, so a key for them is
+// useless anywhere else. The UI never offers creation in that state, this
+// guard makes the API honest anyway.
 export function ensureVendorEndpointAvailable(
   id: ApiEndpointId,
-  isManagedOtlpServiceAvailable: boolean
+  { isManagedOtlpServiceAvailable, vendorEndpointsEnabled }: VendorEndpointAvailability
 ): void {
-  if (VENDOR_ENDPOINT_IDS.includes(id) && !isManagedOtlpServiceAvailable) {
+  if (!VENDOR_ENDPOINT_IDS.includes(id)) {
+    return;
+  }
+  if (!vendorEndpointsEnabled) {
+    throw Boom.badRequest(`The ${id} endpoint is not enabled on this deployment.`);
+  }
+  if (!isManagedOtlpServiceAvailable) {
     throw Boom.badRequest(
       `The ${id} endpoint requires the managed OTLP service, which is not available on this deployment.`
     );
@@ -152,6 +166,10 @@ const createApiKeyRoute = createObservabilityOnboardingServerRoute({
     const managedOtlpPrwEndpointEnabled =
       (await featureFlags.getBooleanValue(IS_MANAGED_OTLP_SERVICE_PRW_ENDPOINT_ENABLED, false)) &&
       Boolean(managedOtlpServiceUrl);
+    const vendorEndpointsEnabled = await featureFlags.getBooleanValue(
+      IS_VENDOR_ENDPOINTS_ENABLED,
+      false
+    );
     const isManagedElasticsearchBulkEndpointAvailable =
       hasManagedElasticsearchBulkEndpoint(managedOtlpServiceUrl);
     const isVendorEndpointAvailable =
@@ -164,7 +182,10 @@ const createApiKeyRoute = createObservabilityOnboardingServerRoute({
       isManagedElasticsearchBulkEndpointAvailable,
     };
 
-    ensureVendorEndpointAvailable(id, isVendorEndpointAvailable);
+    ensureVendorEndpointAvailable(id, {
+      isManagedOtlpServiceAvailable: isVendorEndpointAvailable,
+      vendorEndpointsEnabled,
+    });
 
     const hasPrivileges = await hasRequiredPrivileges(
       id,


### PR DESCRIPTION
## Summary

Adds `observability.vendorEndpointsEnabled` and uses it to gate the Supabase and Vercel vendor endpoints on the  Add Data page.

- Code default is `false` everywhere the flag is read. There is no `isServerless` bypass.
- Client side, `useApiEndpoints` reads the flag and threads it through `ApiEndpointContext`. When the flag is off, `getVendorEndpointsForTab` and `getPopoverVendorEndpoints` return an empty list, which hides the Supabase tab row and the More popover button with zero component changes.
- Server side, the `create_key` route rejects vendor key creation for Supabase and Vercel with a 400 before any privilege check when the flag is off.

Vendor endpoints shipped in #281955 on top of #281279 and are currently live in serverless production with no gating. The ingest team asked to hide them in production while keeping them available in QA and staging for end to end testing.
 See the Slack thread for context: https://elastic.slack.com/archives/C0BENNKL5GV/p1785835522429429?thread_ts=1784897357.106469&cid=C0BENNKL5GV

