### PR TITLE
[Dashboards in Chat] Verify created dashboards with browser tool

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/index.ts
@@ -8,6 +8,7 @@
 export { formatAgentBuilderErrorMessage } from './base/errors';
 export type {
   ToolServiceStartContract,
+  BrowserToolsServiceStartContract,
   ExecuteToolParams,
   ExecuteToolReturn,
   ListWorkflowsParams,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
@@ -18,6 +18,7 @@ import type {
   RendererServiceStartContract,
   EventsServiceStartContract,
   ToolServiceStartContract,
+  BrowserToolsServiceStartContract,
 } from '.';
 
 /**
@@ -190,6 +191,11 @@ export interface AgentBuilderPluginStart {
    * Tool service contract, can be used to list or execute tools.
    */
   tools: ToolServiceStartContract;
+  /**
+   * Browser tools registry contract, can be used to register browser API tools that are
+   * available in every conversation surface (standalone app and embedded hosts).
+   */
+  browserTools: BrowserToolsServiceStartContract;
   /**
    * Events service contract, can be used to listen to chat events.
    */

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/browser_api_tool.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/browser_api_tool.ts
@@ -9,6 +9,15 @@ import type { BrowserApiToolMetadata } from '@kbn/agent-builder-common';
 import { z, type ZodType } from '@kbn/zod/v4';
 
 /**
+ * Context handed to a browser API tool handler alongside the validated parameters.
+ * Populated by the conversation UI running the tool.
+ */
+export interface BrowserApiToolHandlerContext {
+  /** Id of the conversation the tool call belongs to. Undefined for unsaved conversations. */
+  conversationId?: string;
+}
+
+/**
  * Definition of a browser API tool that can be provided by consumers
  * and executed in the browser when requested by the LLM.
  */
@@ -38,13 +47,14 @@ export interface BrowserApiToolDefinition<TParams = unknown> {
 
   /**
    * Handler function that executes when the tool is called.
-   * This function runs in the browser and receives validated parameters.
+   * This function runs in the browser and receives validated parameters, plus a
+   * context object describing where the call is running (e.g. the conversation id).
    * May return a promise.
    *
    * The returned value is only sent back to the LLM when `returnsResult` is true;
    * otherwise it is discarded (one-way communication).
    */
-  handler: (params: TParams) => unknown;
+  handler: (params: TParams, context: BrowserApiToolHandlerContext) => unknown;
 
   /**
    * Opt in to two-way communication.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/browser_api_tool.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/browser_api_tool.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BrowserApiToolMetadata } from '@kbn/agent-builder-common';
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import { z, type ZodType } from '@kbn/zod/v4';
 
 /**
@@ -15,6 +16,12 @@ import { z, type ZodType } from '@kbn/zod/v4';
 export interface BrowserApiToolHandlerContext {
   /** Id of the conversation the tool call belongs to. Undefined for unsaved conversations. */
   conversationId?: string;
+  /**
+   * Attachments of the conversation the tool call belongs to, as streamed to the client.
+   * Includes attachments created during the current round, which may not be persisted yet —
+   * handlers must read attachments from here rather than fetching the stored conversation.
+   */
+  attachments?: VersionedAttachment[];
 }
 
 /**

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/browser_api_tool.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/browser_api_tool.ts
@@ -60,6 +60,17 @@ export interface BrowserApiToolDefinition<TParams = unknown> {
    * immediate acknowledgement and does not wait for the handler.
    */
   returnsResult?: boolean;
+
+  /**
+   * Declares the shape of the handler's return value. Only meaningful with `returnsResult: true`.
+   *
+   * - `'json'` (default): the JSON-serialized return value is handed to the model verbatim.
+   * - `'image'`: the return value must be `{ content: <data URL>, mime_type, filename?, image_attachment_key?, ... }`.
+   *   The server extracts the image into a hidden `image` attachment and hands the model
+   *   `{ image_attachment_id, ...other fields }` instead, so base64 never enters the model context.
+   *   Image results are exempt from the ordinary result size limit (bounded by the route's body cap).
+   */
+  resultType?: 'json' | 'image';
 }
 
 export function toToolMetadata<TParams>(
@@ -76,5 +87,6 @@ export function toToolMetadata<TParams>(
       return jsonSchema;
     })(),
     returns_result: tool.returnsResult,
+    result_type: tool.resultType,
   };
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/browser_api_tool.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/browser_api_tool.ts
@@ -39,9 +39,27 @@ export interface BrowserApiToolDefinition<TParams = unknown> {
   /**
    * Handler function that executes when the tool is called.
    * This function runs in the browser and receives validated parameters.
-   * Results are NOT returned to the LLM (one-way communication).
+   * May return a promise.
+   *
+   * The returned value is only sent back to the LLM when `returnsResult` is true;
+   * otherwise it is discarded (one-way communication).
    */
-  handler: (params: TParams) => void | Promise<void>;
+  handler: (params: TParams) => unknown;
+
+  /**
+   * Opt in to two-way communication.
+   *
+   * When true, the agent execution pauses on the tool call and resumes once the handler
+   * settles, with its JSON-serialized return value handed to the model as the tool result.
+   * The value must be JSON-serializable, and stays subject to a size limit.
+   *
+   * Prefer idempotent handlers: reloading the page while a call is pending runs the handler
+   * again, since the pending call is what the reloaded page resumes from.
+   *
+   * Defaults to false, which keeps the fire-and-forget behavior: the model gets an
+   * immediate acknowledgement and does not wait for the handler.
+   */
+  returnsResult?: boolean;
 }
 
 export function toToolMetadata<TParams>(
@@ -57,5 +75,6 @@ export function toToolMetadata<TParams>(
       });
       return jsonSchema;
     })(),
+    returns_result: tool.returnsResult,
   };
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/contract.ts
@@ -7,6 +7,7 @@
 
 import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
 import type { ToolDefinition, ToolDefinitionWithSchema } from '@kbn/agent-builder-common';
