### PR TITLE
Align project Global Search with solution navigation

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -186,6 +186,7 @@ export function createChromeApi({
         InternalChromeStart['getActiveSolutionNavId$']
       >,
     getActiveSolutionNavId: () => projectNavigation.getActiveSolutionNavId(),
+    getDeepLinkNavPaths$: () => projectNavigation.getDeepLinkNavPaths$(),
     project,
     next: {
       get isEnabled() {

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/README.md
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/README.md
@@ -72,6 +72,10 @@ This is the most common function of the service. It determines the currently act
   1.  **Custom Logic (`getIsActive`)**: A node can define its own function for complex activation logic.
   2.  **Longest URL Match**: As a fallback, the utility finds the most specific link by matching the longest URL prefix.
 
+#### Deep-link title paths
+
+`getDeepLinkNavPaths$()` (also on public `ChromeStart`) emits a map of deep-link id → ancestor titles from the parsed tree. Global Search uses this so project-chrome results follow sidenav IA instead of Stack Management section names. Emits `null` until navigation is initialized.
+
 #### Breadcrumbs Generation
 
 Breadcrumbs are automatically generated from the navigation tree structure:

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/README.md
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/README.md
@@ -72,9 +72,9 @@ This is the most common function of the service. It determines the currently act
   1.  **Custom Logic (`getIsActive`)**: A node can define its own function for complex activation logic.
   2.  **Longest URL Match**: As a fallback, the utility finds the most specific link by matching the longest URL prefix.
 
-#### Deep-link title paths
+#### Deep-link nav paths
 
-`getDeepLinkNavPaths$()` (also on public `ChromeStart`) emits a map of deep-link id → ancestor titles from the parsed tree. Global Search uses this so project-chrome results follow sidenav IA instead of Stack Management section names. Emits `null` until navigation is initialized.
+`getDeepLinkNavPaths$()` (also on public `ChromeStart`) emits a map of deep-link id → `{ titles, order, icon?, categoryLabel? }` from the parsed tree. Global Search uses this so project-chrome results follow sidenav IA for labels, empty-search ranking (`order`), section icons (nearest string `icon`), and panel categories (nearest `panelOpener` title). Emits `null` until navigation is initialized.
 
 #### Breadcrumbs Generation
 

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/apply_customization.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/apply_customization.ts
@@ -11,6 +11,7 @@ import type {
   CloudLinks,
   ChromeNavLink,
   ChromeProjectNavigationNode,
+  DeepLinkNavPath,
   NavigationCustomization,
   NavigationTreeDefinition,
   NavigationTreeDefinitionUI,
@@ -39,8 +40,8 @@ export interface ParsedNavigation {
    * regular customizable item.
    */
   renderableNodes: ChromeProjectNavigationNode[];
-  /** deepLink id → ancestor titles (including leaf), for Global Search labels. */
-  deepLinkNavPaths: ReadonlyMap<string, readonly string[]>;
+  /** deepLink id → nav-tree metadata for Global Search (titles, icon, panel category). */
+  deepLinkNavPaths: ReadonlyMap<string, DeepLinkNavPath>;
 }
 
 /**

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/apply_customization.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/apply_customization.ts
@@ -18,6 +18,7 @@ import type {
 } from '@kbn/core-chrome-browser';
 import { replayMoves } from '@kbn/core-chrome-navigation-customization';
 import { i18n } from '@kbn/i18n';
+import { buildDeepLinkNavPaths } from './build_deep_link_nav_paths';
 import { flattenNav, getRenderableNodes, parseNavigationTree } from './utils';
 
 const HOME_TITLE = i18n.translate('core.ui.chrome.sideNavigation.homeItemTitle', {
@@ -38,6 +39,8 @@ export interface ParsedNavigation {
    * regular customizable item.
    */
   renderableNodes: ChromeProjectNavigationNode[];
+  /** deepLink id → ancestor titles (including leaf), for Global Search labels. */
+  deepLinkNavPaths: ReadonlyMap<string, readonly string[]>;
 }
 
 /**
@@ -107,5 +110,6 @@ export const applyCustomization = (
     overflowItemIds,
     defaultItemIds,
     renderableNodes: getRenderableNodes(bodyUI, isHomeCustomizable),
+    deepLinkNavPaths: buildDeepLinkNavPaths(navigationTree),
   };
 };

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/build_deep_link_nav_paths.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/build_deep_link_nav_paths.test.ts
@@ -1,10 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 import type { ChromeNavLink, ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';
@@ -53,11 +51,124 @@ describe('buildDeepLinkNavPaths', () => {
 
     const paths = buildDeepLinkNavPaths(tree);
 
-    expect(paths.get('management:application_connections')).toEqual([
-      'Admin and Settings',
-      'Access',
-      'Application connections',
-    ]);
+    expect(paths.get('management:application_connections')).toEqual({
+      titles: ['Admin and Settings', 'Access', 'Application connections'],
+      order: 0,
+    });
+  });
+
+  it('inherits panelOpener icon and categoryLabel for nested deep links', () => {
+    const tree = [
+      node({
+        id: 'applications',
+        title: 'Applications',
+        path: 'applications',
+        renderAs: 'panelOpener',
+        icon: 'spaces',
+        children: [
+          node({
+            id: 'ux',
+            title: 'User experience',
+            path: 'applications.ux',
+            deepLink: deepLink('ux', 'User experience'),
+          }),
+        ],
+      }),
+    ];
+
+    expect(buildDeepLinkNavPaths(tree).get('ux')).toEqual({
+      titles: ['Applications', 'User experience'],
+      order: 0,
+      icon: 'spaces',
+      categoryLabel: 'Applications',
+    });
+  });
+
+  it('uses the nearest string icon and nearest panelOpener title', () => {
+    const tree = [
+      node({
+        id: 'applications',
+        title: 'Applications',
+        path: 'applications',
+        renderAs: 'panelOpener',
+        icon: 'spaces',
+        children: [
+          node({
+            id: 'synthetics',
+            title: 'Synthetics',
+            path: 'applications.synthetics',
+            icon: 'visLine',
+            children: [
+              node({
+                id: 'monitors',
+                title: 'Monitors',
+                path: 'applications.synthetics.monitors',
+                deepLink: deepLink('synthetics:monitors', 'Monitors'),
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    expect(buildDeepLinkNavPaths(tree).get('synthetics:monitors')).toEqual({
+      titles: ['Applications', 'Synthetics', 'Monitors'],
+      order: 0,
+      icon: 'visLine',
+      categoryLabel: 'Applications',
+    });
+  });
+
+  it('skips React component icons when resolving nearest icon', () => {
+    const FakeIcon = () => null;
+    const tree = [
+      node({
+        id: 'applications',
+        title: 'Applications',
+        path: 'applications',
+        renderAs: 'panelOpener',
+        icon: FakeIcon as unknown as string,
+        children: [
+          node({
+            id: 'leaf',
+            title: 'Leaf',
+            path: 'applications.leaf',
+            icon: 'spaces',
+            deepLink: deepLink('app:leaf', 'Leaf'),
+          }),
+        ],
+      }),
+    ];
+
+    expect(buildDeepLinkNavPaths(tree).get('app:leaf')).toEqual({
+      titles: ['Applications', 'Leaf'],
+      order: 0,
+      icon: 'spaces',
+      categoryLabel: 'Applications',
+    });
+  });
+
+  it('omits icon and categoryLabel when none are present', () => {
+    const tree = [
+      node({
+        id: 'group',
+        title: 'Group',
+        path: 'group',
+        children: [
+          node({
+            id: 'leaf',
+            title: 'Leaf',
+            path: 'group.leaf',
+            deepLink: deepLink('app:leaf', 'Leaf'),
+          }),
+        ],
+      }),
+    ];
+
+    expect(buildDeepLinkNavPaths(tree).get('app:leaf')).toEqual({
+      titles: ['Group', 'Leaf'],
+      order: 0,
+    });
   });
 
   it('skips nodes without a deep link and empty titles', () => {
@@ -84,7 +195,7 @@ describe('buildDeepLinkNavPaths', () => {
 
     const paths = buildDeepLinkNavPaths(tree);
 
-    expect(paths.get('app:leaf')).toEqual(['Leaf']);
+    expect(paths.get('app:leaf')).toEqual({ titles: ['Leaf'], order: 0 });
     expect(paths.size).toBe(1);
   });
 
@@ -104,6 +215,46 @@ describe('buildDeepLinkNavPaths', () => {
       }),
     ];
 
-    expect(buildDeepLinkNavPaths(tree).get('app:dup')).toEqual(['First']);
+    expect(buildDeepLinkNavPaths(tree).get('app:dup')).toEqual({ titles: ['First'], order: 0 });
+  });
+
+  it('assigns DFS order across deep links', () => {
+    const tree = [
+      node({
+        id: 'a',
+        title: 'A',
+        path: 'a',
+        deepLink: deepLink('app:a', 'A'),
+      }),
+      node({
+        id: 'b',
+        title: 'B',
+        path: 'b',
+        deepLink: deepLink('app:b', 'B'),
+      }),
+    ];
+
+    const paths = buildDeepLinkNavPaths(tree);
+    expect(paths.get('app:a')?.order).toBe(0);
+    expect(paths.get('app:b')?.order).toBe(1);
+  });
+
+  it('normalizes renderAs home to Home title and home icon', () => {
+    const tree = [
+      node({
+        id: 'overview',
+        title: 'Observability',
+        path: 'overview',
+        renderAs: 'home',
+        icon: 'logoObservability',
+        deepLink: deepLink('observability-overview', 'Observability'),
+      }),
+    ];
+
+    expect(buildDeepLinkNavPaths(tree).get('observability-overview')).toEqual({
+      titles: ['Home'],
+      order: 0,
+      icon: 'home',
+    });
   });
 });

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/build_deep_link_nav_paths.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/build_deep_link_nav_paths.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ChromeNavLink, ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';
+import { buildDeepLinkNavPaths } from './build_deep_link_nav_paths';
+
+const deepLink = (id: string, title: string): ChromeNavLink =>
+  ({
+    id,
+    title,
+    baseUrl: '',
+    url: `/${id}`,
+    href: `/${id}`,
+  } as ChromeNavLink);
+
+const node = (
+  props: Partial<ChromeProjectNavigationNode> &
+    Pick<ChromeProjectNavigationNode, 'id' | 'title' | 'path'>
+): ChromeProjectNavigationNode => props;
+
+describe('buildDeepLinkNavPaths', () => {
+  it('maps deep links to ancestor title chains including the leaf', () => {
+    const tree = [
+      node({
+        id: 'admin_and_settings',
+        title: 'Admin and Settings',
+        path: 'admin_and_settings',
+        breadcrumbStatus: 'hidden',
+        children: [
+          node({
+            id: 'access',
+            title: 'Access',
+            path: 'admin_and_settings.access',
+            breadcrumbStatus: 'hidden',
+            children: [
+              node({
+                id: 'application_connections',
+                title: 'Application connections',
+                path: 'admin_and_settings.access.application_connections',
+                deepLink: deepLink('management:application_connections', 'Application connections'),
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    const paths = buildDeepLinkNavPaths(tree);
+
+    expect(paths.get('management:application_connections')).toEqual([
+      'Admin and Settings',
+      'Access',
+      'Application connections',
+    ]);
+  });
+
+  it('skips nodes without a deep link and empty titles', () => {
+    const tree = [
+      node({
+        id: 'group',
+        title: '',
+        path: 'group',
+        children: [
+          node({
+            id: 'leaf',
+            title: 'Leaf',
+            path: 'group.leaf',
+            deepLink: deepLink('app:leaf', 'Leaf'),
+          }),
+          node({
+            id: 'no-link',
+            title: 'No link',
+            path: 'group.no-link',
+          }),
+        ],
+      }),
+    ];
+
+    const paths = buildDeepLinkNavPaths(tree);
+
+    expect(paths.get('app:leaf')).toEqual(['Leaf']);
+    expect(paths.size).toBe(1);
+  });
+
+  it('keeps the first DFS hit when a deep link appears twice', () => {
+    const tree = [
+      node({
+        id: 'first',
+        title: 'First',
+        path: 'first',
+        deepLink: deepLink('app:dup', 'Dup'),
+      }),
+      node({
+        id: 'second',
+        title: 'Second',
+        path: 'second',
+        deepLink: deepLink('app:dup', 'Dup'),
+      }),
+    ];
+
+    expect(buildDeepLinkNavPaths(tree).get('app:dup')).toEqual(['First']);
+  });
+});

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/build_deep_link_nav_paths.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/build_deep_link_nav_paths.ts
@@ -1,38 +1,64 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
-import type { ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';
+import type { ChromeProjectNavigationNode, DeepLinkNavPath } from '@kbn/core-chrome-browser';
+import { i18n } from '@kbn/i18n';
+
+const HOME_TITLE = i18n.translate('core.ui.chrome.sideNavigation.homeItemTitle', {
+  defaultMessage: 'Home',
+});
 
 /**
- * Builds a map of nav deep-link id → ancestor title chain (including the leaf).
+ * Builds a map of nav deep-link id → {@link DeepLinkNavPath}.
  * First DFS hit wins. Empty titles are skipped. breadcrumbStatus is ignored so
  * search labels can include parents hidden from page breadcrumbs.
+ *
+ * Icon is the nearest ancestor (including leaf) with an explicit string `icon`
+ * (React component icons are skipped). categoryLabel is the nearest panelOpener
+ * ancestor title. order is the DFS discovery index among registered deep links.
+ *
+ * `renderAs: 'home'` is normalized to the shared Home title/icon, matching the
+ * sidenav treatment in applyCustomization.
  */
 export const buildDeepLinkNavPaths = (
   nodes: ChromeProjectNavigationNode[]
-): ReadonlyMap<string, readonly string[]> => {
-  const paths = new Map<string, readonly string[]>();
+): ReadonlyMap<string, DeepLinkNavPath> => {
+  const paths = new Map<string, DeepLinkNavPath>();
+  let order = 0;
 
-  const visit = (node: ChromeProjectNavigationNode, ancestorTitles: readonly string[]): void => {
-    const titles = node.title ? [...ancestorTitles, node.title] : [...ancestorTitles];
+  const visit = (
+    node: ChromeProjectNavigationNode,
+    ancestorTitles: readonly string[],
+    nearestIcon: string | undefined,
+    nearestPanelTitle: string | undefined
+  ): void => {
+    const isHome = node.renderAs === 'home';
+    const nodeTitle = isHome ? HOME_TITLE : node.title;
+    const titles = nodeTitle ? [...ancestorTitles, nodeTitle] : [...ancestorTitles];
+    const icon = isHome ? 'home' : typeof node.icon === 'string' ? node.icon : nearestIcon;
+    const panelTitle =
+      node.renderAs === 'panelOpener' && nodeTitle ? nodeTitle : nearestPanelTitle;
 
     if (node.deepLink?.id && !paths.has(node.deepLink.id)) {
-      paths.set(node.deepLink.id, titles);
+      paths.set(node.deepLink.id, {
+        titles,
+        order: order++,
+        ...(icon !== undefined ? { icon } : {}),
+        ...(panelTitle !== undefined ? { categoryLabel: panelTitle } : {}),
+      });
     }
 
     for (const child of node.children ?? []) {
-      visit(child, titles);
+      visit(child, titles, icon, panelTitle);
     }
   };
 
   for (const node of nodes) {
-    visit(node, []);
+    visit(node, [], undefined, undefined);
   }
 
   return paths;

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/build_deep_link_nav_paths.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/build_deep_link_nav_paths.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';
+
+/**
+ * Builds a map of nav deep-link id → ancestor title chain (including the leaf).
+ * First DFS hit wins. Empty titles are skipped. breadcrumbStatus is ignored so
+ * search labels can include parents hidden from page breadcrumbs.
+ */
+export const buildDeepLinkNavPaths = (
+  nodes: ChromeProjectNavigationNode[]
+): ReadonlyMap<string, readonly string[]> => {
+  const paths = new Map<string, readonly string[]>();
+
+  const visit = (node: ChromeProjectNavigationNode, ancestorTitles: readonly string[]): void => {
+    const titles = node.title ? [...ancestorTitles, node.title] : [...ancestorTitles];
+
+    if (node.deepLink?.id && !paths.has(node.deepLink.id)) {
+      paths.set(node.deepLink.id, titles);
+    }
+
+    for (const child of node.children ?? []) {
+      visit(child, titles);
+    }
+  };
+
+  for (const node of nodes) {
+    visit(node, []);
+  }
+
+  return paths;
+};

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
@@ -1050,10 +1050,9 @@ describe('getDeepLinkNavPaths$()', () => {
     );
 
     const paths = await lastValueFrom(projectNavigation.getDeepLinkNavPaths$().pipe(take(1)));
-    expect(paths?.get('management:application_connections')).toEqual([
-      'Admin and Settings',
-      'Access',
-      'MANAGEMENT:APPLICATION_CONNECTIONS',
-    ]);
+    expect(paths?.get('management:application_connections')).toEqual({
+      titles: ['Admin and Settings', 'Access', 'MANAGEMENT:APPLICATION_CONNECTIONS'],
+      order: 0,
+    });
   });
 });

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
@@ -1019,3 +1019,41 @@ describe('getActiveSolutionNavId$()', () => {
     expect(activeId).toBe('oblt');
   });
 });
+
+describe('getDeepLinkNavPaths$()', () => {
+  it('should return null initially and a path map after initNavigation', async () => {
+    const { projectNavigation } = setup({
+      navLinkIds: ['management:application_connections'],
+    });
+
+    const before = await lastValueFrom(projectNavigation.getDeepLinkNavPaths$().pipe(take(1)));
+    expect(before).toBeNull();
+
+    projectNavigation.initNavigation<any>(
+      'oblt',
+      of({
+        body: [
+          {
+            id: 'admin_and_settings',
+            title: 'Admin and Settings',
+            breadcrumbStatus: 'hidden',
+            children: [
+              {
+                id: 'access',
+                title: 'Access',
+                children: [{ link: 'management:application_connections' }],
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const paths = await lastValueFrom(projectNavigation.getDeepLinkNavPaths$().pipe(take(1)));
+    expect(paths?.get('management:application_connections')).toEqual([
+      'Admin and Settings',
+      'Access',
+      'MANAGEMENT:APPLICATION_CONNECTIONS',
+    ]);
+  });
+});

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.ts
@@ -14,6 +14,7 @@ import type {
   ChromeSetProjectBreadcrumbsParams,
   ChromeNavLink,
   CloudURLs,
+  DeepLinkNavPath,
   NavigationCustomization,
   NavigationTreeDefinition,
   CloudLinks,
@@ -229,7 +230,7 @@ export class ProjectNavigationService {
       },
       getActiveSolutionNavId$: () => activeSolutionNavId$,
       getActiveSolutionNavId: () => currentNavSource$.getValue()?.id ?? null,
-      getDeepLinkNavPaths$: (): Observable<ReadonlyMap<string, readonly string[]> | null> =>
+      getDeepLinkNavPaths$: (): Observable<ReadonlyMap<string, DeepLinkNavPath> | null> =>
         parsedNavigation$.pipe(
           map((parsed) => parsed?.deepLinkNavPaths ?? null),
           distinctUntilChanged(),

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.ts
@@ -229,6 +229,12 @@ export class ProjectNavigationService {
       },
       getActiveSolutionNavId$: () => activeSolutionNavId$,
       getActiveSolutionNavId: () => currentNavSource$.getValue()?.id ?? null,
+      getDeepLinkNavPaths$: (): Observable<ReadonlyMap<string, readonly string[]> | null> =>
+        parsedNavigation$.pipe(
+          map((parsed) => parsed?.deepLinkNavPaths ?? null),
+          distinctUntilChanged(),
+          shareReplay(1)
+        ),
       setNavigationCustomization: (customization: NavigationCustomization | undefined) =>
         this.customization$.next(customization),
       getCustomizeNavigationHandler$: () => this.customizeNavigationHandler$.asObservable(),

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.tsx
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.tsx
@@ -134,6 +134,7 @@ const createStartContractMock = () => {
     setChromeStyle: jest.fn(),
     getActiveSolutionNavId$: jest.fn().mockReturnValue(new BehaviorSubject(null)),
     getActiveSolutionNavId: jest.fn().mockReturnValue(null),
+    getDeepLinkNavPaths$: jest.fn().mockReturnValue(new BehaviorSubject(null)),
     project: lazyObject({
       setCloudUrls: jest.fn(),
       setKibanaName: jest.fn(),

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -23,7 +23,7 @@ import type {
 } from './breadcrumb';
 import type { ChromeBadge, ChromeBreadcrumbsBadge, ChromeStyle, ChromeUserBanner } from './types';
 import type { ChromeGlobalHelpExtensionMenuLink } from './help_extension';
-import type { SolutionId } from './project_navigation';
+import type { DeepLinkNavPath, SolutionId } from './project_navigation';
 import type { SidebarStart, SidebarSetup } from './sidebar';
 
 /**
@@ -329,11 +329,11 @@ export interface ChromeStart {
   getActiveSolutionNavId(): SolutionId | null;
 
   /**
-   * In project chrome, ancestor titles for each deep link id present in the active
-   * navigation tree (including the leaf). Emits `null` when project navigation is
-   * not initialized (classic chrome, or before `initNavigation`).
+   * In project chrome, nav-tree metadata (titles, section icon, panel category)
+   * for each deep link id in the active navigation tree. Emits `null` when
+   * project navigation is not initialized (classic chrome, or before `initNavigation`).
    */
-  getDeepLinkNavPaths$(): Observable<ReadonlyMap<string, readonly string[]> | null>;
+  getDeepLinkNavPaths$(): Observable<ReadonlyMap<string, DeepLinkNavPath> | null>;
 
   /**
    * Used only by the rendering service and KibanaRenderingContextProvider to wrap the rendering tree in the Chrome context providers

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -329,6 +329,13 @@ export interface ChromeStart {
   getActiveSolutionNavId(): SolutionId | null;
 
   /**
+   * In project chrome, ancestor titles for each deep link id present in the active
+   * navigation tree (including the leaf). Emits `null` when project navigation is
+   * not initialized (classic chrome, or before `initNavigation`).
+   */
+  getDeepLinkNavPaths$(): Observable<ReadonlyMap<string, readonly string[]> | null>;
+
+  /**
    * Used only by the rendering service and KibanaRenderingContextProvider to wrap the rendering tree in the Chrome context providers
    */
   withProvider(component: ReactNode): ReactNode;

--- a/src/core/packages/chrome/browser/src/index.ts
+++ b/src/core/packages/chrome/browser/src/index.ts
@@ -57,6 +57,7 @@ export type { ChromeBadge, ChromeBreadcrumbsBadge, ChromeUserBanner, ChromeStyle
 
 export type {
   ChromeProjectNavigationNode,
+  DeepLinkNavPath,
   RootNodePanelOpenerDefinition,
   PanelOpenerChildDefinition,
   StandardNodeDefinition,

--- a/src/core/packages/chrome/browser/src/project_navigation.ts
+++ b/src/core/packages/chrome/browser/src/project_navigation.ts
@@ -195,6 +195,21 @@ export interface ChromeProjectNavigationNode extends ChromeNavigationNodeCommon 
   isExternalLink?: boolean;
 }
 
+/**
+ * Nav-tree metadata for a deep link, used by Global Search in project chrome.
+ * Built from the parsed navigation tree (first DFS hit wins).
+ */
+export interface DeepLinkNavPath {
+  /** Ancestor titles including the leaf. */
+  titles: readonly string[];
+  /** DFS discovery order in the parsed tree (0-based). Used to rank empty search. */
+  order: number;
+  /** Nearest ancestor (including leaf) with an explicit string `icon`. */
+  icon?: string;
+  /** Nearest `panelOpener` ancestor title. */
+  categoryLabel?: string;
+}
+
 /** @public */
 export interface ChromeSetProjectBreadcrumbsParams {
   absolute: boolean;

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/index.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/index.ts
@@ -26,8 +26,17 @@ const sortByTitle = (a: GlobalSearchResult, b: GlobalSearchResult): number => {
   return 0;
 };
 
+const sortByScoreThenTitle = (a: GlobalSearchResult, b: GlobalSearchResult): number => {
+  const byScore = sortByScore(a, b);
+  if (byScore !== 0) {
+    return byScore;
+  }
+  return sortByTitle(a, b);
+};
+
 /* @internal */
 export const sort = {
   byScore: sortByScore,
   byTitle: sortByTitle,
+  byScoreThenTitle: sortByScoreThenTitle,
 };

--- a/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.test.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.test.ts
@@ -153,7 +153,7 @@ describe('useSearchState', () => {
     expect(globalSearch.find).toHaveBeenCalledTimes(1); // no additional search calls
   });
 
-  it('correctly filters and sorts results by title when the search value is empty', async () => {
+  it('correctly filters and sorts results by score then title when the search value is empty', async () => {
     const { globalSearch, navigateToUrl, reportEvent } = makeDeps();
 
     globalSearch.find.mockReturnValueOnce(

--- a/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.ts
@@ -176,9 +176,10 @@ export const useSearchState = ({
               return;
             }
 
-            // if searchbar is empty, filter to only applications and sort alphabetically
+            // Empty search: applications only. Score carries nav order in project chrome;
+            // title is the tie-breaker (classic chrome uses the same score for every app).
             results = results.filter(({ type }: GlobalSearchResult) => type === 'application');
-            aggregatedResults = [...results, ...aggregatedResults].sort(sort.byTitle);
+            aggregatedResults = [...results, ...aggregatedResults].sort(sort.byScoreThenTitle);
             setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
           },
           error: (err) => {

--- a/x-pack/platform/plugins/private/global_search_providers/public/plugin.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/plugin.ts
@@ -20,8 +20,14 @@ export class GlobalSearchProvidersPlugin
     { getStartServices }: CoreSetup<{}, {}>,
     { globalSearch }: GlobalSearchProvidersPluginSetupDeps
   ) {
-    const applicationPromise = getStartServices().then(([core]) => core.application);
-    globalSearch.registerResultProvider(createApplicationResultProvider(applicationPromise));
+    const startServices = getStartServices();
+    const applicationPromise = startServices.then(([core]) => core.application);
+    const getChromeStylePromise = startServices.then(
+      ([core]) => () => core.chrome.getChromeStyle()
+    );
+    globalSearch.registerResultProvider(
+      createApplicationResultProvider(applicationPromise, getChromeStylePromise)
+    );
     return {};
   }
 

--- a/x-pack/platform/plugins/private/global_search_providers/public/plugin.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/plugin.ts
@@ -22,11 +22,9 @@ export class GlobalSearchProvidersPlugin
   ) {
     const startServices = getStartServices();
     const applicationPromise = startServices.then(([core]) => core.application);
-    const getChromeStylePromise = startServices.then(
-      ([core]) => () => core.chrome.getChromeStyle()
-    );
+    const chromePromise = startServices.then(([core]) => core.chrome);
     globalSearch.registerResultProvider(
-      createApplicationResultProvider(applicationPromise, getChromeStylePromise)
+      createApplicationResultProvider(applicationPromise, chromePromise)
     );
     return {};
   }

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/application.test.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/application.test.ts
@@ -9,7 +9,7 @@ import { getAppResultsMock } from './application.test.mocks';
 
 import { EMPTY, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import type { ApplicationStart, PublicAppInfo } from '@kbn/core/public';
+import type { ApplicationStart, ChromeStart, PublicAppInfo } from '@kbn/core/public';
 import { AppStatus } from '@kbn/core/public';
 import type {
   GlobalSearchProviderFindOptions,
@@ -51,10 +51,15 @@ const createAppMap = (apps: PublicAppInfo[]): Map<string, PublicAppInfo> => {
 const expectApp = (id: string) => expect.objectContaining({ id });
 const expectResult = expectApp;
 
+type ChromeForSearch = Pick<ChromeStart, 'getChromeStyle' | 'getDeepLinkNavPaths$'>;
+
 describe('applicationResultProvider', () => {
   let application: ReturnType<typeof applicationServiceMock.createStartContract>;
-  let getChromeStyle: jest.Mock<'classic' | 'project', []>;
-  let getChromeStylePromise: Promise<() => 'classic' | 'project'>;
+  let chrome: {
+    getChromeStyle: jest.Mock<'classic' | 'project', []>;
+    getDeepLinkNavPaths$: jest.Mock;
+  };
+  let chromePromise: Promise<ChromeForSearch>;
 
   const defaultOption: GlobalSearchProviderFindOptions = {
     preference: 'pref',
@@ -64,8 +69,11 @@ describe('applicationResultProvider', () => {
 
   beforeEach(() => {
     application = applicationServiceMock.createStartContract();
-    getChromeStyle = jest.fn().mockReturnValue('classic');
-    getChromeStylePromise = Promise.resolve(getChromeStyle);
+    chrome = {
+      getChromeStyle: jest.fn().mockReturnValue('classic'),
+      getDeepLinkNavPaths$: jest.fn().mockReturnValue(of(null)),
+    };
+    chromePromise = Promise.resolve(chrome);
     getAppResultsMock.mockReturnValue([]);
   });
 
@@ -74,10 +82,7 @@ describe('applicationResultProvider', () => {
   });
 
   it('has the correct id', () => {
-    const provider = createApplicationResultProvider(
-      Promise.resolve(application),
-      getChromeStylePromise
-    );
+    const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
     expect(provider.id).toBe('application');
   });
 
@@ -90,10 +95,7 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app3', title: 'App 3' }),
         ])
       );
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
 
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
@@ -101,22 +103,24 @@ describe('applicationResultProvider', () => {
       expect(getAppResultsMock).toHaveBeenCalledWith(
         'term',
         [expectApp('app1'), expectApp('app2'), expectApp('app3')],
-        { omitManagementSectionTitles: false }
+        { chromeStyle: 'classic', deepLinkNavPaths: null }
       );
     });
 
-    it('omits management section titles when chrome style is project', async () => {
-      getChromeStyle.mockReturnValue('project');
+    it('passes project chrome style and deep link nav paths to `getAppResults`', async () => {
+      const deepLinkNavPaths = new Map<string, readonly string[]>([
+        ['management:application_connections', ['Admin and Settings', 'Access']],
+      ]);
+      chrome.getChromeStyle.mockReturnValue('project');
+      chrome.getDeepLinkNavPaths$.mockReturnValue(of(deepLinkNavPaths));
       application.applications$ = of(createAppMap([createApp({ id: 'app1', title: 'App 1' })]));
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
 
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
       expect(getAppResultsMock).toHaveBeenCalledWith('term', [expectApp('app1')], {
-        omitManagementSectionTitles: true,
+        chromeStyle: 'project',
+        deepLinkNavPaths,
       });
     });
 
@@ -127,10 +131,7 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app2', title: 'App 2' }),
         ])
       );
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
 
       await provider
         .find({ term: 'term', types: ['dashboard', 'application'] }, defaultOption)
@@ -140,7 +141,7 @@ describe('applicationResultProvider', () => {
       expect(getAppResultsMock).toHaveBeenCalledWith(
         'term',
         [expectApp('app1'), expectApp('app2')],
-        { omitManagementSectionTitles: false }
+        { chromeStyle: 'classic', deepLinkNavPaths: null }
       );
     });
 
@@ -152,10 +153,7 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app3', title: 'App 3' }),
         ])
       );
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
 
       const results = await provider
         .find({ term: 'term', types: ['dashboard', 'map'] }, defaultOption)
@@ -173,10 +171,7 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app3', title: 'App 3' }),
         ])
       );
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
 
       const results = await provider
         .find({ term: 'term', tags: ['some-tag-id'] }, defaultOption)
@@ -193,14 +188,12 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'disabled', title: 'disabled', status: AppStatus.inaccessible }),
         ])
       );
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
       expect(getAppResultsMock).toHaveBeenCalledWith('term', [expectApp('app1')], {
-        omitManagementSectionTitles: false,
+        chromeStyle: 'classic',
+        deepLinkNavPaths: null,
       });
     });
 
@@ -216,16 +209,13 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'hidden', title: 'hidden', visibleIn: [] }),
         ])
       );
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
       expect(getAppResultsMock).toHaveBeenCalledWith(
         'term',
         [expectApp('app1'), expectApp('disabled'), expectApp('hidden')],
-        { omitManagementSectionTitles: false }
+        { chromeStyle: 'classic', deepLinkNavPaths: null }
       );
     });
 
@@ -237,14 +227,12 @@ describe('applicationResultProvider', () => {
         ])
       );
 
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
       expect(getAppResultsMock).toHaveBeenCalledWith('term', [expectApp('app1')], {
-        omitManagementSectionTitles: false,
+        chromeStyle: 'classic',
+        deepLinkNavPaths: null,
       });
     });
 
