### PR TITLE
[Agent Builder] Context Engine — per-agent trace data-stream namespacing

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/common/traces.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/traces.test.ts
@@ -5,18 +5,76 @@
  * 2.0.
  */
 
-import { buildAgentBuilderTracesIndexPattern } from './traces';
+import {
+  buildAgentBuilderTracesIndexName,
+  buildAgentBuilderTracesIndexPattern,
+  buildAgentBuilderTracesNamespace,
+  buildAgentBuilderTracesNamespacePattern,
+  TRACES_INDEX_PREFIX,
+} from './traces';
+
+describe('buildAgentBuilderTracesNamespace', () => {
+  it('returns "<spaceId>.<agentId>" when an agent id is provided', () => {
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'marketing', agentId: 'sales-bot' })).toBe(
+      'marketing.sales-bot'
+    );
+  });
+
+  it('falls back to the space id alone when the agent id is missing', () => {
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'marketing' })).toBe('marketing');
+  });
+
+  it('falls back to the space id alone when the agent id is an empty string', () => {
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'marketing', agentId: '' })).toBe(
+      'marketing'
+    );
+  });
+
+  it('never omits the space id, even without an agent', () => {
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'default' })).toBe('default');
+  });
+});
+
+describe('buildAgentBuilderTracesNamespacePattern', () => {
+  it('returns the wildcard namespace pattern for a space', () => {
+    expect(buildAgentBuilderTracesNamespacePattern('marketing')).toBe('marketing.*');
+  });
+
+  it('returns the wildcard namespace pattern for the default space', () => {
+    expect(buildAgentBuilderTracesNamespacePattern('default')).toBe('default.*');
+  });
+});
+
+describe('buildAgentBuilderTracesIndexName', () => {
+  it('returns the concrete per-agent data-stream name', () => {
+    expect(
+      buildAgentBuilderTracesIndexName({ spaceId: 'marketing', agentId: 'sales-bot' })
+    ).toBe('traces-agent_builder.otel-marketing.sales-bot');
+  });
+
+  it('falls back to the space-scoped stream name when the agent id is missing', () => {
+    expect(buildAgentBuilderTracesIndexName({ spaceId: 'default' })).toBe(
+      'traces-agent_builder.otel-default'
+    );
+  });
+
+  it('is built from TRACES_INDEX_PREFIX', () => {
+    expect(
+      buildAgentBuilderTracesIndexName({ spaceId: 'marketing', agentId: 'sales-bot' })
+    ).toBe(`${TRACES_INDEX_PREFIX}marketing.sales-bot`);
+  });
+});
 
 describe('buildAgentBuilderTracesIndexPattern', () => {
-  it('returns the space-scoped index pattern for a given space', () => {
+  it('returns the per-space wildcard index pattern covering every agent stream', () => {
     expect(buildAgentBuilderTracesIndexPattern('marketing')).toBe(
-      'traces-agent_builder.otel-marketing'
+      'traces-agent_builder.otel-marketing.*'
     );
   });
 
   it('returns the default space index pattern', () => {
     expect(buildAgentBuilderTracesIndexPattern('default')).toBe(
-      'traces-agent_builder.otel-default'
+      'traces-agent_builder.otel-default.*'
     );
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/common/traces.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/traces.test.ts
@@ -11,7 +11,16 @@ import {
   buildAgentBuilderTracesNamespace,
   buildAgentBuilderTracesNamespacePattern,
   TRACES_INDEX_PREFIX,
+  UNRESOLVED_AGENT_NAMESPACE_SEGMENT,
 } from './traces';
+
+/** Mirrors how ES matches a `<prefix>.*` index pattern against a concrete stream name. */
+const patternMatches = (pattern: string, name: string): boolean => {
+  const regex = new RegExp(
+    `^${pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')}$`
+  );
+  return regex.test(name);
+};
 
 describe('buildAgentBuilderTracesNamespace', () => {
   it('returns "<spaceId>.<agentId>" when an agent id is provided', () => {
@@ -20,18 +29,50 @@ describe('buildAgentBuilderTracesNamespace', () => {
     );
   });
 
-  it('falls back to the space id alone when the agent id is missing', () => {
-    expect(buildAgentBuilderTracesNamespace({ spaceId: 'marketing' })).toBe('marketing');
-  });
-
-  it('falls back to the space id alone when the agent id is an empty string', () => {
-    expect(buildAgentBuilderTracesNamespace({ spaceId: 'marketing', agentId: '' })).toBe(
-      'marketing'
+  it('falls back to "<spaceId>.<unresolved>" when the agent id is missing', () => {
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'marketing' })).toBe(
+      `marketing.${UNRESOLVED_AGENT_NAMESPACE_SEGMENT}`
     );
   });
 
-  it('never omits the space id, even without an agent', () => {
-    expect(buildAgentBuilderTracesNamespace({ spaceId: 'default' })).toBe('default');
+  it('falls back to "<spaceId>.<unresolved>" when the agent id is an empty string', () => {
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'marketing', agentId: '' })).toBe(
+      `marketing.${UNRESOLVED_AGENT_NAMESPACE_SEGMENT}`
+    );
+  });
+
+  it('always keeps the space id as the first segment and never emits a bare namespace', () => {
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'default' })).toBe(
+      `default.${UNRESOLVED_AGENT_NAMESPACE_SEGMENT}`
+    );
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'default' })).not.toBe('default');
+  });
+
+  it('keeps the space scope even when an agent id itself contains a dot', () => {
+    // The first `.` after the space id is the space boundary; the read pattern still matches.
+    expect(buildAgentBuilderTracesNamespace({ spaceId: 'marketing', agentId: 'foo.bar' })).toBe(
+      'marketing.foo.bar'
+    );
+  });
+
+  it('produces a namespace the space read pattern always matches (fallback and resolved alike)', () => {
+    const readPattern = buildAgentBuilderTracesNamespacePattern('marketing');
+    expect(
+      patternMatches(readPattern, buildAgentBuilderTracesNamespace({ spaceId: 'marketing' }))
+    ).toBe(true);
+    expect(
+      patternMatches(
+        readPattern,
+        buildAgentBuilderTracesNamespace({ spaceId: 'marketing', agentId: 'sales-bot' })
+      )
+    ).toBe(true);
+    // ...but never matches a sibling space, even one sharing a name prefix.
+    expect(
+      patternMatches(
+        readPattern,
+        buildAgentBuilderTracesNamespace({ spaceId: 'marketing2', agentId: 'x' })
+      )
+    ).toBe(false);
   });
 });
 
