### PR TITLE
[Lens as code] Fix terms `parentFormat` derivation and `format` round-trip

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.test.ts
@@ -263,6 +263,36 @@ describe('Top Values Transforms', () => {
         label: '',
       });
     });
+
+    it('should derive parentFormat from the number of fields', () => {
+      const single = fromTermsLensApiToLensState(
+        { operation: 'terms', fields: ['status'], limit: 5 },
+        getMetricColumnIdByIndex
+      );
+      expect(single.params.parentFormat).toEqual({ id: 'terms' });
+
+      const multi = fromTermsLensApiToLensState(
+        { operation: 'terms', fields: ['status', 'region'], limit: 5 },
+        getMetricColumnIdByIndex
+      );
+      expect(multi.params.parentFormat).toEqual({ id: 'multi_terms' });
+    });
+
+    it('should read a persisted format', () => {
+      const result = fromTermsLensApiToLensState(
+        {
+          operation: 'terms',
+          fields: ['bytes'],
+          limit: 5,
+          format: { type: 'number', decimals: 2, compact: false },
+        },
+        getMetricColumnIdByIndex
+      );
+      expect(result.params.format).toEqual({
+        id: 'number',
+        params: { decimals: 2, compact: false },
+      });
+    });
   });
 
   describe('fromTermsLensStateToAPI', () => {
@@ -610,6 +640,55 @@ describe('Top Values Transforms', () => {
       expect(result.other_bucket).toEqual({
         include_documents_without_field: false,
       });
+    });
+
+    it('should emit a persisted format', () => {
+      const input: TermsIndexPatternColumn = {
+        operationType: 'terms',
+        sourceField: 'bytes',
+        customLabel: false,
+        label: '',
+        isBucketed: true,
+        dataType: 'number',
+        params: {
+          secondaryFields: [],
+          size: 5,
+          orderBy: { type: 'alphabetical' },
+          orderDirection: 'asc',
+          parentFormat: { id: 'terms' },
+          format: { id: 'number', params: { decimals: 2 } },
+        },
+      };
+
+      const result = fromTermsLensStateToAPI(input, columns);
+      expect(result.format).toEqual({ type: 'number', decimals: 2 });
+    });
+  });
+
+  describe('round-trip', () => {
+    it('should round-trip a multi-field terms column with a format (parentFormat multi_terms)', () => {
+      const original: TermsIndexPatternColumn = {
+        operationType: 'terms',
+        sourceField: 'geo.src',
+        customLabel: false,
+        label: '',
+        isBucketed: true,
+        dataType: 'string',
+        params: {
+          secondaryFields: ['geo.dest'],
+          size: 5,
+          orderBy: { type: 'column', columnId: 'metricCol1' },
+          orderDirection: 'desc',
+          parentFormat: { id: 'multi_terms' },
+          format: { id: 'number', params: { decimals: 2 } },
+        },
+      };
+
+      const api = fromTermsLensStateToAPI(original, columns);
+      const roundTripped = fromTermsLensApiToLensState(api, (index: number) => columns[index]?.id);
+
+      expect(roundTripped.params.parentFormat).toEqual({ id: 'multi_terms' });
+      expect(roundTripped.params.format).toEqual({ id: 'number', params: { decimals: 2 } });
     });
   });
 });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.ts
@@ -22,7 +22,7 @@ import type {
   TermOperationRankByCustomPercentileRankType,
   TermOperationRankByCustomPercentileType,
 } from '../../schema/bucket_ops';
-import { fromFormatAPIToLensState } from './format';
+import { fromFormatAPIToLensState, fromFormatLensStateToAPI } from './format';
 import { getLensAPIBucketSharedProps, getLensStateBucketSharedProps } from './utils';
 import type { AnyLensStateColumn } from './types';
 
@@ -132,7 +132,9 @@ export function fromTermsLensApiToLensState(
       orderDirection,
       ...(rank_by?.type === 'custom' ? { orderAgg: getCustomOrderAgg(rank_by) } : {}),
       ...(format ? { format } : {}),
-      parentFormat: { id: 'terms' },
+      // Mirror runtime `getParentFormatter` (`terms/index.tsx`): multi-field terms columns render
+      // through the `multi_terms` parent formatter, single-field ones through `terms`.
+      parentFormat: { id: secondaryFields.length ? 'multi_terms' : 'terms' },
     },
   };
 }
@@ -306,5 +308,6 @@ export function fromTermsLensStateToAPI(
         }
       : {}),
     ...(column.params.orderBy ? { rank_by: getRankByConfig(column.params, columns) } : {}),
+    ...(column.params.format ? { format: fromFormatLensStateToAPI(column.params.format) } : {}),
   };
 }


### PR DESCRIPTION
Found in the #282534 investigation

## Summary
Lens as-code always wrote terms `parentFormat` as `{ id: 'terms' }`, so multi-field terms lost `multi_terms` on round-trip. Persisted column `format` was also dropped SO→API.

## Changes

- API→SO: derive `parentFormat` from field count (`terms` vs `multi_terms`), matching runtime `getParentFormatter`.
- SO→API: emit `format` when present.

## Screenshots

- Left: api flag off
- Right: api flag on

Before:

<img width="2545" height="1202" alt="Screenshot 2026-08-04 at 7 32 41 PM" src="https://github.com/user-attachments/assets/f013ae79-4bfd-46f8-bc3d-91b2d8ead81a" />

After:

<img width="2537" height="1198" alt="Screenshot 2026-08-04 at 7 26 34 PM" src="https://github.com/user-attachments/assets/edd09f79-9e1d-4e89-8242-31d3a6d45ad1" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->