### PR TITLE
[Cases] Include entity attachments in Associated Users/Hosts metrics

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MAX_ALERTS_PER_CASE } from '../../../../../common/constants';
+import { AlertHosts } from './hosts';
+
+const topFieldsFor = (hostName: string) => ({
+  hits: {
+    hits: [
+      {
+        fields: {
+          'host.name': [hostName],
+        },
+      },
+    ],
+  },
+});
+
+describe('AlertHosts', () => {
+  it('builds a terms aggregation sized to capture every unique value in a case', () => {
+    const agg = new AlertHosts();
+
+    expect(agg.build()).toMatchObject({
+      hosts_frequency: {
+        terms: {
+          field: 'host.id',
+          size: MAX_ALERTS_PER_CASE,
+        },
+      },
+      hosts_total: {
+        cardinality: {
+          field: 'host.id',
+        },
+      },
+    });
+  });
+
+  it('caps the displayed values to the display limit but keeps the true total', () => {
+    const agg = new AlertHosts(1);
+
+    const response = agg.formatResponse({
+      hosts_total: { value: 2 },
+      hosts_frequency: {
+        buckets: [
+          { key: 'id-1', doc_count: 2, top_fields: topFieldsFor('web01') },
+          { key: 'id-2', doc_count: 1, top_fields: topFieldsFor('db01') },
+        ],
+      },
+    });
+
+    expect(response).toEqual({
+      alerts: {
+        hosts: {
+          total: 2,
+          values: [{ id: 'id-1', name: 'web01', count: 2 }],
+        },
+      },
+    });
+  });
+
+  it('returns zero values when the aggregation is undefined', () => {
+    const agg = new AlertHosts();
+    // @ts-expect-error
+    expect(agg.formatResponse()).toEqual({ alerts: { hosts: { total: 0, values: [] } } });
+  });
+
+  it('getAllNames returns every unique host display name, unbounded by the display limit', () => {
+    const names = AlertHosts.getAllNames({
+      hosts_total: { value: 2 },
+      hosts_frequency: {
+        buckets: [
+          { key: 'id-1', doc_count: 2, top_fields: topFieldsFor('web01') },
+          { key: 'id-2', doc_count: 1, top_fields: topFieldsFor('db01') },
+        ],
+      },
+    });
+
+    expect(names).toEqual(['web01', 'db01']);
+  });
+
+  it('getAllNames returns an empty array when the aggregation is missing', () => {
+    expect(AlertHosts.getAllNames({})).toEqual([]);
+  });
+
+  it('gets the name correctly', () => {
+    expect(new AlertHosts().getName()).toBe('hosts');
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.test.ts
@@ -21,19 +21,33 @@ const topFieldsFor = (hostName: string) => ({
 });
 
 describe('AlertHosts', () => {
-  it('builds a terms aggregation sized to capture every unique value in a case', () => {
+  it('builds a terms aggregation sized to the display limit by default', () => {
     const agg = new AlertHosts();
 
     expect(agg.build()).toMatchObject({
       hosts_frequency: {
         terms: {
           field: 'host.id',
-          size: MAX_ALERTS_PER_CASE,
+          size: 10,
         },
       },
       hosts_total: {
         cardinality: {
           field: 'host.id',
+        },
+      },
+    });
+  });
+
+  it('widenToExhaustive sizes the terms aggregation to capture every unique value in a case', () => {
+    const agg = new AlertHosts();
+    agg.widenToExhaustive();
+
+    expect(agg.build()).toMatchObject({
+      hosts_frequency: {
+        terms: {
+          field: 'host.id',
+          size: MAX_ALERTS_PER_CASE,
         },
       },
     });

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.ts
@@ -41,10 +41,8 @@ export class AlertHosts implements AggregationBuilder<SingleCaseMetricsResponse>
       hosts_frequency: {
         terms: {
           field: hostId,
-          // A case can have at most MAX_ALERTS_PER_CASE alerts, so it can have at most that
-          // many unique host.id values. Sizing the bucket to that bound guarantees this
-          // aggregation captures every unique value (not just the displayed top-N), which
-          // callers rely on to exactly dedupe against entity attachment names.
+          // Sized to MAX_ALERTS_PER_CASE so buckets capture every unique host.id, not just
+          // the displayed top-N — callers need the full set to dedupe against entities exactly.
           size: MAX_ALERTS_PER_CASE,
         },
         aggs: {

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.ts
@@ -8,6 +8,7 @@
 import { get } from 'lodash';
 
 import type { estypes } from '@elastic/elasticsearch';
+import { MAX_ALERTS_PER_CASE } from '../../../../../common/constants';
 import type { SingleCaseMetricsResponse } from '../../../../../common/types/api';
 import type { AggregationBuilder, AggregationResponse } from '../../types';
 
@@ -30,16 +31,21 @@ interface FieldAggregateBucket {
 
 const hostName = 'host.name';
 const hostId = 'host.id';
+const DISPLAY_LIMIT = 10;
 
 export class AlertHosts implements AggregationBuilder<SingleCaseMetricsResponse> {
-  constructor(private readonly uniqueValuesLimit: number = 10) {}
+  constructor(private readonly displayLimit: number = DISPLAY_LIMIT) {}
 
   build(): Record<string, estypes.AggregationsAggregationContainer> {
     return {
       hosts_frequency: {
         terms: {
           field: hostId,
-          size: this.uniqueValuesLimit,
+          // A case can have at most MAX_ALERTS_PER_CASE alerts, so it can have at most that
+          // many unique host.id values. Sizing the bucket to that bound guarantees this
+          // aggregation captures every unique value (not just the displayed top-N), which
+          // callers rely on to exactly dedupe against entity attachment names.
+          size: MAX_ALERTS_PER_CASE,
         },
         aggs: {
           top_fields: {
@@ -68,7 +74,7 @@ export class AlertHosts implements AggregationBuilder<SingleCaseMetricsResponse>
   formatResponse(aggregations: AggregationResponse) {
     const aggs = aggregations as HostsAggregate;
 
-    const topFrequentHosts = aggs?.hosts_frequency?.buckets.map((bucket) => ({
+    const allHosts = aggs?.hosts_frequency?.buckets.map((bucket) => ({
       name: AlertHosts.getHostName(bucket),
       id: bucket.key,
       count: bucket.doc_count,
@@ -77,11 +83,17 @@ export class AlertHosts implements AggregationBuilder<SingleCaseMetricsResponse>
     const totalHosts = aggs?.hosts_total?.value;
 
     const hostFields =
-      topFrequentHosts && totalHosts
-        ? { total: totalHosts, values: topFrequentHosts }
+      allHosts && totalHosts
+        ? { total: totalHosts, values: allHosts.slice(0, this.displayLimit) }
         : { total: 0, values: [] };
 
     return { alerts: { hosts: hostFields } };
+  }
+
+  /** Every unique host display name present in the case's alerts (not limited to the displayed top-N). */
+  static getAllNames(aggregations: AggregationResponse): string[] {
+    const aggs = aggregations as HostsAggregate;
+    return aggs?.hosts_frequency?.buckets.map((bucket) => AlertHosts.getHostName(bucket)) ?? [];
   }
 
   private static getHostName(bucket: FieldAggregateBucket) {

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.ts
@@ -34,16 +34,28 @@ const hostId = 'host.id';
 const DISPLAY_LIMIT = 10;
 
 export class AlertHosts implements AggregationBuilder<SingleCaseMetricsResponse> {
-  constructor(private readonly displayLimit: number = DISPLAY_LIMIT) {}
+  private termsSize: number;
+
+  constructor(private readonly displayLimit: number = DISPLAY_LIMIT) {
+    this.termsSize = displayLimit;
+  }
+
+  /**
+   * Widens the terms aggregation from the display limit to MAX_ALERTS_PER_CASE so it
+   * captures every unique host.id, not just the displayed top-N. Only call this when there
+   * are entity attachments to dedupe against — it also multiplies the per-bucket top_hits
+   * sub-aggregation cost, so callers should skip it otherwise.
+   */
+  widenToExhaustive(): void {
+    this.termsSize = MAX_ALERTS_PER_CASE;
+  }
 
   build(): Record<string, estypes.AggregationsAggregationContainer> {
     return {
       hosts_frequency: {
         terms: {
           field: hostId,
-          // Sized to MAX_ALERTS_PER_CASE so buckets capture every unique host.id, not just
-          // the displayed top-N — callers need the full set to dedupe against entities exactly.
-          size: MAX_ALERTS_PER_CASE,
+          size: this.termsSize,
         },
         aggs: {
           top_fields: {

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MAX_ALERTS_PER_CASE } from '../../../../../common/constants';
+import { AlertUsers } from './users';
+
+describe('AlertUsers', () => {
+  it('builds a terms aggregation sized to capture every unique value in a case', () => {
+    const agg = new AlertUsers();
+
+    expect(agg.build()).toEqual({
+      users_frequency: {
+        terms: {
+          field: 'user.name',
+          size: MAX_ALERTS_PER_CASE,
+        },
+      },
+      users_total: {
+        cardinality: {
+          field: 'user.name',
+        },
+      },
+    });
+  });
+
+  it('caps the displayed values to the display limit but keeps the true total', () => {
+    const agg = new AlertUsers(2);
+
+    const response = agg.formatResponse({
+      users_total: { value: 3 },
+      users_frequency: {
+        buckets: [
+          { key: 'alice', doc_count: 3 },
+          { key: 'bob', doc_count: 2 },
+          { key: 'carol', doc_count: 1 },
+        ],
+      },
+    });
+
+    expect(response).toEqual({
+      alerts: {
+        users: {
+          total: 3,
+          values: [
+            { name: 'alice', count: 3 },
+            { name: 'bob', count: 2 },
+          ],
+        },
+      },
+    });
+  });
+
+  it('returns zero values when the aggregation is undefined', () => {
+    const agg = new AlertUsers();
+    // @ts-expect-error
+    expect(agg.formatResponse()).toEqual({ alerts: { users: { total: 0, values: [] } } });
+  });
+
+  it('getAllNames returns every unique bucket key, unbounded by the display limit', () => {
+    const names = AlertUsers.getAllNames({
+      users_total: { value: 3 },
+      users_frequency: {
+        buckets: [
+          { key: 'alice', doc_count: 3 },
+          { key: 'bob', doc_count: 2 },
+          { key: 'carol', doc_count: 1 },
+        ],
+      },
+    });
+
+    expect(names).toEqual(['alice', 'bob', 'carol']);
+  });
+
+  it('getAllNames returns an empty array when the aggregation is missing', () => {
+    expect(AlertUsers.getAllNames({})).toEqual([]);
+  });
+
+  it('gets the name correctly', () => {
+    expect(new AlertUsers().getName()).toBe('users');
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.test.ts
@@ -9,19 +9,33 @@ import { MAX_ALERTS_PER_CASE } from '../../../../../common/constants';
 import { AlertUsers } from './users';
 
 describe('AlertUsers', () => {
-  it('builds a terms aggregation sized to capture every unique value in a case', () => {
+  it('builds a terms aggregation sized to the display limit by default', () => {
     const agg = new AlertUsers();
 
     expect(agg.build()).toEqual({
       users_frequency: {
         terms: {
           field: 'user.name',
-          size: MAX_ALERTS_PER_CASE,
+          size: 10,
         },
       },
       users_total: {
         cardinality: {
           field: 'user.name',
+        },
+      },
+    });
+  });
+
+  it('widenToExhaustive sizes the terms aggregation to capture every unique value in a case', () => {
+    const agg = new AlertUsers();
+    agg.widenToExhaustive();
+
+    expect(agg.build()).toMatchObject({
+      users_frequency: {
+        terms: {
+          field: 'user.name',
+          size: MAX_ALERTS_PER_CASE,
         },
       },
     });

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.ts
@@ -19,10 +19,8 @@ export class AlertUsers implements AggregationBuilder<SingleCaseMetricsResponse>
       users_frequency: {
         terms: {
           field: userName,
-          // A case can have at most MAX_ALERTS_PER_CASE alerts, so it can have at most that
-          // many unique user.name values. Sizing the bucket to that bound guarantees this
-          // aggregation captures every unique value (not just the displayed top-N), which
-          // callers rely on to exactly dedupe against entity attachment names.
+          // Sized to MAX_ALERTS_PER_CASE so buckets capture every unique user.name, not just
+          // the displayed top-N — callers need the full set to dedupe against entities exactly.
           size: MAX_ALERTS_PER_CASE,
         },
       },

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.ts
@@ -5,18 +5,25 @@
  * 2.0.
  */
 
+import { MAX_ALERTS_PER_CASE } from '../../../../../common/constants';
 import type { SingleCaseMetricsResponse } from '../../../../../common/types/api';
 import type { AggregationBuilder, AggregationResponse } from '../../types';
 
+const DISPLAY_LIMIT = 10;
+
 export class AlertUsers implements AggregationBuilder<SingleCaseMetricsResponse> {
-  constructor(private readonly uniqueValuesLimit: number = 10) {}
+  constructor(private readonly displayLimit: number = DISPLAY_LIMIT) {}
 
   build() {
     return {
       users_frequency: {
         terms: {
           field: userName,
-          size: this.uniqueValuesLimit,
+          // A case can have at most MAX_ALERTS_PER_CASE alerts, so it can have at most that
+          // many unique user.name values. Sizing the bucket to that bound guarantees this
+          // aggregation captures every unique value (not just the displayed top-N), which
+          // callers rely on to exactly dedupe against entity attachment names.
+          size: MAX_ALERTS_PER_CASE,
         },
       },
       users_total: {
@@ -30,7 +37,7 @@ export class AlertUsers implements AggregationBuilder<SingleCaseMetricsResponse>
   formatResponse(aggregations: AggregationResponse) {
     const aggs = aggregations as UsersAggregate;
 
-    const topFrequentUsers = aggs?.users_frequency?.buckets.map((bucket) => ({
+    const allUsers = aggs?.users_frequency?.buckets.map((bucket) => ({
       name: bucket.key,
       count: bucket.doc_count,
     }));
@@ -38,11 +45,17 @@ export class AlertUsers implements AggregationBuilder<SingleCaseMetricsResponse>
     const totalUsers = aggs?.users_total?.value;
 
     const usersFields =
-      topFrequentUsers && totalUsers
-        ? { total: totalUsers, values: topFrequentUsers }
+      allUsers && totalUsers
+        ? { total: totalUsers, values: allUsers.slice(0, this.displayLimit) }
         : { total: 0, values: [] };
 
     return { alerts: { users: usersFields } };
+  }
+
+  /** Every unique `user.name` value present in the case's alerts (not limited to the displayed top-N). */
+  static getAllNames(aggregations: AggregationResponse): string[] {
+    const aggs = aggregations as UsersAggregate;
+    return aggs?.users_frequency?.buckets.map((bucket) => bucket.key) ?? [];
   }
 
   getName() {

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/users.ts
@@ -12,16 +12,27 @@ import type { AggregationBuilder, AggregationResponse } from '../../types';
 const DISPLAY_LIMIT = 10;
 
 export class AlertUsers implements AggregationBuilder<SingleCaseMetricsResponse> {
-  constructor(private readonly displayLimit: number = DISPLAY_LIMIT) {}
+  private termsSize: number;
+
+  constructor(private readonly displayLimit: number = DISPLAY_LIMIT) {
+    this.termsSize = displayLimit;
+  }
+
+  /**
+   * Widens the terms aggregation from the display limit to MAX_ALERTS_PER_CASE so it
+   * captures every unique user.name, not just the displayed top-N. Only call this when
+   * there are entity attachments to dedupe against — it's otherwise wasted aggregation cost.
+   */
+  widenToExhaustive(): void {
+    this.termsSize = MAX_ALERTS_PER_CASE;
+  }
 
   build() {
     return {
       users_frequency: {
         terms: {
           field: userName,
-          // Sized to MAX_ALERTS_PER_CASE so buckets capture every unique user.name, not just
-          // the displayed top-N — callers need the full set to dedupe against entities exactly.
-          size: MAX_ALERTS_PER_CASE,
+          size: this.termsSize,
         },
       },
       users_total: {

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.test.ts
@@ -12,12 +12,33 @@ import { loggingSystemMock } from '@kbn/core/server/mocks';
 
 import { AlertDetails } from './details';
 import { mockAlertsService } from '../test_utils/alerts';
-import type { SingleCaseBaseHandlerCommonOptions } from '../types';
+import type { SingleCaseBaseHandlerCommonOptions, AggregationBuilder } from '../types';
 import { CaseMetricsFeature } from '../../../../common/types/api';
 import { createAttachmentServiceMock } from '../../../services/mocks';
 import { SECURITY_ENTITY_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
-import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../../common/constants';
+import { CASE_ATTACHMENT_SAVED_OBJECT, MAX_ALERTS_PER_CASE } from '../../../../common/constants';
 import { getOwnersFilter } from '../../../authorization/utils';
+import { AlertHosts, AlertUsers } from './aggregations';
+
+const DISPLAY_LIMIT = 10;
+
+const buildEntityAttachment = (id: string, entityName: string, entityType: 'user' | 'host') => ({
+  id,
+  type: 'cases-attachments',
+  references: [],
+  attributes: {
+    type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+    attachmentId: `${entityType}:${entityName}@default`,
+    metadata: { entityName, entityType },
+    owner: 'securitySolution',
+    created_at: '2020-01-01T00:00:00.000Z',
+    created_by: { username: 'elastic', full_name: null, email: null },
+    pushed_at: null,
+    pushed_by: null,
+    updated_at: null,
+    updated_by: null,
+  },
+});
 
 describe('AlertDetails', () => {
   let client: CasesClientMock;
@@ -57,6 +78,28 @@ describe('AlertDetails', () => {
       filter: getOwnersFilter(CASE_ATTACHMENT_SAVED_OBJECT, ['securitySolution']),
     });
     expect(getAuthorizationFilter).toHaveBeenCalled();
+  });
+
+  it('fetches alerts and entity attachments concurrently rather than sequentially', async () => {
+    let resolveAlerts: (
+      value: Array<{ id: string; index: string; attached_at: string }>
+    ) => void = () => {};
+    client.attachments.getAllDocumentsAttachedToCase.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAlerts = resolve;
+      })
+    );
+
+    const handler = new AlertDetails(constructorOptions);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
+    const computePromise = handler.compute();
+
+    // The entity attachment fetch shouldn't wait on the (still-pending) alerts fetch.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(attachmentService.getter.getUnifiedAttachmentsByTypes).toHaveBeenCalled();
+
+    resolveAlerts([]);
+    await computePromise;
   });
 
   it('returns empty alert details metrics when no features were setup', async () => {
@@ -352,6 +395,85 @@ describe('AlertDetails', () => {
         users: { total: 0, values: [] },
         hosts: { total: 0, values: [] },
       },
+    });
+  });
+
+  describe('aggregation widening', () => {
+    const getBuiltAggregationSizes = () => {
+      const { aggregationBuilders } = mockServices.services.alertsService.executeAggregations.mock
+        .calls[0][0] as { aggregationBuilders: Array<AggregationBuilder<unknown>> };
+
+      const usersBuilder = aggregationBuilders.find((builder) => builder instanceof AlertUsers);
+      const hostsBuilder = aggregationBuilders.find((builder) => builder instanceof AlertHosts);
+
+      return {
+        users: (usersBuilder?.build() as { users_frequency: { terms: { size: number } } })
+          ?.users_frequency.terms.size,
+        hosts: (hostsBuilder?.build() as { hosts_frequency: { terms: { size: number } } })
+          ?.hosts_frequency.terms.size,
+      };
+    };
+
+    it('keeps the display-limit-sized aggregations when there are no entity attachments', async () => {
+      const handler = new AlertDetails(constructorOptions);
+      handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
+      handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
+
+      await handler.compute();
+
+      expect(getBuiltAggregationSizes()).toEqual({ users: DISPLAY_LIMIT, hosts: DISPLAY_LIMIT });
+    });
+
+    it('widens only the users aggregation when there are only user entity attachments', async () => {
+      attachmentService.getter.getUnifiedAttachmentsByTypes.mockResolvedValue([
+        buildEntityAttachment('entity-1', 'alice', 'user'),
+      ]);
+
+      const handler = new AlertDetails(constructorOptions);
+      handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
+      handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
+
+      await handler.compute();
+
+      expect(getBuiltAggregationSizes()).toEqual({
+        users: MAX_ALERTS_PER_CASE,
+        hosts: DISPLAY_LIMIT,
+      });
+    });
+
+    it('widens only the hosts aggregation when there are only host entity attachments', async () => {
+      attachmentService.getter.getUnifiedAttachmentsByTypes.mockResolvedValue([
+        buildEntityAttachment('entity-1', 'web01', 'host'),
+      ]);
+
+      const handler = new AlertDetails(constructorOptions);
+      handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
+      handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
+
+      await handler.compute();
+
+      expect(getBuiltAggregationSizes()).toEqual({
+        users: DISPLAY_LIMIT,
+        hosts: MAX_ALERTS_PER_CASE,
+      });
+    });
+
+    it('widens both aggregations when there are both user and host entity attachments', async () => {
+      attachmentService.getter.getUnifiedAttachmentsByTypes.mockResolvedValue([
+        buildEntityAttachment('entity-1', 'alice', 'user'),
+        buildEntityAttachment('entity-2', 'web01', 'host'),
+      ]);
+
+      const handler = new AlertDetails(constructorOptions);
+      handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
+      handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
+
+      await handler.compute();
+
+      expect(getBuiltAggregationSizes()).toEqual({
+        users: MAX_ALERTS_PER_CASE,
+        hosts: MAX_ALERTS_PER_CASE,
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.test.ts
@@ -14,16 +14,23 @@ import { AlertDetails } from './details';
 import { mockAlertsService } from '../test_utils/alerts';
 import type { SingleCaseBaseHandlerCommonOptions } from '../types';
 import { CaseMetricsFeature } from '../../../../common/types/api';
+import { createAttachmentServiceMock } from '../../../services/mocks';
+import { SECURITY_ENTITY_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
+import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../../common/constants';
+import { getOwnersFilter } from '../../../authorization/utils';
 
 describe('AlertDetails', () => {
   let client: CasesClientMock;
   let mockServices: ReturnType<typeof createMockClientArgs>['mockServices'];
   let clientArgs: ReturnType<typeof createMockClientArgs>['clientArgs'];
   let constructorOptions: SingleCaseBaseHandlerCommonOptions;
+  let attachmentService: ReturnType<typeof createAttachmentServiceMock>;
+  let getAuthorizationFilter: jest.Mock;
 
   beforeEach(() => {
     client = createMockClient();
-    ({ mockServices, clientArgs } = createMockClientArgs());
+    ({ mockServices, clientArgs, attachmentService, getAuthorizationFilter } =
+      createMockClientArgs());
     constructorOptions = { caseId: '', casesClient: client, clientArgs };
   });
 
@@ -36,29 +43,39 @@ describe('AlertDetails', () => {
       return [];
     });
 
-    const handler = new AlertDetails({
-      caseId: '',
-      casesClient: client,
-      clientArgs: { services: {} } as CasesClientArgs,
-    });
+    const handler = new AlertDetails(constructorOptions);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
     await handler.compute();
 
     expect(jest.mocked(client.attachments.getAllDocumentsAttachedToCase)).toHaveBeenCalledWith({
       attachmentTypes: ['alert'],
       caseId: '',
     });
+    expect(attachmentService.getter.getUnifiedAttachmentsByTypes).toHaveBeenCalledWith({
+      caseId: '',
+      types: [SECURITY_ENTITY_ATTACHMENT_TYPE],
+      filter: getOwnersFilter(CASE_ATTACHMENT_SAVED_OBJECT, ['securitySolution']),
+    });
+    expect(getAuthorizationFilter).toHaveBeenCalled();
   });
 
-  it('returns empty alert details metrics when there are no alerts', async () => {
+  it('returns empty alert details metrics when no features were setup', async () => {
     client.attachments.getAllDocumentsAttachedToCase.mockImplementation(async () => {
-      return [];
+      return [{ id: '1', index: '2', attached_at: '3' }];
     });
 
-    const handler = new AlertDetails({
-      caseId: '',
-      casesClient: client,
-      clientArgs: { services: {} } as CasesClientArgs,
+    const handler = new AlertDetails(constructorOptions);
+    expect(await handler.compute()).toEqual({});
+    expect(attachmentService.getter.getUnifiedAttachmentsByTypes).not.toHaveBeenCalled();
+  });
+
+  it('returns empty alert details metrics when no features were setup when called twice', async () => {
+    client.attachments.getAllDocumentsAttachedToCase.mockImplementation(async () => {
+      return [{ id: '1', index: '2', attached_at: '3' }];
     });
+
+    const handler = new AlertDetails(constructorOptions);
+    expect(await handler.compute()).toEqual({});
     expect(await handler.compute()).toEqual({});
   });
 
@@ -67,11 +84,7 @@ describe('AlertDetails', () => {
       return [];
     });
 
-    const handler = new AlertDetails({
-      caseId: '',
-      casesClient: client,
-      clientArgs: { services: {} } as CasesClientArgs,
-    });
+    const handler = new AlertDetails(constructorOptions);
     handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
 
     expect(await handler.compute()).toEqual({
@@ -114,65 +127,6 @@ describe('AlertDetails', () => {
         },
       },
     });
-  });
-
-  it('returns the default zero values for hosts when the top hits aggregation returns undefined', async () => {
-    mockServices.services.alertsService.executeAggregations.mockImplementation(async () => ({}));
-
-    const handler = new AlertDetails(constructorOptions);
-    handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
-
-    expect(await handler.compute()).toEqual({
-      alerts: {
-        hosts: {
-          total: 0,
-          values: [],
-        },
-      },
-    });
-  });
-
-  it('returns the default zero values for users when the top hits aggregation returns undefined', async () => {
-    mockServices.services.alertsService.executeAggregations.mockImplementation(async () => ({}));
-
-    const handler = new AlertDetails(constructorOptions);
-    handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
-
-    expect(await handler.compute()).toEqual({
-      alerts: {
-        users: {
-          total: 0,
-          values: [],
-        },
-      },
-    });
-  });
-
-  it('returns empty alert details metrics when no features were setup', async () => {
-    client.attachments.getAllDocumentsAttachedToCase.mockImplementation(async () => {
-      return [{ id: '1', index: '2', attached_at: '3' }];
-    });
-
-    const handler = new AlertDetails({
-      caseId: '',
-      casesClient: client,
-      clientArgs: { services: {} } as CasesClientArgs,
-    });
-    expect(await handler.compute()).toEqual({});
-  });
-
-  it('returns empty alert details metrics when no features were setup when called twice', async () => {
-    client.attachments.getAllDocumentsAttachedToCase.mockImplementation(async () => {
-      return [{ id: '1', index: '2', attached_at: '3' }];
-    });
-
-    const handler = new AlertDetails({
-      caseId: '',
-      casesClient: client,
-      clientArgs: { services: {} } as CasesClientArgs,
-    });
-    expect(await handler.compute()).toEqual({});
-    expect(await handler.compute()).toEqual({});
   });
 
   it('returns host details when the host feature is setup', async () => {
@@ -224,6 +178,182 @@ describe('AlertDetails', () => {
       },
     });
   });
+
+  it('includes entity-only user attachments in associated users total', async () => {
+    client.attachments.getAllDocumentsAttachedToCase.mockResolvedValue([]);
+    attachmentService.getter.getUnifiedAttachmentsByTypes.mockResolvedValue([
+      {
+        id: 'entity-1',
+        type: 'cases-attachments',
+        references: [],
+        attributes: {
+          type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+          attachmentId: 'user:alice@default',
+          metadata: { entityName: 'alice', entityType: 'user' },
+          owner: 'securitySolution',
+          created_at: '2020-01-01T00:00:00.000Z',
+          created_by: { username: 'elastic', full_name: null, email: null },
+          pushed_at: null,
+          pushed_by: null,
+          updated_at: null,
+          updated_by: null,
+        },
+      },
+    ]);
+
+    const handler = new AlertDetails(constructorOptions);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
+
+    expect(await handler.compute()).toEqual({
+      alerts: {
+        users: {
+          total: 1,
+          values: [{ name: 'alice', count: 1 }],
+        },
+      },
+    });
+  });
+
+  it('includes entity-only host attachments in associated hosts total', async () => {
+    client.attachments.getAllDocumentsAttachedToCase.mockResolvedValue([]);
+    attachmentService.getter.getUnifiedAttachmentsByTypes.mockResolvedValue([
+      {
+        id: 'entity-1',
+        type: 'cases-attachments',
+        references: [],
+        attributes: {
+          type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+          attachmentId: 'host:web01@default',
+          metadata: { entityName: 'web01', entityType: 'host' },
+          owner: 'securitySolution',
+          created_at: '2020-01-01T00:00:00.000Z',
+          created_by: { username: 'elastic', full_name: null, email: null },
+          pushed_at: null,
+          pushed_by: null,
+          updated_at: null,
+          updated_by: null,
+        },
+      },
+    ]);
+
+    const handler = new AlertDetails(constructorOptions);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
+
+    expect(await handler.compute()).toEqual({
+      alerts: {
+        hosts: {
+          total: 1,
+          values: [{ id: 'host:web01@default', name: 'web01', count: 1 }],
+        },
+      },
+    });
+  });
+
+  it('unions alert and entity user names without double counting', async () => {
+    attachmentService.getter.getUnifiedAttachmentsByTypes.mockResolvedValue([
+      {
+        id: 'entity-1',
+        type: 'cases-attachments',
+        references: [],
+        attributes: {
+          type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+          attachmentId: 'user:user1@default',
+          metadata: { entityName: 'user1', entityType: 'user' },
+          owner: 'securitySolution',
+          created_at: '2020-01-01T00:00:00.000Z',
+          created_by: { username: 'elastic', full_name: null, email: null },
+          pushed_at: null,
+          pushed_by: null,
+          updated_at: null,
+          updated_by: null,
+        },
+      },
+      {
+        id: 'entity-2',
+        type: 'cases-attachments',
+        references: [],
+        attributes: {
+          type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+          attachmentId: 'user:bob@default',
+          metadata: { entityName: 'bob', entityType: 'user' },
+          owner: 'securitySolution',
+          created_at: '2020-01-01T00:00:00.000Z',
+          created_by: { username: 'elastic', full_name: null, email: null },
+          pushed_at: null,
+          pushed_by: null,
+          updated_at: null,
+          updated_by: null,
+        },
+      },
+    ]);
+
+    const handler = new AlertDetails(constructorOptions);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
+
+    // Alert mock: total 2 with values containing user1; entity adds bob and overlaps user1.
+    expect(await handler.compute()).toEqual({
+      alerts: {
+        users: {
+          total: 3,
+          values: [
+            { name: 'user1', count: 1 },
+            { name: 'bob', count: 1 },
+          ],
+        },
+      },
+    });
+  });
+
+  it('does not count service or generic entity attachments toward users or hosts', async () => {
+    client.attachments.getAllDocumentsAttachedToCase.mockResolvedValue([]);
+    attachmentService.getter.getUnifiedAttachmentsByTypes.mockResolvedValue([
+      {
+        id: 'entity-1',
+        type: 'cases-attachments',
+        references: [],
+        attributes: {
+          type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+          attachmentId: 'service:nginx@default',
+          metadata: { entityName: 'nginx', entityType: 'service' },
+          owner: 'securitySolution',
+          created_at: '2020-01-01T00:00:00.000Z',
+          created_by: { username: 'elastic', full_name: null, email: null },
+          pushed_at: null,
+          pushed_by: null,
+          updated_at: null,
+          updated_by: null,
+        },
+      },
+      {
+        id: 'entity-2',
+        type: 'cases-attachments',
+        references: [],
+        attributes: {
+          type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+          attachmentId: 'generic:thing@default',
+          metadata: { entityName: 'thing', entityType: 'generic' },
+          owner: 'securitySolution',
+          created_at: '2020-01-01T00:00:00.000Z',
+          created_by: { username: 'elastic', full_name: null, email: null },
+          pushed_at: null,
+          pushed_by: null,
+          updated_at: null,
+          updated_by: null,
+        },
+      },
+    ]);
+
+    const handler = new AlertDetails(constructorOptions);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_USERS);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
+
+    expect(await handler.compute()).toEqual({
+      alerts: {
+        users: { total: 0, values: [] },
+        hosts: { total: 0, values: [] },
+      },
+    });
+  });
 });
 
 function createMockClient() {
@@ -237,15 +367,29 @@ function createMockClient() {
 
 function createMockClientArgs() {
   const alertsService = mockAlertsService();
+  const attachmentService = createAttachmentServiceMock();
+  attachmentService.getter.getUnifiedAttachmentsByTypes.mockResolvedValue([]);
 
   const logger = loggingSystemMock.createLogger();
+  const getAuthorizationFilter = jest.fn().mockResolvedValue({
+    authorizedOwners: ['securitySolution'],
+  });
 
   const clientArgs = {
     logger,
+    authorization: {
+      getAuthorizationFilter,
+    },
     services: {
       alertsService,
+      attachmentService,
     },
   };
 
-  return { mockServices: clientArgs, clientArgs: clientArgs as unknown as CasesClientArgs };
+  return {
+    mockServices: clientArgs,
+    clientArgs: clientArgs as unknown as CasesClientArgs,
+    attachmentService,
+    getAuthorizationFilter,
+  };
 }

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
@@ -68,9 +68,8 @@ export class AlertDetails extends SingleCaseAggregationHandler {
         };
       }
 
-      // Entity attachments only live on cases-attachments. Use an owners filter for that
-      // SO type alone — getAttachmentAuthorizationFilter ORs in cases-comments, which
-      // Saved Objects rejects when the find `type` list is attachments-only.
+      // Entity attachments only live on cases-attachments; getAttachmentAuthorizationFilter
+      // ORs in cases-comments, which Saved Objects rejects for an attachments-only find.
       const { authorizedOwners } = await authorization.getAuthorizationFilter(
         Operations.getAttachmentMetrics
       );

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { SavedObject } from '@kbn/core/server';
 import { AttachmentType } from '../../../../common';
 import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../../common/constants';
 import { SECURITY_ENTITY_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
@@ -13,11 +14,12 @@ import { CaseMetricsFeature } from '../../../../common/types/api';
 import { Operations } from '../../../authorization';
 import { getOwnersFilter } from '../../../authorization/utils';
 import { createCaseError } from '../../../common/error';
+import type { UnifiedAttachmentAttributes } from '../../../common/types/attachments_v2';
 
 import { SingleCaseAggregationHandler } from '../single_case_aggregation_handler';
 import type { AggregationBuilder, SingleCaseBaseHandlerCommonOptions } from '../types';
 import { AlertHosts, AlertUsers } from './aggregations';
-import type { KnownAlertNames } from './entity_associated';
+import type { EntityAssociatedNames, KnownAlertNames } from './entity_associated';
 import {
   collectEntityAssociatedNames,
   mergeAlertMetricsWithEntityNames,
@@ -36,8 +38,7 @@ export class AlertDetails extends SingleCaseAggregationHandler {
 
   public async compute(): Promise<SingleCaseMetricsResponse> {
     const {
-      authorization,
-      services: { alertsService, attachmentService },
+      services: { alertsService },
       logger,
     } = this.options.clientArgs;
     const { casesClient } = this.options;
@@ -47,10 +48,17 @@ export class AlertDetails extends SingleCaseAggregationHandler {
         return {};
       }
 
-      const alerts = await casesClient.attachments.getAllDocumentsAttachedToCase({
-        caseId: this.caseId,
-        attachmentTypes: [AttachmentType.alert],
-      });
+      // Independent of each other until merged below, so fetch them concurrently.
+      const [alerts, entityAttachments] = await Promise.all([
+        casesClient.attachments.getAllDocumentsAttachedToCase({
+          caseId: this.caseId,
+          attachmentTypes: [AttachmentType.alert],
+        }),
+        this.getEntityAttachments(),
+      ]);
+
+      const entityNames = collectEntityAssociatedNames(entityAttachments);
+      this.widenAggregationsForEntities(entityNames);
 
       let metrics: SingleCaseMetricsResponse =
         this.formatResponse<SingleCaseMetricsResponse>(undefined);
@@ -68,32 +76,59 @@ export class AlertDetails extends SingleCaseAggregationHandler {
         };
       }
 
-      // Entity attachments only live on cases-attachments; getAttachmentAuthorizationFilter
-      // ORs in cases-comments, which Saved Objects rejects for an attachments-only find.
-      const { authorizedOwners } = await authorization.getAuthorizationFilter(
-        Operations.getAttachmentMetrics
-      );
-      const authorizationFilter = authorizedOwners?.length
-        ? getOwnersFilter(CASE_ATTACHMENT_SAVED_OBJECT, authorizedOwners)
-        : undefined;
-
-      const entityAttachments = await attachmentService.getter.getUnifiedAttachmentsByTypes({
-        caseId: this.caseId,
-        types: [SECURITY_ENTITY_ATTACHMENT_TYPE],
-        filter: authorizationFilter,
-      });
-
-      return mergeAlertMetricsWithEntityNames(
-        metrics,
-        collectEntityAssociatedNames(entityAttachments),
-        knownAlertNames
-      );
+      return mergeAlertMetricsWithEntityNames(metrics, entityNames, knownAlertNames);
     } catch (error) {
       throw createCaseError({
         message: `Failed to retrieve alerts details attached case id: ${this.caseId}: ${error}`,
         error,
         logger,
       });
+    }
+  }
+
+  private async getEntityAttachments(): Promise<Array<SavedObject<UnifiedAttachmentAttributes>>> {
+    const {
+      authorization,
+      services: { attachmentService },
+    } = this.options.clientArgs;
+
+    // Entity attachments only live on cases-attachments; getAttachmentAuthorizationFilter
+    // ORs in cases-comments, which Saved Objects rejects for an attachments-only find.
+    const { authorizedOwners } = await authorization.getAuthorizationFilter(
+      Operations.getAttachmentMetrics
+    );
+    const authorizationFilter = authorizedOwners?.length
+      ? getOwnersFilter(CASE_ATTACHMENT_SAVED_OBJECT, authorizedOwners)
+      : undefined;
+
+    return attachmentService.getter.getUnifiedAttachmentsByTypes({
+      caseId: this.caseId,
+      types: [SECURITY_ENTITY_ATTACHMENT_TYPE],
+      filter: authorizationFilter,
+    });
+  }
+
+  /**
+   * Widens the underlying alert aggregations to capture every unique name (not just the
+   * displayed top-N) so they can be exactly deduped against entity names — but only for the
+   * entity kinds actually present, since widening is expensive (up to 100x the aggregation
+   * buckets) and pointless when there's nothing of that kind to reconcile against.
+   */
+  private widenAggregationsForEntities(entityNames: EntityAssociatedNames): void {
+    const widenUsers = entityNames.userNames.size > 0;
+    const widenHosts = entityNames.hostsByName.size > 0;
+
+    if (!widenUsers && !widenHosts) {
+      return;
+    }
+
+    for (const builder of this.aggregationBuilders) {
+      if (widenUsers && builder instanceof AlertUsers) {
+        builder.widenToExhaustive();
+      }
+      if (widenHosts && builder instanceof AlertHosts) {
+        builder.widenToExhaustive();
+      }
     }
   }
 }

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
@@ -6,13 +6,21 @@
  */
 
 import { AttachmentType } from '../../../../common';
+import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../../common/constants';
+import { SECURITY_ENTITY_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
 import type { SingleCaseMetricsResponse } from '../../../../common/types/api';
 import { CaseMetricsFeature } from '../../../../common/types/api';
+import { Operations } from '../../../authorization';
+import { getOwnersFilter } from '../../../authorization/utils';
 import { createCaseError } from '../../../common/error';
 
 import { SingleCaseAggregationHandler } from '../single_case_aggregation_handler';
 import type { AggregationBuilder, SingleCaseBaseHandlerCommonOptions } from '../types';
 import { AlertHosts, AlertUsers } from './aggregations';
+import {
+  collectEntityAssociatedNames,
+  mergeAlertMetricsWithEntityNames,
+} from './entity_associated';
 
 export class AlertDetails extends SingleCaseAggregationHandler {
   constructor(options: SingleCaseBaseHandlerCommonOptions) {
@@ -27,27 +35,53 @@ export class AlertDetails extends SingleCaseAggregationHandler {
 
   public async compute(): Promise<SingleCaseMetricsResponse> {
     const {
-      services: { alertsService },
+      authorization,
+      services: { alertsService, attachmentService },
       logger,
     } = this.options.clientArgs;
     const { casesClient } = this.options;
 
     try {
+      if (this.aggregationBuilders.length <= 0) {
+        return {};
+      }
+
       const alerts = await casesClient.attachments.getAllDocumentsAttachedToCase({
         caseId: this.caseId,
         attachmentTypes: [AttachmentType.alert],
       });
 
-      if (alerts.length <= 0 || this.aggregationBuilders.length <= 0) {
-        return this.formatResponse();
+      let metrics: SingleCaseMetricsResponse =
+        this.formatResponse<SingleCaseMetricsResponse>(undefined);
+
+      if (alerts.length > 0) {
+        const aggregationsResponse = await alertsService.executeAggregations({
+          aggregationBuilders: this.aggregationBuilders,
+          alerts,
+        });
+        metrics = this.formatResponse<SingleCaseMetricsResponse>(aggregationsResponse);
       }
 
-      const aggregationsResponse = await alertsService.executeAggregations({
-        aggregationBuilders: this.aggregationBuilders,
-        alerts,
+      // Entity attachments only live on cases-attachments. Use an owners filter for that
+      // SO type alone — getAttachmentAuthorizationFilter ORs in cases-comments, which
+      // Saved Objects rejects when the find `type` list is attachments-only.
+      const { authorizedOwners } = await authorization.getAuthorizationFilter(
+        Operations.getAttachmentMetrics
+      );
+      const authorizationFilter = authorizedOwners?.length
+        ? getOwnersFilter(CASE_ATTACHMENT_SAVED_OBJECT, authorizedOwners)
+        : undefined;
+
+      const entityAttachments = await attachmentService.getter.getUnifiedAttachmentsByTypes({
+        caseId: this.caseId,
+        types: [SECURITY_ENTITY_ATTACHMENT_TYPE],
+        filter: authorizationFilter,
       });
 
-      return this.formatResponse<SingleCaseMetricsResponse>(aggregationsResponse);
+      return mergeAlertMetricsWithEntityNames(
+        metrics,
+        collectEntityAssociatedNames(entityAttachments)
+      );
     } catch (error) {
       throw createCaseError({
         message: `Failed to retrieve alerts details attached case id: ${this.caseId}: ${error}`,

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
@@ -17,6 +17,7 @@ import { createCaseError } from '../../../common/error';
 import { SingleCaseAggregationHandler } from '../single_case_aggregation_handler';
 import type { AggregationBuilder, SingleCaseBaseHandlerCommonOptions } from '../types';
 import { AlertHosts, AlertUsers } from './aggregations';
+import type { KnownAlertNames } from './entity_associated';
 import {
   collectEntityAssociatedNames,
   mergeAlertMetricsWithEntityNames,
@@ -53,6 +54,7 @@ export class AlertDetails extends SingleCaseAggregationHandler {
 
       let metrics: SingleCaseMetricsResponse =
         this.formatResponse<SingleCaseMetricsResponse>(undefined);
+      let knownAlertNames: KnownAlertNames = { userNames: new Set(), hostNames: new Set() };
 
       if (alerts.length > 0) {
         const aggregationsResponse = await alertsService.executeAggregations({
@@ -60,6 +62,10 @@ export class AlertDetails extends SingleCaseAggregationHandler {
           alerts,
         });
         metrics = this.formatResponse<SingleCaseMetricsResponse>(aggregationsResponse);
+        knownAlertNames = {
+          userNames: new Set(AlertUsers.getAllNames(aggregationsResponse)),
+          hostNames: new Set(AlertHosts.getAllNames(aggregationsResponse)),
+        };
       }
 
       // Entity attachments only live on cases-attachments. Use an owners filter for that
@@ -80,7 +86,8 @@ export class AlertDetails extends SingleCaseAggregationHandler {
 
       return mergeAlertMetricsWithEntityNames(
         metrics,
-        collectEntityAssociatedNames(entityAttachments)
+        collectEntityAssociatedNames(entityAttachments),
+        knownAlertNames
       );
     } catch (error) {
       throw createCaseError({

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.test.ts
@@ -114,7 +114,8 @@ describe('mergeAlertMetricsWithEntityNames', () => {
       {
         userNames: new Set(['alice', 'bob']),
         hostsByName: new Map(),
-      }
+      },
+      { userNames: new Set(['alice']), hostNames: new Set() }
     );
 
     expect(merged.alerts?.users).toEqual({
@@ -126,7 +127,11 @@ describe('mergeAlertMetricsWithEntityNames', () => {
     });
   });
 
-  it('preserves unknown alert user cardinality beyond top-N values', () => {
+  it('does not double count an entity name that matches an alert identity hidden beyond the displayed top-N', () => {
+    // Alert total is 5, but only 1 name ("alice") is in the displayed top-N `values`.
+    // "bob" is one of the other 4 alert-derived identities that ISN'T displayed — the
+    // exhaustive `knownAlertNames.userNames` set is what lets us recognize that and avoid
+    // double-counting it.
     const merged = mergeAlertMetricsWithEntityNames(
       {
         alerts: {
@@ -139,7 +144,28 @@ describe('mergeAlertMetricsWithEntityNames', () => {
       {
         userNames: new Set(['bob']),
         hostsByName: new Map(),
-      }
+      },
+      { userNames: new Set(['alice', 'bob', 'carol', 'dave', 'erin']), hostNames: new Set() }
+    );
+
+    expect(merged.alerts?.users?.total).toBe(5);
+  });
+
+  it('adds an entity name that is genuinely absent from all alert-derived identities', () => {
+    const merged = mergeAlertMetricsWithEntityNames(
+      {
+        alerts: {
+          users: {
+            total: 5,
+            values: [{ name: 'alice', count: 1 }],
+          },
+        },
+      },
+      {
+        userNames: new Set(['frank']),
+        hostsByName: new Map(),
+      },
+      { userNames: new Set(['alice', 'bob', 'carol', 'dave', 'erin']), hostNames: new Set() }
     );
 
     expect(merged.alerts?.users?.total).toBe(6);
@@ -161,7 +187,8 @@ describe('mergeAlertMetricsWithEntityNames', () => {
           ['web01', 'host:web01@default'],
           ['db01', 'host:db01@default'],
         ]),
-      }
+      },
+      { userNames: new Set(), hostNames: new Set(['web01']) }
     );
 
     expect(merged.alerts?.hosts).toEqual({
@@ -181,10 +208,14 @@ describe('mergeAlertMetricsWithEntityNames', () => {
     };
 
     expect(
-      mergeAlertMetricsWithEntityNames(metrics, {
-        userNames: new Set(),
-        hostsByName: new Map(),
-      })
+      mergeAlertMetricsWithEntityNames(
+        metrics,
+        {
+          userNames: new Set(),
+          hostsByName: new Map(),
+        },
+        { userNames: new Set(['alice']), hostNames: new Set() }
+      )
     ).toBe(metrics);
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.test.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObject } from '@kbn/core/server';
+import { SECURITY_ENTITY_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
+import type { UnifiedAttachmentAttributes } from '../../../common/types/attachments_v2';
+import {
+  collectEntityAssociatedNames,
+  mergeAlertMetricsWithEntityNames,
+} from './entity_associated';
+
+const basicAttrs = {
+  owner: 'securitySolution',
+  created_at: '2020-01-01T00:00:00.000Z',
+  created_by: { username: 'elastic', full_name: null, email: null },
+  pushed_at: null,
+  pushed_by: null,
+  updated_at: null,
+  updated_by: null,
+};
+
+const entitySo = (
+  overrides: Partial<UnifiedAttachmentAttributes> & {
+    attachmentId: string;
+    metadata: Record<string, string | number>;
+  }
+): SavedObject<UnifiedAttachmentAttributes> => ({
+  id: `so-${overrides.attachmentId}`,
+  type: 'cases-attachments',
+  references: [],
+  attributes: {
+    type: SECURITY_ENTITY_ATTACHMENT_TYPE,
+    ...basicAttrs,
+    ...overrides,
+  },
+});
+
+describe('collectEntityAssociatedNames', () => {
+  it('collects unique user and host entity display names', () => {
+    const result = collectEntityAssociatedNames([
+      entitySo({
+        attachmentId: 'user:alice@default',
+        metadata: { entityName: 'alice', entityType: 'user' },
+      }),
+      entitySo({
+        attachmentId: 'user:alice@default-dup',
+        metadata: { entityName: 'alice', entityType: 'user' },
+      }),
+      entitySo({
+        attachmentId: 'host:web01@default',
+        metadata: { entityName: 'web01', entityType: 'host' },
+      }),
+    ]);
+
+    expect([...result.userNames]).toEqual(['alice']);
+    expect([...result.hostsByName.entries()]).toEqual([['web01', 'host:web01@default']]);
+  });
+
+  it('ignores service and generic entity types', () => {
+    const result = collectEntityAssociatedNames([
+      entitySo({
+        attachmentId: 'service:nginx@default',
+        metadata: { entityName: 'nginx', entityType: 'service' },
+      }),
+      entitySo({
+        attachmentId: 'generic:thing@default',
+        metadata: { entityName: 'thing', entityType: 'generic' },
+      }),
+    ]);
+
+    expect(result.userNames.size).toBe(0);
+    expect(result.hostsByName.size).toBe(0);
+  });
+
+  it('skips attachments missing entity metadata', () => {
+    const result = collectEntityAssociatedNames([
+      entitySo({
+        attachmentId: 'user:incomplete@default',
+        metadata: { entityType: 'user' },
+      }),
+      {
+        id: 'other',
+        type: 'cases-attachments',
+        references: [],
+        attributes: {
+          type: 'security.alert',
+          attachmentId: 'alert-1',
+          metadata: { index: 'alerts' },
+          ...basicAttrs,
+        },
+      },
+    ]);
+
+    expect(result.userNames.size).toBe(0);
+    expect(result.hostsByName.size).toBe(0);
+  });
+});
+
+describe('mergeAlertMetricsWithEntityNames', () => {
+  it('unions overlapping alert and entity user names', () => {
+    const merged = mergeAlertMetricsWithEntityNames(
+      {
+        alerts: {
+          users: {
+            total: 1,
+            values: [{ name: 'alice', count: 3 }],
+          },
+        },
+      },
+      {
+        userNames: new Set(['alice', 'bob']),
+        hostsByName: new Map(),
+      }
+    );
+
+    expect(merged.alerts?.users).toEqual({
+      total: 2,
+      values: [
+        { name: 'alice', count: 3 },
+        { name: 'bob', count: 1 },
+      ],
+    });
+  });
+
+  it('preserves unknown alert user cardinality beyond top-N values', () => {
+    const merged = mergeAlertMetricsWithEntityNames(
+      {
+        alerts: {
+          users: {
+            total: 5,
+            values: [{ name: 'alice', count: 1 }],
+          },
+        },
+      },
+      {
+        userNames: new Set(['bob']),
+        hostsByName: new Map(),
+      }
+    );
+
+    expect(merged.alerts?.users?.total).toBe(6);
+  });
+
+  it('unions host display names and appends entity-only hosts', () => {
+    const merged = mergeAlertMetricsWithEntityNames(
+      {
+        alerts: {
+          hosts: {
+            total: 1,
+            values: [{ id: 'id-1', name: 'web01', count: 2 }],
+          },
+        },
+      },
+      {
+        userNames: new Set(),
+        hostsByName: new Map([
+          ['web01', 'host:web01@default'],
+          ['db01', 'host:db01@default'],
+        ]),
+      }
+    );
+
+    expect(merged.alerts?.hosts).toEqual({
+      total: 2,
+      values: [
+        { id: 'id-1', name: 'web01', count: 2 },
+        { id: 'host:db01@default', name: 'db01', count: 1 },
+      ],
+    });
+  });
+
+  it('returns metrics unchanged when there are no entity names', () => {
+    const metrics = {
+      alerts: {
+        users: { total: 1, values: [{ name: 'alice', count: 1 }] },
+      },
+    };
+
+    expect(
+      mergeAlertMetricsWithEntityNames(metrics, {
+        userNames: new Set(),
+        hostsByName: new Map(),
+      })
+    ).toBe(metrics);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.ts
@@ -66,12 +66,26 @@ export const collectEntityAssociatedNames = (
 };
 
 /**
+ * Every unique alert-derived display name for a case, independent of the top-N `values`
+ * shown in the response. Required to exactly dedupe entity attachment names against alert
+ * identities: the response's `values` array is capped for display, so checking membership
+ * against it alone could either double-count an entity name that is actually one of the
+ * alert identities that fell outside that cap, or skip a genuinely new one.
+ */
+export interface KnownAlertNames {
+  userNames: Set<string>;
+  hostNames: Set<string>;
+}
+
+/**
  * Unions alert-derived associated users/hosts with entity attachment display names.
- * `total` accounts for alert cardinalities that may exceed the top-N `values` list.
+ * `knownAlertNames` must contain every alert-derived name (not just the displayed top-N)
+ * so overlap with entity names can be determined exactly, without double- or under-counting.
  */
 export const mergeAlertMetricsWithEntityNames = (
   metrics: SingleCaseMetricsResponse,
-  entityNames: EntityAssociatedNames
+  entityNames: EntityAssociatedNames,
+  knownAlertNames: KnownAlertNames
 ): SingleCaseMetricsResponse => {
   const { userNames, hostsByName } = entityNames;
   if (userNames.size === 0 && hostsByName.size === 0) {
@@ -85,7 +99,7 @@ export const mergeAlertMetricsWithEntityNames = (
       ...result,
       alerts: {
         ...result.alerts,
-        users: mergeUsers(metrics.alerts.users, userNames),
+        users: mergeUsers(metrics.alerts.users, userNames, knownAlertNames.userNames),
       },
     };
   }
@@ -95,7 +109,7 @@ export const mergeAlertMetricsWithEntityNames = (
       ...result,
       alerts: {
         ...result.alerts,
-        hosts: mergeHosts(metrics.alerts.hosts, hostsByName),
+        hosts: mergeHosts(metrics.alerts.hosts, hostsByName, knownAlertNames.hostNames),
       },
     };
   }
@@ -105,14 +119,13 @@ export const mergeAlertMetricsWithEntityNames = (
 
 const mergeUsers = (
   users: NonNullable<NonNullable<SingleCaseMetricsResponse['alerts']>['users']>,
-  entityUserNames: Set<string>
+  entityUserNames: Set<string>,
+  allAlertUserNames: Set<string>
 ): NonNullable<NonNullable<SingleCaseMetricsResponse['alerts']>['users']> => {
-  const knownNames = new Set(users.values.map((value) => value.name));
-  const unknownAlertCount = Math.max(0, users.total - knownNames.size);
-  const newNames = [...entityUserNames].filter((name) => !knownNames.has(name));
+  const newNames = [...entityUserNames].filter((name) => !allAlertUserNames.has(name));
 
   return {
-    total: knownNames.size + unknownAlertCount + newNames.length,
+    total: users.total + newNames.length,
     values: [
       ...users.values,
       ...newNames.map((name) => ({
@@ -125,25 +138,15 @@ const mergeUsers = (
 
 const mergeHosts = (
   hosts: NonNullable<NonNullable<SingleCaseMetricsResponse['alerts']>['hosts']>,
-  entityHostsByName: Map<string, string>
+  entityHostsByName: Map<string, string>,
+  allAlertHostNames: Set<string>
 ): NonNullable<NonNullable<SingleCaseMetricsResponse['alerts']>['hosts']> => {
-  const knownNames = new Set<string>();
-  let hostsWithoutName = 0;
-
-  for (const value of hosts.values) {
-    if (typeof value.name === 'string' && value.name.length > 0) {
-      knownNames.add(value.name);
-    } else {
-      hostsWithoutName += 1;
-    }
-  }
-
-  const knownCount = knownNames.size + hostsWithoutName;
-  const unknownAlertCount = Math.max(0, hosts.total - knownCount);
-  const newHosts = [...entityHostsByName.entries()].filter(([name]) => !knownNames.has(name));
+  const newHosts = [...entityHostsByName.entries()].filter(
+    ([name]) => !allAlertHostNames.has(name)
+  );
 
   return {
-    total: knownCount + unknownAlertCount + newHosts.length,
+    total: hosts.total + newHosts.length,
     values: [
       ...hosts.values,
       ...newHosts.map(([name, id]) => ({

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.ts
@@ -66,11 +66,8 @@ export const collectEntityAssociatedNames = (
 };
 
 /**
- * Every unique alert-derived display name for a case, independent of the top-N `values`
- * shown in the response. Required to exactly dedupe entity attachment names against alert
- * identities: the response's `values` array is capped for display, so checking membership
- * against it alone could either double-count an entity name that is actually one of the
- * alert identities that fell outside that cap, or skip a genuinely new one.
+ * Every alert-derived display name for a case, not just the displayed top-N `values`.
+ * Needed to dedupe entity attachment names against alert identities exactly.
  */
 export interface KnownAlertNames {
   userNames: Set<string>;
@@ -78,9 +75,8 @@ export interface KnownAlertNames {
 }
 
 /**
- * Unions alert-derived associated users/hosts with entity attachment display names.
- * `knownAlertNames` must contain every alert-derived name (not just the displayed top-N)
- * so overlap with entity names can be determined exactly, without double- or under-counting.
+ * Unions alert-derived users/hosts with entity attachment names. `knownAlertNames` must be
+ * exhaustive so overlaps are caught precisely (no double- or under-counting).
  */
 export const mergeAlertMetricsWithEntityNames = (
   metrics: SingleCaseMetricsResponse,

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObject } from '@kbn/core/server';
+import { SECURITY_ENTITY_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
+import type { SingleCaseMetricsResponse } from '../../../../common/types/api';
+import type { UnifiedAttachmentAttributes } from '../../../common/types/attachments_v2';
+
+const USER_ENTITY_TYPE = 'user';
+const HOST_ENTITY_TYPE = 'host';
+
+export interface EntityAssociatedNames {
+  /** Unique user entity display names (`metadata.entityName`). */
+  userNames: Set<string>;
+  /** Host entity display name → attachment id (EUID), keyed by `metadata.entityName`. */
+  hostsByName: Map<string, string>;
+}
+
+/**
+ * Collects unique user/host display names from `security.entity` attachments.
+ * Service and generic entity types are ignored.
+ */
+export const collectEntityAssociatedNames = (
+  attachments: Array<SavedObject<UnifiedAttachmentAttributes>>
+): EntityAssociatedNames => {
+  const userNames = new Set<string>();
+  const hostsByName = new Map<string, string>();
+
+  for (const { attributes } of attachments) {
+    if (attributes.type === SECURITY_ENTITY_ATTACHMENT_TYPE) {
+      const metadata = attributes.metadata;
+      if (metadata != null && typeof metadata === 'object') {
+        const entityType = metadata.entityType;
+        const entityName = metadata.entityName;
+        if (
+          typeof entityType === 'string' &&
+          typeof entityName === 'string' &&
+          entityName.length > 0
+        ) {
+          if (entityType === USER_ENTITY_TYPE) {
+            userNames.add(entityName);
+          } else if (entityType === HOST_ENTITY_TYPE && 'attachmentId' in attributes) {
+            const rawAttachmentId = attributes.attachmentId;
+            const attachmentId = Array.isArray(rawAttachmentId)
+              ? rawAttachmentId[0]
+              : rawAttachmentId;
+            if (
+              typeof attachmentId === 'string' &&
+              attachmentId.length > 0 &&
+              !hostsByName.has(entityName)
+            ) {
+              // First attachment wins for id when duplicate names appear.
+              hostsByName.set(entityName, attachmentId);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { userNames, hostsByName };
+};
+
+/**
+ * Unions alert-derived associated users/hosts with entity attachment display names.
+ * `total` accounts for alert cardinalities that may exceed the top-N `values` list.
+ */
+export const mergeAlertMetricsWithEntityNames = (
+  metrics: SingleCaseMetricsResponse,
+  entityNames: EntityAssociatedNames
+): SingleCaseMetricsResponse => {
+  const { userNames, hostsByName } = entityNames;
+  if (userNames.size === 0 && hostsByName.size === 0) {
+    return metrics;
+  }
+
+  let result = metrics;
+
+  if (metrics.alerts?.users != null && userNames.size > 0) {
+    result = {
+      ...result,
+      alerts: {
+        ...result.alerts,
+        users: mergeUsers(metrics.alerts.users, userNames),
+      },
+    };
+  }
+
+  if (metrics.alerts?.hosts != null && hostsByName.size > 0) {
+    result = {
+      ...result,
+      alerts: {
+        ...result.alerts,
+        hosts: mergeHosts(metrics.alerts.hosts, hostsByName),
+      },
+    };
+  }
+
+  return result;
+};
+
+const mergeUsers = (
+  users: NonNullable<NonNullable<SingleCaseMetricsResponse['alerts']>['users']>,
+  entityUserNames: Set<string>
+): NonNullable<NonNullable<SingleCaseMetricsResponse['alerts']>['users']> => {
+  const knownNames = new Set(users.values.map((value) => value.name));
+  const unknownAlertCount = Math.max(0, users.total - knownNames.size);
+  const newNames = [...entityUserNames].filter((name) => !knownNames.has(name));
+
+  return {
+    total: knownNames.size + unknownAlertCount + newNames.length,
+    values: [
+      ...users.values,
+      ...newNames.map((name) => ({
+        name,
+        count: 1,
+      })),
+    ],
+  };
+};
+
+const mergeHosts = (
+  hosts: NonNullable<NonNullable<SingleCaseMetricsResponse['alerts']>['hosts']>,
+  entityHostsByName: Map<string, string>
+): NonNullable<NonNullable<SingleCaseMetricsResponse['alerts']>['hosts']> => {
+  const knownNames = new Set<string>();
+  let hostsWithoutName = 0;
+
+  for (const value of hosts.values) {
+    if (typeof value.name === 'string' && value.name.length > 0) {
+      knownNames.add(value.name);
+    } else {
+      hostsWithoutName += 1;
+    }
+  }
+
+  const knownCount = knownNames.size + hostsWithoutName;
+  const unknownAlertCount = Math.max(0, hosts.total - knownCount);
+  const newHosts = [...entityHostsByName.entries()].filter(([name]) => !knownNames.has(name));
+
+  return {
+    total: knownCount + unknownAlertCount + newHosts.length,
+    values: [
+      ...hosts.values,
+      ...newHosts.map(([name, id]) => ({
+        name,
+        id,
+        count: 1,
+      })),
+    ],
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.test.ts
@@ -377,6 +377,70 @@ describe('AttachmentService getter', () => {
     });
   });
 
+  describe('getUnifiedAttachmentsByTypes', () => {
+    it('returns an empty array when types is empty without querying', async () => {
+      const res = await attachmentGetter.getUnifiedAttachmentsByTypes({
+        caseId: '1',
+        types: [],
+      });
+
+      expect(res).toEqual([]);
+      expect(unsecuredSavedObjectsClient.createPointInTimeFinder).not.toHaveBeenCalled();
+    });
+
+    it('preserves entity metadata fields that the document codec would drop', async () => {
+      const soFindRes = createSOFindResponse([
+        {
+          id: 'entity-so-1',
+          type: CASE_ATTACHMENT_SAVED_OBJECT,
+          references: [],
+          score: 0,
+          attributes: {
+            type: 'security.entity',
+            attachmentId: 'user:alice@default',
+            metadata: {
+              entityName: 'alice',
+              entityType: 'user',
+              index: '.entities.*',
+            },
+            owner: 'securitySolution',
+            created_at: '2020-01-01T00:00:00.000Z',
+            created_by: {
+              username: 'elastic',
+              full_name: null,
+              email: null,
+            },
+            pushed_at: null,
+            pushed_by: null,
+            updated_at: null,
+            updated_by: null,
+          },
+        },
+      ]);
+
+      mockFinder(soFindRes);
+
+      const res = await attachmentGetter.getUnifiedAttachmentsByTypes({
+        caseId: '1',
+        types: ['security.entity'],
+      });
+
+      expect(res).toEqual([
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            type: 'security.entity',
+            attachmentId: 'user:alice@default',
+            metadata: {
+              entityName: 'alice',
+              entityType: 'user',
+              index: '.entities.*',
+            },
+          }),
+        }),
+      ]);
+    });
+  });
+
   describe('get', () => {
     it('falls back to legacy SO when unified SO returns 404', async () => {
       const attachmentGetterWithFlagOn = createAttachmentGetter(true);

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.test.ts
@@ -439,6 +439,44 @@ describe('AttachmentService getter', () => {
         }),
       ]);
     });
+
+    it('skips a malformed attachment and logs a warning instead of throwing', async () => {
+      const validAttachment = {
+        id: 'entity-so-valid',
+        type: CASE_ATTACHMENT_SAVED_OBJECT,
+        references: [],
+        score: 0,
+        attributes: {
+          type: 'security.entity',
+          attachmentId: 'user:alice@default',
+          metadata: { entityName: 'alice', entityType: 'user' },
+          owner: 'securitySolution',
+          created_at: '2020-01-01T00:00:00.000Z',
+          created_by: { username: 'elastic', full_name: null, email: null },
+          pushed_at: null,
+          pushed_by: null,
+          updated_at: null,
+          updated_by: null,
+        },
+      };
+      const malformedAttachment = {
+        ...validAttachment,
+        id: 'entity-so-malformed',
+        attributes: { ...validAttachment.attributes },
+      };
+      unset(malformedAttachment, 'attributes.attachmentId');
+      const soFindRes = createSOFindResponse([malformedAttachment, validAttachment]);
+
+      mockFinder(soFindRes);
+
+      const res = await attachmentGetter.getUnifiedAttachmentsByTypes({
+        caseId: '1',
+        types: ['security.entity'],
+      });
+
+      expect(res).toEqual([expect.objectContaining({ id: 'entity-so-valid' })]);
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('entity-so-malformed'));
+    });
   });
 
   describe('get', () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
@@ -39,13 +39,18 @@ import type {
   AttachmentTotals,
   DocumentAttachmentAttributesV2,
 } from '../../../../common/types/domain';
-import { AttachmentType, DocumentAttachmentAttributesRtV2 } from '../../../../common/types/domain';
+import {
+  AttachmentType,
+  DocumentAttachmentAttributesRtV2,
+  UnifiedAttachmentAttributesRt,
+} from '../../../../common/types/domain';
 import type {
   AlertIdsAggsResult,
   BulkOptionalAttributes,
   EventIdsAggsResult,
   GetAllAlertsAttachToCaseArgs as GetAllDocumentsAttachedToCaseArgs,
   GetAttachmentArgs,
+  GetUnifiedAttachmentsByTypesArgs,
   MixSavedObjectResponse,
   ServiceContext,
 } from '../types';
@@ -323,6 +328,68 @@ export class AttachmentGetter {
     return response.saved_objects.map((so) => {
       const validatedAttributes = decodeOrThrow(DocumentAttachmentAttributesRtV2)(so.attributes);
 
+      return Object.assign(so, { attributes: validatedAttributes });
+    });
+  }
+
+  /**
+   * Retrieves unified attachments of the given `types` attached to a case.
+   * Preserves full unified `metadata` (unlike {@link getAllDocumentsAttachedToCase},
+   * whose document codec only keeps alert/event index/rule fields).
+   */
+  public async getUnifiedAttachmentsByTypes({
+    caseId,
+    types,
+    filter,
+  }: GetUnifiedAttachmentsByTypesArgs): Promise<Array<SavedObject<UnifiedAttachmentAttributes>>> {
+    if (types.length === 0) {
+      return [];
+    }
+
+    try {
+      this.context.log.debug(
+        `Attempting to GET unified attachments [${types.join(', ')}] for case id ${caseId}`
+      );
+
+      const typeFilter = buildFilter({
+        filters: types,
+        field: 'type',
+        operator: 'or',
+        type: CASE_ATTACHMENT_SAVED_OBJECT,
+      });
+      const combinedFilter = combineFilters([typeFilter, filter]);
+
+      const finder =
+        this.context.unsecuredSavedObjectsClient.createPointInTimeFinder<UnifiedAttachmentAttributes>(
+          {
+            type: CASE_ATTACHMENT_SAVED_OBJECT,
+            hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
+            sortField: 'created_at',
+            sortOrder: 'asc',
+            filter: combinedFilter,
+            perPage: MAX_DOCS_PER_PAGE,
+          }
+        );
+
+      let result: Array<SavedObject<UnifiedAttachmentAttributes>> = [];
+      for await (const page of finder.find()) {
+        result = result.concat(AttachmentGetter.decodeUnifiedAttachments(page));
+      }
+
+      return result;
+    } catch (error) {
+      this.context.log.error(
+        `Error on GET unified attachments [${types.join(', ')}] for case id ${caseId}: ${error}`
+      );
+      throw error;
+    }
+  }
+
+  private static decodeUnifiedAttachments(
+    response: SavedObjectsFindResponse<UnifiedAttachmentAttributes>
+  ): Array<SavedObject<UnifiedAttachmentAttributes>> {
+    return response.saved_objects.map((so) => {
+      const validatedAttributes = decodeOrThrow(UnifiedAttachmentAttributesRt)(so.attributes);
       return Object.assign(so, { attributes: validatedAttributes });
     });
   }

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
@@ -372,7 +372,7 @@ export class AttachmentGetter {
 
       let result: Array<SavedObject<UnifiedAttachmentAttributes>> = [];
       for await (const page of finder.find()) {
-        result = result.concat(AttachmentGetter.decodeUnifiedAttachments(page));
+        result = result.concat(this.decodeUnifiedAttachments(page));
       }
 
       return result;
@@ -384,13 +384,29 @@ export class AttachmentGetter {
     }
   }
 
-  private static decodeUnifiedAttachments(
+  /**
+   * Decodes each attachment individually and skips (with a warning) any that fail: unlike
+   * {@link decodeDocuments}, callers of this method (e.g. case metrics) can still return
+   * useful data derived from the other attachments, so one non-conforming `security.entity`
+   * document shouldn't fail the whole call.
+   */
+  private decodeUnifiedAttachments(
     response: SavedObjectsFindResponse<UnifiedAttachmentAttributes>
   ): Array<SavedObject<UnifiedAttachmentAttributes>> {
-    return response.saved_objects.map((so) => {
-      const validatedAttributes = decodeOrThrow(UnifiedAttachmentAttributesRt)(so.attributes);
-      return Object.assign(so, { attributes: validatedAttributes });
-    });
+    const decoded: Array<SavedObject<UnifiedAttachmentAttributes>> = [];
+
+    for (const so of response.saved_objects) {
+      try {
+        const validatedAttributes = decodeOrThrow(UnifiedAttachmentAttributesRt)(so.attributes);
+        decoded.push(Object.assign(so, { attributes: validatedAttributes }));
+      } catch (error) {
+        this.context.log.warn(
+          `Failed to decode unified attachment id ${so.id} of type ${so.type}, skipping it: ${error}`
+        );
+      }
+    }
+
+    return decoded;
   }
 
   /**

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
@@ -333,9 +333,8 @@ export class AttachmentGetter {
   }
 
   /**
-   * Retrieves unified attachments of the given `types` attached to a case.
-   * Preserves full unified `metadata` (unlike {@link getAllDocumentsAttachedToCase},
-   * whose document codec only keeps alert/event index/rule fields).
+   * Retrieves unified attachments of the given `types`, preserving full metadata
+   * (unlike {@link getAllDocumentsAttachedToCase}, which only keeps alert/event fields).
    */
   public async getUnifiedAttachmentsByTypes({
     caseId,

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
@@ -83,6 +83,22 @@ export type GetAllAlertsAttachToCaseArgs = AttachedToCaseArgs & {
   unifiedAttachmentTypes?: string[];
 };
 
+/**
+ * Fetches unified-only attachments (e.g. `security.entity`) for a case by exact `type`
+ * values. Unlike {@link GetAllAlertsAttachToCaseArgs}, this does not map legacy alert/event
+ * types and returns full unified attributes so callers can read metadata fields that the
+ * document-attachment codec would drop.
+ *
+ * `filter` must only reference `cases-attachments` fields. Do not pass
+ * {@link getAttachmentAuthorizationFilter}'s combined filter (it ORs in `cases-comments`
+ * and Saved Objects will reject that on an attachments-only find).
+ */
+export interface GetUnifiedAttachmentsByTypesArgs {
+  caseId: string;
+  types: string[];
+  filter?: KueryNode;
+}
+
 export interface AlertIdsAggsResult {
   alertIds: {
     buckets: Array<{

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
@@ -84,14 +84,11 @@ export type GetAllAlertsAttachToCaseArgs = AttachedToCaseArgs & {
 };
 
 /**
- * Fetches unified-only attachments (e.g. `security.entity`) for a case by exact `type`
- * values. Unlike {@link GetAllAlertsAttachToCaseArgs}, this does not map legacy alert/event
- * types and returns full unified attributes so callers can read metadata fields that the
- * document-attachment codec would drop.
+ * Fetches unified-only attachments (e.g. `security.entity`) by exact `type`, returning full
+ * unified attributes (unlike {@link GetAllAlertsAttachToCaseArgs}).
  *
- * `filter` must only reference `cases-attachments` fields. Do not pass
- * {@link getAttachmentAuthorizationFilter}'s combined filter (it ORs in `cases-comments`
- * and Saved Objects will reject that on an attachments-only find).
+ * `filter` must only reference `cases-attachments` fields — don't pass
+ * {@link getAttachmentAuthorizationFilter}'s combined filter (it also matches `cases-comments`).
  */
 export interface GetUnifiedAttachmentsByTypesArgs {
   caseId: string;

--- a/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
@@ -169,6 +169,7 @@ const createAttachmentGetterServiceMock = (): AttachmentGetterServiceMock => {
     get: jest.fn(),
     bulkGet: jest.fn(),
     getAllDocumentsAttachedToCase: jest.fn(),
+    getUnifiedAttachmentsByTypes: jest.fn().mockResolvedValue([]),
     getCaseAttatchmentStats: jest.fn(),
     getAttachmentIdsForCases: jest.fn(),
     getFileAttachments: jest.fn(),

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics_alerts.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics_alerts.ts
@@ -7,7 +7,11 @@
 
 import expect from '@kbn/expect';
 import { CaseMetricsFeature } from '@kbn/cases-plugin/common';
-import { getPostCaseRequest, postCommentAlertReq } from '../../../../../common/lib/mock';
+import {
+  getPostCaseRequest,
+  postCommentAlertReq,
+  postCommentEntityReq,
+} from '../../../../../common/lib/mock';
 
 import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
@@ -101,6 +105,121 @@ export default ({ getService }: FtrProviderContext): void => {
             { name: 'jf9e87gsut', count: 1 },
           ])
         ).to.be(true);
+      });
+    });
+
+    describe('alert details merged with entity attachments', () => {
+      before(async () => {
+        await esArchiver.load(
+          'x-pack/platform/test/fixtures/es_archives/cases/signals/hosts_users'
+        );
+      });
+
+      after(async () => {
+        await esArchiver.unload(
+          'x-pack/platform/test/fixtures/es_archives/cases/signals/hosts_users'
+        );
+      });
+
+      afterEach(async () => {
+        await deleteAllCaseItems(es);
+      });
+
+      it('adds an entity attachment name that is not already an alert identity to the total', async () => {
+        const caseId = await createCaseWithAlerts();
+
+        await createComment({
+          supertest,
+          caseId,
+          params: {
+            ...postCommentEntityReq,
+            attachmentId: 'entity-new-user',
+            metadata: { entityName: 'brand-new-user', entityType: 'user' },
+          },
+        });
+        await createComment({
+          supertest,
+          caseId,
+          params: {
+            ...postCommentEntityReq,
+            attachmentId: 'entity-new-host',
+            metadata: { entityName: 'brand-new-host', entityType: 'host' },
+          },
+        });
+
+        const metrics = await getCaseMetrics({
+          supertest,
+          caseId,
+          features: [CaseMetricsFeature.ALERTS_USERS, CaseMetricsFeature.ALERTS_HOSTS],
+        });
+
+        expect(metrics.alerts?.users?.total).to.be(5);
+        expect(metrics.alerts?.hosts?.total).to.be(4);
+      });
+
+      it('does not double count an entity attachment name that matches an existing alert identity', async () => {
+        const caseId = await createCaseWithAlerts();
+
+        // 'zpxm4rqnze' and 'Host-abc' already come from the alert documents loaded above.
+        await createComment({
+          supertest,
+          caseId,
+          params: {
+            ...postCommentEntityReq,
+            attachmentId: 'entity-existing-user',
+            metadata: { entityName: 'zpxm4rqnze', entityType: 'user' },
+          },
+        });
+        await createComment({
+          supertest,
+          caseId,
+          params: {
+            ...postCommentEntityReq,
+            attachmentId: 'entity-existing-host',
+            metadata: { entityName: 'Host-abc', entityType: 'host' },
+          },
+        });
+
+        const metrics = await getCaseMetrics({
+          supertest,
+          caseId,
+          features: [CaseMetricsFeature.ALERTS_USERS, CaseMetricsFeature.ALERTS_HOSTS],
+        });
+
+        expect(metrics.alerts?.users?.total).to.be(4);
+        expect(metrics.alerts?.hosts?.total).to.be(3);
+      });
+
+      it('counts entity attachments on a case with no alerts', async () => {
+        const theCase = await createCase(supertest, getPostCaseRequest());
+
+        await createComment({
+          supertest,
+          caseId: theCase.id,
+          params: {
+            ...postCommentEntityReq,
+            attachmentId: 'entity-only-user',
+            metadata: { entityName: 'entity-only-user-name', entityType: 'user' },
+          },
+        });
+        await createComment({
+          supertest,
+          caseId: theCase.id,
+          params: {
+            ...postCommentEntityReq,
+            attachmentId: 'entity-only-host',
+            metadata: { entityName: 'entity-only-host-name', entityType: 'host' },
+          },
+        });
+
+        const metrics = await getCaseMetrics({
+          supertest,
+          caseId: theCase.id,
+          features: [CaseMetricsFeature.ALERTS_USERS, CaseMetricsFeature.ALERTS_HOSTS],
+        });
+
+        expect(metrics.alerts?.users?.total).to.be(1);
+        expect(metrics.alerts?.hosts?.total).to.be(1);
       });
     });
 


### PR DESCRIPTION
## What & Why
The Case Details metrics bar's "Associated Users"/"Associated Hosts" counts only reflected users/hosts derived from attached alerts, ignoring directly-attached `security.entity` user/host attachments. This adds those entity attachments into the count, using an exact dedup strategy (full alert-identity sets, not just the displayed top-N) so an entity name that coincides with an alert identity isn't double-counted.

## How to Test
1. Create a case and attach a few alerts with known `user.name`/`host.id` values.
2. Attach a `security.entity` user and host attachment to the same case (e.g. via "Add to case" on an entity flyout, or `POST /api/cases/{caseId}/comments` with `type: security.entity`).
3. Open the case's details page and confirm the metrics bar's Associated Users/Hosts counts reflect the union of alert-derived and entity-derived names, without double-counting overlapping names.
4. Run `node scripts/jest x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/entity_associated.test.ts x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.test.ts --config=x-pack/platform/plugins/shared/cases/jest.config.js`.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->