### PR TITLE
[ESO Key Rotation] Add maxLength to string param

### DIFF
--- a/x-pack/platform/plugins/shared/encrypted_saved_objects/server/routes/key_rotation.ts
+++ b/x-pack/platform/plugins/shared/encrypted_saved_objects/server/routes/key_rotation.ts
@@ -37,7 +37,7 @@ export function defineKeyRotationRoutes({
             max: DEFAULT_MAX_RESULT_WINDOW,
             defaultValue: DEFAULT_MAX_RESULT_WINDOW,
           }),
-          type: schema.maybe(schema.string()),
+          type: schema.maybe(schema.string({ maxLength: 256 })),
         }),
       },
       security: {


### PR DESCRIPTION
## Summary

Adds a `maxLength` to the `type` property of the ESO Key Rotation API. This is meant to capture an optional Saved Object Type when re-encrypting saved objects.



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->