### PR TITLE
[Dataset quality] Fix invalid aria-controls on quality issue flyout mitigation accordions

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/field_limit/field_mapping_limit.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/field_limit/field_mapping_limit.tsx
@@ -34,8 +34,6 @@ export function FieldMappingLimit({
 }: {
   areIntegrationAssetsAvailable: boolean;
 }) {
-  // The prefix must be a valid HTML id fragment, so the localized title cannot be used here:
-  // it contains spaces which would produce an invalid `aria-controls` reference on the accordion button.
   const accordionId = useGeneratedHtmlId({
     prefix: 'datasetQualityDetailsDegradedFieldFlyoutFieldLimitMitigation',
   });

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/field_limit/field_mapping_limit.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/field_limit/field_mapping_limit.tsx
@@ -34,8 +34,10 @@ export function FieldMappingLimit({
 }: {
   areIntegrationAssetsAvailable: boolean;
 }) {
+  // The prefix must be a valid HTML id fragment, so the localized title cannot be used here:
+  // it contains spaces which would produce an invalid `aria-controls` reference on the accordion button.
   const accordionId = useGeneratedHtmlId({
-    prefix: increaseFieldMappingLimitTitle,
+    prefix: 'datasetQualityDetailsDegradedFieldFlyoutFieldLimitMitigation',
   });
 
   const { degradedFieldAnalysis } = useQualityIssues();

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/index.test.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/index.test.tsx
@@ -321,6 +321,63 @@ describe('PossibleDegradedFieldMitigations', () => {
     });
   });
 
+  describe('accordion aria-controls', () => {
+    const expectValidAriaControls = (container: HTMLElement) => {
+      const elementsWithAriaControls = Array.from(container.querySelectorAll('[aria-controls]'));
+
+      expect(elementsWithAriaControls.length).toBeGreaterThan(0);
+
+      elementsWithAriaControls.forEach((element) => {
+        const ariaControls = element.getAttribute('aria-controls') as string;
+
+        // `aria-controls` is a space separated list of ID references, so a single
+        // ID must not contain whitespace, otherwise it cannot be resolved.
+        expect(ariaControls).not.toMatch(/\s/);
+        expect(container.ownerDocument.getElementById(ariaControls)).not.toBeNull();
+      });
+    };
+
+    it('references valid ids for the field character limit mitigations', () => {
+      mockUseQualityIssues.mockReturnValue({
+        ...defaultQualityIssuesData,
+        degradedFieldAnalysisFormattedResult: {
+          isFieldLimitIssue: false,
+          isFieldCharacterLimitIssue: true,
+          isFieldMalformedIssue: false,
+        },
+      });
+
+      mockUseDatasetQualityDetailsState.mockReturnValue({
+        ...defaultDetailsState,
+        view: 'wired',
+      });
+
+      const { container } = renderWithI18n(<PossibleDegradedFieldMitigations />);
+
+      expectValidAriaControls(container);
+    });
+
+    it('references valid ids for the manual and field limit mitigations', () => {
+      mockUseQualityIssues.mockReturnValue({
+        ...defaultQualityIssuesData,
+        degradedFieldAnalysisFormattedResult: {
+          isFieldLimitIssue: true,
+          isFieldCharacterLimitIssue: false,
+          isFieldMalformedIssue: false,
+        },
+        degradedFieldAnalysis: {
+          totalFieldLimit: 1000,
+        },
+        totalFieldsLimit: 1000,
+        totalFieldCount: 1200,
+      });
+
+      const { container } = renderWithI18n(<PossibleDegradedFieldMitigations />);
+
+      expectValidAriaControls(container);
+    });
+  });
+
   describe('field malformed issue', () => {
     it('should render FieldMalformed when isFieldMalformedIssue is true and view is not dataQuality', () => {
       mockUseQualityIssues.mockReturnValue({

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/mitigation_accordion.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/mitigation_accordion.tsx
@@ -30,8 +30,6 @@ export function MitigationAccordion({
   children,
   initialIsOpen = false,
 }: MitigationAccordionProps) {
-  // The prefix must be a valid HTML id fragment, so the localized `title` cannot be used here:
-  // it contains spaces which would produce an invalid `aria-controls` reference on the accordion button.
   const accordionId = useGeneratedHtmlId({
     prefix: dataTestSubjPrefix,
   });

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/mitigation_accordion.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/mitigation_accordion.tsx
@@ -30,8 +30,10 @@ export function MitigationAccordion({
   children,
   initialIsOpen = false,
 }: MitigationAccordionProps) {
+  // The prefix must be a valid HTML id fragment, so the localized `title` cannot be used here:
+  // it contains spaces which would produce an invalid `aria-controls` reference on the accordion button.
   const accordionId = useGeneratedHtmlId({
-    prefix: title,
+    prefix: dataTestSubjPrefix,
   });
 
   return (


### PR DESCRIPTION
## Summary

Closes #276745

The mitigation accordions in the dataset quality issue flyout derived their generated HTML `id` from the **localized accordion title**, so ids such as `Modify field value:r2a3j:` ended up in the accordion button's `aria-controls`.

Since `aria-controls` is a **space-separated list of ID references**, the spaces made assistive technologies (and axe-core) try to resolve three nonexistent ids — `Modify`, `field`, `value:r2a3j:` — instead of the controlled panel. That is the `aria-valid-attr-value` / "ARIA attributes must conform to valid values" violation reported in the issue.

Note: the colons are *not* the problem — they are legal HTML5 id characters and React's `useId()` emits them for every generated id. Only the whitespace breaks the reference.

## Root cause

`MitigationAccordion` passed the translated title straight through as the id prefix:

```ts
useGeneratedHtmlId({ prefix: title }); // title = "Modify field value"
```

On React 18, `useGeneratedHtmlId` returns `` `${prefix}${React.useId()}` ``, so the space-containing title leaks directly into the id.

## Changes

- `mitigation_accordion.tsx` — use the stable, ID-safe `dataTestSubjPrefix` as the id prefix instead of the localized title. This covers all five consumers of the shared component: **Modify field value**, **Increase field character limit**, **Add or edit custom ingest pipeline** (the three named in the issue), plus **Create convert processor** and **Change field type in schema**.
- `field_limit/field_mapping_limit.tsx` — the same bug (prefix `"Increase field mapping limit"`) existed on the field mapping limit accordion in the same flyout; fixed with a static ID-safe prefix.
- `index.test.tsx` — new `accordion aria-controls` tests asserting every `[aria-controls]` value contains no whitespace and resolves to a real element in the document.

## Testing

- `node scripts/jest x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/index.test.tsx` → **15/15 pass**.
- Regression-verified: with only the two source fixes reverted, the two new tests fail (2 failed, 13 passed), confirming they actually cover the defect.
- ESLint clean on changed files.

Existing FTR suites reference these accordions by `data-test-subj` only, which is unchanged.

## Follow-ups

- `useGeneratedHtmlId({ prefix: <translated string> })` is a general anti-pattern worth a repo-wide sweep; out of scope here. Tracking: elastic/kibana-team#3515.
- Fix is verified at the DOM/unit level; an axe-core run in a live browser would be a nice extra confirmation.

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->