### PR TITLE
[Task Manager] Fail clearly when scheduling a user-scoped task with an organization-level UIAM API key

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/api_key_strategy/es_and_uiam_api_key_strategy.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/api_key_strategy/es_and_uiam_api_key_strategy.test.ts
@@ -321,6 +321,37 @@ describe('EsAndUiamApiKeyStrategy', () => {
       );
     });
 
+    test('does not throw when getApiKeyFromRequest returns a result without api_key (undefined-safe UIAM check)', async () => {
+      const { strategy, coreStart } = createStrategy();
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: 'ApiKey essu_raw-org-level-key' },
+      });
+
+      const esKeyMap = new Map();
+      esKeyMap.set('task-1', {
+        apiKey: Buffer.from('esId:esSecret').toString('base64'),
+        apiKeyId: 'esId',
+      });
+      createApiKeyMock.mockResolvedValueOnce(esKeyMap);
+      hasApiKeyMock.mockReturnValue(true);
+      // A malformed credential parse result: id present, api_key undefined. Previously this
+      // crashed grantUiamApiKeys with `TypeError: Cannot read properties of undefined
+      // (reading 'startsWith')`.
+      getApiKeyFromRequestMock.mockReturnValue({
+        id: 'garbage',
+        api_key: undefined as unknown as string,
+      });
+      (coreStart.security.authc.getCurrentUser as jest.Mock).mockReturnValue({
+        username: 'testuser',
+      });
+
+      const tasks = [{ id: 'task-1', taskType: 'report', params: {}, state: {} }];
+      const result = await strategy.grantApiKeys(tasks, request, coreStart.security);
+
+      const fields = result.get('task-1');
+      expect(fields?.uiamApiKey).toBeUndefined();
+    });
+
     test('grants both ES and UIAM keys when request has UIAM credential', async () => {
       const { strategy, coreStart, mockUiam } = createStrategy();
       const request = httpServerMock.createKibanaRequest({

--- a/x-pack/platform/plugins/shared/task_manager/server/api_key_strategy/es_and_uiam_api_key_strategy.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/api_key_strategy/es_and_uiam_api_key_strategy.ts
@@ -174,7 +174,7 @@ export class EsAndUiamApiKeyStrategy implements ApiKeyStrategy {
 
     if (apiKeyCreatedByUser) {
       const apiKeyResult = getApiKeyFromRequest(request);
-      if (apiKeyResult && isUiamCredential(apiKeyResult.api_key)) {
+      if (apiKeyResult?.api_key && isUiamCredential(apiKeyResult.api_key)) {
         taskInstances.forEach((task) => {
           uiamKeyByTaskIdMap.set(task.id!, {
             apiKey: apiKeyResult.api_key,

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.test.ts
@@ -55,6 +55,48 @@ describe('api_key_utils', () => {
       const result = getApiKeyFromRequest(request);
       expect(result).toBeNull();
     });
+
+    test('should throw a 400 when the request carries a raw organization-level UIAM API key', () => {
+      // Organization-level keys are presented as the raw `essu_` secret, not `base64(id:key)`
+      const request = httpServerMock.createKibanaRequest({
+        headers: {
+          authorization: `ApiKey essu_raw_org_level_key`,
+        },
+      });
+
+      let thrownError;
+      try {
+        getApiKeyFromRequest(request);
+      } catch (e) {
+        thrownError = e;
+      }
+      expect(thrownError.isBoom).toBe(true);
+      expect(thrownError.output.statusCode).toBe(400);
+      expect(thrownError.message).toMatchInlineSnapshot(
+        `"Cannot schedule a user-scoped task using an organization-level API key. Organization-level API keys are not supported for task scheduling; use a project-scoped Elasticsearch API key instead."`
+      );
+    });
+
+    test('should throw a 400 instead of returning a partial result when the credential is malformed', () => {
+      // decodes to a string without an `id:key` separator
+      const request = httpServerMock.createKibanaRequest({
+        headers: {
+          authorization: `ApiKey ${Buffer.from('no-separator-here').toString('base64')}`,
+        },
+      });
+
+      let thrownError;
+      try {
+        getApiKeyFromRequest(request);
+      } catch (e) {
+        thrownError = e;
+      }
+      expect(thrownError.isBoom).toBe(true);
+      expect(thrownError.output.statusCode).toBe(400);
+      expect(thrownError.message).toMatchInlineSnapshot(
+        `"Failed to parse API key credentials from the request authorization header."`
+      );
+    });
   });
 
   describe('createApiKey', () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
 import type { AuthenticatedUser, SecurityServiceStart } from '@kbn/core/server';
 import type { KibanaRequest } from '@kbn/core/server';
+import { isUiamCredential } from '@kbn/core-security-server';
 import { truncate } from 'lodash';
 import type { TaskInstance, TaskUserScope } from '../task';
 import type { GrantApiKeysOpts } from '../api_key_strategy/api_key_strategy';
@@ -51,11 +53,31 @@ export const requestHasApiKey = (security: SecurityServiceStart, request: Kibana
 export const getApiKeyFromRequest = (request: KibanaRequest) => {
   const credentials = getCredentialsFromRequest(request);
   if (credentials) {
-    const apiKey = Buffer.from(credentials, 'base64').toString().split(':');
+    // A raw UIAM credential (`essu_...`) means the request was authenticated with a
+    // user-created organization-level API key. Unlike framework-granted UIAM keys
+    // (encoded as `base64(id:key)`), it carries no key id, so it cannot be persisted
+    // on the task for execution and invalidation bookkeeping.
+    if (isUiamCredential(credentials)) {
+      throw Boom.badRequest(
+        'Cannot schedule a user-scoped task using an organization-level API key. ' +
+          'Organization-level API keys are not supported for task scheduling; ' +
+          'use a project-scoped Elasticsearch API key instead.'
+      );
+    }
+
+    const [id, apiKey] = Buffer.from(credentials, 'base64').toString().split(':');
+
+    // Fail loudly on any malformed credential — persisting a partial value would
+    // schedule a task that can never authenticate at run time.
+    if (!id || !apiKey) {
+      throw Boom.badRequest(
+        'Failed to parse API key credentials from the request authorization header.'
+      );
+    }
 
     return {
-      id: apiKey[0],
-      api_key: apiKey[1],
+      id,
+      api_key: apiKey,
     };
   }
   return null;


### PR DESCRIPTION
## Summary

Addresses steps 1–2 of #282930.

`getApiKeyFromRequest` decoded the request's authorization credential with no validation. A raw organization-level UIAM key (`essu_...` — no `id:key` separator on the wire) produced `{ id: <garbage>, api_key: undefined }`, which broke in one of two ways:

- `EsAndUiamApiKeyStrategy.grantUiamApiKeys` crashed with `TypeError: Cannot read properties of undefined (reading 'startsWith')` — observed in production serverless via `agent_builder`, surfacing as an opaque 500.
- On the `onEsKey: true` path (UIAM branch skipped), the corrupt credential `base64("<garbage>:undefined")` was **silently persisted** on the task — scheduling a task that can never authenticate at run time, with zero schedule-time signal.

## Fix

- **`getApiKeyFromRequest`**: detect a raw UIAM credential *before* decoding and throw `Boom.badRequest` with an actionable message (mirrors the alerting rules client fix in #282287); independently guard the decode result so any credential missing an id or key fails loudly instead of returning a partial result.
- **`EsAndUiamApiKeyStrategy`**: the `isUiamCredential(apiKeyResult.api_key)` call is now undefined-safe (defense in depth — the throw above fires first on this path).

Framework-granted keys (`base64(id:key)`, including `base64(id:essu_key)`) are unaffected.

### Error surfacing note

Task Manager has no REST API; the error reaches users through each calling plugin's route. Of the four callers that schedule user-scoped tasks without `cloneApiKey: true` (`agent_builder`, `entity_store`, `reporting`, `workflows_management`), none currently convert a generic Boom error to its status code — so users get the **clear message** but typically with a 500 status until the owning teams add Boom handling (tracked as step 3–4 of #282930). `agent_builder`'s `wrap_handler` for example returns `e.message` in the 500 body, which is already a big improvement over the raw TypeError.

## Testing

- [x] `node scripts/jest x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.test.ts x-pack/platform/plugins/shared/task_manager/server/api_key_strategy/` (67 passing; 3 new: raw org key → Boom 400, malformed credential → Boom 400, undefined-safe UIAM check regression)
- [x] `node scripts/type_check --project x-pack/platform/plugins/shared/task_manager/tsconfig.json`
- [x] ESLint on changed files

## Release note

Scheduling a user-scoped task with an organization-level API key now fails with a clear error explaining that organization-level API keys are not supported, instead of an internal TypeError or silently persisting unusable task credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)