### PR TITLE
[Security Solution][Flyout] fix tools header overlapping with cross icon that closes flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.tsx
@@ -11,6 +11,7 @@ import type { IconType } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { ToolsFlyoutTitle } from './tools_flyout_title';
 import { TOOLS_FLYOUT_HEADER_TEST_ID, TOOLS_FLYOUT_HEADER_TIMESTAMP_TEST_ID } from './test_ids';
+import { useFlyoutHasBackButton } from '../hooks/use_flyout_has_back_button';
 
 export interface ToolsFlyoutHeaderProps {
   /**
@@ -50,13 +51,17 @@ export const ToolsFlyoutHeader: FC<ToolsFlyoutHeaderProps> = memo(
     const { euiTheme } = useEuiTheme();
     const showSourceContext = !!onTitleClick && !!label && !!iconType;
 
+    // When the flyout menu renders a back button, the header is pushed onto its own row and no
+    // longer overlaps the close button, so we only reserve room for the close button otherwise.
+    const hasBackButton = useFlyoutHasBackButton();
+
     return (
       <EuiFlexGroup
         justifyContent="spaceBetween"
         alignItems="center"
         gutterSize="m"
         responsive={false}
-        css={{ flexWrap: 'nowrap' }}
+        css={{ flexWrap: 'nowrap', paddingRight: hasBackButton ? 0 : euiTheme.size.l }}
         data-test-subj={TOOLS_FLYOUT_HEADER_TEST_ID}
       >
         <EuiFlexItem grow={false} css={{ flexShrink: 0 }}>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_flyout_has_back_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_flyout_has_back_button.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useSyncExternalStore } from 'react';
+import { getFlyoutManagerStore } from '@elastic/eui';
+
+/**
+ * Returns `true` when the EUI flyout menu is currently rendering a "Back" button.
+ *
+ * The managed flyout shows the back button (`data-test-subj="euiFlyoutMenuBackButton"`) exactly
+ * when the current session has navigation history, i.e. `store.historyItems.length > 0`. We read
+ * that same value from the EUI flyout manager store (a module-level singleton shared across React
+ * roots) and stay reactive to navigation via `useSyncExternalStore`.
+ *
+ * This is a stopgap: EUI does not expose whether a flyout was opened first vs. as part of a
+ * navigation stack. It lets the tools flyout header only reserve room for the close button when
+ * there is no back button pushing the header onto its own row. It should be removed once the
+ * flyout headers are reworked.
+ */
+export const useFlyoutHasBackButton = (): boolean => {
+  const store = getFlyoutManagerStore();
+  return useSyncExternalStore(
+    store.subscribe,
+    () => store.historyItems.length > 0,
+    () => false
+  );
+};


### PR DESCRIPTION
## Summary

This PR fixes a small UI issue where the tools header flyout was overlapping with the cross icon that close the flyout.

#### Issue on `main`

<img width="681" height="737" alt="Screenshot 2026-08-04 at 8 22 57 PM" src="https://github.com/user-attachments/assets/66e33eb0-6e41-4ed5-a9b1-ff261822811b" />

#### Fix

https://github.com/user-attachments/assets/de2f2e93-2cb8-4c82-b1ba-7cbea608a6d0

To fix this, we're leveraging the `getFlyoutManagerStore` from EUI that allows us to know if the flyout is opened first (when we had the issue) or next in the history. Doing this, we can control when we add the padding or not. That way we don't have to show the padding when the tools header is rendered below the flyout's header when the `Back` button is rendered (which is handled internally in the EUI flyout).

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->