### PR TITLE
[Security Solution] fix openai connector PKI authentication issue

### DIFF
--- a/src/platform/packages/shared/kbn-connector-schemas/openai/schemas/v1.test.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/openai/schemas/v1.test.ts
@@ -104,6 +104,28 @@ describe('OpenAI Schema', () => {
       ).not.toThrow();
     });
 
+    it('does not default verificationMode when omitted for Other provider', () => {
+      const result = ConfigSchema.parse({
+        apiProvider: 'Other',
+        apiUrl: 'https://custom-api.example.com',
+        defaultModel: 'custom-model',
+      });
+      // A PKI-off save must not persist verificationMode, otherwise the UI
+      // re-derives the "Enable PKI Authentication" toggle as ON on reopen.
+      expect(result).not.toHaveProperty('verificationMode');
+      expect((result as { verificationMode?: string }).verificationMode).toBeUndefined();
+    });
+
+    it('preserves an explicitly provided verificationMode for Other provider', () => {
+      const result = ConfigSchema.parse({
+        apiProvider: 'Other',
+        apiUrl: 'https://custom-api.example.com',
+        defaultModel: 'custom-model',
+        verificationMode: 'full',
+      });
+      expect((result as { verificationMode?: string }).verificationMode).toBe('full');
+    });
+
     it('throws on invalid apiProvider', () => {
       expect(() =>
         ConfigSchema.parse({

--- a/src/platform/packages/shared/kbn-connector-schemas/openai/schemas/v1.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/openai/schemas/v1.ts
@@ -50,7 +50,7 @@ export const ConfigSchema = lazySchema(() =>
           apiProvider: z.enum([OpenAiProviderType.Other]),
           apiUrl: z.string(),
           defaultModel: z.string(),
-          verificationMode: z.enum(['full', 'certificate', 'none']).default('full').optional(),
+          verificationMode: z.enum(['full', 'certificate', 'none']).optional(),
           headers: z.record(z.string(), z.string()).optional(),
           contextWindowLength: z.coerce.number().optional(),
           temperature: z.coerce.number().optional(),

--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -1067,7 +1067,6 @@ Object {
           "type": "number",
         },
         "verificationMode": Object {
-          "default": "full",
           "enum": Array [
             "full",
             "certificate",


### PR DESCRIPTION
## Summary

Fixes the "Other" (OpenAI-compatible) connector re-enabling **PKI Authentication** on its own after every save.

When creating/editing an OpenAI connector with `apiProvider: "Other"` and the **Enable PKI Authentication** toggle **off**, the connector still persisted `config.verificationMode: "full"`. Because the UI derives the toggle state from `!!config.verificationMode`, the toggle flipped back **on** on every reopen, and the client cert/key fields then became required — so users without PKI could not cleanly save.

### Root cause

The `verificationMode` field in the "Other" provider config schema was declared as:

```ts
verificationMode: z.enum(['full', 'certificate', 'none']).default('full').optional(),
```

Under **Zod v4** (upgraded in #252702), `.default('full')` is applied even though the field is `.optional()`, so a PKI-off save persisted `verificationMode: 'full'`. The field was originally introduced with the "Other" connector PKI support in #219984.

### Fix

Drop the default so the field is purely optional:

```ts
verificationMode: z.enum(['full', 'certificate', 'none']).optional(),
```

Now a PKI-off save stores no `verificationMode`, and the toggle correctly stays off on reopen. This is safe because:
- The server never takes the PKI/mTLS path unless a cert/key **secret** is also present,   so `verificationMode` alone was never functional.
- When PKI is actually enabled, the UI still supplies its own `'full'` default for the  `config.verificationMode` select, so real PKI setups are unaffected.

https://github.com/user-attachments/assets/ea12c01a-267b-4aa7-90c4-457a25249df3

### Known limitation

Connectors saved **before** this fix still have `verificationMode: 'full'` stored and will show the toggle on until re-saved. This change only prevents new PKI-off saves from persisting the value; it does not migrate existing saved objects.

## Testing

- Added regression tests to `kbn-connector-schemas/openai/schemas/v1.test.ts`:
  - `verificationMode` is absent when omitted for the "Other" provider.
  - An explicitly provided `verificationMode` is preserved.
- Manual repro (before/after) using a local "Other (OpenAI Compatible Service)"
  connector: create with PKI off → reopen → toggle stays off after the fix.

## Backport

- Affected branches carry the Zod v4 upgrade: `main`, `9.5`, `9.4`.
- `9.3` and earlier are on Zod v3 and are **not** affected — no backport needed there.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->