### PR TITLE
[9.4] [Fleet] Fix incoming-data detection for agentless OTel integrations (Supabase) (#282227)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.test.ts
@@ -11,10 +11,16 @@ import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 
 import { appContextService } from '../../services';
 
-import { getAgentStatusForAgentPolicy } from '../../services/agents/status';
+import {
+  getAgentStatusForAgentPolicy,
+  getIncomingDataByAgentsId,
+  getIncomingDataByDataStreams,
+} from '../../services/agents/status';
+import { agentPolicyService } from '../../services/agent_policy';
 import { fetchAndAssignAgentMetrics } from '../../services/agents/agent_metrics';
+import { getPackageInfo } from '../../services/epm/packages';
 
-import { getAgentEffectiveConfigHandler } from './handlers';
+import { getAgentEffectiveConfigHandler, getAgentDataHandler } from './handlers';
 
 import {
   getAgentStatusForAgentPolicyHandler,
@@ -34,6 +40,7 @@ jest.mock('../../services/app_context', () => {
     appContextService: {
       getLogger: () => loggerMock.create(),
       getInternalUserESClient: jest.fn(),
+      getExperimentalFeatures: jest.fn(),
     },
   };
 });
@@ -44,10 +51,22 @@ jest.mock('../../services/spaces/helpers', () => ({
 
 jest.mock('../../services/agents/status', () => ({
   getAgentStatusForAgentPolicy: jest.fn(),
+  getIncomingDataByAgentsId: jest.fn(),
+  getIncomingDataByDataStreams: jest.fn(),
+}));
+
+jest.mock('../../services/agent_policy', () => ({
+  agentPolicyService: {
+    getByIds: jest.fn(),
+  },
 }));
 
 jest.mock('../../services/agents/agent_metrics', () => ({
   fetchAndAssignAgentMetrics: jest.fn(),
+}));
+
+jest.mock('../../services/epm/packages', () => ({
+  getPackageInfo: jest.fn(),
 }));
 
 describe('Handlers', () => {
@@ -421,6 +440,613 @@ describe('Handlers', () => {
       await expect(
         getAgentEffectiveConfigHandler(mockContext, request as any, mockResponse)
       ).rejects.toThrow('agent-1 not found in namespace');
+    });
+  });
+
+  describe('getAgentDataHandler', () => {
+    let mockResponse: any;
+    let mockContext: any;
+    let mockGetByIds: jest.Mock;
+
+    beforeEach(() => {
+      (getIncomingDataByAgentsId as jest.Mock).mockResolvedValue({ items: [], dataPreview: [] });
+      (getIncomingDataByDataStreams as jest.Mock).mockResolvedValue({ items: [], dataPreview: [] });
+      // Not found by default, so the identity-free gate falls back unless a test opts an agent in.
+      mockGetByIds = jest.fn().mockResolvedValue([]);
+      (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([]);
+      mockResponse = httpServerMock.createResponseFactory();
+      mockContext = {
+        core: Promise.resolve({
+          elasticsearch: { client: { asCurrentUser: {} } },
+          savedObjects: { client: { getCurrentNamespace: jest.fn().mockReturnValue('default') } },
+        }),
+        fleet: Promise.resolve({
+          agentClient: { asCurrentUser: { getByIds: mockGetByIds } },
+          internalSoClient: {},
+        }),
+      };
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('passes dataStreamPattern: undefined when the package has empty data_streams (prevents empty string reaching hasPrivileges)', async () => {
+      (getPackageInfo as jest.Mock).mockResolvedValue({ data_streams: [] });
+
+      await getAgentDataHandler(
+        mockContext,
+        {
+          query: {
+            agentsIds: ['agent-1'],
+            pkgName: 'aws_cloudwatch_input_otel',
+            pkgVersion: '0.5.0',
+            previewData: false,
+          },
+        } as any,
+        mockResponse
+      );
+
+      expect(getIncomingDataByAgentsId).toHaveBeenCalledWith(
+        expect.objectContaining({ dataStreamPattern: undefined })
+      );
+    });
+
+    it('passes dataStreamPattern: undefined when data_streams is absent from the package info', async () => {
+      (getPackageInfo as jest.Mock).mockResolvedValue({});
+
+      await getAgentDataHandler(
+        mockContext,
+        {
+          query: {
+            agentsIds: ['agent-1'],
+            pkgName: 'aws_cloudwatch_input_otel',
+            pkgVersion: '0.5.0',
+            previewData: false,
+          },
+        } as any,
+        mockResponse
+      );
+
+      expect(getIncomingDataByAgentsId).toHaveBeenCalledWith(
+        expect.objectContaining({ dataStreamPattern: undefined })
+      );
+    });
+
+    it('passes a non-empty dataStreamPattern when the package has data_streams', async () => {
+      (getPackageInfo as jest.Mock).mockResolvedValue({
+        data_streams: [{ type: 'logs', dataset: 'aws.cloudwatch' }],
+      });
+
+      await getAgentDataHandler(
+        mockContext,
+        {
+          query: {
+            agentsIds: ['agent-1'],
+            pkgName: 'aws',
+            pkgVersion: '1.0.0',
+            previewData: false,
+          },
+        } as any,
+        mockResponse
+      );
+
+      const [[{ dataStreamPattern }]] = (getIncomingDataByAgentsId as jest.Mock).mock.calls;
+      expect(dataStreamPattern).toBeDefined();
+      expect(dataStreamPattern).not.toBe('');
+    });
+
+    it('appends the .otel dataset suffix only for data streams on the OTel input', async () => {
+      (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+        enableOtelIntegrations: true,
+      });
+      (getPackageInfo as jest.Mock).mockResolvedValue({
+        policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+        data_streams: [
+          {
+            type: 'metrics',
+            dataset: 'supabase.metrics',
+            path: 'metrics',
+            streams: [{ input: 'otelcol' }],
+          },
+          {
+            type: 'logs',
+            dataset: 'supabase.logs',
+            path: 'logs',
+            streams: [{ input: 'logfile' }],
+          },
+        ],
+      });
+
+      await getAgentDataHandler(
+        mockContext,
+        {
+          query: {
+            agentsIds: ['agent-1'],
+            pkgName: 'supabase',
+            pkgVersion: '1.0.0',
+            previewData: false,
+          },
+        } as any,
+        mockResponse
+      );
+
+      const [[{ dataStreamPattern }]] = (getIncomingDataByAgentsId as jest.Mock).mock.calls;
+      expect(dataStreamPattern).toBe('metrics-supabase.metrics.otel-*,logs-supabase.logs-*');
+    });
+
+    describe('identity-free gate for agentless OTel', () => {
+      const otelPackageInfo = {
+        policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+        data_streams: [
+          {
+            type: 'metrics',
+            dataset: 'supabase.metrics',
+            path: 'metrics',
+            streams: [{ input: 'otelcol' }],
+          },
+        ],
+      };
+
+      beforeEach(() => {
+        (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+          enableOtelIntegrations: true,
+        });
+      });
+
+      it('uses getIncomingDataByDataStreams with a namespace-scoped pattern for one agentless agent', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'production' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByAgentsId).not.toHaveBeenCalled();
+        expect(getIncomingDataByDataStreams).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentId: 'agent-1',
+            dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+          })
+        );
+      });
+
+      it('falls back to getIncomingDataByAgentsId for a non-agentless agent', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { id: 'policy-1', namespace: 'default', supports_agentless: false },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for a regular (non-OTel) package even with an agentless agent', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue({
+          data_streams: [{ type: 'logs', dataset: 'aws.cloudwatch', path: 'logs' }],
+        });
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { id: 'policy-1', namespace: 'default', supports_agentless: true },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'aws',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(mockGetByIds).not.toHaveBeenCalled();
+      });
+
+      it('falls back and skips agent/policy lookups when no pkgName or pkgVersion is given', async () => {
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(mockGetByIds).not.toHaveBeenCalled();
+        expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for more than one requested id, even with an OTel package and agentless agents', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1', 'agent-2'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(mockGetByIds).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for an agent that is notFound', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for an agent whose policy cannot be resolved', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('scopes the pattern to the namespace of the agent whose policy is silent, so a healthy sibling does not mask it', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-2', policy_id: 'policy-2' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-2',
+            namespace: 'staging',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'staging' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-2'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        const [[{ dataStreamPattern }]] = (getIncomingDataByDataStreams as jest.Mock).mock.calls;
+        expect(dataStreamPattern).toBe('metrics-supabase.metrics.otel-staging');
+        expect(dataStreamPattern).not.toContain('*');
+      });
+
+      it('falls back for an agentless agent whose policy has no package policy matching pkgName', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [{ package: { name: 'other-package' }, namespace: 'production' }],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for an agentless agent whose attached package policy runs a different version', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '2.0.0' }, namespace: 'production' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back for an agentless agent whose policy has more than one package policy matching pkgName and pkgVersion', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            // Same name+version attached under two namespaces; the match is ambiguous.
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'production' },
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'staging' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('falls back and skips agent/policy lookups when enableOtelIntegrations is disabled, even for an otherwise-eligible agentless setup', async () => {
+        (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+          enableOtelIntegrations: false,
+        });
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'production' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        // With the flag off, otelDataStreams stays empty, so the gate never looks up the agent.
+        expect(mockGetByIds).not.toHaveBeenCalled();
+        expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+        expect(getIncomingDataByDataStreams).not.toHaveBeenCalled();
+        expect(getIncomingDataByAgentsId).toHaveBeenCalledWith(
+          expect.objectContaining({ dataStreamPattern: 'metrics-supabase.metrics-*' })
+        );
+      });
+
+      it('passes ignoreMissing so a deleted agent policy falls back instead of throwing', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        expect(agentPolicyService.getByIds).toHaveBeenCalledWith(
+          expect.anything(),
+          ['policy-1'],
+          expect.objectContaining({ ignoreMissing: true })
+        );
+        expect(getIncomingDataByAgentsId).toHaveBeenCalled();
+      });
+
+      it('combines the identity-free OTel answer with the identity answer for a mixed package', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue({
+          policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+          data_streams: [
+            {
+              type: 'metrics',
+              dataset: 'supabase.metrics',
+              path: 'metrics',
+              streams: [{ input: 'otelcol' }],
+            },
+            {
+              type: 'logs',
+              dataset: 'supabase.logs',
+              path: 'logs',
+              streams: [{ input: 'logfile' }],
+            },
+          ],
+        });
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'production' },
+            ],
+          },
+        ]);
+        (getIncomingDataByDataStreams as jest.Mock).mockResolvedValue({
+          items: [{ 'agent-1': { data: false } }],
+          dataPreview: [{ _index: 'otel-preview' }],
+        });
+        (getIncomingDataByAgentsId as jest.Mock).mockResolvedValue({
+          items: [{ 'agent-1': { data: true } }],
+          dataPreview: [{ _index: 'regular-preview' }],
+        });
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: true,
+            },
+          } as any,
+          mockResponse
+        );
+
+        // Only the non-OTel stream is queried through the identity path, not the OTel one.
+        expect(getIncomingDataByAgentsId).toHaveBeenCalledWith(
+          expect.objectContaining({ dataStreamPattern: 'logs-supabase.logs-*' })
+        );
+        expect(mockResponse.ok).toHaveBeenCalledWith({
+          body: {
+            items: [{ 'agent-1': { data: true } }],
+            dataPreview: [{ _index: 'otel-preview' }, { _index: 'regular-preview' }],
+          },
+        });
+      });
+
+      it('allows an ordinary Fleet reader through the agent client, not the raw ES client', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue(otelPackageInfo);
+        mockGetByIds.mockResolvedValue([{ id: 'agent-1', policy_id: 'policy-1' }]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          {
+            id: 'policy-1',
+            namespace: 'default',
+            supports_agentless: true,
+            package_policies: [
+              { package: { name: 'supabase', version: '1.0.0' }, namespace: 'default' },
+            ],
+          },
+        ]);
+
+        await getAgentDataHandler(
+          mockContext,
+          {
+            query: {
+              agentsIds: ['agent-1'],
+              pkgName: 'supabase',
+              pkgVersion: '1.0.0',
+              previewData: false,
+            },
+          } as any,
+          mockResponse
+        );
+
+        // The agent lookup went through fleetContext.agentClient, which runs its own authz
+        // preflight, rather than a direct query against the hidden .fleet-agents index.
+        expect(mockGetByIds).toHaveBeenCalledWith(['agent-1'], { ignoreMissing: true });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
@@ -7,6 +7,7 @@
 
 import { omit, uniq } from 'lodash';
 import { type RequestHandler, SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 
 import type { Script } from '@elastic/elasticsearch/lib/api/types';
@@ -47,10 +48,16 @@ import { getAgentStatusForAgentPolicy } from '../../services/agents';
 import { isAgentInNamespace } from '../../services/spaces/agent_namespaces';
 import { getCurrentNamespace } from '../../services/spaces/get_current_namespace';
 import { getPackageInfo } from '../../services/epm/packages';
-import { generateTemplateIndexPattern } from '../../services/epm/elasticsearch/template/template';
+import {
+  generateTemplateIndexPattern,
+  generateNamespaceTemplateIndexPattern,
+  isOtelDataStream,
+} from '../../services/epm/elasticsearch/template/template';
 import { buildAgentStatusRuntimeField } from '../../services/agents/build_status_runtime_field';
-import { appContextService } from '../../services';
+import { appContextService, agentPolicyService } from '../../services';
 import { AGENTS_INDEX } from '../../constants';
+import type { AgentClient } from '../../services';
+import type { RegistryDataStream } from '../../types';
 
 async function verifyNamespace(agent: Agent, namespace?: string) {
   if (!(await isAgentInNamespace(agent, namespace))) {
@@ -369,7 +376,63 @@ export const getAgentStatusForAgentPolicyHandler: FleetRequestHandler<
   return response.ok({ body });
 };
 
-export const getAgentDataHandler: RequestHandler<
+/**
+ * Resolves the namespace-scoped OTel pattern for the identity-free incoming-data path, or
+ * undefined if any condition of the gate (agent, policy, namespace) does not hold. The pattern
+ * is scoped to a single namespace, never a wildcard, since there is no `agent.id` left to
+ * narrow the match once the identity filter is dropped.
+ */
+async function resolveAgentlessOtelDataStreamPattern({
+  agentClient,
+  soClient,
+  agentId,
+  pkgName,
+  pkgVersion,
+  otelDataStreams,
+}: {
+  agentClient: AgentClient;
+  soClient: SavedObjectsClientContract;
+  agentId: string;
+  pkgName: string;
+  pkgVersion: string;
+  otelDataStreams: RegistryDataStream[];
+}): Promise<string | undefined> {
+  const [agent] = await agentClient.getByIds([agentId], { ignoreMissing: true });
+  if (!agent?.policy_id) {
+    return undefined;
+  }
+
+  const [agentPolicy] = await agentPolicyService.getByIds(soClient, [agent.policy_id], {
+    withPackagePolicies: true,
+    ignoreMissing: true,
+  });
+  if (!agentPolicy?.supports_agentless) {
+    return undefined;
+  }
+
+  // Require exactly one attached package policy matching pkgName and pkgVersion; zero or more
+  // than one (e.g. attached in multiple namespaces) is ambiguous, so fall back to the identity
+  // path instead of guessing.
+  const matchingPackagePolicies = (agentPolicy.package_policies ?? []).filter(
+    (packagePolicy) =>
+      packagePolicy.package?.name === pkgName && packagePolicy.package?.version === pkgVersion
+  );
+  if (matchingPackagePolicies.length !== 1) {
+    return undefined;
+  }
+  const [matchingPackagePolicy] = matchingPackagePolicies;
+
+  const namespace = matchingPackagePolicy.namespace || agentPolicy.namespace;
+  if (!namespace) {
+    return undefined;
+  }
+
+  return otelDataStreams
+    .map((ds) => generateNamespaceTemplateIndexPattern(ds, namespace, true))
+    .join(',');
+}
+
+export const getAgentDataHandler: FleetRequestHandler<
   undefined,
   TypeOf<typeof GetAgentDataRequestSchema.query>
 > = async (context, request, response) => {
@@ -383,6 +446,8 @@ export const getAgentDataHandler: RequestHandler<
   // If a package is specified, get data stream patterns for that package
   // and scope incoming data query to that pattern
   let dataStreamPattern: string | undefined;
+  let otelDataStreams: RegistryDataStream[] = [];
+  let nonOtelDataStreams: RegistryDataStream[] = [];
   if (pkgName && pkgVersion) {
     const packageInfo = await getPackageInfo({
       savedObjectsClient: coreContext.savedObjects.client,
@@ -390,9 +455,60 @@ export const getAgentDataHandler: RequestHandler<
       pkgName,
       pkgVersion,
     });
-    dataStreamPattern = (packageInfo.data_streams || [])
-      .map((ds) => generateTemplateIndexPattern(ds))
-      .join(',');
+    // Input-only OTel packages declare no manifest data streams, so this falls through to the
+    // identity path. Known gap: https://github.com/elastic/ingest-dev/issues/8988.
+    const dataStreams = packageInfo.data_streams || [];
+    otelDataStreams = dataStreams.filter((ds) => isOtelDataStream(ds, packageInfo));
+    nonOtelDataStreams = dataStreams.filter((ds) => !isOtelDataStream(ds, packageInfo));
+    dataStreamPattern =
+      dataStreams
+        .map((ds) => generateTemplateIndexPattern(ds, isOtelDataStream(ds, packageInfo)))
+        .join(',') || undefined;
+
+    // Native OTel data has no queryable agent identity, so only a single-agent, namespace-scoped
+    // lookup can answer for it.
+    if (otelDataStreams.length > 0 && agentsIds.length === 1) {
+      const fleetContext = await context.fleet;
+      // internalSoClient reads only policy metadata for the gate below; the route still requires
+      // agents:read, and ES data is queried with asCurrentUser.
+      const namespacedPattern = await resolveAgentlessOtelDataStreamPattern({
+        agentClient: fleetContext.agentClient.asCurrentUser,
+        soClient: fleetContext.internalSoClient,
+        agentId: agentsIds[0],
+        pkgName,
+        pkgVersion,
+        otelDataStreams,
+      });
+
+      if (namespacedPattern) {
+        const identityFreeResult = await AgentService.getIncomingDataByDataStreams({
+          esClient,
+          agentId: agentsIds[0],
+          dataStreamPattern: namespacedPattern,
+          returnDataPreview,
+        });
+
+        // Combine with the identity path's answer so non-OTel streams in a mixed package
+        // aren't silently ignored.
+        if (nonOtelDataStreams.length === 0) {
+          return response.ok({ body: identityFreeResult });
+        }
+
+        const nonOtelPattern = nonOtelDataStreams
+          .map((ds) => generateTemplateIndexPattern(ds, false))
+          .join(',');
+        const identityResult = await AgentService.getIncomingDataByAgentsId({
+          esClient,
+          agentsIds,
+          dataStreamPattern: nonOtelPattern,
+          returnDataPreview,
+        });
+
+        return response.ok({
+          body: combineIncomingDataResults(agentsIds[0], identityFreeResult, identityResult),
+        });
+      }
+    }
   }
 
   const { items, dataPreview } = await AgentService.getIncomingDataByAgentsId({
@@ -406,6 +522,34 @@ export const getAgentDataHandler: RequestHandler<
 
   return response.ok({ body });
 };
+
+interface IncomingDataResult {
+  items: Array<Record<string, { data: boolean }>>;
+  dataPreview: unknown[];
+}
+
+/**
+ * Combines the identity-free OTel answer with the identity-based answer for a mixed
+ * package's non-OTel streams. Either source reporting data is enough to report data overall,
+ * since a mixed package can deliver a healthy signal through only one of its stream groups.
+ */
+function combineIncomingDataResults(
+  agentId: string,
+  identityFreeResult: IncomingDataResult,
+  identityResult: IncomingDataResult
+): IncomingDataResult {
+  const hasData =
+    (identityFreeResult.items[0]?.[agentId]?.data ?? false) ||
+    (identityResult.items[0]?.[agentId]?.data ?? false);
+
+  return {
+    items: [{ [agentId]: { data: hasData } }],
+    dataPreview: [...identityFreeResult.dataPreview, ...identityResult.dataPreview].slice(
+      0,
+      AgentService.MAX_AGENT_DATA_PREVIEW_SIZE
+    ),
+  };
+}
 
 function isStringArray(arr: unknown | string[]): arr is string[] {
   return Array.isArray(arr) && arr.every((p) => typeof p === 'string');

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.test.ts
@@ -14,7 +14,11 @@ import { createAppContextStartContractMock } from '../../mocks';
 
 import { appContextService } from '../app_context';
 
-import { getAgentStatusForAgentPolicy, getIncomingDataByAgentsId } from './status';
+import {
+  getAgentStatusForAgentPolicy,
+  getIncomingDataByAgentsId,
+  getIncomingDataByDataStreams,
+} from './status';
 
 describe('getAgentStatusForAgentPolicy', () => {
   beforeEach(async () => {
@@ -337,5 +341,113 @@ describe('getIncomingDataByAgentsId', () => {
     const searchArgs = esClient.search.mock.calls[0][0] as any;
     const rangeFilter = searchArgs.query.bool.filter.find((f: any) => f.range);
     expect(Object.keys(rangeFilter.range)).toEqual(['event.ingested']);
+  });
+});
+
+describe('getIncomingDataByDataStreams', () => {
+  beforeEach(() => {
+    appContextService.start(createAppContextStartContractMock());
+  });
+
+  afterEach(() => {
+    appContextService.stop();
+  });
+
+  it('queries only the given pattern with the event.ingested recency filter, no agent.id filter or aggregation', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    esClient.search.mockReturnValueOnce({ hits: { total: { value: 0 } } } as any);
+
+    await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+    });
+
+    const searchArgs = esClient.search.mock.calls[0][0] as any;
+    expect(searchArgs.index).toBe('metrics-supabase.metrics.otel-production');
+    expect(searchArgs.aggs).toBeUndefined();
+    expect(searchArgs.query.bool.filter).toEqual([
+      { range: { 'event.ingested': { gte: 'now-5m', lte: 'now' } } },
+    ]);
+  });
+
+  it('sets ignore_unavailable so a not-yet-created namespace-scoped data stream reports zero hits instead of throwing', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    esClient.search.mockReturnValueOnce({ hits: { total: { value: 0 } } } as any);
+
+    await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+    });
+
+    const searchArgs = esClient.search.mock.calls[0][0] as any;
+    expect(searchArgs.ignore_unavailable).toBe(true);
+  });
+
+  it('reports data: true for the requested agent when the search reports a hit', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    esClient.search.mockReturnValueOnce({ hits: { total: { value: 1 } } } as any);
+
+    const result = await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+    });
+
+    expect(result).toEqual({ items: [{ 'agent-1': { data: true } }], dataPreview: [] });
+  });
+
+  it('reports data: false for the requested agent when the search reports no hits', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    esClient.search.mockReturnValueOnce({ hits: { total: { value: 0 } } } as any);
+
+    const result = await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+    });
+
+    expect(result).toEqual({ items: [{ 'agent-1': { data: false } }], dataPreview: [] });
+  });
+
+  it('returnDataPreview controls _source and size, and dataPreview carries the hits through unchanged', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true } as any);
+    const previewHits = [{ _index: 'metrics-supabase.metrics.otel-production', _source: {} }];
+    esClient.search.mockReturnValueOnce({
+      hits: { total: { value: 1 }, hits: previewHits },
+    } as any);
+
+    const result = await getIncomingDataByDataStreams({
+      esClient,
+      agentId: 'agent-1',
+      dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+      returnDataPreview: true,
+    });
+
+    const searchArgs = esClient.search.mock.calls[0][0] as any;
+    expect(searchArgs._source).toBe(true);
+    expect(searchArgs.size).toBeGreaterThan(0);
+    expect(result.dataPreview).toEqual(previewHits);
+  });
+
+  it('surfaces missing read access the same way getIncomingDataByAgentsId does', async () => {
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    esClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: false } as any);
+
+    await expect(
+      getIncomingDataByDataStreams({
+        esClient,
+        agentId: 'agent-1',
+        dataStreamPattern: 'metrics-supabase.metrics.otel-production',
+      })
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Unable to retrieve incoming data'),
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
@@ -13,6 +13,7 @@ import type {
   AggregationsTermsAggregateBase,
   AggregationsTermsBucketBase,
   QueryDslQueryContainer,
+  SearchTotalHits,
 } from '@elastic/elasticsearch/lib/api/types';
 
 import { ALL_SPACES_ID } from '../../../common/constants';
@@ -39,7 +40,7 @@ interface AggregationsStatusTermsBucketKeys extends AggregationsTermsBucketBase 
 }
 
 const DATA_STREAM_INDEX_PATTERN = 'logs-*-*,metrics-*-*,traces-*-*,synthetics-*-*';
