### PR TITLE
[Cases]User activity and all cases list fixes

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -425,3 +425,4 @@ export type ViewToggleId = typeof VIEW_TOGGLE_LIST_ID | typeof VIEW_TOGGLE_TABLE
  */
 export const CASE_EXTENDED_FIELDS = 'extended_fields' as const;
 export const CASE_EXTENDED_FIELDS_LABELS = 'extended_fields_labels' as const;
+export const CASE_EXTENDED_FIELDS_CONTROLS = 'extended_fields_controls' as const;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/case/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/case/v1.ts
@@ -7,7 +7,11 @@
 
 import * as rt from 'io-ts';
 import { CaseStatuses } from '@kbn/cases-components/src/status/types';
-import { CASE_EXTENDED_FIELDS, CASE_EXTENDED_FIELDS_LABELS } from '../../../constants';
+import {
+  CASE_EXTENDED_FIELDS,
+  CASE_EXTENDED_FIELDS_LABELS,
+  CASE_EXTENDED_FIELDS_CONTROLS,
+} from '../../../constants';
 import { ExternalServiceRt } from '../external_service/v1';
 import { CaseAssigneesRt, UserRt } from '../user/v1';
 import { CaseConnectorRt } from '../connector/v1';
@@ -183,6 +187,11 @@ export const CaseRt = rt.intersection([
       // Populated at response time by enrichCasesWithFieldLabels — not persisted to the SO.
       // Maps storage keys (e.g. `priority_as_keyword`) to user-facing labels (e.g. "Priority").
       [CASE_EXTENDED_FIELDS_LABELS]: rt.record(rt.string, rt.string),
+      // Populated alongside extended_fields_labels by enrichCasesWithFieldLabels — not persisted.
+      // Maps storage keys to the field's control type (e.g. `USER_PICKER`), so a value that needs
+      // parsing (user picker, checkbox group, toggle) can be rendered correctly wherever a case is
+      // displayed without threading full field definitions through every consumer.
+      [CASE_EXTENDED_FIELDS_CONTROLS]: rt.record(rt.string, rt.string),
     })
   ),
 ]);

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.tsx
@@ -16,7 +16,10 @@ import type { EuiBasicTableOnChange } from './types';
 
 import { SortFieldCase } from '../../../common/ui/types';
 import type { CaseStatuses } from '../../../common/types/domain';
+import { FieldType } from '../../../common/types/domain/template/fields';
 import { useCasesColumns } from './use_cases_columns';
+import { getUserPickerUidsFromCase } from './extended_field_columns';
+import { useGlobalInlineFields } from './hooks/use_global_inline_fields';
 import { CasesTableFilters } from './table_filters';
 import { CASES_TABLE_PER_PAGE_VALUES } from './types';
 import { CasesTable } from './table';
@@ -26,6 +29,7 @@ import { useGetSupportedActionConnectors } from '../../containers/configure/use_
 import { initialData, useGetCases } from '../../containers/use_get_cases';
 import { useBulkGetUserProfiles } from '../../containers/user_profiles/use_bulk_get_user_profiles';
 import { useGetCurrentUserProfile } from '../../containers/user_profiles/use_get_current_user_profile';
+import { useCasesConfig } from '../../common/lib/kibana';
 import { getAllPermissionsExceptFrom, isReadOnlyPermissions } from '../../utils/permissions';
 import { useIsLoadingCases } from './use_is_loading_cases';
 import { useAllCasesState } from './use_all_cases_state';
@@ -72,6 +76,13 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       getAttachments,
     });
 
