### PR TITLE
[9.4] [Discover][Traces] Fix flaky "fullscreen" waterfall flyout E2E test (#264999)

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/flyout.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/flyout.ts
@@ -33,6 +33,7 @@ export interface TracesFlyout {
     readonly openInDiscoverButton: Locator;
     readonly tourOkButton: Locator;
     getServiceBadge(name: string): Locator;
+    clickWaterfallPreview(): Promise<void>;
   };
 
   readonly errors: {
@@ -122,6 +123,13 @@ export function createTracesFlyout(page: ScoutPage): TracesFlyout {
           .locator('traceItemRowWrapper')
           .filter({ hasText: name })
           .locator('[data-test-subj="apmBarDetailsServiceNameBadge"]');
+      },
+      async clickWaterfallPreview() {
+        const waterfallClickArea = page.testSubj.locator(
+          'unifiedDocViewerTraceSummaryTraceWaterfallClickArea'
+        );
+        await waterfallClickArea.waitFor({ state: 'visible' });
+        await waterfallClickArea.dispatchEvent('click');
       },
     },
 

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/overview_tab_usage.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/overview_tab_usage.spec.ts
@@ -164,7 +164,7 @@ spaceTest.describe(
         await spaceTest.step(
           'click waterfall preview to open expanded timeline flyout',
           async () => {
-            await flyout.traceSummary.waterfallClickArea.click();
+            await flyout.traceSummary.clickWaterfallPreview();
             await expect(flyout.waterfallFlyout.container).toBeVisible();
             await flyout.waterfallFlyout.backButton.click();
             await expect(flyout.waterfallFlyout.container).toBeHidden();

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace_waterfall/index.tsx
@@ -180,29 +180,23 @@ function InternalTraceWaterfall({ traceId, docId, serviceName, dataView }: Props
   // effect runs on the next render, and the state is cleared.
   //
   // See: https://github.com/elastic/eui/blob/v113.3.0/packages/eui/src/components/flyout/manager/flyout_managed.tsx
-  const pendingCloseRef = useRef<'exit' | 'child' | null>(null);
-  // We have special conditions here where we want to force an effect to fire as
-  // result of a callback. Because we're relying on a ref to handle this state (which
-  // cannot trigger a re-render), calling a setState will force the component to render.
-  // Without doing this, when the user exits the flyout using the back button, it won't
-  // end up rendering, and the traces flyout will never re-open again.
-  const [, forceRender] = useState(0);
+  const [pendingClose, setPendingClose] = useState<'exit' | 'child' | null>(null);
 
   useEffect(() => {
-    if (pendingCloseRef.current === 'exit') {
+    if (pendingClose === 'exit') {
       setShowFullScreenWaterfall(false);
       clearActiveFlyout();
-    } else if (pendingCloseRef.current === 'child') {
+      setPendingClose(null);
+    } else if (pendingClose === 'child') {
       clearActiveFlyout();
+      setPendingClose(null);
     }
-    pendingCloseRef.current = null;
-  });
+  }, [pendingClose, setShowFullScreenWaterfall, clearActiveFlyout]);
 
   const onExitFullScreen = useCallback<NonNullable<EuiFlyoutProps['onClose']>>(
     (event) => {
       if (event.type === 'navigation') {
-        pendingCloseRef.current = 'exit';
-        forceRender((n) => n + 1);
+        setPendingClose('exit');
         return;
       }
 
@@ -215,8 +209,7 @@ function InternalTraceWaterfall({ traceId, docId, serviceName, dataView }: Props
   const onCloseFlyout = useCallback<NonNullable<EuiFlyoutProps['onClose']>>(
     (event) => {
       if (event.type === 'navigation') {
-        pendingCloseRef.current = 'child';
-        forceRender((n) => n + 1);
+        setPendingClose('child');
         return;
       }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Discover][Traces] Fix flaky "fullscreen" waterfall flyout E2E test (#264999)](https://github.com/elastic/kibana/pull/264999)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Marques","email":"tiago.marques@elastic.co"},"sourceCommit":{"committedDate":"2026-04-24T17:32:47Z","message":"[Discover][Traces] Fix flaky \"fullscreen\" waterfall flyout E2E test (#264999)\n\n## Summary\n\nCloses #261265\n\nTwo issues were causing flakiness in the E2E Scout test:\n\n1. In `trace_waterfall`, the deferred EUI flyout `onClose('navigation')`\nhandling used a `pendingCloseRef` + `forceRender` pattern with a depless\n`useEffect`. (TIL) Under React 18 batching, a\n`setShowFullScreenWaterfall(true)` from a rapid click could land in the\nsame commit as the pending \"exit\" signal, and the effect would then\nclear it, silently undoing the click. Replaced with a `pendingClose`\nstate variable and a dependency scoped effect so the clear only runs\nwhen `pendingClose` actually changes.\n\n2. The spec clicked the whole waterfall preview area, which overlaps\nwith the service badge `<a>` links rendered along the left of each row.\nA click that landed on a badge would navigate to APM and the full-screen\nflyout never opened. Added a `clickWaterfallPreview()` page-object\nhelper that clicks at the right edge of the container, safely away from\nthe badges.\n\n### Testing locally \n\n1. Open Discover, switch to a traces data source (e.g. traces-apm*) and\nenter the Traces experience.\n2. Click any row → document viewer flyout opens on the Overview tab.\n3. Waterfall-area click path: click the waterfall preview area (away\nfrom the service badges on the left, e.g. on a span bar on the right) →\nfull-screen waterfall flyout opens.\n4. Click the back button (top-left chevron) → return to the overview.\n4.1. Repeat step 3–4 rapidly, 5+ times in a row. The flyout should open\nand stay open every time.\n5. Full-screen button path\n5.1. Click the Expand trace timeline button in the Trace summary section\nheader → flyout opens\n5.2. Click back → returns cleanly.\n6. Tab switch preserves state\n6.1. Open the full-screen waterfall, open a span flyout inside it.\n6.2. Switch Discover tabs and backThe full-screen waterfall and the\nactive span flyout should restore to the same state.\n7. Back button clears state\n7.1. Open the full-screen waterfall, open a span flyout inside it\n7.2. Press back all the way out.\n7.3. Reopen the full-screen waterfall, it should open fresh with no\nleftover active span flyout.","sha":"6721a93cec302c039b99986a5aa00e5add882578","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Feature:Traces in Discover","Team:obs-exploration","v9.5.0"],"title":"[Discover][Traces] Fix flaky \"fullscreen\" waterfall flyout E2E test","number":264999,"url":"https://github.com/elastic/kibana/pull/264999","mergeCommit":{"message":"[Discover][Traces] Fix flaky \"fullscreen\" waterfall flyout E2E test (#264999)\n\n## Summary\n\nCloses #261265\n\nTwo issues were causing flakiness in the E2E Scout test:\n\n1. In `trace_waterfall`, the deferred EUI flyout `onClose('navigation')`\nhandling used a `pendingCloseRef` + `forceRender` pattern with a depless\n`useEffect`. (TIL) Under React 18 batching, a\n`setShowFullScreenWaterfall(true)` from a rapid click could land in the\nsame commit as the pending \"exit\" signal, and the effect would then\nclear it, silently undoing the click. Replaced with a `pendingClose`\nstate variable and a dependency scoped effect so the clear only runs\nwhen `pendingClose` actually changes.\n\n2. The spec clicked the whole waterfall preview area, which overlaps\nwith the service badge `<a>` links rendered along the left of each row.\nA click that landed on a badge would navigate to APM and the full-screen\nflyout never opened. Added a `clickWaterfallPreview()` page-object\nhelper that clicks at the right edge of the container, safely away from\nthe badges.\n\n### Testing locally \n\n1. Open Discover, switch to a traces data source (e.g. traces-apm*) and\nenter the Traces experience.\n2. Click any row → document viewer flyout opens on the Overview tab.\n3. Waterfall-area click path: click the waterfall preview area (away\nfrom the service badges on the left, e.g. on a span bar on the right) →\nfull-screen waterfall flyout opens.\n4. Click the back button (top-left chevron) → return to the overview.\n4.1. Repeat step 3–4 rapidly, 5+ times in a row. The flyout should open\nand stay open every time.\n5. Full-screen button path\n5.1. Click the Expand trace timeline button in the Trace summary section\nheader → flyout opens\n5.2. Click back → returns cleanly.\n6. Tab switch preserves state\n6.1. Open the full-screen waterfall, open a span flyout inside it.\n6.2. Switch Discover tabs and backThe full-screen waterfall and the\nactive span flyout should restore to the same state.\n7. Back button clears state\n7.1. Open the full-screen waterfall, open a span flyout inside it\n7.2. Press back all the way out.\n7.3. Reopen the full-screen waterfall, it should open fresh with no\nleftover active span flyout.","sha":"6721a93cec302c039b99986a5aa00e5add882578"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264999","number":264999,"mergeCommit":{"message":"[Discover][Traces] Fix flaky \"fullscreen\" waterfall flyout E2E test (#264999)\n\n## Summary\n\nCloses #261265\n\nTwo issues were causing flakiness in the E2E Scout test:\n\n1. In `trace_waterfall`, the deferred EUI flyout `onClose('navigation')`\nhandling used a `pendingCloseRef` + `forceRender` pattern with a depless\n`useEffect`. (TIL) Under React 18 batching, a\n`setShowFullScreenWaterfall(true)` from a rapid click could land in the\nsame commit as the pending \"exit\" signal, and the effect would then\nclear it, silently undoing the click. Replaced with a `pendingClose`\nstate variable and a dependency scoped effect so the clear only runs\nwhen `pendingClose` actually changes.\n\n2. The spec clicked the whole waterfall preview area, which overlaps\nwith the service badge `<a>` links rendered along the left of each row.\nA click that landed on a badge would navigate to APM and the full-screen\nflyout never opened. Added a `clickWaterfallPreview()` page-object\nhelper that clicks at the right edge of the container, safely away from\nthe badges.\n\n### Testing locally \n\n1. Open Discover, switch to a traces data source (e.g. traces-apm*) and\nenter the Traces experience.\n2. Click any row → document viewer flyout opens on the Overview tab.\n3. Waterfall-area click path: click the waterfall preview area (away\nfrom the service badges on the left, e.g. on a span bar on the right) →\nfull-screen waterfall flyout opens.\n4. Click the back button (top-left chevron) → return to the overview.\n4.1. Repeat step 3–4 rapidly, 5+ times in a row. The flyout should open\nand stay open every time.\n5. Full-screen button path\n5.1. Click the Expand trace timeline button in the Trace summary section\nheader → flyout opens\n5.2. Click back → returns cleanly.\n6. Tab switch preserves state\n6.1. Open the full-screen waterfall, open a span flyout inside it.\n6.2. Switch Discover tabs and backThe full-screen waterfall and the\nactive span flyout should restore to the same state.\n7. Back button clears state\n7.1. Open the full-screen waterfall, open a span flyout inside it\n7.2. Press back all the way out.\n7.3. Reopen the full-screen waterfall, it should open fresh with no\nleftover active span flyout.","sha":"6721a93cec302c039b99986a5aa00e5add882578"}}]}] BACKPORT-->