### PR TITLE
[9.3] [Fleet] Correct additional_datastreams_permissions validation regex grouping (#282404)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
@@ -1161,6 +1161,85 @@ describe('Fleet - validateConditionalRequiredVars()', () => {
   });
 });
 
+describe('Fleet - validatePackagePolicy() additional_datastreams_permissions', () => {
+  const minimalPackage = {
+    name: 'mock-package',
+    title: 'Mock package',
+    version: '0.0.0',
+    description: 'description',
+    type: 'mock',
+    categories: [],
+    requirement: { kibana: { versions: '' }, elasticsearch: { versions: '' } },
+    format_version: '',
+    download: '',
+    path: '',
+    assets: {
+      kibana: { dashboard: [], visualization: [], search: [], 'index-pattern': [] },
+    },
+    status: installationStatuses.NotInstalled,
+    data_streams: [],
+    policy_templates: [],
+  } as unknown as PackageInfo;
+
+  const buildPolicy = (permissions: string[]): NewPackagePolicy =>
+    ({
+      name: 'pkgPolicy-perms',
+      namespace: 'default',
+      enabled: true,
+      policy_id: 'test',
+      policy_ids: ['test'],
+      package: { name: 'mock-package', title: 'Mock package', version: '0.0.0' },
+      inputs: [],
+      additional_datastreams_permissions: permissions,
+    } as unknown as NewPackagePolicy);
+
+  const errorsFor = (permissions: string[]) =>
+    validatePackagePolicy(buildPolicy(permissions), minimalPackage, parse)
+      .additional_datastreams_permissions;
+
+  // Values that must be accepted: a datastream-type prefix (logs/metrics/traces/synthetics/
+  // profiling) followed by "-" and a non-empty suffix (wildcards in the suffix are allowed).
+  const LEGITIMATE = [
+    'logs-myapp',
+    'metrics-foo-default',
+    'traces-apm-default',
+    'synthetics-http-default',
+    'profiling-events-all',
+    'logs-nginx.access-*',
+    'metrics-system.cpu-*',
+  ];
+
+  // Values that must be rejected: leading wildcards, substring matches, dot-prefixed system
+  // indices, and bare prefixes with no suffix. The mis-grouped alternation accepted every one.
+  const REJECTED = [
+    '*metrics*',
+    'logs*',
+    '.metrics-endpoint.metadata_united_default',
+    '.kibana_alerting_cases*metrics*',
+    'xxxsyntheticsxxx',
+    'anything-with-metrics-in-the-middle',
+    '*',
+    '.*',
+    'logs-',
+    'metrics-',
+  ];
+
+  it.each(LEGITIMATE)('accepts legitimate datastream permission %p', (value) => {
+    expect(errorsFor([value])).toBeNull();
+  });
+
+  it.each(REJECTED)('rejects out-of-scope datastream permission %p', (value) => {
+    const errors = errorsFor([value]);
+    expect(errors).not.toBeNull();
+    expect(errors).toHaveLength(1);
+  });
+
+  it('reports every invalid value when a mix is supplied', () => {
+    const errors = errorsFor(['logs-myapp', '*metrics*', 'xxxsyntheticsxxx']);
+    expect(errors).toHaveLength(2);
+  });
+});
+
 describe('Fleet - validationHasErrors()', () => {
   it('returns true for stream validation results with errors', () => {
     expect(

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
@@ -196,8 +196,7 @@ const validatePackageRequiredVars = (
   return hasMetRequiredCriteria ? null : evaluatedRequiredVars;
 };
 
-const VALIDATE_DATASTREAMS_PERMISSION_REGEX =
-  /^(logs)|(metrics)|(traces)|(synthetics)|(profiling)-(.*)$/;
+const VALIDATE_DATASTREAMS_PERMISSION_REGEX = /^(logs|metrics|traces|synthetics|profiling)-(.+)$/;
 
 /*
  * Returns validation information for a given package policy and package info

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/package_policy_schema.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/package_policy_schema.ts
@@ -349,8 +349,7 @@ export const SimplifiedPackagePolicyInputsSchema = schema.maybe(
   )
 );
 
-const VALIDATE_DATASTREAMS_PERMISSION_REGEX =
-  /^(logs)|(metrics)|(traces)|(synthetics)|(profiling)-(.*)$/;
+const VALIDATE_DATASTREAMS_PERMISSION_REGEX = /^(logs|metrics|traces|synthetics|profiling)-(.+)$/;
 
 function validateAdditionalDatastreamsPermissions(values: string[]) {
   for (const val of values) {


### PR DESCRIPTION
Backport of #282404 to `9.3`.

## Summary

The `additional_datastreams_permissions` validation regex groups its alternation outside the `^…$` anchors, so it does not enforce the intended `<type>-<suffix>` datastream prefix grammar. This corrects the grouping in both copies (`validate_package_policy.ts` and `package_policy_schema.ts`) and adds table-driven unit tests.

Conflict resolution: on `9.3` the datastream type token is `profiling` (not `profiles` as on newer lines), so both regex copies and the corresponding test value use `profiling`. The `var_group` helper code present around the regex on newer lines does not exist on `9.3` and was not brought back.

## Release note

Fleet now validates the package policy `additional_datastreams_permissions` field against the documented `<type>-<suffix>` datastream grammar (e.g. `logs-nginx-*`). Values that don't match — for example a dashless or leading wildcard such as `logs*` — are now rejected; update any such values to the `<type>-<suffix>` form.
