### PR TITLE
[9.3] [Fleet] Validate target package when updating a package policy under a limited package scope (#282403)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
@@ -399,6 +399,47 @@ describe('When calling package policy', () => {
       });
     });
 
+    describe('when the caller is limited to a set of packages', () => {
+      it('should reject an update that retargets the policy to a package outside the caller scope', async () => {
+        (await context.fleet).limitedToPackages = ['endpoint'];
+        const request = getUpdateKibanaRequest({
+          package: { name: 'osquery_manager', title: 'Osquery Manager', version: '1.6.0' },
+        } as any);
+
+        await routeHandler(context, request, response);
+
+        expect(response.forbidden).toHaveBeenCalledWith({
+          body: { message: `Update for package name osquery_manager is not authorized.` },
+        });
+        expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should reject an update when the existing package is outside the caller scope', async () => {
+        (await context.fleet).limitedToPackages = ['osquery_manager'];
+        const request = getUpdateKibanaRequest({
+          package: { name: 'osquery_manager', title: 'Osquery Manager', version: '1.6.0' },
+        } as any);
+
+        await routeHandler(context, request, response);
+
+        expect(response.forbidden).toHaveBeenCalledWith({
+          body: { message: `Update for package name endpoint is not authorized.` },
+        });
+        expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should allow an update that keeps the policy within the caller scope', async () => {
+        (await context.fleet).limitedToPackages = ['endpoint'];
+        const request = getUpdateKibanaRequest({
+          package: { name: 'endpoint', title: 'Elastic Endpoint', version: '0.6.0' },
+        } as any);
+
+        await routeHandler(context, request, response);
+
+        expect(response.forbidden).not.toHaveBeenCalled();
+        expect(packagePolicyServiceMock.update).toHaveBeenCalled();
+      });
+    });
     it('should throw if policy_ids changed on agentless integration', async () => {
       (agentPolicyService.get as jest.Mock).mockResolvedValue({
         supports_agentless: true,

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -376,11 +376,17 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
   }
 
   if (limitedToPackages && limitedToPackages.length) {
-    const packageName = packagePolicy?.package?.name;
-    if (packageName && !limitedToPackages.includes(packageName)) {
-      return response.forbidden({
-        body: { message: `Update for package name ${packageName} is not authorized.` },
-      });
+    // Enforce the package scope against both the existing package policy and the
+    // package supplied in the update body. Checking only the saved package would
+    // allow a scoped caller to retarget the policy to a package outside its scope.
+    const existingPackageName = packagePolicy?.package?.name;
+    const requestedPackageName = request.body.package?.name;
+    for (const packageName of [existingPackageName, requestedPackageName]) {
+      if (packageName && !limitedToPackages.includes(packageName)) {
+        return response.forbidden({
+          body: { message: `Update for package name ${packageName} is not authorized.` },
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Backport of #282403 to `9.3`.

## Summary

When a caller is restricted to a set of packages (a package-scoped API caller), the package policy update endpoint (`PUT /api/fleet/package_policies/{id}`) only validated the existing policy's package against the allowed set. A scoped caller could therefore move a policy to a package outside its allowed set by supplying a different `package` in the update body. This validates the package supplied in the update body against the caller's allowed set in addition to the existing package.

Conflict resolution: the new unit tests were placed within the update-handler `describe` block; the adjacent `var_group_selections` test they sit next to on newer lines does not exist on `9.3`. The fix itself is unchanged.
