### PR TITLE
[Lens as code] Fix bucket terms operation schema to support both string and numeric values in `includes`/`excludes`

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -97236,11 +97236,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -97260,11 +97265,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -110381,11 +110381,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -110405,11 +110410,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
@@ -187,13 +187,11 @@ export const bucketTermsOperationSchema = z
      */
     includes: z
       .object({
+        // A terms field is either string- or number-typed, so the values are homogeneous: an array of
+        // strings or an array of numbers, never mixed.
         values: z
-          .array(
-            z.string().meta({
-              description: 'Values to include.',
-            })
-          )
-          .max(100),
+          .union([z.array(z.string()).max(100), z.array(z.number()).max(100)])
+          .meta({ description: 'Values to include.' }),
         as_regex: z.boolean().optional().meta({
           description: 'When `true`, treats the values as regular expressions.',
         }),
@@ -206,12 +204,8 @@ export const bucketTermsOperationSchema = z
     excludes: z
       .object({
         values: z
-          .array(
-            z.string().meta({
-              description: 'Values to exclude.',
-            })
-          )
-          .max(100),
+          .union([z.array(z.string()).max(100), z.array(z.number()).max(100)])
+          .meta({ description: 'Values to exclude.' }),
         as_regex: z.boolean().optional().meta({
           description: 'When `true`, treats the values as regular expressions.',
         }),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.test.ts
@@ -102,6 +102,20 @@ describe('Top Values Transforms', () => {
       expect(result.params.excludeIsRegex).toBe(false);
     });
 
+    it('should preserve numeric includes and excludes verbatim', () => {
+      const input: LensApiTermsOperation = {
+        operation: 'terms',
+        fields: ['destination.port'],
+        limit: 5,
+        includes: { as_regex: false, values: [443] },
+        excludes: { as_regex: false, values: [22, 23, 53] },
+      };
+
+      const result = fromTermsLensApiToLensState(input, getMetricColumnIdByIndex);
+      expect(result.params.include).toEqual([443]);
+      expect(result.params.exclude).toEqual([22, 23, 53]);
+    });
+
     it('should handle orderBy column type', () => {
       const input: LensApiTermsOperation = {
         operation: 'terms',
@@ -358,6 +372,35 @@ describe('Top Values Transforms', () => {
         as_regex: false,
         values: ['inactive'],
       });
+    });
+
+    it('should emit numeric includes and excludes without stringifying them', () => {
+      const input: TermsIndexPatternColumn = {
+        operationType: 'terms',
+        sourceField: 'destination.port',
+        customLabel: false,
+        label: 'Top 5 values for destination.port',
+        isBucketed: true,
+        dataType: 'number',
+        params: {
+          secondaryFields: [],
+          size: 5,
+          accuracyMode: false,
+          include: [443],
+          includeIsRegex: false,
+          exclude: [22, 23, 53],
+          excludeIsRegex: false,
+          otherBucket: false,
+          missingBucket: false,
+          orderBy: { type: 'alphabetical' },
+          orderDirection: 'asc',
+          parentFormat: { id: 'terms' },
+        },
+      };
+
+      const result = fromTermsLensStateToAPI(input, columns);
+      expect(result.includes).toEqual({ as_regex: false, values: [443] });
+      expect(result.excludes).toEqual({ as_regex: false, values: [22, 23, 53] });
     });
 
     it('should handle orderBy column type', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.ts
@@ -116,13 +116,10 @@ export function fromTermsLensApiToLensState(
       size: limit, // it cannot be 0 (zero)
       ...(increase_accuracy != null ? { accuracyMode: increase_accuracy } : {}),
       ...(includes?.values
-        ? { include: includes?.values, includeIsRegex: includes?.as_regex ?? false }
+        ? { include: includes.values, includeIsRegex: includes?.as_regex ?? false }
         : {}),
       ...(excludes?.values
-        ? {
-            exclude: excludes.values,
-            excludeIsRegex: excludes?.as_regex ?? false,
-          }
+        ? { exclude: excludes.values, excludeIsRegex: excludes?.as_regex ?? false }
         : {}),
       ...(other_bucket != null ? { otherBucket: true } : {}),
       ...(other_bucket?.include_documents_without_field != null
@@ -286,7 +283,10 @@ export function fromTermsLensStateToAPI(
       ? {
           includes: {
             as_regex: column.params.includeIsRegex,
-            values: column.params.include?.map((value) => String(value)) || [],
+            // Preserve the value type verbatim: numeric fields store numbers and the runtime terms
+            // agg drops stringified numbers at render (`migrateIncludeExcludeFormat` filters with
+            // `Number.isFinite`), so coercing to strings would silently lose the include filter.
+            values: column.params.include ?? [],
           },
         }
       : {}),
@@ -294,7 +294,7 @@ export function fromTermsLensStateToAPI(
       ? {
           excludes: {
             as_regex: column.params.excludeIsRegex,
-            values: column.params.exclude?.map((value) => String(value)) || [],
+            values: column.params.exclude ?? [],
           },
         }
       : {}),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.ts
@@ -294,6 +294,9 @@ export function fromTermsLensStateToAPI(
       ? {
           excludes: {
             as_regex: column.params.excludeIsRegex,
+            // Preserve the value type verbatim: numeric fields store numbers and the runtime terms
+            // agg drops stringified numbers at render (`migrateIncludeExcludeFormat` filters with
+            // `Number.isFinite`), so coercing to strings would silently lose the exclude filter.
             values: column.params.exclude ?? [],
           },
         }


### PR DESCRIPTION
Found in the #282534 investigation

## Summary
Terms includes / excludes values were string-only in the API schema and could be stringified on round-trip. Numeric fields (e.g. ports) then failed at render because finite numbers were dropped.

## Changes

- Schema: `includes.values` / `excludes.values` accept `string[]` or `number[]` (homogeneous).
- Transform: pass values through verbatim both ways.
- Unit tests for numeric include/exclude preserve + emit.

Not a breaking change: existing `string` arrays remain valid. This only widens the schema (additive union) and stops coercing numbers to strings — no previously accepted payload is rejected, and string-field callers are unchanged.

## Release Notes

Fixed Lens as-code terms include/exclude to preserve numeric values instead of stringifying them.

## Screenshots

- Left: api flag off
- Right: api flag on

Before: 

<img width="2541" height="1201" alt="Screenshot 2026-08-04 at 7 09 02 PM" src="https://github.com/user-attachments/assets/00aaaa33-7c3d-4866-9cac-2e5b4e6601e3" />


After:

<img width="2546" height="1195" alt="Screenshot 2026-08-04 at 7 01 04 PM" src="https://github.com/user-attachments/assets/206684c9-bfc7-4a2e-ae4a-0a12b477a159" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->