### PR TITLE
[9.5] Refactor LogsLocator to use data view spec instead of ID (#279118)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_all_logs_data_view_spec.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_all_logs_data_view_spec.test.ts
@@ -19,4 +19,8 @@ describe('getAllLogsDataViewSpec', () => {
       })
     );
   });
+
+  it('marks the data view as managed so it is not editable, since it is recreated on every navigation', () => {
+    expect(getAllLogsDataViewSpec({ allLogsIndexPattern: 'logs-*' }).managed).toBe(true);
+  });
 });

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_all_logs_data_view_spec.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_all_logs_data_view_spec.ts
@@ -22,4 +22,7 @@ export const getAllLogsDataViewSpec = ({
   }),
   title: allLogsIndexPattern,
   timeFieldName: '@timestamp',
+  // This data view is recreated from this spec on every navigation, so user edits would be
+  // silently discarded. Marking it managed steers them to duplicate it instead.
+  managed: true,
 });

--- a/src/platform/plugins/shared/discover/public/__mocks__/services.ts
+++ b/src/platform/plugins/shared/discover/public/__mocks__/services.ts
@@ -10,6 +10,7 @@
 import type { Observable } from 'rxjs';
 import { BehaviorSubject, of } from 'rxjs';
 import type { DiscoverServices, HistoryLocationState } from '../build_services';
+import { InitialTabStateService } from '../plugin_imports/initial_tab_state_service';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { uiActionsPluginMock } from '@kbn/ui-actions-plugin/public/mocks';
 import { expressionsPluginMock } from '@kbn/expressions-plugin/public/mocks';
