### PR TITLE
[Lens] Show an empty datatable summary instead of NaN for columns without valid values

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/datatable/summary.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/datatable/summary.test.ts
@@ -109,6 +109,40 @@ describe('Summary row helpers', () => {
       ).toBe(1);
     });
 
+    it('should return an empty summary instead of NaN/Infinity for an all-null column', () => {
+      const allNullTable = { ...mockNumericTable, rows: [{ myColumn: null }, { myColumn: null }] };
+      for (const op of ['avg', 'sum', 'min', 'max'] as const) {
+        expect(
+          computeSummaryRowForColumn(
+            { summaryRow: op, columnId: 'myColumn' },
+            allNullTable,
+            { myColumn: customNumericFormatter },
+            defaultFormatter
+          )
+        ).toBe('');
+      }
+    });
+
+    it('should skip NaN values instead of poisoning the summary', () => {
+      const tableWithNaN = { ...mockNumericTable, rows: [{ myColumn: 45 }, { myColumn: NaN }] };
+      expect(
+        computeSummaryRowForColumn(
+          { summaryRow: 'sum', columnId: 'myColumn' },
+          tableWithNaN,
+          { myColumn: customNumericFormatter },
+          defaultFormatter
+        )
+      ).toBe('45.00');
+      expect(
+        computeSummaryRowForColumn(
+          { summaryRow: 'count', columnId: 'myColumn' },
+          tableWithNaN,
+          { myColumn: customNumericFormatter },
+          defaultFormatter
+        )
+      ).toBe(1);
+    });
+
     it('should count numeric arrays as valid and distinct values', () => {
       expect(
         computeSummaryRowForColumn(

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/datatable/summary.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/datatable/summary.ts
@@ -97,6 +97,10 @@ export function computeSummaryRowForColumn(
   if (columnArgs.summaryRow === 'count') {
     return defaultFormatter.convertToText(summaryValue);
   }
+  // no valid values to summarize: show an empty summary rather than NaN/Infinity
+  if (summaryValue === undefined) {
+    return '';
+  }
   return formatters[getOriginalId(columnArgs.columnId)].convertToText(summaryValue);
 }
 
@@ -105,17 +109,27 @@ function computeFinalValue(
   columnId: string,
   rows: Datatable['rows']
 ) {
-  // flatten the row structure, to easier handle numeric arrays
-  const validRows = rows.filter((v) => v[columnId] != null).flatMap((v) => v[columnId]);
+  // flatten the row structure to handle numeric arrays, then keep only finite
+  // numbers: NaN (e.g. from formula math) would otherwise poison every summary,
+  // consistently with how the rest of the datatable treats it as an empty value
+  const validRows = rows
+    .flatMap((v) => v[columnId])
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
   const count = validRows.length;
+  if (type === 'count') {
+    return count;
+  }
+  // sum/avg/min/max are meaningless without any valid value (avg would be NaN,
+  // min/max would be ±Infinity, which the number formatter renders as "NaN")
+  if (count === 0) {
+    return undefined;
+  }
   const sum = validRows.reduce<number>((partialSum: number, value: number) => {
     return partialSum + value;
   }, 0);
   switch (type) {
     case 'sum':
       return sum;
-    case 'count':
-      return count;
     case 'avg':
       return sum / count;
     case 'min':


### PR DESCRIPTION
## Summary

Closes #282923

The datatable summary row filtered rows only for null, so an all-null numeric column produced `avg` = `NaN` and `min`/`max` = ±`Infinity` — all rendered by the number formatter as the literal string `"NaN"` in the footer — and a single `NaN` value (e.g. from formula math) poisoned Sum/Avg/Min/Max while inflating Value count, inconsistently with the rest of the datatable which treats NaN as an empty value.

The fix keeps only finite numbers when computing summaries and renders an empty summary when no valid values remain; `count` reports the number of valid values.

Regression tests included for both facets (both fail against the unfixed code).

Note: the `lens` project type check currently reports 8 pre-existing errors at today's main in unrelated files (`autoops_promotion_callout`, `expression_xy`) — verified identical with and without this change; this PR introduces none.

## Testing

- `node scripts/jest .../datatable/` — 19/19 pass (2 new; both fail unfixed)
- ESLint clean; type check introduces no new errors (see note)
