### PR TITLE
[Alerting V2] Namespace Agent Builder attachment types under platform.alerting

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -279,8 +279,8 @@ export const AGENT_BUILDER_BUILTIN_ATTACHMENTS = [
   'cases',
 
   // Platform – Alerting v2
-  'rule',
-  'action_policy',
+  'platform.alerting.rule',
+  'platform.alerting.action_policy',
 
   // Security Solution
   'security.alert',

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluate_dataset.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluate_dataset.test.ts
@@ -10,6 +10,7 @@ import type { PromptRequest } from '@kbn/agent-builder-common/agents';
 import type { Conversation, ConversationRound } from '@kbn/agent-builder-common';
 import type { AgentBuilderClient, AgentBuilderClientResponse, TaskOutput } from '@kbn/evals';
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import { RULE_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import { buildPromptResponses, collectScoredCriteria, createTask } from './evaluate_dataset';
 
 const askUserQuestion = (id: string, questionCount = 1): PromptRequest =>
@@ -256,7 +257,7 @@ describe('createTask', () => {
     const attachments = [
       {
         id: 'att-1',
-        type: 'rule',
+        type: RULE_ATTACHMENT_TYPE,
         current_version: 1,
         versions: [
           {
@@ -287,7 +288,7 @@ describe('createTask', () => {
     expect(output.attachments).toEqual([
       expect.objectContaining({
         id: 'att-1',
-        type: 'rule',
+        type: RULE_ATTACHMENT_TYPE,
       }),
     ]);
   });

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_attachment.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_attachment.test.ts
@@ -8,6 +8,10 @@
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import type { TaskOutput } from '@kbn/evals';
 import {
+  ACTION_POLICY_ATTACHMENT_TYPE,
+  RULE_ATTACHMENT_TYPE,
+} from '@kbn/alerting-v2-schemas';
+import {
   RENDER_ATTACHMENT_TAG_RE,
   createExpectedAttachmentDataEvaluator,
   createExpectedRenderAttachmentEvaluator,
@@ -114,17 +118,27 @@ describe('createExpectedRenderAttachmentEvaluator', () => {
           '<render_attachment id="policy-1" version="1"/>',
         ].join('\n'),
         [
-          attachment('rule-1', 'rule'),
+          attachment('rule-1', RULE_ATTACHMENT_TYPE),
           attachment('wf-1', 'workflow.yaml'),
-          attachment('policy-1', 'action_policy'),
+          attachment('policy-1', ACTION_POLICY_ATTACHMENT_TYPE),
         ]
       ),
-      { expectRenderAttachment: ['rule', 'workflow.yaml', 'action_policy'] }
+      {
+        expectRenderAttachment: [
+          RULE_ATTACHMENT_TYPE,
+          'workflow.yaml',
+          ACTION_POLICY_ATTACHMENT_TYPE,
+        ],
+      }
     );
     expect(result.score).toBe(1);
     expect(result.metadata).toEqual(
       expect.objectContaining({
-        renderedTypes: expect.arrayContaining(['rule', 'workflow.yaml', 'action_policy']),
+        renderedTypes: expect.arrayContaining([
+          RULE_ATTACHMENT_TYPE,
+          'workflow.yaml',
+          ACTION_POLICY_ATTACHMENT_TYPE,
+        ]),
         missingTypes: [],
       })
     );
@@ -133,23 +147,23 @@ describe('createExpectedRenderAttachmentEvaluator', () => {
   it('scores 0 when an expected attachment type was not rendered', async () => {
     const result = await runRender(
       conversation('<render_attachment id="rule-1" version="1"/>', [
-        attachment('rule-1', 'rule'),
-        attachment('policy-1', 'action_policy'),
+        attachment('rule-1', RULE_ATTACHMENT_TYPE),
+        attachment('policy-1', ACTION_POLICY_ATTACHMENT_TYPE),
       ]),
-      { expectRenderAttachment: ['rule', 'action_policy'] }
+      { expectRenderAttachment: [RULE_ATTACHMENT_TYPE, ACTION_POLICY_ATTACHMENT_TYPE] }
     );
     expect(result.score).toBe(0);
     expect(result.metadata).toEqual(
       expect.objectContaining({
-        renderedTypes: ['rule'],
-        missingTypes: ['action_policy'],
+        renderedTypes: [RULE_ATTACHMENT_TYPE],
+        missingTypes: [ACTION_POLICY_ATTACHMENT_TYPE],
       })
     );
   });
 
   it('scores 0 when no render tag is present', async () => {
     const result = await runRender(conversation('I created a rule but forgot to render it.'), {
-      expectRenderAttachment: ['rule'],
+      expectRenderAttachment: [RULE_ATTACHMENT_TYPE],
     });
     expect(result.score).toBe(0);
   });
@@ -158,7 +172,7 @@ describe('createExpectedRenderAttachmentEvaluator', () => {
 describe('createExpectedAttachmentDataEvaluator', () => {
   it('skips when there is no expectAttachmentData expectation', async () => {
     const result = await runAttachmentData(
-      { attachments: [attachment('a1', 'rule')] } as TaskOutput,
+      { attachments: [attachment('a1', RULE_ATTACHMENT_TYPE)] } as TaskOutput,
       {}
     );
     expect(result.score).toBeNull();
@@ -175,10 +189,18 @@ describe('createExpectedAttachmentDataEvaluator', () => {
 
   it('scores 1 when the callback passes', async () => {
     const result = await runAttachmentData(
-      { attachments: [attachment('a1', 'rule'), attachment('a2', 'action_policy')] } as TaskOutput,
+      {
+        attachments: [
+          attachment('a1', RULE_ATTACHMENT_TYPE),
+          attachment('a2', ACTION_POLICY_ATTACHMENT_TYPE),
+        ],
+      } as TaskOutput,
       {
         expectAttachmentData: (attachments: VersionedAttachment[]) => {
-          expect(attachments.map((a) => a.type)).toEqual(['rule', 'action_policy']);
+          expect(attachments.map((a) => a.type)).toEqual([
+            RULE_ATTACHMENT_TYPE,
+            ACTION_POLICY_ATTACHMENT_TYPE,
+          ]);
         },
       }
     );
@@ -187,7 +209,7 @@ describe('createExpectedAttachmentDataEvaluator', () => {
 
   it('scores 0 when the callback throws', async () => {
     const result = await runAttachmentData(
-      { attachments: [attachment('a1', 'rule')] } as TaskOutput,
+      { attachments: [attachment('a1', RULE_ATTACHMENT_TYPE)] } as TaskOutput,
       {
         expectAttachmentData: (attachments: VersionedAttachment[]) => {
           expect(attachments).toHaveLength(2);

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_attachment.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_attachment.test.ts
@@ -7,10 +7,7 @@
 
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import type { TaskOutput } from '@kbn/evals';
-import {
-  ACTION_POLICY_ATTACHMENT_TYPE,
-  RULE_ATTACHMENT_TYPE,
-} from '@kbn/alerting-v2-schemas';
+import { ACTION_POLICY_ATTACHMENT_TYPE, RULE_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import {
   RENDER_ATTACHMENT_TAG_RE,
   createExpectedAttachmentDataEvaluator,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/action_policy_attachment_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/action_policy_attachment_schema.ts
@@ -8,7 +8,8 @@
 import type { z } from '@kbn/zod/v4';
 import { actionPolicyResponseSchema } from './action_policy_response_schema';
 
-export const ACTION_POLICY_ATTACHMENT_TYPE = 'action_policy' as const;
+/** Namespaced to match `ALERTING_NAMESPACE` in `@kbn/alerting-v2-constants`. */
+export const ACTION_POLICY_ATTACHMENT_TYPE = 'platform.alerting.action_policy' as const;
 export const ACTION_POLICY_SML_TYPE = 'alerting_v2_action_policy' as const;
 
 /**

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_attachment_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_attachment_schema.ts
@@ -9,7 +9,6 @@ import type { z } from '@kbn/zod/v4';
 import { optionalWithDescription as opt } from './common';
 import { ruleResponseSchema } from './rule_data_schema';
 
-/** Namespaced to match `ALERTING_NAMESPACE` in `@kbn/alerting-v2-constants`. */
 export const RULE_ATTACHMENT_TYPE = 'platform.alerting.rule' as const;
 export const RULE_SML_TYPE = 'alerting_v2_rule' as const;
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_attachment_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_attachment_schema.ts
@@ -9,7 +9,8 @@ import type { z } from '@kbn/zod/v4';
 import { optionalWithDescription as opt } from './common';
 import { ruleResponseSchema } from './rule_data_schema';
 
-export const RULE_ATTACHMENT_TYPE = 'rule' as const;
+/** Namespaced to match `ALERTING_NAMESPACE` in `@kbn/alerting-v2-constants`. */
+export const RULE_ATTACHMENT_TYPE = 'platform.alerting.rule' as const;
 export const RULE_SML_TYPE = 'alerting_v2_rule' as const;
 
 /**

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/action_policy_attachment_definition.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/action_policy_attachment_definition.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import { ACTION_POLICY_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import { createActionPolicyAttachmentDefinition } from './action_policy_attachment_definition';
 
 jest.mock('./action_policy_inline_content', () => ({
@@ -23,7 +24,7 @@ const createMockServices = () => ({
 
 const createAttachment = (overrides: { origin?: string } = {}) => ({
   id: 'att-1',
-  type: 'action_policy' as const,
+  type: ACTION_POLICY_ATTACHMENT_TYPE,
   versions: [],
   current_version: 1,
   origin: overrides.origin,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/action_policy_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/action_policy_canvas_content.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render, act } from '@testing-library/react';
+import { ACTION_POLICY_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import { ActionPolicyCanvasContent } from './action_policy_canvas_content';
 
 const flushPromises = async () => {
@@ -85,7 +86,7 @@ const createAttachment = ({
   data,
 }: { origin?: string; data?: Record<string, unknown> } = {}) => ({
   id: 'att-1',
-  type: 'action_policy' as const,
+  type: ACTION_POLICY_ATTACHMENT_TYPE,
   versions: [],
   current_version: 1,
   origin,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/action_policy_inline_content.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/action_policy_inline_content.test.tsx
@@ -7,11 +7,12 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { ACTION_POLICY_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import { ActionPolicyInlineContent } from './action_policy_inline_content';
 
 const createAttachment = (overrides: { origin?: string; enabled?: boolean } = {}) => ({
   id: 'att-1',
-  type: 'action_policy' as const,
+  type: ACTION_POLICY_ATTACHMENT_TYPE,
   versions: [],
   current_version: 1,
   origin: overrides.origin,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_attachment_definition.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_attachment_definition.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import { RULE_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import { createRuleAttachmentDefinition } from './rule_attachment_definition';
 
 const mockUpsertRule = jest.fn().mockResolvedValue({});
@@ -56,7 +57,7 @@ const createMockServices = () => ({
 
 const createAttachment = (overrides: { origin?: string; enabled?: boolean } = {}) => ({
   id: 'att-1',
-  type: 'rule' as const,
+  type: RULE_ATTACHMENT_TYPE,
   versions: [],
   current_version: 1,
   origin: overrides.origin,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import { RULE_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import { RuleCanvasContent } from './rule_canvas_content';
 
 const mockUpsertRule = jest.fn().mockResolvedValue({});
@@ -51,7 +52,7 @@ const createAttachment = (
   overrides: { origin?: string; enabled?: boolean; dataId?: string } = {}
 ) => ({
   id: 'att-1',
-  type: 'rule' as const,
+  type: RULE_ATTACHMENT_TYPE,
   versions: [],
   current_version: 1,
   origin: overrides.origin,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_inline_content.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_inline_content.test.tsx
@@ -7,11 +7,12 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import { RULE_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
 import { RuleInlineContent } from './rule_inline_content';
 
 const createAttachment = (overrides: { origin?: string; enabled?: boolean } = {}) => ({
   id: 'att-1',
-  type: 'rule' as const,
+  type: RULE_ATTACHMENT_TYPE,
   versions: [],
   current_version: 1,
   origin: overrides.origin,


### PR DESCRIPTION
## Summary
- Renames Alerting v2 Agent Builder attachment type ids from bare `rule` / `action_policy` to `platform.alerting.rule` / `platform.alerting.action_policy`, matching the existing tool namespace (`platform.alerting.manage_*`) and newer Agent Builder naming conventions (`security.rule`, `observability.alert`, etc.).
- Updates `AGENT_BUILDER_BUILTIN_ATTACHMENTS` so registration continues to pass the Agent Builder allow-list gate.
- Switches public and eval tests that hard-coded the bare literals over to the shared constants.

## Why now
Alerting v2’s Agent Builder tools already live under the protected platform.alerting.* namespace (platform.alerting.manage_rule, platform.alerting.manage_action_policy); namespacing the attachment types to platform.alerting.rule and platform.alerting.action_policy keeps every id in this domain on the same prefix. That also avoids colliding with other teams’ attachment types in the global allow list (e.g. Security’s security.rule) as we add more Alerting attachments.

## Persistence note
Attachment `type` is stored verbatim in `.chat-conversations`. There is no alias/migration path for renamed attachment types. Already-persisted `rule` / `action_policy` attachments in preview deployments will load but lose custom UI, agent description, and update validation until recreated.

That is accepted here because the entire Alerting v2 Agent Builder surface is experimental and gated behind `alerting:v2:enabled` (default `false`). Skill ids, tool ids, and SML type ids are unchanged.

## Test plan
- [x] `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments`
- [x] `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments`
- [x] `node scripts/jest x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src`
- [ ] Confirm Kibana starts with Agent Builder + Alerting v2 enabled (allow-list registration of the new ids)
- [ ] Create a rule via the rule-management skill and confirm the attachment type in the conversation is `platform.alerting.rule`
- [ ] Create an action policy via the action-policy-management skill and confirm `platform.alerting.action_policy`


Made with [Cursor](https://cursor.com)