+    const { templatesEnabled } = useCasesConfig();
+    const { globalInlineFields } = useGlobalInlineFields({ enabled: templatesEnabled });
+    const userPickerFields = useMemo(
+      () => globalInlineFields.filter((field) => field.control === FieldType.USER_PICKER),
+      [globalInlineFields]
+    );
+
     const assigneesFromCases = useMemo(() => {
       return data.cases.reduce<Set<string>>((acc, caseInfo) => {
         if (!caseInfo) {
@@ -81,9 +92,15 @@ export const AllCasesList = React.memo<AllCasesListProps>(
         for (const assignee of caseInfo.assignees) {
           acc.add(assignee.uid);
         }
+
+        // Global user-picker fields render avatars too; fold their uids into the same bulk
+        // fetch as assignees so the table pays for one profile request, not two.
+        for (const uid of getUserPickerUidsFromCase(caseInfo, userPickerFields)) {
+          acc.add(uid);
+        }
         return acc;
       }, new Set());
-    }, [data.cases]);
+    }, [data.cases, userPickerFields]);
 
     const { data: userProfiles } = useBulkGetUserProfiles({
       uids: Array.from(assigneesFromCases),

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/assignees_column.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/assignees_column.test.tsx
@@ -37,7 +37,9 @@ describe('AssigneesColumn', () => {
     expect(
       screen.queryByTestId('case-table-column-assignee-damaged_raccoon')
     ).not.toBeInTheDocument();
-    expect(screen.queryByTestId('case-table-column-expand-button')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-table-column-assignee-expand-button')
+    ).not.toBeInTheDocument();
     // u2014 is the unicode for a long dash
     expect(screen.getByText('\u2014')).toBeInTheDocument();
   });
@@ -74,7 +76,7 @@ describe('AssigneesColumn', () => {
 
     renderWithTestingProviders(<AssigneesColumn {...props} />);
 
-    expect(screen.getByTestId('case-table-column-expand-button')).toBeInTheDocument();
+    expect(screen.getByTestId('case-table-column-assignee-expand-button')).toBeInTheDocument();
     expect(screen.getByText('+1 more')).toBeInTheDocument();
   });
 
@@ -86,7 +88,9 @@ describe('AssigneesColumn', () => {
 
     renderWithTestingProviders(<AssigneesColumn {...props} />);
 
-    expect(screen.queryByTestId('case-table-column-expand-button')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-table-column-assignee-expand-button')
+    ).not.toBeInTheDocument();
   });
 
   it('does not show the show more button when the limit is the same number of the assignees', async () => {
@@ -97,7 +101,9 @@ describe('AssigneesColumn', () => {
 
     renderWithTestingProviders(<AssigneesColumn {...props} />);
 
-    expect(screen.queryByTestId('case-table-column-expand-button')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-table-column-assignee-expand-button')
+    ).not.toBeInTheDocument();
   });
 
   it('displays the show less avatars button when the show more is clicked', async () => {
@@ -110,10 +116,10 @@ describe('AssigneesColumn', () => {
 
     expect(screen.queryByTestId('case-table-column-assignee-wet_dingo')).not.toBeInTheDocument();
 
-    expect(screen.getByTestId('case-table-column-expand-button')).toBeInTheDocument();
+    expect(screen.getByTestId('case-table-column-assignee-expand-button')).toBeInTheDocument();
     expect(screen.getByText('+1 more')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId('case-table-column-expand-button'));
+    await userEvent.click(screen.getByTestId('case-table-column-assignee-expand-button'));
     expect(await screen.findByText('show less')).toBeInTheDocument();
 
     expect(screen.getByTestId('case-table-column-assignee-wet_dingo')).toBeInTheDocument();
@@ -129,17 +135,17 @@ describe('AssigneesColumn', () => {
 
     expect(screen.queryByTestId('case-table-column-assignee-wet_dingo')).not.toBeInTheDocument();
 
-    expect(screen.getByTestId('case-table-column-expand-button')).toBeInTheDocument();
+    expect(screen.getByTestId('case-table-column-assignee-expand-button')).toBeInTheDocument();
     expect(screen.getByText('+1 more')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId('case-table-column-expand-button'));
+    await userEvent.click(screen.getByTestId('case-table-column-assignee-expand-button'));
 
     expect(await screen.findByText('show less')).toBeInTheDocument();
     expect(screen.getByTestId('case-table-column-assignee-wet_dingo')).toBeInTheDocument();
 
     await waitFor(() => {});
 
-    await userEvent.click(screen.getByTestId('case-table-column-expand-button'));
+    await userEvent.click(screen.getByTestId('case-table-column-assignee-expand-button'));
 
     expect(await screen.findByText('+1 more')).toBeInTheDocument();
     expect(screen.queryByTestId('case-table-column-assignee-wet_dingo')).not.toBeInTheDocument();

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/assignees_column.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/assignees_column.tsx
@@ -21,12 +21,16 @@ export interface AssigneesColumnProps {
   assignees: CaseUI['assignees'];
   userProfiles: Map<string, UserProfileWithAvatar>;
   compressedDisplayLimit?: number;
+  /** Distinguishes this column's test subjects when reused for a non-assignee field (e.g. a
+   * user-picker global field) so they don't collide with the assignees column or each other. */
+  testSubjPrefix?: string;
 }
 
 const AssigneesColumnComponent: React.FC<AssigneesColumnProps> = ({
   assignees,
   userProfiles,
   compressedDisplayLimit = COMPRESSED_AVATAR_LIMIT,
+  testSubjPrefix = 'assignee',
 }) => {
   const [isAvatarListExpanded, setIsAvatarListExpanded] = useState<boolean>(false);
 
@@ -61,14 +65,14 @@ const AssigneesColumnComponent: React.FC<AssigneesColumnProps> = ({
   }
 
   return (
-    <EuiFlexGroup gutterSize="xs" data-test-subj="case-table-column-assignee" wrap>
+    <EuiFlexGroup gutterSize="xs" data-test-subj={`case-table-column-${testSubjPrefix}`} wrap>
       {avatarsToDisplay.map((assignee) => {
         const dataTestSubjName = getUsernameDataTestSubj(assignee);
         return (
           <EuiFlexItem
             grow={false}
             key={assignee.uid}
-            data-test-subj={`case-table-column-assignee-${dataTestSubjName}`}
+            data-test-subj={`case-table-column-${testSubjPrefix}-${dataTestSubjName}`}
           >
             <CaseUserAvatar size="s" userInfo={assignee.profile} />
           </EuiFlexItem>
@@ -78,7 +82,7 @@ const AssigneesColumnComponent: React.FC<AssigneesColumnProps> = ({
       {shouldShowExpandListButton ? (
         <EuiButtonEmpty
           size="xs"
-          data-test-subj="case-table-column-expand-button"
+          data-test-subj={`case-table-column-${testSubjPrefix}-expand-button`}
           onClick={toggleExpandedAvatars}
           style={{ alignSelf: 'center' }}
         >

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.test.tsx
@@ -153,7 +153,10 @@ describe('extended_field_columns helpers', () => {
         },
       } as unknown as CaseUI;
 
-      const column = getExtendedFieldTableColumn(userPickerField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+      const column = getExtendedFieldTableColumn(
+        userPickerField,
+        userProfiles
+      ) as EuiTableFieldDataColumnType<CaseUI>;
       renderWithTestingProviders(<>{column.render?.(theCase, theCase)}</>);
 
       expect(
@@ -166,7 +169,10 @@ describe('extended_field_columns helpers', () => {
     it('renders an empty avatar row for a user-picker field with no stored value', () => {
       const theCase = { extendedFields: {} } as unknown as CaseUI;
 
-      const column = getExtendedFieldTableColumn(userPickerField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+      const column = getExtendedFieldTableColumn(
+        userPickerField,
+        userProfiles
+      ) as EuiTableFieldDataColumnType<CaseUI>;
       const { container } = renderWithTestingProviders(<>{column.render?.(theCase, theCase)}</>);
 
       expect(container).toHaveTextContent('—');
@@ -182,7 +188,10 @@ describe('extended_field_columns helpers', () => {
         control: FieldType.INPUT_TEXT,
       } as InlineField;
 
-      const column = getExtendedFieldTableColumn(priorityField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+      const column = getExtendedFieldTableColumn(
+        priorityField,
+        userProfiles
+      ) as EuiTableFieldDataColumnType<CaseUI>;
       renderWithTestingProviders(<>{column.render?.(theCase, theCase)}</>);
 
       expect(screen.getByText('high')).toBeInTheDocument();
@@ -209,10 +218,16 @@ describe('extended_field_columns helpers', () => {
         },
       } as unknown as CaseUI;
 
-      const reviewersColumn = getExtendedFieldTableColumn(userPickerField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
-      const approversColumn = getExtendedFieldTableColumn(approversField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+      const reviewersColumn = getExtendedFieldTableColumn(
+        userPickerField,
+        userProfiles
+      ) as EuiTableFieldDataColumnType<CaseUI>;
+      const approversColumn = getExtendedFieldTableColumn(
+        approversField,
+        userProfiles
+      ) as EuiTableFieldDataColumnType<CaseUI>;
 
-      const { container } = renderWithTestingProviders(
+      renderWithTestingProviders(
         <>
           {reviewersColumn.render?.(theCase, theCase)}
           {approversColumn.render?.(theCase, theCase)}
@@ -221,14 +236,10 @@ describe('extended_field_columns helpers', () => {
 
       // Each column's wrapping element must carry a distinct test subject.
       expect(
-        container.querySelectorAll(
-          '[data-test-subj="case-table-column-extendedField-reviewers_as_keyword"]'
-        )
+        screen.getAllByTestId('case-table-column-extendedField-reviewers_as_keyword')
       ).toHaveLength(1);
       expect(
-        container.querySelectorAll(
-          '[data-test-subj="case-table-column-extendedField-approvers_as_keyword"]'
-        )
+        screen.getAllByTestId('case-table-column-extendedField-approvers_as_keyword')
       ).toHaveLength(1);
     });
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.test.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 import { screen } from '@testing-library/react';
+import type { EuiTableFieldDataColumnType } from '@elastic/eui';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { renderWithTestingProviders } from '../../common/mock';
 import type { CaseUI } from '../../../common/ui/types';
 import type { InlineField } from '../../../common/types/domain/template/fields';
@@ -14,6 +16,8 @@ import { FieldType } from '../../../common/types/domain/template/fields';
 import {
   getExtendedFieldCellValue,
   getExtendedFieldColumnKey,
+  getExtendedFieldTableColumn,
+  getUserPickerUidsFromCase,
   renderExtendedFieldValue,
 } from './extended_field_columns';
 
@@ -69,6 +73,27 @@ describe('extended_field_columns helpers', () => {
       expect(screen.getByText('jdoe, asmith')).toBeInTheDocument();
     });
 
+    it('extracts a user picker name containing an escaped quote', () => {
+      // JSON.stringify escapes an embedded `"` in a display name (e.g. a nickname like
+      // `Robert "Bob" Smith`); a naive regex over the raw string would mis-split on it.
+      renderWithTestingProviders(
+        <>
+          {renderExtendedFieldValue(
+            field(FieldType.USER_PICKER),
+            JSON.stringify([{ uid: 'u-1', name: 'Robert "Bob" Smith' }])
+          )}
+        </>
+      );
+      expect(screen.getByText('Robert "Bob" Smith')).toBeInTheDocument();
+    });
+
+    it('falls back to the raw value for malformed user picker JSON', () => {
+      renderWithTestingProviders(
+        <>{renderExtendedFieldValue(field(FieldType.USER_PICKER), 'not-json')}</>
+      );
+      expect(screen.getByText('not-json')).toBeInTheDocument();
+    });
+
     it('renders a plain text value as-is', () => {
       renderWithTestingProviders(
         <>{renderExtendedFieldValue(field(FieldType.INPUT_TEXT), 'hello')}</>
@@ -98,6 +123,157 @@ describe('extended_field_columns helpers', () => {
         </>
       );
       expect(container).toHaveTextContent('—');
+    });
+  });
+
+  describe('getExtendedFieldTableColumn', () => {
+    const userPickerField = {
+      name: 'reviewers',
+      type: 'keyword',
+      control: FieldType.USER_PICKER,
+      label: 'Reviewers',
+    } as InlineField;
+
+    const damagedRaccoon = {
+      uid: 'u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0',
+      enabled: true,
+      data: {},
+      user: {
+        username: 'damaged_raccoon',
+        email: 'damaged_raccoon@elastic.co',
+        full_name: 'Damaged Raccoon',
+      },
+    } as UserProfileWithAvatar;
+    const userProfiles = new Map([[damagedRaccoon.uid, damagedRaccoon]]);
+
+    it('renders avatars for a user-picker field using the resolved profile', () => {
+      const theCase = {
+        extendedFields: {
+          reviewersAsKeyword: JSON.stringify([{ uid: damagedRaccoon.uid, name: 'stale name' }]),
+        },
+      } as unknown as CaseUI;
+
+      const column = getExtendedFieldTableColumn(userPickerField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+      renderWithTestingProviders(<>{column.render?.(theCase, theCase)}</>);
+
+      expect(
+        screen.getByTestId('case-table-column-extendedField-reviewers_as_keyword')
+      ).toBeInTheDocument();
+      // Avatar rendering always prefers the live profile over the stored name snapshot.
+      expect(screen.getByText('DR')).toBeInTheDocument();
+    });
+
+    it('renders an empty avatar row for a user-picker field with no stored value', () => {
+      const theCase = { extendedFields: {} } as unknown as CaseUI;
+
+      const column = getExtendedFieldTableColumn(userPickerField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+      const { container } = renderWithTestingProviders(<>{column.render?.(theCase, theCase)}</>);
+
+      expect(container).toHaveTextContent('—');
+    });
+
+    it('renders plain text (not avatars) for a non-user-picker field', () => {
+      const theCase = {
+        extendedFields: { priorityAsKeyword: 'high' },
+      } as unknown as CaseUI;
+      const priorityField = {
+        name: 'priority',
+        type: 'keyword',
+        control: FieldType.INPUT_TEXT,
+      } as InlineField;
+
+      const column = getExtendedFieldTableColumn(priorityField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+      renderWithTestingProviders(<>{column.render?.(theCase, theCase)}</>);
+
+      expect(screen.getByText('high')).toBeInTheDocument();
+      expect(screen.queryByTestId('case-table-column-assignee')).not.toBeInTheDocument();
+    });
+
+    it('bounds the column width so a single field cannot push the rest off-screen', () => {
+      const column = getExtendedFieldTableColumn(userPickerField, userProfiles);
+      expect(column.maxWidth).toBe('18em');
+      expect(column.minWidth).toBe('6em');
+    });
+
+    it('uses unique testSubjPrefixes for two user-picker columns rendered simultaneously', () => {
+      const approversField = {
+        name: 'approvers',
+        type: 'keyword',
+        control: FieldType.USER_PICKER,
+        label: 'Approvers',
+      } as InlineField;
+      const theCase = {
+        extendedFields: {
+          reviewersAsKeyword: JSON.stringify([{ uid: damagedRaccoon.uid, name: 'stale name' }]),
+          approversAsKeyword: JSON.stringify([{ uid: damagedRaccoon.uid, name: 'stale name' }]),
+        },
+      } as unknown as CaseUI;
+
+      const reviewersColumn = getExtendedFieldTableColumn(userPickerField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+      const approversColumn = getExtendedFieldTableColumn(approversField, userProfiles) as EuiTableFieldDataColumnType<CaseUI>;
+
+      const { container } = renderWithTestingProviders(
+        <>
+          {reviewersColumn.render?.(theCase, theCase)}
+          {approversColumn.render?.(theCase, theCase)}
+        </>
+      );
+
+      // Each column's wrapping element must carry a distinct test subject.
+      expect(
+        container.querySelectorAll(
+          '[data-test-subj="case-table-column-extendedField-reviewers_as_keyword"]'
+        )
+      ).toHaveLength(1);
+      expect(
+        container.querySelectorAll(
+          '[data-test-subj="case-table-column-extendedField-approvers_as_keyword"]'
+        )
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('getUserPickerUidsFromCase', () => {
+    const userPickerField = {
+      name: 'reviewers',
+      type: 'keyword',
+      control: FieldType.USER_PICKER,
+    } as InlineField;
+    const textField = {
+      name: 'priority',
+      type: 'keyword',
+      control: FieldType.INPUT_TEXT,
+    } as InlineField;
+
+    it('collects uids from every user-picker field on the case', () => {
+      const theCase = {
+        extendedFields: {
+          reviewersAsKeyword: JSON.stringify([
+            { uid: 'u-1', name: 'a' },
+            { uid: 'u-2', name: 'b' },
+          ]),
+          priorityAsKeyword: 'high',
+        },
+      } as unknown as CaseUI;
+
+      expect(getUserPickerUidsFromCase(theCase, [userPickerField, textField])).toEqual([
+        'u-1',
+        'u-2',
+      ]);
+    });
+
+    it('returns an empty array when the case has no user-picker value', () => {
+      const theCase = { extendedFields: { priorityAsKeyword: 'high' } } as unknown as CaseUI;
+
+      expect(getUserPickerUidsFromCase(theCase, [userPickerField])).toEqual([]);
+    });
+
+    it('ignores malformed user-picker JSON without throwing', () => {
+      const theCase = {
+        extendedFields: { reviewersAsKeyword: 'not-json' },
+      } as unknown as CaseUI;
+
+      expect(getUserPickerUidsFromCase(theCase, [userPickerField])).toEqual([]);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.tsx
@@ -47,13 +47,15 @@ const parseUserPickerField = <T,>(
     if (!Array.isArray(parsed)) {
       return null;
     }
-    const values = parsed
-      .map((item) =>
-        item != null && typeof item === 'object'
-          ? extract(item as Record<string, unknown>)
-          : undefined
-      )
-      .filter((v): v is T => v !== undefined);
+    const values = parsed.reduce<T[]>((acc, item) => {
+      if (item != null && typeof item === 'object') {
+        const extracted = extract(item as Record<string, unknown>);
+        if (extracted !== undefined) {
+          acc.push(extracted);
+        }
+      }
+      return acc;
+    }, []);
     return values.length > 0 ? values : null;
   } catch {
     return null;

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/extended_field_columns.tsx
@@ -5,14 +5,16 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import type { CaseUI } from '../../../common/ui/types';
 import type { InlineField } from '../../../common/types/domain/template/fields';
 import { FieldType } from '../../../common/types/domain/template/fields';
 import { getFieldCamelKey, getFieldSnakeKey } from '../../../common/utils';
 import { getEmptyCellValue } from '../empty_value';
 import { TOGGLE_FIELD_ON_LABEL, TOGGLE_FIELD_OFF_LABEL } from '../custom_fields/translations';
+import { AssigneesColumn } from './assignees_column';
 
 /**
  * Stable column/config identity for a global field (e.g. `priority_as_keyword`). Kept snake so the
@@ -28,6 +30,95 @@ const parseJsonArray = (raw: string): string[] | null => {
   } catch {
     return null;
   }
+};
+
+// Selected users are persisted as JSON-stringified `{ uid, name }` objects (see SelectedUser in
+// templates_v2/field_types/controls/user_picker/utils.ts). Parsing properly (rather than
+// regex-matching the raw string) is required because a display name can itself contain a `"`
+// (e.g. a nickname like `Robert "Bob" Smith`), which JSON.stringify escapes but a naive
+// `"name":"([^"]*)"` regex would mis-split on.
+// Trailing comma on <T,> disambiguates the generic from JSX in a .tsx file.
+const parseUserPickerField = <T,>(
+  raw: string,
+  extract: (item: Record<string, unknown>) => T | undefined
+): T[] | null => {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    const values = parsed
+      .map((item) =>
+        item != null && typeof item === 'object'
+          ? extract(item as Record<string, unknown>)
+          : undefined
+      )
+      .filter((v): v is T => v !== undefined);
+    return values.length > 0 ? values : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseUserPickerNames = (raw: string): string[] | null =>
+  parseUserPickerField(raw, (item) => (typeof item.name === 'string' ? item.name : undefined));
+
+/**
+ * Parses a stored user-picker value into the `{ uid }` shape `AssigneesColumn` expects. Only the
+ * uid is kept — like assignees, avatar rendering always prefers the live profile over the
+ * point-in-time `name` snapshot stored alongside it. Exported so both the table and the
+ * redesigned list (card) view can render user-picker fields as avatars identically.
+ */
+export const parseUserPickerAssignees = (raw: string): Array<{ uid: string }> | null =>
+  parseUserPickerField(raw, (item) =>
+    typeof item.uid === 'string' ? { uid: item.uid } : undefined
+  );
+
+/**
+ * Collects every uid referenced by a case's user-picker global-field values, so callers (the
+ * all-cases list views) can aggregate uids across all rows into a single bulk profile fetch —
+ * matching the existing `assignees` pattern — instead of fetching per row.
+ */
+export const getUserPickerUidsFromCase = (
+  theCase: CaseUI,
+  userPickerFields: readonly InlineField[]
+): string[] => {
+  const uids: string[] = [];
+  for (const field of userPickerFields) {
+    const rawValue = theCase.extendedFields?.[getFieldCamelKey(field.name, field.type)];
+    if (rawValue) {
+      const parsed = parseUserPickerAssignees(rawValue);
+      if (parsed) {
+        uids.push(...parsed.map(({ uid }) => uid));
+      }
+    }
+  }
+  return uids;
+};
+
+/**
+ * Coerces a stored `extended_fields` raw string value to a plain, human-readable display string
+ * for the given control type. Shared by the all-cases table/list view (which wraps this in a
+ * `<span>`) and the user-actions activity log (which interpolates it into an i18n message) —
+ * both need identical parsing (toggle → On/Off, checkbox group/user picker → joined JSON values)
+ * so a change to one doesn't silently drift from the other.
+ */
+export const getExtendedFieldDisplayValue = (control: string, rawValue: string): string => {
+  if (control === FieldType.TOGGLE) {
+    return rawValue === 'true' ? TOGGLE_FIELD_ON_LABEL : TOGGLE_FIELD_OFF_LABEL;
+  }
+
+  if (control === FieldType.CHECKBOX_GROUP) {
+    const values = parseJsonArray(rawValue);
+    return values ? values.join(', ') : rawValue;
+  }
+
+  if (control === FieldType.USER_PICKER) {
+    const names = parseUserPickerNames(rawValue);
+    return names ? names.join(', ') : rawValue;
+  }
+
+  return rawValue;
 };
 
 /**
@@ -46,35 +137,9 @@ export const renderExtendedFieldValue = (
   // getExtendedFieldTableColumn) so one field can't stretch the whole table.
   const dataTestSubj = `case-table-column-extendedField-${getExtendedFieldColumnKey(field)}`;
 
-  if (field.control === FieldType.TOGGLE) {
-    return (
-      <span className="eui-textTruncate" data-test-subj={dataTestSubj}>
-        {rawValue === 'true' ? TOGGLE_FIELD_ON_LABEL : TOGGLE_FIELD_OFF_LABEL}
-      </span>
-    );
-  }
-
-  if (field.control === FieldType.CHECKBOX_GROUP) {
-    const values = parseJsonArray(rawValue);
-    return (
-      <span className="eui-textTruncate" data-test-subj={dataTestSubj}>
-        {values ? values.join(', ') : rawValue}
-      </span>
-    );
-  }
-
-  if (field.control === FieldType.USER_PICKER) {
-    const names = [...rawValue.matchAll(/"name":"([^"]*)"/g)].map((match) => match[1]);
-    return (
-      <span className="eui-textTruncate" data-test-subj={dataTestSubj}>
-        {names.length ? names.join(', ') : rawValue}
-      </span>
-    );
-  }
-
   return (
     <span className="eui-textTruncate" data-test-subj={dataTestSubj}>
-      {rawValue}
+      {getExtendedFieldDisplayValue(field.control, rawValue)}
     </span>
   );
 };
@@ -91,12 +156,50 @@ export const getExtendedFieldCellValue = (field: InlineField, theCase: CaseUI): 
   );
 
 /**
+ * Renders a user-picker global field as avatars (reusing `AssigneesColumn` — same overflow and
+ * empty-state behavior as the assignees column) instead of the comma-joined name text used for
+ * every other control type. `testSubjPrefix` keeps each user-picker column's test subjects unique
+ * from the assignees column and from each other when multiple user-picker fields are shown.
+ */
+const UserPickerFieldCell: React.FC<{
+  field: InlineField;
+  theCase: CaseUI;
+  userProfiles: Map<string, UserProfileWithAvatar>;
+}> = ({ field, theCase, userProfiles }) => {
+  const rawValue = theCase.extendedFields?.[getFieldCamelKey(field.name, field.type)];
+  const assignees = useMemo(
+    () => (rawValue ? parseUserPickerAssignees(rawValue) ?? [] : []),
+    [rawValue]
+  );
+
+  return (
+    <AssigneesColumn
+      assignees={assignees}
+      userProfiles={userProfiles}
+      testSubjPrefix={`extendedField-${getExtendedFieldColumnKey(field)}`}
+    />
+  );
+};
+
+UserPickerFieldCell.displayName = 'UserPickerFieldCell';
+
+/**
  * Builds the all-cases table column for a global field. Width is bounded (matching the legacy
  * text custom-field column) so a single extended-field column can't push the rest off-screen.
+ * User-picker fields render avatars (via `userProfiles`, bulk-fetched once by the caller from all
+ * rows' uids — see `getUserPickerUidsFromCase`); every other control type renders as text.
  */
-export const getExtendedFieldTableColumn = (field: InlineField): EuiBasicTableColumn<CaseUI> => ({
+export const getExtendedFieldTableColumn = (
+  field: InlineField,
+  userProfiles: Map<string, UserProfileWithAvatar>
+): EuiBasicTableColumn<CaseUI> => ({
   name: field.label ?? field.name,
   maxWidth: '18em',
   minWidth: '6em',
-  render: (theCase: CaseUI) => getExtendedFieldCellValue(field, theCase),
+  render: (theCase: CaseUI) =>
+    field.control === FieldType.USER_PICKER ? (
+      <UserPickerFieldCell field={field} theCase={theCase} userProfiles={userProfiles} />
+    ) : (
+      getExtendedFieldCellValue(field, theCase)
+    ),
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/hooks/use_global_inline_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/hooks/use_global_inline_fields.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { renderHook } from '@testing-library/react';
+import { TestProviders } from '../../../common/mock';
+import { useGlobalInlineFields } from './use_global_inline_fields';
+import { useGetFieldDefinitions } from '../../field_library/hooks/use_get_field_definitions';
+
+jest.mock('../../field_library/hooks/use_get_field_definitions');
+const useGetFieldDefinitionsMock = useGetFieldDefinitions as jest.Mock;
+
+describe('useGlobalInlineFields', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('filters out display-only (e.g. MARKDOWN) fields — they hold no per-case value', () => {
+    useGetFieldDefinitionsMock.mockReturnValue({
+      data: {
+        fieldDefinitions: [
+          {
+            definition: 'name: priority\nlabel: Priority\ncontrol: INPUT_TEXT\ntype: keyword\n',
+          },
+          {
+            definition:
+              'name: instructions\nlabel: Instructions\ncontrol: MARKDOWN\ntype: keyword\nmetadata:\n  content: "read me"\n',
+          },
+        ],
+      },
+      isFetching: false,
+    });
+
+    const { result } = renderHook(() => useGlobalInlineFields(), {
+      wrapper: TestProviders,
+    });
+
+    expect(result.current.globalInlineFields.map((f) => f.name)).toEqual(['priority']);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/hooks/use_global_inline_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/hooks/use_global_inline_fields.tsx
@@ -7,12 +7,22 @@
 
 import { useMemo } from 'react';
 import type { InlineField } from '../../../../common/types/domain/template/fields';
+import { isDisplayOnlyField } from '../../../../common/types/domain/template/fields';
 import { parseFieldDefinitionsToInlineFields } from '../../../../common/utils';
 import { useCasesContext } from '../../cases_context/use_cases_context';
 import { useGetFieldDefinitions } from '../../field_library/hooks/use_get_field_definitions';
 
 /**
  * Fetches and parses the owner's global field definitions into inline fields.
+ * Global (isGlobal) fields apply to every case, so they map 1:1 to columns; migrated
+ * legacy custom fields also surface here (migration writes them as global fields).
+ * The fetch is skipped (owner undefined) when `enabled` is false so the legacy
+ * customFields path pays no extra request.
+ *
+ * Display-only fields (e.g. MARKDOWN) are excluded: they hold no per-case value (they're static
+ * authored content on the template form, not case data — see `isDisplayOnlyField`), so they can
+ * never render anything in a column/field cell. Offering one as a toggleable column/field would
+ * just be an always-empty option that looks broken.
  */
 export const useGlobalInlineFields = ({ enabled = true }: { enabled?: boolean } = {}): {
   globalInlineFields: InlineField[];
@@ -27,7 +37,10 @@ export const useGlobalInlineFields = ({ enabled = true }: { enabled?: boolean } 
   });
 
   const globalInlineFields = useMemo(
-    () => parseFieldDefinitionsToInlineFields(data?.fieldDefinitions ?? []),
+    () =>
+      parseFieldDefinitionsToInlineFields(data?.fieldDefinitions ?? []).filter(
+        (field) => !isDisplayOnlyField(field)
+      ),
     [data]
   );
 

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
@@ -351,7 +351,10 @@ export const useCasesColumns = ({
   // `extendedFields`; otherwise they come from the legacy customFields config.
   if (templatesEnabled) {
     globalInlineFields.forEach((field) => {
-      columnsDict[getExtendedFieldColumnKey(field)] = getExtendedFieldTableColumn(field);
+      columnsDict[getExtendedFieldColumnKey(field)] = getExtendedFieldTableColumn(
+        field,
+        userProfiles
+      );
     });
   } else {
     customFields.forEach(({ key, type, label }) => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
@@ -16,7 +16,10 @@ import type { EuiBasicTableOnChange } from './types';
 
 import { SortFieldCase } from '../../../../common/ui/types';
 import type { CaseStatuses } from '../../../../common/types/domain';
+import { FieldType } from '../../../../common/types/domain/template/fields';
 import { useCasesColumns } from './hooks/use_cases_columns';
+import { getUserPickerUidsFromCase } from '../../all_cases/extended_field_columns';
+import { useGlobalInlineFields } from '../../all_cases/hooks/use_global_inline_fields';
 import { CasesTableFilters } from './components/table_filters';
 import { CASES_TABLE_PER_PAGE_VALUES } from './types';
 import { CasesTable } from '../../all_cases/table';
@@ -29,6 +32,7 @@ import { useGetSupportedActionConnectors } from '../../../containers/configure/u
 import { initialData, useGetCases } from '../../../containers/use_get_cases';
 import { useBulkGetUserProfiles } from '../../../containers/user_profiles/use_bulk_get_user_profiles';
 import { useGetCurrentUserProfile } from '../../../containers/user_profiles/use_get_current_user_profile';
+import { useCasesConfig } from '../../../common/lib/kibana';
 import { getAllPermissionsExceptFrom, isReadOnlyPermissions } from '../../../utils/permissions';
 import { useIsLoadingCases } from '../../all_cases/use_is_loading_cases';
 import { useAllCasesState } from '../../all_cases/use_all_cases_state';
@@ -82,6 +86,13 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       getAttachments,
     });
 
+    const { templatesEnabled } = useCasesConfig();
+    const { globalInlineFields } = useGlobalInlineFields({ enabled: templatesEnabled });
+    const userPickerFields = useMemo(
+      () => globalInlineFields.filter((field) => field.control === FieldType.USER_PICKER),
+      [globalInlineFields]
+    );
+
     const assigneesFromCases = useMemo(() => {
       return data.cases.reduce<Set<string>>((acc, caseInfo) => {
         if (!caseInfo) {
@@ -91,9 +102,16 @@ export const AllCasesList = React.memo<AllCasesListProps>(
         for (const assignee of caseInfo.assignees) {
           acc.add(assignee.uid);
         }
+
+        // Global user-picker fields render avatars too; fold their uids into the same bulk
+        // fetch as assignees so the table pays for one profile request, not two.
+        for (const uid of getUserPickerUidsFromCase(caseInfo, userPickerFields)) {
+          acc.add(uid);
+        }
+
         return acc;
       }, new Set());
-    }, [data.cases]);
+    }, [data.cases, userPickerFields]);
 
     const { data: userProfiles } = useBulkGetUserProfiles({
       uids: Array.from(assigneesFromCases),

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
@@ -331,7 +331,11 @@ export const CaseListItem: React.FC<{
                 </EuiFlexGroup>
               </EuiLink>
             </div>
-            <ListItemOptionalFields theCase={theCase} selectedFields={selectedFields} />
+            <ListItemOptionalFields
+              theCase={theCase}
+              selectedFields={selectedFields}
+              userProfiles={userProfiles}
+            />
           </EuiFlexItem>
 
           <EuiFlexItem grow={false} css={styles.actions}>

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/field_content_getters.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/field_content_getters.tsx
@@ -8,15 +8,19 @@
 import React from 'react';
 import { EuiLink } from '@elastic/eui';
 import { CaseStatuses } from '@kbn/cases-components';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 
 import type { CaseUI, CaseUICustomField } from '../../../../../../../common/ui/types';
 import type { InlineField } from '../../../../../../../common/types/domain/template/fields';
+import { FieldType } from '../../../../../../../common/types/domain/template/fields';
 import { getFieldCamelKey } from '../../../../../../../common/utils';
 import { FormattedRelativePreferenceDate } from '../../../../../formatted_date';
 import {
   getExtendedFieldColumnKey,
-  renderExtendedFieldValue,
+  getExtendedFieldDisplayValue,
+  parseUserPickerAssignees,
 } from '../../../../../all_cases/extended_field_columns';
+import { AssigneesColumn } from '../../../../../all_cases/assignees_column';
 import type { ListItemFieldContent } from './types';
 import * as i18n from '../../../translations';
 
@@ -92,19 +96,40 @@ const getCustomFieldContent = (field: string, theCase: CaseUI): ListItemFieldCon
 
 // Templates v2 renders global/extended fields (keyed `<name>_as_<type>`) instead of legacy
 // customFields. Values live on `theCase.extendedFields` under the camelCased key; empty values are
-// omitted so the card doesn't show a dangling label.
+// omitted so the card doesn't show a dangling label. User-picker fields render avatars (matching
+// the all-cases table column) instead of the comma-joined name text used for every other type.
 export const getExtendedFieldContent = (
   field: InlineField,
-  theCase: CaseUI
+  theCase: CaseUI,
+  userProfiles: Map<string, UserProfileWithAvatar>
 ): ListItemFieldContent | null => {
   const rawValue = theCase.extendedFields?.[getFieldCamelKey(field.name, field.type)];
   if (rawValue == null || rawValue === '') {
     return null;
   }
+
+  const label = field.label ?? field.name;
+  const testSubj = `cases-list-item-field-${getExtendedFieldColumnKey(field)}`;
+
+  if (field.control === FieldType.USER_PICKER) {
+    const assignees = parseUserPickerAssignees(rawValue) ?? [];
+    return {
+      label,
+      content: (
+        <AssigneesColumn
+          assignees={assignees}
+          userProfiles={userProfiles}
+          testSubjPrefix={`extendedField-${getExtendedFieldColumnKey(field)}`}
+        />
+      ),
+      testSubj,
+    };
+  }
+
   return {
-    label: field.label ?? field.name,
-    content: renderExtendedFieldValue(field, rawValue),
-    testSubj: `cases-list-item-field-${getExtendedFieldColumnKey(field)}`,
+    label,
+    content: getExtendedFieldDisplayValue(field.control, rawValue),
+    testSubj,
   };
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_field_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_field_text.tsx
@@ -43,7 +43,7 @@ export const ListItemFieldText: React.FC<ListItemFieldTextProps> = ({
           <EuiText size="xs" color="subdued">
             <span css={styles.label}>
               {label}
-              {':'}
+              {': '}
             </span>
           </EuiText>
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_field_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_field_text.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
-import { EuiFlexItem, EuiText, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText, useEuiTheme } from '@elastic/eui';
 
 interface ListItemFieldTextProps {
   label: string;
@@ -33,13 +33,26 @@ export const ListItemFieldText: React.FC<ListItemFieldTextProps> = ({
 
   return (
     <EuiFlexItem grow={false}>
-      <EuiText size="xs" color="subdued" data-test-subj={testSubj}>
-        <span css={styles.label}>
-          {label}
-          {':'}
-        </span>{' '}
-        {children}
-      </EuiText>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        data-test-subj={testSubj}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            <span css={styles.label}>
+              {label}
+              {':'}
+            </span>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            {children}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiFlexItem>
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.test.tsx
@@ -41,6 +41,7 @@ describe('ListItemOptionalFields', () => {
       <ListItemOptionalFields
         theCase={basicCase}
         selectedFields={[{ field: 'tags', name: i18n.TAGS, isChecked: false }]}
+        userProfiles={new Map()}
       />
     );
 
@@ -52,6 +53,7 @@ describe('ListItemOptionalFields', () => {
       <ListItemOptionalFields
         theCase={{ ...basicCase, tags: ['coke', 'pepsi'] }}
         selectedFields={[{ field: 'tags', name: i18n.TAGS, isChecked: true }]}
+        userProfiles={new Map()}
       />
     );
 
@@ -67,6 +69,7 @@ describe('ListItemOptionalFields', () => {
           customFields: [{ key: 'priority', value: 'high', type: CustomFieldTypes.TEXT }],
         }}
         selectedFields={[{ field: 'priority', name: 'Priority', isChecked: true }]}
+        userProfiles={new Map()}
       />
     );
 
@@ -88,6 +91,7 @@ describe('ListItemOptionalFields', () => {
       <ListItemOptionalFields
         theCase={{ ...basicCase, extendedFields: { priorityAsKeyword: 'high' } } as never}
         selectedFields={[{ field: 'priority_as_keyword', name: 'Priority', isChecked: true }]}
+        userProfiles={new Map()}
       />
     );
 
@@ -109,9 +113,60 @@ describe('ListItemOptionalFields', () => {
       <ListItemOptionalFields
         theCase={{ ...basicCase, extendedFields: {} } as never}
         selectedFields={[{ field: 'priority_as_keyword', name: 'Priority', isChecked: true }]}
+        userProfiles={new Map()}
       />
     );
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders avatars for a user-picker extended field using the resolved profile', () => {
+    useCasesConfigMock.mockReturnValue({ templatesEnabled: true });
+    useGlobalInlineFieldsMock.mockReturnValue({
+      globalInlineFields: [
+        {
+          name: 'reviewers',
+          type: 'keyword',
+          control: FieldType.USER_PICKER,
+          label: 'Reviewers',
+        },
+      ],
+      isLoading: false,
+    });
+
+    const uid = 'u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0';
+    const userProfiles = new Map([
+      [
+        uid,
+        {
+          uid,
+          enabled: true,
+          data: {},
+          user: {
+            username: 'damaged_raccoon',
+            email: 'damaged_raccoon@elastic.co',
+            full_name: 'Damaged Raccoon',
+          },
+        },
+      ],
+    ]) as never;
+
+    renderWithTestingProviders(
+      <ListItemOptionalFields
+        theCase={
+          {
+            ...basicCase,
+            extendedFields: {
+              reviewersAsKeyword: JSON.stringify([{ uid, name: 'stale name' }]),
+            },
+          } as never
+        }
+        selectedFields={[{ field: 'reviewers_as_keyword', name: 'Reviewers', isChecked: true }]}
+        userProfiles={userProfiles}
+      />
+    );
+
+    expect(screen.getByTestId('cases-list-item-field-reviewers_as_keyword')).toBeInTheDocument();
+    expect(screen.getByText('DR')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.tsx
@@ -19,6 +19,7 @@ import { useGlobalInlineFields } from '../../../../../all_cases/hooks/use_global
 export const ListItemOptionalFields: React.FC<ListItemOptionalFieldsProps> = ({
   theCase,
   selectedFields,
+  userProfiles,
 }) => {
   const { euiTheme } = useEuiTheme();
   const { templatesEnabled } = useCasesConfig();
@@ -53,7 +54,7 @@ export const ListItemOptionalFields: React.FC<ListItemOptionalFieldsProps> = ({
           if (isChecked) {
             const globalInlineField = globalInlineFieldsByKey.get(field);
             const fieldContent = globalInlineField
-              ? getExtendedFieldContent(globalInlineField, theCase)
+              ? getExtendedFieldContent(globalInlineField, theCase, userProfiles)
               : getListItemFieldContent(field, theCase);
             if (fieldContent != null) {
               acc.push({ ...fieldContent, field, label: name ?? fieldContent.label });
@@ -63,7 +64,7 @@ export const ListItemOptionalFields: React.FC<ListItemOptionalFieldsProps> = ({
         },
         []
       ),
-    [selectedFields, theCase, globalInlineFieldsByKey]
+    [selectedFields, theCase, globalInlineFieldsByKey, userProfiles]
   );
 
   if (visibleFields.length === 0) {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import type { CasesColumnSelection } from '../../../types';
 import type { CaseUI } from '../../../../../../../common/ui/types';
 
@@ -17,4 +18,5 @@ export interface ListItemFieldContent {
 export interface ListItemOptionalFieldsProps {
   theCase: CaseUI;
   selectedFields: CasesColumnSelection[];
+  userProfiles: Map<string, UserProfileWithAvatar>;
 }

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.tsx
@@ -362,7 +362,7 @@ export const useCasesColumns = ({
     // `extendedFields`; otherwise they come from the legacy customFields config.
     if (templatesEnabled) {
       globalInlineFields.forEach((field) => {
-        dict[getExtendedFieldColumnKey(field)] = getExtendedFieldTableColumn(field);
+        dict[getExtendedFieldColumnKey(field)] = getExtendedFieldTableColumn(field, userProfiles);
       });
 
       return dict;
@@ -390,7 +390,7 @@ export const useCasesColumns = ({
     });
 
     return dict;
-  }, [columnsDict, customFields, templatesEnabled, globalInlineFields]);
+  }, [columnsDict, customFields, templatesEnabled, globalInlineFields, userProfiles]);
 
   const columns: CasesColumns[] = [];
 

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.test.tsx
@@ -86,6 +86,77 @@ describe('createExtendedFieldsUserActionBuilder', () => {
     expect(screen.getByText('set My Field to yo')).toBeInTheDocument();
   });
 
+  it('formats a user picker value using the control resolved from extendedFieldsControls', () => {
+    // Reproduces the reported bug: without a control type, the raw JSON-stringified
+    // `{ uid, name }[]` payload value was shown verbatim instead of the parsed name(s).
+    const userAction = getUserAction('extended_fields', UserActionActions.update, {
+      type: 'extended_fields',
+      payload: {
+        extendedFields: {
+          usersAsKeyword: JSON.stringify([
+            { uid: 'u-1', name: 'Bobby "Bob" Thorton' },
+            { uid: 'u-2', name: 'jdoe' },
+          ]),
+        },
+      },
+    });
+
+    const builder = createExtendedFieldsUserActionBuilder({
+      ...builderArgs,
+      caseData: {
+        ...builderArgs.caseData,
+        extendedFieldsLabels: { users_as_keyword: 'Users' },
+        extendedFieldsControls: { users_as_keyword: 'USER_PICKER' },
+      },
+      userAction,
+    });
+
+    const createdUserAction = builder.build();
+    renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
+
+    expect(screen.getByText('set Users to Bobby "Bob" Thorton, jdoe')).toBeInTheDocument();
+  });
+
+  it('falls back to the raw string when extendedFieldsControls is undefined', () => {
+    const userAction = getUserAction('extended_fields', UserActionActions.update, {
+      type: 'extended_fields',
+      payload: { extendedFields: { riskScoreAsKeyword: 'high' } },
+    });
+
+    const builder = createExtendedFieldsUserActionBuilder({
+      ...builderArgs,
+      caseData: { ...builderArgs.caseData, extendedFieldsControls: undefined },
+      userAction,
+    });
+
+    const createdUserAction = builder.build();
+    renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
+
+    expect(screen.getByText('set Risk Score to high')).toBeInTheDocument();
+  });
+
+  it('falls back to the raw string when extendedFieldsControls is defined but the specific key is absent', () => {
+    // extendedFieldsControls is present (covers other keys) but does NOT contain `riskScoreAsKeyword`.
+    const userAction = getUserAction('extended_fields', UserActionActions.update, {
+      type: 'extended_fields',
+      payload: { extendedFields: { riskScoreAsKeyword: 'high' } },
+    });
+
+    const builder = createExtendedFieldsUserActionBuilder({
+      ...builderArgs,
+      caseData: {
+        ...builderArgs.caseData,
+        extendedFieldsControls: { severity_as_keyword: 'SELECT_BASIC' },
+      },
+      userAction,
+    });
+
+    const createdUserAction = builder.build();
+    renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
+
+    expect(screen.getByText('set Risk Score to high')).toBeInTheDocument();
+  });
+
   it('renders generic label when multiple fields are updated at once', () => {
     const userAction = getUserAction('extended_fields', UserActionActions.update, {
       type: 'extended_fields',

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.tsx
@@ -12,6 +12,7 @@ import type { ExtendedFieldsUserAction } from '../../../common/types/domain';
 import type { CasesConfigurationUI } from '../../../common/ui';
 import type { CaseUI } from '../../../common/ui/types';
 import { getFieldCamelKey, getV2FieldType } from '../../../common/utils/template_fields';
+import { getExtendedFieldDisplayValue } from '../all_cases/extended_field_columns';
 import type { UserActionBuilder } from './types';
 import { createCommonUpdateUserActionBuilder } from './common';
 import { ScrollableMarkdown } from '../markdown_editor';
@@ -47,6 +48,21 @@ const buildFieldLabels = (
   return labels;
 };
 
+// Maps a payload key (camelCased) to its field's control type (e.g. "USER_PICKER"), so a value
+// that needs parsing — rather than a plain `String(value)` — is rendered correctly. Sourced from
+// the case's server-enriched `extendedFieldsControls` (covers template + global fields, keyed by
+// snake storage key e.g. `new_field_as_keyword`); a key with no entry (e.g. a not-yet-migrated
+// legacy custom field) falls back to plain string rendering, matching prior behavior.
+const buildFieldControls = (
+  extendedFieldsControls: CaseUI['extendedFieldsControls'] | undefined
+): Map<string, string> => {
+  const controls = new Map<string, string>();
+  for (const [storageKey, control] of Object.entries(extendedFieldsControls ?? {})) {
+    controls.set(camelCase(storageKey), control);
+  }
+  return controls;
+};
+
 const isMultilineValue = (value: unknown): value is string =>
   typeof value === 'string' && value.includes('\n');
 
@@ -57,7 +73,8 @@ interface LabelAndBody {
 
 const getLabelAndBody = (
   userAction: SnakeToCamelCase<ExtendedFieldsUserAction>,
-  fieldLabels: Map<string, string>
+  fieldLabels: Map<string, string>,
+  fieldControls: Map<string, string>
 ): LabelAndBody => {
   const extendedFields = userAction.payload.extendedFields ?? {};
   const entries = Object.entries(extendedFields);
@@ -87,7 +104,13 @@ const getLabelAndBody = (
       };
     }
 
-    return { label: i18n.SET_TEMPLATE_FIELD_LABEL(displayName, String(value)) };
+    const control = fieldControls.get(key);
+    const displayValue =
+      control != null && typeof value === 'string'
+        ? getExtendedFieldDisplayValue(control, value)
+        : String(value);
+
+    return { label: i18n.SET_TEMPLATE_FIELD_LABEL(displayName, displayValue) };
   }
 
   return { label: i18n.UPDATED_TEMPLATE_FIELDS };
@@ -106,7 +129,8 @@ export const createExtendedFieldsUserActionBuilder: UserActionBuilder = ({
       casesConfiguration.customFields,
       caseData.extendedFieldsLabels
     );
-    const { label, body } = getLabelAndBody(extendedFieldsUserAction, fieldLabels);
+    const fieldControls = buildFieldControls(caseData.extendedFieldsControls);
+    const { label, body } = getLabelAndBody(extendedFieldsUserAction, fieldLabels, fieldControls);
     const commonBuilder = createCommonUpdateUserActionBuilder({
       userAction,
       userProfiles,

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/get.test.ts
@@ -136,7 +136,9 @@ describe('get', () => {
           attributes: {
             templateId: 'tmpl-1',
             templateVersion: 2,
-            fieldDefinitions: [{ name: 'sev', type: 'keyword', label: 'Severity' }],
+            fieldDefinitions: [
+              { name: 'sev', type: 'keyword', label: 'Severity', control: 'SELECT_BASIC' },
+            ],
           },
         } as unknown as SavedObject<Template>);
 
@@ -149,6 +151,10 @@ describe('get', () => {
         expect(result.extended_fields_labels).toEqual({
           priority_as_keyword: 'Priority',
           sev_as_keyword: 'Severity',
+        });
+        expect(result.extended_fields_controls).toEqual({
+          priority_as_keyword: 'INPUT_TEXT',
+          sev_as_keyword: 'SELECT_BASIC',
         });
       });
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
@@ -55,6 +55,7 @@ import {
   CaseSeverity,
   ConnectorTypes,
 } from '../../../common/types/domain';
+import { FieldType } from '../../../common/types/domain/template/fields';
 import { flattenCaseSavedObject } from '../../common/utils';
 import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { casesConnectors } from '../../connectors';
@@ -2398,6 +2399,36 @@ describe('enrichCasesWithFieldLabels', () => {
     });
     expect(result[1].extended_fields_labels).toEqual({
       severity_as_keyword: 'Severity Label',
+    });
+  });
+
+  it('populates extended_fields_controls alongside extended_fields_labels', () => {
+    const result = enrichCasesWithFieldLabels([caseWithTemplate], [templateSO]);
+
+    expect(result[0].extended_fields_controls).toEqual({
+      priority_as_keyword: 'INPUT_TEXT',
+      effort_as_integer: 'INPUT_NUMBER',
+    });
+  });
+
+  it('merges global and template controls with template winning on key collision', () => {
+    const globalFields = [
+      {
+        name: 'priority',
+        label: 'Global Priority',
+        control: FieldType.USER_PICKER,
+        type: 'keyword' as const,
+      },
+      { name: 'team', label: 'Team', control: FieldType.USER_PICKER, type: 'keyword' as const },
+    ];
+
+    const result = enrichCasesWithFieldLabels([caseWithTemplate], [templateSO], globalFields);
+
+    expect(result[0].extended_fields_controls).toEqual({
+      // template wins over the global definition for the same key
+      priority_as_keyword: 'INPUT_TEXT',
+      effort_as_integer: 'INPUT_NUMBER',
+      team_as_keyword: 'USER_PICKER',
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
@@ -769,9 +769,13 @@ export const processObservables = (
 /**
  *
  * For cases that have extended fields, populates `extended_fields_labels` with a mapping from
- * storage keys (e.g., `priority_as_keyword`) to user-facing labels (e.g., "Priority").
- * Labels come from the case's template `fieldDefinitions` (when present) merged with global
- * field-library definitions. Template labels win on key collision. Cases without extended
+ * storage keys (e.g., `priority_as_keyword`) to user-facing labels (e.g., "Priority"), and
+ * `extended_fields_controls` with a mapping from the same storage keys to the field's control
+ * type (e.g., `USER_PICKER`) — needed by any consumer that must parse a value (user picker,
+ * checkbox group, toggle) rather than display it verbatim, without having to re-fetch or thread
+ * through full field definitions itself.
+ * Both come from the case's template `fieldDefinitions` (when present) merged with global
+ * field-library definitions. Template entries win on key collision. Cases without extended
  * fields are returned unchanged.
  *
  * @param cases - Array of cases to enrich
@@ -803,34 +807,53 @@ export const enrichCasesWithFieldLabels = (
       field.label ?? field.name,
     ])
   );
+  const globalControlMap = Object.fromEntries(
+    globalFields.map((field) => [getFieldSnakeKey(field.name, field.type), field.control])
+  );
 
   const labelsByTemplateKey = new Map<string, Record<string, string>>();
+  const controlsByTemplateKey = new Map<string, Record<string, string>>();
   for (const so of templateSOs) {
-    const fieldKeyToLabel = Object.fromEntries(
-      (so.attributes.fieldDefinitions ?? []).map((field) => [
-        getFieldSnakeKey(field.name, field.type),
-        field.label,
-      ])
-    );
+    const fieldDefinitions = so.attributes.fieldDefinitions ?? [];
+    const templateKey = `${so.attributes.templateId}:${so.attributes.templateVersion}`;
     labelsByTemplateKey.set(
-      `${so.attributes.templateId}:${so.attributes.templateVersion}`,
-      fieldKeyToLabel
+      templateKey,
+      Object.fromEntries(
+        fieldDefinitions.map((field) => [getFieldSnakeKey(field.name, field.type), field.label])
+      )
+    );
+    controlsByTemplateKey.set(
+      templateKey,
+      Object.fromEntries(
+        fieldDefinitions.map((field) => [getFieldSnakeKey(field.name, field.type), field.control])
+      )
     );
   }
 
   const enrichedCasesById = new Map(
     eligibleCases.flatMap((c) => {
-      const templateLabelMap =
-        c.template?.id != null
-          ? labelsByTemplateKey.get(`${c.template.id}:${c.template.version}`)
-          : undefined;
+      const templateKey = c.template?.id != null ? `${c.template.id}:${c.template.version}` : null;
       const fieldKeyToLabel = {
         ...globalLabelMap,
-        ...(templateLabelMap ?? {}),
+        ...(templateKey != null ? labelsByTemplateKey.get(templateKey) ?? {} : {}),
       };
-      return Object.keys(fieldKeyToLabel).length > 0
-        ? [[c.id, { ...c, extended_fields_labels: fieldKeyToLabel }]]
-        : [];
+      if (Object.keys(fieldKeyToLabel).length === 0) {
+        return [];
+      }
+      const fieldKeyToControl = {
+        ...globalControlMap,
+        ...(templateKey != null ? controlsByTemplateKey.get(templateKey) ?? {} : {}),
+      };
+      return [
+        [
+          c.id,
+          {
+            ...c,
+            extended_fields_labels: fieldKeyToLabel,
+            extended_fields_controls: fieldKeyToControl,
+          },
+        ],
+      ];
     })
   );
 

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/search_cases.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/search_cases.ts
@@ -33,12 +33,15 @@ import {
   obsSec,
 } from '../../../../common/lib/authentication/users';
 
-// Search enriches results with `extended_fields_labels` (populated only when the templates
-// flag is on), which the create response used as the expectation does not carry. Drop it so
-// these filter assertions compare the persisted case shape regardless of the flag state.
-const stripExtendedFieldLabels = (response: CasesFindResponse): CasesFindResponse => ({
+// Search enriches results with `extended_fields_labels` and `extended_fields_controls` (both
+// are populated server-side from field definitions when templates are enabled and the case
+// carries extended_fields). The create response used as the expectation does not carry either
+// field. Strip both so these filter assertions compare the persisted case shape only.
+const stripSearchEnrichedFields = (response: CasesFindResponse): CasesFindResponse => ({
   ...response,
-  cases: response.cases.map(({ extended_fields_labels, ...rest }) => rest),
+  cases: response.cases.map(
+    ({ extended_fields_labels, extended_fields_controls, ...rest }) => rest
+  ),
 });
 
 // Unlike the public find API, the internal search API also returns `mttr` so the cases list
@@ -121,7 +124,7 @@ export default ({ getService }: FtrProviderContext): void => {
           body: { customFields: { valid_key_2: [true] }, owner: 'securitySolutionFixture' },
         });
 
-        expect(stripExtendedFieldLabels(cases)).to.eql({
+        expect(stripSearchEnrichedFields(cases)).to.eql({
           ...searchCasesResp,
           total: 1,
           cases: [postedCase],
@@ -209,7 +212,7 @@ export default ({ getService }: FtrProviderContext): void => {
           },
         });
 
-        expect(stripExtendedFieldLabels(cases)).to.eql({
+        expect(stripSearchEnrichedFields(cases)).to.eql({
           ...searchCasesResp,
           total: 1,
           cases: [postedCase2],
@@ -322,7 +325,7 @@ export default ({ getService }: FtrProviderContext): void => {
         });
 
         expect(
-          stripExtendedFieldLabels(
+          stripSearchEnrichedFields(
             await searchCases({
               supertest,
               body: { customFields: { valid_key_2: [false] }, owner: 'securitySolutionFixture' },
@@ -336,7 +339,7 @@ export default ({ getService }: FtrProviderContext): void => {
         });
 
         expect(
-          stripExtendedFieldLabels(
+          stripSearchEnrichedFields(
             await searchCases({
               supertest,
               body: { customFields: { valid_obs_key_2: [false] }, owner: 'observabilityFixture' },
@@ -416,7 +419,7 @@ export default ({ getService }: FtrProviderContext): void => {
           },
         });
 
-        expect(stripExtendedFieldLabels(cases)).to.eql({
+        expect(stripSearchEnrichedFields(cases)).to.eql({
           ...searchCasesResp,
           total: 1,
           cases: [postedCase],


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/282129 and fixes from https://github.com/elastic/kibana/pull/282474

- User picker field now rendered as avatar in all cases list
  
<img width="673" height="301" alt="image" src="https://github.com/user-attachments/assets/b0fea502-24e2-41bd-b3ee-566653ad7ef6" />

- Redesign card view now renders user fields as avatar

<img width="880" height="309" alt="image" src="https://github.com/user-attachments/assets/83c22d91-5dc6-4c87-805d-b7acfd483b21" />


- Activity log shows correct values for user-picker / toggle / checkbox fields
<img width="697" height="158" alt="image" src="https://github.com/user-attachments/assets/ce8221a5-c92c-4849-a9e0-b9bc2df80e58" />


- Markdown-only fields showed up as an always-empty option. Fixed: markdown fields are hidden from `Column` button 



### Checklist


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->