### PR TITLE
[9.4] Use realm-qualified id as ownership fallback instead of username alone (#280890)

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/access_control.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/access_control.test.ts
@@ -38,10 +38,16 @@ describe('isAgentOwner', () => {
     expect(isAgentOwner({ owner, currentUser })).toBe(true);
   });
 
-  test('returns true when usernames match (id not used)', () => {
+  test('falls back to username for legacy owners that never stored an id', () => {
     const ownerByUsername: UserIdAndName = { username: 'alice' };
     const userByUsername: UserIdAndName = { username: 'alice' };
     expect(isAgentOwner({ owner: ownerByUsername, currentUser: userByUsername })).toBe(true);
+    expect(
+      isAgentOwner({
+        owner: { username: 'alice' },
+        currentUser: { id: 'realm:["file","file1","alice"]', username: 'alice' },
+      })
+    ).toBe(true);
   });
 
   test('returns false when ids differ and usernames differ', () => {
@@ -53,12 +59,18 @@ describe('isAgentOwner', () => {
     expect(isAgentOwner({ owner, currentUser: sameIdUser })).toBe(true);
   });
 
-  test('returns false when both ids are defined but differ (no username fallback)', () => {
+  test('does not fall back to username when the agent document stored an id', () => {
     const ownerWithId: UserIdAndName = { id: 'owner-id', username: 'alice' };
     const userSameUsernameDifferentId: UserIdAndName = { id: 'other-id', username: 'alice' };
     expect(isAgentOwner({ owner: ownerWithId, currentUser: userSameUsernameDifferentId })).toBe(
       false
     );
+    expect(
+      isAgentOwner({
+        owner: { id: 'owner-id', username: 'alice' },
+        currentUser: { username: 'alice' },
+      })
+    ).toBe(false);
   });
 
   test('returns false when owner has username only and current user has different username', () => {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/access_control.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/access_control.ts
@@ -10,6 +10,14 @@ import type { AgentDefinition } from './definition';
 import { agentBuilderDefaultAgentId } from './definition';
 import { AgentVisibility } from './visibility';
 
+/**
+ * Checks whether the current user owns the agent.
+ *
+ * Stable ids are preferred when the agent document stored a `created_by_id` (profile uid or
+ * realm-qualified id). Username matching is kept only for legacy documents that never stored an
+ * id, so those owners are not orphaned after upgrade. That legacy path cannot distinguish
+ * same-username principals across realms.
+ */
 export const isAgentOwner = ({
   owner,
   currentUser,
@@ -23,7 +31,12 @@ export const isAgentOwner = ({
   if (owner.id !== undefined && currentUser.id !== undefined) {
     return owner.id === currentUser.id;
   }
-  if (owner.username !== undefined && currentUser.username !== undefined) {
+  // Legacy docs without created_by_id: fall back to username so the original owner keeps access.
+  if (
+    owner.id === undefined &&
+    owner.username !== undefined &&
+    currentUser.username !== undefined
+  ) {
     return owner.username === currentUser.username;
   }
   return false;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.ts
@@ -314,16 +314,17 @@ class AgentClientImpl implements AgentClient {
       await this.validateAgentToolSelection(profileUpdate.configuration.tools);
     }
 
-    const updatedConversation = updateRequestToEs({
+    const updatedAgent = updateRequestToEs({
       agentId,
       currentProps: document._source,
       update: profileUpdate,
       updateDate: new Date(),
+      user: this.user,
     });
 
     await this.storage.getClient().index({
       id: document._id,
-      document: updatedConversation,
+      document: updatedAgent,
     });
 
     return this.get(agentId);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.test.ts
@@ -414,4 +414,57 @@ describe('updateRequestToEs', () => {
     expect(docProperties.config!.enable_elastic_capabilities).toBe(true);
     expect(docProperties.config!.instructions).toBe('instructions');
   });
+
+  it('backfills created_by_id when the owner updates a legacy agent that only stored created_by_name', () => {
+    const agentProps: AgentProperties = {
+      id: 'id',
+      type: AgentType.chat,
+      name: 'name',
+      description: 'description',
+      space: 'space',
+      config: { tools: [] },
+      labels: [],
+      visibility: AgentVisibility.Private,
+      created_by_name: 'legacy-owner',
+      created_at: creationDate,
+      updated_at: updateDate,
+    };
+
+    const docProperties = updateRequestToEs({
+      agentId: 'id',
+      currentProps: agentProps,
+      update: { name: 'renamed' },
+      updateDate: new Date(),
+      user: { id: 'profile-or-realm-id', username: 'legacy-owner' },
+    });
+
+    expect(docProperties.created_by_id).toBe('profile-or-realm-id');
+    expect(docProperties.created_by_name).toBe('legacy-owner');
+  });
+
+  it('does not backfill created_by_id for a non-owner updater', () => {
+    const agentProps: AgentProperties = {
+      id: 'id',
+      type: AgentType.chat,
+      name: 'name',
+      description: 'description',
+      space: 'space',
+      config: { tools: [] },
+      labels: [],
+      visibility: AgentVisibility.Public,
+      created_by_name: 'legacy-owner',
+      created_at: creationDate,
+      updated_at: updateDate,
+    };
+
+    const docProperties = updateRequestToEs({
+      agentId: 'id',
+      currentProps: agentProps,
+      update: { name: 'renamed' },
+      updateDate: new Date(),
+      user: { id: 'editor-id', username: 'someone-else' },
+    });
+
+    expect(docProperties.created_by_id).toBeUndefined();
+  });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
@@ -6,7 +6,12 @@
  */
 
 import type { GetResponse } from '@elastic/elasticsearch/lib/api/types';
-import { agentBuilderDefaultAgentId, AgentType, AgentVisibility } from '@kbn/agent-builder-common';
+import {
+  agentBuilderDefaultAgentId,
+  AgentType,
+  AgentVisibility,
+  isAgentOwner,
+} from '@kbn/agent-builder-common';
 import type { UserIdAndName } from '@kbn/agent-builder-common';
 import type { AgentCreateRequest, AgentUpdateRequest } from '../../../../../common/agents';
 import type { AgentConfigurationProperties, AgentProperties } from './storage';
@@ -97,11 +102,13 @@ export const updateRequestToEs = ({
   currentProps,
   update,
   updateDate,
+  user,
 }: {
   agentId: string;
   currentProps: AgentProperties;
   update: AgentUpdateRequest;
   updateDate: Date;
+  user?: UserIdAndName;
 }): AgentProperties => {
   const currentConfig = currentProps.configuration ?? currentProps.config;
   const { configuration, ...restUpdate } = update;
@@ -118,6 +125,18 @@ export const updateRequestToEs = ({
     },
     updated_at: updateDate.toISOString(),
   };
+
+  if (
+    currentProps.created_by_id === undefined &&
+    currentProps.created_by_name !== undefined &&
+    user?.id &&
+    isAgentOwner({
+      owner: { username: currentProps.created_by_name },
+      currentUser: user,
+    })
+  ) {
+    updated.created_by_id = user.id;
+  }
 
   return updated;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/utils/access_control.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/utils/access_control.test.ts
@@ -36,13 +36,29 @@ describe('hasReadAccess', () => {
   });
 
   it('returns true for owner regardless of visibility', () => {
-    const source = { ...baseSource, visibility: AgentVisibility.Private, created_by_name: 'owner' };
+    const source = {
+      ...baseSource,
+      visibility: AgentVisibility.Private,
+      created_by_id: ownerUser.id,
+      created_by_name: 'owner',
+    };
     expect(hasReadAccess({ source, user: ownerUser, isAdmin: false })).toBe(true);
   });
 
-  it('returns true for owner by username only', () => {
+  it('returns true for legacy owners that only stored created_by_name', () => {
     const source = { ...baseSource, visibility: AgentVisibility.Private, created_by_name: 'owner' };
     expect(hasReadAccess({ source, user: ownerByUsernameOnly, isAdmin: false })).toBe(true);
+    expect(hasReadAccess({ source, user: ownerUser, isAdmin: false })).toBe(true);
+  });
+
+  it('returns false for same username when the document stored a different created_by_id', () => {
+    const source = {
+      ...baseSource,
+      visibility: AgentVisibility.Private,
+      created_by_id: 'other-realm-id',
+      created_by_name: 'owner',
+    };
+    expect(hasReadAccess({ source, user: ownerUser, isAdmin: false })).toBe(false);
   });
 
   it('returns true for non-owner when visibility is undefined (legacy agent treated as public)', () => {
@@ -76,7 +92,12 @@ describe('hasWriteAccess', () => {
   });
 
   it('returns true for owner regardless of visibility', () => {
-    const source = { ...baseSource, visibility: AgentVisibility.Private, created_by_name: 'owner' };
+    const source = {
+      ...baseSource,
+      visibility: AgentVisibility.Private,
+      created_by_id: ownerUser.id,
+      created_by_name: 'owner',
+    };
     expect(hasWriteAccess({ source, user: ownerUser, isAdmin: false })).toBe(true);
   });
 
@@ -105,26 +126,36 @@ describe('hasWriteAccess', () => {
 });
 
 describe('buildVisibilityReadFilter', () => {
-  it('includes owner username clause and must_not private visibility', () => {
+  it('includes owner id clause, legacy username ownership, and must_not private visibility', () => {
     const filter = buildVisibilityReadFilter({ user: ownerUser });
     expect(filter).toEqual({
       bool: {
         should: [
           { bool: { must_not: { term: { visibility: AgentVisibility.Private } } } },
-          { term: { created_by_name: 'owner' } },
           { term: { created_by_id: 'user-1' } },
+          {
+            bool: {
+              must_not: { exists: { field: 'created_by_id' } },
+              filter: { term: { created_by_name: 'owner' } },
+            },
+          },
         ],
         minimum_should_match: 1,
       },
     });
   });
 
-  it('omits created_by_id clause when user.id is undefined', () => {
+  it('omits created_by_id clause when user.id is undefined but still adds legacy username clause', () => {
     const filter = buildVisibilityReadFilter({ user: ownerByUsernameOnly });
     expect(filter.bool.should).toHaveLength(2);
     expect(filter.bool.should).toEqual([
       { bool: { must_not: { term: { visibility: AgentVisibility.Private } } } },
-      { term: { created_by_name: 'owner' } },
+      {
+        bool: {
+          must_not: { exists: { field: 'created_by_id' } },
+          filter: { term: { created_by_name: 'owner' } },
+        },
+      },
     ]);
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/utils/access_control.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/utils/access_control.ts
@@ -63,10 +63,18 @@ export const buildVisibilityReadFilter = ({ user }: { user: UserIdAndName }) => 
     },
   ];
 
-  shouldClauses.push({ term: { created_by_name: user.username } });
   if (user.id !== undefined) {
     shouldClauses.push({ term: { created_by_id: user.id } });
   }
+
+  // Legacy ownership: username match only when created_by_id was never stored, so owners of those
+  // docs keep list access without reopening cross-realm collisions for id-backed documents.
+  shouldClauses.push({
+    bool: {
+      must_not: { exists: { field: 'created_by_id' } },
+      filter: { term: { created_by_name: user.username } },
+    },
+  });
 
   return {
     bool: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.test.ts
@@ -10,8 +10,14 @@ import {
   securityServiceMock,
   elasticsearchServiceMock,
 } from '@kbn/core/server/mocks';
+import { errors } from '@elastic/elasticsearch';
 import { APPLICATION_PREFIX } from '@kbn/security-plugin/common/constants';
-import { isAdminFromRequest, getAgentApiAccessFromRequest, getUserFromRequest } from './utils';
+import {
+  isAdminFromRequest,
+  getAgentApiAccessFromRequest,
+  getUserFromRequest,
+  toStableUserId,
+} from './utils';
 import { apiPrivileges } from '../../common/features';
 
 const EXPECTED_ADMIN_HAS_PRIVILEGES_REQUEST = {
@@ -23,6 +29,99 @@ const EXPECTED_ADMIN_HAS_PRIVILEGES_REQUEST = {
     },
   ],
 };
+
+describe('toStableUserId', () => {
+  it('prefers profile uid when present', async () => {
+    await expect(
+      toStableUserId({
+        authUser: {
+          username: 'shareduser',
+          profile_uid: 'profile-123',
+          authentication_type: 'realm',
+          authentication_realm: { type: 'file', name: 'file1' },
+        },
+      })
+    ).resolves.toBe('profile-123');
+  });
+
+  it('falls back to a realm-qualified id when profile uid is missing', async () => {
+    await expect(
+      toStableUserId({
+        authUser: {
+          username: 'shareduser',
+          authentication_type: 'realm',
+          authentication_realm: { type: 'file', name: 'file1' },
+        },
+      })
+    ).resolves.toBe('realm:["file","file1","shareduser"]');
+    await expect(
+      toStableUserId({
+        authUser: {
+          username: 'shareduser',
+          authentication_type: 'realm',
+          authentication_realm: { type: 'native', name: 'native1' },
+        },
+      })
+    ).resolves.toBe('realm:["native","native1","shareduser"]');
+  });
+
+  it('returns undefined when neither profile uid nor realm identity is available', async () => {
+    await expect(
+      toStableUserId({
+        authUser: { username: 'shareduser', authentication_type: 'realm' },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves API key creator profile uid via the injected callback', async () => {
+    const resolveApiKeyProfileUid = jest.fn().mockResolvedValue('profile-from-api-key');
+
+    await expect(
+      toStableUserId({
+        authUser: {
+          username: 'shareduser',
+          authentication_type: 'api_key',
+          authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+        },
+        resolveApiKeyProfileUid,
+      })
+    ).resolves.toBe('profile-from-api-key');
+    expect(resolveApiKeyProfileUid).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not use the _es_api_key realm when no profile uid is available', async () => {
+    const resolveApiKeyProfileUid = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      toStableUserId({
+        authUser: {
+          username: 'shareduser',
+          authentication_type: 'api_key',
+          authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+        },
+        resolveApiKeyProfileUid,
+      })
+    ).resolves.toBeUndefined();
+    expect(resolveApiKeyProfileUid).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call resolveApiKeyProfileUid when profile uid is already present', async () => {
+    const resolveApiKeyProfileUid = jest.fn();
+
+    await expect(
+      toStableUserId({
+        authUser: {
+          username: 'shareduser',
+          profile_uid: 'profile-123',
+          authentication_type: 'api_key',
+          authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+        },
+        resolveApiKeyProfileUid,
+      })
+    ).resolves.toBe('profile-123');
+    expect(resolveApiKeyProfileUid).not.toHaveBeenCalled();
+  });
+});
 
 describe('getUserFromRequest', () => {
   let security: ReturnType<typeof securityServiceMock.createStart>;
@@ -48,24 +147,194 @@ describe('getUserFromRequest', () => {
     expect(esClient.security.authenticate).not.toHaveBeenCalled();
   });
 
-  it('falls back to ES authenticate API when getCurrentUser returns null for a real request', async () => {
+  it('uses a realm-qualified id when profile uid is missing for realm auth', async () => {
+    const request = httpServerMock.createKibanaRequest();
+
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'shareduser',
+      authentication_type: 'realm',
+      authentication_realm: { type: 'file', name: 'file1' },
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({
+      id: 'realm:["file","file1","shareduser"]',
+      username: 'shareduser',
+    });
+  });
+
+  it('resolves the API key creator profile uid when getCurrentUser omits it', async () => {
+    const apiKeyId = 'api-key-id';
+    const request = httpServerMock.createKibanaRequest({
+      headers: {
+        authorization: `ApiKey ${Buffer.from(`${apiKeyId}:secret`).toString('base64')}`,
+      },
+    });
+
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'shareduser',
+      authentication_type: 'api_key',
+      authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+    } as any);
+    esClient.security.getApiKey.mockResolvedValue({
+      api_keys: [{ id: apiKeyId, profile_uid: 'profile-from-api-key' }],
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({
+      id: 'profile-from-api-key',
+      username: 'shareduser',
+    });
+    expect(esClient.security.getApiKey).toHaveBeenCalledWith({
+      with_profile_uid: true,
+      id: apiKeyId,
+    });
+  });
+
+  it('falls back to username-only for api_key auth when creator profile uid is unavailable', async () => {
+    const apiKeyId = 'api-key-id';
+    const request = httpServerMock.createKibanaRequest({
+      headers: {
+        authorization: `ApiKey ${Buffer.from(`${apiKeyId}:secret`).toString('base64')}`,
+      },
+    });
+
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'shareduser',
+      authentication_type: 'api_key',
+      authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+    } as any);
+    esClient.security.getApiKey.mockResolvedValue({
+      api_keys: [{ id: apiKeyId }],
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({
+      username: 'shareduser',
+    });
+    expect(esClient.security.getApiKey).toHaveBeenCalledWith({
+      with_profile_uid: true,
+      id: apiKeyId,
+    });
+  });
+
+  it('treats a 403 from API key profile lookup as profile not resolvable', async () => {
+    const apiKeyId = 'api-key-id';
+    const request = httpServerMock.createKibanaRequest({
+      headers: {
+        authorization: `ApiKey ${Buffer.from(`${apiKeyId}:secret`).toString('base64')}`,
+      },
+    });
+
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'shareduser',
+      authentication_type: 'api_key',
+      authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+    } as any);
+    esClient.security.getApiKey.mockRejectedValue(
+      new errors.ResponseError({
+        statusCode: 403,
+        body: { error: { type: 'security_exception' }, status: 403 },
+        headers: {},
+        warnings: [],
+        meta: {} as never,
+      })
+    );
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({
+      username: 'shareduser',
+    });
+  });
+
+  it('propagates non-403 API key profile lookup failures', async () => {
+    const apiKeyId = 'api-key-id';
+    const request = httpServerMock.createKibanaRequest({
+      headers: {
+        authorization: `ApiKey ${Buffer.from(`${apiKeyId}:secret`).toString('base64')}`,
+      },
+    });
+
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'shareduser',
+      authentication_type: 'api_key',
+      authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+    } as any);
+    esClient.security.getApiKey.mockRejectedValue(
+      new errors.ResponseError({
+        statusCode: 500,
+        body: { error: { type: 'server_error' }, status: 500 },
+        headers: {},
+        warnings: [],
+        meta: {} as never,
+      })
+    );
+
+    await expect(getUserFromRequest({ request, security, esClient })).rejects.toThrow();
+  });
+
+  it('prefers profile uid on the authenticated user for api_key auth without looking up the key', async () => {
+    const request = httpServerMock.createKibanaRequest();
+
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'shareduser',
+      profile_uid: 'profile-123',
+      authentication_type: 'api_key',
+      authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({
+      id: 'profile-123',
+      username: 'shareduser',
+    });
+    expect(esClient.security.getApiKey).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ES authenticate for username without synthesizing a realm id', async () => {
     const request = httpServerMock.createKibanaRequest();
 
     security.authc.getCurrentUser.mockReturnValue(null);
     esClient.security.authenticate.mockResolvedValue({
       username: 'api-key-user',
+      authentication_realm: { type: 'native', name: 'native1' },
     } as any);
 
     const result = await getUserFromRequest({ request, security, esClient });
 
-    expect(result).toEqual({ username: 'api-key-user' });
+    // Leaving id undefined preserves username ownership fallback for un-enriched paths;
+    // a realm id from authenticate would mismatch profile_uid-backed agents.
+    expect(result).toEqual({
+      username: 'api-key-user',
+    });
     expect(security.authc.getCurrentUser).toHaveBeenCalledWith(request);
     expect(esClient.security.authenticate).toHaveBeenCalledTimes(1);
   });
 
-  it('skips getCurrentUser and falls back to ES authenticate API for fake requests', async () => {
+  it('returns the enriched identity for a fake request without calling ES authenticate', async () => {
     const request = httpServerMock.createFakeKibanaRequest({});
 
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'originating-user',
+      profile_uid: 'profile-123',
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({ id: 'profile-123', username: 'originating-user' });
+    expect(security.authc.getCurrentUser).toHaveBeenCalledWith(request);
+    expect(esClient.security.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ES authenticate API for un-enriched fake requests', async () => {
+    const request = httpServerMock.createFakeKibanaRequest({});
+
+    security.authc.getCurrentUser.mockReturnValue(null);
     esClient.security.authenticate.mockResolvedValue({
       username: 'task-manager-user',
     } as any);
@@ -73,21 +342,23 @@ describe('getUserFromRequest', () => {
     const result = await getUserFromRequest({ request, security, esClient });
 
     expect(result).toEqual({ username: 'task-manager-user' });
-    expect(security.authc.getCurrentUser).not.toHaveBeenCalled();
+    expect(security.authc.getCurrentUser).toHaveBeenCalledWith(request);
     expect(esClient.security.authenticate).toHaveBeenCalledTimes(1);
   });
 
-  it('does not include id in the result when falling back to ES authenticate', async () => {
+  it('includes the id from getCurrentUser when falling back to ES authenticate for the username', async () => {
     const request = httpServerMock.createFakeKibanaRequest({});
 
+    // getCurrentUser resolves a profile_uid but no username, so we still fall back to ES for the username
+    security.authc.getCurrentUser.mockReturnValue({ profile_uid: 'profile-456' } as any);
     esClient.security.authenticate.mockResolvedValue({
       username: 'some-user',
     } as any);
 
     const result = await getUserFromRequest({ request, security, esClient });
 
-    expect(result).not.toHaveProperty('id');
-    expect(result.username).toBe('some-user');
+    expect(result).toEqual({ id: 'profile-456', username: 'some-user' });
+    expect(esClient.security.authenticate).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
@@ -7,22 +7,114 @@
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { SecurityServiceStart } from '@kbn/core-security-server';
+import {
+  extractApiKeyIdFromAuthzHeader,
+  type SecurityServiceStart,
+} from '@kbn/core-security-server';
 import type { UserIdAndName } from '@kbn/agent-builder-common';
+import { errors } from '@elastic/elasticsearch';
 import { APPLICATION_PREFIX } from '@kbn/security-plugin/common/constants';
 import { apiPrivileges } from '../../common/features';
 
 const KIBANA_APPLICATION = `${APPLICATION_PREFIX}.kibana`;
 
+interface StableUserIdAuthUser {
+  username?: string;
+  profile_uid?: string;
+  authentication_type?: string;
+  authentication_realm?: { type?: string; name?: string };
+}
+
+/**
+ * Builds a stable principal id for Agent Builder ownership checks.
+ *
+ * Usernames alone are not unique across Elasticsearch authentication realms
+ * (e.g. file vs native). Prefer the Kibana user profile uid when present;
+ * otherwise encode realm type/name with the username so same-username
+ * principals in different realms remain distinct.
+ *
+ * The `realm:` prefix keeps synthetic ids distinguishable from profile uids.
+ */
+export const toStableUserId = async ({
+  authUser,
+  resolveApiKeyProfileUid,
+}: {
+  authUser: StableUserIdAuthUser;
+  resolveApiKeyProfileUid?: () => Promise<string | undefined>;
+}): Promise<string | undefined> => {
+  const isApiKey = authUser.authentication_type === 'api_key';
+  let profileUid = authUser.profile_uid;
+
+  if (isApiKey && profileUid === undefined && resolveApiKeyProfileUid) {
+    profileUid = await resolveApiKeyProfileUid();
+  }
+
+  if (profileUid) {
+    return profileUid;
+  }
+
+  if (isApiKey) {
+    return undefined;
+  }
+
+  const realmType = authUser.authentication_realm?.type;
+  const realmName = authUser.authentication_realm?.name;
+  const { username } = authUser;
+  if (!realmType || !realmName || !username) {
+    return undefined;
+  }
+
+  return `realm:${JSON.stringify([realmType, realmName, username])}`;
+};
+
+/**
+ * Resolves the API key creator's profile uid via Elasticsearch, when available.
+ *
+ * `getUserIdAndName` for API-key auth often omits `profile_uid`. Looking up the key with
+ * `with_profile_uid` recovers the creator's profile so ownership can match interactive
+ * sessions for the same user. Older keys or creators without an activated profile return
+ * undefined and callers fall back to username matching.
+ */
+const resolveApiKeyOwnerProfileUid = async ({
+  request,
+  esClient,
+}: {
+  request: KibanaRequest;
+  esClient: ElasticsearchClient;
+}): Promise<string | undefined> => {
+  const id = extractApiKeyIdFromAuthzHeader(request.headers.authorization);
+  if (!id) {
+    return undefined;
+  }
+
+  try {
+    const response = await esClient.security.getApiKey({
+      with_profile_uid: true,
+      id,
+    });
+
+    return response.api_keys?.[0]?.profile_uid;
+  } catch (error) {
+    if (error instanceof errors.ResponseError && error.statusCode === 403) {
+      return undefined;
+    }
+    throw error;
+  }
+};
+
 /**
  * Resolves the current user from a request.
  *
- * For real HTTP requests, `security.authc.getCurrentUser` returns the authenticated user
- * (including profile_uid and username).
+ * For real HTTP requests, `security.authc.getUserIdAndName` returns the authenticated user
+ * (including profile_uid, username, and authentication_realm).
  *
- * For fake requests (e.g. from Task Manager using an API key), `getCurrentUser` returns null.
- * In that case, we fall back to the ES `_security/_authenticate` API, which works with API keys
- * and returns the username of the API key owner.
+ * For fake requests (e.g. from Task Manager using an API key), `getUserIdAndName` returns the
+ * originating user's identity when the request was enriched at schedule time (profile_uid and
+ * username persisted on the task's userScope). This is required for Cross-Project Search, where
+ * the API key owner's username does not match the originating user.
+ *
+ * For un-enriched fake requests (e.g. tasks scheduled before enrichment was available), we fall
+ * back to the ES `_security/_authenticate` API for the username only.
  */
 export const getUserFromRequest = async ({
   request,
@@ -33,16 +125,22 @@ export const getUserFromRequest = async ({
   security: SecurityServiceStart;
   esClient: ElasticsearchClient;
 }): Promise<UserIdAndName> => {
-  if (!request.isFakeRequest) {
-    const authUser = security.authc.getCurrentUser(request);
-    if (authUser) {
-      return { id: authUser.profile_uid!, username: authUser.username };
-    }
+  const authUser = security.authc.getUserIdAndName(request);
+  if (authUser?.username) {
+    return {
+      id: await toStableUserId({
+        authUser,
+        resolveApiKeyProfileUid: () => resolveApiKeyOwnerProfileUid({ request, esClient }),
+      }),
+      username: authUser.username,
+    };
   }
 
-  // Fallback for fake requests (e.g. Task Manager execution): call ES _security/_authenticate
   const authResponse = await esClient.security.authenticate();
-  return { username: authResponse.username };
+  return {
+    id: authUser?.profile_uid,
+    username: authResponse.username,
+  };
 };
 
 const ADMIN_PRIVILEGE = 'agent_builder:admin'; // intentionally unregistered privilege
@@ -84,7 +182,10 @@ export const getAgentApiAccessFromRequest = async ({
 }: {
   esClient: ElasticsearchClient;
   space: string;
-}): Promise<{ canReadAgents: boolean; canManageAgents: boolean }> => {
+}): Promise<{
+  canReadAgents: boolean;
+  canManageAgents: boolean;
+}> => {
   const resource = `space:${space}`;
   const response = await esClient.security.hasPrivileges({
     application: [

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
@@ -70,7 +70,7 @@ export const toStableUserId = async ({
 /**
  * Resolves the API key creator's profile uid via Elasticsearch, when available.
  *
- * `getUserIdAndName` for API-key auth often omits `profile_uid`. Looking up the key with
+ * `getCurrentUser` for API-key auth often omits `profile_uid`. Looking up the key with
  * `with_profile_uid` recovers the creator's profile so ownership can match interactive
  * sessions for the same user. Older keys or creators without an activated profile return
  * undefined and callers fall back to username matching.
@@ -105,10 +105,10 @@ const resolveApiKeyOwnerProfileUid = async ({
 /**
  * Resolves the current user from a request.
  *
- * For real HTTP requests, `security.authc.getUserIdAndName` returns the authenticated user
+ * For real HTTP requests, `security.authc.getCurrentUser` returns the authenticated user
  * (including profile_uid, username, and authentication_realm).
  *
- * For fake requests (e.g. from Task Manager using an API key), `getUserIdAndName` returns the
+ * For fake requests (e.g. from Task Manager using an API key), `getCurrentUser` returns the
  * originating user's identity when the request was enriched at schedule time (profile_uid and
  * username persisted on the task's userScope). This is required for Cross-Project Search, where
  * the API key owner's username does not match the originating user.
@@ -125,7 +125,7 @@ export const getUserFromRequest = async ({
   security: SecurityServiceStart;
   esClient: ElasticsearchClient;
 }): Promise<UserIdAndName> => {
-  const authUser = security.authc.getUserIdAndName(request);
+  const authUser = security.authc.getCurrentUser(request);
   if (authUser?.username) {
     return {
       id: await toStableUserId({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Use realm-qualified id as ownership fallback instead of username alone (#280890)](https://github.com/elastic/kibana/pull/280890)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Meghan Murphy","email":"meghan.murphy@elastic.co"},"sourceCommit":{"committedDate":"2026-08-04T17:03:55Z","message":"Use realm-qualified id as ownership fallback instead of username alone (#280890)\n\n## Summary\n\nThis PR:\n- If an agent is created with a profile_uid, use that for ownership\n- Otherwise, instead of falling back to username alone, use a realm +\nusername id\n- Keep username-only owner checks for legacy agents that never stored\ncreated_by_id\n- When the owner updates a legacy agent that only has created_by_name,\nbackfill created_by_id\n\n** Noted that if the realm is changed in the config then loss of agent\nownership seems like a reasonable/expected outcome .\n\n** It's a known limitation that if a user creates an agent without a\n`profile uid` and then gets the stable id with realm + username that\nwhen they do create a profile that they may be locked out of their agent\nsince `created_by_id` is now that stable id. However, an admin can just\ngrant the user Editor access to the agent as a workaround.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"cf25ad54798897d1029c2942bbef8e5ce0de3ac9","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.6.0","v9.4.5","v9.5.1"],"title":"Use realm-qualified id as ownership fallback instead of username alone","number":280890,"url":"https://github.com/elastic/kibana/pull/280890","mergeCommit":{"message":"Use realm-qualified id as ownership fallback instead of username alone (#280890)\n\n## Summary\n\nThis PR:\n- If an agent is created with a profile_uid, use that for ownership\n- Otherwise, instead of falling back to username alone, use a realm +\nusername id\n- Keep username-only owner checks for legacy agents that never stored\ncreated_by_id\n- When the owner updates a legacy agent that only has created_by_name,\nbackfill created_by_id\n\n** Noted that if the realm is changed in the config then loss of agent\nownership seems like a reasonable/expected outcome .\n\n** It's a known limitation that if a user creates an agent without a\n`profile uid` and then gets the stable id with realm + username that\nwhen they do create a profile that they may be locked out of their agent\nsince `created_by_id` is now that stable id. However, an admin can just\ngrant the user Editor access to the agent as a workaround.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"cf25ad54798897d1029c2942bbef8e5ce0de3ac9"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282768","number":282768,"state":"MERGED","mergeCommit":{"sha":"15564ab6a628d34596b7a5c52dc4da189b0f4986","message":"[9.5] Use realm-qualified id as ownership fallback instead of username alone (#280890) (#282768)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [Use realm-qualified id as ownership fallback instead of username\nalone (#280890)](https://github.com/elastic/kibana/pull/280890)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Meghan Murphy <meghan.murphy@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280890","number":280890,"mergeCommit":{"message":"Use realm-qualified id as ownership fallback instead of username alone (#280890)\n\n## Summary\n\nThis PR:\n- If an agent is created with a profile_uid, use that for ownership\n- Otherwise, instead of falling back to username alone, use a realm +\nusername id\n- Keep username-only owner checks for legacy agents that never stored\ncreated_by_id\n- When the owner updates a legacy agent that only has created_by_name,\nbackfill created_by_id\n\n** Noted that if the realm is changed in the config then loss of agent\nownership seems like a reasonable/expected outcome .\n\n** It's a known limitation that if a user creates an agent without a\n`profile uid` and then gets the stable id with realm + username that\nwhen they do create a profile that they may be locked out of their agent\nsince `created_by_id` is now that stable id. However, an admin can just\ngrant the user Editor access to the agent as a workaround.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"cf25ad54798897d1029c2942bbef8e5ce0de3ac9"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->