### PR TITLE
chore(eslint): enforce `@elastic/eui/require-aria-label-for-modals` rule at the error level

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -472,6 +472,7 @@ module.exports = {
     '@elastic/eui/tooltip-button-icon-wrap': 'error',
     '@elastic/eui/tooltip-focusable-anchor': 'error',
     '@elastic/eui/no-unnamed-radio-group': 'error',
+    '@elastic/eui/require-aria-label-for-modals': 'error',
   },
 
   overrides: [

--- a/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/wizard/wizard.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/wizard/wizard.tsx
@@ -9,7 +9,13 @@ import React, { createContext, type FC, useCallback, useEffect, useMemo, useStat
 import { pick } from 'lodash';
 
 import type { EuiStepStatus } from '@elastic/eui';
-import { EuiConfirmModal, EuiFormRow, EuiSteps, EuiToolTip } from '@elastic/eui';
+import {
+  EuiConfirmModal,
+  EuiFormRow,
+  EuiSteps,
+  EuiToolTip,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 
 import { i18n } from '@kbn/i18n';
@@ -114,6 +120,7 @@ export const Wizard: FC<WizardProps> = React.memo(
     const [stepCreateState, setStepCreateState] = useState(getDefaultStepCreateState);
     const [savedDataViews, setSavedDataViews] = useState<DataViewListItem[]>([]);
     const [pendingDataViewId, setPendingDataViewId] = useState<string>();
+    const changeDataViewModalTitleId = useGeneratedHtmlId();
 
     const resetWizardState = useCallback(
       (nextSearchItems: SearchItems, transformFunction: TransformFunction) => {
@@ -356,6 +363,8 @@ export const Wizard: FC<WizardProps> = React.memo(
               <EuiSteps css={styles.steps} steps={stepsConfig} />
               {pendingDataViewId ? (
                 <EuiConfirmModal
+                  aria-labelledby={changeDataViewModalTitleId}
+                  titleProps={{ id: changeDataViewModalTitleId }}
                   title={i18n.translate(
                     'xpack.transform.transformsWizard.changeDataViewConfirmModalTitle',
                     {

--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/create_transform_button/create_transform_button.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/create_transform_button/create_transform_button.tsx
@@ -17,6 +17,7 @@ import {
   EuiPopoverTitle,
   EuiText,
   EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -40,6 +41,7 @@ export const CreateTransformButton: FC<CreateTransformButtonProps> = ({
 }) => {
   const capabilities = useTransformCapabilities();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const disabled =
     !capabilities.canCreateTransform ||
@@ -139,6 +141,7 @@ export const CreateTransformButton: FC<CreateTransformButtonProps> = ({
 
   return (
     <EuiPopover
+      aria-labelledby={popoverTitleId}
       button={createTransformButton}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
@@ -146,7 +149,7 @@ export const CreateTransformButton: FC<CreateTransformButtonProps> = ({
       data-test-subj="transformCreatePopover"
     >
       <>
-        <EuiPopoverTitle paddingSize="m">
+        <EuiPopoverTitle id={popoverTitleId} paddingSize="m">
           {i18n.translate('xpack.transform.transformList.createTransformTypePopoverTitle', {
             defaultMessage: 'Select transform type',
           })}


### PR DESCRIPTION
## Summary

This PR enforces the `@elastic/eui/require-aria-label-for-modals` rule at the error level

- **`@elastic/eui/require-aria-label-for-modals`** — Ensure that EUI modal components (`EuiModal`, `EuiFlyout`, `EuiFlyoutResizable` ,`EuiConfirmModal`, `EuiPopover`, `EuiWrappingPopover`) have either an `aria-label` or `aria-labelledby` prop for accessibility. This helps screen reader users understand the purpose and content of modal dialogs.


### Changes
- `packages/kbn-eslint-config/.eslintrc.js`