@@ -202,6 +203,7 @@ export function createDiscoverServicesMock(): DiscoverServices {
     chrome: corePluginMock.chrome,
     history,
     getScopedHistory: () => scopedHistoryMock.create(),
+    initialTabStateService: new InitialTabStateService(),
     data: dataPlugin,
     dataVisualizer: {
       FieldStatisticsTable: jest.fn(() => createElement('div')),

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view.tsx
@@ -14,7 +14,6 @@ import type { ControlPanelsState } from '@kbn/control-group-renderer';
 import useLatest from 'react-use/lib/useLatest';
 import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
 import { createDataViewDataSource } from '../../../../../common/data_sources';
-import type { MainHistoryLocationState } from '../../../../../common';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import type { DiscoverAppState } from '../../state_management/redux';
 import { getDataStateContainer } from '../../state_management/discover_data_state_container';
@@ -126,14 +125,14 @@ export const SingleTabView = ({
 
   useEffect(() => {
     if (currentTabInitializationState.initializationStatus === TabInitializationStatus.NotStarted) {
-      const historyLocationState = services.getScopedHistory<
-        MainHistoryLocationState & { defaultState?: DiscoverAppState }
-      >()?.location.state;
+      // The location state is captured by `initializeTabs` before the tab ID is pushed to the URL,
+      // which discards it, so it can't be read from the history here
+      const initialTabState = services.initialTabStateService.consume();
 
       initializeTab.current({
-        dataViewSpec: historyLocationState?.dataViewSpec,
-        esqlControls: historyLocationState?.esqlControls,
-        defaultUrlState: historyLocationState?.defaultState,
+        dataViewSpec: initialTabState?.dataViewSpec,
+        esqlControls: initialTabState?.esqlControls,
+        defaultUrlState: initialTabState?.defaultState,
       });
     }
   }, [currentTabInitializationState.initializationStatus, initializeTab, services]);

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -43,6 +43,7 @@ import { setBreadcrumbs } from '../../../../../utils/breadcrumbs';
 import { DEFAULT_TAB_STATE } from '../constants';
 import type { DiscoverAppLocatorParams } from '../../../../../../common';
 import { parseAppLocatorParams } from '../../../../../../common/app_locator_get_location';
+import type { InitialTabState } from '../../../../../plugin_imports/initial_tab_state_service';
 import { fetchData } from './tab_state';
 import { fromSavedObjectTabToTabState } from '../tab_mapping_utils';
 import { initializeAndSync, stopSyncing } from './tab_sync';
@@ -392,21 +393,17 @@ export const initializeTabs = createInternalStateAsyncThunk(
       defaultTabState: byValueEmbeddableTabState ?? DEFAULT_TAB_STATE,
     });
 
-    const history = services.getScopedHistory();
-    const locationState = history?.location.state;
+    // Hand the location state over to the tab initialization before updating the URL below, which
+    // discards it, so initial state such as ad hoc data view specs is passed on
+    services.initialTabStateService.capture(
+      services.getScopedHistory<InitialTabState>()?.location.state
+    );
 
     // Replace instead of push the tab ID to the URL on initialization in order to
     // avoid capturing a browser history entry with a potentially empty _tab state
     await tabsStorageManager.pushSelectedTabIdToUrl(initialTabsState.selectedTabId, {
       replace: true,
     });
-
-    // Manually restore the previous location state since pushing the tab ID
-    // to the URL clears it, but initial location state must be passed on,
-    // e.g. ad hoc data views specs
-    if (locationState) {
-      history.replace({ ...history.location, state: locationState });
-    }
 
     dispatch(
       setTabs({

--- a/src/platform/plugins/shared/discover/public/build_services.ts
+++ b/src/platform/plugins/shared/discover/public/build_services.ts
@@ -79,6 +79,7 @@ import {
   IS_ESQL_DEFAULT_FEATURE_FLAG_KEY,
 } from './constants';
 import { EmbeddableEditorService } from './plugin_imports/embeddable_editor_service';
+import { InitialTabStateService } from './plugin_imports/initial_tab_state_service';
 
 /**
  * Location state of internal Discover history instance
@@ -118,6 +119,7 @@ export interface DiscoverServices {
   embeddable: EmbeddableStart;
   history: History<HistoryLocationState>;
   getScopedHistory: <T>() => ScopedHistory<T | undefined> | undefined;
+  initialTabStateService: InitialTabStateService;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
   theme: ThemeServiceStart;
   userProfile: UserProfileService;
@@ -228,6 +230,7 @@ export const buildServices = ({
     filterManager: plugins.data.query.filterManager,
     history,
     getScopedHistory: <T>() => scopedHistory as ScopedHistory<T | undefined>,
+    initialTabStateService: new InitialTabStateService(),
     setHeaderActionMenu,
     dataViews: plugins.data.dataViews,
     inspector: plugins.inspector,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/classic_nav_root_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/classic_nav_root_profile/profile.test.ts
@@ -58,6 +58,7 @@ describe('classicNavRootProfileProvider', () => {
           name: 'All logs',
           timeFieldName: '@timestamp',
           title: 'logs-*',
+          managed: true,
         },
       ]);
     });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/profile.test.ts
@@ -71,6 +71,7 @@ describe('observabilityRootProfileProvider', () => {
           name: 'All logs',
           timeFieldName: '@timestamp',
           title: 'logs-*',
+          managed: true,
         },
       ]);
     });

--- a/src/platform/plugins/shared/discover/public/plugin_imports/initial_tab_state_service.test.ts
+++ b/src/platform/plugins/shared/discover/public/plugin_imports/initial_tab_state_service.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { InitialTabStateService, type InitialTabState } from './initial_tab_state_service';
+
+const allLogsSpec: InitialTabState = {
+  dataViewSpec: { id: 'all-logs', title: 'logs*' },
+};
+
+describe('InitialTabStateService', () => {
+  it('returns undefined when nothing has been captured', () => {
+    expect(new InitialTabStateService().consume()).toBeUndefined();
+  });
+
+  it('returns the captured state', () => {
+    const service = new InitialTabStateService();
+
+    service.capture(allLogsSpec);
+
+    expect(service.consume()).toEqual(allLogsSpec);
+  });
+
+  it('clears the captured state once consumed, so it applies only to the tab it was captured for', () => {
+    const service = new InitialTabStateService();
+
+    service.capture(allLogsSpec);
+
+    expect(service.consume()).toEqual(allLogsSpec);
+    expect(service.consume()).toBeUndefined();
+  });
+
+  it('supersedes a state that was never consumed', () => {
+    const service = new InitialTabStateService();
+    const nextState: InitialTabState = { defaultState: { interval: 'auto' } };
+
+    service.capture(allLogsSpec);
+    service.capture(nextState);
+
+    expect(service.consume()).toEqual(nextState);
+  });
+
+  it('clears the captured state when a navigation supplies none', () => {
+    const service = new InitialTabStateService();
+
+    service.capture(allLogsSpec);
+    service.capture(undefined);
+
+    expect(service.consume()).toBeUndefined();
+  });
+});

--- a/src/platform/plugins/shared/discover/public/plugin_imports/initial_tab_state_service.ts
+++ b/src/platform/plugins/shared/discover/public/plugin_imports/initial_tab_state_service.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { MainHistoryLocationState } from '../../common';
+import type { DiscoverAppState } from '../application/main/state_management/redux';
+
+/**
+ * The location state a navigation can hand to Discover to seed the tab it is about to initialize,
+ * e.g. an ad hoc data view spec from a locator, or the default app state from the "New session"
+ * action.
+ */
+export interface InitialTabState extends MainHistoryLocationState {
+  defaultState?: DiscoverAppState;
+}
+
+/**
+ * Carries the initial tab state from the navigation that supplied it to the tab initialization that
+ * consumes it.
+ *
+ * Location state cannot simply be read from the history when it's needed: pushing the selected tab
+ * ID to the URL goes through the hash history, which updates the URL with `window.location.replace`
+ * and discards `window.history.state` in the process. Tab initialization therefore snapshots the
+ * state up front and hands it over here, instead of writing it back to the history entry.
+ */
+export class InitialTabStateService {
+  private pendingState: InitialTabState | undefined;
+
+  /**
+   * Snapshots the initial tab state for the navigation currently being handled. Must be called
+   * before any URL update, since those discard the location state. A capture with no consumer is
+   * superseded by the next one.
+   */
+  capture(initialTabState: InitialTabState | undefined) {
+    this.pendingState = initialTabState;
+  }
+
+  /**
+   * Returns the snapshotted initial tab state and clears it, so it's applied only to the tab it was
+   * captured for.
+   */
+  consume(): InitialTabState | undefined {
+    const initialTabState = this.pendingState;
+    this.pendingState = undefined;
+    return initialTabState;
+  }
+}

--- a/x-pack/platform/plugins/shared/logs_shared/common/locators/logs_locator.test.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/common/locators/logs_locator.test.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { ALL_LOGS_DATA_VIEW_ID } from '@kbn/discover-utils/src';
+import { getAllLogsDataViewSpec } from '@kbn/discover-utils/src';
 import { LogsLocatorDefinition } from './logs_locator';
 
 const CUSTOM_LOG_PATTERN = 'custom-logs-*,remote:custom-logs-*';
+
+const ALL_LOGS_DATA_VIEW_SPEC = getAllLogsDataViewSpec({ allLogsIndexPattern: CUSTOM_LOG_PATTERN });
 
 const mockGetLocation = jest.fn().mockResolvedValue({
   app: 'discover',
@@ -26,7 +28,11 @@ const mockGetLogSourcesService = jest.fn().mockResolvedValue({
   getFlattenedLogSources: mockGetFlattenedLogSources,
 });
 
-const createLocator = (isEsqlDefault: boolean) =>
+const createLocator = ({
+  isEsqlDefault = false,
+}: {
+  isEsqlDefault?: boolean;
+} = {}) =>
   new LogsLocatorDefinition({
     locators: mockLocators as any,
     getLogSourcesService: mockGetLogSourcesService,
@@ -40,7 +46,7 @@ describe('LogsLocatorDefinition', () => {
 
   describe('when discover.isEsqlDefault is true', () => {
     it('delegates to DISCOVER_APP_LOCATOR with an ES|QL query when no query param is provided', async () => {
-      const locator = createLocator(true);
+      const locator = createLocator({ isEsqlDefault: true });
 
       await locator.getLocation({});
 
@@ -50,21 +56,21 @@ describe('LogsLocatorDefinition', () => {
       });
     });
 
-    it('preserves the caller-provided query when one is given', async () => {
-      const locator = createLocator(true);
+    it('falls through to the data view resolution when a query is given', async () => {
+      const locator = createLocator({ isEsqlDefault: true });
       const callerQuery = { language: 'kuery', query: 'host.name: "my-host"' };
 
       await locator.getLocation({ query: callerQuery });
 
       expect(mockGetLocation).toHaveBeenCalledWith({
-        dataViewId: ALL_LOGS_DATA_VIEW_ID,
+        dataViewSpec: ALL_LOGS_DATA_VIEW_SPEC,
         query: callerQuery,
       });
-      expect(mockGetFlattenedLogSources).not.toHaveBeenCalled();
+      expect(mockGetFlattenedLogSources).toHaveBeenCalled();
     });
 
     it('spreads consumer-provided params into the delegated call', async () => {
-      const locator = createLocator(true);
+      const locator = createLocator({ isEsqlDefault: true });
       const extraParams = {
         timeRange: { from: 'now-15m', to: 'now' },
         filters: [{ meta: { alias: 'test' } }],
@@ -80,29 +86,66 @@ describe('LogsLocatorDefinition', () => {
   });
 
   describe('when discover.isEsqlDefault is false', () => {
-    it('delegates to DISCOVER_APP_LOCATOR with dataViewId', async () => {
-      const locator = createLocator(false);
+    describe('by default', () => {
+      it('builds and delegates the all-logs ad-hoc data view spec', async () => {
+        const locator = createLocator();
 
-      await locator.getLocation({});
+        await locator.getLocation({});
 
-      expect(mockLocators.get).toHaveBeenCalledWith('DISCOVER_APP_LOCATOR');
-      expect(mockGetLocation).toHaveBeenCalledWith({
-        dataViewId: ALL_LOGS_DATA_VIEW_ID,
+        expect(mockLocators.get).toHaveBeenCalledWith('DISCOVER_APP_LOCATOR');
+        const delegatedParams = mockGetLocation.mock.calls[0][0];
+        expect(mockGetFlattenedLogSources).toHaveBeenCalled();
+        expect(delegatedParams.dataViewSpec).toEqual(ALL_LOGS_DATA_VIEW_SPEC);
+        expect(delegatedParams).not.toHaveProperty('dataViewId');
+      });
+
+      it('delegates a managed spec, so the data view matches the one the root profiles register', async () => {
+        const locator = createLocator();
+
+        await locator.getLocation({});
+
+        expect(mockGetLocation.mock.calls[0][0].dataViewSpec.managed).toBe(true);
+      });
+
+      it('spreads consumer-provided params into the delegated call', async () => {
+        const locator = createLocator();
+        const extraParams = {
+          timeRange: { from: 'now-1h', to: 'now' },
+          columns: ['message', '@timestamp'],
+        };
+
+        await locator.getLocation(extraParams as any);
+
+        const delegatedParams = mockGetLocation.mock.calls[0][0];
+        expect(delegatedParams.dataViewSpec).toEqual(ALL_LOGS_DATA_VIEW_SPEC);
+        expect(delegatedParams.timeRange).toEqual(extraParams.timeRange);
+        expect(delegatedParams.columns).toEqual(extraParams.columns);
       });
     });
 
-    it('spreads consumer-provided params into the delegated call', async () => {
-      const locator = createLocator(false);
-      const extraParams = {
-        timeRange: { from: 'now-1h', to: 'now' },
-        columns: ['message', '@timestamp'],
-      };
+    describe('when the caller provides a data view', () => {
+      it('respects a caller-provided dataViewId', async () => {
+        const locator = createLocator();
+        const callerQuery = { language: 'kuery', query: 'aws.cloudwatch.namespace: AWS/EC2' };
 
-      await locator.getLocation(extraParams as any);
+        await locator.getLocation({ dataViewId: 'metrics-*', query: callerQuery } as any);
 
-      expect(mockGetLocation).toHaveBeenCalledWith({
-        dataViewId: ALL_LOGS_DATA_VIEW_ID,
-        ...extraParams,
+        const delegatedParams = mockGetLocation.mock.calls[0][0];
+        expect(delegatedParams).toEqual({ dataViewId: 'metrics-*', query: callerQuery });
+        expect(delegatedParams).not.toHaveProperty('dataViewSpec');
+        expect(mockGetFlattenedLogSources).not.toHaveBeenCalled();
+      });
+
+      it('respects a caller-provided dataViewSpec', async () => {
+        const locator = createLocator();
+        const callerDataViewSpec = { title: 'logs-aws.ec2-*', timeFieldName: '@timestamp' };
+
+        await locator.getLocation({ dataViewSpec: callerDataViewSpec } as any);
+
+        const delegatedParams = mockGetLocation.mock.calls[0][0];
+        expect(delegatedParams).toEqual({ dataViewSpec: callerDataViewSpec });
+        expect(delegatedParams.dataViewSpec).not.toEqual(ALL_LOGS_DATA_VIEW_SPEC);
+        expect(mockGetFlattenedLogSources).not.toHaveBeenCalled();
       });
     });
   });

--- a/x-pack/platform/plugins/shared/logs_shared/common/locators/logs_locator.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/common/locators/logs_locator.ts
@@ -6,7 +6,7 @@
  */
 
 import { type DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
-import { ALL_LOGS_DATA_VIEW_ID } from '@kbn/discover-utils/src';
+import { getAllLogsDataViewSpec } from '@kbn/discover-utils/src';
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
 import type { LocatorDefinition } from '@kbn/share-plugin/common';
 import type { LocatorClient } from '@kbn/share-plugin/common/url_service';
@@ -17,7 +17,7 @@ import type { LocatorClient } from '@kbn/share-plugin/common/url_service';
 export const LOGS_LOCATOR_ID = 'LOGS_LOCATOR';
 
 /**
- * Accepts the same parameters as `DiscoverAppLocatorParams`, but automatically sets the `dataViewId` param to all log sources.
+ * Accepts the same parameters as `DiscoverAppLocatorParams`, but automatically sets the data view to all log sources.
  */
 export type LogsLocatorParams = DiscoverAppLocatorParams;
 
@@ -39,8 +39,7 @@ export class LogsLocatorDefinition implements LocatorDefinition<LogsLocatorParam
     const isEsqlDefault = await this.deps.getIsEsqlDefault();
 
     if (isEsqlDefault && !params.query) {
-      const logSourcesService = await this.deps.getLogSourcesService();
-      const flattenedLogSources = await logSourcesService.getFlattenedLogSources();
+      const flattenedLogSources = await this.getFlattenedLogSources();
 
       return discoverAppLocator.getLocation({
         ...params,
@@ -48,9 +47,21 @@ export class LogsLocatorDefinition implements LocatorDefinition<LogsLocatorParam
       });
     }
 
+    // Respect a caller-provided data view (e.g. onboarding wired streams).
+    if (params.dataViewId || params.dataViewSpec) {
+      return discoverAppLocator.getLocation(params);
+    }
+
+    const flattenedLogSources = await this.getFlattenedLogSources();
+
     return discoverAppLocator.getLocation({
-      dataViewId: ALL_LOGS_DATA_VIEW_ID,
+      dataViewSpec: getAllLogsDataViewSpec({ allLogsIndexPattern: flattenedLogSources }),
       ...params,
     });
   };
+
+  private async getFlattenedLogSources() {
+    const logSourcesService = await this.deps.getLogSourcesService();
+    return logSourcesService.getFlattenedLogSources();
+  }
 }

--- a/x-pack/platform/plugins/shared/logs_shared/tsconfig.json
+++ b/x-pack/platform/plugins/shared/logs_shared/tsconfig.json
@@ -55,6 +55,6 @@
     "@kbn/xstate-utils",
     "@kbn/ml-plugin",
     "@kbn/saved-search-component",
-    "@kbn/core-execution-context-common"
+    "@kbn/core-execution-context-common",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Refactor LogsLocator to use data view spec instead of ID (#279118)](https://github.com/elastic/kibana/pull/279118)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lucas Francisco López","email":"lucaslopezf@gmail.com"},"sourceCommit":{"committedDate":"2026-08-04T09:46:53Z","message":"Refactor LogsLocator to use data view spec instead of ID (#279118)\n\nCloses: #278850\n\n## Summary\n\nThe Logs locator (`LOGS_LOCATOR`) navigates Discover to the \"All logs\"\ndata view\n(`discover-observability-solution-all-logs`). That id is only registered\nas an ad-hoc data view by\nthe **Observability** and **Classic** Discover root profiles. In other\nsolutions (e.g. **Security**,\nSearch) the id is never registered, so any \"Open in Discover\" entry\npoint that relied on the\nlocator failed with:\n\n```\nError: discover-observability-solution-all-logs\" is not a configured data view ID\n```\n\nThis PR fixes the problem in two parts:\n\n1. **Discover (root cause):** the tab initialization now waits for the\nroot profile's ad-hoc data\nviews to be registered before it resolves the tab's data view.\nPreviously these two steps ran as\nindependent, unordered effects, which allowed a race on the instance\ncache when a navigation\n   passed a data view spec colliding with a profile-managed id.\n2. **logs_shared (locator):** the locator always builds the ad-hoc \"All\nlogs\" `dataViewSpec` for its\ndefault navigation. It works out of the box in solutions that do not\nregister the id (Security,\nSearch), and — with the Discover ordering fix — no longer races the\nprofile registration in\n   solutions that do (Observability, Classic).\n\nThe result: no per-solution allow-list in the locator, and no consumer\nchanges.\n\n## History\n\nThis is the third iteration on the same underlying bug:\n\n- The original fix, https://github.com/elastic/kibana/pull/276647,\nswitched the locator to always\npass the ad-hoc `dataViewSpec`. It fixed the Security scenario but\ncaused a timeout in the FTR\n  test `redirects to Discover when logs data is present`\n\n(`x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/landing/redirects.ts`),\n  so it was reverted in https://github.com/elastic/kibana/pull/278845.\n- An interim iteration made the locator solution-aware (branch on the\nactive solution nav id). It\nworked, but hard-coded an allow-list of solutions inside the locator\nthat had to be kept in sync\n  with the Discover root profiles.\n- This PR instead fixes the race at its source in Discover (init\nordering), which lets the locator\n  stay simple (always pass the spec) without reintroducing the timeout.\n\n## Background: the reported bug\n\nIn a **Security** serverless project, clicking **\"Open in Discover\"**\nfrom Fleet\n(agent details -> Logs tab, and the Custom Logs integration \"Logs\"\nasset) threw the error above.\n\nRoot cause: the locator relied on `ALL_LOGS_DATA_VIEW_ID`, but the\nad-hoc \"All logs\" data view is\nregistered at runtime by the active Discover **root profile** via\n`getDefaultAdHocDataViews`:\n\n- Observability root profile -> registers it.\n- Classic nav root profile -> registers it.\n- Security root profile -> does **not** register it.\n\nSo in Security (and any non-obs/non-classic solution) the id is unknown\nto Discover and resolution\nfails.\n\n## Why the \"always pass the spec\" attempt failed on its own\n\nThe generated spec reuses `id = ALL_LOGS_DATA_VIEW_ID`, which\n**collides** with the same id\nregistered by the Observability root profile. The failure was a **race\ncondition** in Discover\ninitialization, not a stable behavior:\n\n- `initializeMainRoute` registers the profile's ad-hoc data views\n(`getDefaultAdHocDataViews` ->\n  `clearInstanceCache` + `create` for the all-logs id).\n- `initializeDiscoverSession` -> `initializeTabs` ->\n`initializeSingleTab` resolves the tab's data\nview. When a `locationDataViewSpec` is present, `loadDataView` runs\n`clearInstanceCache(id)` +\n  `create(spec)` for the **same** id.\n\nThese two ran in **separate, unordered `useEffect`s**. When the tab\nresolution won the race, it\nseeded a competing instance for the all-logs id before (or while) the\nprofile registered its own,\nso both sides thrashed the data views instance cache for that id.\nDiscover's data view never\nstabilized, the search never finished, and the navigation exceeded the\nWebDriver `pageLoadTimeout`\n(300s) -> `Timeout of 360000ms exceeded` in `redirects.ts`. Infra jitter\nonly decided **which side\nwon the race**, which is why the test passed on some CI runs and hung on\nothers.\n\nBecause the Fleet entry points are reachable from **both** Observability\nand Security projects (Fleet\nis enabled for both serverless project types), the locator alone could\nnot both avoid the collision\nin Observability and produce a working data view in Security.\n\n## Chosen approach and why\n\nFix the race where it belongs — in Discover's initialization order — so\nthe locator no longer needs\nto know which solutions register the id:\n\n- In `discover_main_route.tsx`, the effect that initializes the tabs is\ngated on\n`mainRouteInitializationState.value`, i.e. it only runs after\n`initializeMainRoute` (which\nregisters the profile ad-hoc data views) has resolved. This guarantees a\nsingle owner of the\nall-logs id by the time the tab resolves its data view, eliminating the\ninstance-cache thrash.\n- The locator (`logs_locator.ts`) always builds the ad-hoc\n`dataViewSpec` for its default\nnavigation, dropping the solution allow-list, the\n`getActiveSolutionNavId` dependency, and the\n  hard-coded `ALL_LOGS_DATA_VIEW_ID` id.\n\nThe ordering change is safe for the rest of Discover: rendering was\nalready blocked on both\ninitializations (`isLoading`), and `useAsyncFn` preserves the resolved\n`value` across re-runs, so\nthe guard does not introduce spurious tab re-initializations.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"bd16985949f4585e9a4d86b5d75a87f58c136260","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:obs-exploration","v9.4.0","v9.5.0","v9.6.0"],"title":"Refactor LogsLocator to use data view spec instead of ID","number":279118,"url":"https://github.com/elastic/kibana/pull/279118","mergeCommit":{"message":"Refactor LogsLocator to use data view spec instead of ID (#279118)\n\nCloses: #278850\n\n## Summary\n\nThe Logs locator (`LOGS_LOCATOR`) navigates Discover to the \"All logs\"\ndata view\n(`discover-observability-solution-all-logs`). That id is only registered\nas an ad-hoc data view by\nthe **Observability** and **Classic** Discover root profiles. In other\nsolutions (e.g. **Security**,\nSearch) the id is never registered, so any \"Open in Discover\" entry\npoint that relied on the\nlocator failed with:\n\n```\nError: discover-observability-solution-all-logs\" is not a configured data view ID\n```\n\nThis PR fixes the problem in two parts:\n\n1. **Discover (root cause):** the tab initialization now waits for the\nroot profile's ad-hoc data\nviews to be registered before it resolves the tab's data view.\nPreviously these two steps ran as\nindependent, unordered effects, which allowed a race on the instance\ncache when a navigation\n   passed a data view spec colliding with a profile-managed id.\n2. **logs_shared (locator):** the locator always builds the ad-hoc \"All\nlogs\" `dataViewSpec` for its\ndefault navigation. It works out of the box in solutions that do not\nregister the id (Security,\nSearch), and — with the Discover ordering fix — no longer races the\nprofile registration in\n   solutions that do (Observability, Classic).\n\nThe result: no per-solution allow-list in the locator, and no consumer\nchanges.\n\n## History\n\nThis is the third iteration on the same underlying bug:\n\n- The original fix, https://github.com/elastic/kibana/pull/276647,\nswitched the locator to always\npass the ad-hoc `dataViewSpec`. It fixed the Security scenario but\ncaused a timeout in the FTR\n  test `redirects to Discover when logs data is present`\n\n(`x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/landing/redirects.ts`),\n  so it was reverted in https://github.com/elastic/kibana/pull/278845.\n- An interim iteration made the locator solution-aware (branch on the\nactive solution nav id). It\nworked, but hard-coded an allow-list of solutions inside the locator\nthat had to be kept in sync\n  with the Discover root profiles.\n- This PR instead fixes the race at its source in Discover (init\nordering), which lets the locator\n  stay simple (always pass the spec) without reintroducing the timeout.\n\n## Background: the reported bug\n\nIn a **Security** serverless project, clicking **\"Open in Discover\"**\nfrom Fleet\n(agent details -> Logs tab, and the Custom Logs integration \"Logs\"\nasset) threw the error above.\n\nRoot cause: the locator relied on `ALL_LOGS_DATA_VIEW_ID`, but the\nad-hoc \"All logs\" data view is\nregistered at runtime by the active Discover **root profile** via\n`getDefaultAdHocDataViews`:\n\n- Observability root profile -> registers it.\n- Classic nav root profile -> registers it.\n- Security root profile -> does **not** register it.\n\nSo in Security (and any non-obs/non-classic solution) the id is unknown\nto Discover and resolution\nfails.\n\n## Why the \"always pass the spec\" attempt failed on its own\n\nThe generated spec reuses `id = ALL_LOGS_DATA_VIEW_ID`, which\n**collides** with the same id\nregistered by the Observability root profile. The failure was a **race\ncondition** in Discover\ninitialization, not a stable behavior:\n\n- `initializeMainRoute` registers the profile's ad-hoc data views\n(`getDefaultAdHocDataViews` ->\n  `clearInstanceCache` + `create` for the all-logs id).\n- `initializeDiscoverSession` -> `initializeTabs` ->\n`initializeSingleTab` resolves the tab's data\nview. When a `locationDataViewSpec` is present, `loadDataView` runs\n`clearInstanceCache(id)` +\n  `create(spec)` for the **same** id.\n\nThese two ran in **separate, unordered `useEffect`s**. When the tab\nresolution won the race, it\nseeded a competing instance for the all-logs id before (or while) the\nprofile registered its own,\nso both sides thrashed the data views instance cache for that id.\nDiscover's data view never\nstabilized, the search never finished, and the navigation exceeded the\nWebDriver `pageLoadTimeout`\n(300s) -> `Timeout of 360000ms exceeded` in `redirects.ts`. Infra jitter\nonly decided **which side\nwon the race**, which is why the test passed on some CI runs and hung on\nothers.\n\nBecause the Fleet entry points are reachable from **both** Observability\nand Security projects (Fleet\nis enabled for both serverless project types), the locator alone could\nnot both avoid the collision\nin Observability and produce a working data view in Security.\n\n## Chosen approach and why\n\nFix the race where it belongs — in Discover's initialization order — so\nthe locator no longer needs\nto know which solutions register the id:\n\n- In `discover_main_route.tsx`, the effect that initializes the tabs is\ngated on\n`mainRouteInitializationState.value`, i.e. it only runs after\n`initializeMainRoute` (which\nregisters the profile ad-hoc data views) has resolved. This guarantees a\nsingle owner of the\nall-logs id by the time the tab resolves its data view, eliminating the\ninstance-cache thrash.\n- The locator (`logs_locator.ts`) always builds the ad-hoc\n`dataViewSpec` for its default\nnavigation, dropping the solution allow-list, the\n`getActiveSolutionNavId` dependency, and the\n  hard-coded `ALL_LOGS_DATA_VIEW_ID` id.\n\nThe ordering change is safe for the rest of Discover: rendering was\nalready blocked on both\ninitializations (`isLoading`), and `useAsyncFn` preserves the resolved\n`value` across re-runs, so\nthe guard does not introduce spurious tab re-initializations.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"bd16985949f4585e9a4d86b5d75a87f58c136260"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279118","number":279118,"mergeCommit":{"message":"Refactor LogsLocator to use data view spec instead of ID (#279118)\n\nCloses: #278850\n\n## Summary\n\nThe Logs locator (`LOGS_LOCATOR`) navigates Discover to the \"All logs\"\ndata view\n(`discover-observability-solution-all-logs`). That id is only registered\nas an ad-hoc data view by\nthe **Observability** and **Classic** Discover root profiles. In other\nsolutions (e.g. **Security**,\nSearch) the id is never registered, so any \"Open in Discover\" entry\npoint that relied on the\nlocator failed with:\n\n```\nError: discover-observability-solution-all-logs\" is not a configured data view ID\n```\n\nThis PR fixes the problem in two parts:\n\n1. **Discover (root cause):** the tab initialization now waits for the\nroot profile's ad-hoc data\nviews to be registered before it resolves the tab's data view.\nPreviously these two steps ran as\nindependent, unordered effects, which allowed a race on the instance\ncache when a navigation\n   passed a data view spec colliding with a profile-managed id.\n2. **logs_shared (locator):** the locator always builds the ad-hoc \"All\nlogs\" `dataViewSpec` for its\ndefault navigation. It works out of the box in solutions that do not\nregister the id (Security,\nSearch), and — with the Discover ordering fix — no longer races the\nprofile registration in\n   solutions that do (Observability, Classic).\n\nThe result: no per-solution allow-list in the locator, and no consumer\nchanges.\n\n## History\n\nThis is the third iteration on the same underlying bug:\n\n- The original fix, https://github.com/elastic/kibana/pull/276647,\nswitched the locator to always\npass the ad-hoc `dataViewSpec`. It fixed the Security scenario but\ncaused a timeout in the FTR\n  test `redirects to Discover when logs data is present`\n\n(`x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/landing/redirects.ts`),\n  so it was reverted in https://github.com/elastic/kibana/pull/278845.\n- An interim iteration made the locator solution-aware (branch on the\nactive solution nav id). It\nworked, but hard-coded an allow-list of solutions inside the locator\nthat had to be kept in sync\n  with the Discover root profiles.\n- This PR instead fixes the race at its source in Discover (init\nordering), which lets the locator\n  stay simple (always pass the spec) without reintroducing the timeout.\n\n## Background: the reported bug\n\nIn a **Security** serverless project, clicking **\"Open in Discover\"**\nfrom Fleet\n(agent details -> Logs tab, and the Custom Logs integration \"Logs\"\nasset) threw the error above.\n\nRoot cause: the locator relied on `ALL_LOGS_DATA_VIEW_ID`, but the\nad-hoc \"All logs\" data view is\nregistered at runtime by the active Discover **root profile** via\n`getDefaultAdHocDataViews`:\n\n- Observability root profile -> registers it.\n- Classic nav root profile -> registers it.\n- Security root profile -> does **not** register it.\n\nSo in Security (and any non-obs/non-classic solution) the id is unknown\nto Discover and resolution\nfails.\n\n## Why the \"always pass the spec\" attempt failed on its own\n\nThe generated spec reuses `id = ALL_LOGS_DATA_VIEW_ID`, which\n**collides** with the same id\nregistered by the Observability root profile. The failure was a **race\ncondition** in Discover\ninitialization, not a stable behavior:\n\n- `initializeMainRoute` registers the profile's ad-hoc data views\n(`getDefaultAdHocDataViews` ->\n  `clearInstanceCache` + `create` for the all-logs id).\n- `initializeDiscoverSession` -> `initializeTabs` ->\n`initializeSingleTab` resolves the tab's data\nview. When a `locationDataViewSpec` is present, `loadDataView` runs\n`clearInstanceCache(id)` +\n  `create(spec)` for the **same** id.\n\nThese two ran in **separate, unordered `useEffect`s**. When the tab\nresolution won the race, it\nseeded a competing instance for the all-logs id before (or while) the\nprofile registered its own,\nso both sides thrashed the data views instance cache for that id.\nDiscover's data view never\nstabilized, the search never finished, and the navigation exceeded the\nWebDriver `pageLoadTimeout`\n(300s) -> `Timeout of 360000ms exceeded` in `redirects.ts`. Infra jitter\nonly decided **which side\nwon the race**, which is why the test passed on some CI runs and hung on\nothers.\n\nBecause the Fleet entry points are reachable from **both** Observability\nand Security projects (Fleet\nis enabled for both serverless project types), the locator alone could\nnot both avoid the collision\nin Observability and produce a working data view in Security.\n\n## Chosen approach and why\n\nFix the race where it belongs — in Discover's initialization order — so\nthe locator no longer needs\nto know which solutions register the id:\n\n- In `discover_main_route.tsx`, the effect that initializes the tabs is\ngated on\n`mainRouteInitializationState.value`, i.e. it only runs after\n`initializeMainRoute` (which\nregisters the profile ad-hoc data views) has resolved. This guarantees a\nsingle owner of the\nall-logs id by the time the tab resolves its data view, eliminating the\ninstance-cache thrash.\n- The locator (`logs_locator.ts`) always builds the ad-hoc\n`dataViewSpec` for its default\nnavigation, dropping the solution allow-list, the\n`getActiveSolutionNavId` dependency, and the\n  hard-coded `ALL_LOGS_DATA_VIEW_ID` id.\n\nThe ordering change is safe for the rest of Discover: rendering was\nalready blocked on both\ninitializations (`isLoading`), and `useAsyncFn` preserves the resolved\n`value` across re-runs, so\nthe guard does not introduce spurious tab re-initializations.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"bd16985949f4585e9a4d86b5d75a87f58c136260"}}]}] BACKPORT-->