### PR TITLE
[9.5] [ML] Improving trained model ID check (#280511)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/server/lib/ml_client/ml_client.ts
+++ b/x-pack/platform/plugins/shared/ml/server/lib/ml_client/ml_client.ts
@@ -12,6 +12,8 @@ import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 import type { JobType } from '@kbn/ml-common-types/saved_objects';
 import type { Datafeed } from '@kbn/ml-common-types/anomaly_detection_jobs/datafeed';
 import type { Job } from '@kbn/ml-common-types/anomaly_detection_jobs/job';
+import { LANG_IDENT_MODEL_ID } from '@kbn/ml-trained-models-utils';
+import { isNLPModelItem } from '@kbn/ml-common-types/trained_models';
 import type { MlLicense } from '../../../common/license/ml_license';
 import { getJobDetailsFromTrainedModel } from '../../saved_objects/util';
 import type { MLSavedObjectService } from '../../saved_objects';
@@ -168,6 +170,64 @@ export function getMlClient(
     }
     if (missingIds.length) {
       throw new MLModelNotFound(`No known model with id '${missingIds.join(',')}'`);
+    }
+  }
+
+  /**
+   * Validates that the supplied deployment IDs belong to the model ID in the request.
+   * Loads trained model stats for the model and checks each deployment ID against
+   * the deployments reported for that model. Wildcards are not allowed.
+   */
+  async function deploymentIdsCheck(p: MlClientParams) {
+    const deploymentIds = filterAll(getDeploymentIdsFromRequest(p));
+    if (deploymentIds.length === 0) {
+      return;
+    }
+
+    const [modelId] = filterAll(getModelIdsFromRequest(p as MlGetTrainedModelParams));
+    if (modelId === undefined || modelId === LANG_IDENT_MODEL_ID) {
+      return;
+    }
+
+    const hasWildcard = (id: string) => id.includes('*') || id.includes('?');
+    if (hasWildcard(modelId) || deploymentIds.some(hasWildcard)) {
+      throw new MLModelNotFound('Model and deployment ids must not contain wildcard characters');
+    }
+
+    const [{ trained_model_stats: modelStats }, { trained_model_configs: models }] =
+      await Promise.all([
+        mlClient.getTrainedModelsStats({
+          model_id: modelId,
+        }),
+        mlClient.getTrainedModels({
+          model_id: modelId,
+        }),
+      ]);
+
+    const [model] = models;
+
+    if (isNLPModelItem(model)) {
+      // if the model is pytorch, we need to check that the deployment ids are valid
+      const validDeploymentIds = new Set(
+        modelStats
+          .map((stats) => stats.deployment_stats?.deployment_id)
+          .filter((id): id is string => id !== undefined)
+      );
+
+      for (const id of deploymentIds) {
+        if (validDeploymentIds.has(id) === false) {
+          throw new MLModelNotFound(`No known deployment with id '${id}'`);
+        }
+      }
+    } else {
+      // Non-pytorch models should not have deployments
+      for (const stats of modelStats) {
+        if (stats.deployment_stats !== undefined) {
+          throw new MLModelNotFound(
+            `Unexpected deployment stats for non-pytorch model '${modelId}'`
+          );
+        }
+      }
     }
   }
 
