### PR TITLE
[9.5] [Fleet] Don't allow proxy config in Kafka outputs (#282313)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -93699,6 +93699,8 @@ components:
           nullable: true
           type: string
         proxy_id:
+          deprecated: true
+          description: Kafka outputs do not support proxy configuration. This field is accepted for backwards compatibility but is ignored — it is cleared to null on save and has no effect on the compiled agent policy.
           nullable: true
           type: string
         random:
@@ -95007,6 +95009,8 @@ components:
           nullable: true
           type: string
         proxy_id:
+          deprecated: true
+          description: Kafka outputs do not support proxy configuration. This field is accepted for backwards compatibility but is ignored — it is cleared to null on save and has no effect on the compiled agent policy.
           nullable: true
           type: string
         random:
@@ -103772,6 +103776,8 @@ components:
           nullable: true
           type: string
         proxy_id:
+          deprecated: true
+          description: Kafka outputs do not support proxy configuration. This field is accepted for backwards compatibility but is ignored — it is cleared to null on save and has no effect on the compiled agent policy.
           nullable: true
           type: string
         random:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -106773,6 +106773,8 @@ components:
           nullable: true
           type: string
         proxy_id:
+          deprecated: true
+          description: Kafka outputs do not support proxy configuration. This field is accepted for backwards compatibility but is ignored — it is cleared to null on save and has no effect on the compiled agent policy.
           nullable: true
           type: string
         random:
@@ -108081,6 +108083,8 @@ components:
           nullable: true
           type: string
         proxy_id:
+          deprecated: true
+          description: Kafka outputs do not support proxy configuration. This field is accepted for backwards compatibility but is ignored — it is cleared to null on save and has no effect on the compiled agent policy.
           nullable: true
           type: string
         random:
@@ -116846,6 +116850,8 @@ components:
           nullable: true
           type: string
         proxy_id:
+          deprecated: true
+          description: Kafka outputs do not support proxy configuration. This field is accepted for backwards compatibility but is ignored — it is cleared to null on save and has no effect on the compiled agent policy.
           nullable: true
           type: string
         random:

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.test.tsx
@@ -213,6 +213,42 @@ describe('EditOutputFlyout', () => {
     });
   });
 
