### PR TITLE
[SLO] Add observability.slo.cpsEnabled for CPS header picker

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/common/feature_flags.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/feature_flags.ts
@@ -11,4 +11,4 @@ export const SLO_COMPOSITE_ENABLED = 'slo.compositeSloEnabled';
 export const OBSERVABILITY_SLO_CPS_ENABLED_FEATURE_FLAG = 'observability.slo.cpsEnabled' as const;
 
 /** Fallback when the flag is unset and no override exists. */
-export const OBSERVABILITY_SLO_CPS_ENABLED_DEFAULT = false;
+export const OBSERVABILITY_SLO_CPS_ENABLED_DEFAULT = true;

--- a/x-pack/solutions/observability/plugins/slo/common/feature_flags.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/feature_flags.ts
@@ -6,3 +6,9 @@
  */
 
 export const SLO_COMPOSITE_ENABLED = 'slo.compositeSloEnabled';
+
+/** Use with `feature_flags.overrides` in kibana.yml to toggle CPS header picker for SLO. */
+export const OBSERVABILITY_SLO_CPS_ENABLED_FEATURE_FLAG = 'observability.slo.cpsEnabled' as const;
+
+/** Fallback when the flag is unset and no override exists. */
+export const OBSERVABILITY_SLO_CPS_ENABLED_DEFAULT = false;

--- a/x-pack/solutions/observability/plugins/slo/moon.yml
+++ b/x-pack/solutions/observability/plugins/slo/moon.yml
@@ -141,6 +141,7 @@ dependsOn:
   - '@kbn/core-feature-flags-server'
   - '@kbn/cps'
   - '@kbn/cps-server-utils'
+  - '@kbn/cps-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/plugins/slo/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/plugin.ts
@@ -14,6 +14,7 @@ import type {
   PluginInitializerContext,
 } from '@kbn/core/public';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
+import { ProjectRoutingAccess } from '@kbn/cps-utils';
 import type { DefaultClientOptions } from '@kbn/server-route-repository-client';
 import { createRepositoryClient } from '@kbn/server-route-repository-client';
 import { SLOS_BASE_PATH } from '@kbn/slo-shared-plugin/common/locators/paths';
@@ -21,6 +22,10 @@ import { lazy } from 'react';
 import { BehaviorSubject } from 'rxjs';
 import { PLUGIN_NAME, sloAppId } from '../common';
 import type { ExperimentalFeatures, SLOConfig } from '../common/config';
+import {
+  OBSERVABILITY_SLO_CPS_ENABLED_DEFAULT,
+  OBSERVABILITY_SLO_CPS_ENABLED_FEATURE_FLAG,
+} from '../common/feature_flags';
 import type { SLORouteRepository } from '../server/routes/utils/get_slo_server_route_repository';
 import { registerEmbeddables } from './register_embeddables';
 import { SloDetailsLocatorDefinition } from './locators/slo_details';
@@ -141,6 +146,15 @@ export class SLOPlugin
 
   public start(core: CoreStart, plugins: SLOPublicPluginsStart) {
     const kibanaVersion = this.initContext.env.packageInfo.version;
+
+    if (
+      core.featureFlags.getBooleanValue(
+        OBSERVABILITY_SLO_CPS_ENABLED_FEATURE_FLAG,
+        OBSERVABILITY_SLO_CPS_ENABLED_DEFAULT
+      )
+    ) {
+      plugins.cps?.cpsManager?.registerAppAccess(sloAppId, () => ProjectRoutingAccess.READONLY);
+    }
 
     const sloClient = createRepositoryClient<SLORouteRepository, DefaultClientOptions>(core);
 

--- a/x-pack/solutions/observability/plugins/slo/public/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/types.ts
@@ -56,6 +56,7 @@ import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/publ
 import type { ApmSourceAccessPluginStart } from '@kbn/apm-sources-access-plugin/public';
 import type { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
+import type { CPSPluginStart } from '@kbn/cps/public';
 import type { SLORouteRepository } from '../server/routes/utils/get_slo_server_route_repository';
 import type { SLOPlugin } from './plugin';
 
@@ -82,6 +83,7 @@ export interface SLOPublicPluginsStart {
   cases?: CasesPublicStart;
   charts: ChartsPluginStart;
   cloud?: CloudStart;
+  cps?: CPSPluginStart;
   dashboard: DashboardStart;
   data: DataPublicPluginStart;
   dataViewEditor: DataViewEditorStart;

--- a/x-pack/solutions/observability/plugins/slo/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/slo/tsconfig.json
@@ -135,6 +135,7 @@
     "@kbn/core-spaces-common",
     "@kbn/core-feature-flags-server",
     "@kbn/cps",
-    "@kbn/cps-server-utils"
+    "@kbn/cps-server-utils",
+    "@kbn/cps-utils"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `observability.slo.cpsEnabled` feature flag (default `true`) to gate CPS header picker registration for the SLO app.
- When enabled, register `ProjectRoutingAccess.READONLY` so the header picker is CPS-aware but not interactive.
- Wire `cps` into SLO public start deps (`cps?: CPSPluginStart`).

Addresses #252955


Made with [Cursor](https://cursor.com)