### PR TITLE
[Discover] Render pattern analysis view in the dashboard saved search embeddable

### DIFF
--- a/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_pattern_analysis_component.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_pattern_analysis_component.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo } from 'react';
+import type { BehaviorSubject } from 'rxjs';
+
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { FetchContext } from '@kbn/presentation-publishing';
+import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
+import type { AiopsAppContextValue } from '@kbn/aiops-plugin/public/hooks/use_aiops_app_context';
+import type { LogCategorizationEmbeddableProps } from '@kbn/aiops-plugin/public/components/log_categorization/log_categorization_for_embeddable/log_categorization_for_discover';
+import { useDiscoverServices } from '../../hooks/use_discover_services';
+import type { SearchEmbeddableApi } from '../types';
+
+interface SavedSearchEmbeddablePatternAnalysisComponentProps {
+  api: SearchEmbeddableApi & {
+    fetchContext$: BehaviorSubject<FetchContext | undefined>;
+  };
+  dataView: DataView;
+}
+
+export function SearchEmbeddablePatternAnalysisComponent({
+  api,
+  dataView,
+}: SavedSearchEmbeddablePatternAnalysisComponentProps) {
+  const [fetchContext, savedSearch] = useBatchedPublishingSubjects(
+    api.fetchContext$,
+    api.savedSearch$
+  );
+  const services = useDiscoverServices();
+  const aiopsService = services.aiops;
+
+  // `savedSearch.searchSource` is kept up to date with the panel's query/filters/time range by
+  // `updateSearchSource` (see `initialize_fetch.ts`), so it can be passed straight through, the
+  // same way the documents grid does for its own fetch.
+  // fetchContext changes whenever the panel should refetch (query, filters, time range, or a
+  // manual refresh), so re-derive a fresh timestamp each time to trigger the aiops component's fetch.
+  const patternAnalysisComponentProps: LogCategorizationEmbeddableProps = useMemo(
+    () => ({
+      input: {
+        dataView,
+        savedSearch: { searchSource: savedSearch.searchSource },
+        lastReloadRequestTime: Date.now(),
+      },
+      renderViewModeToggle: () => <></>,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dataView, savedSearch, fetchContext]
+  );
+
+  if (!aiopsService) {
+    return null;
+  }
+
+  return (
+    <div data-test-subj="dscPatternAnalysisEmbeddedContent">
+      <aiopsService.PatternAnalysisComponent
+        props={patternAnalysisComponentProps}
+        appContextValue={
+          { embeddingOrigin: 'dashboard', ...services } as unknown as AiopsAppContextValue
+        }
+      />
+    </div>
+  );
+}

--- a/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.test.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.test.tsx
@@ -227,6 +227,33 @@ describe('saved search embeddable', () => {
 
       expect(discoverComponent.queryByTestId('dscFieldStatsEmbeddedContent')).toBeInTheDocument();
     });
+
+    it('should render pattern analysis table in PATTERN_LEVEL view mode and not fetch documents', async () => {
+      const { search } = createSearchFnMock(0);
+      runtimeState = getInitialRuntimeState({
+        searchMock: search,
+        partialState: { viewMode: VIEW_MODE.PATTERN_LEVEL },
+      });
+
+      const { Component, api } = await factory.buildEmbeddable({
+        initializeDrilldownsManager: mockInitializeDrilldownsManager,
+        initialState: { ref_id: 'id', overrides: {} },
+        finalizeApi: finalizeApiMock,
+        uuid,
+        parentApi: mockedDashboardApi,
+      });
+      await waitOneTick(); // wait for build to complete
+
+      const discoverComponent = render(<Component />);
+
+      // Pattern analysis mode should not trigger document fetching
+      expect(search).not.toHaveBeenCalled();
+      expect(api.dataLoading$.getValue()).toBe(false);
+
+      expect(
+        discoverComponent.queryByTestId('dscPatternAnalysisEmbeddedContent')
+      ).toBeInTheDocument();
+    });
   });
 
   describe('missing data view', () => {

--- a/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -39,6 +39,7 @@ import {
 } from './utils/get_search_embeddable_comparators';
 import type { DiscoverServices } from '../build_services';
 import { SearchEmbeddablFieldStatsTableComponent } from './components/search_embeddable_field_stats_table_component';
+import { SearchEmbeddablePatternAnalysisComponent } from './components/search_embeddable_pattern_analysis_component';
 import { SearchEmbeddableGridComponent } from './components/search_embeddable_grid_component';
 import { SearchEmbeddableInlineEditHoverActions } from './components/search_embeddable_inline_edit_hover_actions';
 import { SearchEmbeddableDeletedTabPrompt } from './components/search_embeddable_deleted_tab_prompt';
@@ -52,6 +53,7 @@ import { deserializeState, serializeState } from './utils/serialization_utils';
 import { createInMemoryContextAwarenessToolkit } from '../context_awareness';
 import { ScopedServicesProvider } from '../components/scoped_services_provider';
 import { isFieldStatsMode } from './utils/is_field_stats_mode';
+import { isPatternAnalysisMode } from './utils/is_pattern_analysis_mode';
 import { isTabDeleted } from './utils/is_tab_deleted';
 
 export const getSearchEmbeddableFactory = ({
@@ -406,6 +408,11 @@ export const getSearchEmbeddableFactory = ({
             [savedSearch, dataView]
           );
 
+          const renderAsPatternAnalysisTable = useMemo(
+            () => isPatternAnalysisMode(savedSearch, dataView),
+            [savedSearch, dataView]
+          );
+
           if (isSelectedTabDeletedForDisplay) {
             return (
               <SearchEmbeddableDeletedTabPrompt
@@ -460,6 +467,14 @@ export const getSearchEmbeddableFactory = ({
                         isEsqlMode(savedSearch) || !enableFilters ? undefined : addFilter
                       }
                       stateManager={searchEmbeddable.stateManager}
+                    />
+                  ) : renderAsPatternAnalysisTable ? (
+                    <SearchEmbeddablePatternAnalysisComponent
+                      api={{
+                        ...api,
+                        fetchContext$,
+                      }}
+                      dataView={dataView!}
                     />
                   ) : (
                     <CellActionsProvider

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.ts
@@ -46,6 +46,7 @@ import { getTimeRangeFromFetchContext, updateSearchSource } from './utils/update
 import { createDataSource } from '../../common/data_sources';
 import type { ScopedProfilesManager } from '../context_awareness';
 import { isFieldStatsMode } from './utils/is_field_stats_mode';
+import { isPatternAnalysisMode } from './utils/is_pattern_analysis_mode';
 
 type SavedSearchPartialFetchApi = PublishesSavedSearch &
   PublishesSavedObjectId &
@@ -179,8 +180,12 @@ export function initializeFetch({
             sortDir: discoverServices.uiSettings.get(SORT_DEFAULT_ORDER_SETTING),
           }
         );
-        // Still update search source for field stats mode, but not necessarily fetch data
-        if (isFieldStatsMode(savedSearch, dataView, discoverServices.uiSettings)) {
+        // Still update search source for field stats and pattern analysis modes, but not
+        // necessarily fetch data — those modes fetch their own data via the search source.
+        if (
+          isFieldStatsMode(savedSearch, dataView, discoverServices.uiSettings) ||
+          isPatternAnalysisMode(savedSearch, dataView)
+        ) {
           api.fetchContext$.next(fetchContext);
           return;
         }

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/is_pattern_analysis_mode.test.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/is_pattern_analysis_mode.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { VIEW_MODE } from '@kbn/saved-search-plugin/common';
+import { buildDataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { isPatternAnalysisMode } from './is_pattern_analysis_mode';
+import type { SavedSearch } from '@kbn/saved-search-plugin/common';
+
+const dataViewMock = buildDataViewMock({ name: 'test-data-view' });
+
+const createMockSavedSearch = (
+  viewMode: VIEW_MODE,
+  query: { language: string; esql?: string } = { language: 'kuery' }
+): SavedSearch => {
+  return {
+    viewMode,
+    searchSource: {
+      getField: jest.fn((field: string) => {
+        if (field === 'query') {
+          return query;
+        }
+        return undefined;
+      }),
+    },
+  } as unknown as SavedSearch;
+};
+
+describe('isPatternAnalysisMode', () => {
+  it('should return false when in DOCUMENT_LEVEL view mode', () => {
+    const savedSearch = createMockSavedSearch(VIEW_MODE.DOCUMENT_LEVEL);
+
+    expect(isPatternAnalysisMode(savedSearch, dataViewMock)).toBe(false);
+  });
+
+  it('should return false when in AGGREGATED_LEVEL view mode', () => {
+    const savedSearch = createMockSavedSearch(VIEW_MODE.AGGREGATED_LEVEL);
+
+    expect(isPatternAnalysisMode(savedSearch, dataViewMock)).toBe(false);
+  });
+
+  it('should return true when in PATTERN_LEVEL view mode', () => {
+    const savedSearch = createMockSavedSearch(VIEW_MODE.PATTERN_LEVEL);
+
+    expect(isPatternAnalysisMode(savedSearch, dataViewMock)).toBe(true);
+  });
+
+  it('should return false when dataView is undefined', () => {
+    const savedSearch = createMockSavedSearch(VIEW_MODE.PATTERN_LEVEL);
+
+    expect(isPatternAnalysisMode(savedSearch, undefined)).toBe(false);
+  });
+
+  it('should return false when in PATTERN_LEVEL view mode but the query is ES|QL', () => {
+    const savedSearch = createMockSavedSearch(VIEW_MODE.PATTERN_LEVEL, {
+      language: 'esql',
+      esql: 'FROM kibana_sample_data_logs | LIMIT 1',
+    });
+
+    expect(isPatternAnalysisMode(savedSearch, dataViewMock)).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/is_pattern_analysis_mode.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/is_pattern_analysis_mode.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { VIEW_MODE } from '@kbn/saved-search-plugin/common';
+import type { SavedSearch } from '@kbn/saved-search-plugin/common';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { getValidViewMode } from '../../application/main/utils/get_valid_view_mode';
+import { isEsqlMode } from '../initialize_fetch';
+
+export function isPatternAnalysisMode(
+  savedSearch: SavedSearch,
+  dataView: DataView | undefined
+): boolean {
+  const validatedViewMode = getValidViewMode({
+    viewMode: savedSearch.viewMode,
+    isEsqlMode: isEsqlMode(savedSearch),
+  });
+
+  return validatedViewMode === VIEW_MODE.PATTERN_LEVEL && Boolean(dataView);
+}


### PR DESCRIPTION
## Summary

Fixes #191026.

A saved search created while Discover's "Pattern Analysis" tab is active persists `viewMode: 'patterns'` correctly on the saved object. Reopening it in Discover shows the pattern analysis view as expected. But when that saved search is added to a Dashboard, the panel falls back to the plain documents grid instead.

The dashboard saved-search embeddable's render logic (`get_search_embeddable_factory.tsx`) only special-cased field-stats mode (`isFieldStatsMode`) — there was no equivalent check for `VIEW_MODE.PATTERN_LEVEL`, so pattern-analysis searches silently fell through to the grid component.

## Changes

- Added `isPatternAnalysisMode` (`embeddable/utils/is_pattern_analysis_mode.ts`), mirroring `isFieldStatsMode`.
- Added `SearchEmbeddablePatternAnalysisComponent` (`embeddable/components/search_embeddable_pattern_analysis_component.tsx`), a dashboard-embeddable wrapper around the existing `services.aiops.PatternAnalysisComponent` (the same component used by the standalone "Log Pattern Analysis" panel type).
- Extended `get_search_embeddable_factory.tsx`'s render branch to a three-way choice: field stats / pattern analysis / grid.
- Extended `initialize_fetch.ts` to skip the document-level fetch for pattern-analysis mode too (mirroring the existing field-stats short-circuit), since the aiops component fetches its own data via the search source.

## Test plan

- [x] `is_pattern_analysis_mode.test.ts` — unit tests for the new mode check (documents / aggregated / patterns / patterns+ES|QL).
- [x] `get_search_embeddable_factory.test.tsx` — new case asserting the pattern-analysis component renders (and documents aren't fetched) when `viewMode === PATTERN_LEVEL`.
- [x] `node scripts/type_check --project src/platform/plugins/shared/discover/tsconfig.json`
- [ ] Manual verification in a running Kibana instance: save a search from Discover's Pattern Analysis tab, add it to a Dashboard, confirm it renders the pattern table (not the doc grid) — not yet done, opening as draft pending this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)