@@ -47,21 +88,21 @@ describe('buildAgentBuilderTracesNamespacePattern', () => {
 
 describe('buildAgentBuilderTracesIndexName', () => {
   it('returns the concrete per-agent data-stream name', () => {
-    expect(
-      buildAgentBuilderTracesIndexName({ spaceId: 'marketing', agentId: 'sales-bot' })
-    ).toBe('traces-agent_builder.otel-marketing.sales-bot');
+    expect(buildAgentBuilderTracesIndexName({ spaceId: 'marketing', agentId: 'sales-bot' })).toBe(
+      'traces-agent_builder.otel-marketing.sales-bot'
+    );
   });
 
-  it('falls back to the space-scoped stream name when the agent id is missing', () => {
+  it('falls back to the unresolved-agent stream name when the agent id is missing', () => {
     expect(buildAgentBuilderTracesIndexName({ spaceId: 'default' })).toBe(
-      'traces-agent_builder.otel-default'
+      `traces-agent_builder.otel-default.${UNRESOLVED_AGENT_NAMESPACE_SEGMENT}`
     );
   });
 
   it('is built from TRACES_INDEX_PREFIX', () => {
-    expect(
-      buildAgentBuilderTracesIndexName({ spaceId: 'marketing', agentId: 'sales-bot' })
-    ).toBe(`${TRACES_INDEX_PREFIX}marketing.sales-bot`);
+    expect(buildAgentBuilderTracesIndexName({ spaceId: 'marketing', agentId: 'sales-bot' })).toBe(
+      `${TRACES_INDEX_PREFIX}marketing.sales-bot`
+    );
   });
 });
 

--- a/x-pack/platform/plugins/shared/agent_builder/common/traces.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/traces.ts
@@ -5,8 +5,22 @@
  * 2.0.
  */
 
-/** Prefix shared by every Agent Builder OTel traces data stream, per-agent or otherwise. */
+/**
+ * Prefix shared by every Agent Builder OTel traces data stream, per-agent or otherwise.
+ *
+ * Mirrors the OTel exporter's implicit `traces-<dataset>.otel-` naming (dataset = `agent_builder`):
+ * the write path sets only `data_stream.dataset` / `data_stream.namespace` and the exporter
+ * assembles the final stream name, so this read-side prefix must stay in sync with that convention.
+ */
 export const TRACES_INDEX_PREFIX = 'traces-agent_builder.otel-';
+
+/**
+ * Namespace segment used when a span's agent can't be resolved. It keeps the fallback write both
+ * inside the space AND under the `<spaceId>.*` read pattern — a bare `<spaceId>` namespace would be
+ * written but never read back (the read pattern requires a trailing `.<segment>`). Not a real agent
+ * id; chosen so it can never collide with a resolved agent that carries a `gen_ai.agent.id`.
+ */
+export const UNRESOLVED_AGENT_NAMESPACE_SEGMENT = '_unresolved';
 
 export interface AgentBuilderTracesNamespaceParams {
   spaceId: string;
@@ -16,15 +30,17 @@ export interface AgentBuilderTracesNamespaceParams {
 /**
  * Builds the data-stream namespace segment routing a single agent's traces: `<spaceId>.<agentId>`.
  *
- * When the agent can't be resolved, falls back to the space id alone so the trace still stays
- * scoped to the space — it must never fall through to the exporter's global `default` namespace,
- * which would leak data across spaces.
+ * When the agent can't be resolved, falls back to `<spaceId>.${UNRESOLVED_AGENT_NAMESPACE_SEGMENT}`.
+ * This stays scoped to the space and is still matched by the `<spaceId>.*` read pattern, so the
+ * trace remains readable. It must never fall through to the exporter's global `default` namespace
+ * (which would leak across spaces), and must never be a bare `<spaceId>` (which no read surface
+ * matches — see {@link buildAgentBuilderTracesIndexPattern}).
  */
 export const buildAgentBuilderTracesNamespace = ({
   spaceId,
   agentId,
 }: AgentBuilderTracesNamespaceParams): string => {
-  return agentId ? `${spaceId}.${agentId}` : spaceId;
+  return `${spaceId}.${agentId || UNRESOLVED_AGENT_NAMESPACE_SEGMENT}`;
 };
 
 /**
@@ -37,6 +53,10 @@ export const buildAgentBuilderTracesNamespacePattern = (spaceId: string): string
 /**
  * Builds the concrete per-agent traces data-stream name:
  * `traces-agent_builder.otel-<spaceId>.<agentId>`.
+ *
+ * Omitting `agentId` yields the unresolved-agent fallback stream
+ * (`...-<spaceId>.${UNRESOLVED_AGENT_NAMESPACE_SEGMENT}`), not a bare per-space stream — prefer
+ * always passing a resolved `agentId`.
  */
 export const buildAgentBuilderTracesIndexName = ({
   spaceId,
@@ -49,8 +69,9 @@ export const buildAgentBuilderTracesIndexName = ({
  * Builds the per-space index pattern covering every agent's traces stream within a space:
  * `traces-agent_builder.otel-<spaceId>.*`.
  *
- * Use this for reading/querying (dashboards, the traces skill, trace-exists checks). Never
- * broaden further to `traces-agent_builder.otel-*` — that would mix data across spaces.
+ * Use this for reading/querying (dashboards, the traces skill, trace-exists checks) — it is a read
+ * pattern, never a write target. Never broaden further to `traces-agent_builder.otel-*` — that would
+ * mix data across spaces.
  */
 export const buildAgentBuilderTracesIndexPattern = (spaceId: string): string => {
   return `${TRACES_INDEX_PREFIX}${buildAgentBuilderTracesNamespacePattern(spaceId)}`;

--- a/x-pack/platform/plugins/shared/agent_builder/common/traces.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/traces.ts
@@ -5,6 +5,53 @@
  * 2.0.
  */
 
-export const buildAgentBuilderTracesIndexPattern = (spaceId: string) => {
-  return `traces-agent_builder.otel-${spaceId}`;
+/** Prefix shared by every Agent Builder OTel traces data stream, per-agent or otherwise. */
+export const TRACES_INDEX_PREFIX = 'traces-agent_builder.otel-';
+
+export interface AgentBuilderTracesNamespaceParams {
+  spaceId: string;
+  agentId?: string;
+}
+
+/**
+ * Builds the data-stream namespace segment routing a single agent's traces: `<spaceId>.<agentId>`.
+ *
+ * When the agent can't be resolved, falls back to the space id alone so the trace still stays
+ * scoped to the space — it must never fall through to the exporter's global `default` namespace,
+ * which would leak data across spaces.
+ */
+export const buildAgentBuilderTracesNamespace = ({
+  spaceId,
+  agentId,
+}: AgentBuilderTracesNamespaceParams): string => {
+  return agentId ? `${spaceId}.${agentId}` : spaceId;
+};
+
+/**
+ * Builds the namespace wildcard covering every agent's stream within a space: `<spaceId>.*`.
+ */
+export const buildAgentBuilderTracesNamespacePattern = (spaceId: string): string => {
+  return `${spaceId}.*`;
+};
+
+/**
+ * Builds the concrete per-agent traces data-stream name:
+ * `traces-agent_builder.otel-<spaceId>.<agentId>`.
+ */
+export const buildAgentBuilderTracesIndexName = ({
+  spaceId,
+  agentId,
+}: AgentBuilderTracesNamespaceParams): string => {
+  return `${TRACES_INDEX_PREFIX}${buildAgentBuilderTracesNamespace({ spaceId, agentId })}`;
+};
+
+/**
+ * Builds the per-space index pattern covering every agent's traces stream within a space:
+ * `traces-agent_builder.otel-<spaceId>.*`.
+ *
+ * Use this for reading/querying (dashboards, the traces skill, trace-exists checks). Never
+ * broaden further to `traces-agent_builder.otel-*` — that would mix data across spaces.
+ */
+export const buildAgentBuilderTracesIndexPattern = (spaceId: string): string => {
+  return `${TRACES_INDEX_PREFIX}${buildAgentBuilderTracesNamespacePattern(spaceId)}`;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_trace_exists.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_trace_exists.test.tsx
@@ -63,7 +63,7 @@ describe('useTraceExists', () => {
     expect(mockSearch).toHaveBeenCalledWith(
       expect.objectContaining({
         params: expect.objectContaining({
-          index: 'traces-agent_builder.otel-test-space',
+          index: 'traces-agent_builder.otel-test-space.*',
           body: expect.objectContaining({
             query: { term: { trace_id: 'trace-123' } },
           }),
@@ -119,7 +119,7 @@ describe('useTraceExists', () => {
     queryClient.clear();
   });
 
-  it('uses space-scoped index pattern', async () => {
+  it('uses the per-space wildcard index pattern covering every agent stream', async () => {
     mockSpaceId = 'marketing';
     mockSearch.mockReturnValue(searchResponse(0));
     const { queryClient, Wrapper } = createWrapper();
@@ -131,7 +131,7 @@ describe('useTraceExists', () => {
     expect(mockSearch).toHaveBeenCalledWith(
       expect.objectContaining({
         params: expect.objectContaining({
-          index: 'traces-agent_builder.otel-marketing',
+          index: 'traces-agent_builder.otel-marketing.*',
         }),
       })
     );

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_context.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_context.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { context as otelContext, propagation, TraceFlags } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import type { tracing } from '@elastic/opentelemetry-node/sdk';
+import { CONVERSATION_ID_BAGGAGE_KEY } from '@kbn/inference-tracing';
+import {
+  AGENT_BUILDER_OWNER_BAGGAGE_KEY,
+  AGENT_BUILDER_OWNER_BAGGAGE_VALUE,
+  SPACE_ID_BAGGAGE_KEY,
+  TRACES_NAMESPACE_BAGGAGE_KEY,
+  isAgentBuilderSpan,
+  withAgentBuilderContext,
+} from './agent_builder_context';
+
+const getActiveBaggageEntry = (key: string): string | undefined => {
+  const baggage = propagation.getBaggage(otelContext.active());
+  return baggage?.getEntry(key)?.value;
+};
+
+describe('withAgentBuilderContext', () => {
+  // The default no-op OTel context manager ignores `context.with(...)`, so a real
+  // (AsyncLocalStorage-backed) context manager is required to observe the baggage
+  // that `withAgentBuilderContext` sets on the active context inside its callback.
+  let contextManager: AsyncLocalStorageContextManager;
+
+  beforeEach(() => {
+    contextManager = new AsyncLocalStorageContextManager();
+    otelContext.setGlobalContextManager(contextManager);
+    contextManager.enable();
+  });
+
+  afterEach(() => {
+    contextManager.disable();
+  });
+
+  it('always sets the Agent Builder ownership baggage', () => {
+    withAgentBuilderContext(() => {
+      expect(getActiveBaggageEntry(AGENT_BUILDER_OWNER_BAGGAGE_KEY)).toBe(
+        AGENT_BUILDER_OWNER_BAGGAGE_VALUE
+      );
+    });
+  });
+
+  it('sets the traces-namespace baggage to "<spaceId>.<agentId>" when both are provided', () => {
+    withAgentBuilderContext(
+      () => {
+        expect(getActiveBaggageEntry(TRACES_NAMESPACE_BAGGAGE_KEY)).toBe('marketing.sales-bot');
+        expect(getActiveBaggageEntry(SPACE_ID_BAGGAGE_KEY)).toBe('marketing');
+      },
+      { spaceId: 'marketing', agentId: 'sales-bot' }
+    );
+  });
+
+  it('falls back to the space id alone when the agent cannot be resolved', () => {
+    withAgentBuilderContext(
+      () => {
+        expect(getActiveBaggageEntry(TRACES_NAMESPACE_BAGGAGE_KEY)).toBe('marketing');
+      },
+      { spaceId: 'marketing' }
+    );
+  });
+
+  it('never sets the traces-namespace baggage without a space id', () => {
+    withAgentBuilderContext(
+      () => {
+        expect(getActiveBaggageEntry(TRACES_NAMESPACE_BAGGAGE_KEY)).toBeUndefined();
+      },
+      { agentId: 'sales-bot' }
+    );
+  });
+
+  it('sets the conversation-id baggage when provided', () => {
+    withAgentBuilderContext(
+      () => {
+        expect(getActiveBaggageEntry(CONVERSATION_ID_BAGGAGE_KEY)).toBe('conversation-1');
+      },
+      { spaceId: 'default', conversationId: 'conversation-1' }
+    );
+  });
+
+  it('does not set the conversation-id baggage when omitted', () => {
+    withAgentBuilderContext(
+      () => {
+        expect(getActiveBaggageEntry(CONVERSATION_ID_BAGGAGE_KEY)).toBeUndefined();
+      },
+      { spaceId: 'default' }
+    );
+  });
+
+  it('preserves existing baggage entries set outside the callback', () => {
+    const baggage = propagation.createBaggage({ 'custom.key': { value: 'custom-value' } });
+    const ctx = propagation.setBaggage(otelContext.active(), baggage);
+
+    otelContext.with(ctx, () => {
+      withAgentBuilderContext(
+        () => {
+          expect(getActiveBaggageEntry('custom.key')).toBe('custom-value');
+          expect(getActiveBaggageEntry(AGENT_BUILDER_OWNER_BAGGAGE_KEY)).toBe(
+            AGENT_BUILDER_OWNER_BAGGAGE_VALUE
+          );
+        },
+        { spaceId: 'default' }
+      );
+    });
+  });
+
+  it('does not leak baggage outside of the callback scope', () => {
+    withAgentBuilderContext(() => {}, { spaceId: 'default' });
+
+    expect(getActiveBaggageEntry(TRACES_NAMESPACE_BAGGAGE_KEY)).toBeUndefined();
+  });
+});
+
+describe('isAgentBuilderSpan', () => {
+  const buildSpan = (name: string): tracing.Span =>
+    ({
+      name,
+      instrumentationScope: { name: 'inference' },
+      spanContext: () => ({ traceId: 't', spanId: 's', traceFlags: TraceFlags.NONE }),
+    } as unknown as tracing.Span);
+
+  it('returns false when the Agent Builder ownership baggage is missing', () => {
+    const span = buildSpan('chat gpt-4');
+    expect(isAgentBuilderSpan(span, otelContext.active())).toBe(false);
+  });
+
+  it('returns true for an inference span within an Agent Builder context', () => {
+    const baggage = propagation.createBaggage({
+      [AGENT_BUILDER_OWNER_BAGGAGE_KEY]: { value: AGENT_BUILDER_OWNER_BAGGAGE_VALUE },
+    });
+    const ctx = propagation.setBaggage(otelContext.active(), baggage);
+    const span = buildSpan('chat gpt-4');
+
+    expect(isAgentBuilderSpan(span, ctx)).toBe(true);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_context.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_context.test.ts
@@ -9,10 +9,10 @@ import { context as otelContext, propagation, TraceFlags } from '@opentelemetry/
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import type { tracing } from '@elastic/opentelemetry-node/sdk';
 import { CONVERSATION_ID_BAGGAGE_KEY } from '@kbn/inference-tracing';
+import { UNRESOLVED_AGENT_NAMESPACE_SEGMENT } from '../../common/traces';
 import {
   AGENT_BUILDER_OWNER_BAGGAGE_KEY,
   AGENT_BUILDER_OWNER_BAGGAGE_VALUE,
-  SPACE_ID_BAGGAGE_KEY,
   TRACES_NAMESPACE_BAGGAGE_KEY,
   isAgentBuilderSpan,
   withAgentBuilderContext,
@@ -51,16 +51,17 @@ describe('withAgentBuilderContext', () => {
     withAgentBuilderContext(
       () => {
         expect(getActiveBaggageEntry(TRACES_NAMESPACE_BAGGAGE_KEY)).toBe('marketing.sales-bot');
-        expect(getActiveBaggageEntry(SPACE_ID_BAGGAGE_KEY)).toBe('marketing');
       },
       { spaceId: 'marketing', agentId: 'sales-bot' }
     );
   });
 
-  it('falls back to the space id alone when the agent cannot be resolved', () => {
+  it('falls back to the unresolved-agent namespace when the agent cannot be resolved', () => {
     withAgentBuilderContext(
       () => {
-        expect(getActiveBaggageEntry(TRACES_NAMESPACE_BAGGAGE_KEY)).toBe('marketing');
+        expect(getActiveBaggageEntry(TRACES_NAMESPACE_BAGGAGE_KEY)).toBe(
+          `marketing.${UNRESOLVED_AGENT_NAMESPACE_SEGMENT}`
+        );
       },
       { spaceId: 'marketing' }
     );

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_context.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_context.ts
@@ -13,7 +13,6 @@ import { buildAgentBuilderTracesNamespace } from '../../common/traces';
 
 export const AGENT_BUILDER_OWNER_BAGGAGE_KEY = 'kibana.agent_builder';
 export const AGENT_BUILDER_OWNER_BAGGAGE_VALUE = '1';
-export const SPACE_ID_BAGGAGE_KEY = 'agent_builder.space_id';
 /**
  * W3C baggage key carrying the per-agent trace data-stream namespace (`<spaceId>` or
  * `<spaceId>.<agentId>`). Set by {@link withAgentBuilderContext} on the root span's context so
@@ -30,7 +29,13 @@ export const DATA_STREAM_NAMESPACE_ATTR = 'data_stream.namespace';
  * allowing the AgentBuilderSpanProcessor to filter them from other inference consumers.
  *
  * When `spaceId` is provided, the traces-namespace baggage is always set — falling back to the
- * space id alone when `agentId` is unresolved, so routing never broadens beyond the space.
+ * unresolved-agent namespace when `agentId` can't be resolved, so routing never broadens beyond the
+ * space nor leaves data in an unreadable bare-space stream.
+ *
+ * The namespace is set once on the conversation root context and inherited by every descendant span
+ * via OTel context propagation. In a multi-agent round this means a sub-agent's spans route to the
+ * *root* agent's stream while still carrying their own `gen_ai.agent.id` — break results down by
+ * that attribute, not by stream/index name.
  */
 export const withAgentBuilderContext = <T>(
   fn: () => T,
@@ -42,7 +47,6 @@ export const withAgentBuilderContext = <T>(
     value: AGENT_BUILDER_OWNER_BAGGAGE_VALUE,
   });
   if (options?.spaceId) {
-    baggage = baggage.setEntry(SPACE_ID_BAGGAGE_KEY, { value: options.spaceId });
     baggage = baggage.setEntry(TRACES_NAMESPACE_BAGGAGE_KEY, {
       value: buildAgentBuilderTracesNamespace({
         spaceId: options.spaceId,

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_context.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_context.ts
@@ -9,21 +9,32 @@ import type { api } from '@elastic/opentelemetry-node/sdk';
 import type { tracing } from '@elastic/opentelemetry-node/sdk';
 import { context as otelContext, propagation } from '@opentelemetry/api';
 import { isInferenceSpan, CONVERSATION_ID_BAGGAGE_KEY } from '@kbn/inference-tracing';
+import { buildAgentBuilderTracesNamespace } from '../../common/traces';
 
 export const AGENT_BUILDER_OWNER_BAGGAGE_KEY = 'kibana.agent_builder';
 export const AGENT_BUILDER_OWNER_BAGGAGE_VALUE = '1';
 export const SPACE_ID_BAGGAGE_KEY = 'agent_builder.space_id';
+/**
+ * W3C baggage key carrying the per-agent trace data-stream namespace (`<spaceId>` or
+ * `<spaceId>.<agentId>`). Set by {@link withAgentBuilderContext} on the root span's context so
+ * every descendant span — not just the ones carrying `gen_ai.agent.id` — routes to the same
+ * agent's stream. Mapped onto {@link DATA_STREAM_NAMESPACE_ATTR} by the tracing span processor.
+ */
+export const TRACES_NAMESPACE_BAGGAGE_KEY = 'agent_builder.traces_namespace';
 export const DATA_STREAM_NAMESPACE_ATTR = 'data_stream.namespace';
 
 /**
  * Executes a function within a context that has the Agent Builder ownership baggage set,
- * along with an optional space ID for data stream routing.
+ * along with an optional space ID (and agent ID) for data stream routing.
  * All descendant inference spans created inside this context will be tagged as Agent Builder spans,
  * allowing the AgentBuilderSpanProcessor to filter them from other inference consumers.
+ *
+ * When `spaceId` is provided, the traces-namespace baggage is always set — falling back to the
+ * space id alone when `agentId` is unresolved, so routing never broadens beyond the space.
  */
 export const withAgentBuilderContext = <T>(
   fn: () => T,
-  options?: { spaceId?: string; conversationId?: string }
+  options?: { spaceId?: string; agentId?: string; conversationId?: string }
 ): T => {
   const ctx = otelContext.active();
   let baggage = propagation.getBaggage(ctx) ?? propagation.createBaggage();
@@ -32,6 +43,12 @@ export const withAgentBuilderContext = <T>(
   });
   if (options?.spaceId) {
     baggage = baggage.setEntry(SPACE_ID_BAGGAGE_KEY, { value: options.spaceId });
+    baggage = baggage.setEntry(TRACES_NAMESPACE_BAGGAGE_KEY, {
+      value: buildAgentBuilderTracesNamespace({
+        spaceId: options.spaceId,
+        agentId: options.agentId,
+      }),
+    });
   }
   if (options?.conversationId) {
     baggage = baggage.setEntry(CONVERSATION_ID_BAGGAGE_KEY, { value: options.conversationId });

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/index.ts
@@ -8,6 +8,10 @@
 export { AgentBuilderSpanProcessor } from './agent_builder_span_processor';
 export { withAgentSpan } from './with_agent_span';
 export { withConverseSpan } from './with_converse_span';
-export { withAgentBuilderContext, SPACE_ID_BAGGAGE_KEY } from './agent_builder_context';
+export {
+  withAgentBuilderContext,
+  SPACE_ID_BAGGAGE_KEY,
+  TRACES_NAMESPACE_BAGGAGE_KEY,
+} from './agent_builder_context';
 export { getCurrentTraceId } from './get_current_trace_id';
 export { OpikDistributedTracingSpanProcessor } from './opik_distributed_tracing';

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/index.ts
@@ -8,10 +8,6 @@
 export { AgentBuilderSpanProcessor } from './agent_builder_span_processor';
 export { withAgentSpan } from './with_agent_span';
 export { withConverseSpan } from './with_converse_span';
-export {
-  withAgentBuilderContext,
-  SPACE_ID_BAGGAGE_KEY,
-  TRACES_NAMESPACE_BAGGAGE_KEY,
-} from './agent_builder_context';
+export { withAgentBuilderContext, TRACES_NAMESPACE_BAGGAGE_KEY } from './agent_builder_context';
 export { getCurrentTraceId } from './get_current_trace_id';
 export { OpikDistributedTracingSpanProcessor } from './opik_distributed_tracing';

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/register_tracing.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/register_tracing.test.ts
@@ -191,7 +191,7 @@ describe('registerTracingExporter', () => {
     expect(MockedEvalSpanProcessor).toHaveBeenCalledWith([
       { baggageKey: 'execution.id.baggage.key' },
       { baggageKey: 'experiment.id.baggage.key' },
-      { baggageKey: 'agent_builder.space_id', attributeKey: DATA_STREAM_NAMESPACE_ATTR },
+      { baggageKey: 'agent_builder.traces_namespace', attributeKey: DATA_STREAM_NAMESPACE_ATTR },
     ]);
     const [providerOpts] = jest.mocked(initInferenceTracerProvider).mock.calls[0];
     expect(providerOpts.processors).toHaveLength(3);

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/register_tracing.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/register_tracing.ts
@@ -36,7 +36,7 @@ import type { AgentBuilderConfig } from '../config';
 import { AgentBuilderSpanProcessor } from './agent_builder_span_processor';
 import { GlobalBridgeProcessor } from './global_bridge_processor';
 import { OpikDistributedTracingSpanProcessor } from './opik_distributed_tracing';
-import { DATA_STREAM_NAMESPACE_ATTR, SPACE_ID_BAGGAGE_KEY } from './agent_builder_context';
+import { DATA_STREAM_NAMESPACE_ATTR, TRACES_NAMESPACE_BAGGAGE_KEY } from './agent_builder_context';
 
 const SETTING_CACHE_TTL_MS = 30_000;
 
@@ -144,7 +144,7 @@ export const registerTracingExporter = async ({
     new EvalSpanProcessor([
       { baggageKey: EXECUTION_ID_BAGGAGE_KEY },
       { baggageKey: EVAL_EXPERIMENT_ID_BAGGAGE_KEY },
-      { baggageKey: SPACE_ID_BAGGAGE_KEY, attributeKey: DATA_STREAM_NAMESPACE_ATTR },
+      { baggageKey: TRACES_NAMESPACE_BAGGAGE_KEY, attributeKey: DATA_STREAM_NAMESPACE_ATTR },
     ])
   );
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.ts
@@ -67,6 +67,6 @@ export function withConverseSpan(
           return cb(span);
         }
       ),
-    { spaceId, conversationId }
+    { spaceId, agentId, conversationId }
   );
 }

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/converse_tracing_snapshot_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/converse_tracing_snapshot_api.spec.ts
@@ -22,13 +22,23 @@ import {
   mockFinalAnswer,
 } from '../../../scout_agent_builder_shared/lib/proxy_scenario/calls';
 import type { ChatResponse } from '../../../../common/http_api/chat';
-import { buildAgentBuilderTracesIndexPattern } from '../../../../common/traces';
+import {
+  buildAgentBuilderTracesIndexName,
+  buildAgentBuilderTracesIndexPattern,
+} from '../../../../common/traces';
 import { deleteAllConversationsFromEs } from '../../../scout_agent_builder_shared/lib/conversations_es';
 import { apiTest } from '../fixtures';
 import { API_AGENT_BUILDER } from '../fixtures/constants';
 import { postConverse } from '../fixtures/converse_http';
 
+const TEST_AGENT_ID = 'test_agent';
+/** Wildcard covering every agent's stream in the "default" space — used for cleanup/polling. */
 const TRACE_INDEX = buildAgentBuilderTracesIndexPattern('default');
+/** The concrete per-agent stream every span of this test's conversation must route to. */
+const AGENT_TRACE_INDEX_NAME = buildAgentBuilderTracesIndexName({
+  spaceId: 'default',
+  agentId: TEST_AGENT_ID,
+});
 
 /** Top-level _source keys to drop entirely (environment-specific or volatile) */
 const DROPPED_TOP_LEVEL_KEYS = new Set([
@@ -156,7 +166,7 @@ apiTest.describe(
       // Create a custom agent
       await kbnClient.request({
         method: 'DELETE',
-        path: `${API_AGENT_BUILDER}/agents/test_agent`,
+        path: `${API_AGENT_BUILDER}/agents/${TEST_AGENT_ID}`,
         headers: AGENT_BUILDER_PUBLIC_API_HEADERS,
         ignoreErrors: [404],
       });
@@ -165,8 +175,8 @@ apiTest.describe(
         path: `${API_AGENT_BUILDER}/agents`,
         headers: AGENT_BUILDER_PUBLIC_API_HEADERS,
         body: {
-          id: 'test_agent',
-          name: 'test_agent',
+          id: TEST_AGENT_ID,
+          name: TEST_AGENT_ID,
           description: 'Agent for tracing snapshot test',
           labels: [],
           configuration: {
@@ -184,7 +194,7 @@ apiTest.describe(
       await deleteConnectorById(kbnClient, connectorId);
       await kbnClient.request({
         method: 'DELETE',
-        path: `${API_AGENT_BUILDER}/agents/test_agent`,
+        path: `${API_AGENT_BUILDER}/agents/${TEST_AGENT_ID}`,
         headers: AGENT_BUILDER_PUBLIC_API_HEADERS,
         ignoreErrors: [404],
       });
@@ -200,7 +210,7 @@ apiTest.describe(
       'trace documents match snapshot after conversation with tool call',
       async ({ apiClient, esClient }) => {
         const EXPECTED_SPAN_COUNT = 7;
-        let hits: Array<{ _source?: unknown }> = [];
+        let hits: Array<{ _source?: unknown; _index?: string }> = [];
 
         // Mock the conversation and tool call
         mockTitleGeneration(llmProxy, 'Test Conversation');
@@ -215,7 +225,7 @@ apiTest.describe(
         const res = await postConverse(
           apiClient,
           adminCredentials.apiKeyHeader,
-          { input: 'List all indices', connector_id: connectorId, agent_id: 'test_agent' },
+          { input: 'List all indices', connector_id: connectorId, agent_id: TEST_AGENT_ID },
           'local'
         );
         expect(res).toHaveStatusCode(200);
@@ -244,6 +254,13 @@ apiTest.describe(
             { timeout: 30_000, intervals: [500, 1000, 2000] }
           )
           .toBe(EXPECTED_SPAN_COUNT);
+
+        // Hard requirement: every span of the conversation round — not only the ones carrying
+        // `gen_ai.agent.id` — must route to the agent's own per-agent data stream, never a bare
+        // per-space stream.
+        for (const hit of hits) {
+          expect(hit._index).toContain(AGENT_TRACE_INDEX_NAME);
+        }
 
         const spans = hits
           .map((hit, i) => ({ span: sanitizeSpan(hit._source as Record<string, unknown>), i }))

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/constants.ts
@@ -10,7 +10,11 @@ export const AGENT_BUILDER_OVERVIEW_DASHBOARD_ID = 'agent-builder-overview';
 
 /** Version of the Agent Builder overview dashboard. */
 export const AGENT_BUILDER_OVERVIEW_DASHBOARD_VERSION = 2;
-/** Placeholder in dashboard ES|QL queries replaced with the Kibana space namespace at install time. */
+/**
+ * Placeholder in dashboard ES|QL queries, replaced at install time with
+ * `buildAgentBuilderTracesNamespacePattern(spaceId)` (`<spaceId>.*`) so the dashboard's queries
+ * cover every per-agent traces stream in the space, without broadening across spaces.
+ */
 export const AGENT_BUILDER_TRACES_NAMESPACE_PLACEHOLDER = '__AGENT_BUILDER_TRACES_NAMESPACE__';
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/install_dashboard.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/install_dashboard.test.ts
@@ -87,7 +87,7 @@ describe('setAgentBuilderDashboard', () => {
     expect(importerMock.import).not.toHaveBeenCalled();
   });
 
-  it('replaces the namespace placeholder with the space id in imported objects', async () => {
+  it('replaces the namespace placeholder with the per-space wildcard pattern in imported objects', async () => {
     const { coreStart, importerMock } = buildCoreStart();
 
     await setAgentBuilderDashboard(coreStart as any, true, 'my-space', logger);
@@ -100,6 +100,10 @@ describe('setAgentBuilderDashboard', () => {
 
     const stringified = JSON.stringify(objects);
     expect(stringified).not.toContain(AGENT_BUILDER_TRACES_NAMESPACE_PLACEHOLDER);
+    // Queries must cover every per-agent stream in the space ("my-space.*"), not a bare
+    // space-scoped index ("my-space").
+    expect(stringified).toContain('FROM traces-agent_builder.otel-my-space.*');
+    expect(stringified).not.toMatch(/FROM traces-agent_builder\.otel-my-space\\n/);
   });
 
   it('sets the dashboard id to the space-scoped id in the imported object', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/install_dashboard.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/install_dashboard.test.ts
@@ -101,9 +101,11 @@ describe('setAgentBuilderDashboard', () => {
     const stringified = JSON.stringify(objects);
     expect(stringified).not.toContain(AGENT_BUILDER_TRACES_NAMESPACE_PLACEHOLDER);
     // Queries must cover every per-agent stream in the space ("my-space.*"), not a bare
-    // space-scoped index ("my-space").
+    // space-scoped index ("my-space"). Assert the wildcard form is present and that the bare
+    // form never appears immediately followed by anything other than the `.` wildcard segment
+    // (robust to reformatting/whitespace, unlike matching a specific trailing character).
     expect(stringified).toContain('FROM traces-agent_builder.otel-my-space.*');
-    expect(stringified).not.toMatch(/FROM traces-agent_builder\.otel-my-space\\n/);
+    expect(stringified).not.toMatch(/traces-agent_builder\.otel-my-space(?![.\w*-])/);
   });
 
   it('sets the dashboard id to the space-scoped id in the imported object', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/install_dashboard.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/dashboard/install_dashboard.ts
@@ -13,6 +13,7 @@ import type {
   SavedObjectsClientContract,
 } from '@kbn/core/server';
 import { SavedObjectsClient, SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { buildAgentBuilderTracesNamespacePattern } from '@kbn/agent-builder-plugin/common/traces';
 import {
   AGENT_BUILDER_OVERVIEW_DASHBOARD_ID,
   AGENT_BUILDER_TRACES_NAMESPACE_PLACEHOLDER,
@@ -51,7 +52,7 @@ async function installAgentBuilderOverviewDashboard(
   const dashboard = JSON.parse(
     JSON.stringify(sourceOverviewDashboard).replaceAll(
       AGENT_BUILDER_TRACES_NAMESPACE_PLACEHOLDER,
-      spaceId
+      buildAgentBuilderTracesNamespacePattern(spaceId)
     )
   ) as DashboardSavedObjectAsset;
   dashboard.id = overviewDashboardId(spaceId);

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/agent_builder_traces_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/agent_builder_traces_skill.ts
@@ -107,8 +107,11 @@ Span names follow the OTel \`{operation} {identifier}\` convention:
 - \`attributes.gen_ai.usage.input_tokens\` / \`attributes.gen_ai.usage.output_tokens\` — wrap in \`TO_LONG(...)\` before aggregating.
 - \`attributes.gen_ai.request.model\` — model name.
 - \`attributes.gen_ai.provider.name\` — provider name.
-- \`attributes.gen_ai.agent.id\` — agent id (hashed for custom agents in exported traces). Also the
-  field each agent's data stream is routed on — use it to break results down per agent.
+- \`attributes.gen_ai.agent.id\` — agent id, **hashed** for custom agents unless
+  \`agentBuilder:tracing:includeRealIds\` is on, so it usually does *not* equal the human-readable id.
+  Break results down per agent by grouping \`BY\` this field; do **not** filter
+  \`WHERE attributes.gen_ai.agent.id == "<human-known-id>"\` (that typically returns zero rows) — only
+  filter on a value already seen in returned data.
 - \`attributes.gen_ai.conversation.id\` — conversation id (hashed unless \`agentBuilder:tracing:includeRealIds\` is on).
 - \`attributes.elastic.conversation.title\` — conversation title on the conversation-turn (\`CHAIN\`) span only; omitted unless \`agentBuilder:tracing:includeRealNames\` is on.
 - \`duration\` — span duration in **nanoseconds**; divide by \`1000000000.0\` for seconds.
@@ -129,8 +132,8 @@ Span names follow the OTel \`{operation} {identifier}\` convention:
 
 ### Example query patterns
 
-These patterns assume the current space index. Replace \`<traces-index>\` with the index returned by
-the inline tool.
+These patterns assume the current space's index **pattern**. Replace \`<traces-index>\` with the
+index pattern returned by the inline tool (it covers every agent's stream in the space).
 
 Total tokens by model (last 24h):
 

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/agent_builder_traces_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/agent_builder_traces_skill.ts
@@ -55,14 +55,20 @@ Do **not** use this skill when:
 
 ## Data Source
 
-Agent Builder ships all OTel data — span telemetry **and** captured message content — to a single
-per-space traces index: \`traces-agent_builder.otel-<space-id>\`.
+Agent Builder ships all OTel data — span telemetry **and** captured message content — to a
+**dedicated data stream per agent**: \`traces-agent_builder.otel-<space-id>.<agent-id>\`. There is
+no single shared per-space index anymore; every agent in a space has its own stream.
 
 Always use \`${AGENT_BUILDER_TRACES_ESQL_INLINE_TOOL_ID}\` for trace questions. It resolves the
-current space's index automatically. Do not use a \`traces-agent_builder.otel-*\` wildcard, which
-would mix in other spaces' data.
+current space's index **pattern** automatically — \`traces-agent_builder.otel-<space-id>.*\`, which
+already covers every agent's stream in the space. Never broaden it further to a
+\`traces-agent_builder.otel-*\` wildcard, which would mix in other spaces' data, and never narrow it
+to a single agent's concrete index — filter with \`attributes.gen_ai.agent.id\` instead.
 
-If you need to run ES|QL manually, use the exact index returned by the inline tool.
+To break results down **per agent**, group or filter by \`attributes.gen_ai.agent.id\` — never by
+index name.
+
+If you need to run ES|QL manually, use the exact index pattern returned by the inline tool.
 
 Always constrain the time range with \`@timestamp\` to the window the user asked about (default to
 the last 24 hours when they do not specify one).
@@ -101,7 +107,8 @@ Span names follow the OTel \`{operation} {identifier}\` convention:
 - \`attributes.gen_ai.usage.input_tokens\` / \`attributes.gen_ai.usage.output_tokens\` — wrap in \`TO_LONG(...)\` before aggregating.
 - \`attributes.gen_ai.request.model\` — model name.
 - \`attributes.gen_ai.provider.name\` — provider name.
-- \`attributes.gen_ai.agent.id\` — agent id (hashed for custom agents in exported traces).
+- \`attributes.gen_ai.agent.id\` — agent id (hashed for custom agents in exported traces). Also the
+  field each agent's data stream is routed on — use it to break results down per agent.
 - \`attributes.gen_ai.conversation.id\` — conversation id (hashed unless \`agentBuilder:tracing:includeRealIds\` is on).
 - \`attributes.elastic.conversation.title\` — conversation title on the conversation-turn (\`CHAIN\`) span only; omitted unless \`agentBuilder:tracing:includeRealNames\` is on.
 - \`duration\` — span duration in **nanoseconds**; divide by \`1000000000.0\` for seconds.

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/inline_tools/traces_esql.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/inline_tools/traces_esql.ts
@@ -31,7 +31,10 @@ const tracesEsqlSchema = z.object({
 const buildTracesQueryRules = (tracesIndex: string) =>
   `
 This is a set of rules that you must follow strictly when generating ES|QL for Agent Builder trace spans:
-* Use ONLY this index: ${tracesIndex} — do not use a traces-agent_builder.otel-* wildcard or query any other index.
+* Use ONLY this per-space index pattern: ${tracesIndex} — it already covers every agent's traces stream in the current space. Never broaden it further to a traces-agent_builder.otel-* wildcard (that would mix in other spaces' data), and never narrow it to a single concrete index.
+* Traces are stored per agent, one data stream per agent within the space — attributes.gen_ai.agent.id is the field to break results down by agent. Do not group or filter by index name.
+* When the user's question is about a specific agent, filter with WHERE attributes.gen_ai.agent.id == "<agentId>" rather than trying to target that agent's index directly.
+* When comparing agents, group with BY attributes.gen_ai.agent.id in the STATS aggregation.
 * Always constrain the time range with @timestamp to the window the user asked about (default to the last 24 hours when they do not specify one).
 * LLM / token usage spans: span.name LIKE "chat *"
 * Tool call spans: span.name LIKE "execute_tool *"
@@ -57,8 +60,9 @@ export const createTracesEsqlTool = (): BuiltinSkillBoundedTool<typeof tracesEsq
   id: AGENT_BUILDER_TRACES_ESQL_INLINE_TOOL_ID,
   type: ToolType.builtin,
   description:
-    'Generate and execute ES|QL against the current space Agent Builder OTel traces index ' +
-    '(span telemetry and captured message content). Scopes queries to the active Kibana space automatically.',
+    'Generate and execute ES|QL against the current space Agent Builder OTel traces ' +
+    '(span telemetry and captured message content), covering every agent\'s per-agent traces ' +
+    'stream in the space. Scopes queries to the active Kibana space automatically.',
   schema: tracesEsqlSchema,
   confirmation: { askUser: 'never' },
   handler: async ({ prompt }, context) => {
@@ -93,7 +97,7 @@ export const createTracesEsqlTool = (): BuiltinSkillBoundedTool<typeof tracesEsq
           tool_result_id: getToolResultId(),
           type: ToolResultType.other,
           data: {
-            message: `Agent Builder traces index for this space: ${tracesIndex}.`,
+            message: `Agent Builder traces index pattern for this space (covers every agent): ${tracesIndex}.`,
           },
         },
       ];

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/inline_tools/traces_esql.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/agent_builder_traces/inline_tools/traces_esql.ts
@@ -33,8 +33,8 @@ const buildTracesQueryRules = (tracesIndex: string) =>
 This is a set of rules that you must follow strictly when generating ES|QL for Agent Builder trace spans:
 * Use ONLY this per-space index pattern: ${tracesIndex} — it already covers every agent's traces stream in the current space. Never broaden it further to a traces-agent_builder.otel-* wildcard (that would mix in other spaces' data), and never narrow it to a single concrete index.
 * Traces are stored per agent, one data stream per agent within the space — attributes.gen_ai.agent.id is the field to break results down by agent. Do not group or filter by index name.
-* When the user's question is about a specific agent, filter with WHERE attributes.gen_ai.agent.id == "<agentId>" rather than trying to target that agent's index directly.
-* When comparing agents, group with BY attributes.gen_ai.agent.id in the STATS aggregation.
+* IMPORTANT: attributes.gen_ai.agent.id is HASHED for custom agents unless agentBuilder:tracing:includeRealIds is enabled, so it usually does NOT equal the human-readable agent id. A WHERE attributes.gen_ai.agent.id == "<human-known-id>" filter therefore typically returns zero rows — never assume a guessed/known id will match.
+* Prefer grouping with BY attributes.gen_ai.agent.id in the STATS aggregation and letting the user pick from the returned ids. Only add an equality filter on attributes.gen_ai.agent.id for a value you have already observed in returned data, never for a human-supplied id.
 * Always constrain the time range with @timestamp to the window the user asked about (default to the last 24 hours when they do not specify one).
 * LLM / token usage spans: span.name LIKE "chat *"
 * Tool call spans: span.name LIKE "execute_tool *"
@@ -61,7 +61,7 @@ export const createTracesEsqlTool = (): BuiltinSkillBoundedTool<typeof tracesEsq
   type: ToolType.builtin,
   description:
     'Generate and execute ES|QL against the current space Agent Builder OTel traces ' +
-    '(span telemetry and captured message content), covering every agent\'s per-agent traces ' +
+    "(span telemetry and captured message content), covering every agent's per-agent traces " +
     'stream in the space. Scopes queries to the active Kibana space automatically.',
   schema: tracesEsqlSchema,
   confirmation: { askUser: 'never' },


### PR DESCRIPTION
## Summary

Route each Agent Builder agent's OTel traces to its **own per-agent data stream** (`traces-agent_builder.otel-<space>.<agent>`) instead of a shared per-space stream, and update the traces dashboard + `agent-builder-traces` skill to match. Extracted from the Context Engine self-improvement PoC (elastic/kibana#282241).

Tracks elastic/search-team#15594 (Product Monitoring & Traces workstream). **Independent** of the feedback-loop persistence/detection/UI stack — nothing depends on it.

### How it works

`withConverseSpan` calls `withAgentBuilderContext({spaceId, agentId, conversationId})` on the conversation's root span, setting W3C baggage `agent_builder.traces_namespace = "<spaceId>.<agentId>"`. Baggage propagates down the OTel context, so **every** descendant span inherits it — not only spans carrying `gen_ai.agent.id`. The span processor copies that baggage onto each span as the `data_stream.namespace` attribute; the ES OTel exporter routes the document into `traces-agent_builder.otel-<namespace>`.

**Space isolation is preserved.** When no agent can be resolved, routing falls back to `<spaceId>.<unresolved-sentinel>` (never the global `default` stream, and never a bare `<spaceId>` — see "Space-only fallback" below). Read surfaces use the per-space wildcard `...otel-<space>.*`; the code-driven paths (`useTraceExists`, dashboard install) are hard-scoped to it, while the LLM traces skill enforces it via prompt rules + the caller's ES privileges (see "Accurate scoping" below).

### What changed

> **Ownership note for reviewers:** the entire diff is in `agent_builder` / `agent_builder_platform`, owned by `@elastic/workchat-eng`.

**`agent_builder` (tracing):**
- `common/traces.ts` (+test): namespace/index helpers; `buildAgentBuilderTracesIndexPattern(spaceId)` now returns the per-space **wildcard** `...otel-<space>.*` (a **read pattern**, never a write target).
- `server/tracing/agent_builder_context.ts` (+test): `TRACES_NAMESPACE_BAGGAGE_KEY`, `agentId` option, sets namespace baggage. Removed the now-dead `SPACE_ID_BAGGAGE_KEY` (routing repointed to the namespace key; the space-id baggage had no remaining reader).
- `server/tracing/register_tracing.ts` (+test): maps the namespace baggage → `DATA_STREAM_NAMESPACE_ATTR` (was `SPACE_ID_BAGGAGE_KEY`).
- `server/tracing/with_converse_span.ts`, `index.ts`: pass `agentId`; barrel export.
- `public/.../use_trace_exists.test.tsx`, `test/scout_.../converse_tracing_snapshot_api.spec.ts`: assert per-agent routing.

**`agent_builder_platform`:**
- `server/dashboard/{constants,install_dashboard}.ts` (+test): dashboard query placeholder → per-space wildcard pattern.
- `server/skills/agent_builder_traces/*`: skill/tool guidance — per-space pattern only, never broaden, break down by `attributes.gen_ai.agent.id`.

### Self-review pass (multi-agent review + fixes applied)

Ran a multi-persona review over the whole diff and applied the safe, in-scope fixes in this branch:

- **Skill ES|QL guidance no longer produces silent zero-row answers.** The reworked rules told the model to filter `WHERE attributes.gen_ai.agent.id == "<id>"`, but that attribute is **hashed** under the default `includeRealIds=off`, so a human-known id matches nothing. Guidance now warns the id is hashed, prefers grouping `BY attributes.gen_ai.agent.id`, and only allows equality filtering on a value already seen in returned data. (`inline_tools/traces_esql.ts`, `agent_builder_traces_skill.ts`)
- **Space-only fallback is now readable.** The unresolved-agent fallback wrote to a bare `<spaceId>` stream that the `<spaceId>.*` read pattern can never match (the `.` before `*` is literal) — an unreadable "safety net". It now writes to `<spaceId>.<unresolved-sentinel>`, so the PR's "never a bare per-space stream" invariant holds end-to-end and the fallback stays covered by every read surface. Added a regression test proving fallback + resolved namespaces both match the read pattern while a sibling space never does. (`common/traces.ts` + test, `agent_builder_context.ts` + test)
- **Removed dead `SPACE_ID_BAGGAGE_KEY`** (write-only, no reader after routing repointed) — also shrinks the on-wire baggage surface.
- Doc/robustness nits: sub-agent-routing comment on `withAgentBuilderContext`; JSDoc clarifying `...IndexPattern` is read-only and `...IndexName` without `agentId` yields the fallback; `TRACES_INDEX_PREFIX` documented as mirroring the exporter convention; more reformatting-robust negative assertion in `install_dashboard.test.ts`; skill "index" → "index pattern" wording.

**Verified locally in a bootstrapped clone (node 24.18.0):** `eslint` (clean), `jest` for the changed suites (`traces.test.ts`, `agent_builder_context.test.ts`, `install_dashboard.test.ts` — all green), and `type_check` on both plugins. Scout API test still needs a live stack (see Verification).

### Consciously-owned decisions / accepted risks (need reviewer sign-off before un-drafting)

These were surfaced by review and are **deliberately left as design decisions**, not silently changed:

- **Stream name vs. id-privacy** *(needs a decision).* The namespace is built from the *raw* `agentId`; under `includeRealIds=off` (default) the `gen_ai.agent.id` attribute is hashed, so the stream **name** leaks the id and disagrees with the hashed attribute. Same space / same reader, so not cross-tenant exposure — but it's a contradiction with the anonymization control. Options: hash the namespace segment with the same transform the processor uses; route `includeRealIds=off` custom agents to a single `<space>.custom` bucket; or accept raw names as best-effort and document it. The skill fix above prevents the most user-visible symptom (zero-row filters) in the meantime.
- **Shard budget** *(needs ES / platform-monitoring sign-off).* Write target moves from one stream per space to one per (space, agent); tracing is on by default and agents are cheap, so this is uncapped (~5 spaces × 40 agents ≈ 200 streams; deleting an agent does **not** GC its stream). No per-agent template exists — streams inherit the shared `traces-*` template + ILM. Consider a cap that spills into a shared `<space>.other` bucket (solvable jointly with the fallback shape) and a cleanup story. Reviewers also questioned whether *physical* per-agent streams are needed at all, given every read wildcards across agents and groups by the attribute — if there's a concrete driver (per-agent retention/RBAC) it should be recorded.
- **Historical-trace cutover** *(accepted, bounded).* Traces written before this change live in the bare `<space>` stream and won't match the new `<space>.*` read pattern. Bounded by short ILM retention (~24h skill default); treated as a one-time conscious cutover rather than adding a dual-read/reindex.
- **Namespace length** *(assumption).* `spaceId` has no `maxLength` in its schema; `<spaceId>.<agentId≤64>` could in principle exceed the ~100-byte `data_stream.namespace` cap and drop spans at ingest. Character set is safe (both operands are slug-validated). Left as a documented assumption; a bound/hash can be added if the exporter limit warrants.
- **Multi-agent rounds** *(baseline).* Root baggage routes sub-agent spans into the parent agent's stream while they still carry their own `gen_ai.agent.id`; now called out in a code comment. Break results down by the attribute, not the stream.

### Follow-ups (not in this PR)

- **`useTraceExists` fan-out:** the 5s poll now queries `<space>.*` (all per-agent streams) with no `@timestamp` bound. The concrete win the new layout enables is to target `buildAgentBuilderTracesIndexName({spaceId, agentId})` for a single stream — but the caller doesn't currently thread `agentId`, so it's a small API change left as a follow-up (and/or add a bounded `@timestamp` filter).
- **Skill FROM-clause allowlist (defense-in-depth):** the traces skill's space scoping is prompt + ES-privilege enforced, not a hard post-generation `FROM` allowlist. **Not a regression** (pre-PR was equally prompt-only), but captured trace content is an injection-capable channel, so a hard `FROM`-subset check would harden it.
- **Extract helpers to `@kbn/agent-builder-common`:** the pure trace-naming helpers now form a public convention shared by two plugins + the installed dashboard + the LLM skill. The cross-plugin import is legal and cycle-free today; moving the helpers to the shared package (already referenced by both, already owns `agentIdRegexp`) would give the contract one owner.

### Verification

- Local (bootstrapped clone, node 24.18.0): `eslint`, `jest` (changed suites), `type_check` (both plugins) — green.
- **Scout** `converse_tracing_snapshot_api.spec.ts` needs a live stack — CI must run it; it asserts every span of a round routes to the agent's own stream.

### Risks

- Changes the destination of **all** Agent Builder trace data (per-space → per-agent stream). Existing merged-trace behavior preserved; space isolation now rests on the `<space>.<agent>` / `<space>.<unresolved>` namespace shape (a crafted `spaceId`/`agentId` cannot broaden `<space>.*` because space ids can't contain `.`/`*`). Verify no span escapes to `default`.
