### PR TITLE
[Lens] Fix suggestion preview tooltip nesting and remove eslint ignore

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -199,22 +199,31 @@ const SuggestionPreview = ({
   const { euiTheme } = euiThemeContext;
   const xsFontSize = useEuiFontSize('xs');
   return (
-    <EuiToolTip
-      content={preview.title}
-      anchorProps={
+    <div
+      data-test-subj={`lnsSuggestion-${camelCase(preview.title)}`}
+      css={
         wrapSuggestions
-          ? {
-              css: css`
-                display: flex;
-                flex-direction: column;
-                flex-basis: calc(50% - 9px);
-              `,
-            }
+          ? css`
+              flex-basis: calc(50% - 9px);
+            `
           : undefined
       }
     >
-      {/* eslint-disable-next-line @elastic/eui/tooltip-focusable-anchor */}
-      <div data-test-subj={`lnsSuggestion-${camelCase(preview.title)}`}>
+      <EuiToolTip
+        content={preview.title}
+        // anchor element is button with aria label, tooltip announcement would be redundant
+        disableScreenReaderOutput
+        anchorProps={
+          wrapSuggestions
+            ? {
+                css: css`
+                  display: flex;
+                  flex-direction: column;
+                `,
+              }
+            : undefined
+        }
+      >
         <EuiPanel
           hasBorder={true}
           hasShadow={false}
@@ -296,8 +305,8 @@ const SuggestionPreview = ({
             </span>
           )}
         </EuiPanel>
-      </div>
-    </EuiToolTip>
+      </EuiToolTip>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/281063

Follow-up to this [discussion](https://github.com/elastic/kibana/pull/280440/changes/BASE..f58ab630ad17f6f6721875aed13771c7e798e9ab#r3646204628) in #280440. That PR left the suggestion preview with a `@elastic/eui/tooltip-focusable-anchor eslint disable` because the focusable `<EuiPanel>` button was inside a non-focusable wrapper div used just for test IDs.

This change restructures `<SuggestionPreview>` a bit so that the div with the `lnsSuggestion-{title}` test id wraps the tooltip, and the focusable button becomes the direct tooltip anchor. This satisfies the lint rule without the ignore + keeps test selectors working + avoids duplicate screen reader announcements by using `disableScreenReaderOutput` on the tooltip (the button already has aria-label).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.