### PR TITLE
[9.4] Update publish_oas_docs.sh for 9.5 (#282099)

### DIFF
--- a/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
+++ b/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
@@ -49,7 +49,7 @@ if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
   exit 0;
 fi
 
-if [[ "$BUILDKITE_BRANCH" == "9.4" ]]; then
+if [[ "$BUILDKITE_BRANCH" == "9.5" ]]; then
   BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
   BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"
   deploy_to_bump "$(pwd)/oas_docs/output/kibana.yaml" $BUMP_KIBANA_DOC_NAME $BUMP_KIBANA_DOC_TOKEN v9;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Update publish_oas_docs.sh for 9.5 (#282099)](https://github.com/elastic/kibana/pull/282099)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2026-08-04T13:05:26Z","message":"Update publish_oas_docs.sh for 9.5 (#282099)","sha":"6f6b67f36462b06cb977a57a74c4768e37664d46","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","backport:version","v9.5.0","v9.6.0"],"title":"Update publish_oas_docs.sh for 9.5","number":282099,"url":"https://github.com/elastic/kibana/pull/282099","mergeCommit":{"message":"Update publish_oas_docs.sh for 9.5 (#282099)","sha":"6f6b67f36462b06cb977a57a74c4768e37664d46"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282611","number":282611,"state":"OPEN"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282099","number":282099,"mergeCommit":{"message":"Update publish_oas_docs.sh for 9.5 (#282099)","sha":"6f6b67f36462b06cb977a57a74c4768e37664d46"}}]}] BACKPORT-->