@@ -559,6 +619,7 @@ export function getMlClient(
     },
     async updateTrainedModelDeployment(...p: Parameters<MlClient['updateTrainedModelDeployment']>) {
       await modelIdsCheck(p);
+      await deploymentIdsCheck(p);
 
       const { deployment_id: deploymentId, model_id: modelId, ...bodyParams } = p[0];
       // TODO use mlClient.updateTrainedModelDeployment when esClient is updated
@@ -575,6 +636,7 @@ export function getMlClient(
     },
     async stopTrainedModelDeployment(...p: Parameters<MlClient['stopTrainedModelDeployment']>) {
       await modelIdsCheck(p);
+      await deploymentIdsCheck(p);
       switchDeploymentId(p);
 
       return auditLogger.wrapTask(
@@ -585,6 +647,7 @@ export function getMlClient(
     },
     async inferTrainedModel(...p: Parameters<MlClient['inferTrainedModel']>) {
       await modelIdsCheck(p);
+      await deploymentIdsCheck(p);
       switchDeploymentId(p);
       // Temporary workaround for the incorrect inferTrainedModelDeployment function in the esclient
       if (
@@ -769,6 +832,15 @@ export function getDFAJobIdsFromRequest([params]: MlGetDFAParams): string[] {
 
 export function getModelIdsFromRequest([params]: MlGetTrainedModelParams): string[] {
   const id = params?.model_id;
+  const ids = Array.isArray(id) ? id : id?.split(',');
+  return ids || [];
+}
+
+export function getDeploymentIdsFromRequest([params]: MlClientParams): string[] {
+  const id =
+    params && 'deployment_id' in params
+      ? (params as { deployment_id?: string | string[] }).deployment_id
+      : undefined;
   const ids = Array.isArray(id) ? id : id?.split(',');
   return ids || [];
 }

--- a/x-pack/platform/test/api_integration/apis/ml/trained_models/start_stop_deployment.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/trained_models/start_stop_deployment.ts
@@ -146,6 +146,18 @@ export default ({ getService }: FtrProviderContext) => {
       );
     });
 
+    it('returns an error if the model exists but the deployment does not', async () => {
+      const missingDeploymentId = 'not_existing_deployment';
+      const { body: stopResponseBody, status: stopResponseStatus } = await supertest
+        .post(`/internal/ml/trained_models/${testModel.id}/${missingDeploymentId}/deployment/_stop`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(200, stopResponseStatus, stopResponseBody);
+
+      expect(stopResponseBody[missingDeploymentId].success).to.eql(false);
+      expect(stopResponseBody[missingDeploymentId].error.statusCode).to.eql(404);
+    });
+
     it('stops trained model deployment with the default ID', async () => {
       const { body: stopResponseBody, status: stopResponseStatus } = await supertest
         .post(`/internal/ml/trained_models/${testModel.id}/${testModel.id}/deployment/_stop`)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ML] Improving trained model ID check (#280511)](https://github.com/elastic/kibana/pull/280511)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"James Gowdy","email":"jgowdy@elastic.co"},"sourceCommit":{"committedDate":"2026-08-04T14:12:39Z","message":"[ML] Improving trained model ID check (#280511)\n\nImproves the model ID space check to ensure the infer, update and stop\nAPIs can't be used to access a different model.\nAffects APIs:\n`/ml/trained_models/infer/{modelId}/{deploymentId}` and\n`/ml/trained_models/{modelId}/{deploymentId}/deployment/_stop`\n`/ml/trained_models/{modelId}/{deploymentId}/deployment/_update`\n\nAdds an extra checks:\nIf the model is pytorch, ensure the supplied deployment IDs exist as\ndeployments of the supplied model ID.\nfor non-pytorch (non-deployable) models, ensure there are no deployment\nstats.","sha":"df26e5d41a31401e360c2f7b3676c810844a9ae0","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Feature:3rd Party Models","backport:version","v9.5.0","v9.6.0","v9.4.5","v8.19.20","v9.3.9"],"title":"[ML] Improving trained model ID check","number":280511,"url":"https://github.com/elastic/kibana/pull/280511","mergeCommit":{"message":"[ML] Improving trained model ID check (#280511)\n\nImproves the model ID space check to ensure the infer, update and stop\nAPIs can't be used to access a different model.\nAffects APIs:\n`/ml/trained_models/infer/{modelId}/{deploymentId}` and\n`/ml/trained_models/{modelId}/{deploymentId}/deployment/_stop`\n`/ml/trained_models/{modelId}/{deploymentId}/deployment/_update`\n\nAdds an extra checks:\nIf the model is pytorch, ensure the supplied deployment IDs exist as\ndeployments of the supplied model ID.\nfor non-pytorch (non-deployable) models, ensure there are no deployment\nstats.","sha":"df26e5d41a31401e360c2f7b3676c810844a9ae0"}},"sourceBranch":"main","suggestedTargetBranches":["9.5","9.4","8.19","9.3"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280511","number":280511,"mergeCommit":{"message":"[ML] Improving trained model ID check (#280511)\n\nImproves the model ID space check to ensure the infer, update and stop\nAPIs can't be used to access a different model.\nAffects APIs:\n`/ml/trained_models/infer/{modelId}/{deploymentId}` and\n`/ml/trained_models/{modelId}/{deploymentId}/deployment/_stop`\n`/ml/trained_models/{modelId}/{deploymentId}/deployment/_update`\n\nAdds an extra checks:\nIf the model is pytorch, ensure the supplied deployment IDs exist as\ndeployments of the supplied model ID.\nfor non-pytorch (non-deployable) models, ensure there are no deployment\nstats.","sha":"df26e5d41a31401e360c2f7b3676c810844a9ae0"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.20","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->