### PR TITLE
[9.4] [AI Infra] Fix special tokens in prompts causing Kibana AI Agent to  error out or crashing (#281546)

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/inference_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/inference_adapter.ts
@@ -59,7 +59,7 @@ export const inferenceAdapter: InferenceConnectorAdapter = {
     }).pipe(
       handleConnectorStreamResponse({ processStream: eventSourceStreamIntoObservable }),
       processOpenAIStream(),
-      emitTokenCountEstimateIfMissing({ request }),
+      emitTokenCountEstimateIfMissing({ request, logger }),
       useSimulatedFunctionCalling ? parseInlineFunctionCalls({ logger }) : identity
     );
   },

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.ts
@@ -88,7 +88,7 @@ export const inferenceEndpointAdapter = {
     ).pipe(
       switchMap((stream) => eventSourceStreamIntoObservable(stream)),
       processOpenAIStream(),
-      emitTokenCountEstimateIfMissing({ request }),
+      emitTokenCountEstimateIfMissing({ request, logger }),
       useSimulatedFunctionCalling ? parseInlineFunctionCalls({ logger }) : identity
     );
   },

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/emit_token_count_if_missing.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/emit_token_count_if_missing.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/logging';
 import type { OperatorFunction } from 'rxjs';
 import { Observable } from 'rxjs';
 import type {
@@ -27,11 +28,14 @@ import { manuallyCountPromptTokens, manuallyCountCompletionTokens } from './manu
  * providers that don't support sending token counts for the stream API.
  *
  * @param request the OpenAI request that was sent to the connector.
+ * @param logger optional logger for warnings when token counting fails.
  */
 export function emitTokenCountEstimateIfMissing({
   request,
+  logger,
 }: {
   request: OpenAIRequest;
+  logger?: Logger;
 }): OperatorFunction<
   ChatCompletionChunkEvent | ChatCompletionTokenCountEvent,
   ChatCompletionChunkEvent | ChatCompletionTokenCountEvent
@@ -56,7 +60,11 @@ export function emitTokenCountEstimateIfMissing({
           },
           complete: () => {
             if (!tokenCountEmitted) {
-              subscriber.next(manuallyCountTokens(request, chunks));
+              try {
+                subscriber.next(manuallyCountTokens(request, chunks));
+              } catch (err) {
+                logger?.warn(`Failed to manually count tokens, skipping token count event: ${err}`);
+              }
             }
             subscriber.complete();
           },

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/manually_count_tokens.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/manually_count_tokens.test.ts
@@ -35,6 +35,23 @@ describe('manuallyCountPromptTokens', () => {
   });
 });
 