@@ -256,10 +244,7 @@ describe('applicationResultProvider', () => {
         createResult({ id: 'r75', score: 75 }),
       ]);
 
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
       const results = await provider.find({ term: 'term' }, defaultOption).toPromise();
 
       expect(results).toEqual([
@@ -278,10 +263,7 @@ describe('applicationResultProvider', () => {
         createResult({ id: 'r75', score: 75 }),
       ]);
 
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
 
       const options = {
         ...defaultOption,
@@ -293,7 +275,7 @@ describe('applicationResultProvider', () => {
     });
 
     it('only emits once, even if `application$` emits multiple times', () => {
-      getTestScheduler().run(({ hot, expectObservable }) => {
+      getTestScheduler().run(({ hot, cold, expectObservable }) => {
         const appMap = createAppMap([createApp({ id: 'app1', title: 'App 1' })]);
 
         application.applications$ = hot('--a---b', { a: appMap, b: appMap });
@@ -303,11 +285,19 @@ describe('applicationResultProvider', () => {
         const applicationPromise = hot('a', {
           a: application,
         }) as unknown as Promise<ApplicationStart>;
-        const chromeStylePromise = hot('a', {
-          a: () => 'classic' as const,
-        }) as unknown as Promise<() => 'classic' | 'project'>;
+        const chromeForSearch = {
+          getChromeStyle: () => 'classic' as const,
+          // cold so it emits when combineLatest subscribes (after chrome resolves)
+          getDeepLinkNavPaths$: () => cold('a', { a: null }),
+        };
+        const chromeForSearchPromise = hot('a', {
+          a: chromeForSearch,
+        }) as unknown as Promise<ChromeForSearch>;
 
-        const provider = createApplicationResultProvider(applicationPromise, chromeStylePromise);
+        const provider = createApplicationResultProvider(
+          applicationPromise,
+          chromeForSearchPromise
+        );
 
         const options = {
           ...defaultOption,
@@ -321,7 +311,7 @@ describe('applicationResultProvider', () => {
     });
 
     it('only emits results until `aborted$` emits', () => {
-      getTestScheduler().run(({ hot, expectObservable }) => {
+      getTestScheduler().run(({ hot, cold, expectObservable }) => {
         const appMap = createAppMap([createApp({ id: 'app1', title: 'App 1' })]);
 
         application.applications$ = hot('---a', { a: appMap, b: appMap });
@@ -331,11 +321,18 @@ describe('applicationResultProvider', () => {
         const applicationPromise = hot('a', {
           a: application,
         }) as unknown as Promise<ApplicationStart>;
-        const chromeStylePromise = hot('a', {
-          a: () => 'classic' as const,
-        }) as unknown as Promise<() => 'classic' | 'project'>;
+        const chromeForSearch = {
+          getChromeStyle: () => 'classic' as const,
+          getDeepLinkNavPaths$: () => cold('a', { a: null }),
+        };
+        const chromeForSearchPromise = hot('a', {
+          a: chromeForSearch,
+        }) as unknown as Promise<ChromeForSearch>;
 
-        const provider = createApplicationResultProvider(applicationPromise, chromeStylePromise);
+        const provider = createApplicationResultProvider(
+          applicationPromise,
+          chromeForSearchPromise
+        );
 
         const options = {
           ...defaultOption,
@@ -357,10 +354,7 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app2', title: 'App 2' }),
         ])
       );
-      const provider = createApplicationResultProvider(
-        Promise.resolve(application),
-        getChromeStylePromise
-      );
+      const provider = createApplicationResultProvider(Promise.resolve(application), chromePromise);
 
       expect(await provider.getSearchableTypes()).toEqual(['application']);
     });

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/application.test.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/application.test.ts
@@ -108,8 +108,11 @@ describe('applicationResultProvider', () => {
     });
 
     it('passes project chrome style and deep link nav paths to `getAppResults`', async () => {
-      const deepLinkNavPaths = new Map<string, readonly string[]>([
-        ['management:application_connections', ['Admin and Settings', 'Access']],
+      const deepLinkNavPaths = new Map([
+        [
+          'management:application_connections',
+          { titles: ['Admin and Settings', 'Access'] as const, order: 0 },
+        ],
       ]);
       chrome.getChromeStyle.mockReturnValue('project');
       chrome.getDeepLinkNavPaths$.mockReturnValue(of(deepLinkNavPaths));

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/application.test.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/application.test.ts
@@ -53,6 +53,8 @@ const expectResult = expectApp;
 
 describe('applicationResultProvider', () => {
   let application: ReturnType<typeof applicationServiceMock.createStartContract>;
+  let getChromeStyle: jest.Mock<'classic' | 'project', []>;
+  let getChromeStylePromise: Promise<() => 'classic' | 'project'>;
 
   const defaultOption: GlobalSearchProviderFindOptions = {
     preference: 'pref',
@@ -62,6 +64,8 @@ describe('applicationResultProvider', () => {
 
   beforeEach(() => {
     application = applicationServiceMock.createStartContract();
+    getChromeStyle = jest.fn().mockReturnValue('classic');
+    getChromeStylePromise = Promise.resolve(getChromeStyle);
     getAppResultsMock.mockReturnValue([]);
   });
 
@@ -70,7 +74,10 @@ describe('applicationResultProvider', () => {
   });
 
   it('has the correct id', () => {
-    const provider = createApplicationResultProvider(Promise.resolve(application));
+    const provider = createApplicationResultProvider(
+      Promise.resolve(application),
+      getChromeStylePromise
+    );
     expect(provider.id).toBe('application');
   });
 
@@ -83,16 +90,34 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app3', title: 'App 3' }),
         ])
       );
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
 
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
       expect(getAppResultsMock).toHaveBeenCalledTimes(1);
-      expect(getAppResultsMock).toHaveBeenCalledWith('term', [
-        expectApp('app1'),
-        expectApp('app2'),
-        expectApp('app3'),
-      ]);
+      expect(getAppResultsMock).toHaveBeenCalledWith(
+        'term',
+        [expectApp('app1'), expectApp('app2'), expectApp('app3')],
+        { omitManagementSectionTitles: false }
+      );
+    });
+
+    it('omits management section titles when chrome style is project', async () => {
+      getChromeStyle.mockReturnValue('project');
+      application.applications$ = of(createAppMap([createApp({ id: 'app1', title: 'App 1' })]));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
+
+      await provider.find({ term: 'term' }, defaultOption).toPromise();
+
+      expect(getAppResultsMock).toHaveBeenCalledWith('term', [expectApp('app1')], {
+        omitManagementSectionTitles: true,
+      });
     });
 
     it('calls `getAppResults` when filtering by type with `application` included', async () => {
@@ -102,17 +127,21 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app2', title: 'App 2' }),
         ])
       );
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
 
       await provider
         .find({ term: 'term', types: ['dashboard', 'application'] }, defaultOption)
         .toPromise();
 
       expect(getAppResultsMock).toHaveBeenCalledTimes(1);
-      expect(getAppResultsMock).toHaveBeenCalledWith('term', [
-        expectApp('app1'),
-        expectApp('app2'),
-      ]);
+      expect(getAppResultsMock).toHaveBeenCalledWith(
+        'term',
+        [expectApp('app1'), expectApp('app2')],
+        { omitManagementSectionTitles: false }
+      );
     });
 
     it('does not call `getAppResults` and return no results when filtering by type with `application` not included', async () => {
@@ -123,7 +152,10 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app3', title: 'App 3' }),
         ])
       );
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
 
       const results = await provider
         .find({ term: 'term', types: ['dashboard', 'map'] }, defaultOption)
@@ -141,7 +173,10 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app3', title: 'App 3' }),
         ])
       );
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
 
       const results = await provider
         .find({ term: 'term', tags: ['some-tag-id'] }, defaultOption)
@@ -158,10 +193,15 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'disabled', title: 'disabled', status: AppStatus.inaccessible }),
         ])
       );
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
-      expect(getAppResultsMock).toHaveBeenCalledWith('term', [expectApp('app1')]);
+      expect(getAppResultsMock).toHaveBeenCalledWith('term', [expectApp('app1')], {
+        omitManagementSectionTitles: false,
+      });
     });
 
     it('does not ignore apps with non-visible navlink', async () => {
@@ -176,14 +216,17 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'hidden', title: 'hidden', visibleIn: [] }),
         ])
       );
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
-      expect(getAppResultsMock).toHaveBeenCalledWith('term', [
-        expectApp('app1'),
-        expectApp('disabled'),
-        expectApp('hidden'),
-      ]);
+      expect(getAppResultsMock).toHaveBeenCalledWith(
+        'term',
+        [expectApp('app1'), expectApp('disabled'), expectApp('hidden')],
+        { omitManagementSectionTitles: false }
+      );
     });
 
     it('ignores chromeless apps', async () => {
@@ -194,10 +237,15 @@ describe('applicationResultProvider', () => {
         ])
       );
 
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
       await provider.find({ term: 'term' }, defaultOption).toPromise();
 
-      expect(getAppResultsMock).toHaveBeenCalledWith('term', [expectApp('app1')]);
+      expect(getAppResultsMock).toHaveBeenCalledWith('term', [expectApp('app1')], {
+        omitManagementSectionTitles: false,
+      });
     });
 
     it('sorts the results returned by `getAppResults`', async () => {
@@ -208,7 +256,10 @@ describe('applicationResultProvider', () => {
         createResult({ id: 'r75', score: 75 }),
       ]);
 
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
       const results = await provider.find({ term: 'term' }, defaultOption).toPromise();
 
       expect(results).toEqual([
@@ -227,7 +278,10 @@ describe('applicationResultProvider', () => {
         createResult({ id: 'r75', score: 75 }),
       ]);
 
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
 
       const options = {
         ...defaultOption,
@@ -249,8 +303,11 @@ describe('applicationResultProvider', () => {
         const applicationPromise = hot('a', {
           a: application,
         }) as unknown as Promise<ApplicationStart>;
+        const chromeStylePromise = hot('a', {
+          a: () => 'classic' as const,
+        }) as unknown as Promise<() => 'classic' | 'project'>;
 
-        const provider = createApplicationResultProvider(applicationPromise);
+        const provider = createApplicationResultProvider(applicationPromise, chromeStylePromise);
 
         const options = {
           ...defaultOption,
@@ -274,8 +331,11 @@ describe('applicationResultProvider', () => {
         const applicationPromise = hot('a', {
           a: application,
         }) as unknown as Promise<ApplicationStart>;
+        const chromeStylePromise = hot('a', {
+          a: () => 'classic' as const,
+        }) as unknown as Promise<() => 'classic' | 'project'>;
 
-        const provider = createApplicationResultProvider(applicationPromise);
+        const provider = createApplicationResultProvider(applicationPromise, chromeStylePromise);
 
         const options = {
           ...defaultOption,
@@ -297,7 +357,10 @@ describe('applicationResultProvider', () => {
           createApp({ id: 'app2', title: 'App 2' }),
         ])
       );
-      const provider = createApplicationResultProvider(Promise.resolve(application));
+      const provider = createApplicationResultProvider(
+        Promise.resolve(application),
+        getChromeStylePromise
+      );
 
       expect(await provider.getSearchableTypes()).toEqual(['application']);
     });

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/application.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/application.ts
@@ -7,16 +7,17 @@
 
 import { combineLatest, from, of } from 'rxjs';
 import { take, map, takeUntil, mergeMap, shareReplay } from 'rxjs';
-import type { ApplicationStart } from '@kbn/core/public';
-import type { ChromeStyle } from '@kbn/core-chrome-browser';
+import type { ApplicationStart, ChromeStart } from '@kbn/core/public';
 import type { GlobalSearchResultProvider } from '@kbn/global-search-plugin/public';
 import { getAppResults } from './get_app_results';
 
 const applicationType = 'application';
 
+type ChromeForSearch = Pick<ChromeStart, 'getChromeStyle' | 'getDeepLinkNavPaths$'>;
+
 export const createApplicationResultProvider = (
   applicationPromise: Promise<ApplicationStart>,
-  getChromeStylePromise: Promise<() => ChromeStyle>
+  chromePromise: Promise<ChromeForSearch>
 ): GlobalSearchResultProvider => {
   const searchableApps$ = from(applicationPromise).pipe(
     mergeMap((application) => application.applications$),
@@ -35,15 +36,21 @@ export const createApplicationResultProvider = (
       if (tags || (types && !types.includes(applicationType))) {
         return of([]);
       }
-      return combineLatest([searchableApps$.pipe(take(1)), from(getChromeStylePromise)]).pipe(
+      return combineLatest([searchableApps$.pipe(take(1)), from(chromePromise)]).pipe(
         takeUntil(aborted$),
         take(1),
-        map(([apps, getChromeStyle]) => {
-          const results = getAppResults(term ?? '', [...apps.values()], {
-            omitManagementSectionTitles: getChromeStyle() === 'project',
-          });
-          return results.sort((a, b) => b.score - a.score).slice(0, maxResults);
-        })
+        mergeMap(([apps, chrome]) =>
+          chrome.getDeepLinkNavPaths$().pipe(
+            take(1),
+            map((deepLinkNavPaths) => {
+              const results = getAppResults(term ?? '', [...apps.values()], {
+                chromeStyle: chrome.getChromeStyle(),
+                deepLinkNavPaths,
+              });
+              return results.sort((a, b) => b.score - a.score).slice(0, maxResults);
+            })
+          )
+        )
       );
     },
     getSearchableTypes: () => [applicationType],

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/application.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/application.ts
@@ -5,16 +5,18 @@
  * 2.0.
  */
 
-import { from, of } from 'rxjs';
+import { combineLatest, from, of } from 'rxjs';
 import { take, map, takeUntil, mergeMap, shareReplay } from 'rxjs';
 import type { ApplicationStart } from '@kbn/core/public';
+import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import type { GlobalSearchResultProvider } from '@kbn/global-search-plugin/public';
 import { getAppResults } from './get_app_results';
 
 const applicationType = 'application';
 
 export const createApplicationResultProvider = (
-  applicationPromise: Promise<ApplicationStart>
+  applicationPromise: Promise<ApplicationStart>,
+  getChromeStylePromise: Promise<() => ChromeStyle>
 ): GlobalSearchResultProvider => {
   const searchableApps$ = from(applicationPromise).pipe(
     mergeMap((application) => application.applications$),
@@ -33,11 +35,13 @@ export const createApplicationResultProvider = (
       if (tags || (types && !types.includes(applicationType))) {
         return of([]);
       }
-      return searchableApps$.pipe(
+      return combineLatest([searchableApps$.pipe(take(1)), from(getChromeStylePromise)]).pipe(
         takeUntil(aborted$),
         take(1),
-        map((apps) => {
-          const results = getAppResults(term ?? '', [...apps.values()]);
+        map(([apps, getChromeStyle]) => {
+          const results = getAppResults(term ?? '', [...apps.values()], {
+            omitManagementSectionTitles: getChromeStyle() === 'project',
+          });
           return results.sort((a, b) => b.score - a.score).slice(0, maxResults);
         })
       );

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
@@ -409,7 +409,7 @@ describe('appToResult', () => {
     expect(appToResult(appLink, 42).title).toEqual('Sub1');
   });
 
-  it('uses only the leaf title for nested Stack Management deep links', () => {
+  it('keeps management section titles for nested deep links by default', () => {
     const app = createApp({ id: 'management' });
     const appLink: AppLink = {
       id: 'management-application_connections',
@@ -419,6 +419,21 @@ describe('appToResult', () => {
       keywords: [],
     };
 
-    expect(appToResult(appLink, 42).title).toEqual('Application connections');
+    expect(appToResult(appLink, 42).title).toEqual('Security / Application connections');
+  });
+
+  it('uses only the leaf title for nested Stack Management deep links when omitting section titles', () => {
+    const app = createApp({ id: 'management' });
+    const appLink: AppLink = {
+      id: 'management-application_connections',
+      app,
+      path: '/security/application_connections',
+      subLinkTitles: ['Security', 'Application connections'],
+      keywords: [],
+    };
+
+    expect(appToResult(appLink, 42, { omitManagementSectionTitles: true }).title).toEqual(
+      'Application connections'
+    );
   });
 });

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
@@ -401,6 +401,7 @@ describe('appToResult', () => {
     const appLink: AppLink = {
       id: 'management-sub',
       app,
+      deepLinkId: 'sub',
       path: '/sub1',
       subLinkTitles: ['Sub1'],
       keywords: [],
@@ -414,6 +415,7 @@ describe('appToResult', () => {
     const appLink: AppLink = {
       id: 'management-application_connections',
       app,
+      deepLinkId: 'application_connections',
       path: '/security/application_connections',
       subLinkTitles: ['Security', 'Application connections'],
       keywords: [],
@@ -430,14 +432,18 @@ describe('appToResult', () => {
     const appLink: AppLink = {
       id: 'management-application_connections',
       app,
+      deepLinkId: 'application_connections',
       path: '/security/application_connections',
       subLinkTitles: ['Security', 'Application connections'],
       keywords: [],
     };
-    const deepLinkNavPaths = new Map<string, readonly string[]>([
+    const deepLinkNavPaths = new Map([
       [
         'management:application_connections',
-        ['Admin and Settings', 'Access', 'Application connections'],
+        {
+          titles: ['Admin and Settings', 'Access', 'Application connections'] as const,
+        order: 0,
+        },
       ],
     ]);
 
@@ -446,11 +452,176 @@ describe('appToResult', () => {
     ).toEqual('Admin and Settings / Access / Application connections');
   });
 
-  it('falls back to the leaf title in project chrome when the deep link is missing from the nav tree', () => {
+  it('uses nav-tree titles for non-management deep links in project chrome', () => {
+    const app = createApp({ id: 'discover', title: 'Discover' });
+    const appLink: AppLink = {
+      id: 'discover-search',
+      app,
+      deepLinkId: 'search',
+      path: '/search',
+      subLinkTitles: ['Search'],
+      keywords: [],
+    };
+    const deepLinkNavPaths = new Map([
+      ['discover:search', { titles: ['Analytics', 'Discover'] as const, order: 0 }],
+    ]);
+
+    expect(appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths }).title).toEqual(
+      'Analytics / Discover'
+    );
+    expect(appToResult(appLink, 42).title).toEqual('Discover / Search');
+  });
+
+  it('uses nav-tree titles for top-level app links in project chrome', () => {
+    const app = createApp({ id: 'maps', title: 'Maps' });
+    const appLink: AppLink = {
+      id: 'maps',
+      app,
+      path: '/app/maps',
+      subLinkTitles: [],
+      keywords: [],
+    };
+    const deepLinkNavPaths = new Map([['maps', { titles: ['Other tools', 'Maps'] as const, order: 0 }]]);
+
+    expect(appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths }).title).toEqual(
+      'Other tools / Maps'
+    );
+    expect(appToResult(appLink, 42).title).toEqual('Maps');
+  });
+
+  it('uses nav-tree icon and omits panel category when it repeats the title root', () => {
+    const app = createApp({
+      id: 'ux',
+      title: 'User Experience',
+      euiIconType: 'logoObservability',
+      category: DEFAULT_APP_CATEGORIES.observability,
+    });
+    const appLink: AppLink = {
+      id: 'ux',
+      app,
+      path: '/app/ux',
+      subLinkTitles: [],
+      keywords: [],
+    };
+    const deepLinkNavPaths = new Map([
+      [
+        'ux',
+        { titles: ['Applications', 'User experience'] as const, order: 0, icon: 'spaces',
+          categoryLabel: 'Applications',
+        },
+      ],
+    ]);
+
+    expect(appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths })).toEqual(
+      expect.objectContaining({
+        title: 'Applications / User experience',
+        icon: 'spaces',
+        meta: {
+          categoryId: null,
+          categoryLabel: null,
+        },
+      })
+    );
+  });
+
+  it('keeps panel category when it differs from the title root', () => {
+    const app = createApp({
+      id: 'fleet',
+      title: 'Fleet',
+      euiIconType: 'logoObservability',
+      category: DEFAULT_APP_CATEGORIES.observability,
+    });
+    const appLink: AppLink = {
+      id: 'fleet',
+      app,
+      path: '/app/fleet',
+      subLinkTitles: [],
+      keywords: [],
+    };
+    const deepLinkNavPaths = new Map([
+      [
+        'fleet',
+        { titles: ['Ingest and integrations', 'Fleet'] as const, order: 0, icon: 'database',
+          categoryLabel: 'Data management',
+        },
+      ],
+    ]);
+
+    expect(appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths })).toEqual(
+      expect.objectContaining({
+        title: 'Ingest and integrations / Fleet',
+        icon: 'database',
+        meta: {
+          categoryId: null,
+          categoryLabel: 'Data management',
+        },
+      })
+    );
+  });
+
+  it('keeps registration icon but omits registration category for nav hits', () => {
+    const app = createApp({
+      id: 'maps',
+      title: 'Maps',
+      euiIconType: 'logoMaps',
+      category: DEFAULT_APP_CATEGORIES.kibana,
+    });
+    const appLink: AppLink = {
+      id: 'maps',
+      app,
+      path: '/app/maps',
+      subLinkTitles: [],
+      keywords: [],
+    };
+    const deepLinkNavPaths = new Map([['maps', { titles: ['Other tools', 'Maps'] as const, order: 0 }]]);
+
+    expect(appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths })).toEqual(
+      expect.objectContaining({
+        icon: 'logoMaps',
+        meta: {
+          categoryId: null,
+          categoryLabel: null,
+        },
+      })
+    );
+  });
+
+  it('omits registration category for top-level nav apps in project chrome', () => {
+    const app = createApp({
+      id: 'discover',
+      title: 'Discover',
+      euiIconType: 'productDiscover',
+      category: DEFAULT_APP_CATEGORIES.kibana,
+    });
+    const appLink: AppLink = {
+      id: 'discover',
+      app,
+      path: '/app/discover',
+      subLinkTitles: [],
+      keywords: [],
+    };
+    const deepLinkNavPaths = new Map([
+      ['discover', { titles: ['Discover'] as const, order: 0, icon: 'productDiscover' }],
+    ]);
+
+    expect(appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths })).toEqual(
+      expect.objectContaining({
+        title: 'Discover',
+        icon: 'productDiscover',
+        meta: {
+          categoryId: null,
+          categoryLabel: null,
+        },
+      })
+    );
+  });
+
+  it('falls back to the leaf title for management in project chrome when nav is unavailable', () => {
     const app = createApp({ id: 'management' });
     const appLink: AppLink = {
       id: 'management-application_connections',
       app,
+      deepLinkId: 'application_connections',
       path: '/security/application_connections',
       subLinkTitles: ['Security', 'Application connections'],
       keywords: [],
@@ -459,8 +630,168 @@ describe('appToResult', () => {
     expect(
       appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths: null }).title
     ).toEqual('Application connections');
+  });
+});
+
+describe('getAppResults project nav scoping', () => {
+  it('excludes apps that are not in the nav tree', () => {
+    const apps = [
+      createApp({
+        id: 'significant_events',
+        title: 'Significant Events',
+        category: DEFAULT_APP_CATEGORIES.management,
+      }),
+      createApp({ id: 'discover', title: 'Discover' }),
+    ];
+    const deepLinkNavPaths = new Map([
+      ['discover', { titles: ['Discover'] as const, order: 0, icon: 'productDiscover' }],
+    ]);
+
+    const results = getAppResults('e', apps, {
+      chromeStyle: 'project',
+      deepLinkNavPaths,
+    });
+
+    expect(results.map(({ id }) => id)).toEqual(['discover']);
+  });
+
+  it('includes deep links that are in the nav tree', () => {
+    const apps = [
+      createApp({
+        id: 'management',
+        title: 'Stack Management',
+        deepLinks: [
+          {
+            id: 'application_connections',
+            title: 'Application connections',
+            path: '/security/application_connections',
+            deepLinks: [],
+            keywords: [],
+            visibleIn: ['globalSearch'],
+          },
+        ],
+      }),
+    ];
+    const deepLinkNavPaths = new Map([
+      [
+        'management:application_connections',
+        {
+          titles: ['Admin and Settings', 'Access', 'Application connections'] as const,
+        order: 0,
+        },
+      ],
+    ]);
+
+    const results = getAppResults('application', apps, {
+      chromeStyle: 'project',
+      deepLinkNavPaths,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        id: 'management-application_connections',
+        title: 'Admin and Settings / Access / Application connections',
+      }),
+    ]);
+  });
+
+  it('does not apply nav scoping when deepLinkNavPaths is null', () => {
+    const apps = [createApp({ id: 'orphan', title: 'Orphan App' })];
+
+    const results = getAppResults('orphan', apps, {
+      chromeStyle: 'project',
+      deepLinkNavPaths: null,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({ id: 'orphan', title: 'Orphan App' }),
+    ]);
+  });
+});
+
+describe('scoreApp with project nav titles', () => {
+  const managementApp = createApp({ id: 'management', title: 'Stack Management' });
+  const managementLink: AppLink = {
+    id: 'management-application_connections',
+    app: managementApp,
+    deepLinkId: 'application_connections',
+    path: '/security/application_connections',
+    subLinkTitles: ['Security', 'Application connections'],
+    keywords: [],
+  };
+  const discoverApp = createApp({ id: 'discover', title: 'Discover' });
+  const discoverLink: AppLink = {
+    id: 'discover-search',
+    app: discoverApp,
+    deepLinkId: 'search',
+    path: '/search',
+    subLinkTitles: ['Search'],
+    keywords: [],
+  };
+  const deepLinkNavPaths = new Map([
+    [
+      'management:application_connections',
+      {
+        titles: ['Admin and Settings', 'Access', 'Application connections'] as const,
+      order: 0,
+      },
+    ],
+    ['discover:search', { titles: ['Analytics', 'Discover'] as const, order: 0 }],
+  ]);
+  const projectOptions = { chromeStyle: 'project' as const, deepLinkNavPaths };
+
+  it('matches nav-tree ancestor titles for management in project chrome', () => {
+    expect(scoreApp('access', managementLink, projectOptions)).toBe(75);
+    expect(scoreApp('admin and settings', managementLink, projectOptions)).toBe(90);
+  });
+
+  it('still matches registration section titles for management in project chrome', () => {
+    expect(scoreApp('security', managementLink, projectOptions)).toBe(75);
+  });
+
+  it('matches nav-tree ancestor titles for non-management apps in project chrome', () => {
+    expect(scoreApp('analytics', discoverLink, projectOptions)).toBe(90);
+  });
+
+  it('matches nav-tree ancestor titles for top-level apps in project chrome', () => {
+    const mapsApp = createApp({ id: 'maps', title: 'Maps' });
+    const mapsLink: AppLink = {
+      id: 'maps',
+      app: mapsApp,
+      path: '/app/maps',
+      subLinkTitles: [],
+      keywords: [],
+    };
+    const mapsPaths = new Map([['maps', { titles: ['Other tools', 'Maps'] as const, order: 0 }]]);
+
     expect(
-      appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths: new Map() }).title
-    ).toEqual('Application connections');
+      scoreApp('other tools', mapsLink, { chromeStyle: 'project', deepLinkNavPaths: mapsPaths })
+    ).toBe(90);
+  });
+
+  it('ranks empty search by nav order in project chrome', () => {
+    const first = createApp({ id: 'discover', title: 'Discover' });
+    const second = createApp({ id: 'dashboards', title: 'Dashboards' });
+    const firstLink: AppLink = {
+      id: 'discover',
+      app: first,
+      path: '/app/discover',
+      subLinkTitles: [],
+      keywords: [],
+    };
+    const secondLink: AppLink = {
+      id: 'dashboards',
+      app: second,
+      path: '/app/dashboards',
+      subLinkTitles: [],
+      keywords: [],
+    };
+    const paths = new Map([
+      ['discover', { titles: ['Discover'] as const, order: 0 }],
+      ['dashboards', { titles: ['Dashboards'] as const, order: 1 }],
+    ]);
+    const options = { chromeStyle: 'project' as const, deepLinkNavPaths: paths };
+
+    expect(scoreApp('', firstLink, options)).toBeGreaterThan(scoreApp('', secondLink, options));
   });
 });

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
@@ -409,7 +409,7 @@ describe('appToResult', () => {
     expect(appToResult(appLink, 42).title).toEqual('Sub1');
   });
 
-  it('keeps management section titles for nested deep links by default', () => {
+  it('keeps management section titles for nested deep links in classic chrome', () => {
     const app = createApp({ id: 'management' });
     const appLink: AppLink = {
       id: 'management-application_connections',
@@ -420,9 +420,33 @@ describe('appToResult', () => {
     };
 
     expect(appToResult(appLink, 42).title).toEqual('Security / Application connections');
+    expect(appToResult(appLink, 42, { chromeStyle: 'classic' }).title).toEqual(
+      'Security / Application connections'
+    );
   });
 
-  it('uses only the leaf title for nested Stack Management deep links when omitting section titles', () => {
+  it('uses nav-tree titles for nested Stack Management deep links in project chrome', () => {
+    const app = createApp({ id: 'management' });
+    const appLink: AppLink = {
+      id: 'management-application_connections',
+      app,
+      path: '/security/application_connections',
+      subLinkTitles: ['Security', 'Application connections'],
+      keywords: [],
+    };
+    const deepLinkNavPaths = new Map<string, readonly string[]>([
+      [
+        'management:application_connections',
+        ['Admin and Settings', 'Access', 'Application connections'],
+      ],
+    ]);
+
+    expect(
+      appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths }).title
+    ).toEqual('Admin and Settings / Access / Application connections');
+  });
+
+  it('falls back to the leaf title in project chrome when the deep link is missing from the nav tree', () => {
     const app = createApp({ id: 'management' });
     const appLink: AppLink = {
       id: 'management-application_connections',
@@ -432,8 +456,11 @@ describe('appToResult', () => {
       keywords: [],
     };
 
-    expect(appToResult(appLink, 42, { omitManagementSectionTitles: true }).title).toEqual(
-      'Application connections'
-    );
+    expect(
+      appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths: null }).title
+    ).toEqual('Application connections');
+    expect(
+      appToResult(appLink, 42, { chromeStyle: 'project', deepLinkNavPaths: new Map() }).title
+    ).toEqual('Application connections');
   });
 });

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
@@ -408,4 +408,17 @@ describe('appToResult', () => {
 
     expect(appToResult(appLink, 42).title).toEqual('Sub1');
   });
+
+  it('uses only the leaf title for nested Stack Management deep links', () => {
+    const app = createApp({ id: 'management' });
+    const appLink: AppLink = {
+      id: 'management-application_connections',
+      app,
+      path: '/security/application_connections',
+      subLinkTitles: ['Security', 'Application connections'],
+      keywords: [],
+    };
+
+    expect(appToResult(appLink, 42).title).toEqual('Application connections');
+  });
 });

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.test.ts
@@ -489,7 +489,7 @@ describe('appToResult', () => {
     expect(appToResult(appLink, 42).title).toEqual('Maps');
   });
 
-  it('uses nav-tree icon and omits panel category when it repeats the title root', () => {
+  it('uses App category when panel category repeats the title root', () => {
     const app = createApp({
       id: 'ux',
       title: 'User Experience',
@@ -518,7 +518,7 @@ describe('appToResult', () => {
         icon: 'spaces',
         meta: {
           categoryId: null,
-          categoryLabel: null,
+          categoryLabel: 'App',
         },
       })
     );
@@ -559,7 +559,7 @@ describe('appToResult', () => {
     );
   });
 
-  it('keeps registration icon but omits registration category for nav hits', () => {
+  it('uses App category for top-level nav hits without a distinct panel label', () => {
     const app = createApp({
       id: 'maps',
       title: 'Maps',
@@ -580,13 +580,13 @@ describe('appToResult', () => {
         icon: 'logoMaps',
         meta: {
           categoryId: null,
-          categoryLabel: null,
+          categoryLabel: 'App',
         },
       })
     );
   });
 
-  it('omits registration category for top-level nav apps in project chrome', () => {
+  it('uses App category for top-level nav apps in project chrome', () => {
     const app = createApp({
       id: 'discover',
       title: 'Discover',
@@ -610,7 +610,7 @@ describe('appToResult', () => {
         icon: 'productDiscover',
         meta: {
           categoryId: null,
-          categoryLabel: null,
+          categoryLabel: 'App',
         },
       })
     );
@@ -706,6 +706,80 @@ describe('getAppResults project nav scoping', () => {
     expect(results).toEqual([
       expect.objectContaining({ id: 'orphan', title: 'Orphan App' }),
     ]);
+  });
+
+  it('includes deep links whose parent app is in the nav tree', () => {
+    const apps = [
+      createApp({
+        id: 'fleet',
+        title: 'Fleet',
+        euiIconType: 'logoElastic',
+        deepLinks: [
+          {
+            id: 'settings',
+            title: 'Settings',
+            path: '/settings',
+            deepLinks: [],
+            keywords: [],
+            visibleIn: ['globalSearch'],
+          },
+        ],
+      }),
+    ];
+    const deepLinkNavPaths = new Map([
+      [
+        'fleet',
+        {
+          titles: ['Data management', 'Ingest and integrations', 'Fleet'] as const,
+          order: 0,
+          icon: 'database',
+          categoryLabel: 'Data management',
+        },
+      ],
+    ]);
+
+    const results = getAppResults('settings', apps, {
+      chromeStyle: 'project',
+      deepLinkNavPaths,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        id: 'fleet-settings',
+        title: 'Data management / Ingest and integrations / Fleet / Settings',
+        icon: 'database',
+        meta: {
+          categoryId: null,
+          categoryLabel: 'Page',
+        },
+      }),
+    ]);
+  });
+
+  it('still excludes deep links when neither they nor their parent app are in the nav', () => {
+    const apps = [
+      createApp({
+        id: 'significant_events',
+        title: 'Significant Events',
+        deepLinks: [
+          {
+            id: 'knowledge_indicators',
+            title: 'KIs',
+            path: '/knowledge_indicators',
+            deepLinks: [],
+            keywords: [],
+            visibleIn: ['globalSearch'],
+          },
+        ],
+      }),
+    ];
+
+    const results = getAppResults('kis', apps, {
+      chromeStyle: 'project',
+      deepLinkNavPaths: new Map(),
+    });
+
+    expect(results).toEqual([]);
   });
 });
 

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
@@ -96,9 +96,9 @@ const scoreAppByKeywords = (term: string, keywords: string[]): number => {
 
 export const appToResult = (appLink: AppLink, score: number): GlobalSearchProviderResult => {
   const titleParts =
-    // Stack Management app should not include the app title in the concatenated link label
+    // Management: leaf app title only — section names (e.g. "Security") don't match nav IA
     appLink.app.id === 'management' && appLink.subLinkTitles.length > 0
-      ? appLink.subLinkTitles
+      ? [appLink.subLinkTitles[appLink.subLinkTitles.length - 1]]
       : [appLink.app.title, ...appLink.subLinkTitles];
 
   return {

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PublicAppInfo, PublicAppDeepLinkInfo, AppCategory } from '@kbn/core/public';
-import type { ChromeStyle } from '@kbn/core-chrome-browser';
+import type { ChromeStyle, DeepLinkNavPath } from '@kbn/core-chrome-browser';
 import { distance } from 'fastest-levenshtein';
 import type { GlobalSearchProviderResult } from '@kbn/global-search-plugin/public';
 
@@ -19,11 +19,12 @@ export interface AppLink {
   keywords: string[];
   category?: AppCategory;
   euiIconType?: string;
+  deepLinkId?: string;
 }
 
 export interface GetAppResultsOptions {
   chromeStyle?: ChromeStyle;
-  deepLinkNavPaths?: ReadonlyMap<string, readonly string[]> | null;
+  deepLinkNavPaths?: ReadonlyMap<string, DeepLinkNavPath> | null;
 }
 
 export const getAppResults = (
@@ -51,17 +52,47 @@ export const getAppResults = (
       )
       .map((appLink) => ({
         appLink,
-        score: scoreApp(term, appLink),
+        score: scoreApp(term, appLink, options),
       }))
-      .filter(({ score }) => score > 0)
+      .filter(({ appLink, score }) => {
+        if (score <= 0) {
+          return false;
+        }
+        // Project chrome: only apps present in the active nav tree.
+        if (options.chromeStyle === 'project' && options.deepLinkNavPaths != null) {
+          return getNavPath(appLink, options) !== undefined;
+        }
+        return true;
+      })
       .map(({ appLink, score }) => appToResult(appLink, score, options))
   );
 };
 
-export const scoreApp = (term: string, appLink: AppLink): number => {
+/** Base used so earlier nav items outrank later ones on empty search. */
+const NAV_ORDER_SCORE_BASE = 1_000_000;
+
+export const scoreApp = (
+  term: string,
+  appLink: AppLink,
+  options: GetAppResultsOptions = {}
+): number => {
   term = term.toLowerCase();
-  const title = [appLink.app.title, ...appLink.subLinkTitles].join(' ').toLowerCase();
-  const appScoreByTerms = scoreAppByTerms(term, title);
+
+  // Empty search: every title matches `startsWith('')`. Prefer sidenav order.
+  if (term.length === 0) {
+    const navPath = getNavPath(appLink, options);
+    if (navPath) {
+      return Math.max(1, NAV_ORDER_SCORE_BASE - navPath.order);
+    }
+    return 90;
+  }
+
+  const registrationTitle = [appLink.app.title, ...appLink.subLinkTitles].join(' ').toLowerCase();
+  const displayTitle = getDisplayTitleParts(appLink, options).join(' ').toLowerCase();
+  const appScoreByTerms = Math.max(
+    scoreAppByTerms(term, registrationTitle),
+    scoreAppByTerms(term, displayTitle)
+  );
 
   const keywords = [
     ...appLink.app.keywords.map((keyword) => keyword.toLowerCase()),
@@ -101,21 +132,65 @@ const scoreAppByKeywords = (term: string, keywords: string[]): number => {
   return Math.max(...scores);
 };
 
-const getManagementTitleParts = (
+const getNavPath = (
   appLink: AppLink,
   { chromeStyle = 'classic', deepLinkNavPaths = null }: GetAppResultsOptions
-): string[] => {
-  if (chromeStyle !== 'project') {
+): DeepLinkNavPath | undefined => {
+  if (chromeStyle !== 'project' || !deepLinkNavPaths) {
+    return undefined;
+  }
+  const key = appLink.deepLinkId
+    ? `${appLink.app.id}:${appLink.deepLinkId}`
+    : appLink.app.id;
+  const navPath = deepLinkNavPaths.get(key);
+  return navPath && navPath.titles.length > 0 ? navPath : undefined;
+};
+
+const getDisplayTitleParts = (appLink: AppLink, options: GetAppResultsOptions): string[] => {
+  const navPath = getNavPath(appLink, options);
+  if (navPath) {
+    return [...navPath.titles];
+  }
+
+  // Project chrome without a nav hit: leaf-only title (no classic hierarchy).
+  if (options.chromeStyle === 'project') {
+    if (appLink.subLinkTitles.length > 0) {
+      return [appLink.subLinkTitles[appLink.subLinkTitles.length - 1]];
+    }
+    return [appLink.app.title];
+  }
+
+  if (appLink.app.id === 'management' && appLink.subLinkTitles.length > 0) {
     return appLink.subLinkTitles;
   }
 
-  const leafDeepLinkId = appLink.id.slice(appLink.app.id.length + 1);
-  const navTitles = deepLinkNavPaths?.get(`${appLink.app.id}:${leafDeepLinkId}`);
-  if (navTitles && navTitles.length > 0) {
-    return [...navTitles];
+  return [appLink.app.title, ...appLink.subLinkTitles];
+};
+
+const getCategoryMeta = (
+  appLink: AppLink,
+  navPath: DeepLinkNavPath | undefined,
+  options: GetAppResultsOptions
+): { categoryId: string | null; categoryLabel: string | null } => {
+  if (navPath) {
+    // Never use registration AppCategory for nav hits. Panel category only when it
+    // isn't already the title root.
+    const categoryLabel =
+      navPath.categoryLabel && navPath.titles[0] !== navPath.categoryLabel
+        ? navPath.categoryLabel
+        : null;
+    return { categoryId: null, categoryLabel };
   }
 
-  return [appLink.subLinkTitles[appLink.subLinkTitles.length - 1]];
+  // Soft orphans in project chrome: searchable, but no classic taxonomy label.
+  if (options.chromeStyle === 'project') {
+    return { categoryId: null, categoryLabel: null };
+  }
+
+  return {
+    categoryId: appLink.category?.id ?? appLink.app.category?.id ?? null,
+    categoryLabel: appLink.category?.label ?? appLink.app.category?.label ?? null,
+  };
 };
 
 export const appToResult = (
@@ -123,23 +198,15 @@ export const appToResult = (
   score: number,
   options: GetAppResultsOptions = {}
 ): GlobalSearchProviderResult => {
-  const titleParts =
-    // Stack Management app should not include the app title in the concatenated link label
-    appLink.app.id === 'management' && appLink.subLinkTitles.length > 0
-      ? getManagementTitleParts(appLink, options)
-      : [appLink.app.title, ...appLink.subLinkTitles];
+  const navPath = getNavPath(appLink, options);
 
   return {
     id: appLink.id,
-    // Concatenate title using slashes
-    title: titleParts.join(' / '),
+    title: getDisplayTitleParts(appLink, options).join(' / '),
     type: 'application',
-    icon: appLink.euiIconType ?? appLink.app.euiIconType,
+    icon: navPath?.icon ?? appLink.euiIconType ?? appLink.app.euiIconType,
     url: appLink.path,
-    meta: {
-      categoryId: appLink.category?.id ?? appLink.app.category?.id ?? null,
-      categoryLabel: appLink.category?.label ?? appLink.app.category?.label ?? null,
-    },
+    meta: getCategoryMeta(appLink, navPath, options),
     score,
   };
 };
@@ -167,6 +234,7 @@ const flattenDeepLinks = (app: PublicAppInfo, deepLink?: PublicAppDeepLinkInfo):
           {
             ...deepLink,
             id: `${app.id}-${deepLink.id}`,
+            deepLinkId: deepLink.id,
             app,
             path: `${app.appRoute}${deepLink.path}`,
             subLinkTitles: [deepLink.title],

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
@@ -7,8 +7,19 @@
 
 import type { PublicAppInfo, PublicAppDeepLinkInfo, AppCategory } from '@kbn/core/public';
 import type { ChromeStyle, DeepLinkNavPath } from '@kbn/core-chrome-browser';
+import { i18n } from '@kbn/i18n';
 import { distance } from 'fastest-levenshtein';
 import type { GlobalSearchProviderResult } from '@kbn/global-search-plugin/public';
+
+const APP_CATEGORY_LABEL = i18n.translate(
+  'xpack.globalSearchProviders.appResult.categoryAppLabel',
+  { defaultMessage: 'App' }
+);
+
+const PAGE_CATEGORY_LABEL = i18n.translate(
+  'xpack.globalSearchProviders.appResult.categoryPageLabel',
+  { defaultMessage: 'Page' }
+);
 
 /** Type used internally to represent an application unrolled into its separate deepLinks */
 export interface AppLink {
@@ -139,11 +150,28 @@ const getNavPath = (
   if (chromeStyle !== 'project' || !deepLinkNavPaths) {
     return undefined;
   }
+
   const key = appLink.deepLinkId
     ? `${appLink.app.id}:${appLink.deepLinkId}`
     : appLink.app.id;
-  const navPath = deepLinkNavPaths.get(key);
-  return navPath && navPath.titles.length > 0 ? navPath : undefined;
+  const exact = deepLinkNavPaths.get(key);
+  if (exact && exact.titles.length > 0) {
+    return exact;
+  }
+
+  // Deep link not in the tree, but its parent app is (e.g. fleet:settings → fleet).
+  if (!appLink.deepLinkId) {
+    return undefined;
+  }
+  const parent = deepLinkNavPaths.get(appLink.app.id);
+  if (!parent || parent.titles.length === 0) {
+    return undefined;
+  }
+
+  return {
+    ...parent,
+    titles: [...parent.titles, ...appLink.subLinkTitles],
+  };
 };
 
 const getDisplayTitleParts = (appLink: AppLink, options: GetAppResultsOptions): string[] => {
@@ -173,13 +201,16 @@ const getCategoryMeta = (
   options: GetAppResultsOptions
 ): { categoryId: string | null; categoryLabel: string | null } => {
   if (navPath) {
-    // Never use registration AppCategory for nav hits. Panel category only when it
-    // isn't already the title root.
-    const categoryLabel =
+    // Prefer a distinct panel label; otherwise App vs Page by deep-link vs top-level.
+    const panelLabel =
       navPath.categoryLabel && navPath.titles[0] !== navPath.categoryLabel
         ? navPath.categoryLabel
-        : null;
-    return { categoryId: null, categoryLabel };
+        : undefined;
+    return {
+      categoryId: null,
+      categoryLabel:
+        panelLabel ?? (appLink.deepLinkId ? PAGE_CATEGORY_LABEL : APP_CATEGORY_LABEL),
+    };
   }
 
   // Soft orphans in project chrome: searchable, but no classic taxonomy label.

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
@@ -20,9 +20,14 @@ export interface AppLink {
   euiIconType?: string;
 }
 
+export interface GetAppResultsOptions {
+  omitManagementSectionTitles?: boolean;
+}
+
 export const getAppResults = (
   term: string,
-  apps: PublicAppInfo[]
+  apps: PublicAppInfo[],
+  options: GetAppResultsOptions = {}
 ): GlobalSearchProviderResult[] => {
   return (
     apps
@@ -47,7 +52,7 @@ export const getAppResults = (
         score: scoreApp(term, appLink),
       }))
       .filter(({ score }) => score > 0)
-      .map(({ appLink, score }) => appToResult(appLink, score))
+      .map(({ appLink, score }) => appToResult(appLink, score, options))
   );
 };
 
@@ -94,11 +99,17 @@ const scoreAppByKeywords = (term: string, keywords: string[]): number => {
   return Math.max(...scores);
 };
 
-export const appToResult = (appLink: AppLink, score: number): GlobalSearchProviderResult => {
+export const appToResult = (
+  appLink: AppLink,
+  score: number,
+  { omitManagementSectionTitles = false }: GetAppResultsOptions = {}
+): GlobalSearchProviderResult => {
   const titleParts =
-    // Management: leaf app title only — section names (e.g. "Security") don't match nav IA
+    // Stack Management app should not include the app title in the concatenated link label
     appLink.app.id === 'management' && appLink.subLinkTitles.length > 0
-      ? [appLink.subLinkTitles[appLink.subLinkTitles.length - 1]]
+      ? omitManagementSectionTitles
+        ? [appLink.subLinkTitles[appLink.subLinkTitles.length - 1]]
+        : appLink.subLinkTitles
       : [appLink.app.title, ...appLink.subLinkTitles];
 
   return {

--- a/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
+++ b/x-pack/platform/plugins/private/global_search_providers/public/providers/get_app_results.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PublicAppInfo, PublicAppDeepLinkInfo, AppCategory } from '@kbn/core/public';
+import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import { distance } from 'fastest-levenshtein';
 import type { GlobalSearchProviderResult } from '@kbn/global-search-plugin/public';
 
@@ -21,7 +22,8 @@ export interface AppLink {
 }
 
 export interface GetAppResultsOptions {
-  omitManagementSectionTitles?: boolean;
+  chromeStyle?: ChromeStyle;
+  deepLinkNavPaths?: ReadonlyMap<string, readonly string[]> | null;
 }
 
 export const getAppResults = (
@@ -99,17 +101,32 @@ const scoreAppByKeywords = (term: string, keywords: string[]): number => {
   return Math.max(...scores);
 };
 
+const getManagementTitleParts = (
+  appLink: AppLink,
+  { chromeStyle = 'classic', deepLinkNavPaths = null }: GetAppResultsOptions
+): string[] => {
+  if (chromeStyle !== 'project') {
+    return appLink.subLinkTitles;
+  }
+
+  const leafDeepLinkId = appLink.id.slice(appLink.app.id.length + 1);
+  const navTitles = deepLinkNavPaths?.get(`${appLink.app.id}:${leafDeepLinkId}`);
+  if (navTitles && navTitles.length > 0) {
+    return [...navTitles];
+  }
+
+  return [appLink.subLinkTitles[appLink.subLinkTitles.length - 1]];
+};
+
 export const appToResult = (
   appLink: AppLink,
   score: number,
-  { omitManagementSectionTitles = false }: GetAppResultsOptions = {}
+  options: GetAppResultsOptions = {}
 ): GlobalSearchProviderResult => {
   const titleParts =
     // Stack Management app should not include the app title in the concatenated link label
     appLink.app.id === 'management' && appLink.subLinkTitles.length > 0
-      ? omitManagementSectionTitles
-        ? [appLink.subLinkTitles[appLink.subLinkTitles.length - 1]]
-        : appLink.subLinkTitles
+      ? getManagementTitleParts(appLink, options)
       : [appLink.app.title, ...appLink.subLinkTitles];
 
   return {

--- a/x-pack/platform/plugins/private/global_search_providers/tsconfig.json
+++ b/x-pack/platform/plugins/private/global_search_providers/tsconfig.json
@@ -10,7 +10,8 @@
   ],
   "kbn_references": [
     "@kbn/core",
-    "@kbn/global-search-plugin"
+    "@kbn/global-search-plugin",
+    "@kbn/i18n"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Closes #283025

## Summary

Global Search in project chrome was still driven by classic app registration (management section titles, `AppCategory`, logos). This aligns application results with the active solution nav tree.

- Chrome builds `deepLinkId → { titles, order, icon?, categoryLabel? }` from the parsed nav tree (`getDeepLinkNavPaths$()`)
- Project Search uses that for titles, section icons, panel categories (omit when they repeat the title root), and empty-search ranking
- Hard-scopes results to deep links present in the nav map
- Normalizes `renderAs: 'home'` to Home / `home`
- Classic chrome unchanged