+import type { BrowserApiToolDefinition } from './browser_api_tool';
 
 export interface ExecuteToolParams {
   toolId: string;
@@ -53,4 +54,18 @@ export interface ToolServiceStartContract {
    * List available workflows for pre-execution selection.
    */
   listWorkflows(params: ListWorkflowsParams): Promise<ListWorkflowsResponse>;
+}
+
+/**
+ * Public-facing contract for AgentBuilder's browser tools registry.
+ *
+ * Plugins register browser API tools here so they are available in every
+ * agent builder conversation surface (standalone app and embedded hosts),
+ * without having to pass them as embed props.
+ */
+export interface BrowserToolsServiceStartContract {
+  /**
+   * Registers a browser API tool. Throws if a tool with the same id is already registered.
+   */
+  register(tool: BrowserApiToolDefinition<any>): void;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/prompts.ts
@@ -9,6 +9,7 @@ export enum AgentPromptType {
   confirmation = 'confirmation',
   authorization = 'authorization',
   ask_user_question = 'ask_user_question',
+  browser_tool_call = 'browser_tool_call',
 }
 
 export enum AgentPromptRequestSourceType {
@@ -102,6 +103,16 @@ export interface AskUserQuestionAnswer {
   skipped?: boolean;
 }
 
+// Browser tool call
+
+export interface BrowserToolCallPromptDefinition {
+  id: string;
+  /** Id of the browser API tool to run, without the `browser_` prefix. */
+  tool_id: string;
+  /** Parameters the agent called the tool with. */
+  params: Record<string, unknown>;
+}
+
 export interface ConfirmationPromptResponse {
   allow: boolean;
 }
@@ -114,10 +125,22 @@ export interface AskUserQuestionPromptResponse {
   answers: AskUserQuestionAnswer[];
 }
 
+export interface BrowserToolCallPromptResponse {
+  /**
+   * JSON-encoded value the browser tool handler returned. Handed to the model as
+   * the tool result. Encoded rather than structured so it can be length-bounded
+   * on the way in - it is client-supplied input.
+   */
+  result?: string;
+  /** Set instead of `result` when the handler threw, timed out, or the tool was not registered. */
+  error?: string;
+}
+
 export type PromptResponse =
   | ConfirmationPromptResponse
   | AuthorizationPromptResponse
-  | AskUserQuestionPromptResponse;
+  | AskUserQuestionPromptResponse
+  | BrowserToolCallPromptResponse;
 
 export const isConfirmationPromptResponse = (
   response: PromptResponse
@@ -137,6 +160,12 @@ export const isAskUserQuestionPromptResponse = (
   return 'answers' in response;
 };
 
+export const isBrowserToolCallPromptResponse = (
+  response: PromptResponse
+): response is BrowserToolCallPromptResponse => {
+  return 'result' in response || 'error' in response;
+};
+
 export interface ConfirmationPrompt extends ConfirmPromptDefinition {
   type: AgentPromptType.confirmation;
 }
@@ -149,7 +178,15 @@ export interface AskUserQuestionPrompt extends AskUserQuestionPromptDefinition {
   type: AgentPromptType.ask_user_question;
 }
 
-export type PromptRequest = ConfirmationPrompt | AuthorizationPrompt | AskUserQuestionPrompt;
+export interface BrowserToolCallPrompt extends BrowserToolCallPromptDefinition {
+  type: AgentPromptType.browser_tool_call;
+}
+
+export type PromptRequest =
+  | ConfirmationPrompt
+  | AuthorizationPrompt
+  | AskUserQuestionPrompt
+  | BrowserToolCallPrompt;
 
 export const isConfirmationPrompt = (prompt: PromptRequest): prompt is ConfirmationPrompt => {
   return prompt.type === AgentPromptType.confirmation;
@@ -161,6 +198,10 @@ export const isAuthorizationPrompt = (prompt: PromptRequest): prompt is Authoriz
 
 export const isAskUserQuestionPrompt = (prompt: PromptRequest): prompt is AskUserQuestionPrompt => {
   return prompt.type === AgentPromptType.ask_user_question;
+};
+
+export const isBrowserToolCallPrompt = (prompt: PromptRequest): prompt is BrowserToolCallPrompt => {
+  return prompt.type === AgentPromptType.browser_tool_call;
 };
 
 export interface ConfirmationPromptResponseState {
@@ -178,10 +219,16 @@ export interface AskUserQuestionPromptResponseState {
   response: AskUserQuestionPromptResponse;
 }
 
+export interface BrowserToolCallPromptResponseState {
+  type: AgentPromptType.browser_tool_call;
+  response: BrowserToolCallPromptResponse;
+}
+
 export type PromptResponseState =
   | ConfirmationPromptResponseState
   | AuthorizationPromptResponseState
-  | AskUserQuestionPromptResponseState;
+  | AskUserQuestionPromptResponseState
+  | BrowserToolCallPromptResponseState;
 
 /**
  * The internal representation of the prompt storage state for the conversation.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/prompts.ts
@@ -111,6 +111,11 @@ export interface BrowserToolCallPromptDefinition {
   tool_id: string;
   /** Parameters the agent called the tool with. */
   params: Record<string, unknown>;
+  /**
+   * Declared result shape, copied from the tool metadata so the resume path knows how to
+   * process the response. `'image'` results are extracted into a hidden `image` attachment.
+   */
+  result_type?: 'json' | 'image';
 }
 
 export interface ConfirmationPromptResponse {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
@@ -17,6 +17,7 @@ export enum AttachmentType {
   text = 'text',
   esql = 'esql',
   connector = 'connector',
+  image = 'image',
 }
 
 interface AttachmentDataMap {
@@ -24,6 +25,7 @@ interface AttachmentDataMap {
   [AttachmentType.text]: TextAttachmentData;
   [AttachmentType.screenContext]: ScreenContextAttachmentData;
   [AttachmentType.connector]: ConnectorAttachmentData;
+  [AttachmentType.image]: ImageAttachmentData;
 }
 
 export const esqlAttachmentDataSchema = z.object({
@@ -124,3 +126,28 @@ export interface ConnectorAttachmentData {
 }
 
 export type AttachmentDataOf<Type extends AttachmentType> = AttachmentDataMap[Type];
+
+export const SUPPORTED_IMAGE_MIME_TYPES = ['image/png', 'image/jpeg'] as const;
+export type SupportedImageMimeType = (typeof SUPPORTED_IMAGE_MIME_TYPES)[number];
+
+const IMAGE_DATA_URL_REGEX = new RegExp(
+  `^data:(${SUPPORTED_IMAGE_MIME_TYPES.map((m) => m.replace('/', '\\/')).join('|')});base64,`
+);
+
+export const imageAttachmentDataSchema = z.object({
+  content: z.string().max(3_000_000).regex(IMAGE_DATA_URL_REGEX),
+  mime_type: z.string(),
+  filename: z.string().optional(),
+});
+
+/**
+ * Data for an image attachment.
+ */
+export interface ImageAttachmentData {
+  /** base64 data URL of the image, e.g. data:image/png;base64,... */
+  content: string;
+  /** MIME type of the image */
+  mime_type: string;
+  /** Optional original filename */
+  filename?: string;
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
@@ -72,3 +72,4 @@ export type TextAttachment = Attachment<AttachmentType.text>;
 export type ScreenContextAttachment = Attachment<AttachmentType.screenContext>;
 export type EsqlAttachment = Attachment<AttachmentType.esql>;
 export type ConnectorAttachment = Attachment<AttachmentType.connector>;
+export type ImageAttachment = Attachment<AttachmentType.image>;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
@@ -12,6 +12,7 @@ export type {
   ScreenContextAttachment,
   EsqlAttachment,
   ConnectorAttachment,
+  ImageAttachment,
 } from './attachments';
 
 export type {
@@ -27,13 +28,17 @@ export {
   esqlAttachmentDataSchema,
   screenContextAttachmentDataSchema,
   connectorAttachmentDataSchema,
+  imageAttachmentDataSchema,
   CONNECTOR_TAG_PREFIX,
+  SUPPORTED_IMAGE_MIME_TYPES,
   type TextAttachmentData,
   type ScreenContextAttachmentData,
   type TimeRange,
   screenContextTimeRangeSchema,
   type EsqlAttachmentData,
   type ConnectorAttachmentData,
+  type ImageAttachmentData,
+  type SupportedImageMimeType,
 } from './attachment_types';
 
 export type {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/browser_tool_metadata.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/browser_tool_metadata.ts
@@ -47,4 +47,12 @@ export interface BrowserApiToolMetadata {
    * return value is discarded (fire-and-forget).
    */
   returns_result?: boolean;
+
+  /**
+   * Declared shape of the handler's return value. Only meaningful with `returns_result: true`.
+   * `'image'` results are extracted server-side into a hidden `image` attachment on resume;
+   * the model receives `{ image_attachment_id }` instead of the raw payload.
+   * Defaults to `'json'` (result handed to the model verbatim).
+   */
+  result_type?: 'json' | 'image';
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/browser_tool_metadata.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/browser_tool_metadata.ts
@@ -37,4 +37,14 @@ export interface BrowserApiToolMetadata {
    * Generated from the tool's Zod schema.
    */
   schema: JSONSchema;
+
+  /**
+   * When true, the agent execution pauses when the tool is called and resumes once
+   * the browser reports back, with the handler's return value handed to the model as
+   * the tool result.
+   *
+   * Defaults to false: the model gets an immediate acknowledgement and the handler's
+   * return value is discarded (fire-and-forget).
+   */
+  returns_result?: boolean;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -255,6 +255,7 @@ export const AGENT_BUILDER_BUILTIN_ATTACHMENTS = [
   'connector',
   'connector_setup',
   'skill',
+  'image',
 
   // Platform – Visualizations
   'visualization',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/round_events.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/round_events.tsx
@@ -47,9 +47,15 @@ export const RoundEvents: React.FC<RoundEventsProps> = ({
               return (
                 <EuiFlexItem grow={false} key={`group-${item.steps[0].tool_call_id}`}>
                   {item.steps.length === 1 ? (
-                    <ToolCallStep step={item.steps[0]} />
+                    <ToolCallStep
+                      step={item.steps[0]}
+                      conversationAttachments={conversationAttachments}
+                    />
                   ) : (
-                    <ToolCallGroup steps={item.steps} />
+                    <ToolCallGroup
+                      steps={item.steps}
+                      conversationAttachments={conversationAttachments}
+                    />
                   )}
                 </EuiFlexItem>
               );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_group.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_group.tsx
@@ -12,14 +12,16 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import { isErrorResult } from '@kbn/agent-builder-common/tools/tool_result';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import { StepLayout } from '../step_layout';
 import { ToolCallStep } from './tool_call_step';
 
 interface ToolCallGroupProps {
   steps: ToolCallStepData[];
+  conversationAttachments?: VersionedAttachment[];
 }
 
-export const ToolCallGroup: React.FC<ToolCallGroupProps> = ({ steps }) => {
+export const ToolCallGroup: React.FC<ToolCallGroupProps> = ({ steps, conversationAttachments }) => {
   const { euiTheme } = useEuiTheme();
   const [isExpanded, setIsExpanded] = useState(false);
   const onToggle = () => setIsExpanded((v) => !v);
@@ -62,7 +64,7 @@ export const ToolCallGroup: React.FC<ToolCallGroupProps> = ({ steps }) => {
             <EuiFlexGroup direction="column" gutterSize="s">
               {steps.map((step) => (
                 <EuiFlexItem grow={false} key={step.tool_call_id}>
-                  <ToolCallStep step={step} />
+                  <ToolCallStep step={step} conversationAttachments={conversationAttachments} />
                 </EuiFlexItem>
               ))}
             </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.test.tsx
@@ -98,6 +98,58 @@ describe('ToolCallStep', () => {
     });
   });
 
+  describe('image results', () => {
+    const BLUE_PIXEL_PNG =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+    const imageAttachment = {
+      id: 'screenshot:dash-1',
+      type: 'image',
+      active: true,
+      current_version: 1,
+      hidden: true,
+      versions: [
+        {
+          version: 1,
+          data: { content: BLUE_PIXEL_PNG, mime_type: 'image/png', filename: 'dashboard.jpg' },
+          created_at: 'now',
+          content_hash: 'h',
+        },
+      ],
+    } as any;
+
+    const imageRefStep = makeStep([
+      {
+        tool_result_id: 'r1',
+        type: ToolResultType.other,
+        data: { image_attachment_id: 'screenshot:dash-1' },
+      },
+    ]);
+
+    it('renders the referenced image inline when the attachment is available', () => {
+      renderWithProviders(
+        <ToolCallStep step={imageRefStep} conversationAttachments={[imageAttachment]} />
+      );
+      const img = screen.getByTestId('agentBuilderToolResultImage');
+      expect(img).toHaveAttribute('src', BLUE_PIXEL_PNG);
+    });
+
+    it('renders no image when the referenced attachment is not available', () => {
+      renderWithProviders(<ToolCallStep step={imageRefStep} conversationAttachments={[]} />);
+      expect(screen.queryByTestId('agentBuilderToolResultImage')).not.toBeInTheDocument();
+    });
+
+    it('renders no image for results without an image reference', () => {
+      renderWithProviders(
+        <ToolCallStep
+          step={makeStep([otherResult('r1')])}
+          conversationAttachments={[imageAttachment]}
+        />
+      );
+      expect(screen.queryByTestId('agentBuilderToolResultImage')).not.toBeInTheDocument();
+    });
+  });
+
   it('is always clickable for a running sub-agent call', () => {
     const step = createToolCallStep({
       tool_call_id: 'call-1',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
@@ -6,24 +6,29 @@
  */
 
 import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
 import { useBoolean } from '@kbn/react-hooks';
 import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import { StepLayout } from '../step_layout';
 import { ToolResponseFlyout } from '../flyouts/tool_response_flyout';
 import { useFlyoutStack } from '../flyouts/flyout_stack_context';
 import { ToolCallStepHeadline } from './tool_call_step_headline';
+import { findResultImageAttachment, ToolResultImage } from './tool_result_image';
 
 interface ToolCallStepProps {
   step: ToolCallStepData;
+  conversationAttachments?: VersionedAttachment[];
 }
 
-export const ToolCallStep: React.FC<ToolCallStepProps> = ({ step }) => {
+export const ToolCallStep: React.FC<ToolCallStepProps> = ({ step, conversationAttachments }) => {
   const flyoutStack = useFlyoutStack();
   const [isFlyoutOpen, { on: openFlyout, off: closeFlyout }] = useBoolean();
 
   const hasResults = step.results.length > 0;
   const handleClick = flyoutStack ? () => flyoutStack.openToolStep(step) : openFlyout;
+  const resultImage = findResultImageAttachment(step, conversationAttachments);
 
   return (
     <div data-test-subj="agentBuilderToolCallStep">
@@ -33,6 +38,12 @@ export const ToolCallStep: React.FC<ToolCallStepProps> = ({ step }) => {
         onClick={handleClick}
         ebtAction={AGENT_BUILDER_UI_EBT.action.conversation.VIEW_TOOL_RESPONSE}
       />
+      {resultImage && (
+        <>
+          <EuiSpacer size="s" />
+          <ToolResultImage image={resultImage} />
+        </>
+      )}
       {isFlyoutOpen && <ToolResponseFlyout step={step} onClose={closeFlyout} />}
     </div>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_result_image.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_result_image.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css } from '@emotion/react';
+import type {
+  ImageAttachmentData,
+  VersionedAttachment,
+} from '@kbn/agent-builder-common/attachments';
+import { AttachmentType, getLatestVersion } from '@kbn/agent-builder-common/attachments';
+import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
+
+/**
+ * Resolves the image attachment a tool result references via `image_attachment_id`
+ * (e.g. a screenshot captured by a browser tool). Returns undefined when the step has no
+ * image reference or the attachment is not (yet) available client-side.
+ */
+export const findResultImageAttachment = (
+  step: ToolCallStepData,
+  conversationAttachments: VersionedAttachment[] | undefined
+): ImageAttachmentData | undefined => {
+  if (!conversationAttachments) {
+    return undefined;
+  }
+  for (const result of step.results) {
+    const data = result.data as Record<string, unknown> | undefined;
+    const imageAttachmentId = data?.image_attachment_id;
+    if (typeof imageAttachmentId !== 'string') {
+      continue;
+    }
+    const attachment = conversationAttachments.find(
+      ({ id, type }) => id === imageAttachmentId && type === AttachmentType.image
+    );
+    if (attachment) {
+      const latestVersion = getLatestVersion(attachment);
+      if (latestVersion) {
+        return latestVersion.data as ImageAttachmentData;
+      }
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Inline preview of an image a tool produced (shown under the tool call step).
+ */
+export const ToolResultImage: React.FC<{ image: ImageAttachmentData }> = ({ image }) => (
+  <img
+    src={image.content}
+    alt={image.filename ?? 'Tool result image'}
+    data-test-subj="agentBuilderToolResultImage"
+    css={css`
+      max-width: 100%;
+      max-height: 300px;
+      width: fit-content;
+      border-radius: 6px;
+      display: block;
+    `}
+  />
+);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.test.tsx
@@ -36,6 +36,10 @@ jest.mock('../../../hooks/use_conversation_stream', () => ({
   useConversationStream: jest.fn(),
 }));
 
+jest.mock('../../../context/conversation/conversation_context', () => ({
+  useConversationContext: () => ({}),
+}));
+
 const useConversationStreamMock = useConversationStream as jest.MockedFunction<
   typeof useConversationStream
 >;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -186,6 +186,8 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
     isAwaitingPrompt,
   ]);
 
+  const browserToolHandlerContext = useMemo(() => ({ conversationId }), [conversationId]);
+
   const roundContainerStyles = css`
     ${roundContainerMinHeight > 0 ? `min-height: ${roundContainerMinHeight}px;` : 'flex-grow: 0;'};
   `;
@@ -289,6 +291,7 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
                   key={prompt.id}
                   prompt={prompt}
                   tool={browserApiTools?.find((tool) => tool.id === prompt.tool_id)}
+                  handlerContext={browserToolHandlerContext}
                   onComplete={(toolResponse) => handlePromptResponse(prompt.id, toolResponse)}
                 />
               );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -23,7 +23,13 @@ import { RoundEvents } from './round_events/round_events';
 import { RoundResponse } from './round_response/round_response';
 import { useConversationStream } from '../../../hooks/use_conversation_stream';
 import { RoundError } from './round_error/round_error';
-import { AuthorizationPrompt, ConfirmationPrompt, AskUserQuestionPrompt } from './round_prompt';
+import {
+  AuthorizationPrompt,
+  ConfirmationPrompt,
+  AskUserQuestionPrompt,
+  BrowserToolCallPrompt,
+} from './round_prompt';
+import { useConversationContext } from '../../../context/conversation/conversation_context';
 import { RoundAttachmentReferences } from './round_attachment_references';
 import { TodosStepDisplay } from './todos_step_display';
 
@@ -113,6 +119,7 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
     resumeRound,
     isResuming,
   } = useConversationStream();
+  const { browserApiTools } = useConversationContext();
   const isHitlDisabled = isStreaming && !isResuming;
 
   const isLoadingCurrentRound = isResponseLoading && isCurrentRound;
@@ -275,6 +282,15 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
                     />
                   </EuiFlexItem>
                 </React.Fragment>
+              );
+            case AgentPromptType.browser_tool_call:
+              return (
+                <BrowserToolCallPrompt
+                  key={prompt.id}
+                  prompt={prompt}
+                  tool={browserApiTools?.find((tool) => tool.id === prompt.tool_id)}
+                  onComplete={(toolResponse) => handlePromptResponse(prompt.id, toolResponse)}
+                />
               );
           }
         })}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -186,7 +186,10 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
     isAwaitingPrompt,
   ]);
 
-  const browserToolHandlerContext = useMemo(() => ({ conversationId }), [conversationId]);
+  const browserToolHandlerContext = useMemo(
+    () => ({ conversationId, attachments: conversationAttachments }),
+    [conversationId, conversationAttachments]
+  );
 
   const roundContainerStyles = css`
     ${roundContainerMinHeight > 0 ? `min-height: ${roundContainerMinHeight}px;` : 'flex-grow: 0;'};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.test.tsx
@@ -42,7 +42,7 @@ describe('BrowserToolCallPrompt', () => {
     );
 
     await waitFor(() => expect(onComplete).toHaveBeenCalled());
-    expect(handler).toHaveBeenCalledWith({ verbose: true });
+    expect(handler).toHaveBeenCalledWith({ verbose: true }, {});
     expect(onComplete).toHaveBeenCalledWith({ result: '{"from":"now-15m","to":"now"}' });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { z } from '@kbn/zod/v4';
+import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
+import {
+  AgentPromptType,
+  type BrowserToolCallPrompt as BrowserToolCallPromptRequest,
+} from '@kbn/agent-builder-common/agents/prompts';
+import { BrowserToolCallPrompt } from './browser_tool_call_prompt';
+
+const prompt: BrowserToolCallPromptRequest = {
+  type: AgentPromptType.browser_tool_call,
+  id: 'p1',
+  tool_id: 'get_time_range',
+  params: { verbose: true },
+};
+
+const makeTool = (
+  handler: (params: { verbose: boolean }) => unknown
+): BrowserApiToolDefinition<any> => ({
+  id: 'get_time_range',
+  description: 'Reads the current time range',
+  schema: z.object({ verbose: z.boolean() }),
+  handler,
+  returnsResult: true,
+});
+
+describe('BrowserToolCallPrompt', () => {
+  it('runs the handler with the validated params and reports the encoded result', async () => {
+    const handler = jest.fn().mockResolvedValue({ from: 'now-15m', to: 'now' });
+    const onComplete = jest.fn();
+
+    render(
+      <BrowserToolCallPrompt prompt={prompt} tool={makeTool(handler)} onComplete={onComplete} />
+    );
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+    expect(handler).toHaveBeenCalledWith({ verbose: true });
+    expect(onComplete).toHaveBeenCalledWith({ result: '{"from":"now-15m","to":"now"}' });
+  });
+
+  it('encodes a handler that returns nothing as null', async () => {
+    const onComplete = jest.fn();
+
+    render(
+      <BrowserToolCallPrompt
+        prompt={prompt}
+        tool={makeTool(() => undefined)}
+        onComplete={onComplete}
+      />
+    );
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledWith({ result: 'null' }));
+  });
+
+  it('reports an error when the tool is not registered on the page', async () => {
+    const onComplete = jest.fn();
+
+    render(<BrowserToolCallPrompt prompt={prompt} onComplete={onComplete} />);
+
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith({
+        error: "Browser tool 'get_time_range' is not registered on this page.",
+      })
+    );
+  });
+
+  it('reports an error when the handler throws', async () => {
+    const onComplete = jest.fn();
+    const tool = makeTool(() => {
+      throw new Error('no active tab');
+    });
+
+    render(<BrowserToolCallPrompt prompt={prompt} tool={tool} onComplete={onComplete} />);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledWith({ error: 'no active tab' }));
+  });
+
+  it('reports an error when the result is not JSON-serializable', async () => {
+    const onComplete = jest.fn();
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    render(
+      <BrowserToolCallPrompt
+        prompt={prompt}
+        tool={makeTool(() => circular)}
+        onComplete={onComplete}
+      />
+    );
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(onComplete.mock.calls[0][0]).toHaveProperty('error');
+  });
+
+  it('runs the handler once across re-renders', async () => {
+    const handler = jest.fn().mockResolvedValue('ok');
+    const onComplete = jest.fn();
+    const tool = makeTool(handler);
+
+    const { rerender } = render(
+      <BrowserToolCallPrompt prompt={prompt} tool={tool} onComplete={onComplete} />
+    );
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+
+    // A fresh inline `onComplete` on every render must not re-trigger the handler.
+    rerender(<BrowserToolCallPrompt prompt={prompt} tool={tool} onComplete={() => {}} />);
+    rerender(<BrowserToolCallPrompt prompt={prompt} tool={tool} onComplete={() => {}} />);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports an error instead of stalling the round when the handler never settles', async () => {
+    jest.useFakeTimers();
+    try {
+      const onComplete = jest.fn();
+      const tool = makeTool(() => new Promise(() => {}));
+
+      render(<BrowserToolCallPrompt prompt={prompt} tool={tool} onComplete={onComplete} />);
+
+      await jest.advanceTimersByTimeAsync(30_000);
+
+      expect(onComplete).toHaveBeenCalledWith({ error: 'Timed out after 30000ms.' });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.tsx
@@ -18,8 +18,13 @@ import type {
  */
 const HANDLER_TIMEOUT_MS = 30_000;
 
-/** Keep in sync with the `result` bound of the converse route's prompt response schema. */
+/**
+ * Ordinary (json) results stay small; image results carry a data URL and are bounded by the
+ * converse route's `result` schema cap (3.1M chars) instead. Keep the image bound in sync with
+ * that schema.
+ */
 const MAX_RESULT_LENGTH = 50_000;
+const MAX_IMAGE_RESULT_LENGTH = 3_100_000;
 
 export interface BrowserToolCallPromptProps {
   prompt: BrowserToolCallPromptRequest;
@@ -67,9 +72,10 @@ export const BrowserToolCallPrompt = ({ prompt, tool, onComplete }: BrowserToolC
         if (encoded === undefined) {
           return { error: 'Result is not JSON-serializable.' };
         }
-        if (encoded.length > MAX_RESULT_LENGTH) {
+        const maxLength = tool.resultType === 'image' ? MAX_IMAGE_RESULT_LENGTH : MAX_RESULT_LENGTH;
+        if (encoded.length > maxLength) {
           return {
-            error: `Result is too large (${encoded.length} characters, limit is ${MAX_RESULT_LENGTH}).`,
+            error: `Result is too large (${encoded.length} characters, limit is ${maxLength}).`,
           };
         }
         return { result: encoded };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
+import type {
+  BrowserToolCallPrompt as BrowserToolCallPromptRequest,
+  BrowserToolCallPromptResponse,
+} from '@kbn/agent-builder-common/agents/prompts';
+
+/**
+ * How long the handler is given to settle before the round is resumed with an error.
+ * Without it, a handler that never settles would leave the round awaiting a prompt forever.
+ */
+const HANDLER_TIMEOUT_MS = 30_000;
+
+/** Keep in sync with the `result` bound of the converse route's prompt response schema. */
+const MAX_RESULT_LENGTH = 50_000;
+
+export interface BrowserToolCallPromptProps {
+  prompt: BrowserToolCallPromptRequest;
+  /** Undefined when the page no longer registers the tool the agent called. */
+  tool?: BrowserApiToolDefinition<any>;
+  onComplete: (response: BrowserToolCallPromptResponse) => void;
+}
+
+/**
+ * Runs a two-way browser API tool the agent called, and reports the outcome back so the round
+ * can resume. Renders nothing: the agent is waiting on the browser, not on the user.
+ */
+export const BrowserToolCallPrompt = ({ prompt, tool, onComplete }: BrowserToolCallPromptProps) => {
+  // The handler may have side effects, so it must run exactly once per prompt - regardless of
+  // how often this component re-renders.
+  const hasRun = useRef(false);
+
+  useEffect(() => {
+    if (hasRun.current) {
+      return;
+    }
+    hasRun.current = true;
+
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const execute = async (): Promise<BrowserToolCallPromptResponse> => {
+      if (!tool) {
+        return { error: `Browser tool '${prompt.tool_id}' is not registered on this page.` };
+      }
+
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`Timed out after ${HANDLER_TIMEOUT_MS}ms.`)),
+          HANDLER_TIMEOUT_MS
+        );
+      });
+
+      try {
+        const result = await Promise.race([
+          Promise.resolve(tool.handler(tool.schema.parse(prompt.params))),
+          timeout,
+        ]);
+
+        const encoded = JSON.stringify(result ?? null);
+        if (encoded === undefined) {
+          return { error: 'Result is not JSON-serializable.' };
+        }
+        if (encoded.length > MAX_RESULT_LENGTH) {
+          return {
+            error: `Result is too large (${encoded.length} characters, limit is ${MAX_RESULT_LENGTH}).`,
+          };
+        }
+        return { result: encoded };
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : String(error) };
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    void execute().then(onComplete);
+  }, [prompt, tool, onComplete]);
+
+  return null;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/browser_tool_call_prompt.tsx
@@ -6,7 +6,10 @@
  */
 
 import { useEffect, useRef } from 'react';
-import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
+import type {
+  BrowserApiToolDefinition,
+  BrowserApiToolHandlerContext,
+} from '@kbn/agent-builder-browser/tools/browser_api_tool';
 import type {
   BrowserToolCallPrompt as BrowserToolCallPromptRequest,
   BrowserToolCallPromptResponse,
@@ -30,6 +33,8 @@ export interface BrowserToolCallPromptProps {
   prompt: BrowserToolCallPromptRequest;
   /** Undefined when the page no longer registers the tool the agent called. */
   tool?: BrowserApiToolDefinition<any>;
+  /** Context handed to the tool handler (e.g. the conversation the call belongs to). */
+  handlerContext?: BrowserApiToolHandlerContext;
   onComplete: (response: BrowserToolCallPromptResponse) => void;
 }
 
@@ -37,7 +42,12 @@ export interface BrowserToolCallPromptProps {
  * Runs a two-way browser API tool the agent called, and reports the outcome back so the round
  * can resume. Renders nothing: the agent is waiting on the browser, not on the user.
  */
-export const BrowserToolCallPrompt = ({ prompt, tool, onComplete }: BrowserToolCallPromptProps) => {
+export const BrowserToolCallPrompt = ({
+  prompt,
+  tool,
+  handlerContext,
+  onComplete,
+}: BrowserToolCallPromptProps) => {
   // The handler may have side effects, so it must run exactly once per prompt - regardless of
   // how often this component re-renders.
   const hasRun = useRef(false);
@@ -64,7 +74,7 @@ export const BrowserToolCallPrompt = ({ prompt, tool, onComplete }: BrowserToolC
 
       try {
         const result = await Promise.race([
-          Promise.resolve(tool.handler(tool.schema.parse(prompt.params))),
+          Promise.resolve(tool.handler(tool.schema.parse(prompt.params), handlerContext ?? {})),
           timeout,
         ]);
 
@@ -87,7 +97,7 @@ export const BrowserToolCallPrompt = ({ prompt, tool, onComplete }: BrowserToolC
     };
 
     void execute().then(onComplete);
-  }, [prompt, tool, onComplete]);
+  }, [prompt, tool, handlerContext, onComplete]);
 
   return null;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/index.ts
@@ -8,3 +8,4 @@
 export { ConfirmationPrompt, type ConfirmationPromptProps } from './confirmation_prompt';
 export { AuthorizationPrompt, type AuthorizationPromptProps } from './authorization_prompt';
 export { AskUserQuestionPrompt, type AskUserQuestionPromptProps } from './ask_user_question_prompt';
+export { BrowserToolCallPrompt, type BrowserToolCallPromptProps } from './browser_tool_call_prompt';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.test.tsx
@@ -85,6 +85,7 @@ const createMockServices = (): AgentBuilderInternalService =>
   ({
     agentService: { list: jest.fn().mockResolvedValue([]) },
     conversationsService: { get: jest.fn().mockRejectedValue(new Error('not found')) },
+    browserToolsService: { getBrowserTools: jest.fn(() => []) },
     startDependencies: {} as AgentBuilderStartDependencies,
   } as unknown as AgentBuilderInternalService);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -18,6 +18,7 @@ import type {
 import { ConversationContext } from './conversation_context';
 import { upsertAttachmentsIntoList } from './upsert_attachments_into_list';
 import { removeAttachmentFromList } from './remove_attachment_from_list';
+import { mergeBrowserApiTools } from './merge_browser_api_tools';
 import { AgentBuilderServicesContext } from '../agent_builder_services_context';
 import { StreamingProvider } from '../streaming/streaming_context';
 import { useConversationActions } from './use_conversation_actions';
@@ -218,6 +219,16 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
     setCurrentProps((prev) => ({ ...prev, agentId: id, newConversation: true }));
   }, []);
 
+  // Plugin-registered tools are available in every embedded conversation; host props win on id collision.
+  const browserApiTools = useMemo(
+    () =>
+      mergeBrowserApiTools(
+        services.browserToolsService.getBrowserTools(),
+        currentProps.browserApiTools
+      ),
+    [services.browserToolsService, currentProps.browserApiTools]
+  );
+
   const conversationContextValue = useMemo(
     () => ({
       conversationId,
@@ -229,7 +240,7 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
       autoSendInitialMessage: currentProps.autoSendInitialMessage ?? false,
       greetingMessage: currentProps.greetingMessage,
       resetInitialMessage,
-      browserApiTools: currentProps.browserApiTools,
+      browserApiTools,
       setConversationId,
       setAgentId,
       attachments: currentProps.attachments,
@@ -245,7 +256,7 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
       currentProps.initialMessage,
       currentProps.autoSendInitialMessage,
       currentProps.greetingMessage,
-      currentProps.browserApiTools,
+      browserApiTools,
       currentProps.attachments,
       upsertAttachments,
       resetInitialMessage,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/merge_browser_api_tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/merge_browser_api_tools.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
+
+/**
+ * Merges plugin-registered browser API tools with the tools an embed host passed as props.
+ * Host tools win on id collision. Returns undefined when there is nothing to expose, keeping
+ * the "no browser tools" shape the rest of the conversation context expects.
+ */
+export const mergeBrowserApiTools = (
+  registryTools: Array<BrowserApiToolDefinition<any>>,
+  hostTools: Array<BrowserApiToolDefinition<any>> | undefined
+): Array<BrowserApiToolDefinition<any>> | undefined => {
+  const host = hostTools ?? [];
+  const merged = [
+    ...host,
+    ...registryTools.filter((tool) => !host.some((hostTool) => hostTool.id === tool.id)),
+  ];
+  return merged.length > 0 ? merged : undefined;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/routed_conversations_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/routed_conversations_provider.test.tsx
@@ -26,6 +26,7 @@ jest.mock('@kbn/react-query', () => ({
 jest.mock('../../hooks/use_agent_builder_service', () => ({
   useAgentBuilderServices: jest.fn(() => ({
     conversationsService: {},
+    browserToolsService: { getBrowserTools: jest.fn(() => []) },
   })),
 }));
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/routed_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/routed_conversations_provider.tsx
@@ -29,7 +29,7 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
   children,
 }) => {
   const queryClient = useQueryClient();
-  const { conversationsService } = useAgentBuilderServices();
+  const { conversationsService, browserToolsService } = useAgentBuilderServices();
   const {
     services: { analytics },
   } = useKibana();
@@ -117,6 +117,12 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
     });
   }, []);
 
+  // Registry tools only: the standalone app has no embed host that could pass tools as props.
+  const browserApiTools = useMemo(() => {
+    const registryTools = browserToolsService.getBrowserTools();
+    return registryTools.length > 0 ? registryTools : undefined;
+  }, [browserToolsService]);
+
   const contextValue = useMemo(
     () => ({
       conversationId,
@@ -130,6 +136,7 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
       upsertAttachments,
       resetAttachments,
       removeAttachment,
+      browserApiTools,
     }),
     [
       conversationId,
@@ -142,6 +149,7 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
       upsertAttachments,
       resetAttachments,
       removeAttachment,
+      browserApiTools,
     ]
   );
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.test.ts
@@ -12,6 +12,7 @@ import {
   createAskUserQuestionStep,
 } from '@kbn/agent-builder-common/chat/conversation';
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { ConversationRoundStatus } from '@kbn/agent-builder-common';
 import { AgentPromptType } from '@kbn/agent-builder-common/agents';
 import type { AskUserQuestionPrompt } from '@kbn/agent-builder-common/agents';
 import type { ConversationsService } from '../../../services/conversations';
@@ -155,5 +156,54 @@ describe('createConversationActions.setAttachments', () => {
     actions.setAttachments({ attachments: attachmentFixture(2) });
 
     expect(queryClient.getQueryData<Conversation>(queryKey)).toBeUndefined();
+  });
+});
+
+describe('createConversationActions.onRoundComplete', () => {
+  it('applies the authoritative status and pending prompts to the cached round', () => {
+    const { queryClient, actions } = buildActions();
+    const queryKey = queryKeys.conversations.byId(conversationId);
+    const conversation = createNewConversation({ id: conversationId, agentId: 'agent-1' });
+    conversation.rounds.push(createNewRound({ userMessage: 'hello' }));
+    queryClient.setQueryData<Conversation>(queryKey, conversation);
+
+    const browserPrompt = {
+      type: AgentPromptType.browser_tool_call,
+      id: 'prompt-b1',
+      tool_id: 'capture_dashboard_screenshot',
+      params: {},
+    };
+    const completedRound = {
+      ...conversation.rounds[0],
+      status: ConversationRoundStatus.awaitingPrompt,
+      pending_prompts: [browserPrompt],
+    } as unknown as Parameters<typeof actions.onRoundComplete>[0];
+
+    actions.onRoundComplete(completedRound);
+
+    const cachedRound = queryClient.getQueryData<Conversation>(queryKey)?.rounds.at(-1);
+    expect(cachedRound?.status).toBe(ConversationRoundStatus.awaitingPrompt);
+    expect(cachedRound?.pending_prompts).toEqual([browserPrompt]);
+  });
+
+  it('clears stale pending prompts when the completed round has none', () => {
+    const { queryClient, actions } = buildActions();
+    const queryKey = queryKeys.conversations.byId(conversationId);
+    const conversation = createNewConversation({ id: conversationId, agentId: 'agent-1' });
+    conversation.rounds.push(createNewRound({ userMessage: 'hello' }));
+    queryClient.setQueryData<Conversation>(queryKey, conversation);
+    actions.addPendingPrompt({ prompt: pendingPrompt });
+
+    const completedRound = {
+      ...conversation.rounds[0],
+      status: ConversationRoundStatus.completed,
+      pending_prompts: undefined,
+    } as unknown as Parameters<typeof actions.onRoundComplete>[0];
+
+    actions.onRoundComplete(completedRound);
+
+    const cachedRound = queryClient.getQueryData<Conversation>(queryKey)?.rounds.at(-1);
+    expect(cachedRound?.status).toBe(ConversationRoundStatus.completed);
+    expect(cachedRound?.pending_prompts).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.ts
@@ -392,6 +392,14 @@ export const createConversationActions = ({
       }
     },
     onRoundComplete: (round: ConversationRound) => {
+      // Apply the authoritative round status and pending prompts to the cached round.
+      // Browser tool call prompts are deliberately NOT added on `prompt_request` (see
+      // `subscribeToChatEvents`): they auto-execute on mount and must only mount once the
+      // attachments delivered alongside this event are in the cache.
+      setCurrentRound((currentRound) => {
+        currentRound.status = round.status;
+        currentRound.pending_prompts = round.pending_prompts;
+      });
       const conversation = queryClient.getQueryData<Conversation>(queryKey);
       if (conversation?.agent_id) {
         patchConversationList({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_subscribe_to_chat_events.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_subscribe_to_chat_events.test.ts
@@ -8,6 +8,7 @@
 import { Subject } from 'rxjs';
 import type { ChatEvent, ConversationRound } from '@kbn/agent-builder-common';
 import { ChatEventType, ConversationRoundStatus } from '@kbn/agent-builder-common';
+import { AgentPromptType } from '@kbn/agent-builder-common/agents/prompts';
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import type { ConversationActions } from '../conversation/use_conversation_actions';
 import { subscribeToChatEvents } from './use_subscribe_to_chat_events';
@@ -124,5 +125,46 @@ describe('subscribeToChatEvents — roundComplete', () => {
     await done;
 
     expect(conversationActions.setAttachments).not.toHaveBeenCalled();
+  });
+});
+
+describe('subscribeToChatEvents — promptRequest', () => {
+  const subscribe = async (event: ChatEvent) => {
+    const events$ = new Subject<ChatEvent>();
+    const conversationActions = buildActionsMock();
+    const done = subscribeToChatEvents({ events$, conversationActions, isAborted: () => false });
+    events$.next(event);
+    events$.complete();
+    await done;
+    return conversationActions;
+  };
+
+  it('adds non-browser prompts as pending on prompt_request', async () => {
+    const prompt = {
+      type: AgentPromptType.confirmation,
+      id: 'prompt-1',
+      message: 'Allow?',
+    };
+    const conversationActions = await subscribe({
+      type: ChatEventType.promptRequest,
+      data: { prompt },
+    } as unknown as ChatEvent);
+
+    expect(conversationActions.addPendingPrompt).toHaveBeenCalledWith({ prompt });
+  });
+
+  it('does not add browser tool call prompts on prompt_request (applied on round_complete instead)', async () => {
+    const prompt = {
+      type: AgentPromptType.browser_tool_call,
+      id: 'prompt-1',
+      tool_id: 'capture_dashboard_screenshot',
+      params: {},
+    };
+    const conversationActions = await subscribe({
+      type: ChatEventType.promptRequest,
+      data: { prompt },
+    } as unknown as ChatEvent);
+
+    expect(conversationActions.addPendingPrompt).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_subscribe_to_chat_events.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_subscribe_to_chat_events.ts
@@ -29,6 +29,7 @@ import {
 } from '@kbn/agent-builder-common/chat/conversation';
 import { finalize, type Observable } from 'rxjs';
 import { isBrowserToolCallEvent } from '@kbn/agent-builder-common/chat/events';
+import { isBrowserToolCallPrompt } from '@kbn/agent-builder-common/agents/prompts';
 import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
 import type { ConversationActions } from '../conversation/use_conversation_actions';
 import type { BrowserToolExecutor } from '../../services/browser_tool_executor';
@@ -140,9 +141,15 @@ export const subscribeToChatEvents = ({
         timeToFirstToken: event.data.time_to_first_token,
       });
     } else if (isPromptRequestEvent(event)) {
-      conversationActions.addPendingPrompt({
-        prompt: event.data.prompt,
-      });
+      // Browser tool call prompts auto-execute on mount, and their handlers read conversation
+      // state (e.g. attachments) that only reaches the cache with `round_complete`. Skip them
+      // here so they mount from the authoritative round applied on `round_complete`, after
+      // `setAttachments` has run.
+      if (!isBrowserToolCallPrompt(event.data.prompt)) {
+        conversationActions.addPendingPrompt({
+          prompt: event.data.prompt,
+        });
+      }
     } else if (isCompactionStartedEvent(event)) {
       conversationActions.addCompactionStep({
         tokenCountBefore: event.data.token_count_before,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_subscribe_to_chat_events.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_subscribe_to_chat_events.ts
@@ -103,7 +103,9 @@ export const subscribeToChatEvents = ({
       const toolId = event.data.tool_id;
       if (toolId && browserToolExecutor && browserApiTools) {
         const toolDef = browserApiTools.find((tool) => tool.id === toolId);
-        if (toolDef) {
+        // Two-way tools are driven by the `browser_tool_call` prompt instead: the round pauses
+        // and `BrowserToolCallPrompt` runs the handler, so running it here would double-execute.
+        if (toolDef && !toolDef.returnsResult) {
           const toolsMap = new Map([[toolId, toolDef]]);
           browserToolExecutor
             .executeToolCalls(

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/services/browser_tool_executor.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/services/browser_tool_executor.ts
@@ -38,7 +38,8 @@ export class BrowserToolExecutor {
 
       try {
         const validatedParams = tool.schema.parse(call.params);
-        await tool.handler(validatedParams);
+        // Fire-and-forget executions have no per-call context today.
+        await tool.handler(validatedParams, {});
 
         if (this.toasts) {
           this.toasts.addSuccess({

--- a/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
@@ -11,6 +11,7 @@ import type {
   AttachmentServiceStartContract,
   RendererServiceStartContract,
   ToolServiceStartContract,
+  BrowserToolsServiceStartContract,
 } from '@kbn/agent-builder-browser';
 import type {
   AgentBuilderPluginSetup,
@@ -27,12 +28,14 @@ export type AgentsServiceStartContractMock = jest.Mocked<AgentsServiceStartContr
 export type AttachmentServiceStartContractMock = jest.Mocked<AttachmentServiceStartContract>;
 export type RendererServiceStartContractMock = jest.Mocked<RendererServiceStartContract>;
 export type ToolServiceStartContractMock = jest.Mocked<ToolServiceStartContract>;
+export type BrowserToolsServiceStartContractMock = jest.Mocked<BrowserToolsServiceStartContract>;
 
 export type AgentBuilderPluginStartMock = jest.Mocked<AgentBuilderPluginStart> & {
   agents: AgentsServiceStartContractMock;
   attachments: AttachmentServiceStartContractMock;
   renderers: RendererServiceStartContractMock;
   tools: ToolServiceStartContractMock;
+  browserTools: BrowserToolsServiceStartContractMock;
 };
 
 const createAgentStartMock = (): AgentsServiceStartContractMock => {
@@ -66,12 +69,19 @@ const createToolStartMock = (): ToolServiceStartContractMock => {
   };
 };
 
+const createBrowserToolsStartMock = (): BrowserToolsServiceStartContractMock => {
+  return {
+    register: jest.fn(),
+  };
+};
+
 const createStartContractMock = (): AgentBuilderPluginStartMock => {
   return {
     agents: createAgentStartMock(),
     attachments: createAttachmentStartMock(),
     renderers: createRendererStartMock(),
     tools: createToolStartMock(),
+    browserTools: createBrowserToolsStartMock(),
     events: {
       chat$: EMPTY,
       getChatEvents$: jest.fn().mockReturnValue(EMPTY),

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -28,6 +28,7 @@ import {
   AgentService,
   AttachmentsService,
   RenderersService,
+  BrowserToolsService,
   ChatService,
   ConversationsService,
   DocLinksService,
@@ -43,6 +44,7 @@ import {
 import { createPublicEmbeddableChatAccess } from './services/access';
 import { createPublicAttachmentContract } from './services/attachments';
 import { createPublicRenderersContract } from './services/renderers';
+import { createPublicBrowserToolsContract } from './services/browser_tools';
 import { createPublicToolContract } from './services/tools';
 import { createPublicAgentsContract } from './services/agents';
 import { createPublicEventsContract } from './services/events';
@@ -156,6 +158,7 @@ export class AgentBuilderPlugin
     const agentService = new AgentService({ http });
     const attachmentsService = new AttachmentsService({ http });
     const renderersService = new RenderersService();
+    const browserToolsService = new BrowserToolsService();
 
     const eventsService = new EventsService();
     const chatService = new ChatService({ http, events: eventsService });
@@ -225,6 +228,7 @@ export class AgentBuilderPlugin
       agentService,
       attachmentsService,
       renderersService,
+      browserToolsService,
       chatService,
       conversationsService,
       docLinksService,
@@ -311,6 +315,7 @@ export class AgentBuilderPlugin
       agents: createPublicAgentsContract({ agentService }),
       attachments: createPublicAttachmentContract({ attachmentsService }),
       renderers: createPublicRenderersContract({ renderersService }),
+      browserTools: createPublicBrowserToolsContract({ browserToolsService }),
       tools: createPublicToolContract({ toolsService }),
       events: createPublicEventsContract({ eventsService }),
       getAgentBuilderAccess: createPublicEmbeddableChatAccess({

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/browser_tools/browser_tools_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/browser_tools/browser_tools_service.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
+import { BrowserToolsService } from './browser_tools_service';
+
+const makeTool = (id: string): BrowserApiToolDefinition<{ value: string }> => ({
+  id,
+  description: `Tool ${id}`,
+  schema: z.object({ value: z.string() }),
+  handler: () => undefined,
+});
+
+describe('BrowserToolsService', () => {
+  it('returns registered tools', () => {
+    const service = new BrowserToolsService();
+    const toolA = makeTool('tool_a');
+    const toolB = makeTool('tool_b');
+
+    service.register(toolA);
+    service.register(toolB);
+
+    expect(service.getBrowserTools()).toEqual([toolA, toolB]);
+  });
+
+  it('returns an empty list when nothing is registered', () => {
+    const service = new BrowserToolsService();
+    expect(service.getBrowserTools()).toEqual([]);
+  });
+
+  it('throws when registering a duplicate tool id', () => {
+    const service = new BrowserToolsService();
+    service.register(makeTool('tool_a'));
+
+    expect(() => service.register(makeTool('tool_a'))).toThrow(
+      'Browser tool "tool_a" is already registered.'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/browser_tools/browser_tools_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/browser_tools/browser_tools_service.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
+
+/**
+ * Internal service maintaining a registry of browser API tools, keyed by tool id.
+ *
+ * Tools registered here are merged into every conversation surface (standalone app
+ * and embedded hosts), in addition to any tools the embed host passes as props.
+ */
+export class BrowserToolsService {
+  private readonly registry: Map<string, BrowserApiToolDefinition<any>> = new Map();
+
+  /**
+   * Registers a browser API tool.
+   *
+   * @throws Error if a tool with the same id is already registered.
+   */
+  register(tool: BrowserApiToolDefinition<any>): void {
+    if (this.registry.has(tool.id)) {
+      throw new Error(`Browser tool "${tool.id}" is already registered.`);
+    }
+    this.registry.set(tool.id, tool);
+  }
+
+  /**
+   * Returns all registered browser API tools.
+   */
+  getBrowserTools(): Array<BrowserApiToolDefinition<any>> {
+    return Array.from(this.registry.values());
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/browser_tools/create_public_browser_tools_contract.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/browser_tools/create_public_browser_tools_contract.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BrowserToolsServiceStartContract } from '@kbn/agent-builder-browser';
+import type { BrowserToolsService } from './browser_tools_service';
+
+export const createPublicBrowserToolsContract = ({
+  browserToolsService,
+}: {
+  browserToolsService: BrowserToolsService;
+}): BrowserToolsServiceStartContract => {
+  return {
+    register: (tool) => {
+      return browserToolsService.register(tool);
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/browser_tools/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/browser_tools/index.ts
@@ -5,12 +5,5 @@
  * 2.0.
  */
 
-export type {
-  ToolServiceStartContract,
-  BrowserToolsServiceStartContract,
-  ExecuteToolParams,
-  ExecuteToolReturn,
-  ListWorkflowsParams,
-  ListWorkflowsResponse,
-  WorkflowListItem,
-} from './contract';
+export { BrowserToolsService } from './browser_tools_service';
+export { createPublicBrowserToolsContract } from './create_public_browser_tools_contract';

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/index.ts
@@ -9,6 +9,7 @@ export { AgentBuilderAccessChecker } from './access';
 export { AgentService } from './agents';
 export { AttachmentsService } from './attachments';
 export { RenderersService } from './renderers';
+export { BrowserToolsService } from './browser_tools';
 export { ChatService } from './chat';
 export { ConversationsService } from './conversations';
 export { DocLinksService } from './doc_links';

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
@@ -12,6 +12,7 @@ import type { OpenSidebarInternalOptions } from '../sidebar/types';
 import type { AgentService } from './agents';
 import type { AttachmentsService } from './attachments';
 import type { RenderersService } from './renderers';
+import type { BrowserToolsService } from './browser_tools';
 import type { ChatService } from './chat';
 import type { ConversationsService } from './conversations';
 import type { DocLinksService } from './doc_links';
@@ -27,6 +28,7 @@ export interface AgentBuilderInternalService {
   agentService: AgentService;
   attachmentsService: AttachmentsService;
   renderersService: RenderersService;
+  browserToolsService: BrowserToolsService;
   chatService: ChatService;
   conversationsService: ConversationsService;
   docLinksService: DocLinksService;

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
@@ -74,7 +74,9 @@ export const promptResponseEntrySchema = schema.oneOf([
     }
   ),
   schema.object(
-    { result: schema.string({ maxLength: 50_000 }) },
+    // Sized for `result_type: 'image'` tools: a ~3M-char data URL plus its JSON envelope.
+    // Ordinary tools are still bounded to 50k client-side (`browser_tool_call_prompt.tsx`).
+    { result: schema.string({ maxLength: 3_100_000 }) },
     {
       meta: {
         availability: { stability: 'tech_preview' },
@@ -278,6 +280,14 @@ export const conversePayloadSchema = schema.object({
             meta: {
               description:
                 'When true, the agent pauses on the tool call and resumes with the result the browser reports back. Defaults to false (fire-and-forget).',
+            },
+          })
+        ),
+        result_type: schema.maybe(
+          schema.oneOf([schema.literal('json'), schema.literal('image')], {
+            meta: {
+              description:
+                "Declared shape of the tool result. 'image' results are extracted server-side into a hidden image attachment. Defaults to 'json'.",
             },
           })
         ),
@@ -567,6 +577,10 @@ export function registerChatRoutes({
         availability: {
           since: '9.2.0',
         },
+        // Fits an image-typed browser tool result (~3M-char data URL) in the resume payload.
+        body: {
+          maxBytes: 4 * 1024 * 1024,
+        },
       },
     })
     .addVersion(
@@ -615,6 +629,10 @@ export function registerChatRoutes({
         tags: ['oas-tag:agent builder'],
         availability: {
           since: '9.2.0',
+        },
+        // Fits an image-typed browser tool result (~3M-char data URL) in the resume payload.
+        body: {
+          maxBytes: 4 * 1024 * 1024,
         },
       },
     })

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
@@ -73,6 +73,26 @@ export const promptResponseEntrySchema = schema.oneOf([
       },
     }
   ),
+  schema.object(
+    { result: schema.string({ maxLength: 50_000 }) },
+    {
+      meta: {
+        availability: { stability: 'tech_preview' },
+        description:
+          'JSON-encoded value returned by the browser tool, answering a `browser_tool_call` prompt.',
+      },
+    }
+  ),
+  schema.object(
+    { error: schema.string({ maxLength: 2_000 }) },
+    {
+      meta: {
+        availability: { stability: 'tech_preview' },
+        description:
+          'Reason the browser tool did not produce a result, answering a `browser_tool_call` prompt.',
+      },
+    }
+  ),
 ]);
 
 export const conversePayloadSchema = schema.object({
@@ -253,6 +273,14 @@ export const conversePayloadSchema = schema.object({
         schema: schema.any({
           meta: { description: 'JSON Schema defining the tool parameters (JsonSchema7Type).' },
         }),
+        returns_result: schema.maybe(
+          schema.boolean({
+            meta: {
+              description:
+                'When true, the agent pauses on the tool call and resumes with the result the browser reports back. Defaults to false (fire-and-forget).',
+            },
+          })
+        ),
       }),
       {
         meta: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -26,6 +26,7 @@ import { HookLifecycle } from '@kbn/agent-builder-server';
 import type { ConversationInternalState, CompactionSummary } from '@kbn/agent-builder-common/chat';
 import type { ToolManager, TodoStateManager } from '@kbn/agent-builder-server/runner';
 import { ToolManagerToolType, type PromptManager } from '@kbn/agent-builder-server/runner';
+import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
 import type { ProcessedConversation } from './utils/prepare_conversation';
 import { createResultTransformer } from './utils/create_result_transformer';
 import {
@@ -330,12 +331,13 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
   logger.debug(`Running chat agent with graph: ${chatAgentGraphName}, runId: ${runId}`);
 
   const eventStream = agentGraph.streamEvents(
-    createInitializerCommand({
+    await createInitializerCommand({
       conversation: processedConversation,
       agentBuilderToLangchainIdMap: reverseMap(toolManager.getToolIdMapping()),
       cycleLimit: CYCLE_LIMIT,
       promptManager,
       eventEmitter,
+      attachmentStateManager: context.attachmentStateManager,
     }),
     {
       version: 'v2',
@@ -451,19 +453,21 @@ const getConversationState = ({
   };
 };
 
-const createInitializerCommand = ({
+const createInitializerCommand = async ({
   conversation,
   cycleLimit,
   agentBuilderToLangchainIdMap,
   promptManager,
   eventEmitter,
+  attachmentStateManager,
 }: {
   conversation: ProcessedConversation;
   cycleLimit: number;
   agentBuilderToLangchainIdMap: ToolIdMapping;
   promptManager: PromptManager;
   eventEmitter: AgentEventEmitterFn;
-}): Command => {
+  attachmentStateManager: AttachmentStateManager;
+}): Promise<Command> => {
   const initialState: Partial<StateType> = { cycleLimit };
   let startAt = steps.init;
 
@@ -472,11 +476,12 @@ const createInitializerCommand = ({
     : undefined;
 
   if (lastRound?.status === ConversationRoundStatus.awaitingPrompt) {
-    const { actions, consumedPromptIds } = buildPendingRoundActions({
+    const { actions, consumedPromptIds } = await buildPendingRoundActions({
       round: lastRound,
       promptState: promptManager.dump(),
       toolIdMapping: agentBuilderToLangchainIdMap,
       eventEmitter,
+      attachmentStateManager,
     });
     initialState.mainActions = actions;
     // on-resume cleanup: ask_user_question responses are consumed once per round.

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.test.ts
@@ -19,6 +19,10 @@ import {
   createAttachmentStateManager,
   type AttachmentStateManager,
 } from '@kbn/agent-builder-server/attachments';
+import {
+  AgentPromptType,
+  AgentPromptRequestSourceType,
+} from '@kbn/agent-builder-common/agents/prompts';
 import { createRound } from '../../../../test_utils/conversations';
 import type { ConvertedEvents } from '../convert_graph_events';
 import { createFinalStateEvent } from '../events';
@@ -394,5 +398,49 @@ describe('addRoundCompleteEvent', () => {
     const events = await runFreshRound(undefined);
     const round = events.find(isRoundCompleteEvent)?.data.round;
     expect(round?.steps.some(isRelevantSkillsStep)).toBe(false);
+  });
+
+  it('completes a round interrupted by a browser tool call prompt without a tool-call step', async () => {
+    // Browser tool calls emit a browserToolCall event instead of a toolCall event, so the
+    // round has no matching tool-call step. buildRoundState must not require one.
+    const promptRequestEvent: ChatEvent = {
+      type: ChatEventType.promptRequest,
+      data: {
+        prompt: {
+          type: AgentPromptType.browser_tool_call,
+          id: 'prompt-1',
+          tool_id: 'capture_dashboard_screenshot',
+          params: { dashboardAttachmentId: 'dash-1' },
+          result_type: 'image',
+        },
+        source: {
+          type: AgentPromptRequestSourceType.toolCall,
+          tool_call_id: 'toolu_vrtx_123',
+        },
+      },
+    };
+
+    const events = await firstValueFrom(
+      of(
+        createFinalStateEvent({ currentCycle: 1, errorCount: 0 } as never) as ConvertedEvents,
+        promptRequestEvent as ConvertedEvents
+      ).pipe(
+        addRoundCompleteEvent({
+          ...createDeps(),
+          pendingRound: undefined,
+          userInput: { message: 'validate the dashboard' },
+          startTime: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        toArray()
+      )
+    );
+
+    const round = events.find(isRoundCompleteEvent)?.data.round;
+    expect(round?.status).toBe(ConversationRoundStatus.awaitingPrompt);
+    expect(round?.pending_prompts).toEqual([
+      expect.objectContaining({ id: 'prompt-1', type: AgentPromptType.browser_tool_call }),
+    ]);
+    // No node-state snapshot for the browser tool prompt.
+    expect(round?.state?.agent.nodes).toEqual([]);
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
@@ -30,7 +30,10 @@ import type {
 import type { ExecutionConversationOrigin } from '@kbn/agent-builder-server/execution';
 import type { AttachmentVersionRef } from '@kbn/agent-builder-common/attachments';
 import { ATTACHMENT_REF_ACTOR } from '@kbn/agent-builder-common/attachments';
-import { isAskUserQuestionPrompt } from '@kbn/agent-builder-common/agents/prompts';
+import {
+  isAskUserQuestionPrompt,
+  isBrowserToolCallPrompt,
+} from '@kbn/agent-builder-common/agents/prompts';
 import type { RoundState } from '@kbn/agent-builder-common/chat/round_state';
 import type { TodoItem } from '@kbn/agent-builder-common/chat/conversation';
 import {
@@ -583,8 +586,11 @@ const buildRoundState = ({
   }
 
   // ask_user_question prompts don't need a node-state snapshot as they are stored as steps.
+  // browser_tool_call prompts don't either: browser tool calls never produce a tool-call
+  // step (they emit a browserToolCall event instead), and the resume path materializes the
+  // call/result pair from the prompt + response rather than re-running a server-side tool.
   const toolCallPromptRequests = promptRequestEvents.filter(
-    (event) => !isAskUserQuestionPrompt(event.prompt)
+    (event) => !isAskUserQuestionPrompt(event.prompt) && !isBrowserToolCallPrompt(event.prompt)
   );
 
   const nodes = toolCallPromptRequests.map((promptRequest) => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/build_pending_round_actions.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/build_pending_round_actions.test.ts
@@ -24,7 +24,7 @@ describe('buildPendingRoundActions', () => {
     response: { message: '' },
   } as any;
 
-  it('concatenates roundToActions output and pending ask_user_question actions, and returns consumedPromptIds', () => {
+  it('concatenates roundToActions output and pending ask_user_question actions, and returns consumedPromptIds', async () => {
     const askStep = createAskUserQuestionStep({
       prompt_id: 's1',
       questions: [
@@ -48,11 +48,12 @@ describe('buildPendingRoundActions', () => {
       },
     } as any;
 
-    const result = buildPendingRoundActions({
+    const result = await buildPendingRoundActions({
       round,
       promptState,
       toolIdMapping: new Map(),
       eventEmitter: jest.fn(),
+      attachmentStateManager: {} as any,
     });
 
     expect(result.actions.length).toBeGreaterThanOrEqual(2);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/build_pending_round_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/build_pending_round_actions.ts
@@ -38,7 +38,12 @@ export const buildPendingRoundActions = async ({
     eventEmitter,
   });
   const { actions: browserToolActions, consumedPromptIds: consumedBrowserToolPromptIds } =
-    await pendingBrowserToolPromptsToActions({ round, promptState, attachmentStateManager });
+    await pendingBrowserToolPromptsToActions({
+      round,
+      promptState,
+      attachmentStateManager,
+      eventEmitter,
+    });
   return {
     actions: [...stepActions, ...askActions, ...browserToolActions],
     consumedPromptIds: [...consumedPromptIds, ...consumedBrowserToolPromptIds],

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/build_pending_round_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/build_pending_round_actions.ts
@@ -8,6 +8,7 @@
 import type { ChatAgentEvent, ConversationRound } from '@kbn/agent-builder-common';
 import type { PromptStorageState } from '@kbn/agent-builder-common/agents/prompts';
 import type { ToolIdMapping } from '@kbn/agent-builder-genai-utils/langchain';
+import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
 import type { ResearchAgentAction } from '../actions';
 import type { ProcessedConversationRound } from './prepare_conversation';
 import { roundToActions } from './round_to_actions';
@@ -17,17 +18,19 @@ import { pendingBrowserToolPromptsToActions } from './pending_browser_tool_promp
 /**
  * Build the action list from the current pending round, for execution resuming (after HITL interrupts).
  */
-export const buildPendingRoundActions = ({
+export const buildPendingRoundActions = async ({
   round,
   promptState,
   toolIdMapping,
   eventEmitter,
+  attachmentStateManager,
 }: {
   round: ConversationRound | ProcessedConversationRound;
   promptState: PromptStorageState;
   toolIdMapping: ToolIdMapping;
   eventEmitter: (event: ChatAgentEvent) => void;
-}): { actions: ResearchAgentAction[]; consumedPromptIds: string[] } => {
+  attachmentStateManager: AttachmentStateManager;
+}): Promise<{ actions: ResearchAgentAction[]; consumedPromptIds: string[] }> => {
   const stepActions = roundToActions({ round, toolIdMapping });
   const { actions: askActions, consumedPromptIds } = pendingAskUserQuestionStepsToActions({
     round,
@@ -35,7 +38,7 @@ export const buildPendingRoundActions = ({
     eventEmitter,
   });
   const { actions: browserToolActions, consumedPromptIds: consumedBrowserToolPromptIds } =
-    pendingBrowserToolPromptsToActions({ round, promptState });
+    await pendingBrowserToolPromptsToActions({ round, promptState, attachmentStateManager });
   return {
     actions: [...stepActions, ...askActions, ...browserToolActions],
     consumedPromptIds: [...consumedPromptIds, ...consumedBrowserToolPromptIds],

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/build_pending_round_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/build_pending_round_actions.ts
@@ -12,6 +12,7 @@ import type { ResearchAgentAction } from '../actions';
 import type { ProcessedConversationRound } from './prepare_conversation';
 import { roundToActions } from './round_to_actions';
 import { pendingAskUserQuestionStepsToActions } from './pending_ask_user_question_steps_to_actions';
+import { pendingBrowserToolPromptsToActions } from './pending_browser_tool_prompts_to_actions';
 
 /**
  * Build the action list from the current pending round, for execution resuming (after HITL interrupts).
@@ -33,8 +34,10 @@ export const buildPendingRoundActions = ({
     promptState,
     eventEmitter,
   });
+  const { actions: browserToolActions, consumedPromptIds: consumedBrowserToolPromptIds } =
+    pendingBrowserToolPromptsToActions({ round, promptState });
   return {
-    actions: [...stepActions, ...askActions],
-    consumedPromptIds,
+    actions: [...stepActions, ...askActions, ...browserToolActions],
+    consumedPromptIds: [...consumedPromptIds, ...consumedBrowserToolPromptIds],
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ConversationRoundStatus, type ConversationRound } from '@kbn/agent-builder-common';
+import {
+  AgentPromptType,
+  type PromptRequest,
+  type PromptStorageState,
+} from '@kbn/agent-builder-common/agents/prompts';
+import { pendingBrowserToolPromptsToActions } from './pending_browser_tool_prompts_to_actions';
+import { AgentActionType } from '../actions';
+
+const browserToolPrompt = (id: string, toolId = 'get_time_range'): PromptRequest => ({
+  type: AgentPromptType.browser_tool_call,
+  id,
+  tool_id: toolId,
+  params: { verbose: true },
+});
+
+const makeRound = (...pendingPrompts: PromptRequest[]): ConversationRound =>
+  ({
+    id: 'r1',
+    status: ConversationRoundStatus.awaitingPrompt,
+    input: { message: '', attachments: [] },
+    started_at: '2026-06-04T00:00:00.000Z',
+    time_to_first_token: 0,
+    time_to_last_token: 0,
+    response: { message: '' },
+    steps: [],
+    pending_prompts: pendingPrompts,
+  } as unknown as ConversationRound);
+
+describe('pendingBrowserToolPromptsToActions', () => {
+  it('emits a toolCall + executeTool action pair carrying the result the browser reported', () => {
+    const round = makeRound(browserToolPrompt('p1'));
+    const promptState: PromptStorageState = {
+      responses: {
+        p1: {
+          type: AgentPromptType.browser_tool_call,
+          response: { result: '{"from":"now-15m","to":"now"}' },
+        },
+      },
+    };
+
+    const result = pendingBrowserToolPromptsToActions({ round, promptState });
+
+    expect(result.actions).toHaveLength(2);
+    const [toolCallAction, executeToolAction] = result.actions as any[];
+    expect(toolCallAction.type).toBe(AgentActionType.ToolCall);
+    expect(toolCallAction.tool_calls[0].toolName).toBe('browser_get_time_range');
+    expect(toolCallAction.tool_calls[0].args).toEqual({ verbose: true });
+    expect(executeToolAction.type).toBe(AgentActionType.ExecuteTool);
+    expect(executeToolAction.tool_results[0].content).toBe('{"from":"now-15m","to":"now"}');
+    expect(toolCallAction.tool_calls[0].toolCallId).toBe(
+      executeToolAction.tool_results[0].toolCallId
+    );
+    expect(result.consumedPromptIds).toEqual(['p1']);
+  });
+
+  it('surfaces the failure to the model when the browser reported an error', () => {
+    const round = makeRound(browserToolPrompt('p1'));
+    const promptState: PromptStorageState = {
+      responses: {
+        p1: {
+          type: AgentPromptType.browser_tool_call,
+          response: { error: 'Timed out after 30000ms.' },
+        },
+      },
+    };
+
+    const result = pendingBrowserToolPromptsToActions({ round, promptState });
+
+    const [, executeToolAction] = result.actions as any[];
+    expect(executeToolAction.tool_results[0].content).toBe(
+      JSON.stringify({ error: 'Timed out after 30000ms.' })
+    );
+  });
+
+  it('handles one pair per pending prompt', () => {
+    const round = makeRound(browserToolPrompt('p1', 'tool_a'), browserToolPrompt('p2', 'tool_b'));
+    const promptState: PromptStorageState = {
+      responses: {
+        p1: { type: AgentPromptType.browser_tool_call, response: { result: '1' } },
+        p2: { type: AgentPromptType.browser_tool_call, response: { result: '2' } },
+      },
+    };
+
+    const result = pendingBrowserToolPromptsToActions({ round, promptState });
+
+    expect(result.actions).toHaveLength(4);
+    expect(result.consumedPromptIds).toEqual(['p1', 'p2']);
+    // Pairs must stay adjacent: the prompt formatter drops a tool call that is not
+    // immediately followed by its result.
+    expect(result.actions.map((action) => action.type)).toEqual([
+      AgentActionType.ToolCall,
+      AgentActionType.ExecuteTool,
+      AgentActionType.ToolCall,
+      AgentActionType.ExecuteTool,
+    ]);
+  });
+
+  it('ignores prompts of other types', () => {
+    const round = makeRound({
+      type: AgentPromptType.confirmation,
+      id: 'c1',
+    } as PromptRequest);
+
+    const result = pendingBrowserToolPromptsToActions({ round, promptState: { responses: {} } });
+
+    expect(result.actions).toEqual([]);
+    expect(result.consumedPromptIds).toEqual([]);
+  });
+
+  it('returns nothing when the round has no pending prompts', () => {
+    const result = pendingBrowserToolPromptsToActions({
+      round: makeRound(),
+      promptState: { responses: {} },
+    });
+
+    expect(result.actions).toEqual([]);
+  });
+
+  it('throws when no response was submitted for a pending prompt', () => {
+    const round = makeRound(browserToolPrompt('p1'));
+
+    expect(() =>
+      pendingBrowserToolPromptsToActions({ round, promptState: { responses: {} } })
+    ).toThrow(/No browser_tool_call response found in prompt state for prompt_id p1/);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.test.ts
@@ -56,9 +56,11 @@ const createMockAttachmentStateManager = () => {
 
 describe('pendingBrowserToolPromptsToActions', () => {
   let attachmentStateManager: jest.Mocked<AttachmentStateManager>;
+  let eventEmitter: jest.Mock;
 
   beforeEach(() => {
     attachmentStateManager = createMockAttachmentStateManager();
+    eventEmitter = jest.fn();
   });
 
   it('emits a toolCall + executeTool action pair carrying the result the browser reported', async () => {
@@ -76,6 +78,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
       round,
       promptState,
       attachmentStateManager,
+      eventEmitter,
     });
 
     expect(result.actions).toHaveLength(2);
@@ -106,6 +109,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
       round,
       promptState,
       attachmentStateManager,
+      eventEmitter,
     });
 
     const [, executeToolAction] = result.actions as any[];
@@ -127,6 +131,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
       round,
       promptState,
       attachmentStateManager,
+      eventEmitter,
     });
 
     expect(result.actions).toHaveLength(4);
@@ -151,6 +156,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
       round,
       promptState: { responses: {} },
       attachmentStateManager,
+      eventEmitter,
     });
 
     expect(result.actions).toEqual([]);
@@ -162,6 +168,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
       round: makeRound(),
       promptState: { responses: {} },
       attachmentStateManager,
+      eventEmitter,
     });
 
     expect(result.actions).toEqual([]);
@@ -175,8 +182,99 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: { responses: {} },
         attachmentStateManager,
+        eventEmitter,
       })
     ).rejects.toThrow(/No browser_tool_call response found in prompt state for prompt_id p1/);
+  });
+
+  describe('transcript step events', () => {
+    it('emits toolCall + toolResult events so the run is persisted as a step', async () => {
+      const round = makeRound(browserToolPrompt('p1'));
+      const promptState: PromptStorageState = {
+        responses: {
+          p1: {
+            type: AgentPromptType.browser_tool_call,
+            response: { result: '{"from":"now-15m","to":"now"}' },
+          },
+        },
+      };
+
+      await pendingBrowserToolPromptsToActions({
+        round,
+        promptState,
+        attachmentStateManager,
+        eventEmitter,
+      });
+
+      expect(eventEmitter).toHaveBeenCalledTimes(2);
+      const [toolCallEvent, toolResultEvent] = eventEmitter.mock.calls.map(([event]) => event);
+      expect(toolCallEvent.type).toBe('tool_call');
+      expect(toolCallEvent.data.tool_id).toBe('browser_get_time_range');
+      expect(toolCallEvent.data.params).toEqual({ verbose: true });
+      expect(toolResultEvent.type).toBe('tool_result');
+      expect(toolResultEvent.data.tool_call_id).toBe(toolCallEvent.data.tool_call_id);
+      expect(toolResultEvent.data.results).toEqual([
+        expect.objectContaining({ type: 'other', data: { from: 'now-15m', to: 'now' } }),
+      ]);
+    });
+
+    it('emits an error result when the browser reported an error', async () => {
+      const round = makeRound(browserToolPrompt('p1'));
+      const promptState: PromptStorageState = {
+        responses: {
+          p1: {
+            type: AgentPromptType.browser_tool_call,
+            response: { error: 'Timed out after 30000ms.' },
+          },
+        },
+      };
+
+      await pendingBrowserToolPromptsToActions({
+        round,
+        promptState,
+        attachmentStateManager,
+        eventEmitter,
+      });
+
+      const toolResultEvent = eventEmitter.mock.calls[1][0];
+      expect(toolResultEvent.data.results).toEqual([
+        expect.objectContaining({ type: 'error', data: { message: 'Timed out after 30000ms.' } }),
+      ]);
+    });
+
+    it('emits the substituted attachment reference for image results, not the base64 payload', async () => {
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+      const promptState: PromptStorageState = {
+        responses: {
+          p1: {
+            type: AgentPromptType.browser_tool_call,
+            response: {
+              result: JSON.stringify({
+                content: BLUE_PIXEL_PNG,
+                mime_type: 'image/png',
+                image_attachment_key: 'screenshot:dash-1',
+              }),
+            },
+          },
+        },
+      };
+
+      await pendingBrowserToolPromptsToActions({
+        round,
+        promptState,
+        attachmentStateManager,
+        eventEmitter,
+      });
+
+      const toolResultEvent = eventEmitter.mock.calls[1][0];
+      expect(toolResultEvent.data.results).toEqual([
+        expect.objectContaining({
+          type: 'other',
+          data: { image_attachment_id: 'screenshot:dash-1' },
+        }),
+      ]);
+      expect(JSON.stringify(toolResultEvent)).not.toContain('base64');
+    });
   });
 
   describe('image results', () => {
@@ -201,6 +299,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: imagePromptState(imageResult()),
         attachmentStateManager,
+        eventEmitter,
       });
 
       expect(attachmentStateManager.add).toHaveBeenCalledWith({
@@ -224,6 +323,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: imagePromptState(imageResult({ panel_count: 4 })),
         attachmentStateManager,
+        eventEmitter,
       });
 
       const [, executeToolAction] = result.actions as any[];
@@ -240,6 +340,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: imagePromptState(imageResult({ image_attachment_key: 'screenshot:dash-1' })),
         attachmentStateManager,
+        eventEmitter,
       });
 
       expect(attachmentStateManager.add).toHaveBeenCalledWith(
@@ -262,6 +363,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: imagePromptState(imageResult({ image_attachment_key: 'screenshot:dash-1' })),
         attachmentStateManager,
+        eventEmitter,
       });
 
       expect(attachmentStateManager.add).not.toHaveBeenCalled();
@@ -285,6 +387,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: imagePromptState(imageResult({ image_attachment_key: 'screenshot:dash-1' })),
         attachmentStateManager,
+        eventEmitter,
       });
 
       expect(attachmentStateManager.add).not.toHaveBeenCalled();
@@ -302,6 +405,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: imagePromptState('not json'),
         attachmentStateManager,
+        eventEmitter,
       });
 
       expect(attachmentStateManager.add).not.toHaveBeenCalled();
@@ -320,6 +424,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
           JSON.stringify({ content: 'https://not-a-data-url', mime_type: 'image/png' })
         ),
         attachmentStateManager,
+        eventEmitter,
       });
 
       expect(attachmentStateManager.add).not.toHaveBeenCalled();
@@ -337,6 +442,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: imagePromptState(imageResult()),
         attachmentStateManager,
+        eventEmitter,
       });
 
       const [, executeToolAction] = result.actions as any[];
@@ -353,6 +459,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
         round,
         promptState: imagePromptState(raw),
         attachmentStateManager,
+        eventEmitter,
       });
 
       expect(attachmentStateManager.add).not.toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.test.ts
@@ -6,19 +6,29 @@
  */
 
 import { ConversationRoundStatus, type ConversationRound } from '@kbn/agent-builder-common';
+import { AttachmentType } from '@kbn/agent-builder-common/attachments';
 import {
   AgentPromptType,
   type PromptRequest,
   type PromptStorageState,
 } from '@kbn/agent-builder-common/agents/prompts';
+import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
 import { pendingBrowserToolPromptsToActions } from './pending_browser_tool_prompts_to_actions';
 import { AgentActionType } from '../actions';
 
-const browserToolPrompt = (id: string, toolId = 'get_time_range'): PromptRequest => ({
+const BLUE_PIXEL_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const browserToolPrompt = (
+  id: string,
+  toolId = 'get_time_range',
+  resultType?: 'json' | 'image'
+): PromptRequest => ({
   type: AgentPromptType.browser_tool_call,
   id,
   tool_id: toolId,
   params: { verbose: true },
+  ...(resultType ? { result_type: resultType } : {}),
 });
 
 const makeRound = (...pendingPrompts: PromptRequest[]): ConversationRound =>
@@ -34,8 +44,24 @@ const makeRound = (...pendingPrompts: PromptRequest[]): ConversationRound =>
     pending_prompts: pendingPrompts,
   } as unknown as ConversationRound);
 
+const createMockAttachmentStateManager = () => {
+  return {
+    getAttachmentRecord: jest.fn().mockReturnValue(undefined),
+    add: jest.fn().mockImplementation(async (input: { id?: string }) => ({
+      id: input.id ?? 'generated-attachment-id',
+    })),
+    update: jest.fn().mockResolvedValue({ id: 'updated' }),
+  } as unknown as jest.Mocked<AttachmentStateManager>;
+};
+
 describe('pendingBrowserToolPromptsToActions', () => {
-  it('emits a toolCall + executeTool action pair carrying the result the browser reported', () => {
+  let attachmentStateManager: jest.Mocked<AttachmentStateManager>;
+
+  beforeEach(() => {
+    attachmentStateManager = createMockAttachmentStateManager();
+  });
+
+  it('emits a toolCall + executeTool action pair carrying the result the browser reported', async () => {
     const round = makeRound(browserToolPrompt('p1'));
     const promptState: PromptStorageState = {
       responses: {
@@ -46,7 +72,11 @@ describe('pendingBrowserToolPromptsToActions', () => {
       },
     };
 
-    const result = pendingBrowserToolPromptsToActions({ round, promptState });
+    const result = await pendingBrowserToolPromptsToActions({
+      round,
+      promptState,
+      attachmentStateManager,
+    });
 
     expect(result.actions).toHaveLength(2);
     const [toolCallAction, executeToolAction] = result.actions as any[];
@@ -61,7 +91,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
     expect(result.consumedPromptIds).toEqual(['p1']);
   });
 
-  it('surfaces the failure to the model when the browser reported an error', () => {
+  it('surfaces the failure to the model when the browser reported an error', async () => {
     const round = makeRound(browserToolPrompt('p1'));
     const promptState: PromptStorageState = {
       responses: {
@@ -72,7 +102,11 @@ describe('pendingBrowserToolPromptsToActions', () => {
       },
     };
 
-    const result = pendingBrowserToolPromptsToActions({ round, promptState });
+    const result = await pendingBrowserToolPromptsToActions({
+      round,
+      promptState,
+      attachmentStateManager,
+    });
 
     const [, executeToolAction] = result.actions as any[];
     expect(executeToolAction.tool_results[0].content).toBe(
@@ -80,7 +114,7 @@ describe('pendingBrowserToolPromptsToActions', () => {
     );
   });
 
-  it('handles one pair per pending prompt', () => {
+  it('handles one pair per pending prompt', async () => {
     const round = makeRound(browserToolPrompt('p1', 'tool_a'), browserToolPrompt('p2', 'tool_b'));
     const promptState: PromptStorageState = {
       responses: {
@@ -89,7 +123,11 @@ describe('pendingBrowserToolPromptsToActions', () => {
       },
     };
 
-    const result = pendingBrowserToolPromptsToActions({ round, promptState });
+    const result = await pendingBrowserToolPromptsToActions({
+      round,
+      promptState,
+      attachmentStateManager,
+    });
 
     expect(result.actions).toHaveLength(4);
     expect(result.consumedPromptIds).toEqual(['p1', 'p2']);
@@ -103,32 +141,223 @@ describe('pendingBrowserToolPromptsToActions', () => {
     ]);
   });
 
-  it('ignores prompts of other types', () => {
+  it('ignores prompts of other types', async () => {
     const round = makeRound({
       type: AgentPromptType.confirmation,
       id: 'c1',
     } as PromptRequest);
 
-    const result = pendingBrowserToolPromptsToActions({ round, promptState: { responses: {} } });
+    const result = await pendingBrowserToolPromptsToActions({
+      round,
+      promptState: { responses: {} },
+      attachmentStateManager,
+    });
 
     expect(result.actions).toEqual([]);
     expect(result.consumedPromptIds).toEqual([]);
   });
 
-  it('returns nothing when the round has no pending prompts', () => {
-    const result = pendingBrowserToolPromptsToActions({
+  it('returns nothing when the round has no pending prompts', async () => {
+    const result = await pendingBrowserToolPromptsToActions({
       round: makeRound(),
       promptState: { responses: {} },
+      attachmentStateManager,
     });
 
     expect(result.actions).toEqual([]);
   });
 
-  it('throws when no response was submitted for a pending prompt', () => {
+  it('throws when no response was submitted for a pending prompt', async () => {
     const round = makeRound(browserToolPrompt('p1'));
 
-    expect(() =>
-      pendingBrowserToolPromptsToActions({ round, promptState: { responses: {} } })
-    ).toThrow(/No browser_tool_call response found in prompt state for prompt_id p1/);
+    await expect(
+      pendingBrowserToolPromptsToActions({
+        round,
+        promptState: { responses: {} },
+        attachmentStateManager,
+      })
+    ).rejects.toThrow(/No browser_tool_call response found in prompt state for prompt_id p1/);
+  });
+
+  describe('image results', () => {
+    const imageResult = (extra: Record<string, unknown> = {}) =>
+      JSON.stringify({
+        content: BLUE_PIXEL_PNG,
+        mime_type: 'image/png',
+        filename: 'dashboard.png',
+        ...extra,
+      });
+
+    const imagePromptState = (result: string): PromptStorageState => ({
+      responses: {
+        p1: { type: AgentPromptType.browser_tool_call, response: { result } },
+      },
+    });
+
+    it('persists the image as a hidden attachment and substitutes the tool result content', async () => {
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState(imageResult()),
+        attachmentStateManager,
+      });
+
+      expect(attachmentStateManager.add).toHaveBeenCalledWith({
+        id: undefined,
+        type: AttachmentType.image,
+        data: { content: BLUE_PIXEL_PNG, mime_type: 'image/png', filename: 'dashboard.png' },
+        hidden: true,
+        description: "Image returned by browser tool 'capture_screenshot'",
+      });
+
+      const [, executeToolAction] = result.actions as any[];
+      const content = JSON.parse(executeToolAction.tool_results[0].content);
+      expect(content).toEqual({ image_attachment_id: 'generated-attachment-id' });
+      expect(executeToolAction.tool_results[0].content).not.toContain('base64');
+    });
+
+    it('passes extra non-image fields through to the substituted content', async () => {
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState(imageResult({ panel_count: 4 })),
+        attachmentStateManager,
+      });
+
+      const [, executeToolAction] = result.actions as any[];
+      expect(JSON.parse(executeToolAction.tool_results[0].content)).toEqual({
+        image_attachment_id: 'generated-attachment-id',
+        panel_count: 4,
+      });
+    });
+
+    it('creates the attachment under the stable key the tool supplied', async () => {
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState(imageResult({ image_attachment_key: 'screenshot:dash-1' })),
+        attachmentStateManager,
+      });
+
+      expect(attachmentStateManager.add).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'screenshot:dash-1' })
+      );
+      const [, executeToolAction] = result.actions as any[];
+      expect(JSON.parse(executeToolAction.tool_results[0].content)).toEqual({
+        image_attachment_id: 'screenshot:dash-1',
+      });
+    });
+
+    it('updates the existing attachment in place when the stable key already exists', async () => {
+      attachmentStateManager.getAttachmentRecord.mockReturnValue({
+        id: 'screenshot:dash-1',
+        type: AttachmentType.image,
+      } as any);
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState(imageResult({ image_attachment_key: 'screenshot:dash-1' })),
+        attachmentStateManager,
+      });
+
+      expect(attachmentStateManager.add).not.toHaveBeenCalled();
+      expect(attachmentStateManager.update).toHaveBeenCalledWith('screenshot:dash-1', {
+        data: { content: BLUE_PIXEL_PNG, mime_type: 'image/png', filename: 'dashboard.png' },
+      });
+      const [, executeToolAction] = result.actions as any[];
+      expect(JSON.parse(executeToolAction.tool_results[0].content)).toEqual({
+        image_attachment_id: 'screenshot:dash-1',
+      });
+    });
+
+    it('rejects a stable key that belongs to a non-image attachment', async () => {
+      attachmentStateManager.getAttachmentRecord.mockReturnValue({
+        id: 'screenshot:dash-1',
+        type: AttachmentType.text,
+      } as any);
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState(imageResult({ image_attachment_key: 'screenshot:dash-1' })),
+        attachmentStateManager,
+      });
+
+      expect(attachmentStateManager.add).not.toHaveBeenCalled();
+      expect(attachmentStateManager.update).not.toHaveBeenCalled();
+      const [, executeToolAction] = result.actions as any[];
+      expect(JSON.parse(executeToolAction.tool_results[0].content)).toEqual({
+        error: expect.stringContaining('conflicts with an existing'),
+      });
+    });
+
+    it('reports an error to the model when the result is not JSON', async () => {
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState('not json'),
+        attachmentStateManager,
+      });
+
+      expect(attachmentStateManager.add).not.toHaveBeenCalled();
+      const [, executeToolAction] = result.actions as any[];
+      expect(JSON.parse(executeToolAction.tool_results[0].content)).toEqual({
+        error: expect.stringContaining('non-JSON image result'),
+      });
+    });
+
+    it('reports an error to the model when the payload is not a valid image', async () => {
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState(
+          JSON.stringify({ content: 'https://not-a-data-url', mime_type: 'image/png' })
+        ),
+        attachmentStateManager,
+      });
+
+      expect(attachmentStateManager.add).not.toHaveBeenCalled();
+      const [, executeToolAction] = result.actions as any[];
+      expect(JSON.parse(executeToolAction.tool_results[0].content)).toEqual({
+        error: expect.stringContaining('invalid image result'),
+      });
+    });
+
+    it('reports an error to the model when persisting the attachment fails', async () => {
+      (attachmentStateManager.add as jest.Mock).mockRejectedValue(new Error('validation failed'));
+      const round = makeRound(browserToolPrompt('p1', 'capture_screenshot', 'image'));
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState(imageResult()),
+        attachmentStateManager,
+      });
+
+      const [, executeToolAction] = result.actions as any[];
+      expect(JSON.parse(executeToolAction.tool_results[0].content)).toEqual({
+        error: expect.stringContaining('validation failed'),
+      });
+    });
+
+    it('hands json-typed results to the model verbatim even when they look like images', async () => {
+      const round = makeRound(browserToolPrompt('p1', 'some_tool'));
+      const raw = imageResult();
+
+      const result = await pendingBrowserToolPromptsToActions({
+        round,
+        promptState: imagePromptState(raw),
+        attachmentStateManager,
+      });
+
+      expect(attachmentStateManager.add).not.toHaveBeenCalled();
+      const [, executeToolAction] = result.actions as any[];
+      expect(executeToolAction.tool_results[0].content).toBe(raw);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { ConversationRound } from '@kbn/agent-builder-common';
+import type { PromptStorageState } from '@kbn/agent-builder-common/agents/prompts';
+import { AgentPromptType, isBrowserToolCallPrompt } from '@kbn/agent-builder-common/agents/prompts';
+import { sanitizeToolId } from '@kbn/agent-builder-genai-utils/langchain';
+import { toolCallAction, executeToolAction } from '../actions';
+import type { ResearchAgentAction } from '../actions';
+import { BROWSER_TOOL_PREFIX } from '../constants';
+import type { ProcessedConversationRound } from './prepare_conversation';
+
+/**
+ * Convert the pending browser tool call prompts + corresponding responses to a list of actions,
+ * for execution resuming.
+ *
+ * Browser tool calls interrupt the execution instead of returning a result, so the tool call
+ * never made it into the LLM message history. Here we materialize the call and the result the
+ * browser reported back, so that on resume the model sees a plain tool call / tool result pair.
+ */
+export const pendingBrowserToolPromptsToActions = ({
+  round,
+  promptState,
+}: {
+  round: ConversationRound | ProcessedConversationRound;
+  promptState: PromptStorageState;
+}): { actions: ResearchAgentAction[]; consumedPromptIds: string[] } => {
+  const actions: ResearchAgentAction[] = [];
+  const consumedPromptIds: string[] = [];
+
+  const pendingPrompts = (round.pending_prompts ?? []).filter(isBrowserToolCallPrompt);
+
+  for (const prompt of pendingPrompts) {
+    const stored = promptState.responses[prompt.id];
+    if (!stored || stored.type !== AgentPromptType.browser_tool_call) {
+      throw new Error(
+        `No browser_tool_call response found in prompt state for prompt_id ${prompt.id}`
+      );
+    }
+    const { result, error } = stored.response;
+
+    const toolCallId = uuidv4();
+    const toolName = sanitizeToolId(`${BROWSER_TOOL_PREFIX}${prompt.tool_id}`);
+
+    actions.push(toolCallAction({ toolCalls: [{ toolName, toolCallId, args: prompt.params }] }));
+    actions.push(
+      executeToolAction({
+        toolResults: [
+          {
+            toolCallId,
+            content: error !== undefined ? JSON.stringify({ error }) : result ?? 'null',
+          },
+        ],
+      })
+    );
+
+    consumedPromptIds.push(prompt.id);
+  }
+
+  return { actions, consumedPromptIds };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.ts
@@ -6,15 +6,21 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import type { ConversationRound } from '@kbn/agent-builder-common';
+import type { ChatAgentEvent, ConversationRound, ToolResult } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { AttachmentType, imageAttachmentDataSchema } from '@kbn/agent-builder-common/attachments';
 import type {
   BrowserToolCallPromptDefinition,
   PromptStorageState,
 } from '@kbn/agent-builder-common/agents/prompts';
 import { AgentPromptType, isBrowserToolCallPrompt } from '@kbn/agent-builder-common/agents/prompts';
-import { sanitizeToolId } from '@kbn/agent-builder-genai-utils/langchain';
+import {
+  sanitizeToolId,
+  createToolCallEvent,
+  createToolResultEvent,
+} from '@kbn/agent-builder-genai-utils/langchain';
 import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
+import { getToolResultId } from '@kbn/agent-builder-server';
 import { toolCallAction, executeToolAction } from '../actions';
 import type { ResearchAgentAction } from '../actions';
 import { BROWSER_TOOL_PREFIX } from '../constants';
@@ -38,15 +44,21 @@ const MAX_ATTACHMENT_KEY_LENGTH = 256;
  * Results of `result_type: 'image'` tools are not handed to the model verbatim: the image is
  * persisted as a hidden `image` attachment and the tool result is substituted with
  * `{ image_attachment_id, ...other fields }`, so base64 never enters the model context.
+ *
+ * Each materialized pair is also emitted as toolCall/toolResult events so the run shows up
+ * in the transcript as a persisted step (browser tool calls emit no tool-call step of their
+ * own during the interrupted round).
  */
 export const pendingBrowserToolPromptsToActions = async ({
   round,
   promptState,
   attachmentStateManager,
+  eventEmitter,
 }: {
   round: ConversationRound | ProcessedConversationRound;
   promptState: PromptStorageState;
   attachmentStateManager: AttachmentStateManager;
+  eventEmitter: (event: ChatAgentEvent) => void;
 }): Promise<{ actions: ResearchAgentAction[]; consumedPromptIds: string[] }> => {
   const actions: ResearchAgentAction[] = [];
   const consumedPromptIds: string[] = [];
@@ -77,10 +89,50 @@ export const pendingBrowserToolPromptsToActions = async ({
     actions.push(toolCallAction({ toolCalls: [{ toolName, toolCallId, args: prompt.params }] }));
     actions.push(executeToolAction({ toolResults: [{ toolCallId, content }] }));
 
+    eventEmitter(createToolCallEvent({ toolId: toolName, toolCallId, params: prompt.params }));
+    eventEmitter(
+      createToolResultEvent({ toolCallId, toolId: toolName, results: [contentToResult(content)] })
+    );
+
     consumedPromptIds.push(prompt.id);
   }
 
   return { actions, consumedPromptIds };
+};
+
+/**
+ * Convert the (JSON-encoded) tool result content into a `ToolResult` for the transcript step.
+ * `{ error }` contents become error results so the step renders as failed.
+ */
+const contentToResult = (content: string): ToolResult => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    parsed = content;
+  }
+
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'error' in parsed &&
+    typeof (parsed as { error: unknown }).error === 'string'
+  ) {
+    return {
+      type: ToolResultType.error,
+      tool_result_id: getToolResultId(),
+      data: { message: (parsed as { error: string }).error },
+    };
+  }
+
+  return {
+    type: ToolResultType.other,
+    tool_result_id: getToolResultId(),
+    data:
+      typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : { value: parsed },
+  };
 };
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/pending_browser_tool_prompts_to_actions.ts
@@ -7,13 +7,25 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { ConversationRound } from '@kbn/agent-builder-common';
-import type { PromptStorageState } from '@kbn/agent-builder-common/agents/prompts';
+import { AttachmentType, imageAttachmentDataSchema } from '@kbn/agent-builder-common/attachments';
+import type {
+  BrowserToolCallPromptDefinition,
+  PromptStorageState,
+} from '@kbn/agent-builder-common/agents/prompts';
 import { AgentPromptType, isBrowserToolCallPrompt } from '@kbn/agent-builder-common/agents/prompts';
 import { sanitizeToolId } from '@kbn/agent-builder-genai-utils/langchain';
+import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
 import { toolCallAction, executeToolAction } from '../actions';
 import type { ResearchAgentAction } from '../actions';
 import { BROWSER_TOOL_PREFIX } from '../constants';
 import type { ProcessedConversationRound } from './prepare_conversation';
+
+/**
+ * Optional field on an image tool result: a stable attachment id the tool supplies so repeated
+ * captures update the same attachment in place (versioned) instead of piling up new ones.
+ */
+const IMAGE_ATTACHMENT_KEY_FIELD = 'image_attachment_key';
+const MAX_ATTACHMENT_KEY_LENGTH = 256;
 
 /**
  * Convert the pending browser tool call prompts + corresponding responses to a list of actions,
@@ -22,14 +34,20 @@ import type { ProcessedConversationRound } from './prepare_conversation';
  * Browser tool calls interrupt the execution instead of returning a result, so the tool call
  * never made it into the LLM message history. Here we materialize the call and the result the
  * browser reported back, so that on resume the model sees a plain tool call / tool result pair.
+ *
+ * Results of `result_type: 'image'` tools are not handed to the model verbatim: the image is
+ * persisted as a hidden `image` attachment and the tool result is substituted with
+ * `{ image_attachment_id, ...other fields }`, so base64 never enters the model context.
  */
-export const pendingBrowserToolPromptsToActions = ({
+export const pendingBrowserToolPromptsToActions = async ({
   round,
   promptState,
+  attachmentStateManager,
 }: {
   round: ConversationRound | ProcessedConversationRound;
   promptState: PromptStorageState;
-}): { actions: ResearchAgentAction[]; consumedPromptIds: string[] } => {
+  attachmentStateManager: AttachmentStateManager;
+}): Promise<{ actions: ResearchAgentAction[]; consumedPromptIds: string[] }> => {
   const actions: ResearchAgentAction[] = [];
   const consumedPromptIds: string[] = [];
 
@@ -44,23 +62,110 @@ export const pendingBrowserToolPromptsToActions = ({
     }
     const { result, error } = stored.response;
 
+    let content: string;
+    if (error !== undefined) {
+      content = JSON.stringify({ error });
+    } else if (prompt.result_type === 'image' && result !== undefined) {
+      content = await imageResultToAttachmentRef({ prompt, result, attachmentStateManager });
+    } else {
+      content = result ?? 'null';
+    }
+
     const toolCallId = uuidv4();
     const toolName = sanitizeToolId(`${BROWSER_TOOL_PREFIX}${prompt.tool_id}`);
 
     actions.push(toolCallAction({ toolCalls: [{ toolName, toolCallId, args: prompt.params }] }));
-    actions.push(
-      executeToolAction({
-        toolResults: [
-          {
-            toolCallId,
-            content: error !== undefined ? JSON.stringify({ error }) : result ?? 'null',
-          },
-        ],
-      })
-    );
+    actions.push(executeToolAction({ toolResults: [{ toolCallId, content }] }));
 
     consumedPromptIds.push(prompt.id);
   }
 
   return { actions, consumedPromptIds };
+};
+
+/**
+ * Persist an image tool result as a hidden `image` attachment and return the substituted
+ * tool result content. Returns a JSON-encoded `{ error }` string when the payload is not a
+ * valid image result, so the model learns the capture failed.
+ */
+const imageResultToAttachmentRef = async ({
+  prompt,
+  result,
+  attachmentStateManager,
+}: {
+  prompt: BrowserToolCallPromptDefinition;
+  result: string;
+  attachmentStateManager: AttachmentStateManager;
+}): Promise<string> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result);
+  } catch {
+    return JSON.stringify({
+      error: `Browser tool '${prompt.tool_id}' returned a non-JSON image result.`,
+    });
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return JSON.stringify({
+      error: `Browser tool '${prompt.tool_id}' returned an invalid image result: expected an object with 'content' and 'mime_type'.`,
+    });
+  }
+
+  const {
+    content,
+    mime_type: mimeType,
+    filename,
+    [IMAGE_ATTACHMENT_KEY_FIELD]: attachmentKey,
+    ...extraFields
+  } = parsed as Record<string, unknown>;
+
+  const validation = imageAttachmentDataSchema.safeParse({
+    content,
+    mime_type: mimeType,
+    filename,
+  });
+  if (!validation.success) {
+    return JSON.stringify({
+      error: `Browser tool '${prompt.tool_id}' returned an invalid image result: ${validation.error.message}`,
+    });
+  }
+
+  const stableId =
+    typeof attachmentKey === 'string' &&
+    attachmentKey.length > 0 &&
+    attachmentKey.length <= MAX_ATTACHMENT_KEY_LENGTH
+      ? attachmentKey
+      : undefined;
+
+  try {
+    let attachmentId: string;
+    const existing = stableId ? attachmentStateManager.getAttachmentRecord(stableId) : undefined;
+    if (existing) {
+      if (existing.type !== AttachmentType.image) {
+        return JSON.stringify({
+          error: `Attachment key '${stableId}' conflicts with an existing '${existing.type}' attachment.`,
+        });
+      }
+      await attachmentStateManager.update(existing.id, { data: validation.data });
+      attachmentId = existing.id;
+    } else {
+      const added = await attachmentStateManager.add({
+        id: stableId,
+        type: AttachmentType.image,
+        data: validation.data,
+        hidden: true,
+        description: `Image returned by browser tool '${prompt.tool_id}'`,
+      });
+      attachmentId = added.id;
+    }
+
+    return JSON.stringify({ image_attachment_id: attachmentId, ...extraFields });
+  } catch (e) {
+    return JSON.stringify({
+      error: `Failed to store the image returned by browser tool '${prompt.tool_id}': ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    });
+  }
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.ts
@@ -30,6 +30,7 @@ import {
   ConfirmationStatus,
   isAskUserQuestionPromptResponse,
   isAuthorizationPromptResponse,
+  isBrowserToolCallPromptResponse,
   isConfirmationPromptResponse,
 } from '@kbn/agent-builder-common/agents/prompts';
 import type { InternalToolDefinition } from '@kbn/agent-builder-server';
@@ -171,6 +172,11 @@ export const getAgentPromptStorageState = ({
       } else if (isAskUserQuestionPromptResponse(response)) {
         state.responses[promptId] = {
           type: AgentPromptType.ask_user_question,
+          response,
+        };
+      } else if (isBrowserToolCallPromptResponse(response)) {
+        state.responses[promptId] = {
+          type: AgentPromptType.browser_tool_call,
           response,
         };
       }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/browser_tool_adapter.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/browser_tool_adapter.ts
@@ -9,6 +9,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { tool as toTool } from '@langchain/core/tools';
 import type { BrowserApiToolMetadata } from '@kbn/agent-builder-common';
 import { ToolResultType } from '@kbn/agent-builder-common';
+import { AgentPromptType } from '@kbn/agent-builder-common/agents/prompts';
+import type { ToolHandlerReturn } from '@kbn/agent-builder-server';
 import { sanitizeToolId } from '@kbn/agent-builder-genai-utils/langchain';
 
 /**
@@ -16,7 +18,23 @@ import { sanitizeToolId } from '@kbn/agent-builder-genai-utils/langchain';
  */
 export function createBrowserToolAdapter({ browserTool }: { browserTool: BrowserApiToolMetadata }) {
   return toTool(
-    async () => {
+    async (params: Record<string, unknown>) => {
+      // Two-way tools interrupt the execution: the browser runs the handler and resumes
+      // the round with its result, which is then handed to the model as the tool result.
+      // See `pendingBrowserToolPromptsToActions`.
+      if (browserTool.returns_result) {
+        const interrupt: ToolHandlerReturn = {
+          prompt: {
+            type: AgentPromptType.browser_tool_call,
+            id: uuidv4(),
+            tool_id: browserTool.id,
+            params,
+          },
+        };
+
+        return [`Waiting for the browser to run '${browserTool.id}'`, interrupt];
+      }
+
       const callId = uuidv4();
 
       const result = {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/browser_tool_adapter.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/browser_tool_adapter.ts
@@ -29,6 +29,9 @@ export function createBrowserToolAdapter({ browserTool }: { browserTool: Browser
             id: uuidv4(),
             tool_id: browserTool.id,
             params,
+            // Persisted on the prompt so the resume path knows how to process the response
+            // (browser tool metadata is no longer available at that point).
+            result_type: browserTool.result_type,
           },
         };
 

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/common/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/common/constants.ts
@@ -23,4 +23,5 @@ const dashboardTool = (toolName: string) => {
  */
 export const dashboardTools = {
   generateDashboard: dashboardTool('generate_dashboard'),
+  validateDashboard: dashboardTool('validate_dashboard'),
 } as const;

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/moon.yml
@@ -46,6 +46,7 @@ dependsOn:
   - '@kbn/data-views-plugin'
   - '@kbn/test-jest-helpers'
   - '@kbn/presentation-publishing'
+  - '@kbn/react-kibana-context-render'
   - '@kbn/scout'
   - '@kbn/ui-actions-plugin'
   - '@kbn/ftr-llm-proxy'

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/capture_node.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/capture_node.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// @ts-expect-error - this module has no exported types
+import domtoimage from 'dom-to-image-more';
+
+/**
+ * Keep in sync with the image attachment schema cap (3M chars) minus JSON envelope headroom.
+ */
+const MAX_DATA_URL_CHARS = 2_700_000;
+
+/**
+ * Quality/scale ladder, tried in order until the encoded image fits the size budget.
+ */
+const ENCODE_ATTEMPTS: Array<{ scale: number; quality: number }> = [
+  { scale: 1, quality: 0.8 },
+  { scale: 1, quality: 0.6 },
+  { scale: 0.75, quality: 0.6 },
+  { scale: 0.75, quality: 0.5 },
+  { scale: 0.5, quality: 0.5 },
+];
+
+/**
+ * Encodes a DOM node as a JPEG data URL, stepping down quality and scale until the
+ * result fits the attachment size budget. The `styleFilter` / `cacheBust` options work
+ * around dom-to-image failing on cross-origin stylesheets and stale image caches.
+ */
+export const captureNodeAsJpeg = async (node: HTMLElement): Promise<string> => {
+  const width = node.scrollWidth;
+  const height = node.scrollHeight;
+  if (width === 0 || height === 0) {
+    throw new Error('The rendered dashboard has no visible size; nothing to capture.');
+  }
+
+  for (const { scale, quality } of ENCODE_ATTEMPTS) {
+    const dataUrl: string = await domtoimage.toJpeg(node, {
+      quality,
+      bgcolor: '#ffffff',
+      cacheBust: true,
+      width: width * scale,
+      height: height * scale,
+      style: {
+        transform: `scale(${scale})`,
+        transformOrigin: 'top left',
+        width: `${width}px`,
+        height: `${height}px`,
+      },
+      styleFilter: (style: CSSStyleSheet) => {
+        try {
+          void style.cssRules;
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    });
+    if (dataUrl.length <= MAX_DATA_URL_CHARS) {
+      return dataUrl;
+    }
+  }
+
+  throw new Error(
+    `The dashboard screenshot exceeds the ${MAX_DATA_URL_CHARS} character budget even at the lowest quality; the dashboard is likely too tall to capture.`
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/index.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart } from '@kbn/core/public';
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { getLatestVersion } from '@kbn/agent-builder-common/attachments';
+import {
+  attachmentDataToDashboardState,
+  DASHBOARD_ATTACHMENT_TYPE,
+} from '@kbn/agent-builder-dashboards-common';
+import type { DashboardAttachmentData } from '@kbn/agent-builder-dashboards-common/types';
+import type { DashboardState } from '@kbn/dashboard-plugin/common';
+import { renderHiddenDashboard } from './render_hidden_dashboard';
+import { waitForRenderComplete } from './wait_for_render_complete';
+import { captureNodeAsJpeg } from './capture_node';
+
+/**
+ * Render + readiness budget. Must stay below the 30s browser tool handler timeout,
+ * leaving headroom for the JPEG encoding passes.
+ */
+const RENDER_TIMEOUT_MS = 20_000;
+
+/** Result shape expected by the server-side `result_type: 'image'` extraction. */
+export interface CaptureDashboardScreenshotResult {
+  content: string;
+  mime_type: 'image/jpeg';
+  filename: string;
+  /** Stable key so re-captures of the same dashboard update one attachment in place. */
+  image_attachment_key: string;
+  /** Surfaced to the model when the capture is usable but possibly incomplete. */
+  capture_warning?: string;
+}
+
+type DashboardWidget = NonNullable<DashboardState['panels']>[number];
+type DashboardSectionWidget = Extract<DashboardWidget, { panels: unknown }>;
+
+// Same discriminator as the dashboard plugin's `isDashboardSection` (not exported publicly).
+const isSectionWidget = (widget: DashboardWidget): widget is DashboardSectionWidget =>
+  'panels' in widget;
+
+/** Panels that will actually render: top-level panels plus panels of expanded sections. */
+const countRenderablePanels = (state: DashboardState): number =>
+  (state.panels ?? []).reduce((count, widget) => {
+    if (isSectionWidget(widget)) {
+      return widget.collapsed ? count : count + widget.panels.length;
+    }
+    return count + 1;
+  }, 0);
+
+export const captureDashboardScreenshot = async ({
+  core,
+  conversationId,
+  dashboardAttachmentId,
+}: {
+  core: CoreStart;
+  conversationId: string;
+  dashboardAttachmentId: string;
+}): Promise<CaptureDashboardScreenshotResult> => {
+  // TODO: Fetched from the server rather than read from the conversation UI state: the client
+  // only learns about attachments on `round_complete`, while this handler runs on the
+  // earlier `prompt_request` event — an attachment created in the same round (the primary
+  // generate → capture flow) may not be in the client cache yet. The persisted conversation
+  // is always at least as fresh. (Public attachments route; no single-attachment GET today.)
+  const { results } = await core.http.get<{ results: VersionedAttachment[] }>(
+    `/api/agent_builder/conversations/${encodeURIComponent(conversationId)}/attachments`
+  );
+
+  const attachment = results.find(({ id }) => id === dashboardAttachmentId);
+  if (!attachment) {
+    throw new Error(`Dashboard attachment '${dashboardAttachmentId}' was not found.`);
+  }
+  if (attachment.type !== DASHBOARD_ATTACHMENT_TYPE) {
+    throw new Error(
+      `Attachment '${dashboardAttachmentId}' is of type '${attachment.type}', not a dashboard.`
+    );
+  }
+
+  const latestVersion = getLatestVersion(attachment);
+  if (!latestVersion) {
+    throw new Error(`Dashboard attachment '${dashboardAttachmentId}' has no content.`);
+  }
+
+  const dashboardState = attachmentDataToDashboardState(
+    latestVersion.data as DashboardAttachmentData
+  );
+  const expectedPanels = countRenderablePanels(dashboardState);
+  if (expectedPanels === 0) {
+    throw new Error('The dashboard has no renderable panels to capture.');
+  }
+
+  const { container, cleanup } = renderHiddenDashboard({ core, dashboardState });
+  try {
+    const waitResult = await waitForRenderComplete({
+      container,
+      expectedPanels,
+      timeoutMs: RENDER_TIMEOUT_MS,
+    });
+
+    if (waitResult.timedOut && waitResult.renderedPanels === 0) {
+      throw new Error(
+        `The dashboard did not render within ${RENDER_TIMEOUT_MS / 1000}s; no panels completed.`
+      );
+    }
+
+    const captureNode = container.querySelector<HTMLElement>('.dashboardViewport') ?? container;
+    const content = await captureNodeAsJpeg(captureNode);
+
+    return {
+      content,
+      mime_type: 'image/jpeg',
+      filename: `dashboard-${dashboardAttachmentId}.jpg`,
+      image_attachment_key: `screenshot:${dashboardAttachmentId}`,
+      ...(waitResult.timedOut
+        ? {
+            capture_warning: `Only ${waitResult.renderedPanels} of ${
+              waitResult.expectedPanels
+            } panels finished rendering within ${
+              RENDER_TIMEOUT_MS / 1000
+            }s; the screenshot may show incomplete panels.`,
+          }
+        : {}),
+    };
+  } finally {
+    cleanup();
+  }
+};

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/index.ts
@@ -53,23 +53,18 @@ const countRenderablePanels = (state: DashboardState): number =>
 
 export const captureDashboardScreenshot = async ({
   core,
-  conversationId,
+  attachments,
   dashboardAttachmentId,
 }: {
   core: CoreStart;
-  conversationId: string;
+  attachments: VersionedAttachment[];
   dashboardAttachmentId: string;
 }): Promise<CaptureDashboardScreenshotResult> => {
-  // TODO: Fetched from the server rather than read from the conversation UI state: the client
-  // only learns about attachments on `round_complete`, while this handler runs on the
-  // earlier `prompt_request` event — an attachment created in the same round (the primary
-  // generate → capture flow) may not be in the client cache yet. The persisted conversation
-  // is always at least as fresh. (Public attachments route; no single-attachment GET today.)
-  const { results } = await core.http.get<{ results: VersionedAttachment[] }>(
-    `/api/agent_builder/conversations/${encodeURIComponent(conversationId)}/attachments`
-  );
-
-  const attachment = results.find(({ id }) => id === dashboardAttachmentId);
+  // Attachments come from the conversation UI's in-stream state (handler context), which
+  // includes attachments created during the current round. The persisted conversation must
+  // NOT be fetched here: persistence lags the stream (on a conversation's first round it is
+  // gated on title generation), so a fetch would miss the just-created dashboard attachment.
+  const attachment = attachments.find(({ id }) => id === dashboardAttachmentId);
   if (!attachment) {
     throw new Error(`Dashboard attachment '${dashboardAttachmentId}' was not found.`);
   }

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/render_hidden_dashboard.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/render_hidden_dashboard.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import type { CoreStart } from '@kbn/core/public';
+import type { DashboardState } from '@kbn/dashboard-plugin/common';
+import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+
+const CAPTURE_WIDTH_PX = 1600;
+
+export interface HiddenDashboardHandle {
+  /** Off-screen element hosting the rendered dashboard. */
+  container: HTMLElement;
+  /** Unmounts the dashboard and removes the container from the DOM. */
+  cleanup: () => void;
+}
+
+/**
+ * Renders a dashboard into a fixed-width container parked off-screen. The container is
+ * kept in the layout flow (NOT `display: none`) because charts need real dimensions to
+ * render. Height is left to the dashboard grid so the whole dashboard is captured.
+ */
+export const renderHiddenDashboard = ({
+  core,
+  dashboardState,
+}: {
+  core: CoreStart;
+  dashboardState: DashboardState;
+}): HiddenDashboardHandle => {
+  const container = document.createElement('div');
+  container.setAttribute('data-test-subj', 'agentBuilderHiddenDashboardCapture');
+  container.style.position = 'fixed';
+  container.style.top = '0';
+  container.style.left = '-10000px';
+  container.style.width = `${CAPTURE_WIDTH_PX}px`;
+  container.style.pointerEvents = 'none';
+  document.body.appendChild(container);
+
+  ReactDOM.render(
+    <KibanaRenderContextProvider {...core}>
+      <DashboardRenderer
+        getCreationOptions={() =>
+          Promise.resolve({
+            getInitialInput: () => ({ ...dashboardState, viewMode: 'view' as const }),
+          })
+        }
+        showPlainSpinner
+        onApiAvailable={(api) => {
+          api.setViewMode('view');
+        }}
+      />
+    </KibanaRenderContextProvider>,
+    container
+  );
+
+  return {
+    container,
+    cleanup: () => {
+      ReactDOM.unmountComponentAtNode(container);
+      container.remove();
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/wait_for_render_complete.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/wait_for_render_complete.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { waitForRenderComplete } from './wait_for_render_complete';
+
+const makeContainer = (children: Array<Record<string, string>>): HTMLElement => {
+  const container = document.createElement('div');
+  for (const attributes of children) {
+    const child = document.createElement('div');
+    for (const [name, value] of Object.entries(attributes)) {
+      child.setAttribute(name, value);
+    }
+    container.appendChild(child);
+  }
+  return container;
+};
+
+const fastOptions = { timeoutMs: 200, pollIntervalMs: 10, settleMs: 0 };
+
+describe('waitForRenderComplete', () => {
+  it('resolves once all expected panels report render completion', async () => {
+    const container = makeContainer([
+      { 'data-render-complete': 'true' },
+      { 'data-render-complete': 'true' },
+    ]);
+
+    const result = await waitForRenderComplete({ container, expectedPanels: 2, ...fastOptions });
+
+    expect(result).toEqual({ timedOut: false, renderedPanels: 2, expectedPanels: 2 });
+  });
+
+  it('waits for panels that are still loading', async () => {
+    const container = makeContainer([
+      { 'data-render-complete': 'true' },
+      { id: 'pending', 'data-render-complete': 'false' },
+    ]);
+    setTimeout(() => {
+      container.querySelector('#pending')!.setAttribute('data-render-complete', 'true');
+    }, 30);
+
+    const result = await waitForRenderComplete({ container, expectedPanels: 2, ...fastOptions });
+
+    expect(result).toEqual({ timedOut: false, renderedPanels: 2, expectedPanels: 2 });
+  });
+
+  it('keeps waiting while a data-loading marker is present', async () => {
+    const container = makeContainer([{ 'data-render-complete': 'true', 'data-loading': 'true' }]);
+    setTimeout(() => {
+      container.querySelector('[data-loading]')!.removeAttribute('data-loading');
+    }, 30);
+
+    const result = await waitForRenderComplete({ container, expectedPanels: 1, ...fastOptions });
+
+    expect(result.timedOut).toBe(false);
+  });
+
+  it('times out and reports how many panels rendered', async () => {
+    const container = makeContainer([
+      { 'data-render-complete': 'true' },
+      { 'data-render-complete': 'false' },
+    ]);
+
+    const result = await waitForRenderComplete({ container, expectedPanels: 2, ...fastOptions });
+
+    expect(result).toEqual({ timedOut: true, renderedPanels: 1, expectedPanels: 2 });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/wait_for_render_complete.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture/wait_for_render_complete.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface RenderWaitResult {
+  timedOut: boolean;
+  renderedPanels: number;
+  expectedPanels: number;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Waits until every panel inside the container reports render completion, using the same
+ * DOM markers reporting and functional tests rely on: presentation panels set
+ * `data-render-complete="true"` once loaded and `data-loading` / `data-render-complete="false"`
+ * while pending.
+ */
+export const waitForRenderComplete = async ({
+  container,
+  expectedPanels,
+  timeoutMs,
+  pollIntervalMs = 500,
+  settleMs = 500,
+}: {
+  container: HTMLElement;
+  expectedPanels: number;
+  timeoutMs: number;
+  pollIntervalMs?: number;
+  settleMs?: number;
+}): Promise<RenderWaitResult> => {
+  const countRendered = () => container.querySelectorAll('[data-render-complete="true"]').length;
+  const countPending = () =>
+    container.querySelectorAll('[data-render-complete="false"], [data-loading]').length;
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (countRendered() >= expectedPanels && countPending() === 0) {
+      // Give charts a moment to finish paint/animation after reporting completion.
+      await sleep(settleMs);
+      return { timedOut: false, renderedPanels: countRendered(), expectedPanels };
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  return { timedOut: true, renderedPanels: countRendered(), expectedPanels };
+};

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture_dashboard_screenshot.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture_dashboard_screenshot.test.ts
@@ -34,26 +34,32 @@ describe('createCaptureDashboardScreenshotTool', () => {
     expect(() => tool.schema.parse({ dashboardAttachmentId: 'x'.repeat(257) })).toThrow();
   });
 
-  it('fails without a conversation id', async () => {
-    await expect(tool.handler({ dashboardAttachmentId: 'dash-1' }, {})).rejects.toThrow(
-      /conversation has not been persisted/
-    );
-    expect(mockCaptureDashboardScreenshot).not.toHaveBeenCalled();
-  });
-
-  it('delegates to the capture implementation with the conversation id', async () => {
+  it('delegates to the capture implementation with the context attachments', async () => {
     mockCaptureDashboardScreenshot.mockResolvedValue({ content: 'data:image/jpeg;base64,x' });
+    const attachments = [{ id: 'dash-1', type: 'dashboard', versions: [] }];
 
     const result = await tool.handler(
       { dashboardAttachmentId: 'dash-1' },
-      { conversationId: 'conv-1' }
+      { conversationId: 'conv-1', attachments: attachments as never }
     );
 
     expect(mockCaptureDashboardScreenshot).toHaveBeenCalledWith({
       core,
-      conversationId: 'conv-1',
+      attachments,
       dashboardAttachmentId: 'dash-1',
     });
     expect(result).toEqual({ content: 'data:image/jpeg;base64,x' });
+  });
+
+  it('delegates with an empty attachment list when the context provides none', async () => {
+    mockCaptureDashboardScreenshot.mockResolvedValue({ content: 'data:image/jpeg;base64,x' });
+
+    await tool.handler({ dashboardAttachmentId: 'dash-1' }, {});
+
+    expect(mockCaptureDashboardScreenshot).toHaveBeenCalledWith({
+      core,
+      attachments: [],
+      dashboardAttachmentId: 'dash-1',
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture_dashboard_screenshot.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture_dashboard_screenshot.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart } from '@kbn/core/public';
+import { createCaptureDashboardScreenshotTool } from './capture_dashboard_screenshot';
+
+const mockCaptureDashboardScreenshot = jest.fn();
+
+jest.mock('./capture', () => ({
+  captureDashboardScreenshot: (args: unknown) => mockCaptureDashboardScreenshot(args),
+}));
+
+describe('createCaptureDashboardScreenshotTool', () => {
+  const core = {} as CoreStart;
+  const tool = createCaptureDashboardScreenshotTool({ core });
+
+  beforeEach(() => {
+    mockCaptureDashboardScreenshot.mockReset();
+  });
+
+  it('declares a two-way image result', () => {
+    expect(tool.id).toBe('capture_dashboard_screenshot');
+    expect(tool.returnsResult).toBe(true);
+    expect(tool.resultType).toBe('image');
+  });
+
+  it('validates params through its schema', () => {
+    expect(() => tool.schema.parse({ dashboardAttachmentId: 'dash-1' })).not.toThrow();
+    expect(() => tool.schema.parse({})).toThrow();
+    expect(() => tool.schema.parse({ dashboardAttachmentId: 'x'.repeat(257) })).toThrow();
+  });
+
+  it('fails without a conversation id', async () => {
+    await expect(tool.handler({ dashboardAttachmentId: 'dash-1' }, {})).rejects.toThrow(
+      /conversation has not been persisted/
+    );
+    expect(mockCaptureDashboardScreenshot).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the capture implementation with the conversation id', async () => {
+    mockCaptureDashboardScreenshot.mockResolvedValue({ content: 'data:image/jpeg;base64,x' });
+
+    const result = await tool.handler(
+      { dashboardAttachmentId: 'dash-1' },
+      { conversationId: 'conv-1' }
+    );
+
+    expect(mockCaptureDashboardScreenshot).toHaveBeenCalledWith({
+      core,
+      conversationId: 'conv-1',
+      dashboardAttachmentId: 'dash-1',
+    });
+    expect(result).toEqual({ content: 'data:image/jpeg;base64,x' });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture_dashboard_screenshot.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture_dashboard_screenshot.ts
@@ -35,15 +35,14 @@ export const createCaptureDashboardScreenshotTool = ({
   schema: captureDashboardScreenshotSchema,
   returnsResult: true,
   resultType: 'image',
-  handler: async ({ dashboardAttachmentId }, { conversationId }) => {
-    if (!conversationId) {
-      throw new Error(
-        'Cannot capture a screenshot: the conversation has not been persisted yet, so the dashboard attachment cannot be resolved.'
-      );
-    }
+  handler: async ({ dashboardAttachmentId }, { attachments }) => {
     // The rendering + encoding machinery is heavy (DashboardRenderer, dom-to-image);
     // load it only when the tool actually runs.
     const { captureDashboardScreenshot } = await import('./capture');
-    return captureDashboardScreenshot({ core, conversationId, dashboardAttachmentId });
+    return captureDashboardScreenshot({
+      core,
+      attachments: attachments ?? [],
+      dashboardAttachmentId,
+    });
   },
 });

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture_dashboard_screenshot.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/capture_dashboard_screenshot.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { CoreStart } from '@kbn/core/public';
+import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
+
+export const CAPTURE_DASHBOARD_SCREENSHOT_TOOL_ID = 'capture_dashboard_screenshot';
+
+const captureDashboardScreenshotSchema = z.object({
+  dashboardAttachmentId: z.string().max(256).describe('Id of the dashboard attachment to capture.'),
+});
+
+export type CaptureDashboardScreenshotParams = z.infer<typeof captureDashboardScreenshotSchema>;
+
+/**
+ * Browser tool that renders a dashboard attachment off-screen in the user's browser and
+ * returns a screenshot of it. The screenshot is persisted server-side as a hidden image
+ * attachment (`result_type: 'image'`); the model only sees the attachment id.
+ */
+export const createCaptureDashboardScreenshotTool = ({
+  core,
+}: {
+  core: CoreStart;
+}): BrowserApiToolDefinition<CaptureDashboardScreenshotParams> => ({
+  id: CAPTURE_DASHBOARD_SCREENSHOT_TOOL_ID,
+  description:
+    'Captures a screenshot of a dashboard attachment by rendering it in the user’s browser. ' +
+    'Returns an image attachment id that visual validation tools accept. ' +
+    'Only works while the user has the conversation open in a browser; it fails in headless runs.',
+  schema: captureDashboardScreenshotSchema,
+  returnsResult: true,
+  resultType: 'image',
+  handler: async ({ dashboardAttachmentId }, { conversationId }) => {
+    if (!conversationId) {
+      throw new Error(
+        'Cannot capture a screenshot: the conversation has not been persisted yet, so the dashboard attachment cannot be resolved.'
+      );
+    }
+    // The rendering + encoding machinery is heavy (DashboardRenderer, dom-to-image);
+    // load it only when the tool actually runs.
+    const { captureDashboardScreenshot } = await import('./capture');
+    return captureDashboardScreenshot({ core, conversationId, dashboardAttachmentId });
+  },
+});

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/browser_tools/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  createCaptureDashboardScreenshotTool,
+  CAPTURE_DASHBOARD_SCREENSHOT_TOOL_ID,
+} from './capture_dashboard_screenshot';

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/plugin.test.ts
@@ -17,6 +17,7 @@ jest.mock('./attachment_types', () => ({
 describe('AgentBuilderDashboardsPlugin', () => {
   const registerActionAsync = jest.fn();
   const openChat = jest.fn();
+  const registerBrowserTool = jest.fn();
 
   const createCoreStart = (showAgentBuilder: boolean) =>
     ({
@@ -31,7 +32,7 @@ describe('AgentBuilderDashboardsPlugin', () => {
 
   const createStartDependencies = () =>
     ({
-      agentBuilder: { openChat },
+      agentBuilder: { openChat, browserTools: { register: registerBrowserTool } },
       dashboard: {},
       share: {
         url: {
@@ -48,6 +49,21 @@ describe('AgentBuilderDashboardsPlugin', () => {
   beforeEach(() => {
     registerActionAsync.mockClear();
     openChat.mockClear();
+    registerBrowserTool.mockClear();
+  });
+
+  it('registers the capture_dashboard_screenshot browser tool', () => {
+    const plugin = new AgentBuilderDashboardsPlugin({} as PluginInitializerContext);
+
+    plugin.start(createCoreStart(true), createStartDependencies());
+
+    expect(registerBrowserTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'capture_dashboard_screenshot',
+        returnsResult: true,
+        resultType: 'image',
+      })
+    );
   });
 
   it('registers a lazy open-dashboard-chat action when Agent Builder is available', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/plugin.ts
@@ -15,6 +15,7 @@ import type {
   AgentBuilderDashboardsPluginPublicStartDependencies,
 } from './types';
 import { registerDashboardAttachmentUiDefinition } from './attachment_types';
+import { createCaptureDashboardScreenshotTool } from './browser_tools';
 
 export class AgentBuilderDashboardsPlugin
   implements
@@ -52,6 +53,8 @@ export class AgentBuilderDashboardsPlugin
       data: plugins.data,
       dashboardPlugin: plugins.dashboard,
     });
+
+    plugins.agentBuilder.browserTools.register(createCaptureDashboardScreenshotTool({ core }));
 
     if (core.application.capabilities.agentBuilder?.show === true) {
       plugins.uiActions.registerActionAsync(OPEN_DASHBOARD_CHAT_ACTION_ID, async () => {

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/dashboard_management_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/dashboard_management_skill.ts
@@ -6,7 +6,7 @@
  */
 
 import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
-import { generateDashboardTool } from '../tools';
+import { generateDashboardTool, validateDashboardTool } from '../tools';
 import { dashboardGeneration } from './generation_guidance';
 import { kibanaRendering } from './rendering_guidance';
 
@@ -36,5 +36,5 @@ ${kibanaRendering.guidance}
     ...(dashboardGeneration.referencedContent ?? []),
     ...(kibanaRendering.referencedContent ?? []),
   ],
-  getInlineTools: () => [generateDashboardTool()],
+  getInlineTools: () => [generateDashboardTool(), validateDashboardTool()],
 });

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/rendering_guidance/kibana_rendering_guidance.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/rendering_guidance/kibana_rendering_guidance.ts
@@ -48,7 +48,8 @@ In Kibana, a dashboard request follows three stages: resolve inputs, generate (w
 
 - To verify a generated dashboard actually renders well, first capture a screenshot with the \`capture_dashboard_screenshot\` browser tool (pass the dashboard \`attachment_id\`; it returns an \`image_attachment_id\`), then call ${dashboardTools.validateDashboard} with the dashboard attachment id and that image attachment id.
 - The capture tool only works while the user has the conversation open in a browser. If it is unavailable or fails, you can still call ${dashboardTools.validateDashboard} without an image for a configuration-only check.
-- The verdict is advisory: apply worthwhile fixes with ${dashboardTools.generateDashboard} operations, re-render, and don't loop endlessly — one validation pass is usually enough.`;
+- The verdict is advisory: apply worthwhile fixes with ${dashboardTools.generateDashboard} operations, re-render, and don't loop endlessly — one validation pass is usually enough.
+- To show the user what the capture saw, render the screenshot inline with \`<render_attachment id="{image_attachment_id}" />\`. Do this only when it helps — e.g. when the user asks to see it, or when walking through visual findings — not on every validation.`;
 
 export const kibanaRendering: DashboardGuidanceModule = {
   guidance,

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/rendering_guidance/kibana_rendering_guidance.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/rendering_guidance/kibana_rendering_guidance.ts
@@ -48,8 +48,7 @@ In Kibana, a dashboard request follows three stages: resolve inputs, generate (w
 
 - To verify a generated dashboard actually renders well, first capture a screenshot with the \`capture_dashboard_screenshot\` browser tool (pass the dashboard \`attachment_id\`; it returns an \`image_attachment_id\`), then call ${dashboardTools.validateDashboard} with the dashboard attachment id and that image attachment id.
 - The capture tool only works while the user has the conversation open in a browser. If it is unavailable or fails, you can still call ${dashboardTools.validateDashboard} without an image for a configuration-only check.
-- The verdict is advisory: apply worthwhile fixes with ${dashboardTools.generateDashboard} operations, re-render, and don't loop endlessly — one validation pass is usually enough.
-- To show the user what the capture saw, render the screenshot inline with \`<render_attachment id="{image_attachment_id}" />\`. Do this only when it helps — e.g. when the user asks to see it, or when walking through visual findings — not on every validation.`;
+- The verdict is advisory: apply worthwhile fixes with ${dashboardTools.generateDashboard} operations, re-render, and don't loop endlessly — one validation pass is usually enough.`;
 
 export const kibanaRendering: DashboardGuidanceModule = {
   guidance,

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/rendering_guidance/kibana_rendering_guidance.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/rendering_guidance/kibana_rendering_guidance.ts
@@ -42,7 +42,13 @@ In Kibana, a dashboard request follows three stages: resolve inputs, generate (w
 ## Rendering Edge Cases
 
 - If the user asks to update a dashboard but no \`attachment_id\` is available in conversation context, ask which dashboard they mean or offer to create a new one.
-- If generation fails, surface the returned error message rather than retrying blindly.`;
+- If generation fails, surface the returned error message rather than retrying blindly.
+
+## Validating a Dashboard (optional)
+
+- To verify a generated dashboard actually renders well, first capture a screenshot with the \`capture_dashboard_screenshot\` browser tool (pass the dashboard \`attachment_id\`; it returns an \`image_attachment_id\`), then call ${dashboardTools.validateDashboard} with the dashboard attachment id and that image attachment id.
+- The capture tool only works while the user has the conversation open in a browser. If it is unavailable or fails, you can still call ${dashboardTools.validateDashboard} without an image for a configuration-only check.
+- The verdict is advisory: apply worthwhile fixes with ${dashboardTools.generateDashboard} operations, re-render, and don't loop endlessly — one validation pass is usually enough.`;
 
 export const kibanaRendering: DashboardGuidanceModule = {
   guidance,

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/validate/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/validate/index.ts
@@ -5,5 +5,4 @@
  * 2.0.
  */
 
-export { generateDashboardTool } from './generate';
-export { validateDashboardTool } from './validate';
+export { validateDashboardTool, type DashboardValidationVerdict } from './validate_dashboard_tool';

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/validate/rubric.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/validate/rubric.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Judge rubric for dashboard validation. Adapted from the authoring guidance the
+ * generation skill uses (`generation_guidance/design/composition.ts` and
+ * `design/grid_layout.ts`) so the judge holds dashboards to the same standard
+ * they were authored against.
+ */
+export const getValidationSystemPrompt = ({ hasImage }: { hasImage: boolean }): string => `
+You are an expert reviewer of Kibana dashboards. Assess the dashboard below and report
+structured findings via the "report_dashboard_validation" tool.
+
+${
+  hasImage
+    ? `You are given the dashboard configuration AND a screenshot of the rendered dashboard.
+The screenshot is the ground truth for rendering and visual quality; the configuration is
+your coordinate system — every finding must reference panel ids from the configuration.`
+    : `You are given ONLY the dashboard configuration — no screenshot is available (the
+dashboard was not rendered). Judge only what the configuration can reveal: layout geometry,
+composition, titles, and suspicious panel configs. Do NOT speculate about visual rendering
+or data availability; never report render_failure or no_data findings in this mode unless
+the configuration itself is clearly invalid.`
+}
+
+## What to check
+
+**render_failure** (screenshot only): panels showing an error message, an empty chart frame,
+a failed query, or a spinner that never resolved.
+
+**no_data** (screenshot only): panels rendering "No results found" or visibly empty
+visualizations. These usually indicate a wrong query, field, or time range.
+
+**layout** — the dashboard uses a 48-column grid; roughly 20-24 rows are visible without
+scrolling:
+- Panels must tile with no dead space and no overlap; x + w must not exceed 48.
+- Panels sharing a row should share the same height so rows align cleanly.
+- Metric/gauge panels must be SMALL (w: 6-12, h: 5-6), never full-width; 4-8 fit per row.
+- Time-series (XY) charts belong at w: 24 or full-width (48) for the primary trend, h: ~10.
+- Datatables should be wide (w: 24-48) so columns are readable.
+- Prefer w values that divide 48 evenly: 6, 8, 12, 24, 48.
+
+**readability** (mostly screenshot): panel titles present and meaningful; axis labels and
+legends legible and not overwhelming; text not truncated; charts not too cramped to read.
+
+**semantic** — the dashboard should tell a coherent story:
+- Lead with high-level KPI metrics, follow with time-series trends, then breakdowns and
+  distributions.
+- Every panel serves a clear purpose; flag duplicated or redundant panels.
+- Titles and content should match the dashboard's stated purpose.
+- Sections (if any) should group panels into meaningful topics, not decoration.
+
+## Verdict rules
+
+- "fail": rendering is broken for a significant part of the dashboard (multiple
+  render_failure / no_data panels), or the layout is unusable.
+- "needs_improvement": the dashboard works but has concrete, fixable findings.
+- "pass": no findings, or only minor/cosmetic ones.
+
+## Rules
+
+- Reference ONLY panel ids that appear in the configuration; never invent ids.
+- Omit panel_id for dashboard-level findings (overall layout, composition, ordering).
+- Every finding needs a concrete suggested_fix that could be applied as a dashboard
+  operation (resize/move a panel, fix a query, retitle, remove, reorder).
+- Be decisive and terse. Do not pad findings; an empty findings list with verdict "pass"
+  is a perfectly good answer.
+`;

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/validate/validate_dashboard_tool.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/validate/validate_dashboard_tool.test.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { DASHBOARD_ATTACHMENT_TYPE } from '@kbn/agent-builder-dashboards-common';
+import { validateDashboardTool, type DashboardValidationVerdict } from './validate_dashboard_tool';
+
+const BLUE_PIXEL_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const dashboardData = {
+  title: 'Web traffic',
+  description: 'Traffic overview',
+  panels: [
+    { id: 'p1', type: 'lens', grid: { x: 0, y: 0, w: 24, h: 10 }, config: { title: 'Hits' } },
+    {
+      id: 's1',
+      title: 'Details',
+      collapsed: false,
+      grid: { y: 10 },
+      panels: [
+        { id: 'p2', type: 'lens', grid: { x: 0, y: 0, w: 48, h: 12 }, config: { title: 'Table' } },
+      ],
+    },
+  ],
+};
+
+const dashboardRecord = {
+  id: 'dash-1',
+  type: DASHBOARD_ATTACHMENT_TYPE,
+  active: true,
+  current_version: 1,
+  versions: [{ version: 1, data: dashboardData, created_at: 'now', content_hash: 'h' }],
+};
+
+const imageRecord = {
+  id: 'img-1',
+  type: 'image',
+  active: true,
+  current_version: 1,
+  versions: [
+    {
+      version: 1,
+      data: { content: BLUE_PIXEL_PNG, mime_type: 'image/png' },
+      created_at: 'now',
+      content_hash: 'h',
+    },
+  ],
+};
+
+const passVerdict: DashboardValidationVerdict = {
+  verdict: 'pass',
+  summary: 'Looks good.',
+  findings: [],
+};
+
+const createContext = (records: Record<string, unknown>) => {
+  const invoke = jest.fn().mockResolvedValue(passVerdict);
+  const withStructuredOutput = jest.fn().mockReturnValue({ invoke });
+  const context = {
+    logger: { info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    attachments: {
+      getAttachmentRecord: jest.fn((id: string) => records[id]),
+    },
+    modelProvider: {
+      getDefaultModel: jest.fn().mockResolvedValue({ chatModel: { withStructuredOutput } }),
+    },
+  };
+  return { context, invoke, withStructuredOutput };
+};
+
+const runTool = async (
+  params: { dashboardAttachmentId: string; imageAttachmentId?: string; focus?: string },
+  context: unknown
+) => {
+  const tool = validateDashboardTool();
+  const result = await tool.handler(params, context as any);
+  if (!('results' in result)) {
+    throw new Error('Expected the handler to return results, got a prompt.');
+  }
+  return result;
+};
+
+describe('validateDashboardTool', () => {
+  it('passes the screenshot as an image_url content part and returns the verdict', async () => {
+    const { context, invoke, withStructuredOutput } = createContext({
+      'dash-1': dashboardRecord,
+      'img-1': imageRecord,
+    });
+
+    const result = await runTool(
+      { dashboardAttachmentId: 'dash-1', imageAttachmentId: 'img-1' },
+      context
+    );
+
+    expect(withStructuredOutput).toHaveBeenCalledWith(expect.anything(), {
+      name: 'report_dashboard_validation',
+    });
+
+    const messages = invoke.mock.calls[0][0];
+    const [system, user] = messages;
+    expect(system[0]).toBe('system');
+    expect(system[1]).toContain('screenshot');
+    expect(user.role).toBe('user');
+    expect(user.content).toEqual([
+      { type: 'text', text: expect.stringContaining('Web traffic') },
+      { type: 'image_url', image_url: { url: BLUE_PIXEL_PNG } },
+    ]);
+    // The panel map (coordinate system) must reference real panel ids.
+    expect(user.content[0].text).toContain('p1');
+    expect(user.content[0].text).toContain('p2');
+
+    expect(result.results[0].type).toBe(ToolResultType.other);
+    expect(result.results[0].data).toEqual(
+      expect.objectContaining({ mode: 'visual', ...passVerdict })
+    );
+  });
+
+  it('runs config-only when no image attachment id is given', async () => {
+    const { context, invoke } = createContext({ 'dash-1': dashboardRecord });
+
+    const result = await runTool({ dashboardAttachmentId: 'dash-1' }, context);
+
+    const [system, user] = invoke.mock.calls[0][0];
+    expect(system[1]).toContain('ONLY the dashboard configuration');
+    expect(user.content).toHaveLength(1);
+    expect(user.content[0].type).toBe('text');
+    expect(user.content[0].text).toContain('configuration-only review');
+
+    expect(result.results[0].type).toBe(ToolResultType.other);
+    expect(result.results[0].data).toEqual(
+      expect.objectContaining({ mode: 'config_only', verdict: 'pass' })
+    );
+  });
+
+  it('includes the focus steer in the judge prompt', async () => {
+    const { context, invoke } = createContext({ 'dash-1': dashboardRecord });
+
+    await runTool({ dashboardAttachmentId: 'dash-1', focus: 'check the top row' }, context);
+
+    const [, user] = invoke.mock.calls[0][0];
+    expect(user.content[0].text).toContain('check the top row');
+  });
+
+  it('returns an error result when the dashboard attachment is missing', async () => {
+    const { context, invoke } = createContext({});
+
+    const result = await runTool({ dashboardAttachmentId: 'nope' }, context);
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(result.results[0].type).toBe(ToolResultType.error);
+    expect(result.results[0].data).toEqual(
+      expect.objectContaining({ message: expect.stringContaining('not found') })
+    );
+  });
+
+  it('returns an error result when the image attachment is not an image', async () => {
+    const { context, invoke } = createContext({
+      'dash-1': dashboardRecord,
+      'img-1': { ...imageRecord, type: 'text' },
+    });
+
+    const result = await runTool(
+      { dashboardAttachmentId: 'dash-1', imageAttachmentId: 'img-1' },
+      context
+    );
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(result.results[0].type).toBe(ToolResultType.error);
+    expect(result.results[0].data).toEqual(
+      expect.objectContaining({ message: expect.stringContaining('not an image') })
+    );
+  });
+
+  it('returns an error result when the judge call fails', async () => {
+    const { context, invoke } = createContext({ 'dash-1': dashboardRecord });
+    invoke.mockRejectedValue(new Error('model unavailable'));
+
+    const result = await runTool({ dashboardAttachmentId: 'dash-1' }, context);
+
+    expect(result.results[0].type).toBe(ToolResultType.error);
+    expect(result.results[0].data).toEqual(
+      expect.objectContaining({ message: expect.stringContaining('model unavailable') })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/validate/validate_dashboard_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/validate/validate_dashboard_tool.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { getToolResultId } from '@kbn/agent-builder-server';
+import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
+import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
+import type { ImageAttachmentData } from '@kbn/agent-builder-common/attachments';
+import { AttachmentType, getLatestVersion } from '@kbn/agent-builder-common/attachments';
+import { isSection, type DashboardAttachmentData } from '@kbn/agent-builder-dashboards-common';
+
+import { dashboardTools } from '../../../common';
+import { retrieveLatestVersion } from '../generate/attachment_state';
+import { getErrorMessage } from '../generate/core';
+import { getValidationSystemPrompt } from './rubric';
+
+const validateDashboardSchema = z.object({
+  dashboardAttachmentId: z
+    .string()
+    .max(256)
+    .describe('Id of the dashboard attachment to validate.'),
+  imageAttachmentId: z
+    .string()
+    .max(256)
+    .optional()
+    .describe(
+      '(optional) Id of the screenshot image attachment returned by the capture_dashboard_screenshot browser tool. Omit for a configuration-only assessment (e.g. when no browser is attached).'
+    ),
+  focus: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe(
+      '(optional) Short free-text steer for the review, e.g. "the user complained the top row looks broken".'
+    ),
+});
+
+const verdictSchema = z.object({
+  verdict: z
+    .enum(['pass', 'needs_improvement', 'fail'])
+    .describe('Overall assessment of the dashboard.'),
+  summary: z.string().describe('One-paragraph plain-language summary of the assessment.'),
+  findings: z
+    .array(
+      z.object({
+        panel_id: z
+          .string()
+          .optional()
+          .describe(
+            'Panel id from the dashboard configuration; omit for dashboard-level findings.'
+          ),
+        category: z.enum(['render_failure', 'no_data', 'layout', 'readability', 'semantic']),
+        severity: z.enum(['low', 'medium', 'high']),
+        issue: z.string().describe('What is wrong, in one or two sentences.'),
+        suggested_fix: z
+          .string()
+          .describe('Concrete fix, phrased so it can be turned into a dashboard operation.'),
+      })
+    )
+    .describe('Concrete findings; empty when the dashboard passes.'),
+});
+
+export type DashboardValidationVerdict = z.infer<typeof verdictSchema>;
+
+/**
+ * Compact projection handed to the judge as its coordinate system: every finding must
+ * reference these panel ids. Kept separate from (and smaller than) the raw payload.
+ */
+const buildPanelMap = (data: DashboardAttachmentData) =>
+  data.panels.map((widget) => {
+    if (isSection(widget)) {
+      return {
+        section_id: widget.id,
+        title: widget.title,
+        collapsed: widget.collapsed,
+        grid: widget.grid,
+        panels: widget.panels.map(({ id, type, grid }) => ({ id, type, grid })),
+      };
+    }
+    return { id: widget.id, type: widget.type, grid: widget.grid };
+  });
+
+/** Bound the raw config so a huge dashboard cannot blow up the judge prompt. */
+const MAX_CONFIG_CHARS = 30_000;
+
+const buildJudgeText = ({
+  data,
+  focus,
+  hasImage,
+}: {
+  data: DashboardAttachmentData;
+  focus?: string;
+  hasImage: boolean;
+}): string => {
+  const rawConfig = JSON.stringify(data, null, 1);
+  const boundedConfig =
+    rawConfig.length > MAX_CONFIG_CHARS
+      ? `${rawConfig.slice(0, MAX_CONFIG_CHARS)}\n... [truncated]`
+      : rawConfig;
+
+  return [
+    `Dashboard title: ${data.title ?? '(untitled)'}`,
+    data.description ? `Dashboard description: ${data.description}` : undefined,
+    `\nPanel map (the panel ids findings must reference):\n${JSON.stringify(
+      buildPanelMap(data),
+      null,
+      1
+    )}`,
+    `\nFull dashboard configuration:\n${boundedConfig}`,
+    focus ? `\nReview focus requested by the caller: ${focus}` : undefined,
+    hasImage
+      ? '\nThe rendered dashboard screenshot is attached as an image.'
+      : '\nNo screenshot is available; this is a configuration-only review.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+const loadImageDataUrl = (
+  attachments: AttachmentStateManager,
+  imageAttachmentId: string
+): string => {
+  const record = attachments.getAttachmentRecord(imageAttachmentId);
+  if (!record) {
+    throw new Error(`Image attachment "${imageAttachmentId}" not found.`);
+  }
+  if (record.type !== AttachmentType.image) {
+    throw new Error(`Attachment "${imageAttachmentId}" is of type "${record.type}", not an image.`);
+  }
+  const latestVersion = getLatestVersion(record);
+  if (!latestVersion) {
+    throw new Error(`Image attachment "${imageAttachmentId}" has no content.`);
+  }
+  return (latestVersion.data as ImageAttachmentData).content;
+};
+
+/**
+ * LLM-judge validation of a generated dashboard.
+ *
+ * Loads the dashboard payload (and optionally a screenshot captured by the
+ * `capture_dashboard_screenshot` browser tool) and has a judge model assess it against
+ * the same authoring rubric dashboards are generated with. The verdict is advisory:
+ * the agent decides whether and how to act on the findings via follow-up
+ * `generate_dashboard` operations.
+ */
+export const validateDashboardTool = (): BuiltinSkillBoundedTool<
+  typeof validateDashboardSchema
+> => {
+  return {
+    id: dashboardTools.validateDashboard,
+    type: ToolType.builtin,
+    description: `Validate a generated dashboard with an LLM judge and get structured findings.
+
+Pass the dashboard attachment id, plus the image attachment id returned by the capture_dashboard_screenshot browser tool when a screenshot is available (strongly recommended — only pixels reveal render failures and visual issues). Without an image the judgment is configuration-only.
+
+Returns a verdict (pass | needs_improvement | fail), a summary, and per-panel findings with suggested fixes. Findings are advisory; apply fixes with ${dashboardTools.generateDashboard} operations.`,
+    schema: validateDashboardSchema,
+    handler: async (
+      { dashboardAttachmentId, imageAttachmentId, focus },
+      { logger, attachments, modelProvider }
+    ) => {
+      try {
+        const latestVersion = retrieveLatestVersion(attachments, dashboardAttachmentId);
+        if (!latestVersion) {
+          throw new Error(`Dashboard attachment "${dashboardAttachmentId}" not found.`);
+        }
+
+        const imageDataUrl = imageAttachmentId
+          ? loadImageDataUrl(attachments, imageAttachmentId)
+          : undefined;
+        const hasImage = imageDataUrl !== undefined;
+
+        const { chatModel } = await modelProvider.getDefaultModel();
+        const judge = chatModel.withStructuredOutput(verdictSchema, {
+          name: 'report_dashboard_validation',
+        });
+
+        const text = buildJudgeText({ data: latestVersion.data, focus, hasImage });
+        const verdict = await judge.invoke([
+          ['system', getValidationSystemPrompt({ hasImage })],
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text },
+              ...(imageDataUrl ? [{ type: 'image_url', image_url: { url: imageDataUrl } }] : []),
+            ],
+          },
+        ]);
+
+        logger.info(
+          `Dashboard validation verdict: ${verdict.verdict} (${verdict.findings.length} findings, ${
+            hasImage ? 'with screenshot' : 'config-only'
+          })`
+        );
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              tool_result_id: getToolResultId(),
+              data: {
+                mode: hasImage ? 'visual' : 'config_only',
+                ...verdict,
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        logger.error(`Error in validate_dashboard tool: ${errorMessage}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Failed to validate dashboard: ${errorMessage}`,
+                metadata: { dashboardAttachmentId, imageAttachmentId },
+              },
+            },
+          ],
+        };
+      }
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/tsconfig.json
@@ -34,6 +34,7 @@
     "@kbn/data-views-plugin",
     "@kbn/test-jest-helpers",
     "@kbn/presentation-publishing",
+    "@kbn/react-kibana-context-render",
     "@kbn/scout",
     "@kbn/ui-actions-plugin",
     "@kbn/ftr-llm-proxy",

--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/image_attachment.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/image_attachment.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
+import type { ImageAttachmentData, UnknownAttachment } from '@kbn/agent-builder-common/attachments';
+import type { AttachmentUIDefinition } from '@kbn/agent-builder-browser/attachments';
+
+type ImageAttachment = UnknownAttachment & { data: ImageAttachmentData };
+
+const ImageInlineContent: React.FC<{ attachment: ImageAttachment }> = ({ attachment }) => (
+  <img
+    src={attachment.data.content}
+    alt={attachment.data.filename ?? 'image'}
+    css={css`
+      max-width: 100%;
+      max-height: 400px;
+      border-radius: 4px;
+      display: block;
+    `}
+  />
+);
+
+export const imageAttachmentDefinition: AttachmentUIDefinition<ImageAttachment> = {
+  getLabel: (attachment) =>
+    attachment.data.filename ??
+    i18n.translate('xpack.agentBuilderPlatform.attachments.image.label', {
+      defaultMessage: 'Image',
+    }),
+  getIcon: () => 'image',
+  renderInlineContent: (props) => <ImageInlineContent attachment={props.attachment} />,
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/index.tsx
@@ -24,6 +24,7 @@ import { screenContextAttachmentDefinition } from './screen_context_attachment';
 import { graphAttachmentDefinition } from './graph_attachment/graph_attachment';
 import { createSkillAttachmentDefinition } from './skill_attachment/skill_attachment';
 import { createConnectorSetupAttachmentDefinition } from './connector_setup/connector_setup_attachment';
+import { imageAttachmentDefinition } from './image_attachment';
 
 export const registerAttachmentUiDefinitions = ({
   attachments,
@@ -38,6 +39,7 @@ export const registerAttachmentUiDefinitions = ({
   core: CoreStart;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
 }) => {
+  attachments.addAttachmentType(AttachmentType.image, imageAttachmentDefinition);
   attachments.addAttachmentType(AttachmentType.text, textAttachmentDefinition);
   attachments.addAttachmentType(AttachmentType.screenContext, screenContextAttachmentDefinition);
   attachments.addAttachmentType(AttachmentType.esql, createEsqlAttachmentDefinition({ locators }));

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/image.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/image.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import { AttachmentType, type ImageAttachmentData } from '@kbn/agent-builder-common/attachments';
+import type { AgentFormattedAttachment } from '@kbn/agent-builder-server/attachments';
+import { createImageAttachmentType } from './image';
+
+const BLUE_PIXEL_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const createAttachment = (
+  data: ImageAttachmentData
+): Attachment<AttachmentType.image, ImageAttachmentData> => ({
+  id: 'test-attachment-id',
+  type: AttachmentType.image,
+  data,
+});
+
+const validData: ImageAttachmentData = {
+  content: BLUE_PIXEL_PNG,
+  mime_type: 'image/png',
+  filename: 'screenshot.png',
+};
+
+const formatContext = {
+  request: httpServerMock.createKibanaRequest(),
+  spaceId: 'default',
+};
+
+describe('image attachment type', () => {
+  const imageType = createImageAttachmentType();
+
+  describe('validate', () => {
+    it('accepts a valid png data URL', () => {
+      const result = imageType.validate(validData);
+      expect(result).toEqual({ valid: true, data: validData });
+    });
+
+    it('accepts a valid jpeg data URL', () => {
+      const data: ImageAttachmentData = {
+        content: 'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+        mime_type: 'image/jpeg',
+      };
+      const result = imageType.validate(data);
+      expect(result).toEqual({ valid: true, data });
+    });
+
+    it('accepts data without a filename', () => {
+      const { filename: _, ...data } = validData;
+      const result = imageType.validate(data);
+      expect(result).toEqual({ valid: true, data });
+    });
+
+    it('rejects content that is not a data URL', () => {
+      const result = imageType.validate({ ...validData, content: 'https://example.com/img.png' });
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+
+    it('rejects unsupported mime types in the data URL', () => {
+      const result = imageType.validate({
+        ...validData,
+        content: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+      });
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+
+    it('rejects content exceeding the size cap', () => {
+      const oversized = `data:image/png;base64,${'A'.repeat(3_000_001)}`;
+      const result = imageType.validate({ ...validData, content: oversized });
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+
+    it('rejects data missing mime_type', () => {
+      const { mime_type: _, ...data } = validData;
+      const result = imageType.validate(data);
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+  });
+
+  describe('format', () => {
+    it('returns a text placeholder with filename and mime type, without the base64 content', () => {
+      const attachment = createAttachment(validData);
+      const formatted = imageType.format(attachment, formatContext) as AgentFormattedAttachment;
+      const representation = formatted.getRepresentation!() as { type: string; value: string };
+
+      expect(representation.type).toBe('text');
+      expect(representation.value).toContain('"screenshot.png"');
+      expect(representation.value).toContain('image/png');
+      expect(representation.value).not.toContain('base64');
+      expect(representation.value).not.toContain(validData.content.slice(-30));
+    });
+
+    it('returns a placeholder without filename when none is set', () => {
+      const { filename: _, ...data } = validData;
+      const attachment = createAttachment(data);
+      const formatted = imageType.format(attachment, formatContext) as AgentFormattedAttachment;
+      const representation = formatted.getRepresentation!() as { type: string; value: string };
+
+      expect(representation.value).toContain('(image/png)');
+      expect(representation.value).not.toContain('"');
+    });
+  });
+
+  describe('getTools', () => {
+    it('returns empty array', () => {
+      expect(imageType.getTools!()).toEqual([]);
+    });
+  });
+
+  describe('isReadonly', () => {
+    it('is true', () => {
+      expect(imageType.isReadonly).toBe(true);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/image.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/image.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ImageAttachmentData } from '@kbn/agent-builder-common/attachments';
+import { AttachmentType, imageAttachmentDataSchema } from '@kbn/agent-builder-common/attachments';
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+
+/**
+ * Creates the definition for the `image` attachment type.
+ */
+export const createImageAttachmentType = (): AttachmentTypeDefinition<
+  AttachmentType.image,
+  ImageAttachmentData
+> => {
+  return {
+    id: AttachmentType.image,
+    isReadonly: true,
+    validate: (input) => {
+      const parseResult = imageAttachmentDataSchema.safeParse(input);
+      if (parseResult.success) {
+        return { valid: true, data: parseResult.data };
+      } else {
+        return { valid: false, error: parseResult.error.message };
+      }
+    },
+    format: (attachment) => {
+      return {
+        // getRepresentation is used here (despite being @deprecated) because the image content
+        // must not appear in the text channel — the placeholder prevents base64 leaking into
+        // the conversation; there is no other override mechanism today.
+        getRepresentation: () => {
+          const { mime_type: mimeType, filename } = attachment.data;
+          const label = filename ? `"${filename}" (${mimeType})` : `(${mimeType})`;
+          return {
+            type: 'text' as const,
+            value: `[Image attachment ${label} — visual input, not inlined]`,
+          };
+        },
+      };
+    },
+    getAgentDescription: () => {
+      return 'An image attachment contains an image. Its binary content is not inlined into the conversation; tools that accept image attachments read it by attachment id.';
+    },
+    getTools: () => [],
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/index.ts
@@ -14,6 +14,7 @@ import { createGraphAttachmentType } from './graph';
 import { createConnectorAttachmentType } from './connector';
 import { createConnectorSetupAttachmentType } from './connector_setup';
 import { createSkillAttachmentType } from './skill';
+import { createImageAttachmentType } from './image';
 import type {
   AgentBuilderPlatformPluginStart,
   PluginSetupDependencies,
@@ -37,6 +38,7 @@ export const registerAttachmentTypes = ({
     createConnectorAttachmentType(),
     createConnectorSetupAttachmentType(),
     createSkillAttachmentType(),
+    createImageAttachmentType(),
   ];
 
   attachmentTypes.forEach((attachmentType) => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.ts
@@ -136,7 +136,7 @@ export function messagesToOpenAI({
       case MessageRole.Assistant:
         const assistantMessage: ChatCompletionAssistantMessageParam = {
           role: 'assistant',
-          content: message.content || null,
+          content: message.content ?? '',
           tool_calls: message.toolCalls?.map((toolCall) => {
             return {
               function: {


### PR DESCRIPTION
## Summary

PoC: gives the agent a visual feedback loop - it can now capture a screenshot of the dashboard and check it with an LLM judge.

- Two-way browser tools: browser API tools get a `returns_result` flag. The tool call pauses the round (same prompt machinery as `ask_user_question`), the browser runs the handler and resumes with the result, which is materialized as a regular tool call/result pair in the model's history
- result_type: `image`: image results are extracted server-side into a hidden image attachment, so base64 never enters model context. - copied from https://github.com/elastic/kibana/pull/282588
- Browser tool registry on the `agent_builder` public contract, so plugins can register client tools globally
- `capture_dashboard_screenshot` browser tool: renders a dashboard attachment off-screen and returns a JPEG.
- validate_dashboard tool: LLM judge that scores the dashboard against a rubric using the screenshot. (not finished, it's missing a guidance on what to exactly look for).

Demo:

https://github.com/user-attachments/assets/0e3552b5-b119-4074-846b-7624e8188b2b