+  it('should not show proxy input for kafka output', async () => {
+    const { utils } = renderFlyout({
+      type: 'kafka',
+      name: 'kafka output',
+      id: 'output123',
+      is_default: false,
+      is_default_monitoring: false,
+    });
+
+    expect(utils.queryByTestId('settingsOutputsFlyout.proxyIdInput')).toBeNull();
+  });
+
+  it('should show proxy input for elasticsearch output', async () => {
+    const { utils } = renderFlyout({
+      type: 'elasticsearch',
+      name: 'es output',
+      id: 'output456',
+      is_default: false,
+      is_default_monitoring: false,
+    });
+
+    expect(utils.queryByTestId('settingsOutputsFlyout.proxyIdInput')).not.toBeNull();
+  });
+
+  it('should show proxy input for logstash output', async () => {
+    const { utils } = renderFlyout({
+      type: 'logstash',
+      name: 'logstash output',
+      id: 'output789',
+      is_default: false,
+      is_default_monitoring: false,
+    });
+
+    expect(utils.queryByTestId('settingsOutputsFlyout.proxyIdInput')).not.toBeNull();
+  });
+
   it('should populate secret input with plain text value when editing kafka output', async () => {
     jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({} as any);
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
@@ -112,6 +112,7 @@ export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = 
 
   const isRemoteESOutput = inputs.typeInput.value === outputType.RemoteElasticsearch;
   const isESOutput = inputs.typeInput.value === outputType.Elasticsearch;
+  const isKafkaOutput = inputs.typeInput.value === outputType.Kafka;
   const supportsPresets = inputs.typeInput.value
     ? outputTypeSupportPresets(inputs.typeInput.value as ValueOf<OutputType>)
     : false;
@@ -339,7 +340,7 @@ export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = 
           </EuiFormRow>
 
           {renderOutputTypeSection(inputs.typeInput.value)}
-          {isRemoteESOutput ? null : (
+          {isRemoteESOutput || isKafkaOutput ? null : (
             <EuiFormRow
               fullWidth
               label={

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -980,8 +980,6 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
                     },
                   }
                 : {}),
-              proxy_id: proxyIdValue,
-
               client_id: kafkaClientIdInput.value || undefined,
               version: kafkaVersionInput.value,
               ...(kafkaKeyInput.value ? { key: kafkaKeyInput.value } : {}),

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/output_preconfiguration.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/output_preconfiguration.test.ts
@@ -37,10 +37,13 @@ describe('Fleet preconfigured outputs', () => {
       },
     });
 
-    esServer = await startES();
     if (kbnServer) {
       await kbnServer.stop();
     }
+    if (esServer) {
+      await esServer.stop();
+    }
+    esServer = await startES();
 
     const root = createRootWithCorePlugins(
       {
@@ -138,6 +141,76 @@ describe('Fleet preconfigured outputs', () => {
         );
         expect(defaultDataOutput!.id).not.toBe(defaultMonitoringOutput!.id);
         expect(defaultDataOutput!.attributes.is_default_monitoring).toBeFalsy();
+      });
+    });
+
+    describe('With a preconfigured Kafka output that has proxy_id set', () => {
+      // Regression test for #267281: Kibana must boot cleanly when a kibana.yml Kafka output
+      // specifies proxy_id, and the stored output must have proxy_id cleared to null.
+      const kafkaOutputConfig = [
+        {
+          name: 'Kafka with proxy',
+          type: 'kafka',
+          id: 'output-kafka-with-proxy',
+          is_default: false,
+          is_default_monitoring: false,
+          hosts: ['kafka:9092'],
+          topic: 'test',
+          auth_type: 'none',
+          proxy_id: 'non-existent-proxy',
+        },
+      ];
+
+      let versionAfterFirstBoot: string;
+
+      beforeAll(async () => {
+        await startServers(kafkaOutputConfig);
+      });
+
+      afterAll(async () => {
+        await stopServers();
+      });
+
+      it('should boot without errors and store the Kafka output with proxy_id cleared', async () => {
+        const outputs = await kbnServer.coreStart.savedObjects
+          .getUnsafeInternalClient()
+          .find<OutputSOAttributes>({
+            type: 'ingest-outputs',
+            perPage: 10000,
+          });
+
+        const kafkaOutput = outputs.saved_objects.find(
+          (so) => so.attributes.output_id === 'output-kafka-with-proxy'
+        );
+
+        expect(kafkaOutput).toBeDefined();
+        expect(kafkaOutput!.attributes.type).toBe('kafka');
+        // proxy_id must be cleared — Kafka does not support proxies (#267281)
+        expect(kafkaOutput!.attributes.proxy_id).toBeNull();
+
+        // Capture version to detect spurious updates on the next boot
+        versionAfterFirstBoot = kafkaOutput!.version!;
+      });
+
+      it('should not trigger a repeated update on a second boot', async () => {
+        // Restart Kibana with the same config — the change-detection guard should see no diff
+        // on proxy_id for Kafka and not re-update the output.
+        await startServers(kafkaOutputConfig);
+
+        const outputs = await kbnServer.coreStart.savedObjects
+          .getUnsafeInternalClient()
+          .find<OutputSOAttributes>({
+            type: 'ingest-outputs',
+            perPage: 10000,
+          });
+
+        const kafkaOutput = outputs.saved_objects.find(
+          (so) => so.attributes.output_id === 'output-kafka-with-proxy'
+        );
+
+        expect(kafkaOutput).toBeDefined();
+        // Version must be unchanged — a different version means a spurious update occurred
+        expect(kafkaOutput!.version).toBe(versionAfterFirstBoot);
       });
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -2750,6 +2750,52 @@ ssl.test: 123
     `);
   });
 
+  it('should not write proxy fields into kafka output even when a proxy is provided', () => {
+    const proxy = {
+      id: 'proxy-1',
+      name: 'Proxy 1',
+      url: 'https://proxy1.fr',
+      certificate_authorities: '/tmp/ssl/ca.crt',
+      proxy_headers: { Authorization: 'Bearer SECRET' },
+      certificate: 'my-cert',
+      certificate_key: 'PRIVATE_KEY',
+      is_preconfigured: false,
+    } as any;
+
+    const policyOutput = transformOutputToFullPolicyOutput(
+      {
+        id: 'id123',
+        hosts: ['test:9999'],
+        topic: 'test',
+        is_default: false,
+        is_default_monitoring: false,
+        name: 'test output',
+        type: 'kafka',
+        config_yaml: '',
+        client_id: 'Elastic',
+        version: '1.0.0',
+        compression: 'none',
+        auth_type: 'none',
+        connection_type: 'plaintext',
+        partition: 'random',
+        random: { group_events: 1 },
+        headers: [],
+        timeout: 30,
+        broker_timeout: 30,
+        required_acks: 1,
+        proxy_id: 'proxy-1',
+      },
+      proxy
+    );
+
+    expect(policyOutput).not.toHaveProperty('proxy_url');
+    expect(policyOutput).not.toHaveProperty('proxy_headers');
+    // proxy-sourced SSL entries must not appear
+    expect((policyOutput as any).ssl?.certificate_authorities).toBeUndefined();
+    expect((policyOutput as any).ssl?.certificate).toBeUndefined();
+    expect((policyOutput as any).ssl?.key).toBeUndefined();
+  });
+
   it('should redact proxy_headers and ssl.key when redactProxySecrets=true', () => {
     const proxy = {
       id: 'proxy-1',

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -676,7 +676,7 @@ export function transformOutputToFullPolicyOutput(
     };
   }
 
-  if (proxy) {
+  if (proxy && type !== outputType.Kafka) {
     newOutput.proxy_url = proxy.url;
     if (!redactProxySecrets && proxy.proxy_headers) {
       newOutput.proxy_headers = proxy.proxy_headers;

--- a/x-pack/platform/plugins/shared/fleet/server/services/output.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/output.test.ts
@@ -1221,6 +1221,38 @@ describe('Output Service', () => {
           { id: 'output-1' }
         );
       });
+
+      it('should clear proxy_id when creating a kafka output that has proxy_id set', async () => {
+        const soClient = getMockedSoClient({
+          defaultOutputId: 'output-test',
+        });
+        mockedAppContextService.getEncryptedSavedObjectsSetup.mockReturnValue({
+          canEncrypt: true,
+        } as any);
+        mockedAgentPolicyService.list.mockResolvedValue(
+          mockedAgentPolicyWithFleetServerResolvedValue
+        );
+        mockedAgentPolicyService.hasFleetServerIntegration.mockReturnValue(true);
+
+        await outputService.create(
+          soClient,
+          esClientMock,
+          {
+            is_default: false,
+            is_default_monitoring: false,
+            name: 'Test',
+            type: 'kafka',
+            proxy_id: 'proxy-1',
+          },
+          { id: 'output-1' }
+        );
+
+        expect(soClient.create).toBeCalledWith(
+          expect.anything(),
+          expect.objectContaining({ proxy_id: null }),
+          expect.anything()
+        );
+      });
     });
 
     describe('remote elasticsearch output', () => {
@@ -1590,6 +1622,26 @@ describe('Output Service', () => {
         version: null,
         preset: 'balanced',
       });
+    });
+
+    it('should clear proxy_id when updating a kafka output that has proxy_id set', async () => {
+      const soClient = getMockedSoClient({});
+      mockedAgentPolicyService.list.mockResolvedValue({
+        items: [{}],
+      } as unknown as ReturnType<typeof mockedAgentPolicyService.list>);
+      mockedAgentPolicyService.hasAPMIntegration.mockReturnValue(false);
+      mockedPackagePolicyService.list.mockResolvedValue({ items: [] } as any);
+
+      await outputService.update(soClient, esClientMock, 'existing-kafka-output', {
+        proxy_id: 'proxy-1',
+        name: 'updated kafka',
+      });
+
+      expect(soClient.update).toBeCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ proxy_id: null })
+      );
     });
 
     // With logstash output
@@ -2050,6 +2102,7 @@ describe('Output Service', () => {
         timeout: 30,
         version: '1.0.0',
         write_to_logs_streams: null,
+        proxy_id: null,
       });
     });
 
@@ -2086,6 +2139,7 @@ describe('Output Service', () => {
         timeout: 30,
         type: 'kafka',
         version: '1.0.0',
+        proxy_id: null,
       });
     });
 
@@ -2125,6 +2179,7 @@ describe('Output Service', () => {
         version: '1.0.0',
         broker_timeout: 10,
         required_acks: 1,
+        proxy_id: null,
       });
       expect(mockedAgentPolicyService.update).toBeCalledWith(
         expect.anything(),
@@ -2179,6 +2234,7 @@ describe('Output Service', () => {
         version: '1.0.0',
         broker_timeout: 10,
         required_acks: 1,
+        proxy_id: null,
       });
       expect(mockedAgentPolicyService.update).toBeCalledWith(
         expect.anything(),
@@ -2223,6 +2279,7 @@ describe('Output Service', () => {
         version: '1.0.0',
         broker_timeout: 10,
         required_acks: 1,
+        proxy_id: null,
       });
       expect(mockedAgentPolicyService.update).toBeCalledWith(
         expect.anything(),
@@ -2275,6 +2332,7 @@ describe('Output Service', () => {
         version: '1.0.0',
         broker_timeout: 10,
         required_acks: 1,
+        proxy_id: null,
       });
       expect(mockedAgentPolicyService.update).toBeCalledWith(
         expect.anything(),
@@ -2320,6 +2378,7 @@ describe('Output Service', () => {
         version: '1.0.0',
         broker_timeout: 10,
         required_acks: 1,
+        proxy_id: null,
       });
       expect(mockedAgentPolicyService.update).toBeCalledWith(
         expect.anything(),
@@ -2373,6 +2432,7 @@ describe('Output Service', () => {
         version: '1.0.0',
         broker_timeout: 10,
         required_acks: 1,
+        proxy_id: null,
       });
       expect(mockedAgentPolicyService.update).toBeCalledWith(
         expect.anything(),

--- a/x-pack/platform/plugins/shared/fleet/server/services/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/output.ts
@@ -715,6 +715,8 @@ class OutputService {
         data.username = undefined;
         data.password = undefined;
       }
+      // Kafka does not support proxies — clear any proxy_id silently (#267281)
+      data.proxy_id = null;
     }
 
     await remoteSyncIntegrationsCheck(esClient, output);
@@ -1162,6 +1164,11 @@ class OutputService {
       updateData.hosts
     ) {
       updateData.hosts = updateData.hosts.map(normalizeHostsForAgents);
+    }
+
+    // Kafka does not support proxies — clear any proxy_id silently (#267281)
+    if (mergedType === outputType.Kafka) {
+      updateData.proxy_id = null;
     }
 
     if (

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
@@ -462,7 +462,9 @@ async function isPreconfiguredOutputDifferentFromCurrent(
           existingOutput.otel_disable_beatsauth,
           preconfiguredOutput.otel_disable_beatsauth
         ))) ||
-    isDifferent(existingOutput.proxy_id, preconfiguredOutput.proxy_id) ||
+    // Kafka does not support proxies; proxy_id is always cleared on save (#267281)
+    (existingOutput.type !== 'kafka' &&
+      isDifferent(existingOutput.proxy_id, preconfiguredOutput.proxy_id)) ||
     isDifferent(existingOutput.allow_edit ?? [], preconfiguredOutput.allow_edit ?? []) ||
     (preconfiguredOutput.preset &&
       isDifferent(existingOutput.preset, preconfiguredOutput.preset)) ||

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/output.ts
@@ -231,6 +231,18 @@ const LogstashUpdateSchema = {
 
 export const KafkaSchema = {
   ...BaseSchema,
+  // Kafka does not support proxies. proxy_id is accepted to avoid breaking existing preconfigured
+  // outputs but is silently cleared to null on save and never written into the compiled agent
+  // policy (#267281). Marked deprecated so API consumers are not misled.
+  proxy_id: schema.maybe(
+    schema.oneOf([schema.literal(null), schema.string()], {
+      meta: {
+        deprecated: true,
+        description:
+          'Kafka outputs do not support proxy configuration. This field is accepted for backwards compatibility but is ignored — it is cleared to null on save and has no effect on the compiled agent policy.',
+      },
+    })
+  ),
   type: schema.literal(outputType.Kafka),
   hosts: schema.arrayOf(schema.string({ validate: validateKafkaHost }), {
     minSize: 1,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Fleet] Don't allow proxy config in Kafka outputs (#282313)](https://github.com/elastic/kibana/pull/282313)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-04T14:06:11Z","message":"[Fleet] Don't allow proxy config in Kafka outputs (#282313)\n\nFixes https://github.com/elastic/kibana/issues/267281\n\n### Summary\n\nThis PR removes the proxy setting from Kafka outputs.\n\n### Changes\n\n#### UI\n\n- Hides the Proxy field in the output editor flyout when the type is\nKafka\n- Removes proxy_id from the Kafka submit payload\n\n#### Policy compiler\nSkips the entire proxy block (including proxy-sourced SSL) for Kafka\noutputs when rendering the full agent policy\n\n#### Output service\n- Clears `proxy_id` to null on Kafka output create and update (silently,\nwithout rejecting the request — this keeps existing preconfigured Kafka\noutputs that set `proxy_id` working on startup)\n- Guards the preconfiguration change-detection comparison for `proxy_id`\non Kafka outputs, preventing a spurious update-on-every-boot when a\n`kibana.yml `Kafka output has `proxy_id` set\n- Proxy-sourced certificate authorities and SSL keys are also excluded\nfrom Kafka outputs.\n\n\n\n###  Testing\n\n- Go to Fleet → Settings → Proxies, create a proxy.\n- Create a new Kafka output — confirm the Proxy field is absent from the\nform.\n- Create an Elasticsearch output — confirm the Proxy field is present;\nswitch the type to Kafka — field disappears; switch back — field\nreappears.\n- Run the follwoing and verify that it returns 200 and `proxy_id: null`\nin the stored output.\n\n ```\n PUT kbn:/api/fleet/outputs/c7461367-58b3-4c1e-967f-4fa106161bf0\n{ \"proxy_id\": \"<proxy-id>\" }\n```\n- Assign the Kafka output to an agent policy and `GET kbn:/api/fleet/agent_policies/<id>/full` — the Kafka output block must contain no `proxy_url`, `proxy_headers`, or proxy-sourced ssl entries.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials\n- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed\n- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.\n\n### Identify risks\n\n- The API accepts `proxy_id` on Kafka and nulls it out rather than returning a 400 (rejecting would break Kibana startup for existing preconfigured Kafka outputs that specify a proxy).\n- No migrations: stale `proxy_id` values on untouched existing Kafka outputs are harmless — the policy compiler no longer reads them and the value is cleared the next time the output is saved.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3c23c48546a09850677fa2887b29abd08edd7596","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v8.19.0","v9.4.0","v9.5.0","v9.6.0"],"title":"[Fleet] Don't allow proxy config in Kafka outputs","number":282313,"url":"https://github.com/elastic/kibana/pull/282313","mergeCommit":{"message":"[Fleet] Don't allow proxy config in Kafka outputs (#282313)\n\nFixes https://github.com/elastic/kibana/issues/267281\n\n### Summary\n\nThis PR removes the proxy setting from Kafka outputs.\n\n### Changes\n\n#### UI\n\n- Hides the Proxy field in the output editor flyout when the type is\nKafka\n- Removes proxy_id from the Kafka submit payload\n\n#### Policy compiler\nSkips the entire proxy block (including proxy-sourced SSL) for Kafka\noutputs when rendering the full agent policy\n\n#### Output service\n- Clears `proxy_id` to null on Kafka output create and update (silently,\nwithout rejecting the request — this keeps existing preconfigured Kafka\noutputs that set `proxy_id` working on startup)\n- Guards the preconfiguration change-detection comparison for `proxy_id`\non Kafka outputs, preventing a spurious update-on-every-boot when a\n`kibana.yml `Kafka output has `proxy_id` set\n- Proxy-sourced certificate authorities and SSL keys are also excluded\nfrom Kafka outputs.\n\n\n\n###  Testing\n\n- Go to Fleet → Settings → Proxies, create a proxy.\n- Create a new Kafka output — confirm the Proxy field is absent from the\nform.\n- Create an Elasticsearch output — confirm the Proxy field is present;\nswitch the type to Kafka — field disappears; switch back — field\nreappears.\n- Run the follwoing and verify that it returns 200 and `proxy_id: null`\nin the stored output.\n\n ```\n PUT kbn:/api/fleet/outputs/c7461367-58b3-4c1e-967f-4fa106161bf0\n{ \"proxy_id\": \"<proxy-id>\" }\n```\n- Assign the Kafka output to an agent policy and `GET kbn:/api/fleet/agent_policies/<id>/full` — the Kafka output block must contain no `proxy_url`, `proxy_headers`, or proxy-sourced ssl entries.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials\n- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed\n- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.\n\n### Identify risks\n\n- The API accepts `proxy_id` on Kafka and nulls it out rather than returning a 400 (rejecting would break Kibana startup for existing preconfigured Kafka outputs that specify a proxy).\n- No migrations: stale `proxy_id` values on untouched existing Kafka outputs are harmless — the policy compiler no longer reads them and the value is cleared the next time the output is saved.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3c23c48546a09850677fa2887b29abd08edd7596"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.4","9.5"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282313","number":282313,"mergeCommit":{"message":"[Fleet] Don't allow proxy config in Kafka outputs (#282313)\n\nFixes https://github.com/elastic/kibana/issues/267281\n\n### Summary\n\nThis PR removes the proxy setting from Kafka outputs.\n\n### Changes\n\n#### UI\n\n- Hides the Proxy field in the output editor flyout when the type is\nKafka\n- Removes proxy_id from the Kafka submit payload\n\n#### Policy compiler\nSkips the entire proxy block (including proxy-sourced SSL) for Kafka\noutputs when rendering the full agent policy\n\n#### Output service\n- Clears `proxy_id` to null on Kafka output create and update (silently,\nwithout rejecting the request — this keeps existing preconfigured Kafka\noutputs that set `proxy_id` working on startup)\n- Guards the preconfiguration change-detection comparison for `proxy_id`\non Kafka outputs, preventing a spurious update-on-every-boot when a\n`kibana.yml `Kafka output has `proxy_id` set\n- Proxy-sourced certificate authorities and SSL keys are also excluded\nfrom Kafka outputs.\n\n\n\n###  Testing\n\n- Go to Fleet → Settings → Proxies, create a proxy.\n- Create a new Kafka output — confirm the Proxy field is absent from the\nform.\n- Create an Elasticsearch output — confirm the Proxy field is present;\nswitch the type to Kafka — field disappears; switch back — field\nreappears.\n- Run the follwoing and verify that it returns 200 and `proxy_id: null`\nin the stored output.\n\n ```\n PUT kbn:/api/fleet/outputs/c7461367-58b3-4c1e-967f-4fa106161bf0\n{ \"proxy_id\": \"<proxy-id>\" }\n```\n- Assign the Kafka output to an agent policy and `GET kbn:/api/fleet/agent_policies/<id>/full` — the Kafka output block must contain no `proxy_url`, `proxy_headers`, or proxy-sourced ssl entries.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials\n- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed\n- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.\n\n### Identify risks\n\n- The API accepts `proxy_id` on Kafka and nulls it out rather than returning a 400 (rejecting would break Kibana startup for existing preconfigured Kafka outputs that specify a proxy).\n- No migrations: stale `proxy_id` values on untouched existing Kafka outputs are harmless — the policy compiler no longer reads them and the value is cleared the next time the output is saved.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3c23c48546a09850677fa2887b29abd08edd7596"}}]}] BACKPORT-->