### PR TITLE
[SigEvents] Fix agent ids to kebab-case namespace

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/investigation/investigation_workflow.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/investigation/investigation_workflow.yaml
@@ -60,7 +60,7 @@ steps:
 
   - name: investigate
     type: ai.agent
-    agent-id: significantEvents.investigation
+    agent-id: significant-events.investigation
     # Keep connector-id-by-feature/plugin-id/aggregate-by in sync with @kbn/significant-events-schema
     # inference_feature_ids.ts (SIGNIFICANT_EVENTS_INVESTIGATION_INFERENCE_FEATURE_ID /
     # SIGNIFICANT_EVENTS_INFERENCE_PARENT_FEATURE_ID).

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/discovery.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/discovery.yaml
@@ -99,7 +99,7 @@ steps:
   # -----------------------------------------------------------------------
   - name: run_discovery_agent
     type: ai.agent
-    agent-id: "significantEvents.discovery"
+    agent-id: "significant-events.discovery"
     # Keep connector-id-by-feature/plugin-id/aggregate-by in sync with @kbn/significant-events-schema
     # inference_feature_ids.ts (SIGNIFICANT_EVENTS_DISCOVERY_INFERENCE_FEATURE_ID /
     # SIGNIFICANT_EVENTS_INFERENCE_PARENT_FEATURE_ID).

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
@@ -108,7 +108,7 @@ steps:
   # -----------------------------------------------------------------------
   - name: run_judge_agent
     type: ai.agent
-    agent-id: "significantEvents.discovery-judge"
+    agent-id: "significant-events.discovery-judge"
     # Keep connector-id-by-feature/plugin-id/aggregate-by in sync with @kbn/significant-events-schema
     # inference_feature_ids.ts (SIGNIFICANT_EVENTS_TRIAGE_INFERENCE_FEATURE_ID /
     # SIGNIFICANT_EVENTS_INFERENCE_PARENT_FEATURE_ID). Own feature — judge is a lighter,

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
@@ -353,7 +353,7 @@ export const runAgentStepCommonDefinition: CommonStepDefinition<
 \`\`\`yaml
 - name: investigate
   type: ${RunAgentStepTypeId}
-  agent-id: "significantEvents.investigation"
+  agent-id: "significant-events.investigation"
   connector-id-by-feature: "significant_events_investigation"
   with:
     message: "Investigate the significant events in this stream."

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/discovery.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/discovery.ts
@@ -11,7 +11,7 @@ import { platformSignificantEventsTools, platformCoreTools } from '@kbn/agent-bu
 import { SIGNIFICANT_EVENTS_KI_GROUNDING_SKILL_ID } from '../../skills/significant_events_ki_grounding';
 import instructions from './instructions/discovery.md.text';
 
-export const SIGNIFICANT_EVENTS_DISCOVERY_AGENT_ID = 'significantEvents.discovery';
+export const SIGNIFICANT_EVENTS_DISCOVERY_AGENT_ID = 'significant-events.discovery';
 export const SIGNIFICANT_EVENTS_DISCOVERY_AGENT_TYPE_ID = 'platform.sig_events.discovery-type';
 
 export const discoveryAgentType = {

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/judge.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/judge.ts
@@ -10,7 +10,7 @@ import type { AgentTypeDefinition } from '@kbn/agent-builder-server/agents';
 import { platformSignificantEventsTools, platformCoreTools } from '@kbn/agent-builder-common/tools';
 import instructions from './instructions/judge.md.text';
 
-export const SIGNIFICANT_EVENTS_JUDGE_AGENT_ID = 'significantEvents.discovery-judge';
+export const SIGNIFICANT_EVENTS_JUDGE_AGENT_ID = 'significant-events.discovery-judge';
 export const SIGNIFICANT_EVENTS_JUDGE_AGENT_TYPE_ID = 'platform.sig_events.discovery-judge-type';
 
 export const judgeAgentType = {

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/index.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/index.ts
@@ -20,7 +20,7 @@ import {
   OBSERVABILITY_GET_TRACES_TOOL_ID,
 } from '../../../agent_builder/agents/discovery/constants';
 
-export const SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_ID = 'significantEvents.investigation';
+export const SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_ID = 'significant-events.investigation';
 export const SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_TYPE_ID =
   'platform.sig_events.investigation-type';
 


### PR DESCRIPTION
## 📓 Summary
After the plugin id rename to `significantEvents`, Agent Builder agent ids were updated to camelCase (`significantEvents.discovery`). That fails Agent Builder validation, which only allows lowercase letters, numbers, dots, hyphens, and underscores, so discovery could not start.

This PR renames the Significant Events agent ids to a kebab-case namespace that matches workflows naming conventions and existing trigger ids (`significant-events.*`).

- Updates discovery, discovery-judge, and investigation agent id constants
- Aligns managed workflow YAML `agent-id` references and the `ai.agent` step docs example
- Leaves the Kibana plugin id as `significantEvents` (plugin ids and agent ids follow different rules)