### PR TITLE
[8.19] Add max length to signature parameter (#282578)

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/routes/analytics/authentication_type.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/analytics/authentication_type.ts
@@ -40,7 +40,10 @@ export function defineRecordAnalyticsOnAuthTypeRoutes({
       },
       validate: {
         body: schema.nullable(
-          schema.object({ signature: schema.string(), timestamp: schema.number() })
+          schema.object({
+            signature: schema.string({ maxLength: 128 }),
+            timestamp: schema.number(),
+          })
         ),
       },
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add max length to signature parameter (#282578)](https://github.com/elastic/kibana/pull/282578)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-08-04T16:52:16Z","message":"Add max length to signature parameter (#282578)\n\n## Summary\n\nAdds a `maxLength` to the `signature` parameter of our\n`/internal/security/analytics/_record_auth_type` endpoint. The signature\nshould not exceed `64` hex characters, so I doubled this to give a safe\nbuffer of `128`\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"95fcc1bd24122b84740631049123d3115b01486c","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.6.0"],"title":"Add max length to signature parameter","number":282578,"url":"https://github.com/elastic/kibana/pull/282578","mergeCommit":{"message":"Add max length to signature parameter (#282578)\n\n## Summary\n\nAdds a `maxLength` to the `signature` parameter of our\n`/internal/security/analytics/_record_auth_type` endpoint. The signature\nshould not exceed `64` hex characters, so I doubled this to give a safe\nbuffer of `128`\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"95fcc1bd24122b84740631049123d3115b01486c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282578","number":282578,"mergeCommit":{"message":"Add max length to signature parameter (#282578)\n\n## Summary\n\nAdds a `maxLength` to the `signature` parameter of our\n`/internal/security/analytics/_record_auth_type` endpoint. The signature\nshould not exceed `64` hex characters, so I doubled this to give a safe\nbuffer of `128`\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"95fcc1bd24122b84740631049123d3115b01486c"}}]}] BACKPORT-->