### PR TITLE
[DOCS] Add advanced setting for showing managed workflows

### DIFF
--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2423,7 +2423,7 @@ groups:
         description: |
           Enables Elastic Workflows and related experiences.
         note: |
-          :applies_to: stack: preview 9.3
+          :applies_to: stack: preview =9.3
           In this version, the default is `false`.
         datatype: bool
         default: true

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2422,10 +2422,13 @@ groups:
         id: "workflows:ui:enabled"
         description: |
           Enables Elastic Workflows and related experiences.
+        note: |
+          :applies_to: stack: ga 9.0-9.3
+          In these versions, the default is `false`.
         datatype: bool
-        default: false
+        default: true
         applies_to:
-          stack: preview 9.3
+          stack: ga 9.4+, preview =9.3
           ech: ga
           ece: ga
           eck: ga

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -579,20 +579,6 @@ groups:
           self: ga
           serverless: unavailable
 
-      - setting: "workflows:ui:enabled"
-        id: "workflows:ui:enabled"
-        description: |
-          Enables Elastic Workflows and related experiences.
-        datatype: bool
-        default: false
-        applies_to:
-          stack: preview 9.3
-          ech: ga
-          ece: ga
-          eck: ga
-          self: ga
-          serverless: preview
-
       - setting: "fields:popularLimit"
         id: fields-popularlimit
         description: |
@@ -2427,3 +2413,35 @@ groups:
           eck: ga
           self: ga
           elasticsearch: ga
+
+  - group: Workflows
+    id: kibana-workflows-settings
+    settings:
+
+      - setting: "workflows:ui:enabled"
+        id: "workflows:ui:enabled"
+        description: |
+          Enables Elastic Workflows and related experiences.
+        datatype: bool
+        default: false
+        applies_to:
+          stack: preview 9.3
+          ech: ga
+          ece: ga
+          eck: ga
+          self: ga
+          serverless: preview
+
+      - setting: "workflows:ui:showManagedWorkflows"
+        id: "workflows:ui:showManagedWorkflows"
+        description: |
+          Shows managed workflows and their executions in workflow experiences.
+        datatype: bool
+        default: false
+        applies_to:
+          stack: ga 9.5
+          ech: ga
+          ece: ga
+          eck: ga
+          self: ga
+          serverless: ga

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2424,7 +2424,7 @@ groups:
           Enables Elastic Workflows and related experiences.
         note: |
           :applies_to: stack: preview 9.3
-          In these versions, the default is `false`.
+          In this version, the default is `false`.
         datatype: bool
         default: true
         applies_to:

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2423,7 +2423,7 @@ groups:
         description: |
           Enables Elastic Workflows and related experiences.
         note: |
-          :applies_to: stack: ga 9.0-9.3
+          :applies_to: stack: preview 9.3
           In these versions, the default is `false`.
         datatype: bool
         default: true


### PR DESCRIPTION
## Summary

Adds the Show managed workflows (`workflows:ui:showManagedWorkflows`) advanced setting to the Kibana
settings reference. The setting controls whether managed workflows and their
executions appear in workflow experiences.

Also groups the Workflows settings together. The `workflows:ui:enabled` setting was
still listed under General, but it moved to a Workflows section in the UI when
the managed workflows setting was added, so this introduces a Workflows group
and moves it there to match what users see on the Advanced Settings page.

Contributes to  elastic/docs-content-internal#1458.
Related docs-content PR that adds docs for managed workflows: https://github.com/elastic/docs-content/pull/7805


