### PR TITLE
[Nightshift] Move i18n ids to the xpack.nightshift namespace

### DIFF
--- a/x-pack/.i18nrc.json
+++ b/x-pack/.i18nrc.json
@@ -92,10 +92,8 @@
       "platform/plugins/shared/ml"
     ],
     "xpack.monitoring": ["platform/plugins/private/monitoring"],
-    "xpack.observability": [
-      "solutions/observability/plugins/observability",
-      "solutions/observability/plugins/nightshift"
-    ],
+    "xpack.observability": "solutions/observability/plugins/observability",
+    "xpack.nightshift": "solutions/observability/plugins/nightshift",
     "xpack.observabilityAgentBuilder": "solutions/observability/plugins/observability_agent_builder",
     "xpack.observabilityAiAssistant": [
       "platform/plugins/shared/observability_ai_assistant",

--- a/x-pack/solutions/observability/plugins/nightshift/public/app/app.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/app/app.tsx
@@ -358,12 +358,12 @@ export function NightshiftApp(): React.ReactElement {
         color="warning"
         iconType="warning"
         size="s"
-        title={i18n.translate('xpack.observability.nightshift.eventNotFoundTitle', {
+        title={i18n.translate('xpack.nightshift.eventNotFoundTitle', {
           defaultMessage: 'Significant Event not found',
         })}
       >
         <EuiText size="s">
-          {i18n.translate('xpack.observability.nightshift.eventNotFoundDescription', {
+          {i18n.translate('xpack.nightshift.eventNotFoundDescription', {
             defaultMessage:
               'The event in this link is no longer in the current results. The URL has been cleared.',
           })}
@@ -439,7 +439,7 @@ export function NightshiftApp(): React.ReactElement {
                 color="warning"
                 iconType="warning"
                 size="s"
-                title={i18n.translate('xpack.observability.nightshift.refreshWarningTitle', {
+                title={i18n.translate('xpack.nightshift.refreshWarningTitle', {
                   defaultMessage: 'Showing the last loaded results; refreshing failed.',
                 })}
               >
@@ -451,7 +451,7 @@ export function NightshiftApp(): React.ReactElement {
                   onClick={() => refetch()}
                   size="s"
                 >
-                  {i18n.translate('xpack.observability.nightshift.retryButtonText', {
+                  {i18n.translate('xpack.nightshift.retryButtonText', {
                     defaultMessage: 'Retry',
                   })}
                 </EuiButtonEmpty>
@@ -493,7 +493,7 @@ export function NightshiftApp(): React.ReactElement {
                     }
                     sectionRef={needsActionSectionRef}
                     statusColor="danger"
-                    title={i18n.translate('xpack.observability.nightshift.list.needActionTitle', {
+                    title={i18n.translate('xpack.nightshift.list.needActionTitle', {
                       defaultMessage: 'Need Action',
                     })}
                   />
@@ -511,7 +511,7 @@ export function NightshiftApp(): React.ReactElement {
                   }
                   sectionRef={resolvedSectionRef}
                   statusColor="success"
-                  title={i18n.translate('xpack.observability.nightshift.list.resolvedTitle', {
+                  title={i18n.translate('xpack.nightshift.list.resolvedTitle', {
                     defaultMessage: 'Resolved',
                   })}
                 />
@@ -570,7 +570,7 @@ function LoadingErrorCallout({ onRetry }: { onRetry: () => void }): React.ReactE
       color="danger"
       iconType="warning"
       announceOnMount
-      title={i18n.translate('xpack.observability.nightshift.loadingErrorTitle', {
+      title={i18n.translate('xpack.nightshift.loadingErrorTitle', {
         defaultMessage: 'Unable to load significant events',
       })}
       css={css`
@@ -584,7 +584,7 @@ function LoadingErrorCallout({ onRetry }: { onRetry: () => void }): React.ReactE
         onClick={onRetry}
         size="s"
       >
-        {i18n.translate('xpack.observability.nightshift.retryButtonText', {
+        {i18n.translate('xpack.nightshift.retryButtonText', {
           defaultMessage: 'Retry',
         })}
       </EuiButton>

--- a/x-pack/solutions/observability/plugins/nightshift/public/app/app_header.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/app/app_header.tsx
@@ -12,11 +12,11 @@ import { getEbtProps } from '@kbn/ebt-click';
 import { i18n } from '@kbn/i18n';
 import { NIGHTSHIFT_EBT_ACTIONS, NIGHTSHIFT_EBT_ELEMENTS } from '../common/ebt_constants';
 
-const nightshiftPageTitle = i18n.translate('xpack.observability.nightshift.pageTitle', {
+const nightshiftPageTitle = i18n.translate('xpack.nightshift.pageTitle', {
   defaultMessage: 'Nightshift',
 });
 
-const settingsLabel = i18n.translate('xpack.observability.nightshift.settingsLinkLabel', {
+const settingsLabel = i18n.translate('xpack.nightshift.settingsLinkLabel', {
   defaultMessage: 'Settings',
 });
 

--- a/x-pack/solutions/observability/plugins/nightshift/public/app/empty_state.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/app/empty_state.tsx
@@ -20,19 +20,19 @@ interface NightshiftEmptyStateProps {
 const processingSteps = [
   {
     icon: 'productStreamsWired',
-    label: i18n.translate('xpack.observability.nightshift.emptyState.streamsStepLabel', {
+    label: i18n.translate('xpack.nightshift.emptyState.streamsStepLabel', {
       defaultMessage: 'Streams',
     }),
   },
   {
     icon: 'analyzeEvent',
-    label: i18n.translate('xpack.observability.nightshift.emptyState.entitiesStepLabel', {
+    label: i18n.translate('xpack.nightshift.emptyState.entitiesStepLabel', {
       defaultMessage: 'Entities',
     }),
   },
   {
     icon: 'radar',
-    label: i18n.translate('xpack.observability.nightshift.emptyState.detectionsStepLabel', {
+    label: i18n.translate('xpack.nightshift.emptyState.detectionsStepLabel', {
       defaultMessage: 'Detections',
     }),
   },
@@ -121,10 +121,10 @@ export function NightshiftEmptyState({
         aria-busy={isProcessing}
         aria-label={
           isProcessing
-            ? i18n.translate('xpack.observability.nightshift.emptyState.processingStepsAriaLabel', {
+            ? i18n.translate('xpack.nightshift.emptyState.processingStepsAriaLabel', {
                 defaultMessage: 'Checking streams, entities, and detections',
               })
-            : i18n.translate('xpack.observability.nightshift.emptyState.completedStepsAriaLabel', {
+            : i18n.translate('xpack.nightshift.emptyState.completedStepsAriaLabel', {
                 defaultMessage: 'Streams, entities, and detections checked',
               })
         }
@@ -194,7 +194,7 @@ export function NightshiftEmptyState({
           element: NIGHTSHIFT_EBT_ELEMENTS.PAGE_HEADER,
         })}
       >
-        {i18n.translate('xpack.observability.nightshift.emptyState.logsLinkLabel', {
+        {i18n.translate('xpack.nightshift.emptyState.logsLinkLabel', {
           defaultMessage: 'What do we know about your logs?',
         })}
       </EuiButtonEmpty>

--- a/x-pack/solutions/observability/plugins/nightshift/public/app/header.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/app/header.tsx
@@ -31,18 +31,18 @@ const getGreeting = (): string => {
   const hour = new Date().getHours();
 
   if (hour < 12) {
-    return i18n.translate('xpack.observability.nightshift.hero.morningGreetingDescription', {
+    return i18n.translate('xpack.nightshift.hero.morningGreetingDescription', {
       defaultMessage: 'Good morning!',
     });
   }
 
   if (hour < 18) {
-    return i18n.translate('xpack.observability.nightshift.hero.afternoonGreetingDescription', {
+    return i18n.translate('xpack.nightshift.hero.afternoonGreetingDescription', {
       defaultMessage: 'Good afternoon!',
     });
   }
 
-  return i18n.translate('xpack.observability.nightshift.hero.eveningGreetingDescription', {
+  return i18n.translate('xpack.nightshift.hero.eveningGreetingDescription', {
     defaultMessage: 'Good evening!',
   });
 };
@@ -57,24 +57,24 @@ const getHeroTitle = ({
   hasNeedsAction: boolean;
 }): string => {
   if (isLoading) {
-    return i18n.translate('xpack.observability.nightshift.hero.checkingTitle', {
+    return i18n.translate('xpack.nightshift.hero.checkingTitle', {
       defaultMessage: 'Looking into your data...',
     });
   }
 
   if (isEmptyState) {
-    return i18n.translate('xpack.observability.nightshift.hero.noEventsTitle', {
+    return i18n.translate('xpack.nightshift.hero.noEventsTitle', {
       defaultMessage: 'No significant events found',
     });
   }
 
   if (hasNeedsAction) {
-    return i18n.translate('xpack.observability.nightshift.hero.needsActionTitle', {
+    return i18n.translate('xpack.nightshift.hero.needsActionTitle', {
       defaultMessage: 'Some significant events need action',
     });
   }
 
-  return i18n.translate('xpack.observability.nightshift.hero.allClearTitle', {
+  return i18n.translate('xpack.nightshift.hero.allClearTitle', {
     defaultMessage: "You're all caught up",
   });
 };
@@ -112,12 +112,9 @@ export function NightshiftHeader({
           >
             <EuiFlexItem grow={false}>
               <div
-                aria-label={i18n.translate(
-                  'xpack.observability.nightshift.hero.nightshiftIconAriaLabel',
-                  {
-                    defaultMessage: 'Nightshift',
-                  }
-                )}
+                aria-label={i18n.translate('xpack.nightshift.hero.nightshiftIconAriaLabel', {
+                  defaultMessage: 'Nightshift',
+                })}
                 role="img"
                 css={css`
                   align-items: center;
@@ -171,7 +168,7 @@ export function NightshiftHeader({
                 color: ${euiTheme.colors.textSubdued};
               `}
             >
-              {i18n.translate('xpack.observability.nightshift.summary.showAllEventsLinkText', {
+              {i18n.translate('xpack.nightshift.summary.showAllEventsLinkText', {
                 defaultMessage: 'Show all events',
               })}
             </EuiButtonEmpty>

--- a/x-pack/solutions/observability/plugins/nightshift/public/chat/agent_builder/significant_event_attachments.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/chat/agent_builder/significant_event_attachments.ts
@@ -19,13 +19,13 @@ const significantEventDetectionAttachmentDefinition: AttachmentUIDefinition<Sign
   {
     getLabel: (attachment) =>
       attachment.data.rule_name ??
-      i18n.translate('xpack.observability.nightshift.detectionAttachment.fallbackLabel', {
+      i18n.translate('xpack.nightshift.detectionAttachment.fallbackLabel', {
         defaultMessage: 'Detection',
       }),
     getIcon: () => 'bell',
     getHeader: () => ({
       icon: 'bell',
-      subtitle: i18n.translate('xpack.observability.nightshift.detectionAttachment.subtitle', {
+      subtitle: i18n.translate('xpack.nightshift.detectionAttachment.subtitle', {
         defaultMessage: 'Significant Events detection',
       }),
     }),
@@ -35,13 +35,13 @@ const kiFeatureAttachmentDefinition: AttachmentUIDefinition<KiFeatureAttachment>
   getLabel: (attachment) =>
     attachment.data.title ??
     attachment.data.id ??
-    i18n.translate('xpack.observability.nightshift.featureAttachment.fallbackLabel', {
+    i18n.translate('xpack.nightshift.featureAttachment.fallbackLabel', {
       defaultMessage: 'Entity',
     }),
   getIcon: () => 'node',
   getHeader: () => ({
     icon: 'node',
-    subtitle: i18n.translate('xpack.observability.nightshift.featureAttachment.subtitle', {
+    subtitle: i18n.translate('xpack.nightshift.featureAttachment.subtitle', {
       defaultMessage: 'Knowledge indicator feature',
     }),
   }),

--- a/x-pack/solutions/observability/plugins/nightshift/public/chat/chat_attachment_description.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/chat/chat_attachment_description.ts
@@ -20,7 +20,7 @@ export const formatChatAttachmentDescription = (
   attachmentType: NightshiftChatAttachmentType,
   name: string
 ): string =>
-  i18n.translate('xpack.observability.nightshift.chatAttachment.description', {
+  i18n.translate('xpack.nightshift.chatAttachment.description', {
     defaultMessage: '[{attachmentType}] {name}',
     values: { attachmentType, name },
   });

--- a/x-pack/solutions/observability/plugins/nightshift/public/chat/open_significant_event_in_chat.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/chat/open_significant_event_in_chat.ts
@@ -21,7 +21,7 @@ export const buildNewSignificantEventChatOptions = (
 ): OpenSignificantEventChatOptions => ({
   newConversation: true,
   autoSendInitialMessage: true,
-  initialMessage: i18n.translate('xpack.observability.nightshift.explainEventPrompt', {
+  initialMessage: i18n.translate('xpack.nightshift.explainEventPrompt', {
     defaultMessage: 'Explain this significant event: {significantEventName}',
     values: { significantEventName: event.title },
   }),

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/flyout_share_url_button.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/flyout_share_url_button.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { useKibana } from '../hooks/use_kibana';
 
 export const getFlyoutShareUrlAriaLabel = (): string =>
-  i18n.translate('xpack.observability.nightshift.flyout.shareUrlAriaLabel', {
+  i18n.translate('xpack.nightshift.flyout.shareUrlAriaLabel', {
     defaultMessage: 'Copy link to this flyout',
   });
 
@@ -25,7 +25,7 @@ export const useFlyoutShareUrlCustomAction = (
     const copied = copyToClipboard(getShareUrl());
     if (copied) {
       notifications.toasts.addSuccess({
-        title: i18n.translate('xpack.observability.nightshift.flyout.shareUrlSuccess', {
+        title: i18n.translate('xpack.nightshift.flyout.shareUrlSuccess', {
           defaultMessage: 'Copied link to clipboard',
         }),
       });

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/format_timestamp.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/format_timestamp.ts
@@ -13,7 +13,7 @@ import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 export const formatTimestamp = (timestamp: string, dateFormat: string): string => {
   const parsed = moment(timestamp);
   if (!parsed.isValid()) {
-    return i18n.translate('xpack.observability.nightshift.invalidTimestamp', {
+    return i18n.translate('xpack.nightshift.invalidTimestamp', {
       defaultMessage: 'Unknown time',
     });
   }
@@ -23,7 +23,7 @@ export const formatTimestamp = (timestamp: string, dateFormat: string): string =
 export const formatShortTime = (timestamp: string): string => {
   const parsed = moment(timestamp);
   if (!parsed.isValid()) {
-    return i18n.translate('xpack.observability.nightshift.invalidTimestamp', {
+    return i18n.translate('xpack.nightshift.invalidTimestamp', {
       defaultMessage: 'Unknown time',
     });
   }

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/investigation_progress_status.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/investigation_progress_status.ts
@@ -10,10 +10,10 @@ import type { InvestigationStatus } from '@kbn/investigation-output';
 
 export const getInvestigationProgressStatusLabel = (isInvestigated: boolean): string =>
   isInvestigated
-    ? i18n.translate('xpack.observability.nightshift.investigation.progressInvestigated', {
+    ? i18n.translate('xpack.nightshift.investigation.progressInvestigated', {
         defaultMessage: 'Investigated',
       })
-    : i18n.translate('xpack.observability.nightshift.investigation.progressInvestigating', {
+    : i18n.translate('xpack.nightshift.investigation.progressInvestigating', {
         defaultMessage: 'Investigating',
       });
 
@@ -31,15 +31,15 @@ export const getInvestigationWorkflowStatusLabel = (status: InvestigationStatus)
 
   switch (status) {
     case 'failed':
-      return i18n.translate('xpack.observability.nightshift.investigation.statusFailed', {
+      return i18n.translate('xpack.nightshift.investigation.statusFailed', {
         defaultMessage: 'Investigation failed',
       });
     case 'unavailable':
-      return i18n.translate('xpack.observability.nightshift.investigation.statusUnavailable', {
+      return i18n.translate('xpack.nightshift.investigation.statusUnavailable', {
         defaultMessage: 'Investigation unavailable',
       });
     case 'loading':
-      return i18n.translate('xpack.observability.nightshift.investigation.statusLoading', {
+      return i18n.translate('xpack.nightshift.investigation.statusLoading', {
         defaultMessage: 'Loading investigation',
       });
     default:

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/truncatable_summary.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/truncatable_summary.tsx
@@ -90,10 +90,10 @@ export function TruncatableSummary({
           `}
         >
           {expanded
-            ? i18n.translate('xpack.observability.nightshift.flyout.showLessButtonText', {
+            ? i18n.translate('xpack.nightshift.flyout.showLessButtonText', {
                 defaultMessage: 'Show less',
               })
-            : i18n.translate('xpack.observability.nightshift.flyout.showMoreButtonText', {
+            : i18n.translate('xpack.nightshift.flyout.showMoreButtonText', {
                 defaultMessage: 'Show more',
               })}
         </EuiLink>

--- a/x-pack/solutions/observability/plugins/nightshift/public/detection/change_point.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/detection/change_point.ts
@@ -9,34 +9,32 @@ import { i18n } from '@kbn/i18n';
 import type { ChangePointType } from '@kbn/significant-events-schema';
 
 const CHANGE_POINT_LABELS: Record<ChangePointType, string> = {
-  spike: i18n.translate('xpack.observability.nightshift.flyout.changePoint.spikeLabel', {
+  spike: i18n.translate('xpack.nightshift.flyout.changePoint.spikeLabel', {
     defaultMessage: 'Spike',
   }),
-  dip: i18n.translate('xpack.observability.nightshift.flyout.changePoint.dipLabel', {
+  dip: i18n.translate('xpack.nightshift.flyout.changePoint.dipLabel', {
     defaultMessage: 'Dip',
   }),
-  trend_change: i18n.translate(
-    'xpack.observability.nightshift.flyout.changePoint.trendChangeLabel',
-    { defaultMessage: 'Trend change' }
-  ),
-  step_change: i18n.translate('xpack.observability.nightshift.flyout.changePoint.stepChangeLabel', {
+  trend_change: i18n.translate('xpack.nightshift.flyout.changePoint.trendChangeLabel', {
+    defaultMessage: 'Trend change',
+  }),
+  step_change: i18n.translate('xpack.nightshift.flyout.changePoint.stepChangeLabel', {
     defaultMessage: 'Step change',
   }),
   distribution_change: i18n.translate(
-    'xpack.observability.nightshift.flyout.changePoint.distributionChangeLabel',
+    'xpack.nightshift.flyout.changePoint.distributionChangeLabel',
     { defaultMessage: 'Distribution change' }
   ),
-  non_stationary: i18n.translate(
-    'xpack.observability.nightshift.flyout.changePoint.nonStationaryLabel',
-    { defaultMessage: 'Non-stationary' }
-  ),
-  stationary: i18n.translate('xpack.observability.nightshift.flyout.changePoint.stationaryLabel', {
+  non_stationary: i18n.translate('xpack.nightshift.flyout.changePoint.nonStationaryLabel', {
+    defaultMessage: 'Non-stationary',
+  }),
+  stationary: i18n.translate('xpack.nightshift.flyout.changePoint.stationaryLabel', {
     defaultMessage: 'Stationary',
   }),
 };
 
 const UNKNOWN_CHANGE_POINT_LABEL = i18n.translate(
-  'xpack.observability.nightshift.flyout.changePoint.unknownLabel',
+  'xpack.nightshift.flyout.changePoint.unknownLabel',
   { defaultMessage: 'Unknown' }
 );
 

--- a/x-pack/solutions/observability/plugins/nightshift/public/detection/change_point_lens_chart.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/detection/change_point_lens_chart.tsx
@@ -34,11 +34,11 @@ type LensESQLConfig = LensConfig & { dataset: LensESQLDataset };
 
 const getStreamTypeLabel = (streamName?: string): string => {
   if (streamName?.startsWith('metrics')) {
-    return i18n.translate('xpack.observability.nightshift.detectionFlyout.trend.metricsLabel', {
+    return i18n.translate('xpack.nightshift.detectionFlyout.trend.metricsLabel', {
       defaultMessage: '[Metrics]',
     });
   }
-  return i18n.translate('xpack.observability.nightshift.detectionFlyout.trend.logsLabel', {
+  return i18n.translate('xpack.nightshift.detectionFlyout.trend.logsLabel', {
     defaultMessage: '[Logs]',
   });
 };
@@ -98,10 +98,9 @@ const buildLensConfig = ({
       xAxis: { field: 'timestamp', type: 'dateHistogram' },
       yAxis: [
         {
-          label: i18n.translate(
-            'xpack.observability.nightshift.detectionFlyout.trend.valueAxisLabel',
-            { defaultMessage: 'Occurrences' }
-          ),
+          label: i18n.translate('xpack.nightshift.detectionFlyout.trend.valueAxisLabel', {
+            defaultMessage: 'Occurrences',
+          }),
           value: 'occurrences',
           format: 'number',
           decimals: 0,
@@ -201,10 +200,9 @@ export function ChangePointLensChart({
         color="warning"
         iconType="warning"
         size="s"
-        title={i18n.translate(
-          'xpack.observability.nightshift.detectionFlyout.trend.lensErrorTitle',
-          { defaultMessage: 'Unable to load occurrence visualization' }
-        )}
+        title={i18n.translate('xpack.nightshift.detectionFlyout.trend.lensErrorTitle', {
+          defaultMessage: 'Unable to load occurrence visualization',
+        })}
       />
     );
   }

--- a/x-pack/solutions/observability/plugins/nightshift/public/detection/detection_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/detection/detection_flyout.tsx
@@ -129,7 +129,7 @@ export function DetectionFlyout({
     agentBuilder?.openChat({
       newConversation: true,
       autoSendInitialMessage: true,
-      initialMessage: i18n.translate('xpack.observability.nightshift.detectionFlyout.chatPrompt', {
+      initialMessage: i18n.translate('xpack.nightshift.detectionFlyout.chatPrompt', {
         defaultMessage: 'Tell me about the {ruleName} detection',
         values: { ruleName: title },
       }),
@@ -172,7 +172,7 @@ export function DetectionFlyout({
           <EuiFlexGroup gutterSize="xs" wrap responsive={false} alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiBadge color="default">
-                {i18n.translate('xpack.observability.nightshift.detectionFlyout.detectionBadge', {
+                {i18n.translate('xpack.nightshift.detectionFlyout.detectionBadge', {
                   defaultMessage: 'Detection',
                 })}
               </EuiBadge>
@@ -185,12 +185,9 @@ export function DetectionFlyout({
             {signal?.confirmed === false && (
               <EuiFlexItem grow={false}>
                 <EuiBadge color="warning">
-                  {i18n.translate(
-                    'xpack.observability.nightshift.detectionFlyout.unconfirmedBadge',
-                    {
-                      defaultMessage: 'Unconfirmed',
-                    }
-                  )}
+                  {i18n.translate('xpack.nightshift.detectionFlyout.unconfirmedBadge', {
+                    defaultMessage: 'Unconfirmed',
+                  })}
                 </EuiBadge>
               </EuiFlexItem>
             )}
@@ -205,7 +202,7 @@ export function DetectionFlyout({
           {summary && (
             <>
               <FlyoutSectionTitle>
-                {i18n.translate('xpack.observability.nightshift.detectionFlyout.summaryTitle', {
+                {i18n.translate('xpack.nightshift.detectionFlyout.summaryTitle', {
                   defaultMessage: 'Summary',
                 })}
               </FlyoutSectionTitle>
@@ -222,7 +219,7 @@ export function DetectionFlyout({
           {(isLoadingStreamFeatures || isStreamFeaturesError || associatedEntities.length > 0) && (
             <>
               <FlyoutSectionTitle>
-                {i18n.translate('xpack.observability.nightshift.detectionFlyout.entitiesTitle', {
+                {i18n.translate('xpack.nightshift.detectionFlyout.entitiesTitle', {
                   defaultMessage: 'Impacted entities',
                 })}
               </FlyoutSectionTitle>
@@ -240,10 +237,9 @@ export function DetectionFlyout({
                   color="warning"
                   iconType="warning"
                   size="s"
-                  title={i18n.translate(
-                    'xpack.observability.nightshift.detectionFlyout.entitiesErrorTitle',
-                    { defaultMessage: 'Unable to load impacted entities' }
-                  )}
+                  title={i18n.translate('xpack.nightshift.detectionFlyout.entitiesErrorTitle', {
+                    defaultMessage: 'Unable to load impacted entities',
+                  })}
                 >
                   <EuiButtonEmpty
                     color="warning"
@@ -253,10 +249,9 @@ export function DetectionFlyout({
                     onClick={() => refetchStreamFeatures()}
                     size="s"
                   >
-                    {i18n.translate(
-                      'xpack.observability.nightshift.detectionFlyout.entitiesRetryButtonText',
-                      { defaultMessage: 'Retry' }
-                    )}
+                    {i18n.translate('xpack.nightshift.detectionFlyout.entitiesRetryButtonText', {
+                      defaultMessage: 'Retry',
+                    })}
                   </EuiButtonEmpty>
                 </EuiCallOut>
               )}
@@ -285,7 +280,7 @@ export function DetectionFlyout({
           )}
 
           <FlyoutSectionTitle>
-            {i18n.translate('xpack.observability.nightshift.detectionFlyout.trendTitle', {
+            {i18n.translate('xpack.nightshift.detectionFlyout.trendTitle', {
               defaultMessage: 'Trend',
             })}
           </FlyoutSectionTitle>
@@ -303,7 +298,7 @@ export function DetectionFlyout({
               >
                 <EuiFlexItem grow={false}>
                   <FlyoutSectionTitle>
-                    {i18n.translate('xpack.observability.nightshift.detectionFlyout.esqlTitle', {
+                    {i18n.translate('xpack.nightshift.detectionFlyout.esqlTitle', {
                       defaultMessage: 'ES|QL query',
                     })}
                   </FlyoutSectionTitle>
@@ -320,10 +315,9 @@ export function DetectionFlyout({
                         element: NIGHTSHIFT_EBT_ELEMENTS.DETECTION_FLYOUT,
                       })}
                     >
-                      {i18n.translate(
-                        'xpack.observability.nightshift.detectionFlyout.openInDiscoverLinkText',
-                        { defaultMessage: 'Open in Discover' }
-                      )}
+                      {i18n.translate('xpack.nightshift.detectionFlyout.openInDiscoverLinkText', {
+                        defaultMessage: 'Open in Discover',
+                      })}
                     </EuiButtonEmpty>
                   </EuiFlexItem>
                 )}
@@ -365,12 +359,9 @@ export function DetectionFlyout({
                     detail: NIGHTSHIFT_EBT_DETAILS.NEW_CONVERSATION,
                   })}
                 >
-                  {i18n.translate(
-                    'xpack.observability.nightshift.detectionFlyout.openInChatButtonLabel',
-                    {
-                      defaultMessage: 'Open in chat',
-                    }
-                  )}
+                  {i18n.translate('xpack.nightshift.detectionFlyout.openInChatButtonLabel', {
+                    defaultMessage: 'Open in chat',
+                  })}
                 </AiButton>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/nightshift/public/entity/entity_chip.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/entity/entity_chip.tsx
@@ -35,7 +35,7 @@ export function EntityChip({
       type="button"
       data-test-subj={testSubj}
       {...(ebt ? getEbtProps(ebt) : {})}
-      aria-label={i18n.translate('xpack.observability.nightshift.entityChip.viewDetailsLabel', {
+      aria-label={i18n.translate('xpack.nightshift.entityChip.viewDetailsLabel', {
         defaultMessage: 'View entity details for {label}',
         values: { label },
       })}

--- a/x-pack/solutions/observability/plugins/nightshift/public/entity/entity_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/entity/entity_flyout.tsx
@@ -62,18 +62,15 @@ const confidenceDotColor = (
 
 function ConfidenceBadge({ confidence }: { confidence: number }) {
   const { euiTheme } = useEuiTheme();
-  const confidenceLabel = i18n.translate(
-    'xpack.observability.nightshift.entityFlyout.confidenceBadge',
-    {
-      defaultMessage: '{confidence}% confidence',
-      values: { confidence },
-    }
-  );
+  const confidenceLabel = i18n.translate('xpack.nightshift.entityFlyout.confidenceBadge', {
+    defaultMessage: '{confidence}% confidence',
+    values: { confidence },
+  });
 
   return (
     <EuiToolTip
       title={confidenceLabel}
-      content={i18n.translate('xpack.observability.nightshift.entityFlyout.confidenceTooltip', {
+      content={i18n.translate('xpack.nightshift.entityFlyout.confidenceTooltip', {
         defaultMessage:
           'How confident Nightshift is that this is a real, distinct entity in your system — based on observation frequency, data consistency, and cross-source corroboration.',
       })}
@@ -159,7 +156,7 @@ export function EntityFlyout({
     agentBuilder?.openChat({
       newConversation: true,
       autoSendInitialMessage: true,
-      initialMessage: i18n.translate('xpack.observability.nightshift.entityFlyout.chatPrompt', {
+      initialMessage: i18n.translate('xpack.nightshift.entityFlyout.chatPrompt', {
         defaultMessage: 'Tell me about {entityName}',
         values: { entityName: title },
       }),
@@ -201,7 +198,7 @@ export function EntityFlyout({
         <EuiFlexGroup gutterSize="xs" wrap responsive={false} alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiBadge color="default">
-              {i18n.translate('xpack.observability.nightshift.entityFlyout.entityBadge', {
+              {i18n.translate('xpack.nightshift.entityFlyout.entityBadge', {
                 defaultMessage: 'Entity',
               })}
             </EuiBadge>
@@ -209,7 +206,7 @@ export function EntityFlyout({
           {isServiceEntity && (
             <EuiFlexItem grow={false}>
               <EuiBadge color="hollow">
-                {i18n.translate('xpack.observability.nightshift.entityFlyout.serviceBadge', {
+                {i18n.translate('xpack.nightshift.entityFlyout.serviceBadge', {
                   defaultMessage: 'Service',
                 })}
               </EuiBadge>
@@ -232,7 +229,7 @@ export function EntityFlyout({
         {feature.description && (
           <>
             <FlyoutSectionTitle>
-              {i18n.translate('xpack.observability.nightshift.entityFlyout.summaryTitle', {
+              {i18n.translate('xpack.nightshift.entityFlyout.summaryTitle', {
                 defaultMessage: 'Summary',
               })}
             </FlyoutSectionTitle>
@@ -247,7 +244,7 @@ export function EntityFlyout({
         )}
 
         <FlyoutSectionTitle>
-          {i18n.translate('xpack.observability.nightshift.entityFlyout.evidenceTitle', {
+          {i18n.translate('xpack.nightshift.entityFlyout.evidenceTitle', {
             defaultMessage: 'Evidence',
           })}
         </FlyoutSectionTitle>
@@ -256,7 +253,7 @@ export function EntityFlyout({
           <EvidenceList evidence={evidence} />
         ) : (
           <EuiText size="s" color="subdued">
-            {i18n.translate('xpack.observability.nightshift.entityFlyout.noEvidenceDescription', {
+            {i18n.translate('xpack.nightshift.entityFlyout.noEvidenceDescription', {
               defaultMessage: 'No evidence available for this entity.',
             })}
           </EuiText>
@@ -265,7 +262,7 @@ export function EntityFlyout({
         <EuiSpacer size="l" />
 
         <FlyoutSectionTitle>
-          {i18n.translate('xpack.observability.nightshift.entityFlyout.rawDocumentTitle', {
+          {i18n.translate('xpack.nightshift.entityFlyout.rawDocumentTitle', {
             defaultMessage: 'Raw document',
           })}
         </FlyoutSectionTitle>
@@ -305,12 +302,9 @@ export function EntityFlyout({
                     detail: NIGHTSHIFT_EBT_DETAILS.NEW_CONVERSATION,
                   })}
                 >
-                  {i18n.translate(
-                    'xpack.observability.nightshift.entityFlyout.openInChatButtonLabel',
-                    {
-                      defaultMessage: 'Open in chat',
-                    }
-                  )}
+                  {i18n.translate('xpack.nightshift.entityFlyout.openInChatButtonLabel', {
+                    defaultMessage: 'Open in chat',
+                  })}
                 </AiButton>
               </EuiFlexItem>
             </EuiFlexGroup>
@@ -320,13 +314,10 @@ export function EntityFlyout({
               color="subdued"
               data-test-subj="nightshiftEntityFlyoutChatUnavailable"
             >
-              {i18n.translate(
-                'xpack.observability.nightshift.entityFlyout.chatUnavailableDescription',
-                {
-                  defaultMessage:
-                    'Open in chat is unavailable for stream-level entities without Knowledge Indicator features.',
-                }
-              )}
+              {i18n.translate('xpack.nightshift.entityFlyout.chatUnavailableDescription', {
+                defaultMessage:
+                  'Open in chat is unavailable for stream-level entities without Knowledge Indicator features.',
+              })}
             </EuiText>
           )}
         </EuiFlyoutFooter>

--- a/x-pack/solutions/observability/plugins/nightshift/public/event/detections_list.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/event/detections_list.tsx
@@ -223,13 +223,10 @@ function DetectionCard({
                 {hiddenEntityCount > 0 && (
                   <EuiFlexItem grow={false}>
                     <EuiBadge color="hollow">
-                      {i18n.translate(
-                        'xpack.observability.nightshift.flyout.detectionEntityOverflow',
-                        {
-                          defaultMessage: '+{count}',
-                          values: { count: hiddenEntityCount },
-                        }
-                      )}
+                      {i18n.translate('xpack.nightshift.flyout.detectionEntityOverflow', {
+                        defaultMessage: '+{count}',
+                        values: { count: hiddenEntityCount },
+                      })}
                     </EuiBadge>
                   </EuiFlexItem>
                 )}
@@ -397,7 +394,7 @@ export function DetectionsList({
     <>
       <EuiTitle size="xs">
         <h3>
-          {i18n.translate('xpack.observability.nightshift.flyout.detectionsTitle', {
+          {i18n.translate('xpack.nightshift.flyout.detectionsTitle', {
             defaultMessage: 'Detections',
           })}
         </h3>
@@ -410,7 +407,7 @@ export function DetectionsList({
           color="danger"
           iconType="warning"
           size="s"
-          title={i18n.translate('xpack.observability.nightshift.flyout.detectionsErrorTitle', {
+          title={i18n.translate('xpack.nightshift.flyout.detectionsErrorTitle', {
             defaultMessage: 'Unable to load detections',
           })}
         >
@@ -422,7 +419,7 @@ export function DetectionsList({
             onClick={() => refetch()}
             size="s"
           >
-            {i18n.translate('xpack.observability.nightshift.flyout.detectionsRetryButtonText', {
+            {i18n.translate('xpack.nightshift.flyout.detectionsRetryButtonText', {
               defaultMessage: 'Retry',
             })}
           </EuiButtonEmpty>
@@ -439,7 +436,7 @@ export function DetectionsList({
 
       {!showDetectionSkeletons && !isError && detections.length === 0 && (
         <EuiText size="s" color="subdued">
-          {i18n.translate('xpack.observability.nightshift.flyout.detectionsEmptyDescription', {
+          {i18n.translate('xpack.nightshift.flyout.detectionsEmptyDescription', {
             defaultMessage: 'No detections found for this event.',
           })}
         </EuiText>

--- a/x-pack/solutions/observability/plugins/nightshift/public/event/event_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/event/event_flyout.tsx
@@ -179,12 +179,9 @@ export function EventFlyout({ event, onClose }: EventFlyoutProps): React.ReactEl
             >
               <NightshiftMarkIcon inline size={14} />
               <span>
-                {i18n.translate(
-                  'xpack.observability.nightshift.flyout.badge.significantEventLabel',
-                  {
-                    defaultMessage: 'Significant Event',
-                  }
-                )}
+                {i18n.translate('xpack.nightshift.flyout.badge.significantEventLabel', {
+                  defaultMessage: 'Significant Event',
+                })}
               </span>
             </EuiBadge>
           </EuiFlexItem>
@@ -198,7 +195,7 @@ export function EventFlyout({ event, onClose }: EventFlyoutProps): React.ReactEl
                   color: ${euiTheme.colors.textDanger} !important;
                 `}
               >
-                {i18n.translate('xpack.observability.nightshift.flyout.badge.needsActionLabel', {
+                {i18n.translate('xpack.nightshift.flyout.badge.needsActionLabel', {
                   defaultMessage: 'Needs action',
                 })}
               </EuiBadge>
@@ -219,7 +216,7 @@ export function EventFlyout({ event, onClose }: EventFlyoutProps): React.ReactEl
 
       <EuiFlyoutBody>
         <FlyoutSectionTitle>
-          {i18n.translate('xpack.observability.nightshift.flyout.summaryTitle', {
+          {i18n.translate('xpack.nightshift.flyout.summaryTitle', {
             defaultMessage: 'Summary',
           })}
         </FlyoutSectionTitle>

--- a/x-pack/solutions/observability/plugins/nightshift/public/event/event_flyout_chat_footer.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/event/event_flyout_chat_footer.tsx
@@ -83,44 +83,35 @@ export function EventFlyoutChatFooter({
   }, [agentBuilder, closeMenu, conversationId]);
 
   const inProgressTooltip = latestInvestigationInProgress
-    ? i18n.translate('xpack.observability.nightshift.flyout.openInChatInProgressTooltip', {
+    ? i18n.translate('xpack.nightshift.flyout.openInChatInProgressTooltip', {
         defaultMessage:
           'An investigation is still running. You can start a new chat about this significant event.',
       })
     : undefined;
 
-  const openInChatLabel = i18n.translate(
-    'xpack.observability.nightshift.flyout.openInChatButtonLabel',
-    {
-      defaultMessage: 'Open in chat',
-    }
-  );
+  const openInChatLabel = i18n.translate('xpack.nightshift.flyout.openInChatButtonLabel', {
+    defaultMessage: 'Open in chat',
+  });
 
-  const newChatItemLabel = i18n.translate(
-    'xpack.observability.nightshift.flyout.openInChatNewConversationItem',
-    {
-      defaultMessage: 'New chat about this event',
-    }
-  );
+  const newChatItemLabel = i18n.translate('xpack.nightshift.flyout.openInChatNewConversationItem', {
+    defaultMessage: 'New chat about this event',
+  });
 
   const investigationMenuItemLabel = truncateForMenu(event.title);
 
   const investigationChatUnavailableLabel = i18n.translate(
-    'xpack.observability.nightshift.flyout.openInChatInvestigationUnavailable',
+    'xpack.nightshift.flyout.openInChatInvestigationUnavailable',
     {
       defaultMessage: 'Investigation chat is still loading',
     }
   );
 
-  const menuAriaLabel = i18n.translate(
-    'xpack.observability.nightshift.flyout.openInChatMenuAriaLabel',
-    {
-      defaultMessage: 'Open in chat options',
-    }
-  );
+  const menuAriaLabel = i18n.translate('xpack.nightshift.flyout.openInChatMenuAriaLabel', {
+    defaultMessage: 'Open in chat options',
+  });
 
   const investigationsMenuTitle = i18n.translate(
-    'xpack.observability.nightshift.flyout.openInChatInvestigationsMenuTitle',
+    'xpack.nightshift.flyout.openInChatInvestigationsMenuTitle',
     {
       defaultMessage: 'Investigations',
     }

--- a/x-pack/solutions/observability/plugins/nightshift/public/event/event_investigation.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/event/event_investigation.tsx
@@ -63,7 +63,7 @@ export function EventInvestigation({
         <EuiFlexItem grow={false}>
           <EuiTitle size="xs">
             <h3>
-              {i18n.translate('xpack.observability.nightshift.flyout.investigationTitle', {
+              {i18n.translate('xpack.nightshift.flyout.investigationTitle', {
                 defaultMessage: 'Investigation',
               })}
             </h3>
@@ -82,7 +82,7 @@ export function EventInvestigation({
                 detail: status,
               })}
             >
-              {i18n.translate('xpack.observability.nightshift.flyout.investigationShowDetails', {
+              {i18n.translate('xpack.nightshift.flyout.investigationShowDetails', {
                 defaultMessage: 'Show details',
               })}
             </EuiButtonEmpty>
@@ -95,7 +95,7 @@ export function EventInvestigation({
       {!investigation ? (
         <EuiText size="s" color="subdued" data-test-subj="nightshiftInvestigationEmptyState">
           <p>
-            {i18n.translate('xpack.observability.nightshift.flyout.investigationEmptyDescription', {
+            {i18n.translate('xpack.nightshift.flyout.investigationEmptyDescription', {
               defaultMessage: 'No investigation yet.',
             })}
           </p>
@@ -106,22 +106,16 @@ export function EventInvestigation({
           color="warning"
           iconType="warning"
           size="s"
-          title={i18n.translate(
-            'xpack.observability.nightshift.flyout.investigationMissingWorkflowTitle',
-            {
-              defaultMessage: 'Investigation unavailable',
-            }
-          )}
+          title={i18n.translate('xpack.nightshift.flyout.investigationMissingWorkflowTitle', {
+            defaultMessage: 'Investigation unavailable',
+          })}
           data-test-subj="nightshiftInvestigationMissingWorkflowCallout"
         >
           <EuiText size="s">
-            {i18n.translate(
-              'xpack.observability.nightshift.flyout.investigationMissingWorkflowDescription',
-              {
-                defaultMessage:
-                  'This investigation is missing workflow details and cannot be loaded.',
-              }
-            )}
+            {i18n.translate('xpack.nightshift.flyout.investigationMissingWorkflowDescription', {
+              defaultMessage:
+                'This investigation is missing workflow details and cannot be loaded.',
+            })}
           </EuiText>
         </EuiCallOut>
       ) : (

--- a/x-pack/solutions/observability/plugins/nightshift/public/hooks/use_close_significant_event.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/hooks/use_close_significant_event.ts
@@ -22,19 +22,13 @@ interface CloseSignificantEventResponse {
   status: SignificantEventStatus;
 }
 
-const CLOSE_SUCCESS_TOAST_TITLE = i18n.translate(
-  'xpack.observability.nightshift.closeEvent.successToastTitle',
-  {
-    defaultMessage: 'Significant event closed',
-  }
-);
+const CLOSE_SUCCESS_TOAST_TITLE = i18n.translate('xpack.nightshift.closeEvent.successToastTitle', {
+  defaultMessage: 'Significant event closed',
+});
 
-const CLOSE_ERROR_TOAST_TITLE = i18n.translate(
-  'xpack.observability.nightshift.closeEvent.errorToastTitle',
-  {
-    defaultMessage: 'Failed to close significant event',
-  }
-);
+const CLOSE_ERROR_TOAST_TITLE = i18n.translate('xpack.nightshift.closeEvent.errorToastTitle', {
+  defaultMessage: 'Failed to close significant event',
+});
 
 const toError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));

--- a/x-pack/solutions/observability/plugins/nightshift/public/investigation/blind_spots_table.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/investigation/blind_spots_table.tsx
@@ -18,12 +18,9 @@ import { formatBlindSpotMarkdown, type BlindSpotItem } from './investigation_pre
 import { NIGHTSHIFT_EBT_ELEMENTS } from '../common/ebt_constants';
 import { nightshiftBackgroundTransition } from '../common/transition';
 
-const blindSpotChatTooltip = i18n.translate(
-  'xpack.observability.nightshift.investigation.blindSpotChatTooltip',
-  {
-    defaultMessage: 'Ask agent about this blind spot',
-  }
-);
+const blindSpotChatTooltip = i18n.translate('xpack.nightshift.investigation.blindSpotChatTooltip', {
+  defaultMessage: 'Ask agent about this blind spot',
+});
 
 export interface BlindSpotsTableProps {
   items: BlindSpotItem[];
@@ -63,7 +60,7 @@ export function BlindSpotsTable({
           >
             <EuiTitle size="xxs">
               <h4>
-                {i18n.translate('xpack.observability.nightshift.investigation.blindSpotsTitle', {
+                {i18n.translate('xpack.nightshift.investigation.blindSpotsTitle', {
                   defaultMessage: 'Blind spots',
                 })}
               </h4>

--- a/x-pack/solutions/observability/plugins/nightshift/public/investigation/investigation_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/investigation/investigation_flyout.tsx
@@ -93,21 +93,21 @@ export type InvestigationFlyoutTabId = 'recommendations' | 'blindSpots' | 'hypot
 type CompletedTabId = InvestigationFlyoutTabId;
 
 const recommendationChatTooltip = i18n.translate(
-  'xpack.observability.nightshift.investigation.recommendationChatTooltip',
+  'xpack.nightshift.investigation.recommendationChatTooltip',
   {
     defaultMessage: 'Ask agent about this recommendation',
   }
 );
 
 const hypothesisChatTooltip = i18n.translate(
-  'xpack.observability.nightshift.investigation.hypothesisChatTooltip',
+  'xpack.nightshift.investigation.hypothesisChatTooltip',
   {
     defaultMessage: 'Ask agent about this hypothesis',
   }
 );
 
 const hypothesisConfirmedAriaLabel = i18n.translate(
-  'xpack.observability.nightshift.investigation.hypothesisConfirmedAriaLabel',
+  'xpack.nightshift.investigation.hypothesisConfirmedAriaLabel',
   {
     defaultMessage: 'Hypothesis confirmed',
   }
@@ -183,10 +183,10 @@ function InvestigationFlyoutRow({
   const canToggle = isExpandable && !isToggleDisabled;
   const shouldShowToggle = (showToggle ?? isExpandable) && canToggle;
   const expandRowLabel = isOpen
-    ? i18n.translate('xpack.observability.nightshift.investigation.collapseRow', {
+    ? i18n.translate('xpack.nightshift.investigation.collapseRow', {
         defaultMessage: 'Collapse row',
       })
-    : i18n.translate('xpack.observability.nightshift.investigation.expandRow', {
+    : i18n.translate('xpack.nightshift.investigation.expandRow', {
         defaultMessage: 'Expand row',
       });
 
@@ -365,7 +365,7 @@ function RecommendationRow({
           <EuiFlexItem grow={false}>
             <EuiBadge color={recommendation.confidence >= 0.9 ? 'success' : 'hollow'}>
               <FormattedMessage
-                id="xpack.observability.nightshift.investigation.recommendationConfidence"
+                id="xpack.nightshift.investigation.recommendationConfidence"
                 defaultMessage="{confidence, number, percent}"
                 values={{ confidence: recommendation.confidence }}
               />
@@ -494,7 +494,7 @@ function HypothesisRow({
         <EuiFlexItem grow={false}>
           <EuiBadge color={isConfidenceWinner ? 'success' : 'default'}>
             <FormattedMessage
-              id="xpack.observability.nightshift.investigation.hypothesisConfidence"
+              id="xpack.nightshift.investigation.hypothesisConfidence"
               defaultMessage="{confidence, number, percent}"
               values={{ confidence }}
             />
@@ -562,18 +562,15 @@ export function InvestigationFlyout({
   }, [agentBuilder, conversationId]);
 
   const investigationChatUnavailableLabel = i18n.translate(
-    'xpack.observability.nightshift.flyout.openInChatInvestigationUnavailable',
+    'xpack.nightshift.flyout.openInChatInvestigationUnavailable',
     {
       defaultMessage: 'Investigation chat is still loading',
     }
   );
 
-  const openInChatLabel = i18n.translate(
-    'xpack.observability.nightshift.flyout.openInChatButtonLabel',
-    {
-      defaultMessage: 'Open in chat',
-    }
-  );
+  const openInChatLabel = i18n.translate('xpack.nightshift.flyout.openInChatButtonLabel', {
+    defaultMessage: 'Open in chat',
+  });
 
   const openRecommendationInChat = useCallback(
     (recommendation: InvestigationRecommendation, index: number) => {
@@ -596,21 +593,21 @@ export function InvestigationFlyout({
   const tabs = [
     {
       id: 'recommendations' as const,
-      name: i18n.translate('xpack.observability.nightshift.investigation.recommendationsTab', {
+      name: i18n.translate('xpack.nightshift.investigation.recommendationsTab', {
         defaultMessage: 'Recommendations',
       }),
       count: recommendations.length,
     },
     {
       id: 'blindSpots' as const,
-      name: i18n.translate('xpack.observability.nightshift.investigation.blindSpotsTab', {
+      name: i18n.translate('xpack.nightshift.investigation.blindSpotsTab', {
         defaultMessage: 'Blind spots',
       }),
       count: blindSpots.length,
     },
     {
       id: 'hypotheses' as const,
-      name: i18n.translate('xpack.observability.nightshift.investigation.hypothesesTab', {
+      name: i18n.translate('xpack.nightshift.investigation.hypothesesTab', {
         defaultMessage: 'Hypotheses',
       }),
       count: hypotheses.length,
@@ -642,7 +639,7 @@ export function InvestigationFlyout({
         <EuiSpacer size="s" />
         <EuiBadgeGroup gutterSize="xs">
           <EuiBadge color="default" data-test-subj="nightshiftInvestigationFlyoutTypeBadge">
-            {i18n.translate('xpack.observability.nightshift.investigation.flyoutBadge', {
+            {i18n.translate('xpack.nightshift.investigation.flyoutBadge', {
               defaultMessage: 'Investigation',
             })}
           </EuiBadge>
@@ -658,7 +655,7 @@ export function InvestigationFlyout({
         {isRunning ? (
           <>
             <FlyoutSectionTitle>
-              {i18n.translate('xpack.observability.nightshift.investigation.goalTitle', {
+              {i18n.translate('xpack.nightshift.investigation.goalTitle', {
                 defaultMessage: 'Goal',
               })}
             </FlyoutSectionTitle>
@@ -668,7 +665,7 @@ export function InvestigationFlyout({
               <>
                 <EuiSpacer size="l" />
                 <FlyoutSectionTitle>
-                  {i18n.translate('xpack.observability.nightshift.investigation.hypothesesTitle', {
+                  {i18n.translate('xpack.nightshift.investigation.hypothesesTitle', {
                     defaultMessage: 'Hypotheses',
                   })}
                 </FlyoutSectionTitle>
@@ -696,7 +693,7 @@ export function InvestigationFlyout({
         ) : (
           <>
             <FlyoutSectionTitle>
-              {i18n.translate('xpack.observability.nightshift.investigation.conclusionTitle', {
+              {i18n.translate('xpack.nightshift.investigation.conclusionTitle', {
                 defaultMessage: 'Conclusion',
               })}
             </FlyoutSectionTitle>
@@ -756,7 +753,7 @@ export function InvestigationFlyout({
                   <EuiFlexItem grow={false}>
                     <EuiText color="subdued" css={flyoutBodyTextCss}>
                       {i18n.translate(
-                        'xpack.observability.nightshift.investigation.flyout.emptyRecommendations',
+                        'xpack.nightshift.investigation.flyout.emptyRecommendations',
                         {
                           defaultMessage:
                             'No recommendations were produced for this investigation.',
@@ -777,12 +774,9 @@ export function InvestigationFlyout({
                 />
               ) : (
                 <EuiText color="subdued" css={flyoutBodyTextCss}>
-                  {i18n.translate(
-                    'xpack.observability.nightshift.investigation.flyout.emptyBlindSpots',
-                    {
-                      defaultMessage: 'No blind spots were identified for this investigation.',
-                    }
-                  )}
+                  {i18n.translate('xpack.nightshift.investigation.flyout.emptyBlindSpots', {
+                    defaultMessage: 'No blind spots were identified for this investigation.',
+                  })}
                 </EuiText>
               ))}
             {selectedTab === 'hypotheses' && (
@@ -809,12 +803,9 @@ export function InvestigationFlyout({
                 {hypotheses.length === 0 && (
                   <EuiFlexItem grow={false}>
                     <EuiText color="subdued" css={flyoutBodyTextCss}>
-                      {i18n.translate(
-                        'xpack.observability.nightshift.investigation.flyout.emptyHypotheses',
-                        {
-                          defaultMessage: 'No hypotheses were recorded for this investigation.',
-                        }
-                      )}
+                      {i18n.translate('xpack.nightshift.investigation.flyout.emptyHypotheses', {
+                        defaultMessage: 'No hypotheses were recorded for this investigation.',
+                      })}
                     </EuiText>
                   </EuiFlexItem>
                 )}

--- a/x-pack/solutions/observability/plugins/nightshift/public/investigation/investigation_presentation.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/investigation/investigation_presentation.ts
@@ -42,12 +42,12 @@ export const formatInvestigationDuration = (
   );
 
   if (minutes < 1) {
-    return i18n.translate('xpack.observability.nightshift.investigation.durationUnderOneMinute', {
+    return i18n.translate('xpack.nightshift.investigation.durationUnderOneMinute', {
       defaultMessage: '< 1 min',
     });
   }
 
-  return i18n.translate('xpack.observability.nightshift.investigation.durationMinutes', {
+  return i18n.translate('xpack.nightshift.investigation.durationMinutes', {
     defaultMessage: '{minutes} min',
     values: { minutes },
   });
@@ -66,20 +66,20 @@ export const getInvestigationTimeLabel = ({
   const duration = formatInvestigationDuration(startedAt, endedAt ?? Date.now());
 
   if (isRunning) {
-    return i18n.translate('xpack.observability.nightshift.investigation.sinceTimeDuration', {
+    return i18n.translate('xpack.nightshift.investigation.sinceTimeDuration', {
       defaultMessage: 'Since {time} ({duration})',
       values: { time, duration },
     });
   }
 
-  return i18n.translate('xpack.observability.nightshift.investigation.completedTimeDuration', {
+  return i18n.translate('xpack.nightshift.investigation.completedTimeDuration', {
     defaultMessage: '{time} ({duration})',
     values: { time, duration },
   });
 };
 
 export const getInvestigationCompleteStatusLabel = (): string =>
-  i18n.translate('xpack.observability.nightshift.investigation.statusComplete', {
+  i18n.translate('xpack.nightshift.investigation.statusComplete', {
     defaultMessage: 'Complete',
   });
 
@@ -310,19 +310,19 @@ export const sortInvestigationHypotheses = (
 export const getHypothesisStatusLabel = (status: InvestigationHypothesis['status']): string => {
   switch (status) {
     case 'investigating':
-      return i18n.translate('xpack.observability.nightshift.investigation.hypothesisChecking', {
+      return i18n.translate('xpack.nightshift.investigation.hypothesisChecking', {
         defaultMessage: 'Checking',
       });
     case 'confirmed':
-      return i18n.translate('xpack.observability.nightshift.investigation.hypothesisConfirmed', {
+      return i18n.translate('xpack.nightshift.investigation.hypothesisConfirmed', {
         defaultMessage: 'Confirmed',
       });
     case 'dismissed':
-      return i18n.translate('xpack.observability.nightshift.investigation.hypothesisRejected', {
+      return i18n.translate('xpack.nightshift.investigation.hypothesisRejected', {
         defaultMessage: 'Rejected',
       });
     default:
-      return i18n.translate('xpack.observability.nightshift.investigation.hypothesisUnknown', {
+      return i18n.translate('xpack.nightshift.investigation.hypothesisUnknown', {
         defaultMessage: 'Unknown',
       });
   }

--- a/x-pack/solutions/observability/plugins/nightshift/public/investigation/investigation_status_badge.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/investigation/investigation_status_badge.tsx
@@ -205,7 +205,7 @@ function InvestigationCompleteStatus({
 }): React.ReactElement {
   const { euiTheme } = useEuiTheme();
   const completeStatusLabel = i18n.translate(
-    'xpack.observability.nightshift.investigation.completeStatusAriaLabel',
+    'xpack.nightshift.investigation.completeStatusAriaLabel',
     {
       defaultMessage: 'Investigation complete',
     }

--- a/x-pack/solutions/observability/plugins/nightshift/public/investigation/investigation_summary_card.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/investigation/investigation_summary_card.tsx
@@ -50,14 +50,14 @@ const INLINE_BLIND_SPOT_LIMIT = 4;
 const tryNextRowActionClassName = 'nightshiftInvestigationTryNextRowAction';
 
 const recommendationChatTooltip = i18n.translate(
-  'xpack.observability.nightshift.investigation.recommendationChatTooltip',
+  'xpack.nightshift.investigation.recommendationChatTooltip',
   {
     defaultMessage: 'Ask agent about this recommendation',
   }
 );
 
 const completedStatusLabel = i18n.translate(
-  'xpack.observability.nightshift.investigation.summaryCompleteStatusLabel',
+  'xpack.nightshift.investigation.summaryCompleteStatusLabel',
   {
     defaultMessage: 'Complete',
   }
@@ -142,7 +142,7 @@ function TryNextPanel({
         <EuiFlexItem grow={false}>
           <EuiTitle size="xxs">
             <h4>
-              {i18n.translate('xpack.observability.nightshift.investigation.tryNextTitle', {
+              {i18n.translate('xpack.nightshift.investigation.tryNextTitle', {
                 defaultMessage: 'Try next',
               })}
             </h4>
@@ -160,7 +160,7 @@ function TryNextPanel({
                 element: NIGHTSHIFT_EBT_ELEMENTS.INVESTIGATION_SUMMARY,
               })}
             >
-              {i18n.translate('xpack.observability.nightshift.investigation.moreRecommendations', {
+              {i18n.translate('xpack.nightshift.investigation.moreRecommendations', {
                 defaultMessage: 'More recommendations',
               })}
             </EuiButtonEmpty>

--- a/x-pack/solutions/observability/plugins/nightshift/public/investigation/open_investigation_item_in_chat.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/investigation/open_investigation_item_in_chat.ts
@@ -19,13 +19,10 @@ export const buildBlindSpotChatOptions = (
 ): OpenSignificantEventChatOptions => ({
   newConversation: true,
   autoSendInitialMessage: true,
-  initialMessage: i18n.translate(
-    'xpack.observability.nightshift.investigation.blindSpotChatPrompt',
-    {
-      defaultMessage: 'Tell me about this blind spot: {title}',
-      values: { title: blindSpot.title },
-    }
-  ),
+  initialMessage: i18n.translate('xpack.nightshift.investigation.blindSpotChatPrompt', {
+    defaultMessage: 'Tell me about this blind spot: {title}',
+    values: { title: blindSpot.title },
+  }),
   attachments: [
     {
       id: attachmentId,
@@ -44,13 +41,10 @@ export const buildHypothesisChatOptions = (
 ): OpenSignificantEventChatOptions => ({
   newConversation: true,
   autoSendInitialMessage: true,
-  initialMessage: i18n.translate(
-    'xpack.observability.nightshift.investigation.hypothesisChatPrompt',
-    {
-      defaultMessage: 'Tell me about this hypothesis: {candidate}',
-      values: { candidate: hypothesis.candidate },
-    }
-  ),
+  initialMessage: i18n.translate('xpack.nightshift.investigation.hypothesisChatPrompt', {
+    defaultMessage: 'Tell me about this hypothesis: {candidate}',
+    values: { candidate: hypothesis.candidate },
+  }),
   attachments: [
     {
       id: attachmentId,
@@ -69,13 +63,10 @@ export const buildRecommendationChatOptions = (
 ): OpenSignificantEventChatOptions => ({
   newConversation: true,
   autoSendInitialMessage: true,
-  initialMessage: i18n.translate(
-    'xpack.observability.nightshift.investigation.recommendationChatPrompt',
-    {
-      defaultMessage: 'Tell me about this recommendation: {title}',
-      values: { title: recommendation.title },
-    }
-  ),
+  initialMessage: i18n.translate('xpack.nightshift.investigation.recommendationChatPrompt', {
+    defaultMessage: 'Tell me about this recommendation: {title}',
+    values: { title: recommendation.title },
+  }),
   attachments: [
     {
       id: attachmentId,

--- a/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_entities.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_entities.tsx
@@ -48,7 +48,7 @@ function BlastRadiusEntityButton({
 
   return (
     <button
-      aria-label={i18n.translate('xpack.observability.nightshift.blastRadiusChipAriaLabel', {
+      aria-label={i18n.translate('xpack.nightshift.blastRadiusChipAriaLabel', {
         defaultMessage: '{name}: {count}',
         values: { count, name },
       })}
@@ -190,7 +190,7 @@ export function BlastRadiusEntities({
             margin-bottom: ${euiTheme.size.m};
           `}
         >
-          {i18n.translate('xpack.observability.nightshift.blastRadiusTitle', {
+          {i18n.translate('xpack.nightshift.blastRadiusTitle', {
             defaultMessage: 'Impacted entities',
           })}
         </span>
@@ -231,7 +231,7 @@ export function BlastRadiusEntities({
                   element: NIGHTSHIFT_EBT_ELEMENTS.BLAST_RADIUS,
                 })}
               >
-                {i18n.translate('xpack.observability.nightshift.blastRadiusShowMore', {
+                {i18n.translate('xpack.nightshift.blastRadiusShowMore', {
                   defaultMessage: '+{count} more',
                   values: { count: hiddenCount },
                 })}
@@ -255,7 +255,7 @@ export function BlastRadiusEntities({
                   element: NIGHTSHIFT_EBT_ELEMENTS.BLAST_RADIUS,
                 })}
               >
-                {i18n.translate('xpack.observability.nightshift.blastRadiusShowLess', {
+                {i18n.translate('xpack.nightshift.blastRadiusShowLess', {
                   defaultMessage: 'Show less',
                 })}
               </EuiButtonEmpty>

--- a/x-pack/solutions/observability/plugins/nightshift/public/landing/significant_event_item.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/landing/significant_event_item.tsx
@@ -133,16 +133,13 @@ export function SignificantEventItem({
               {onChatClick && (
                 <EuiFlexItem grow={false}>
                   <EuiToolTip
-                    content={i18n.translate(
-                      'xpack.observability.nightshift.event.openInChatTooltip',
-                      {
-                        defaultMessage: 'Open in chat',
-                      }
-                    )}
+                    content={i18n.translate('xpack.nightshift.event.openInChatTooltip', {
+                      defaultMessage: 'Open in chat',
+                    })}
                   >
                     <AiButtonIcon
                       aria-label={i18n.translate(
-                        'xpack.observability.nightshift.event.openInChatButtonAriaLabel',
+                        'xpack.nightshift.event.openInChatButtonAriaLabel',
                         {
                           defaultMessage: 'Open {eventTitle} in chat',
                           values: { eventTitle: event.title },
@@ -181,17 +178,14 @@ export function SignificantEventItem({
               {onCloseClick && event.status === 'open' && (
                 <EuiFlexItem grow={false}>
                   <EuiToolTip
-                    content={i18n.translate(
-                      'xpack.observability.nightshift.event.closeEventTooltip',
-                      {
-                        defaultMessage: 'Close significant event',
-                      }
-                    )}
+                    content={i18n.translate('xpack.nightshift.event.closeEventTooltip', {
+                      defaultMessage: 'Close significant event',
+                    })}
                     disableScreenReaderOutput
                   >
                     <EuiButtonIcon
                       aria-label={i18n.translate(
-                        'xpack.observability.nightshift.event.closeEventButtonAriaLabel',
+                        'xpack.nightshift.event.closeEventButtonAriaLabel',
                         {
                           defaultMessage: 'Close {eventTitle}',
                           values: { eventTitle: event.title },

--- a/x-pack/solutions/observability/plugins/nightshift/public/landing/significant_event_list.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/landing/significant_event_list.tsx
@@ -95,16 +95,13 @@ export function SignificantEventList({
             <p>
               {filterActive
                 ? statusColor === 'success'
-                  ? i18n.translate(
-                      'xpack.observability.nightshift.list.filteredResolvedEmptyDescription',
-                      {
-                        defaultMessage: 'No resolved events match this filter.',
-                      }
-                    )
-                  : i18n.translate('xpack.observability.nightshift.list.filteredEmptyDescription', {
+                  ? i18n.translate('xpack.nightshift.list.filteredResolvedEmptyDescription', {
+                      defaultMessage: 'No resolved events match this filter.',
+                    })
+                  : i18n.translate('xpack.nightshift.list.filteredEmptyDescription', {
                       defaultMessage: 'No events match this filter.',
                     })
-                : i18n.translate('xpack.observability.nightshift.list.emptyDescription', {
+                : i18n.translate('xpack.nightshift.list.emptyDescription', {
                     defaultMessage: 'No significant events found',
                   })}
             </p>
@@ -128,7 +125,7 @@ export function SignificantEventList({
                           : NIGHTSHIFT_EBT_DETAILS.RESOLVED,
                     })}
                   >
-                    {i18n.translate('xpack.observability.nightshift.list.clearFilterButton', {
+                    {i18n.translate('xpack.nightshift.list.clearFilterButton', {
                       defaultMessage: 'Clear filter',
                     })}
                   </EuiButtonEmpty>

--- a/x-pack/solutions/observability/plugins/nightshift/public/landing/significant_event_statuses.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/landing/significant_event_statuses.tsx
@@ -198,7 +198,7 @@ export function SignificantEventStatuses({
         <EuiFlexItem>
           <SignificantEventStatusCard
             count={needsActionCount}
-            label={i18n.translate('xpack.observability.nightshift.summary.needActionLabel', {
+            label={i18n.translate('xpack.nightshift.summary.needActionLabel', {
               defaultMessage: 'Need action',
             })}
             onClick={onNeedsActionClick}
@@ -209,7 +209,7 @@ export function SignificantEventStatuses({
         <EuiFlexItem>
           <SignificantEventStatusCard
             count={resolvedCount}
-            label={i18n.translate('xpack.observability.nightshift.summary.resolvedLabel', {
+            label={i18n.translate('xpack.nightshift.summary.resolvedLabel', {
               defaultMessage: 'Resolved',
             })}
             onClick={onResolvedClick}

--- a/x-pack/solutions/observability/plugins/nightshift/public/nightshift_page.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/nightshift_page.tsx
@@ -45,7 +45,7 @@ export function NightshiftPage(): React.ReactElement | null {
     [
       {
         href: basePath.prepend(NIGHTSHIFT_APP_ROUTE),
-        text: i18n.translate('xpack.observability.nightshift.breadcrumbs.linkText', {
+        text: i18n.translate('xpack.nightshift.breadcrumbs.linkText', {
           defaultMessage: 'Nightshift',
         }),
         deepLinkId: NIGHTSHIFT_APP_ID,

--- a/x-pack/solutions/observability/plugins/nightshift/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/plugin.ts
@@ -44,7 +44,7 @@ export class NightshiftPlugin
 
     coreSetup.application.register({
       id: NIGHTSHIFT_APP_ID,
-      title: i18n.translate('xpack.observability.nightshift.appTitle', {
+      title: i18n.translate('xpack.nightshift.appTitle', {
         defaultMessage: 'Nightshift',
       }),
       appRoute: NIGHTSHIFT_APP_ROUTE,


### PR DESCRIPTION
## 📓 Summary

PR 5 of 6. Flips the Nightshift i18n ids to the `xpack.nightshift` namespace.

- **All 145 message ids** move from `xpack.observability.nightshift.*` to `xpack.nightshift.*`.
- `x-pack/.i18nrc.json` returns to **one namespace per directory**: `xpack.observability` drops the temporary second path it carried through PRs 2–4, and `xpack.nightshift` points at the plugin. That namespace was freed when the dead `@kbn/nightshift` package was retired in #282682, which is why no directory is ever mapped to two namespaces at any point in this stack.
- **Two keys did need translation cleanup after all.** `xpack.observability.nightshiftLinkTitle` and `xpack.observability.breadcrumbs.nightshiftLinkText` are camelCase and therefore sat *outside* the `.nightshift.` namespace, so unlike the 145 namespaced ids they had been translated. Removed from `de-DE`, `fr-FR`, `ja-JP`, `zh-CN` (2 keys × 4 locales). `i18n_check` is what surfaced them.

Mostly `i18n_check --fix` output; the interesting part is the `.i18nrc.json` change and the four locale files.

## 🧑‍💻 Stack

1. #282682 · 2. #282685 · 3. #282686 · 4. #282689 · **5. PR5 ← you are here** · 6. Cleanup
