### PR TITLE
[8.19] Remove uuid resolution from request-crypto 2.0.4 upgrade (#282519)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@aws-sdk/client-bedrock-runtime": "3.994.0",
     "@aws-sdk/client-kendra": "3.994.0",
     "@aws-sdk/credential-provider-node": "3.972.10",
-    "@elastic/request-crypto/node-jose/uuid": "11.1.1",
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0",
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31371,7 +31371,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@11.1.1, uuid@^11.1.0, uuid@^9.0.0:
+uuid@11.1.1, uuid@^11.1.0:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
@@ -31400,6 +31400,11 @@ uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Remove uuid resolution from request-crypto 2.0.4 upgrade (#282519)](https://github.com/elastic/kibana/pull/282519)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-08-05T07:29:10Z","message":"Remove uuid resolution from request-crypto 2.0.4 upgrade (#282519)\n\n## Summary\n\nRemoves the `\"@elastic/request-crypto/node-jose/uuid\": \"11.1.1\"`\nresolution added in #281820 and restores `uuid@^9.0.0` to its own valid\nlockfile entry pointing to `9.0.1`.\n\n### Why the resolution produces an invalid lockfile entry\n\nYarn 1's resolution mechanism works through a global\ndescriptor-to-manifest map (`addPattern`). When the narrow path\nresolution intercepts `node-jose@2.2.0`'s `uuid@^9.0.0` request and\nredirects it to `11.1.1`, it calls `addPattern('uuid@^9.0.0',\n<11.1.1-manifest>)` globally. Every other package requesting the same\ndescriptor — including `@storybook/addon-actions@8.6.17` — is then\nserved 11.1.1 from that same map entry. Yarn writes the combined\nlockfile key:\n\n```\nuuid@11.1.1, uuid@^11.1.0, uuid@^9.0.0:   # 11.1.1 does not satisfy ^9.0.0 — semver-invalid\n```\n\nThere is no Yarn 1 resolution syntax that can scope a redirect to a\nsingle consuming path without this side effect. The resolution key\nformat only supports package paths (slash-separated names), not\nversion-qualified descriptors.\n\n### What this PR does\n\nRemoves the resolution. Without it:\n\n- `uuid@^9.0.0` resolves naturally to `9.0.1` (already present in\n`.yarn-local-mirror`)\n- `node-jose@2.2.0` installs a nested `uuid@9.0.1` copy (since the\nhoisted `uuid@11.1.1` does not satisfy `^9.0.0`, Yarn nests it)\n- `@storybook/addon-actions` also gets `9.0.1` — identical to the state\nbefore #281820, and it is a devDependency that does not ship\n- The lockfile entry is semver-valid: `uuid@11.1.1, uuid@^11.1.0:` and\n`uuid@^9.0.0: → 9.0.1` are separate, correct entries\n- The `Resolution field \"uuid@11.1.1\" is incompatible with requested\nversion \"uuid@^9.0.0\"` warning in `yarn kbn bootstrap` output disappears\n\nVerified locally: `yarn kbn bootstrap` completes cleanly with the split\nintact.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Release note\n\nNo release note — dependency lockfile hygiene fix.\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"23551b6e8a83182f4198b3b306d684a869610856","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.6.0"],"title":"Remove uuid resolution from request-crypto 2.0.4 upgrade","number":282519,"url":"https://github.com/elastic/kibana/pull/282519","mergeCommit":{"message":"Remove uuid resolution from request-crypto 2.0.4 upgrade (#282519)\n\n## Summary\n\nRemoves the `\"@elastic/request-crypto/node-jose/uuid\": \"11.1.1\"`\nresolution added in #281820 and restores `uuid@^9.0.0` to its own valid\nlockfile entry pointing to `9.0.1`.\n\n### Why the resolution produces an invalid lockfile entry\n\nYarn 1's resolution mechanism works through a global\ndescriptor-to-manifest map (`addPattern`). When the narrow path\nresolution intercepts `node-jose@2.2.0`'s `uuid@^9.0.0` request and\nredirects it to `11.1.1`, it calls `addPattern('uuid@^9.0.0',\n<11.1.1-manifest>)` globally. Every other package requesting the same\ndescriptor — including `@storybook/addon-actions@8.6.17` — is then\nserved 11.1.1 from that same map entry. Yarn writes the combined\nlockfile key:\n\n```\nuuid@11.1.1, uuid@^11.1.0, uuid@^9.0.0:   # 11.1.1 does not satisfy ^9.0.0 — semver-invalid\n```\n\nThere is no Yarn 1 resolution syntax that can scope a redirect to a\nsingle consuming path without this side effect. The resolution key\nformat only supports package paths (slash-separated names), not\nversion-qualified descriptors.\n\n### What this PR does\n\nRemoves the resolution. Without it:\n\n- `uuid@^9.0.0` resolves naturally to `9.0.1` (already present in\n`.yarn-local-mirror`)\n- `node-jose@2.2.0` installs a nested `uuid@9.0.1` copy (since the\nhoisted `uuid@11.1.1` does not satisfy `^9.0.0`, Yarn nests it)\n- `@storybook/addon-actions` also gets `9.0.1` — identical to the state\nbefore #281820, and it is a devDependency that does not ship\n- The lockfile entry is semver-valid: `uuid@11.1.1, uuid@^11.1.0:` and\n`uuid@^9.0.0: → 9.0.1` are separate, correct entries\n- The `Resolution field \"uuid@11.1.1\" is incompatible with requested\nversion \"uuid@^9.0.0\"` warning in `yarn kbn bootstrap` output disappears\n\nVerified locally: `yarn kbn bootstrap` completes cleanly with the split\nintact.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Release note\n\nNo release note — dependency lockfile hygiene fix.\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"23551b6e8a83182f4198b3b306d684a869610856"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282519","number":282519,"mergeCommit":{"message":"Remove uuid resolution from request-crypto 2.0.4 upgrade (#282519)\n\n## Summary\n\nRemoves the `\"@elastic/request-crypto/node-jose/uuid\": \"11.1.1\"`\nresolution added in #281820 and restores `uuid@^9.0.0` to its own valid\nlockfile entry pointing to `9.0.1`.\n\n### Why the resolution produces an invalid lockfile entry\n\nYarn 1's resolution mechanism works through a global\ndescriptor-to-manifest map (`addPattern`). When the narrow path\nresolution intercepts `node-jose@2.2.0`'s `uuid@^9.0.0` request and\nredirects it to `11.1.1`, it calls `addPattern('uuid@^9.0.0',\n<11.1.1-manifest>)` globally. Every other package requesting the same\ndescriptor — including `@storybook/addon-actions@8.6.17` — is then\nserved 11.1.1 from that same map entry. Yarn writes the combined\nlockfile key:\n\n```\nuuid@11.1.1, uuid@^11.1.0, uuid@^9.0.0:   # 11.1.1 does not satisfy ^9.0.0 — semver-invalid\n```\n\nThere is no Yarn 1 resolution syntax that can scope a redirect to a\nsingle consuming path without this side effect. The resolution key\nformat only supports package paths (slash-separated names), not\nversion-qualified descriptors.\n\n### What this PR does\n\nRemoves the resolution. Without it:\n\n- `uuid@^9.0.0` resolves naturally to `9.0.1` (already present in\n`.yarn-local-mirror`)\n- `node-jose@2.2.0` installs a nested `uuid@9.0.1` copy (since the\nhoisted `uuid@11.1.1` does not satisfy `^9.0.0`, Yarn nests it)\n- `@storybook/addon-actions` also gets `9.0.1` — identical to the state\nbefore #281820, and it is a devDependency that does not ship\n- The lockfile entry is semver-valid: `uuid@11.1.1, uuid@^11.1.0:` and\n`uuid@^9.0.0: → 9.0.1` are separate, correct entries\n- The `Resolution field \"uuid@11.1.1\" is incompatible with requested\nversion \"uuid@^9.0.0\"` warning in `yarn kbn bootstrap` output disappears\n\nVerified locally: `yarn kbn bootstrap` completes cleanly with the split\nintact.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Release note\n\nNo release note — dependency lockfile hygiene fix.\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"23551b6e8a83182f4198b3b306d684a869610856"}}]}] BACKPORT-->