-const MAX_AGENT_DATA_PREVIEW_SIZE = 20;
+export const MAX_AGENT_DATA_PREVIEW_SIZE = 20;
 export async function getAgentStatusById(
   esClient: ElasticsearchClient,
   soClient: SavedObjectsClientContract,
@@ -209,7 +210,7 @@ export async function getIncomingDataByAgentsId({
 
     const searchResult = await retryTransientEsErrors(
       () =>
-        esClient.search({
+        esClient.search<unknown, Record<'agent_ids', { buckets: Array<{ key: string }> }>>({
           index: dataStreamPattern,
           allow_partial_search_results: true,
           _source: returnDataPreview,
@@ -255,9 +256,9 @@ export async function getIncomingDataByAgentsId({
 
     const dataPreview = searchResult.hits?.hits || [];
 
-    const agentIdsWithData: string[] =
-      // @ts-expect-error aggregation type is not specified
-      searchResult.aggregations.agent_ids.buckets.map((bucket: any) => bucket.key as string) ?? [];
+    const agentIdsWithData: string[] = searchResult.aggregations.agent_ids.buckets.map(
+      (bucket) => bucket.key
+    );
 
     const items = agentsIds.map((id) =>
       agentIdsWithData.includes(id) ? { [id]: { data: true } } : { [id]: { data: false } }
@@ -266,6 +267,81 @@ export async function getIncomingDataByAgentsId({
     return { items, dataPreview };
   } catch (error) {
     logger.debug(`Error getting incoming data for agents: ${error}`);
+    throw new FleetError(
+      `Unable to retrieve incoming data for agents due to error: ${error.message}`
+    );
+  }
+}
+
+/**
+ * Identity-free incoming-data check for a single agentless agent whose data streams carry no
+ * queryable agent identity (native OTel documents). The caller must scope `dataStreamPattern` to
+ * the agent's own namespace; see `getAgentDataHandler` for the gate that guarantees this.
+ */
+export async function getIncomingDataByDataStreams({
+  esClient,
+  agentId,
+  dataStreamPattern,
+  returnDataPreview = false,
+}: {
+  esClient: ElasticsearchClient;
+  agentId: string;
+  dataStreamPattern: string;
+  returnDataPreview?: boolean;
+}) {
+  const logger = appContextService.getLogger();
+
+  try {
+    const { has_all_requested: hasAllPrivileges } = await esClient.security.hasPrivileges({
+      index: [
+        {
+          names: dataStreamPattern.split(','),
+          privileges: ['read'],
+        },
+      ],
+    });
+
+    if (!hasAllPrivileges) {
+      throw new FleetUnauthorizedError('Missing permissions to read data streams indices');
+    }
+
+    const searchResult = await retryTransientEsErrors(
+      () =>
+        esClient.search({
+          index: dataStreamPattern,
+          // The pattern names concrete data streams that may not exist yet; without this,
+          // Elasticsearch throws index_not_found_exception instead of returning zero hits.
+          ignore_unavailable: true,
+          allow_partial_search_results: true,
+          _source: returnDataPreview,
+          timeout: '5s',
+          size: returnDataPreview ? MAX_AGENT_DATA_PREVIEW_SIZE : 0,
+          terminate_after: returnDataPreview ? undefined : 1,
+          query: {
+            bool: {
+              filter: [
+                {
+                  range: {
+                    'event.ingested': {
+                      gte: 'now-5m',
+                      lte: 'now',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        }),
+      { logger }
+    );
+
+    const dataPreview = searchResult.hits?.hits || [];
+    const total = searchResult.hits.total as SearchTotalHits | undefined;
+    const hasData = (total?.value ?? 0) > 0;
+
+    return { items: [{ [agentId]: { data: hasData } }], dataPreview };
+  } catch (error) {
+    logger.debug(`Error getting incoming data for data streams: ${error}`);
     throw new FleetError(
       `Unable to retrieve incoming data for agents due to error: ${error.message}`
     );

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -31,7 +31,8 @@ import {
 
 import { createAppContextStartContractMock } from '../../../../mocks';
 import { appContextService } from '../../..';
-import type { RegistryDataStream } from '../../../../types';
+import type { PackageInfo, RegistryDataStream } from '../../../../types';
+import type { ExperimentalFeatures } from '../../../../../common/experimental_features';
 import { processFields } from '../../fields/field';
 import type { Field } from '../../fields/field';
 import {
@@ -45,6 +46,9 @@ import {
   getTemplate,
   getTemplatePriority,
   generateTemplateIndexPattern,
+  generateNamespaceTemplateIndexPattern,
+  generateESIndexPatterns,
+  isOtelDataStream,
   updateCurrentWriteIndices,
 } from './template';
 
@@ -2050,6 +2054,169 @@ describe('EPM template', () => {
       );
 
       expect(templateIndexPattern).toEqual(`metrics-package.dataset.otel-*`);
+    });
+  });
+
+  describe('generateNamespaceTemplateIndexPattern', () => {
+    it('pins the namespace segment exactly for a normal data stream', () => {
+      const dataStream = {
+        type: 'logs',
+        dataset: 'nginx.access',
+        path: 'access',
+      } as RegistryDataStream;
+
+      expect(generateNamespaceTemplateIndexPattern(dataStream, 'production')).toEqual(
+        'logs-nginx.access-production'
+      );
+    });
+
+    it('pins the namespace segment exactly for a dataset_is_prefix data stream', () => {
+      const dataStream = {
+        type: 'metrics',
+        dataset: 'test',
+        path: 'test',
+        dataset_is_prefix: true,
+      } as RegistryDataStream;
+
+      expect(generateNamespaceTemplateIndexPattern(dataStream, 'production')).toEqual(
+        'metrics-test.*-production'
+      );
+    });
+
+    it('includes the .otel suffix before the namespace segment', () => {
+      const dataStream = {
+        type: 'metrics',
+        dataset: 'supabase.metrics',
+        path: 'metrics',
+      } as RegistryDataStream;
+
+      expect(generateNamespaceTemplateIndexPattern(dataStream, 'production', true)).toEqual(
+        'metrics-supabase.metrics.otel-production'
+      );
+    });
+  });
+
+  describe('isOtelDataStream', () => {
+    const otelDataStream = {
+      type: 'metrics',
+      dataset: 'supabase.metrics',
+      path: 'metrics',
+      streams: [{ input: 'otelcol' }],
+    } as RegistryDataStream;
+    const packageInfo = {
+      policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+    } as PackageInfo;
+
+    it('is true when the data stream uses the OTel input and the feature flag is enabled', () => {
+      appContextService.start(
+        createAppContextStartContractMock({}, undefined, undefined, {
+          enableOtelIntegrations: true,
+        } as ExperimentalFeatures)
+      );
+
+      expect(isOtelDataStream(otelDataStream, packageInfo)).toBe(true);
+    });
+
+    it('is false when the feature flag is disabled, even if the data stream uses the OTel input', () => {
+      appContextService.start(
+        createAppContextStartContractMock({}, undefined, undefined, {
+          enableOtelIntegrations: false,
+        } as ExperimentalFeatures)
+      );
+
+      expect(isOtelDataStream(otelDataStream, packageInfo)).toBe(false);
+    });
+
+    it('is false when the feature flag is enabled but the data stream does not use the OTel input', () => {
+      appContextService.start(
+        createAppContextStartContractMock({}, undefined, undefined, {
+          enableOtelIntegrations: true,
+        } as ExperimentalFeatures)
+      );
+      const nonOtelDataStream = {
+        ...otelDataStream,
+        streams: [{ input: 'logfile' }],
+      } as RegistryDataStream;
+
+      expect(isOtelDataStream(nonOtelDataStream, packageInfo)).toBe(false);
+    });
+  });
+
+  describe('generateESIndexPatterns', () => {
+    const regularDataStream = {
+      type: 'logs',
+      dataset: 'nginx.access',
+      title: 'Nginx access logs',
+      release: 'ga',
+      package: 'nginx',
+      path: 'access',
+      ingest_pipeline: 'default',
+      streams: [{ input: 'logfile' }],
+    } as RegistryDataStream;
+
+    const otelDataStream = {
+      type: 'metrics',
+      dataset: 'supabase.metrics',
+      title: 'Supabase OTel metrics',
+      release: 'ga',
+      package: 'supabase',
+      path: 'metrics',
+      ingest_pipeline: 'default',
+      streams: [{ input: 'otelcol' }],
+    } as RegistryDataStream;
+
+    const packageInfo = {
+      policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] }],
+    } as PackageInfo;
+
+    beforeEach(() => {
+      appContextService.start(
+        createAppContextStartContractMock({}, undefined, undefined, {
+          enableOtelIntegrations: true,
+        } as ExperimentalFeatures)
+      );
+    });
+
+    it('appends the .otel suffix only for data streams on the OTel input', () => {
+      expect(generateESIndexPatterns([regularDataStream, otelDataStream], packageInfo)).toEqual({
+        access: 'logs-nginx.access-*',
+        metrics: 'metrics-supabase.metrics.otel-*',
+      });
+    });
+
+    it('resolves an input referenced by name', () => {
+      const namedInputDataStream = {
+        ...otelDataStream,
+        streams: [{ input: 'otel_metrics' }],
+      } as RegistryDataStream;
+
+      expect(
+        generateESIndexPatterns([namedInputDataStream], {
+          policy_templates: [
+            { name: 'supabase', inputs: [{ type: 'otelcol', name: 'otel_metrics' }] },
+          ],
+        } as PackageInfo)
+      ).toEqual({
+        metrics: 'metrics-supabase.metrics.otel-*',
+      });
+    });
+
+    it('leaves patterns unsuffixed when no package context is given', () => {
+      expect(generateESIndexPatterns([otelDataStream])).toEqual({
+        metrics: 'metrics-supabase.metrics-*',
+      });
+    });
+
+    it('leaves patterns unsuffixed when OTel integrations are disabled', () => {
+      appContextService.start(
+        createAppContextStartContractMock({}, undefined, undefined, {
+          enableOtelIntegrations: false,
+        } as ExperimentalFeatures)
+      );
+
+      expect(generateESIndexPatterns([otelDataStream], packageInfo)).toEqual({
+        metrics: 'metrics-supabase.metrics-*',
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -30,10 +30,14 @@ import type {
   IndexTemplateEntry,
   IndexTemplate,
   IndexTemplateMappings,
+  PackageInfo,
   RegistryElasticsearch,
 } from '../../../../types';
 import { appContextService } from '../../..';
-import { getRegistryDataStreamAssetBaseName } from '../../../../../common/services';
+import {
+  getRegistryDataStreamAssetBaseName,
+  dataStreamUsesOtelInput,
+} from '../../../../../common/services';
 import type { FleetConfigType } from '../../../../../common/types';
 import {
   STACK_COMPONENT_TEMPLATE_ECS_MAPPINGS,
@@ -859,6 +863,43 @@ export function generateTemplateIndexPattern(
   }
 }
 
+/**
+ * Same as `generateTemplateIndexPattern`, but pins the namespace segment to an exact match
+ * (no trailing wildcard) instead of `-*`. Used by the identity-free agentless OTel incoming-data
+ * check, which has no `agent.id` to narrow the match once the identity filter is dropped, so the
+ * pattern itself must not resolve to any namespace other than the caller's own.
+ */
+export function generateNamespaceTemplateIndexPattern(
+  dataStream: RegistryDataStream,
+  namespace: string,
+  isOtelInputType?: boolean
+): string {
+  // undefined or explicitly set to false
+  // See also https://github.com/elastic/package-spec/pull/102
+  if (!dataStream.dataset_is_prefix) {
+    return getRegistryDataStreamAssetBaseName(dataStream, isOtelInputType) + '-' + namespace;
+  } else {
+    return getRegistryDataStreamAssetBaseName(dataStream, isOtelInputType) + '.*-' + namespace;
+  }
+}
+
+/**
+ * Returns true if the given data stream should use the `.otel` dataset suffix: it effectively
+ * uses the OTel collector input (`dataStreamUsesOtelInput`) and the `enableOtelIntegrations`
+ * experimental feature is enabled. All pattern-producing call sites (template installation, the
+ * live incoming-data handler, and stored `es_index_patterns`) must use this same decision so they
+ * cannot diverge.
+ */
+export function isOtelDataStream(
+  dataStream: RegistryDataStream,
+  packageInfo: Pick<PackageInfo, 'policy_templates'>
+): boolean {
+  return (
+    !!appContextService.getExperimentalFeatures()?.enableOtelIntegrations &&
+    dataStreamUsesOtelInput(packageInfo, dataStream)
+  );
+}
+
 // Template priorities are discussed in https://github.com/elastic/kibana/issues/88307
 // See also https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html
 //
@@ -881,9 +922,12 @@ export function getTemplatePriority(dataStream: RegistryDataStream): number {
 /**
  * Returns a map of the data stream path fields to elasticsearch index pattern.
  * @param dataStreams an array of RegistryDataStream objects
+ * @param packageInfo package context used to detect OTel input data streams, which carry a
+ * `.otel` dataset suffix. Callers that omit it get unsuffixed patterns.
  */
 export function generateESIndexPatterns(
-  dataStreams: RegistryDataStream[] | undefined
+  dataStreams: RegistryDataStream[] | undefined,
+  packageInfo?: Pick<PackageInfo, 'policy_templates'>
 ): Record<string, string> {
   if (!dataStreams) {
     return {};
@@ -891,7 +935,10 @@ export function generateESIndexPatterns(
 
   const patterns: Record<string, string> = {};
   for (const dataStream of dataStreams) {
-    patterns[dataStream.path] = generateTemplateIndexPattern(dataStream);
+    patterns[dataStream.path] = generateTemplateIndexPattern(
+      dataStream,
+      packageInfo ? isOtelDataStream(dataStream, packageInfo) : undefined
+    );
   }
   return patterns;
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
@@ -166,6 +166,44 @@ describe('createInstallation', () => {
       });
     });
   });
+
+  describe('es_index_patterns', () => {
+    beforeEach(() => {
+      (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+        enableOtelIntegrations: true,
+      });
+      soClient.create.mockClear();
+    });
+
+    it('stores an .otel pattern for an OTel data stream', async () => {
+      const otelPackageInfo: InstallablePackage = {
+        ...packageInfo,
+        policy_templates: [{ name: 'test-package', inputs: [{ type: 'otelcol' }] } as any],
+        data_streams: [
+          {
+            type: 'metrics',
+            dataset: 'test-package.metrics',
+            path: 'metrics',
+            title: 'metrics',
+            release: 'ga',
+            streams: [{ input: 'otelcol' } as any],
+          } as any,
+        ],
+      };
+
+      await createInstallation({
+        savedObjectsClient: soClient,
+        packageInfo: otelPackageInfo,
+        installSource: 'registry',
+        spaceId: DEFAULT_SPACE_ID,
+      });
+
+      const [, savedObject] = soClient.create.mock.calls[0];
+      expect((savedObject as Installation).es_index_patterns).toEqual({
+        metrics: 'metrics-test-package.metrics.otel-*',
+      });
+    });
+  });
 });
 
 describe('install', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -1298,7 +1298,7 @@ export async function createInstallation(options: {
   const typedStreams = getNormalizedDataStreams(packageInfo, GENERIC_DATASET_NAME).filter(
     (ds): ds is RegistryDataStream => !!ds.type
   );
-  const toSaveESIndexPatterns = generateESIndexPatterns(typedStreams);
+  const toSaveESIndexPatterns = generateESIndexPatterns(typedStreams, packageInfo);
 
   // For "stack-aligned" packages, default the `keep_policies_up_to_date` setting to true. For all other
   // packages, default it to undefined. Use undefined rather than false to allow us to differentiate

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.test.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SavedObjectsClientContract, ElasticsearchClient } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import {
   savedObjectsClientMock,
   elasticsearchServiceMock,
@@ -100,6 +101,7 @@ describe('updateLatestExecutedState', () => {
           version: '1.0.0',
         },
       ],
+      ['epm-packages', 'test-integration', { es_index_patterns: {} }, { version: undefined }],
     ]);
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
@@ -168,6 +170,7 @@ describe('updateLatestExecutedState', () => {
           version: '1.0.0',
         },
       ],
+      ['epm-packages', 'test-integration', { es_index_patterns: {} }, { version: undefined }],
     ]);
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
@@ -246,6 +249,322 @@ describe('updateLatestExecutedState', () => {
           version: '1.0.0',
         },
       ],
+      ['epm-packages', 'test-integration', { es_index_patterns: {} }, { version: undefined }],
     ]);
+  });
+
+  describe('es_index_patterns recompute', () => {
+    const baseArgs = {
+      installType: 'install' as const,
+      installSource: 'registry' as const,
+      spaceId: DEFAULT_SPACE_ID,
+    };
+
+    beforeEach(() => {
+      appContextService.start(
+        createAppContextStartContractMock({}, undefined, undefined, {
+          enableOtelIntegrations: true,
+        } as any)
+      );
+    });
+
+    it('produces an .otel pattern for an OTel data stream in the package manifest', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'supabase',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'supabase',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: {},
+        },
+      } as any);
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'supabase',
+            version: '1.0.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+            policy_templates: [{ name: 'supabase', inputs: [{ type: 'otelcol' }] } as any],
+            data_streams: [
+              {
+                type: 'metrics',
+                dataset: 'supabase.metrics',
+                path: 'metrics',
+                title: 'metrics',
+                release: 'ga',
+                streams: [{ input: 'otelcol' } as any],
+              } as any,
+            ],
+          },
+        },
+      });
+
+      const [, , esIndexPatternsUpdate] = soClient.update.mock.calls[1];
+      expect(esIndexPatternsUpdate).toEqual({
+        es_index_patterns: { metrics: 'metrics-supabase.metrics.otel-*' },
+      });
+    });
+
+    it('keeps a stored entry for a dataset absent from the manifest', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'test-integration',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'test-integration',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: { custom_dataset: 'logs-test-integration.custom_dataset-*' },
+        },
+      } as any);
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'test-integration',
+            version: '1.0.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+          },
+        },
+      });
+
+      const [, , esIndexPatternsUpdate] = soClient.update.mock.calls[1];
+      expect(esIndexPatternsUpdate).toEqual({
+        es_index_patterns: { custom_dataset: 'logs-test-integration.custom_dataset-*' },
+      });
+    });
+
+    it('adds a manifest data stream missing from the stored map, with no OTel stream in the package', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'all_assets',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'all_assets',
+          version: '0.2.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: { test_logs: 'logs-all_assets.test_logs-*' },
+        },
+      } as any);
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'all_assets',
+            version: '0.2.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+            data_streams: [
+              {
+                type: 'logs',
+                dataset: 'all_assets.test_logs',
+                path: 'test_logs',
+                title: 'test_logs',
+                release: 'ga',
+                streams: [{ input: 'logfile' } as any],
+              } as any,
+              {
+                type: 'logs',
+                dataset: 'all_assets.test_logs2',
+                path: 'test_logs2',
+                title: 'test_logs2',
+                release: 'ga',
+                streams: [{ input: 'logfile' } as any],
+              } as any,
+            ],
+          },
+        },
+      });
+
+      const [, , esIndexPatternsUpdate] = soClient.update.mock.calls[1];
+      expect(esIndexPatternsUpdate).toEqual({
+        es_index_patterns: {
+          test_logs: 'logs-all_assets.test_logs-*',
+          test_logs2: 'logs-all_assets.test_logs2-*',
+        },
+      });
+    });
+
+    it('carries the version returned by the read inside the retry', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'test-integration',
+        version: 'WzUsNV0=',
+        attributes: {
+          title: 'title',
+          name: 'test-integration',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: {},
+        },
+      } as any);
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'test-integration',
+            version: '1.0.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+          },
+        },
+      });
+
+      const [, , , esIndexPatternsOptions] = soClient.update.mock.calls[1];
+      expect(esIndexPatternsOptions).toEqual({ version: 'WzUsNV0=' });
+    });
+
+    it('retries once on a conflict and succeeds', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'test-integration',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'test-integration',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: {},
+        },
+      } as any);
+      soClient.update
+        .mockResolvedValueOnce({} as any) // install-status update
+        .mockRejectedValueOnce(
+          SavedObjectsErrorHelpers.createConflictError('epm-packages', 'test-integration')
+        )
+        .mockResolvedValueOnce({} as any); // es_index_patterns update, second attempt
+
+      await stepSaveSystemObject({
+        ...baseArgs,
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        packageInstallContext: {
+          archiveIterator: createArchiveIteratorFromMap(new Map()),
+          paths: [],
+          packageInfo: {
+            title: 'title',
+            name: 'test-integration',
+            version: '1.0.0',
+            description: 'test',
+            type: 'integration',
+            categories: ['cloud', 'custom'],
+            format_version: 'string',
+            release: 'experimental',
+            conditions: { kibana: { version: 'x.y.z' } },
+            owner: { github: 'elastic/fleet' },
+          },
+        },
+      });
+
+      expect(soClient.update).toHaveBeenCalledTimes(3);
+    });
+
+    it('rethrows a non-conflict error without retrying', async () => {
+      soClient.get.mockResolvedValue({
+        id: 'test-integration',
+        version: 'WzEsMV0=',
+        attributes: {
+          title: 'title',
+          name: 'test-integration',
+          version: '1.0.0',
+          install_source: 'registry',
+          install_status: 'installed',
+          package_assets: [],
+          es_index_patterns: {},
+        },
+      } as any);
+      soClient.update
+        .mockResolvedValueOnce({} as any) // install-status update
+        .mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        stepSaveSystemObject({
+          ...baseArgs,
+          savedObjectsClient: soClient,
+          esClient,
+          logger,
+          packageInstallContext: {
+            archiveIterator: createArchiveIteratorFromMap(new Map()),
+            paths: [],
+            packageInfo: {
+              title: 'title',
+              name: 'test-integration',
+              version: '1.0.0',
+              description: 'test',
+              type: 'integration',
+              categories: ['cloud', 'custom'],
+              format_version: 'string',
+              release: 'experimental',
+              conditions: { kibana: { version: 'x.y.z' } },
+              owner: { github: 'elastic/fleet' },
+            },
+          },
+        })
+      ).rejects.toThrow('boom');
+
+      expect(soClient.update).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 import semverLt from 'semver/functions/lt';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import pRetry from 'p-retry';
 
 import {
   PACKAGES_SAVED_OBJECT_TYPE,
@@ -12,7 +14,9 @@ import {
   SO_SEARCH_LIMIT,
   FLEET_INSTALL_FORMAT_VERSION,
 } from '../../../../../constants';
-import type { Installation } from '../../../../../types';
+import { GENERIC_DATASET_NAME } from '../../../../../../common/constants';
+import type { Installation, RegistryDataStream } from '../../../../../types';
+import { getNormalizedDataStreams } from '../../../../../../common/services';
 
 import { packagePolicyService } from '../../../../package_policy';
 
@@ -21,8 +25,15 @@ import { auditLoggingService } from '../../../../audit_logging';
 import { withPackageSpan } from '../../utils';
 
 import { clearLatestFailedAttempts } from '../../install_errors_helpers';
+import { generateESIndexPatterns } from '../../../elasticsearch/template/template';
 
 import type { InstallContext } from '../_state_machine_package_install';
+
+const onlyRetryConflictErrors = (err: Error) => {
+  if (!SavedObjectsErrorHelpers.isConflictError(err)) {
+    throw err;
+  }
+};
 
 export async function stepSaveSystemObject(context: InstallContext) {
   const {
@@ -65,6 +76,41 @@ export async function stepSaveSystemObject(context: InstallContext) {
     pkgName
   );
   logger.debug(`Package install - Install status ${updatedPackage?.attributes?.install_status}`);
+
+  // Recompute es_index_patterns from the manifest and merge over the stored map so install/
+  // upgrade repairs stale entries (e.g. missing '.otel' suffixes). The merge base is re-read on
+  // every retry attempt so this doesn't clobber entries other install flows add concurrently.
+  const recomputedEsIndexPatterns = generateESIndexPatterns(
+    getNormalizedDataStreams(packageInfo, GENERIC_DATASET_NAME).filter(
+      (ds): ds is RegistryDataStream => !!ds.type
+    ),
+    packageInfo
+  );
+
+  const updateEsIndexPatterns = async () => {
+    const latest = await savedObjectsClient.get<Installation>(PACKAGES_SAVED_OBJECT_TYPE, pkgName);
+
+    auditLoggingService.writeCustomSoAuditLog({
+      action: 'update',
+      id: pkgName,
+      name: pkgName,
+      savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
+    });
+
+    return savedObjectsClient.update<Installation>(
+      PACKAGES_SAVED_OBJECT_TYPE,
+      pkgName,
+      {
+        es_index_patterns: { ...latest.attributes.es_index_patterns, ...recomputedEsIndexPatterns },
+      },
+      { version: latest.version }
+    );
+  };
+
+  await withPackageSpan('Update es_index_patterns', () =>
+    pRetry(updateEsIndexPatterns, { retries: 5, onFailedAttempt: onlyRetryConflictErrors })
+  );
+
   // If the package is flagged with the `keep_policies_up_to_date` flag, upgrade its
   // associated package policies after installation
   if (updatedPackage.attributes.keep_policies_up_to_date) {

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -487,6 +487,7 @@ export default function (providerContext: FtrProviderContext) {
           ),
           es_index_patterns: {
             test_logs: 'logs-all_assets.test_logs-*',
+            test_logs2: 'logs-all_assets.test_logs2-*',
             test_metrics: 'metrics-all_assets.test_metrics-*',
           },
           package_assets: [


### PR DESCRIPTION
## Manual 9.4 backport of #282227

This is a **manual** 9.4 backport of #282227 ([Fleet] Fix incoming-data detection for agentless OTel integrations (Supabase)).

The automated 9.4 backport failed with merge conflicts: https://github.com/elastic/kibana/pull/282227#issuecomment-5179899975. The automated 9.5 backport (#282607) succeeded independently and is not affected by this PR.

### 9.4-specific adaptations

9.4 has real structural drift from `main` around OTel detection and template generation, so this backport adapts the original PR's behavior to 9.4's actual code rather than importing `main`-only infrastructure:

- **OTel detection helper**: `isOtelDataStream` does not exist on 9.4. Added it directly in `template.ts`, reusing the existing 9.4 `dataStreamUsesOtelInput(packageInfo, dataStream)` helper and preserving the `appContextService.getExperimentalFeatures().enableOtelIntegrations` gate. The unrelated `main`-only namespace-template/ILM infrastructure (`namespace_template_utils`) was intentionally **not** backported.
- **Exact namespace pattern**: `generateNamespaceTemplateIndexPattern` does not exist on 9.4. Added the minimal equivalent alongside the existing pattern helpers in `template.ts`, reusing `getRegistryDataStreamAssetBaseName`, producing `<base>-<namespace>` (or `<base>.*-<namespace>` for `dataset_is_prefix`, with `.otel` folded into `<base>` for OTel streams) with no trailing wildcard.
- **Saved-object update**: Adapted `stepSaveSystemObject`'s `es_index_patterns` recompute to 9.4's existing `pRetry` + `SavedObjectsErrorHelpers.isConflictError` precedent (from `es_assets_reference.ts`), rather than introducing a new retry abstraction.
- **Tests**: `template.test.ts` and `handlers.test.ts` had diverged significantly from `main` on 9.4, causing large merge conflicts. Both were reset to their 9.4 base and the relevant behavioral tests from the original PR were reapplied against 9.4's existing test structure and mocks — no tests were deleted, skipped, or weakened.

### Required behavior parity (preserved from #282227)

1. **OTel-aware index patterns**: the live incoming-data handler and stored `es_index_patterns` both query/generate `.otel`-suffixed patterns for manifest-backed OTel data streams; install/upgrade/reinstall recompute and merge `es_index_patterns` via the conflict-safe retry; non-OTel pattern behavior is unchanged.
2. **Identity-free agentless OTel detection**: `getIncomingDataByDataStreams` remains an `event.ingested`-only recency query with no `agent.id` filter or aggregation, taken only when the package has manifest-backed OTel data streams, exactly one agent was requested, that agent belongs to an agentless policy, exactly one attached package policy matches the requested name/version, and a namespace can be resolved — scoped to that exact namespace, never `-*`. Every other case (non-OTel, feature flag disabled, multiple agents, ambiguous/missing package policies, non-agentless policies) falls back unchanged to the identity-based path.

`aws_cloudwatch_input_otel` and `verifier_otel` remain out of scope, tracked by https://github.com/elastic/ingest-dev/issues/9012.

### Verification

- Focused Jest suites (all 6 from the plan, run together): **207/207 passed**, 0 failures
  - `handlers.test.ts`, `status.test.ts`, `template.test.ts`, `install.test.ts`, `step_install_index_template_pipelines.test.ts`, `step_save_system_object.test.ts`
- `node scripts/type_check --project x-pack/platform/plugins/shared/fleet/tsconfig.json`: **0 errors**
- `node scripts/eslint` on all 11 changed files: **0 errors**
- `git diff --check`: clean, no conflict markers or whitespace errors
- `node scripts/check.js --scope=branch --base-ref=HEAD~1`: tsproj ✓ (3 projects), moon ✓ (up to date), lint ✓ (11 files, 0 errors), tsc ✓ (43 projects, 0 errors). The jest step in this script reported "no affected configs" — a pre-existing tooling limitation in `run_jest_via_moon.ts`'s affected-package detection, which only checks for a jest config at a package's root directory and misses Fleet's nested `server/jest.config.js`; the 6 focused suites above were run directly instead and all pass.
- Branch rebased onto the latest `9.4` (`37122237b40e`, "[9.4] [scout] retry failed test within running config (#282252) (#282715)") immediately before opening this PR.

This backport is a single cohesive commit, matching the original PR's own reasoning for not splitting: the two root-cause fixes are interdependent, and a partial change would leave a blocking chain where neither half fixes the user-visible failure.