+describe('manuallyCountPromptTokens - special tokens', () => {
+  it('does not throw when the prompt contains a GPT special token', () => {
+    expect(() =>
+      manuallyCountPromptTokens({
+        messages: [{ role: 'user', content: 'Summarize: <|endoftext|>' }],
+      })
+    ).not.toThrow();
+  });
+
+  it('returns a positive count when the prompt contains a GPT special token', () => {
+    const count = manuallyCountPromptTokens({
+      messages: [{ role: 'user', content: 'Summarize: <|endoftext|>' }],
+    });
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
 describe('manuallyCountCompletionTokens', () => {
   const reference = manuallyCountCompletionTokens([chunkEvent('chunk-1')]);
 
@@ -46,6 +63,17 @@ describe('manuallyCountCompletionTokens', () => {
     ]);
 
     expect(count).toBeGreaterThan(reference);
+  });
+
+  it('does not throw when a chunk contains a GPT special token', () => {
+    expect(() =>
+      manuallyCountCompletionTokens([chunkEvent('Result: <|endoftext|>')])
+    ).not.toThrow();
+  });
+
+  it('returns a positive count when a chunk contains a GPT special token', () => {
+    const count = manuallyCountCompletionTokens([chunkEvent('Result: <|endoftext|>')]);
+    expect(count).toBeGreaterThan(0);
   });
 
   it('counts tokens from chunks with tool calls', () => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/manually_count_tokens.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/manually_count_tokens.ts
@@ -10,13 +10,25 @@ import type { ChatCompletionChunkEvent } from '@kbn/inference-common';
 import type { OpenAIRequest } from './types';
 import { mergeChunks } from '../../utils';
 
+const ENCODE_OPTIONS = { allowedSpecial: 'all' as const };
+
+function contentToString(
+  content: string | Array<{ type: string; text?: string; refusal?: string }> | null | undefined
+): string {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  return content
+    .map((part) => (part.type === 'text' ? part.text ?? '' : part.refusal ?? ''))
+    .join('\n');
+}
+
 export const manuallyCountPromptTokens = (request: OpenAIRequest) => {
   // per https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
   const tokensFromMessages = encode(
     request.messages
       .map(
         (msg) =>
-          `<|start|>${msg.role}\n${msg.content}\n${
+          `<|start|>${msg.role}\n${contentToString(msg.content)}\n${
             'name' in msg
               ? msg.name
               : 'function_call' in msg && msg.function_call
@@ -24,7 +36,8 @@ export const manuallyCountPromptTokens = (request: OpenAIRequest) => {
               : ''
           }<|end|>`
       )
-      .join('\n')
+      .join('\n'),
+    ENCODE_OPTIONS
   ).length;
 
   // this is an approximation. OpenAI cuts off a function schema
@@ -36,7 +49,8 @@ export const manuallyCountPromptTokens = (request: OpenAIRequest) => {
           ?.map(({ function: fn }) => {
             return `${fn.name}:${fn.description}:${JSON.stringify(fn.parameters)}`;
           })
-          .join('\n')
+          .join('\n'),
+        ENCODE_OPTIONS
       ).length
     : 0;
 
@@ -46,7 +60,7 @@ export const manuallyCountPromptTokens = (request: OpenAIRequest) => {
 export const manuallyCountCompletionTokens = (chunks: ChatCompletionChunkEvent[]) => {
   const message = mergeChunks(chunks);
 
-  const tokenFromContent = encode(message.content).length;
+  const tokenFromContent = encode(message.content, ENCODE_OPTIONS).length;
 
   const tokenFromToolCalls = message.tool_calls?.length
     ? encode(
@@ -54,7 +68,8 @@ export const manuallyCountCompletionTokens = (chunks: ChatCompletionChunkEvent[]
           .map((toolCall) => {
             return JSON.stringify(toolCall);
           })
-          .join('\n')
+          .join('\n'),
+        ENCODE_OPTIONS
       ).length
     : 0;
 

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.ts
@@ -110,7 +110,7 @@ export const openAIAdapter: InferenceConnectorAdapter = {
       return connectorResult$.pipe(
         handleConnectorStreamResponse({ processStream: eventSourceStreamIntoObservable }),
         processOpenAIStream(),
-        emitTokenCountEstimateIfMissing({ request }),
+        emitTokenCountEstimateIfMissing({ request, logger }),
         useSimulatedFunctionCalling ? parseInlineFunctionCalls({ logger }) : passThrough
       );
     } else {
@@ -119,7 +119,7 @@ export const openAIAdapter: InferenceConnectorAdapter = {
           parseData: (data) => data as OpenAI.ChatCompletion,
         }),
         processOpenAIResponse(),
-        emitTokenCountEstimateIfMissing({ request }),
+        emitTokenCountEstimateIfMissing({ request, logger }),
         useSimulatedFunctionCalling ? parseInlineFunctionCalls({ logger }) : passThrough
       );
     }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.test.ts
@@ -212,7 +212,7 @@ describe('messagesToOpenAI', () => {
     ).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             function: {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.ts
@@ -136,7 +136,7 @@ export function messagesToOpenAI({
       case MessageRole.Assistant:
         const assistantMessage: ChatCompletionAssistantMessageParam = {
           role: 'assistant',
-          content: message.content ?? '',
+          content: message.content || null,
           tool_calls: message.toolCalls?.map((toolCall) => {
             return {
               function: {
@@ -215,9 +215,8 @@ function mergeConsecutiveMessages(
       } else if (message.role === 'assistant' && previous.role === 'assistant') {
         const prevContent = (previous as ChatCompletionAssistantMessageParam).content ?? '';
         const curContent = (message as ChatCompletionAssistantMessageParam).content ?? '';
-        (previous as ChatCompletionAssistantMessageParam).content = [prevContent, curContent]
-          .filter(Boolean)
-          .join('\n');
+        (previous as ChatCompletionAssistantMessageParam).content =
+          [prevContent, curContent].filter(Boolean).join('\n') || null;
         const prevCalls = (previous as ChatCompletionAssistantMessageParam).tool_calls;
         const curCalls = (message as ChatCompletionAssistantMessageParam).tool_calls;
         if (curCalls?.length) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[AI Infra] Fix special tokens in prompts causing Kibana AI Agent to  error out or crashing (#281546)](https://github.com/elastic/kibana/pull/281546)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Quynh Nguyen (Quinn)","email":"43350163+qn895@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-04T16:59:45Z","message":"[AI Infra] Fix special tokens in prompts causing Kibana AI Agent to  error out or crashing (#281546)\n\nThis PR addresses https://github.com/elastic/kibana/issues/278976. It\nfixes special tokens in prompts causing Kibana AI Agent to error out or\ncrashing and improves the robustness of the token counting logic in the\nOpenAI adapter.\n\nTo test:\n- Create an External chat_completion inference endpoint for Anthropic's\nClaude model & OpenAI model\n- Go to Agent builder, test with the following prompts for both models\n\n```\nSummarize:\n With this magnetic screen door, you can bring fresh air in to your home everyday, and still keep the obnoxious elements out! It is sturdy and tear resistant so you can feel safe and secure with your kids walking through it. <|endoftext|> xxxxxxxxxxx Plain Text xxxxxxxxxxx <|endoftext|> Plus, it is a pet friendly mesh screen that can withstand frequent use. It makes a thoughtful idea to pet parents who want a safe and affordable solution for easy pet entry indoors and outdoors` it's working with openai but not anthropic claude models in agent builder. \n``` \n\nSee that the agent responds with a summary instead of showing an error\n\n<img width=\"779\" height=\"873\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69de1718-b6d4-415b-ab3b-e053e14573ab\"\n/>\n\n<img width=\"779\" height=\"873\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ccac7ac5-aba4-45ba-af1e-ad19a75bce98\"\n/>\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"278399d3ef17ed65ac23d1415621e829c8933f4d","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix",":ml","backport:version","Team:AI Infra","v9.6.0","v9.4.5","v9.5.1"],"title":"[AI Infra] Fix special tokens in prompts causing Kibana AI Agent to  error out or crashing ","number":281546,"url":"https://github.com/elastic/kibana/pull/281546","mergeCommit":{"message":"[AI Infra] Fix special tokens in prompts causing Kibana AI Agent to  error out or crashing (#281546)\n\nThis PR addresses https://github.com/elastic/kibana/issues/278976. It\nfixes special tokens in prompts causing Kibana AI Agent to error out or\ncrashing and improves the robustness of the token counting logic in the\nOpenAI adapter.\n\nTo test:\n- Create an External chat_completion inference endpoint for Anthropic's\nClaude model & OpenAI model\n- Go to Agent builder, test with the following prompts for both models\n\n```\nSummarize:\n With this magnetic screen door, you can bring fresh air in to your home everyday, and still keep the obnoxious elements out! It is sturdy and tear resistant so you can feel safe and secure with your kids walking through it. <|endoftext|> xxxxxxxxxxx Plain Text xxxxxxxxxxx <|endoftext|> Plus, it is a pet friendly mesh screen that can withstand frequent use. It makes a thoughtful idea to pet parents who want a safe and affordable solution for easy pet entry indoors and outdoors` it's working with openai but not anthropic claude models in agent builder. \n``` \n\nSee that the agent responds with a summary instead of showing an error\n\n<img width=\"779\" height=\"873\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69de1718-b6d4-415b-ab3b-e053e14573ab\"\n/>\n\n<img width=\"779\" height=\"873\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ccac7ac5-aba4-45ba-af1e-ad19a75bce98\"\n/>\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"278399d3ef17ed65ac23d1415621e829c8933f4d"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281546","number":281546,"mergeCommit":{"message":"[AI Infra] Fix special tokens in prompts causing Kibana AI Agent to  error out or crashing (#281546)\n\nThis PR addresses https://github.com/elastic/kibana/issues/278976. It\nfixes special tokens in prompts causing Kibana AI Agent to error out or\ncrashing and improves the robustness of the token counting logic in the\nOpenAI adapter.\n\nTo test:\n- Create an External chat_completion inference endpoint for Anthropic's\nClaude model & OpenAI model\n- Go to Agent builder, test with the following prompts for both models\n\n```\nSummarize:\n With this magnetic screen door, you can bring fresh air in to your home everyday, and still keep the obnoxious elements out! It is sturdy and tear resistant so you can feel safe and secure with your kids walking through it. <|endoftext|> xxxxxxxxxxx Plain Text xxxxxxxxxxx <|endoftext|> Plus, it is a pet friendly mesh screen that can withstand frequent use. It makes a thoughtful idea to pet parents who want a safe and affordable solution for easy pet entry indoors and outdoors` it's working with openai but not anthropic claude models in agent builder. \n``` \n\nSee that the agent responds with a summary instead of showing an error\n\n<img width=\"779\" height=\"873\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69de1718-b6d4-415b-ab3b-e053e14573ab\"\n/>\n\n<img width=\"779\" height=\"873\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ccac7ac5-aba4-45ba-af1e-ad19a75bce98\"\n/>\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"278399d3ef17ed65ac23d1415621e829c8933f4d"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282765","number":282765,"state":"OPEN"}]}] BACKPORT-->