### PR TITLE
[CI] Normalize testless Nightshift Jest config

### DIFF
--- a/x-pack/solutions/observability/plugins/nightshift/jest.config.js
+++ b/x-pack/solutions/observability/plugins/nightshift/jest.config.js
@@ -8,14 +8,5 @@
 module.exports = {
   preset: '@kbn/test',
   rootDir: '../../../../..',
-  roots: [
-    '<rootDir>/x-pack/solutions/observability/plugins/nightshift/public',
-    '<rootDir>/x-pack/solutions/observability/plugins/nightshift/common',
-  ],
-  coverageDirectory:
-    '<rootDir>/target/kibana-coverage/jest/x-pack/solutions/observability/plugins/nightshift',
-  coverageReporters: ['html'],
-  collectCoverageFrom: [
-    '<rootDir>/x-pack/solutions/observability/plugins/nightshift/{common,public}/**/*.{ts,tsx}',
-  ],
+  roots: ['<rootDir>/x-pack/solutions/observability/plugins/nightshift'],
 };


### PR DESCRIPTION
The Nightshift scaffold in 82018ebd63a2 added a customized Jest config before its tests were moved into the plugin. The stricter empty-config validation added by 9bcc4cac8187 therefore rejected the config and broke kibana-on-merge build 105193.

Use the generated boilerplate shape so the intentionally testless scaffold is filtered from CI until its tests land. The root still covers those future tests, and coverage customization can return with them.