### PR TITLE
[8.19] [scout] retry failed test within running config (#282252)

### DIFF
--- a/.buildkite/scripts/steps/test/scout/flaky_configs.sh
+++ b/.buildkite/scripts/steps/test/scout/flaky_configs.sh
@@ -11,6 +11,9 @@ if [[ -z "${SCOUT_REPORTER_ENABLED:-}" ]]; then
   echo "⚠️ SCOUT_REPORTER_ENABLED not set; defaulting to true for flaky runner"
 fi
 
+# Disabling retries to ensure that the flaky test runner measures failure rates accurately.
+export SCOUT_TEST_RETRIES=0
+
 if [[ -z "$SCOUT_CONFIG" ]]; then
   echo "Missing SCOUT_CONFIG env var"
   exit 1

--- a/.buildkite/scripts/steps/test/scout/run_test_lane.sh
+++ b/.buildkite/scripts/steps/test/scout/run_test_lane.sh
@@ -13,6 +13,7 @@ PASSED=()
 FAILED=()
 SKIPPED=()
 RETRY_SPEC_FILES=()
+TOTAL_FLAKY=0
 
 # Fail early if any of the given environment variable names are unset or empty
 check_required_env_vars() {
@@ -48,6 +49,14 @@ failed_specs_artifact_path() {
 # against this script's cwd rather than the config's directory.
 json_report_path() {
   echo ".scout/test-results-${1}.json"
+}
+
+# Reads stats.flaky from a config's JSON report. Echoes 0 if the report is missing or malformed.
+flaky_count() {
+  local idx="$1" report
+  report="$(json_report_path "$idx")"
+  [[ -f "$report" ]] || { echo 0; return; }
+  jq -r '.stats.flaky // 0' "$report" 2>/dev/null || echo 0
 }
 
 # After a config fails, persist its failed spec files so the next attempt can re-run only those.
@@ -256,7 +265,14 @@ run_scout_tests() {
     0)
       upload_report_events "$config_path"
       mark_index_passed "$idx"
-      PASSED+=("$config_path ($duration)")
+      local flaky
+      flaky="$(flaky_count "$idx")"
+      if [[ "$flaky" -gt 0 ]]; then
+        TOTAL_FLAKY=$(( TOTAL_FLAKY + flaky ))
+        PASSED+=("$config_path ($duration, ⚠️ $flaky flaky)")
+      else
+        PASSED+=("$config_path ($duration)")
+      fi
       ;;
     *)
       upload_report_events "$config_path"
@@ -303,7 +319,12 @@ upload_report_events() {
 get_config_status() {
   local config="$1" s
   for s in "${SKIPPED[@]+"${SKIPPED[@]}"}"; do [[ "$s" == "$config" ]] && echo "skipped" && return; done
-  for s in "${PASSED[@]+"${PASSED[@]}"}"; do [[ "$s" == "$config"* ]] && echo "passed" && return; done
+  for s in "${PASSED[@]+"${PASSED[@]}"}"; do
+    if [[ "$s" == "$config"* ]]; then
+      [[ "$s" == *"⚠️"* ]] && echo "passed (⚠️ Flaky)" || echo "passed"
+      return
+    fi
+  done
   for s in "${FAILED[@]+"${FAILED[@]}"}"; do [[ "$s" == "$config" ]] && echo "failed" && return; done
   echo "unknown"
 }
@@ -333,7 +354,11 @@ print_summary() {
   echo "  Server config set: $SCOUT_TEST_SERVER_CONFIG_SET"
   echo ""
   echo "Test count by status:"
-  [[ ${#PASSED[@]}   -gt 0 ]] && echo "✅  Passed: ${#PASSED[@]}"
+  if [[ ${#PASSED[@]} -gt 0 ]]; then
+    local passed_suffix=""
+    [[ "$TOTAL_FLAKY" -gt 0 ]] && passed_suffix=" (⚠️ $TOTAL_FLAKY Flaky)"
+    echo "✅  Passed: ${#PASSED[@]}${passed_suffix}"
+  fi
   [[ ${#FAILED[@]}   -gt 0 ]] && echo "❌  Failed: ${#FAILED[@]}"
   [[ ${#SKIPPED[@]}  -gt 0 ]] && echo "⏩️ Skipped: ${#SKIPPED[@]}"
   echo ""

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.test.ts
@@ -7,7 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { FullConfig, Suite, TestCase, TestResult } from '@playwright/test/reporter';
+import type {
+  FullConfig,
+  FullResult,
+  Suite,
+  TestCase,
+  TestResult,
+} from '@playwright/test/reporter';
 import { BROWSER_CONSOLE_ERRORS_ATTACHMENT } from '@kbn/scout-info';
 import { ScoutReportEventAction } from '../../report';
 import { ScoutPlaywrightReporter } from './playwright_reporter';
@@ -21,7 +27,8 @@ jest.mock('@kbn/code-owners', () => ({
 const createMockConfig = (): FullConfig =>
   ({ configFile: undefined, fullyParallel: false } as unknown as FullConfig);
 
-const createMockSuite = (): Suite => ({} as Suite);
+const createMockSuite = (tests: TestCase[] = []): Suite =>
+  ({ allTests: () => tests } as unknown as Suite);
 
 const createMockTest = (): TestCase =>
   ({
@@ -38,13 +45,43 @@ const createMockTest = (): TestCase =>
     },
   } as unknown as TestCase);
 
+/** A `TestCase` with a fixed `outcome()` and one `TestResult` per given status. */
+const createMockTestCase = (overrides: {
+  outcome: ReturnType<TestCase['outcome']>;
+  statuses: Array<TestResult['status']>;
+  title?: string;
+  filePath?: string;
+}): TestCase => {
+  const { outcome, statuses, title = 'should work', filePath = 'path/to/file.spec.ts' } = overrides;
+
+  return {
+    titlePath: () => ['', 'local', filePath, 'My Suite', title],
+    title,
+    tags: [],
+    annotations: [],
+    expectedStatus: 'passed',
+    location: { file: `/repo-root/${filePath}`, line: 42, column: 0 },
+    parent: {
+      title: 'My Suite',
+      type: 'describe',
+      titlePath: () => ['', 'local', filePath, 'My Suite'],
+    },
+    outcome: () => outcome,
+    results: statuses.map((status) => ({ status, duration: 100 })),
+  } as unknown as TestCase;
+};
+
+const createMockFullResult = (status: FullResult['status'] = 'passed'): FullResult =>
+  ({ status, duration: 1000 } as FullResult);
+
 const createMockResult = (
-  overrides: { attachments?: TestResult['attachments'] } = {}
+  overrides: { attachments?: TestResult['attachments']; retry?: number } = {}
 ): TestResult =>
   ({
     status: 'failed',
     startTime: new Date(),
     duration: 1000,
+    retry: overrides.retry ?? 0,
     attachments: overrides.attachments ?? [],
     error: undefined,
     stdout: [],
@@ -58,13 +95,24 @@ describe('ScoutPlaywrightReporter', () => {
   beforeEach(() => {
     reporter = new ScoutPlaywrightReporter({ runId: 'test-run-id' });
     logEventSpy = jest.spyOn((reporter as any).report, 'logEvent').mockImplementation(() => {});
+    // `onEnd` also calls save()/conclude(), which otherwise touch the filesystem for real.
+    jest.spyOn((reporter as any).report, 'save').mockImplementation(() => {});
+    jest.spyOn((reporter as any).report, 'conclude').mockImplementation(() => {});
     reporter.onBegin(createMockConfig(), createMockSuite());
   });
 
+  const getLoggedEvents = () => logEventSpy.mock.calls.map(([event]) => event);
+
   const getTestEndEvent = () =>
-    logEventSpy.mock.calls
-      .map(([event]) => event)
-      .find((event) => event.event?.action === ScoutReportEventAction.TEST_END);
+    getLoggedEvents().find((event) => event.event?.action === ScoutReportEventAction.TEST_END);
+
+  const getTestOutcomeEvents = () =>
+    getLoggedEvents().filter(
+      (event) => event.event?.action === ScoutReportEventAction.TEST_OUTCOME
+    );
+
+  const getRunEndEvent = () =>
+    getLoggedEvents().find((event) => event.event?.action === ScoutReportEventAction.RUN_END);
 
   describe('getScoutConfigInfo', () => {
     const getInfo = (configPath: string) => (reporter as any).getScoutConfigInfo(configPath);
@@ -135,6 +183,119 @@ describe('ScoutPlaywrightReporter', () => {
       reporter.onTestEnd(createMockTest(), createMockResult());
 
       expect(getTestEndEvent()?.test?.console_errors).toBeUndefined();
+    });
+
+    it('sets attempt to result.retry', () => {
+      reporter.onTestEnd(createMockTest(), createMockResult({ retry: 1 }));
+
+      expect(getTestEndEvent()?.test?.attempt).toBe(1);
+    });
+
+    it('does not emit a test-begin event (dropped to keep event volume neutral)', () => {
+      reporter.onTestEnd(createMockTest(), createMockResult());
+
+      expect(
+        getLoggedEvents().some((event) => event.event?.action === ScoutReportEventAction.TEST_BEGIN)
+      ).toBe(false);
+    });
+  });
+
+  describe('onEnd', () => {
+    const expectedTest = createMockTestCase({
+      outcome: 'expected',
+      statuses: ['passed'],
+      title: 'passes first time',
+    });
+    const flakyTest = createMockTestCase({
+      outcome: 'flaky',
+      statuses: ['failed', 'passed'],
+      title: 'flaky test',
+    });
+    const unexpectedTest = createMockTestCase({
+      outcome: 'unexpected',
+      statuses: ['failed', 'failed'],
+      title: 'hard fail',
+    });
+    const skippedTest = createMockTestCase({
+      outcome: 'skipped',
+      statuses: ['skipped'],
+      title: 'statically skipped',
+    });
+
+    it('emits one test-outcome event per test, with the outcome and attempt count', async () => {
+      reporter.onBegin(
+        createMockConfig(),
+        createMockSuite([expectedTest, flakyTest, unexpectedTest, skippedTest])
+      );
+
+      await reporter.onEnd(createMockFullResult('failed'));
+
+      const outcomeByTitle = Object.fromEntries(
+        getTestOutcomeEvents().map((event) => [event.test?.title, event.test])
+      );
+
+      expect(outcomeByTitle['passes first time']).toMatchObject({
+        outcome: 'expected',
+        attempts: 1,
+        status: 'passed',
+      });
+      expect(outcomeByTitle['flaky test']).toMatchObject({
+        outcome: 'flaky',
+        attempts: 2,
+        // Last attempt's status, not the first failing one.
+        status: 'passed',
+      });
+      expect(outcomeByTitle['hard fail']).toMatchObject({
+        outcome: 'unexpected',
+        attempts: 2,
+        status: 'failed',
+      });
+      expect(outcomeByTitle['statically skipped']).toMatchObject({
+        outcome: 'skipped',
+        attempts: 1,
+        status: 'skipped',
+      });
+      expect(getTestOutcomeEvents()).toHaveLength(4);
+    });
+
+    it('derives run-end stats from final outcomes, counting a flaky test as a pass', async () => {
+      reporter.onBegin(
+        createMockConfig(),
+        createMockSuite([expectedTest, flakyTest, unexpectedTest, skippedTest])
+      );
+
+      await reporter.onEnd(createMockFullResult('failed'));
+
+      expect(getRunEndEvent()?.test_run?.tests).toEqual({
+        passes: 2,
+        failures: 1,
+        pending: 1,
+        flaky: 1,
+        total: 4,
+      });
+    });
+
+    it('produces empty stats when the suite was never captured (no onBegin)', async () => {
+      // Reporter constructed but onBegin never called — should not throw.
+      const freshReporter = new ScoutPlaywrightReporter({ runId: 'no-begin' });
+      const freshLogEventSpy: jest.SpyInstance = jest
+        .spyOn((freshReporter as any).report, 'logEvent')
+        .mockImplementation(() => {});
+      jest.spyOn((freshReporter as any).report, 'save').mockImplementation(() => {});
+      jest.spyOn((freshReporter as any).report, 'conclude').mockImplementation(() => {});
+
+      await freshReporter.onEnd(createMockFullResult('passed'));
+
+      const runEndEvent = freshLogEventSpy.mock.calls
+        .map(([event]) => event)
+        .find((event) => event.event?.action === ScoutReportEventAction.RUN_END);
+      expect(runEndEvent?.test_run?.tests).toEqual({
+        passes: 0,
+        failures: 0,
+        pending: 0,
+        flaky: 0,
+        total: 0,
+      });
     });
   });
 });

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -41,11 +41,13 @@ import {
   ScoutReportEventAction,
   type ScoutTestRunInfo,
   type ScoutFileInfo,
+  type ScoutTestInfo,
   type ScoutReportEvent,
 } from '../../report';
 import { environmentMetadata } from '../../../datasources';
 import type { ScoutPlaywrightReporterOptions } from '../scout_playwright_reporter';
-import { generateTestRunId, computeTestID } from '../../../helpers';
+import { generateTestRunId } from '../../../helpers';
+import { getTestIdentity } from '../test_identity';
 
 /**
  * Scout Playwright reporter
@@ -58,6 +60,10 @@ export class ScoutPlaywrightReporter implements Reporter {
   private report: ScoutEventsReport;
   private baseTestRunInfo: ScoutTestRunInfo;
   private readonly codeOwnersEntries: CodeOwnersEntry[];
+  /** Root suite captured in `onBegin`; walked in `onEnd` once every attempt is known. */
+  private suite?: Suite;
+  /** CODEOWNERS lookup repeats for every attempt and every test in a file; memoize by path. */
+  private readonly scoutFileInfoCache = new Map<string, ScoutFileInfo>();
 
   constructor(private reporterOptions: ScoutPlaywrightReporterOptions = {}) {
     this.log = new ToolingLog({
@@ -95,14 +101,21 @@ export class ScoutPlaywrightReporter implements Reporter {
   }
 
   private getScoutFileInfoForPath(filePath: string): ScoutFileInfo {
+    const cached = this.scoutFileInfoCache.get(filePath);
+    if (cached) {
+      return cached;
+    }
+
     const fileOwners = this.getFileOwners(filePath);
     const areas = this.getOwnerAreas(fileOwners);
-
-    return {
+    const fileInfo: ScoutFileInfo = {
       path: filePath,
       owner: fileOwners.length > 0 ? fileOwners : 'unknown',
       area: areas.length > 0 ? areas : 'unknown',
     };
+
+    this.scoutFileInfoCache.set(filePath, fileInfo);
+    return fileInfo;
   }
 
   private getScoutConfigInfo(absoluteConfigPath: string): {
@@ -135,16 +148,15 @@ export class ScoutPlaywrightReporter implements Reporter {
     test: TestCase,
     step?: TestStep,
     result?: TestResult
-  ): ScoutReportEvent['test'] {
-    const fullTestTitle = test.titlePath().slice(3).join(' ');
-    const testFilePath = path.relative(REPO_ROOT, test.location.file);
-    const testProps: ScoutReportEvent['test'] = {
-      id: computeTestID(testFilePath, fullTestTitle),
+  ): ScoutTestInfo {
+    const { id, filePath } = getTestIdentity(test);
+    const testProps: ScoutTestInfo = {
+      id,
       title: test.title,
       tags: test.tags,
       annotations: test.annotations,
       expected_status: test.expectedStatus,
-      file: this.getScoutFileInfoForPath(testFilePath),
+      file: this.getScoutFileInfoForPath(filePath),
     };
 
     if (step) {
@@ -157,6 +169,8 @@ export class ScoutPlaywrightReporter implements Reporter {
     if (result) {
       testProps.status = result.status;
       testProps.duration = result.duration;
+      // Zero-based attempt index; 0 is the first run, 1 the first retry.
+      testProps.attempt = result.retry;
       const consoleErrors = result.attachments
         .find((a) => a.name === BROWSER_CONSOLE_ERRORS_ATTACHMENT)
         ?.body?.toString('utf-8');
@@ -181,7 +195,9 @@ export class ScoutPlaywrightReporter implements Reporter {
     return false;
   }
 
-  onBegin(config: FullConfig, _: Suite) {
+  onBegin(config: FullConfig, suite: Suite) {
+    this.suite = suite;
+
     // Enrich base test run info with config file info
     let configInfo: ScoutTestRunInfo['config'];
 
@@ -210,23 +226,6 @@ export class ScoutPlaywrightReporter implements Reporter {
       test_run: this.baseTestRunInfo,
       event: {
         action: ScoutReportEventAction.RUN_BEGIN,
-      },
-    });
-  }
-
-  onTestBegin(test: TestCase, result: TestResult) {
-    this.report.logEvent({
-      '@timestamp': result.startTime,
-      ...environmentMetadata,
-      reporter: {
-        name: this.name,
-        type: 'playwright',
-      },
-      test_run: this.baseTestRunInfo,
-      suite: this.getSuitePropsFromTest(test),
-      test: this.getTestPropsFromTest(test),
-      event: {
-        action: ScoutReportEventAction.TEST_BEGIN,
       },
     });
   }
@@ -292,7 +291,63 @@ export class ScoutPlaywrightReporter implements Reporter {
     });
   }
 
+  /**
+   * Derived from each test's final `outcome()` rather than accumulated per-attempt in
+   * `onTestEnd`, since a retried test would otherwise be counted as both a failure and a pass.
+   */
+  private deriveTestStats(tests: TestCase[]): NonNullable<ScoutTestRunInfo['tests']> {
+    const stats = { passes: 0, failures: 0, pending: 0, flaky: 0, total: tests.length };
+
+    for (const test of tests) {
+      switch (test.outcome()) {
+        case 'expected':
+          stats.passes++;
+          break;
+        case 'flaky':
+          stats.passes++;
+          stats.flaky++;
+          break;
+        case 'skipped':
+          stats.pending++;
+          break;
+        case 'unexpected':
+          stats.failures++;
+          break;
+      }
+    }
+
+    return stats;
+  }
+
   async onEnd(result: FullResult) {
+    const tests = this.suite?.allTests() ?? [];
+
+    // One `test-outcome` event per test with its final classification, in addition to the
+    // per-attempt `test-end` events already logged by onTestEnd.
+    for (const test of tests) {
+      const attempts = test.results;
+      this.report.logEvent({
+        ...environmentMetadata,
+        reporter: {
+          name: this.name,
+          type: 'playwright',
+        },
+        test_run: this.baseTestRunInfo,
+        suite: this.getSuitePropsFromTest(test),
+        test: {
+          ...this.getTestPropsFromTest(test),
+          // Status of the last attempt
+          status: attempts.at(-1)?.status,
+          outcome: test.outcome(),
+          attempts: attempts.length,
+          duration: attempts.reduce((total, attempt) => total + attempt.duration, 0),
+        },
+        event: {
+          action: ScoutReportEventAction.TEST_OUTCOME,
+        },
+      });
+    }
+
     this.report.logEvent({
       ...environmentMetadata,
       reporter: {
@@ -303,6 +358,7 @@ export class ScoutPlaywrightReporter implements Reporter {
         ...this.baseTestRunInfo,
         status: result.status,
         duration: result.duration,
+        tests: this.deriveTestStats(tests),
       },
       event: {
         action: ScoutReportEventAction.RUN_END,

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type {
+  FullConfig,
+  FullResult,
+  Suite,
+  TestCase,
+  TestResult,
+} from '@playwright/test/reporter';
+import { ScoutFailedTestReporter } from './failed_test_reporter';
+import { ScoutFailureTracker } from './failure_tracking';
+
+jest.mock('@kbn/code-owners', () => ({
+  getCodeOwnersEntries: jest.fn(() => []),
+  getOwningTeamsForPath: jest.fn(() => []),
+}));
+
+const createMockConfig = (): FullConfig => ({ configFile: undefined } as unknown as FullConfig);
+
+const createMockSuite = (tests: TestCase[]): Suite =>
+  ({ allTests: () => tests } as unknown as Suite);
+
+const createMockTestCase = (overrides: {
+  outcome: ReturnType<TestCase['outcome']>;
+  title?: string;
+  filePath?: string;
+}): TestCase => {
+  const { outcome, title = 'should work', filePath = 'path/to/file.spec.ts' } = overrides;
+
+  return {
+    titlePath: () => ['', 'local', filePath, 'My Suite', title],
+    title,
+    location: { file: `/repo-root/${filePath}`, line: 1, column: 1 },
+    parent: {
+      title: 'My Suite',
+      type: 'describe',
+      titlePath: () => ['', 'local', filePath, 'My Suite'],
+    },
+    outcome: () => outcome,
+  } as unknown as TestCase;
+};
+
+const createMockResult = (
+  overrides: { status?: TestResult['status']; retry?: number } = {}
+): TestResult =>
+  ({
+    status: overrides.status ?? 'failed',
+    retry: overrides.retry ?? 0,
+    duration: 500,
+    attachments: [],
+    error: { message: 'boom', stack: 'stack trace' },
+    stdout: [],
+  } as unknown as TestResult);
+
+const createMockFullResult = (): FullResult => ({ status: 'failed', duration: 1000 } as FullResult);
+
+describe('ScoutFailedTestReporter', () => {
+  let reporter: ScoutFailedTestReporter;
+  let reportLogEventSpy: jest.SpyInstance;
+  let trackerSaveSpy: jest.SpyInstance;
+  let trackerAddFailureSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    reporter = new ScoutFailedTestReporter({ runId: 'test-run-id' });
+    reportLogEventSpy = jest
+      .spyOn((reporter as any).report, 'logEvent')
+      .mockImplementation(() => {});
+    jest.spyOn((reporter as any).report, 'save').mockImplementation(() => {});
+    jest.spyOn((reporter as any).report, 'conclude').mockImplementation(() => {});
+    trackerSaveSpy = jest.spyOn(ScoutFailureTracker.prototype, 'save').mockImplementation(() => {});
+    trackerAddFailureSpy = jest.spyOn(ScoutFailureTracker.prototype, 'addFailure');
+  });
+
+  afterEach(() => {
+    // Spies on ScoutFailureTracker.prototype are shared across tests and must be restored.
+    jest.restoreAllMocks();
+  });
+
+  it('logs a flaky test to the report artifact but excludes it from the tracker', () => {
+    const flakyTest = createMockTestCase({ outcome: 'flaky', title: 'flaky test' });
+    const hardFailure = createMockTestCase({ outcome: 'unexpected', title: 'hard failure' });
+
+    reporter.onBegin(createMockConfig(), createMockSuite([flakyTest, hardFailure]));
+
+    // Flaky test: fails once, then passes. onTestEnd only ever forwards a failing attempt.
+    reporter.onTestEnd(flakyTest, createMockResult({ status: 'failed', retry: 0 }));
+    reporter.onTestEnd(flakyTest, createMockResult({ status: 'passed', retry: 1 }));
+
+    // Hard failure: fails on both attempts.
+    reporter.onTestEnd(hardFailure, createMockResult({ status: 'failed', retry: 0 }));
+    reporter.onTestEnd(hardFailure, createMockResult({ status: 'failed', retry: 1 }));
+
+    reporter.onEnd(createMockFullResult());
+
+    // Every failing attempt of both tests lands in the report artifact — including the
+    // flaky test's failing first attempt, which is still useful debugging material.
+    const loggedTitles = reportLogEventSpy.mock.calls.map(([failure]) => failure.title);
+    expect(loggedTitles).toEqual(['flaky test', 'hard failure', 'hard failure']);
+
+    // Only the flaky test is excluded from the GitHub-issue tracker.
+    expect(trackerSaveSpy).toHaveBeenCalledTimes(1);
+    const { excludeTestIds } = trackerSaveSpy.mock.calls[0][0];
+    const flakyId = reportLogEventSpy.mock.calls[0][0].id;
+    const hardFailureId = reportLogEventSpy.mock.calls[1][0].id;
+
+    expect(excludeTestIds.has(flakyId)).toBe(true);
+    expect(excludeTestIds.has(hardFailureId)).toBe(false);
+  });
+
+  it('stamps distinct attempt numbers on each attempt of a repeatedly-failing test', () => {
+    const hardFailure = createMockTestCase({ outcome: 'unexpected', title: 'hard failure' });
+    reporter.onBegin(createMockConfig(), createMockSuite([hardFailure]));
+
+    reporter.onTestEnd(hardFailure, createMockResult({ status: 'failed', retry: 0 }));
+    reporter.onTestEnd(hardFailure, createMockResult({ status: 'failed', retry: 1 }));
+
+    const attempts = reportLogEventSpy.mock.calls.map(([failure]) => failure.attempt);
+    expect(attempts).toEqual([0, 1]);
+  });
+
+  it('tracks a repeatedly-failing test once, not once per attempt (avoids double-updating its GitHub issue)', () => {
+    const hardFailure = createMockTestCase({ outcome: 'unexpected', title: 'hard failure' });
+    reporter.onBegin(createMockConfig(), createMockSuite([hardFailure]));
+
+    reporter.onTestEnd(hardFailure, createMockResult({ status: 'failed', retry: 0 }));
+    reporter.onTestEnd(hardFailure, createMockResult({ status: 'failed', retry: 1 }));
+
+    // The artifact keeps both attempts (asserted above); the tracker must not, or the test's
+    // GitHub issue would get bumped twice for one CI run.
+    expect(trackerAddFailureSpy).toHaveBeenCalledTimes(2);
+    expect((reporter as any).failureTracker.failures.size).toBe(1);
+  });
+
+  it('ignores a passed attempt entirely: no artifact entry, no tracker entry', () => {
+    const flakyTest = createMockTestCase({ outcome: 'flaky', title: 'flaky test' });
+    reporter.onBegin(createMockConfig(), createMockSuite([flakyTest]));
+
+    reporter.onTestEnd(flakyTest, createMockResult({ status: 'passed', retry: 1 }));
+
+    expect(reportLogEventSpy).not.toHaveBeenCalled();
+    expect(trackerAddFailureSpy).not.toHaveBeenCalled();
+  });
+
+  it('excludes nothing when no test in the suite ended up flaky', () => {
+    const hardFailure = createMockTestCase({ outcome: 'unexpected', title: 'hard failure' });
+    reporter.onBegin(createMockConfig(), createMockSuite([hardFailure]));
+
+    expect(() => reporter.onEnd(createMockFullResult())).not.toThrow();
+    expect(trackerSaveSpy).toHaveBeenCalledWith({ excludeTestIds: new Set() });
+  });
+});

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.ts
@@ -21,7 +21,6 @@ import {
   getOwningTeamsForPath,
   type CodeOwnersEntry,
 } from '@kbn/code-owners';
-import { REPO_ROOT } from '@kbn/repo-info';
 import { ToolingLog } from '@kbn/tooling-log';
 import path from 'node:path';
 import {
@@ -30,7 +29,6 @@ import {
   ScoutTestTarget,
 } from '@kbn/scout-info';
 import {
-  computeTestID,
   excapeHtmlCharacters,
   generateTestRunId,
   getKibanaModuleData,
@@ -42,6 +40,7 @@ import {
 import type { TestFailure } from '../../report';
 import { ScoutFailureReport } from '../../report';
 import type { ScoutPlaywrightReporterOptions } from '../scout_playwright_reporter';
+import { getTestIdentity } from '../test_identity';
 import { ScoutFailureTracker } from './failure_tracking';
 
 /**
@@ -56,6 +55,8 @@ export class ScoutFailedTestReporter implements Reporter {
   private readonly testTarget: string;
   private failureTracker?: ScoutFailureTracker;
   private kibanaModule: TestFailure['kibanaModule'];
+  /** Root suite captured in `onBegin`; walked in `onEnd` to identify tests that ended up flaky. */
+  private suite?: Suite;
 
   constructor(private readonly reporterOptions: ScoutPlaywrightReporterOptions = {}) {
     this.log = new ToolingLog({
@@ -94,6 +95,8 @@ export class ScoutFailedTestReporter implements Reporter {
   }
 
   onBegin(config: FullConfig, suite: Suite) {
+    this.suite = suite;
+
     // Get plugin or package metadata from kibana.jsonc
     if (config.configFile) {
       const metadata = getKibanaModuleData(config.configFile);
@@ -124,10 +127,7 @@ export class ScoutFailedTestReporter implements Reporter {
       return;
     }
 
-    // We don't include the first three elements in the title path (root suite, project, test file path)
-    // for full test titles in Scout, especially not when calculating test IDs
-    const fullTestTitle = test.titlePath().slice(3).join(' ');
-    const testFilePath = path.relative(REPO_ROOT, test.location.file);
+    const { id, filePath } = getTestIdentity(test);
 
     const consoleErrorsAttachment = result.attachments.find(
       (a) => a.name === BROWSER_CONSOLE_ERRORS_ATTACHMENT
@@ -135,13 +135,13 @@ export class ScoutFailedTestReporter implements Reporter {
     const consoleErrors = consoleErrorsAttachment?.body?.toString('utf-8');
 
     const testFailure: TestFailure = {
-      id: computeTestID(testFilePath, fullTestTitle),
+      id,
       suite: test.parent.title,
       title: test.title,
       target: this.testTarget,
       command: this.command,
       location: stripFilePath(test.location.file),
-      owner: this.getFileOwners(path.relative(REPO_ROOT, test.location.file)),
+      owner: this.getFileOwners(filePath),
       kibanaModule: this.kibanaModule,
       duration: result.duration,
       error: this.formatTestError(result),
@@ -154,6 +154,8 @@ export class ScoutFailedTestReporter implements Reporter {
           path: attachment.path,
           contentType: attachment.contentType,
         })),
+      // Zero-based attempt index; 0 is the first run, 1 the first retry.
+      attempt: result.retry,
     };
 
     this.report.logEvent(testFailure);
@@ -163,11 +165,21 @@ export class ScoutFailedTestReporter implements Reporter {
   }
 
   onEnd(result: FullResult) {
+    // A test's outcome is only knowable once every attempt has run, so flaky tests are excluded
+    // here rather than in onTestEnd. Their failing attempt still stays in the report artifact
+    // above (useful debugging material); only the GitHub-issue tracker excludes them, since it
+    // shouldn't open issues for tests that ultimately passed.
+    const flakyTestIds = new Set(
+      (this.suite?.allTests() ?? [])
+        .filter((test) => test.outcome() === 'flaky')
+        .map((test) => getTestIdentity(test).id)
+    );
+
     // Save & conclude the report
     try {
       this.report.save(this.reportRootPath);
       // Save failure tracking file for GitHub issue integration
-      this.failureTracker?.save();
+      this.failureTracker?.save({ excludeTestIds: flakyTestIds });
     } finally {
       this.report.conclude();
     }

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failure_tracking.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failure_tracking.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { TestFailure } from '../../report/failed_test/test_failure';
+import { ScoutFailureTracker } from './failure_tracking';
+
+const createMockLog = (): ToolingLog =>
+  ({
+    info: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+  } as unknown as ToolingLog);
+
+const createMockFailure = (overrides: Partial<TestFailure> = {}): TestFailure => ({
+  id: 'test-id-1',
+  suite: 'My Suite',
+  title: 'should work',
+  target: 'local',
+  command: 'node scripts/playwright test',
+  location: 'path/to/file.spec.ts:1:1',
+  owner: ['@elastic/kibana-scout'],
+  duration: 1000,
+  error: { message: 'boom', stack_trace: 'stack' },
+  attachments: [],
+  ...overrides,
+});
+
+describe('ScoutFailureTracker', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-failure-tracker-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const readTrackingFile = (tracker: ScoutFailureTracker): TestFailure[] => {
+    const filePath = tracker.getTrackingFilePath();
+    if (!fs.existsSync(filePath)) {
+      return [];
+    }
+    return fs
+      .readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => JSON.parse(line));
+  };
+
+  it('writes every tracked failure when no exclusion set is given', () => {
+    const tracker = new ScoutFailureTracker(createMockLog(), tempDir, 'run-1');
+    tracker.addFailure(createMockFailure({ id: 'a' }));
+    tracker.addFailure(createMockFailure({ id: 'b' }));
+
+    tracker.save();
+
+    expect(readTrackingFile(tracker).map((f) => f.id)).toEqual(['a', 'b']);
+  });
+
+  it('keeps only the last attempt when a test fails on more than one attempt', () => {
+    const tracker = new ScoutFailureTracker(createMockLog(), tempDir, 'run-1b');
+    tracker.addFailure(createMockFailure({ id: 'flaky-or-hard', duration: 100 }));
+    tracker.addFailure(createMockFailure({ id: 'flaky-or-hard', duration: 200 }));
+
+    tracker.save();
+
+    const written = readTrackingFile(tracker);
+    expect(written).toHaveLength(1);
+    expect(written[0].duration).toBe(200);
+  });
+
+  it('drops entries whose id is in excludeTestIds, keeping the rest', () => {
+    const tracker = new ScoutFailureTracker(createMockLog(), tempDir, 'run-2');
+    tracker.addFailure(createMockFailure({ id: 'flaky-test' }));
+    tracker.addFailure(createMockFailure({ id: 'hard-failure' }));
+
+    tracker.save({ excludeTestIds: new Set(['flaky-test']) });
+
+    expect(readTrackingFile(tracker).map((f) => f.id)).toEqual(['hard-failure']);
+  });
+
+  it('an empty exclusion set is a no-op', () => {
+    const tracker = new ScoutFailureTracker(createMockLog(), tempDir, 'run-3');
+    tracker.addFailure(createMockFailure({ id: 'a' }));
+    tracker.addFailure(createMockFailure({ id: 'b' }));
+
+    tracker.save({ excludeTestIds: new Set() });
+
+    expect(readTrackingFile(tracker).map((f) => f.id)).toEqual(['a', 'b']);
+  });
+
+  it('does not write a file when every failure is excluded', () => {
+    const tracker = new ScoutFailureTracker(createMockLog(), tempDir, 'run-4');
+    tracker.addFailure(createMockFailure({ id: 'flaky-test' }));
+
+    tracker.save({ excludeTestIds: new Set(['flaky-test']) });
+
+    expect(fs.existsSync(tracker.getTrackingFilePath())).toBe(false);
+  });
+});

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failure_tracking.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failure_tracking.ts
@@ -50,7 +50,10 @@ export interface ScoutFailureTrackingEntry {
 export class ScoutFailureTracker {
   private readonly log: ToolingLog;
   private readonly trackingFilePath: string;
-  private failures: ScoutFailureTrackingEntry[] = [];
+  // Keyed by test ID, not a plain array: a test that fails on every retry calls `addFailure`
+  // more than once, and this keeps only the last attempt so its GitHub issue is updated once
+  // per run rather than once per attempt.
+  private readonly failures = new Map<string, ScoutFailureTrackingEntry>();
 
   constructor(log: ToolingLog, reportRootPath: string, runId: string) {
     this.log = log;
@@ -62,7 +65,7 @@ export class ScoutFailureTracker {
    * Add a test failure to the tracking file
    */
   addFailure(failure: TestFailure) {
-    const trackingEntry: ScoutFailureTrackingEntry = {
+    this.failures.set(failure.id, {
       id: failure.id,
       suite: failure.suite,
       title: failure.title,
@@ -83,16 +86,22 @@ export class ScoutFailureTracker {
         pipeline: process.env.BUILDKITE_PIPELINE_SLUG,
         branch: process.env.BUILDKITE_BRANCH,
       },
-    };
-
-    this.failures.push(trackingEntry);
+    });
   }
 
   /**
-   * Save all tracked failures to the tracking file
+   * Save all tracked failures to the tracking file.
+   *
+   * @param excludeTestIds - IDs of tests to drop before writing, e.g. flaky tests that passed
+   * on retry and so should not open/update a GitHub issue.
    */
-  save() {
-    if (this.failures.length === 0) {
+  save({ excludeTestIds }: { excludeTestIds?: Set<string> } = {}) {
+    const allFailures = [...this.failures.values()];
+    const failuresToSave = excludeTestIds
+      ? allFailures.filter((failure) => !excludeTestIds.has(failure.id))
+      : allFailures;
+
+    if (failuresToSave.length === 0) {
       this.log.info('No Scout failures to track');
       return;
     }
@@ -102,12 +111,12 @@ export class ScoutFailureTracker {
     fs.mkdirSync(dir, { recursive: true });
 
     // Write failures as NDJSON
-    const content = this.failures.map((failure) => JSON.stringify(failure)).join('\n') + '\n';
+    const content = failuresToSave.map((failure) => JSON.stringify(failure)).join('\n') + '\n';
 
     fs.writeFileSync(this.trackingFilePath, content, 'utf-8');
 
     this.log.info(
-      `Saved ${this.failures.length} Scout failures to tracking file: ${this.trackingFilePath}`
+      `Saved ${failuresToSave.length} Scout failures to tracking file: ${this.trackingFilePath}`
     );
   }
 

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/test_identity.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/test_identity.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TestCase } from '@playwright/test/reporter';
+import path from 'node:path';
+import { REPO_ROOT } from '@kbn/repo-info';
+import { computeTestID } from '../../helpers';
+
+export interface ScoutTestIdentity {
+  id: string;
+  filePath: string;
+  fullTitle: string;
+}
+
+const cache = new WeakMap<TestCase, ScoutTestIdentity>();
+
+/**
+ * Derives the repo-relative file path, full title and computed ID for a Playwright `TestCase`.
+ * Shared by both reporters and memoized per `TestCase` so `computeTestID` isn't re-hashed on
+ * every attempt and event.
+ */
+export function getTestIdentity(test: TestCase): ScoutTestIdentity {
+  const cached = cache.get(test);
+  if (cached) {
+    return cached;
+  }
+
+  const filePath = path.relative(REPO_ROOT, test.location.file);
+  // The first three elements of the title path are the root suite, project and test file path;
+  // Scout's test titles and IDs never include them.
+  const fullTitle = test.titlePath().slice(3).join(' ');
+  const identity: ScoutTestIdentity = {
+    id: computeTestID(filePath, fullTitle),
+    filePath,
+    fullTitle,
+  };
+
+  cache.set(test, identity);
+  return identity;
+}

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
@@ -7,8 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
-import { BuildkiteMetadata, HostMetadata } from '../../../datasources';
+import type { TestCase } from '@playwright/test/reporter';
+import type { ScoutTestRunConfigCategory } from '@kbn/scout-info';
+import type { BuildkiteMetadata, HostMetadata } from '../../../datasources';
+
+/** A test's final classification, once no more retries can happen. Mirrors `TestCase.outcome()`. */
+export type ScoutTestOutcome = ReturnType<TestCase['outcome']>;
 
 /**
  * Scout reporter event type
@@ -18,6 +22,8 @@ export enum ScoutReportEventAction {
   RUN_END = 'run-end',
   TEST_BEGIN = 'test-begin',
   TEST_END = 'test-end',
+  /** One per test, emitted at `onEnd` once every attempt (incl. retries) is known. */
+  TEST_OUTCOME = 'test-outcome',
   TEST_STEP_BEGIN = 'test-step-begin',
   TEST_STEP_END = 'test-step-end',
   ERROR = 'error',
@@ -76,6 +82,8 @@ export interface ScoutTestRunInfo {
     passes?: number;
     pending?: number;
     failures?: number;
+    /** Passed, but only after at least one failed attempt. A subset of `passes`. */
+    flaky?: number;
     total?: number;
   };
 }
@@ -101,7 +109,14 @@ export interface ScoutTestInfo {
   }>;
   expected_status?: string;
   duration?: number;
+  /** On `test-end`, this attempt's status. On `test-outcome`, the last attempt's status. */
   status?: string;
+  /** Zero-based attempt index; 0 is the first run, 1 the first retry. Present on `test-end`. */
+  attempt?: number;
+  /** Final classification, once the test can no longer be retried. Only on `test-outcome`. */
+  outcome?: ScoutTestOutcome;
+  /** Total number of attempts the test took. Only on `test-outcome`. */
+  attempts?: number;
   console_errors?: string;
   step?: {
     title: string;

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
@@ -48,7 +48,7 @@ export const reporterMappings: ClusterPutComponentTemplateRequest = {
 
 export const testRunMappings: ClusterPutComponentTemplateRequest = {
   name: 'scout-test-event.mappings.test-run',
-  version: 5,
+  version: 6,
   template: {
     mappings: {
       properties: {
@@ -78,7 +78,7 @@ export const suiteMappings: ClusterPutComponentTemplateRequest = {
 
 export const testMappings: ClusterPutComponentTemplateRequest = {
   name: 'scout-test-event.mappings.test',
-  version: 3,
+  version: 4,
   template: {
     mappings: {
       properties: {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
@@ -163,6 +163,9 @@ export const testRunProperties: Record<PropertyName, MappingProperty> = {
       pending: {
         type: 'long',
       },
+      flaky: {
+        type: 'long',
+      },
       total: {
         type: 'long',
       },
@@ -223,6 +226,15 @@ export const testProperties: Record<PropertyName, MappingProperty> = {
   },
   status: {
     type: 'keyword',
+  },
+  attempt: {
+    type: 'short',
+  },
+  outcome: {
+    type: 'keyword',
+  },
+  attempts: {
+    type: 'short',
   },
   console_errors: {
     type: 'match_only_text',

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/html.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/html.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { buildFailureHtml } from './html';
+import type { TestFailure } from './test_failure';
+
+const createMockFailure = (overrides: Partial<TestFailure> = {}): TestFailure => ({
+  id: 'test-id-1',
+  suite: 'My Suite',
+  title: 'should work',
+  target: 'local',
+  command: 'node scripts/playwright test',
+  location: 'path/to/file.spec.ts:1:1',
+  owner: ['@elastic/kibana-scout'],
+  duration: 1000,
+  error: { message: 'boom', stack_trace: 'stack' },
+  attachments: [],
+  ...overrides,
+});
+
+describe('buildFailureHtml', () => {
+  it('omits the retries row when attempt is undefined (not a retry-aware run)', () => {
+    const html = buildFailureHtml(createMockFailure());
+    expect(html).not.toContain('Retries:');
+  });
+
+  it('omits the retries row for a first attempt (attempt 0)', () => {
+    const html = buildFailureHtml(createMockFailure({ attempt: 0 }));
+    expect(html).not.toContain('Retries:');
+  });
+
+  it('shows that the test failed again on retry when attempt is greater than 0', () => {
+    const html = buildFailureHtml(createMockFailure({ attempt: 1 }));
+    expect(html).toContain('Retries:');
+    expect(html).toContain('Failed again on retry (attempt 2)');
+  });
+});

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/html.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/html.ts
@@ -24,9 +24,20 @@ export const buildFailureHtml = (testFailure: TestFailure): string => {
     stdout,
     consoleErrors,
     attachments,
+    attempt,
   } = testFailure;
 
   const testDuration = duration < 1000 ? `${duration}ms` : `${(duration / 1000).toFixed(2)}s`;
+
+  // `attempt` is only > 0 once this failure has gone through at least one Playwright retry.
+  // Most failures never retry, so this row is omitted rather than always shown as "Attempt 1".
+  const retryRow =
+    attempt !== undefined && attempt > 0
+      ? `
+            <span class="info-label">Retries:</span>
+            <span class="info-value">Failed again on retry (attempt ${attempt + 1})</span>
+`
+      : '';
 
   const screenshots = attachments
     .filter((a) => a.contentType.startsWith('image/'))
@@ -364,6 +375,7 @@ export const buildFailureHtml = (testFailure: TestFailure): string => {
 
             <span class="info-label">Duration:</span>
             <span class="info-value">${testDuration}</span>
+${retryRow}
 
             <span class="info-label">Module:</span>
             <span class="info-value">${kibanaModule?.id} ${kibanaModule?.type}</span>

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/report.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/report.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { ToolingLog } from '@kbn/tooling-log';
+import { ScoutFailureReport } from './report';
+import type { TestFailure } from './test_failure';
+
+const createMockLog = (): ToolingLog =>
+  ({
+    info: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+  } as unknown as ToolingLog);
+
+const createMockFailure = (overrides: Partial<TestFailure> = {}): TestFailure => ({
+  id: 'test-id-1',
+  suite: 'My Suite',
+  title: 'should work',
+  target: 'local',
+  command: 'node scripts/playwright test',
+  location: 'path/to/file.spec.ts:1:1',
+  owner: ['@elastic/kibana-scout'],
+  duration: 1000,
+  error: { message: 'boom', stack_trace: 'stack' },
+  attachments: [],
+  ...overrides,
+});
+
+describe('ScoutFailureReport', () => {
+  let destination: string;
+
+  beforeEach(() => {
+    destination = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'scout-report-')), 'out');
+  });
+
+  afterEach(() => {
+    fs.rmSync(path.dirname(destination), { recursive: true, force: true });
+  });
+
+  const readSummary = (): Array<{ name: string; htmlReportFilename: string }> =>
+    JSON.parse(fs.readFileSync(path.join(destination, 'test-failures-summary.json'), 'utf-8'));
+
+  it('writes one HTML report and one summary row per unique test id', () => {
+    const report = new ScoutFailureReport(createMockLog());
+    report.logEvent(createMockFailure({ id: 'a' }));
+    report.logEvent(createMockFailure({ id: 'b' }));
+
+    report.save(destination);
+
+    expect(fs.existsSync(path.join(destination, 'a.html'))).toBe(true);
+    expect(fs.existsSync(path.join(destination, 'b.html'))).toBe(true);
+    expect(readSummary()).toHaveLength(2);
+  });
+
+  it('keeps only the last attempt when a test fails on more than one attempt', () => {
+    const report = new ScoutFailureReport(createMockLog());
+    report.logEvent(createMockFailure({ id: 'retried', attempt: 0, duration: 100 }));
+    report.logEvent(createMockFailure({ id: 'retried', attempt: 1, duration: 200 }));
+
+    report.save(destination);
+
+    // One summary row, not two, and the surviving HTML reflects the retried attempt.
+    expect(readSummary()).toHaveLength(1);
+    const html = fs.readFileSync(path.join(destination, 'retried.html'), 'utf-8');
+    expect(html).toContain('Failed again on retry (attempt 2)');
+  });
+});

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/report.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/report.ts
@@ -60,12 +60,17 @@ export class ScoutFailureReport extends ScoutReport {
       throw new ScoutReportError(`Save destination path '${destination}' already exists`);
     }
 
-    const testFailures: TestFailure[] = this.readFailuresFromNDJSON();
+    const allFailures: TestFailure[] = this.readFailuresFromNDJSON();
 
-    if (testFailures.length === 0) {
+    if (allFailures.length === 0) {
       this.log.info('No test failures to report');
       return;
     }
+
+    // A test retried on CI logs one entry per failing attempt, all sharing the same id; keep
+    // only the last (Playwright never has a passing attempt sandwiched between two failing
+    // ones), so each test gets one HTML report and one summary row, not one per attempt.
+    const testFailures = [...new Map(allFailures.map((f) => [f.id, f])).values()];
 
     // Create the destination directory
     this.log.info(

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/test_failure.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/test_failure.ts
@@ -33,4 +33,6 @@ export interface TestFailure {
     path?: string;
     contentType: string;
   }>;
+  /** Zero-based attempt index; 0 is the first run, 1 the first retry. */
+  attempt?: number;
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
@@ -34,9 +34,27 @@ describe('createPlaywrightConfig', () => {
   const mockedScoutPlaywrightReporter = scoutPlaywrightReporter as jest.Mock;
   const mockedScoutFailedTestsReporter = scoutFailedTestsReporter as jest.Mock;
 
+  const originalCI = process.env.CI;
+  const originalRetries = process.env.SCOUT_TEST_RETRIES;
+
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.TEST_RUN_ID;
+    delete process.env.CI;
+    delete process.env.SCOUT_TEST_RETRIES;
+  });
+
+  afterAll(() => {
+    if (originalCI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCI;
+    }
+    if (originalRetries === undefined) {
+      delete process.env.SCOUT_TEST_RETRIES;
+    } else {
+      process.env.SCOUT_TEST_RETRIES = originalRetries;
+    }
   });
 
   it('should return a valid default Playwright configuration', () => {
@@ -61,7 +79,7 @@ describe('createPlaywrightConfig', () => {
       navigationTimeout: 20000,
       screenshot: 'only-on-failure',
       testIdAttribute: 'data-test-subj',
-      trace: 'on-first-retry',
+      trace: 'off',
     });
     expect(config.globalSetup).toBeUndefined();
     expect(config.globalTeardown).toBeUndefined();
@@ -167,6 +185,46 @@ describe('createPlaywrightConfig', () => {
       expect(teardown!.testMatch).toEqual(/global.teardown\.ts/);
       expect(teardown!.timeout).toBe(defaultGlobalHookTimeout);
     }
+  });
+
+  describe('retries', () => {
+    it('is 0 locally (CI unset)', () => {
+      const config = createPlaywrightConfig({ testDir: './my_tests' });
+      expect(config.retries).toBe(0);
+    });
+
+    it('is 1 on CI', () => {
+      process.env.CI = 'true';
+      const config = createPlaywrightConfig({ testDir: './my_tests' });
+      expect(config.retries).toBe(1);
+    });
+
+    it('SCOUT_TEST_RETRIES=0 overrides CI=true — the flaky-runner guard', () => {
+      process.env.CI = 'true';
+      process.env.SCOUT_TEST_RETRIES = '0';
+      const config = createPlaywrightConfig({ testDir: './my_tests' });
+      expect(config.retries).toBe(0);
+    });
+
+    it('SCOUT_TEST_RETRIES overrides the local default too', () => {
+      process.env.SCOUT_TEST_RETRIES = '2';
+      const config = createPlaywrightConfig({ testDir: './my_tests' });
+      expect(config.retries).toBe(2);
+    });
+
+    it('throws on a non-numeric override', () => {
+      process.env.SCOUT_TEST_RETRIES = 'not-a-number';
+      expect(() => createPlaywrightConfig({ testDir: './my_tests' })).toThrow(
+        /SCOUT_TEST_RETRIES must be a non-negative integer/
+      );
+    });
+
+    it('throws on a negative override', () => {
+      process.env.SCOUT_TEST_RETRIES = '-1';
+      expect(() => createPlaywrightConfig({ testDir: './my_tests' })).toThrow(
+        /SCOUT_TEST_RETRIES must be a non-negative integer/
+      );
+    });
   });
 
   it('should generate and cache runId in process.env.TEST_RUN_ID', () => {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -16,6 +16,27 @@ import {
 import { SCOUT_SERVERS_ROOT } from '@kbn/scout-info';
 import { ScoutPlaywrightOptions, ScoutTestOptions, VALID_CONFIG_MARKER } from '../types';
 
+const DEFAULT_CI_RETRIES = 1;
+
+/**
+ * Number of Playwright retries: 1 on CI, 0 locally. `SCOUT_TEST_RETRIES` overrides both —
+ * e.g. the flaky-test runner sets it to 0.
+ */
+const resolveRetries = (): number => {
+  const override = process.env.SCOUT_TEST_RETRIES;
+
+  if (override === undefined) {
+    return process.env.CI ? DEFAULT_CI_RETRIES : 0;
+  }
+
+  const parsed = Number.parseInt(override, 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    throw new Error(`SCOUT_TEST_RETRIES must be a non-negative integer, got '${override}'`);
+  }
+
+  return parsed;
+};
+
 export function createPlaywrightConfig(options: ScoutPlaywrightOptions): PlaywrightTestConfig {
   /**
    * Playwright loads the config file multiple times, so we need to generate a unique run id
@@ -83,8 +104,8 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
     fullyParallel: false,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
-    /* Retry on CI only */
-    retries: 0, // disable retry for Playwright runner
+    /* Retries happen immediately, in a fresh worker. See resolveRetries(). */
+    retries: resolveRetries(),
     /* Opt out of parallel tests on CI. */
     workers: options.workers ?? 1,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -106,8 +127,10 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
       /* Base URL to use in actions like `await page.goto('/')`. */
       // baseURL: 'http://127.0.0.1:3000',
 
-      /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-      trace: 'on-first-retry',
+      /* Tracing adds per-test overhead (screenshots, DOM snapshots, network/console capture)
+       * for every attempt, which can push already-marginal tests over their timeout in a
+       * shared CI lane. Keep it off, as it was before retries existed. */
+      trace: 'off',
       screenshot: 'only-on-failure',
       // video: 'retain-on-failure',
       // storageState: './output/reports/state.json', // Store session state (like cookies)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] retry failed test within running config (#282252)](https://github.com/elastic/kibana/pull/282252)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-08-04T14:14:20Z","message":"[scout] retry failed test within running config (#282252)\n\n## Summary\n\ncloses https://github.com/elastic/apps-dx/issues/47\n\nWe now let Playwright retry a failed test immediately in the same run,\ninstead of only relying on Buildkite restarting the whole step (new\nworker, bootstrap, servers start).\n\n- **Test fails once** → Playwright retries it right away in a fresh\nPlaywright worker (same servers, just re-running the spec).\n- **Retry passes** → the test is marked \"flaky,\" the config counts as\npassed, and it's called out with `⚠️ flaky` in the lane summary and in\nthe failure report instead of silently failing the whole config the way\nit used to.\n- **Retry also fails** → nothing changes from before: the config is\nmarked failed, and Buildkite's existing \"restart the step with fresh\nbrowsers, re-run just the failed specs\" fallback kicks in as usual.\n\nOutcome: fewer false-red CI runs caused by one-off flakiness, while\ngenuinely broken tests still fail the build and go through the same\nreporting path as today.\n\nFlaky config is marked only in CI job + test results are ingested\n<img width=\"1937\" height=\"837\" alt=\"Screenshot 2026-08-03 at 16 38 16\"\nsrc=\"https://github.com/user-attachments/assets/0d0d0369-944d-4130-afa7-45eb151613b2\"\n/>\n\nIn some test runs 9 of 23 tests were successfully retried without\nservers restart (new worker).","sha":"b2ed746dddb1e694954e7320f7ddb22ed1260ddb","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0","reviewer:scout","v9.6.0","v9.4.5","v9.3.9"],"title":"[scout] retry failed test within running config","number":282252,"url":"https://github.com/elastic/kibana/pull/282252","mergeCommit":{"message":"[scout] retry failed test within running config (#282252)\n\n## Summary\n\ncloses https://github.com/elastic/apps-dx/issues/47\n\nWe now let Playwright retry a failed test immediately in the same run,\ninstead of only relying on Buildkite restarting the whole step (new\nworker, bootstrap, servers start).\n\n- **Test fails once** → Playwright retries it right away in a fresh\nPlaywright worker (same servers, just re-running the spec).\n- **Retry passes** → the test is marked \"flaky,\" the config counts as\npassed, and it's called out with `⚠️ flaky` in the lane summary and in\nthe failure report instead of silently failing the whole config the way\nit used to.\n- **Retry also fails** → nothing changes from before: the config is\nmarked failed, and Buildkite's existing \"restart the step with fresh\nbrowsers, re-run just the failed specs\" fallback kicks in as usual.\n\nOutcome: fewer false-red CI runs caused by one-off flakiness, while\ngenuinely broken tests still fail the build and go through the same\nreporting path as today.\n\nFlaky config is marked only in CI job + test results are ingested\n<img width=\"1937\" height=\"837\" alt=\"Screenshot 2026-08-03 at 16 38 16\"\nsrc=\"https://github.com/user-attachments/assets/0d0d0369-944d-4130-afa7-45eb151613b2\"\n/>\n\nIn some test runs 9 of 23 tests were successfully retried without\nservers restart (new worker).","sha":"b2ed746dddb1e694954e7320f7ddb22ed1260ddb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282716","number":282716,"state":"MERGED","mergeCommit":{"sha":"d796b47945708704c0d94e56c0f80866c9f9557d","message":"[9.5] [scout] retry failed test within running config (#282252) (#282716)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[scout] retry failed test within running config\n(#282252)](https://github.com/elastic/kibana/pull/282252)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282252","number":282252,"mergeCommit":{"message":"[scout] retry failed test within running config (#282252)\n\n## Summary\n\ncloses https://github.com/elastic/apps-dx/issues/47\n\nWe now let Playwright retry a failed test immediately in the same run,\ninstead of only relying on Buildkite restarting the whole step (new\nworker, bootstrap, servers start).\n\n- **Test fails once** → Playwright retries it right away in a fresh\nPlaywright worker (same servers, just re-running the spec).\n- **Retry passes** → the test is marked \"flaky,\" the config counts as\npassed, and it's called out with `⚠️ flaky` in the lane summary and in\nthe failure report instead of silently failing the whole config the way\nit used to.\n- **Retry also fails** → nothing changes from before: the config is\nmarked failed, and Buildkite's existing \"restart the step with fresh\nbrowsers, re-run just the failed specs\" fallback kicks in as usual.\n\nOutcome: fewer false-red CI runs caused by one-off flakiness, while\ngenuinely broken tests still fail the build and go through the same\nreporting path as today.\n\nFlaky config is marked only in CI job + test results are ingested\n<img width=\"1937\" height=\"837\" alt=\"Screenshot 2026-08-03 at 16 38 16\"\nsrc=\"https://github.com/user-attachments/assets/0d0d0369-944d-4130-afa7-45eb151613b2\"\n/>\n\nIn some test runs 9 of 23 tests were successfully retried without\nservers restart (new worker).","sha":"b2ed746dddb1e694954e7320f7ddb22ed1260ddb"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282715","number":282715,"state":"MERGED","mergeCommit":{"sha":"37122237b40e751815e480981d3b70d2f3aebdec","message":"[9.4] [scout] retry failed test within running config (#282252) (#282715)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[scout] retry failed test within running config\n(#282252)](https://github.com/elastic/kibana/pull/282252)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"9.3","label":"v9.3.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282714","number":282714,"state":"MERGED","mergeCommit":{"sha":"cc8e5bf7e1dbe809c0ede0cbdd4c1e64e3582d45","message":"[9.3] [scout] retry failed test within running config (#282252) (#282714)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[scout] retry failed test within running config\n(#282252)](https://github.com/elastic/kibana/pull/282252)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}}]}] BACKPORT-->