### PR TITLE
Remove DGA ML integration from Security Serverless exclude list

### DIFF
--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -208,9 +208,6 @@ xpack.fleet.internal.registry.excludePackages: [
     'symantec',
     'tomcat',
 
-    # ML integrations
-    'dga',
-
     # Unsupported in serverless
     'cloud_defend',
   ]


### PR DESCRIPTION
## Summary

<!-- Summarize your PR. If it involves visual changes include a screenshot or gif. -->

Remove the DGA ML integration from the Security Serverless exclusion list. Previously, an issue with the DGA integration prevented us from promoting it to Serverless during the initial launch. The issue was related to the ingest node sizing requirements for large models like DGA. This has now been resolved by the ML team under: https://github.com/elastic/elasticsearch/pull/152981 and https://github.com/elastic/elasticsearch-serverless/pull/7182
I also tested installing the integration on a Search project, and it was successful. The model was deployed correctly and worked as expected.
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



