### PR TITLE
Add max length to signature parameter

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/routes/analytics/authentication_type.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/analytics/authentication_type.ts
@@ -41,7 +41,10 @@ export function defineRecordAnalyticsOnAuthTypeRoutes({
       },
       validate: {
         body: schema.nullable(
-          schema.object({ signature: schema.string({ maxLength: 128 }), timestamp: schema.number() })
+          schema.object({
+            signature: schema.string({ maxLength: 128 }),
+            timestamp: schema.number(),
+          })
         ),
       },
     },

--- a/x-pack/platform/plugins/shared/security/server/routes/analytics/authentication_type.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/analytics/authentication_type.ts
@@ -41,7 +41,7 @@ export function defineRecordAnalyticsOnAuthTypeRoutes({
       },
       validate: {
         body: schema.nullable(
-          schema.object({ signature: schema.string(), timestamp: schema.number() })
+          schema.object({ signature: schema.string({ maxLength: 128 }), timestamp: schema.number() })
         ),
       },
     },


### PR DESCRIPTION
## Summary

Adds a `maxLength` to the `signature` parameter of our `/internal/security/analytics/_record_auth_type` endpoint. The signature should not exceed `64` hex characters, so I doubled this to give a safe buffer of `128`

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->