### PR TITLE
[Entity Analytics] Set anomalies signal to null if there are no values

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_details/highlights.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_details/highlights.gen.ts
@@ -62,7 +62,10 @@ export const EntityDetailsHighlightsResponse = lazySchema(() =>
       riskScore: z.array(z.object({}).catchall(z.unknown())).optional(),
       vulnerabilities: z.array(z.object({}).catchall(z.unknown())).optional(),
       vulnerabilitiesTotal: z.object({}).catchall(z.number()).optional(),
-      anomalies: z.array(z.object({}).catchall(z.unknown())).optional(),
+      /**
+       * ML anomaly findings. Null when there are none.
+       */
+      anomalies: z.array(z.object({}).catchall(z.unknown())).nullable().optional(),
     }),
     replacements: Replacements,
     /**

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_details/highlights.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_details/highlights.schema.yaml
@@ -79,6 +79,8 @@ paths:
                           type: number
                       anomalies:
                         type: array
+                        nullable: true
+                        description: ML anomaly findings. Null when there are none.
                         items:
                           type: object
                           additionalProperties: true

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_details/entity_details_highlights_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_details/entity_details_highlights_service.ts
@@ -499,7 +499,9 @@ export const entityDetailsHighlightsServiceFactory = ({
             vulnerabilitiesTotal: enrichedEntity.vulnerabilitiesTotal,
           }
         : {}),
-      anomalies: anomaliesAnonymized,
+      // Null when empty so the model gets an explicit "no ML anomalies" signal
+      // (clearer than [] or omitting the key).
+      anomalies: anomaliesAnonymized.length > 0 ? anomaliesAnonymized : null,
     };
   };
 
@@ -542,7 +544,9 @@ export const entityDetailsHighlightsServiceFactory = ({
             vulnerabilitiesTotal: vulnerabilityData.vulnerabilitiesTotal,
           }
         : {}),
-      anomalies: anomaliesAnonymized,
+      // Null when empty so the model gets an explicit "no ML anomalies" signal
+      // (clearer than [] or omitting the key).
+      anomalies: anomaliesAnonymized.length > 0 ? anomaliesAnonymized : null,
     };
   };
 
@@ -575,11 +579,11 @@ export const entityDetailsHighlightsServiceFactory = ({
     });
 
     if (!enrichedEntities || enrichedEntities.length === 0) {
-      // No entity → omit vulnerabilities entirely (nothing applicable to report)
+      // No entity → omit vulnerabilities; anomalies are explicitly null (no ML findings).
       return {
         riskScore: [],
         assetCriticality: [],
-        anomalies: [],
+        anomalies: null,
       };
     }
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_details/trial_license_complete_tier/highlights.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_details/trial_license_complete_tier/highlights.ts
@@ -309,7 +309,8 @@ export default function ({ getService }: FtrProviderContext) {
           MEDIUM: 0,
           NONE: 0,
         },
-        anomalies: [],
+        // anomalies is null when there are no ML findings
+        anomalies: null,
       });
       expect(Object.values(body.replacements)).toEqual(['un-existent-host']);
       expect(body.prompt).toContain(

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/highlights_v2.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/highlights_v2.ts
@@ -438,9 +438,8 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(body.summary.vulnerabilities).toBeUndefined();
       expect(body.summary.vulnerabilitiesTotal).toBeUndefined();
 
-      // Anomalies
-      expect(body.summary.anomalies).toBeDefined();
-      expect(body.summary.anomalies).toHaveLength(0);
+      // Anomalies are explicitly null when there are no ML findings
+      expect(body.summary.anomalies).toBeNull();
 
       // Prompt and replacements
       expect(body.replacements).toBeDefined();
@@ -492,7 +491,8 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(body.summary.assetCriticality).toEqual([]);
       expect(body.summary.vulnerabilities).toBeUndefined();
       expect(body.summary.vulnerabilitiesTotal).toBeUndefined();
-      expect(body.summary.anomalies).toEqual([]);
+      // Anomalies are explicitly null when there are no ML findings
+      expect(body.summary.anomalies).toBeNull();
       expect(body.prompt).toContain(
         'Generate structured information for an entity so a Security analyst can act.'
       );


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/security-team/issues/18415

When an entity had a detection-alert-driven risk score but no ML anomalies, Entity AI Summary still produced an Anomalies highlight — the model was treating risk-score `alert_inputs` as anomaly findings.

**Fix:** setting anomalies explicitly to null seems to cue the LLM to ignore it. The prompt already instructed the model not to generate the section when there was no data, but with an empty array it was still generating it.

## How to test

1. Start Elasticsearch with EIS enabled (to use Agent Builder).
2. Load some data. I used the `risk-score-v2` command from [security-documents-generator](https://github.com/elastic/security-documents-generator):
  ```
  yarn start risk-score-v2
  ```
3. Open an entity that has a risk score / alert inputs but no ML anomalies → generate AI summary
4. Try with a couple of entities since the output is not deterministic

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->