### PR TITLE
[Alerting V2] Add request-scoped PrivilegeChecker service

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
@@ -10,6 +10,7 @@ import type {
   SubFeatureConfig,
   SubFeaturePrivilegeConfig,
 } from '@kbn/features-plugin/common';
+import { ApiPrivileges } from '@kbn/core-security-server';
 import {
   ALERTING_V2_ACTION_POLICIES_APP_ID,
   ALERTING_V2_EPISODES_APP_ID,
@@ -28,22 +29,27 @@ type NestedValueOf<T extends Record<string, Record<string, string>>> = ValueOf<{
  * UI capability keys, and future sub-feature definitions.
  *
  * Add all new alerting_v2 privilege strings here and derive from this file.
+ *
+ * Values use the `ApiPrivileges` format (`operation_subject`) so that both the
+ * feature privilege builder and runtime privilege checks produce the same
+ * fully-qualified action string without relying on the deprecated single-arg
+ * `actions.api.get(subject)` overload.
  */
 export const ALERTING_V2_API_PRIVILEGES = {
   rules: {
-    read: 'read-alerting-v2-rules',
-    write: 'write-alerting-v2-rules',
+    read: ApiPrivileges.read('alerting-v2-rules'),
+    write: ApiPrivileges.manage('alerting-v2-rules'),
   },
   alerts: {
-    read: 'read-alerting-v2-alerts',
-    write: 'write-alerting-v2-alerts',
+    read: ApiPrivileges.read('alerting-v2-alerts'),
+    write: ApiPrivileges.manage('alerting-v2-alerts'),
   },
   actionPolicies: {
-    read: 'read-alerting-v2-action-policies',
-    write: 'write-alerting-v2-action-policies',
+    read: ApiPrivileges.read('alerting-v2-action-policies'),
+    write: ApiPrivileges.manage('alerting-v2-action-policies'),
   },
   executionHistory: {
-    read: 'read-alerting-v2-execution-history',
+    read: ApiPrivileges.read('alerting-v2-execution-history'),
   },
 } as const;
 
@@ -242,6 +248,12 @@ export const ALERTING_V2_FEATURES = {
 
 export type AlertingV2Feature = keyof typeof ALERTING_V2_FEATURES;
 
+export type WritableAlertingV2Feature = {
+  [K in AlertingV2Feature]: 'write' extends keyof (typeof ALERTING_V2_API_PRIVILEGES)[K]
+    ? K
+    : never;
+}[AlertingV2Feature];
+
 type TopLevelUiOf<F extends AlertingV2Feature> =
   | (typeof ALERTING_V2_FEATURES)[F]['privileges']['all']['ui'][number]
   | (typeof ALERTING_V2_FEATURES)[F]['privileges']['read']['ui'][number];
@@ -252,3 +264,21 @@ type SubFeatureUiOf<F extends AlertingV2Feature> =
 export type AlertingV2UICapabilityFor<F extends AlertingV2Feature> =
   | TopLevelUiOf<F>
   | SubFeatureUiOf<F>;
+
+type AlertingV2PrivilegeLevel = 'read' | 'all';
+
+/**
+ * Returns a user-facing privilege display name for the given feature and level,
+ * matching the format shown in Kibana Role Management and the
+ * RequiredPrivilegesPrompt interstitial (e.g. "Rules: All",
+ * "Action Policies: Read"). Suitable for embedding in agent tool-error messages
+ * so the agent can relay the missing privilege to the user in plain language.
+ */
+export const getAlertingPrivilegeDisplayName = (
+  feature: AlertingV2Feature,
+  level: AlertingV2PrivilegeLevel
+): string => {
+  const { name } = ALERTING_V2_FEATURES[feature];
+  const levelLabel = level === 'all' ? 'All' : 'Read';
+  return `${name}: ${levelLabel}`;
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
@@ -10,7 +10,6 @@ import type {
   SubFeatureConfig,
   SubFeaturePrivilegeConfig,
 } from '@kbn/features-plugin/common';
-import { ApiPrivileges } from '@kbn/core-security-server';
 import {
   ALERTING_V2_ACTION_POLICIES_APP_ID,
   ALERTING_V2_EPISODES_APP_ID,
@@ -24,32 +23,21 @@ type NestedValueOf<T extends Record<string, Record<string, string>>> = ValueOf<{
   [K in keyof T]: ValueOf<T[K]>;
 }>;
 
-/**
- * Single source of truth for alerting_v2 feature ids, API privilege strings,
- * UI capability keys, and future sub-feature definitions.
- *
- * Add all new alerting_v2 privilege strings here and derive from this file.
- *
- * Values use the `ApiPrivileges` format (`operation_subject`) so that both the
- * feature privilege builder and runtime privilege checks produce the same
- * fully-qualified action string without relying on the deprecated single-arg
- * `actions.api.get(subject)` overload.
- */
 export const ALERTING_V2_API_PRIVILEGES = {
   rules: {
-    read: ApiPrivileges.read('alerting-v2-rules'),
-    write: ApiPrivileges.manage('alerting-v2-rules'),
+    read: 'read_alerting-v2-rules',
+    write: 'manage_alerting-v2-rules',
   },
   alerts: {
-    read: ApiPrivileges.read('alerting-v2-alerts'),
-    write: ApiPrivileges.manage('alerting-v2-alerts'),
+    read: 'read_alerting-v2-alerts',
+    write: 'manage_alerting-v2-alerts',
   },
   actionPolicies: {
-    read: ApiPrivileges.read('alerting-v2-action-policies'),
-    write: ApiPrivileges.manage('alerting-v2-action-policies'),
+    read: 'read_alerting-v2-action-policies',
+    write: 'manage_alerting-v2-action-policies',
   },
   executionHistory: {
-    read: ApiPrivileges.read('alerting-v2-execution-history'),
+    read: 'read_alerting-v2-execution-history',
   },
 } as const;
 

--- a/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
@@ -267,13 +267,6 @@ export type AlertingV2UICapabilityFor<F extends AlertingV2Feature> =
 
 type AlertingV2PrivilegeLevel = 'read' | 'all';
 
-/**
- * Returns a user-facing privilege display name for the given feature and level,
- * matching the format shown in Kibana Role Management and the
- * RequiredPrivilegesPrompt interstitial (e.g. "Rules: All",
- * "Action Policies: Read"). Suitable for embedding in agent tool-error messages
- * so the agent can relay the missing privilege to the user in plain language.
- */
 export const getAlertingPrivilegeDisplayName = (
   feature: AlertingV2Feature,
   level: AlertingV2PrivilegeLevel

--- a/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.ts
@@ -253,11 +253,9 @@ export type AlertingV2UICapabilityFor<F extends AlertingV2Feature> =
   | TopLevelUiOf<F>
   | SubFeatureUiOf<F>;
 
-type AlertingV2PrivilegeLevel = 'read' | 'all';
-
 export const getAlertingPrivilegeDisplayName = (
   feature: AlertingV2Feature,
-  level: AlertingV2PrivilegeLevel
+  level: 'read' | 'all'
 ): string => {
   const { name } = ALERTING_V2_FEATURES[feature];
   const levelLabel = level === 'all' ? 'All' : 'Read';

--- a/x-pack/platform/plugins/shared/alerting_v2/moon.yml
+++ b/x-pack/platform/plugins/shared/alerting_v2/moon.yml
@@ -137,6 +137,8 @@ dependsOn:
   - '@kbn/content-list-toolbar'
   - '@kbn/es'
   - '@kbn/test-es-server'
+  - '@kbn/security-authorization-core'
+  - '@kbn/security-plugin-types-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.test.ts
@@ -13,37 +13,21 @@ import { PrivilegeChecker } from './privilege_checker';
 
 const spaceId = 'default';
 
-// securityMock auto-mocks ApiActions via jest.mock, so we must use
-// jest.requireActual to get the real implementation for actionFromRouteTag.
+// securityMock stubs ApiActions, so pull the real class for actionFromRouteTag.
 const { ApiActions } = jest.requireActual(
   '@kbn/security-authorization-core/src/actions/api'
 ) as typeof import('@kbn/security-authorization-core/src/actions/api');
 const apiActions = new ApiActions();
 
-/**
- * Resolve the fully-qualified action string for a privilege tag using the real
- * `ApiActions` implementation — same code path the production security plugin
- * uses to convert `operation_subject` route tags to action strings.
- */
 const actionFor = (privilege: string) => apiActions.actionFromRouteTag(privilege);
 
-/**
- * Create a `KibanaRequest` mock that represents a user with a specific set of
- * granted API privileges. Returns the request and its pre-resolved action
- * strings so they can be registered with the shared security mock.
- */
 const createRequestMock = (grantedPrivileges: string[]) => {
   const request = httpServerMock.createKibanaRequest();
   const grantedActions = grantedPrivileges.map(actionFor);
   return { request, grantedActions };
 };
 
-/**
- * Build a `SecurityPluginStart` mock backed by `securityMock.createStart()`
- * that evaluates privilege checks against a per-request privilege mapping.
- * The real `ApiActions` class handles `actionFromRouteTag` so the test
- * exercises the actual `operation_subject` parsing logic.
- */
+// securityMock has no privilege-check mock implementation, so map granted actions per request.
 const createSecurity = (privilegesByRequest: Map<KibanaRequest, string[]>) => {
   const security = securityMock.createStart();
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.test.ts
@@ -6,90 +6,297 @@
  */
 
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { securityMock } from '@kbn/security-plugin/server/mocks';
 import { ALERTING_V2_API_PRIVILEGES } from '../../../../common/feature_privileges';
 import { PrivilegeChecker } from './privilege_checker';
 
-const request = {} as KibanaRequest;
 const spaceId = 'default';
 
-const createSecurityMock = (hasAllRequested: boolean) => {
-  const atSpace = jest.fn().mockResolvedValue({ hasAllRequested });
-  const checkPrivilegesWithRequest = jest.fn().mockReturnValue({ atSpace });
-  const actionFromRouteTag = jest.fn((tag: string) => `api:${tag}`);
+// securityMock auto-mocks ApiActions via jest.mock, so we must use
+// jest.requireActual to get the real implementation for actionFromRouteTag.
+const { ApiActions } = jest.requireActual(
+  '@kbn/security-authorization-core/src/actions/api'
+) as typeof import('@kbn/security-authorization-core/src/actions/api');
+const apiActions = new ApiActions();
 
-  const security = {
-    authz: {
-      actions: { api: { actionFromRouteTag } },
-      checkPrivilegesWithRequest,
-    },
-  } as unknown as SecurityPluginStart;
+/**
+ * Resolve the fully-qualified action string for a privilege tag using the real
+ * `ApiActions` implementation — same code path the production security plugin
+ * uses to convert `operation_subject` route tags to action strings.
+ */
+const actionFor = (privilege: string) => apiActions.actionFromRouteTag(privilege);
 
-  return { security, atSpace, actionFromRouteTag };
+/**
+ * Create a `KibanaRequest` mock that represents a user with a specific set of
+ * granted API privileges. Returns the request and its pre-resolved action
+ * strings so they can be registered with the shared security mock.
+ */
+const createRequestMock = (grantedPrivileges: string[]) => {
+  const request = httpServerMock.createKibanaRequest();
+  const grantedActions = grantedPrivileges.map(actionFor);
+  return { request, grantedActions };
+};
+
+/**
+ * Build a `SecurityPluginStart` mock backed by `securityMock.createStart()`
+ * that evaluates privilege checks against a per-request privilege mapping.
+ * The real `ApiActions` class handles `actionFromRouteTag` so the test
+ * exercises the actual `operation_subject` parsing logic.
+ */
+const createSecurity = (privilegesByRequest: Map<KibanaRequest, string[]>) => {
+  const security = securityMock.createStart();
+
+  jest
+    .mocked(security.authz.actions.api.actionFromRouteTag)
+    .mockImplementation((tag: string) => apiActions.actionFromRouteTag(tag));
+
+  security.authz.checkPrivilegesWithRequest.mockImplementation((req: KibanaRequest) => ({
+    globally: jest.fn(),
+    atSpace: jest.fn().mockImplementation((_sid: string, { kibana }: { kibana: string[] }) => {
+      const granted = privilegesByRequest.get(req) ?? [];
+      const hasAllRequested = kibana.every((action) => granted.includes(action));
+      return Promise.resolve({ hasAllRequested });
+    }),
+    atSpaces: jest.fn(),
+  }));
+
+  return security;
 };
 
 describe('PrivilegeChecker', () => {
-  describe('canRead', () => {
-    it('checks the read API privilege for the given feature', async () => {
-      const { security, atSpace, actionFromRouteTag } = createSecurityMock(true);
-      const checker = new PrivilegeChecker(request, spaceId, security);
+  const rulesAll = createRequestMock([
+    ALERTING_V2_API_PRIVILEGES.rules.read,
+    ALERTING_V2_API_PRIVILEGES.rules.write,
+  ]);
+  const rulesRead = createRequestMock([ALERTING_V2_API_PRIVILEGES.rules.read]);
+  const actionPoliciesAll = createRequestMock([
+    ALERTING_V2_API_PRIVILEGES.actionPolicies.read,
+    ALERTING_V2_API_PRIVILEGES.actionPolicies.write,
+  ]);
+  const actionPoliciesRead = createRequestMock([ALERTING_V2_API_PRIVILEGES.actionPolicies.read]);
+  const alertsAll = createRequestMock([
+    ALERTING_V2_API_PRIVILEGES.alerts.read,
+    ALERTING_V2_API_PRIVILEGES.alerts.write,
+  ]);
+  const alertsRead = createRequestMock([ALERTING_V2_API_PRIVILEGES.alerts.read]);
+  const execHistoryAll = createRequestMock([ALERTING_V2_API_PRIVILEGES.executionHistory.read]);
+  const execHistoryRead = createRequestMock([ALERTING_V2_API_PRIVILEGES.executionHistory.read]);
+  const noAccess = createRequestMock([]);
 
+  const security = createSecurity(
+    new Map([
+      [rulesAll.request, rulesAll.grantedActions],
+      [rulesRead.request, rulesRead.grantedActions],
+      [actionPoliciesAll.request, actionPoliciesAll.grantedActions],
+      [actionPoliciesRead.request, actionPoliciesRead.grantedActions],
+      [alertsAll.request, alertsAll.grantedActions],
+      [alertsRead.request, alertsRead.grantedActions],
+      [execHistoryAll.request, execHistoryAll.grantedActions],
+      [execHistoryRead.request, execHistoryRead.grantedActions],
+      [noAccess.request, noAccess.grantedActions],
+    ])
+  );
+
+  describe('rules:all user', () => {
+    const checker = new PrivilegeChecker(rulesAll.request, spaceId, security);
+
+    it('can read rules', async () => {
       await expect(checker.canRead('rules')).resolves.toBe(true);
-
-      expect(actionFromRouteTag).toHaveBeenCalledWith(ALERTING_V2_API_PRIVILEGES.rules.read);
-      expect(atSpace).toHaveBeenCalledWith(spaceId, {
-        kibana: [`api:${ALERTING_V2_API_PRIVILEGES.rules.read}`],
-      });
     });
 
-    it('returns false when the user lacks the read privilege', async () => {
-      const { security } = createSecurityMock(false);
-      const checker = new PrivilegeChecker(request, spaceId, security);
-
-      await expect(checker.canRead('rules')).resolves.toBe(false);
+    it('can write rules', async () => {
+      await expect(checker.canWrite('rules')).resolves.toBe(true);
     });
 
-    it('checks the correct privilege for action policies', async () => {
-      const { security, actionFromRouteTag } = createSecurityMock(true);
-      const checker = new PrivilegeChecker(request, spaceId, security);
+    it('cannot read action policies', async () => {
+      await expect(checker.canRead('actionPolicies')).resolves.toBe(false);
+    });
 
-      await checker.canRead('actionPolicies');
+    it('cannot write action policies', async () => {
+      await expect(checker.canWrite('actionPolicies')).resolves.toBe(false);
+    });
 
-      expect(actionFromRouteTag).toHaveBeenCalledWith(
-        ALERTING_V2_API_PRIVILEGES.actionPolicies.read
-      );
+    it('cannot read alerts', async () => {
+      await expect(checker.canRead('alerts')).resolves.toBe(false);
+    });
+
+    it('cannot read execution history', async () => {
+      await expect(checker.canRead('executionHistory')).resolves.toBe(false);
     });
   });
 
-  describe('canWrite', () => {
-    it('checks the write API privilege for the given feature', async () => {
-      const { security, atSpace, actionFromRouteTag } = createSecurityMock(true);
-      const checker = new PrivilegeChecker(request, spaceId, security);
+  describe('rules:read user', () => {
+    const checker = new PrivilegeChecker(rulesRead.request, spaceId, security);
 
-      await expect(checker.canWrite('rules')).resolves.toBe(true);
-
-      expect(actionFromRouteTag).toHaveBeenCalledWith(ALERTING_V2_API_PRIVILEGES.rules.write);
-      expect(atSpace).toHaveBeenCalledWith(spaceId, {
-        kibana: [`api:${ALERTING_V2_API_PRIVILEGES.rules.write}`],
-      });
+    it('can read rules', async () => {
+      await expect(checker.canRead('rules')).resolves.toBe(true);
     });
 
-    it('returns false when the user lacks the write privilege', async () => {
-      const { security } = createSecurityMock(false);
-      const checker = new PrivilegeChecker(request, spaceId, security);
-
+    it('cannot write rules', async () => {
       await expect(checker.canWrite('rules')).resolves.toBe(false);
     });
 
-    it('checks the correct privilege for action policies', async () => {
-      const { security, actionFromRouteTag } = createSecurityMock(true);
-      const checker = new PrivilegeChecker(request, spaceId, security);
+    it('cannot read action policies', async () => {
+      await expect(checker.canRead('actionPolicies')).resolves.toBe(false);
+    });
+  });
 
-      await checker.canWrite('actionPolicies');
+  describe('action_policies:all user', () => {
+    const checker = new PrivilegeChecker(actionPoliciesAll.request, spaceId, security);
 
-      expect(actionFromRouteTag).toHaveBeenCalledWith(
-        ALERTING_V2_API_PRIVILEGES.actionPolicies.write
+    it('can read action policies', async () => {
+      await expect(checker.canRead('actionPolicies')).resolves.toBe(true);
+    });
+
+    it('can write action policies', async () => {
+      await expect(checker.canWrite('actionPolicies')).resolves.toBe(true);
+    });
+
+    it('cannot read rules', async () => {
+      await expect(checker.canRead('rules')).resolves.toBe(false);
+    });
+
+    it('cannot write rules', async () => {
+      await expect(checker.canWrite('rules')).resolves.toBe(false);
+    });
+
+    it('cannot read alerts', async () => {
+      await expect(checker.canRead('alerts')).resolves.toBe(false);
+    });
+
+    it('cannot read execution history', async () => {
+      await expect(checker.canRead('executionHistory')).resolves.toBe(false);
+    });
+  });
+
+  describe('action_policies:read user', () => {
+    const checker = new PrivilegeChecker(actionPoliciesRead.request, spaceId, security);
+
+    it('can read action policies', async () => {
+      await expect(checker.canRead('actionPolicies')).resolves.toBe(true);
+    });
+
+    it('cannot write action policies', async () => {
+      await expect(checker.canWrite('actionPolicies')).resolves.toBe(false);
+    });
+
+    it('cannot read rules', async () => {
+      await expect(checker.canRead('rules')).resolves.toBe(false);
+    });
+  });
+
+  describe('alerts:all user', () => {
+    const checker = new PrivilegeChecker(alertsAll.request, spaceId, security);
+
+    it('can read alerts', async () => {
+      await expect(checker.canRead('alerts')).resolves.toBe(true);
+    });
+
+    it('cannot read rules', async () => {
+      await expect(checker.canRead('rules')).resolves.toBe(false);
+    });
+
+    it('cannot read action policies', async () => {
+      await expect(checker.canRead('actionPolicies')).resolves.toBe(false);
+    });
+
+    it('cannot read execution history', async () => {
+      await expect(checker.canRead('executionHistory')).resolves.toBe(false);
+    });
+  });
+
+  describe('alerts:read user', () => {
+    const checker = new PrivilegeChecker(alertsRead.request, spaceId, security);
+
+    it('can read alerts', async () => {
+      await expect(checker.canRead('alerts')).resolves.toBe(true);
+    });
+
+    it('cannot read rules', async () => {
+      await expect(checker.canRead('rules')).resolves.toBe(false);
+    });
+  });
+
+  describe('execution_history:all user', () => {
+    const checker = new PrivilegeChecker(execHistoryAll.request, spaceId, security);
+
+    it('can read execution history', async () => {
+      await expect(checker.canRead('executionHistory')).resolves.toBe(true);
+    });
+
+    it('cannot read rules', async () => {
+      await expect(checker.canRead('rules')).resolves.toBe(false);
+    });
+
+    it('cannot read action policies', async () => {
+      await expect(checker.canRead('actionPolicies')).resolves.toBe(false);
+    });
+
+    it('cannot read alerts', async () => {
+      await expect(checker.canRead('alerts')).resolves.toBe(false);
+    });
+  });
+
+  describe('execution_history:read user', () => {
+    const checker = new PrivilegeChecker(execHistoryRead.request, spaceId, security);
+
+    it('can read execution history', async () => {
+      await expect(checker.canRead('executionHistory')).resolves.toBe(true);
+    });
+
+    it('cannot read rules', async () => {
+      await expect(checker.canRead('rules')).resolves.toBe(false);
+    });
+  });
+
+  describe('no-access user', () => {
+    const checker = new PrivilegeChecker(noAccess.request, spaceId, security);
+
+    it('cannot read rules', async () => {
+      await expect(checker.canRead('rules')).resolves.toBe(false);
+    });
+
+    it('cannot write rules', async () => {
+      await expect(checker.canWrite('rules')).resolves.toBe(false);
+    });
+
+    it('cannot read action policies', async () => {
+      await expect(checker.canRead('actionPolicies')).resolves.toBe(false);
+    });
+
+    it('cannot write action policies', async () => {
+      await expect(checker.canWrite('actionPolicies')).resolves.toBe(false);
+    });
+
+    it('cannot read alerts', async () => {
+      await expect(checker.canRead('alerts')).resolves.toBe(false);
+    });
+
+    it('cannot read execution history', async () => {
+      await expect(checker.canRead('executionHistory')).resolves.toBe(false);
+    });
+  });
+
+  describe('plumbing', () => {
+    it('passes the correct request to checkPrivilegesWithRequest', async () => {
+      const checker = new PrivilegeChecker(rulesAll.request, spaceId, security);
+      await checker.canRead('rules');
+
+      expect(security.authz.checkPrivilegesWithRequest).toHaveBeenCalledWith(rulesAll.request);
+    });
+
+    it('passes the spaceId to atSpace', async () => {
+      const testRequest = createRequestMock([ALERTING_V2_API_PRIVILEGES.rules.read]);
+      const testSecurity = createSecurity(
+        new Map([[testRequest.request, testRequest.grantedActions]])
       );
+      const checker = new PrivilegeChecker(testRequest.request, spaceId, testSecurity);
+      await checker.canRead('rules');
+
+      const atSpace =
+        testSecurity.authz.checkPrivilegesWithRequest.mock.results[0].value.atSpace;
+      expect(atSpace).toHaveBeenCalledWith(spaceId, expect.any(Object));
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
+import { ALERTING_V2_API_PRIVILEGES } from '../../../../common/feature_privileges';
+import { PrivilegeChecker } from './privilege_checker';
+
+const request = {} as KibanaRequest;
+const spaceId = 'default';
+
+const createSecurityMock = (hasAllRequested: boolean) => {
+  const atSpace = jest.fn().mockResolvedValue({ hasAllRequested });
+  const checkPrivilegesWithRequest = jest.fn().mockReturnValue({ atSpace });
+  const actionFromRouteTag = jest.fn((tag: string) => `api:${tag}`);
+
+  const security = {
+    authz: {
+      actions: { api: { actionFromRouteTag } },
+      checkPrivilegesWithRequest,
+    },
+  } as unknown as SecurityPluginStart;
+
+  return { security, atSpace, actionFromRouteTag };
+};
+
+describe('PrivilegeChecker', () => {
+  describe('canRead', () => {
+    it('checks the read API privilege for the given feature', async () => {
+      const { security, atSpace, actionFromRouteTag } = createSecurityMock(true);
+      const checker = new PrivilegeChecker(request, spaceId, security);
+
+      await expect(checker.canRead('rules')).resolves.toBe(true);
+
+      expect(actionFromRouteTag).toHaveBeenCalledWith(ALERTING_V2_API_PRIVILEGES.rules.read);
+      expect(atSpace).toHaveBeenCalledWith(spaceId, {
+        kibana: [`api:${ALERTING_V2_API_PRIVILEGES.rules.read}`],
+      });
+    });
+
+    it('returns false when the user lacks the read privilege', async () => {
+      const { security } = createSecurityMock(false);
+      const checker = new PrivilegeChecker(request, spaceId, security);
+
+      await expect(checker.canRead('rules')).resolves.toBe(false);
+    });
+
+    it('checks the correct privilege for action policies', async () => {
+      const { security, actionFromRouteTag } = createSecurityMock(true);
+      const checker = new PrivilegeChecker(request, spaceId, security);
+
+      await checker.canRead('actionPolicies');
+
+      expect(actionFromRouteTag).toHaveBeenCalledWith(
+        ALERTING_V2_API_PRIVILEGES.actionPolicies.read
+      );
+    });
+  });
+
+  describe('canWrite', () => {
+    it('checks the write API privilege for the given feature', async () => {
+      const { security, atSpace, actionFromRouteTag } = createSecurityMock(true);
+      const checker = new PrivilegeChecker(request, spaceId, security);
+
+      await expect(checker.canWrite('rules')).resolves.toBe(true);
+
+      expect(actionFromRouteTag).toHaveBeenCalledWith(ALERTING_V2_API_PRIVILEGES.rules.write);
+      expect(atSpace).toHaveBeenCalledWith(spaceId, {
+        kibana: [`api:${ALERTING_V2_API_PRIVILEGES.rules.write}`],
+      });
+    });
+
+    it('returns false when the user lacks the write privilege', async () => {
+      const { security } = createSecurityMock(false);
+      const checker = new PrivilegeChecker(request, spaceId, security);
+
+      await expect(checker.canWrite('rules')).resolves.toBe(false);
+    });
+
+    it('checks the correct privilege for action policies', async () => {
+      const { security, actionFromRouteTag } = createSecurityMock(true);
+      const checker = new PrivilegeChecker(request, spaceId, security);
+
+      await checker.canWrite('actionPolicies');
+
+      expect(actionFromRouteTag).toHaveBeenCalledWith(
+        ALERTING_V2_API_PRIVILEGES.actionPolicies.write
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.test.ts
@@ -278,8 +278,7 @@ describe('PrivilegeChecker', () => {
       const checker = new PrivilegeChecker(testRequest.request, spaceId, testSecurity);
       await checker.canRead('rules');
 
-      const atSpace =
-        testSecurity.authz.checkPrivilegesWithRequest.mock.results[0].value.atSpace;
+      const atSpace = testSecurity.authz.checkPrivilegesWithRequest.mock.results[0].value.atSpace;
       expect(atSpace).toHaveBeenCalledWith(spaceId, expect.any(Object));
     });
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/privilege_checker/privilege_checker.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PluginStart } from '@kbn/core-di';
+import { Request } from '@kbn/core-di-server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
+import { inject, injectable } from 'inversify';
+import {
+  ALERTING_V2_API_PRIVILEGES,
+  type AlertingV2Feature,
+  type WritableAlertingV2Feature,
+} from '../../../../common/feature_privileges';
+import type { AlertingServerStartDependencies } from '../../../types';
+import { RequestSpaceIdToken } from '../spaces_service/tokens';
+
+@injectable()
+export class PrivilegeChecker {
+  constructor(
+    @inject(Request) private readonly request: KibanaRequest,
+    @inject(RequestSpaceIdToken) private readonly spaceId: string,
+    @inject(PluginStart<AlertingServerStartDependencies['security']>('security'))
+    private readonly security: SecurityPluginStart
+  ) {}
+
+  public async canRead(feature: AlertingV2Feature): Promise<boolean> {
+    return this.hasApiPrivileges(ALERTING_V2_API_PRIVILEGES[feature].read);
+  }
+
+  public async canWrite(feature: WritableAlertingV2Feature): Promise<boolean> {
+    return this.hasApiPrivileges(ALERTING_V2_API_PRIVILEGES[feature].write);
+  }
+
+  private async hasApiPrivileges(...actions: string[]): Promise<boolean> {
+    const kibana = actions.map((a) => this.security.authz.actions.api.actionFromRouteTag(a));
+    const { hasAllRequested } = await this.security.authz
+      .checkPrivilegesWithRequest(this.request)
+      .atSpace(this.spaceId, { kibana });
+    return hasAllRequested;
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -103,6 +103,7 @@ import {
   WorkflowsManagementApiToken,
 } from '../lib/dispatcher/steps/dispatch_step_tokens';
 import { MatcherSuggestionsService } from '../lib/services/matcher_suggestions_service/matcher_suggestions_service';
+import { PrivilegeChecker } from '../lib/services/privilege_checker/privilege_checker';
 import type { AlertingServerSetupDependencies, AlertingServerStartDependencies } from '../types';
 
 export function bindServices({ bind }: ContainerModuleLoadOptions) {
@@ -330,6 +331,7 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
     .inSingletonScope();
 
   bind(MatcherSuggestionsService).toSelf().inRequestScope();
+  bind(PrivilegeChecker).toSelf().inRequestScope();
 
   bind(DispatcherService).toSelf().inSingletonScope();
   bind(DispatcherServiceInternalToken).toService(DispatcherService);

--- a/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
@@ -134,7 +134,9 @@
     "@kbn/content-list-provider",
     "@kbn/content-list-toolbar",
     "@kbn/es",
-    "@kbn/test-es-server"
+    "@kbn/test-es-server",
+    "@kbn/security-authorization-core",
+    "@kbn/security-plugin-types-server"
   ],
   "exclude": ["target/**/*", ".storybook/**/*.js"]
 }


### PR DESCRIPTION
## Summary

Introduces a DI-injected `PrivilegeChecker` service for Alerting V2 that encapsulates Kibana security privilege checks behind a clean `canRead(feature)` / `canWrite(feature)` API.

This is intended for use by backend components that aren't accessed via a dedicated alerting v2 api, such as agent builder tools. 

While all these resources are still ultimately blocked at the SO or ES level, my intention here is have an early check where I can provide helpful human readible in the tool response that the agent can then present back to the user. 

- **`PrivilegeChecker` service** — request-scoped, injected via `@inject(Request)`, `@inject(RequestSpaceIdToken)`, and `@inject(PluginStart('security'))`. Calls `security.authz.actions.api.actionFromRouteTag()` instead of the deprecated single-arg `actions.api.get()` overload.
- **`ApiPrivileges` migration** — updates `ALERTING_V2_API_PRIVILEGES` to use `ApiPrivileges.read()` / `ApiPrivileges.manage()` for consistent `operation_subject` format that aligns with `actionFromRouteTag`.
- **`WritableAlertingV2Feature` type** — compile-time filter that restricts `canWrite()` to features that actually have write privileges.
- **`getAlertingPrivilegeDisplayName` helper** — returns user-facing labels like "Rules: All" for privilege-related error messages.
- **DI registration** — registered as `.inRequestScope()` in `bind_services.ts`.

This PR introduces the service only; integration with Agent Builder tools will follow in a separate PR.

## Test plan

- [x] Unit tests for `PrivilegeChecker.canRead()` and `canWrite()` (authorized, unauthorized, per-feature)
- [ ] CI passes (types, lint, Jest)

Made with [Cursor](https://cursor.com)