### PR TITLE
[9.5] [Lens as code] Fix bucket terms operation schema to support both string and numeric values in `includes`/`excludes` (#282752)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -76762,11 +76762,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -76786,11 +76791,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -87528,11 +87538,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -87552,11 +87567,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -92151,11 +92171,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -92175,11 +92200,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -92375,11 +92405,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -92399,11 +92434,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -96577,11 +96617,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -96601,11 +96646,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -98054,11 +98104,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -98078,11 +98133,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -101866,11 +101926,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -101890,11 +101955,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -102710,11 +102780,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -102734,11 +102809,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -105218,11 +105298,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -105242,11 +105327,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -107605,11 +107695,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -107629,11 +107724,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -109584,11 +109684,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -109608,11 +109713,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -101946,11 +101946,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -101970,11 +101975,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -115020,11 +115020,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -115044,11 +115049,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -89836,11 +89836,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -89860,11 +89865,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -100602,11 +100612,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -100626,11 +100641,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -105225,11 +105245,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -105249,11 +105274,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -105449,11 +105479,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -105473,11 +105508,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -109651,11 +109691,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -109675,11 +109720,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -111128,11 +111178,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -111152,11 +111207,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -114940,11 +115000,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -114964,11 +115029,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -115784,11 +115854,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -115808,11 +115883,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -118292,11 +118372,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -118316,11 +118401,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -120679,11 +120769,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -120703,11 +120798,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:
@@ -122658,11 +122758,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to exclude.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to exclude.
           required:
             - values
         fields:
@@ -122682,11 +122787,16 @@ components:
               description: When `true`, treats the values as regular expressions.
               type: boolean
             values:
-              items:
-                description: Values to include.
-                type: string
-              maxItems: 100
-              type: array
+              anyOf:
+                - items:
+                    type: string
+                  maxItems: 100
+                  type: array
+                - items:
+                    type: number
+                  maxItems: 100
+                  type: array
+              description: Values to include.
           required:
             - values
         increase_accuracy:

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
@@ -231,12 +231,15 @@ export const bucketTermsOperationSchema = schema.object(
     includes: schema.maybe(
       schema.object({
         // A terms field is either string- or number-typed, so values are homogeneous.
-        values: schema.oneOf([
-          schema.arrayOf(schema.string(), { maxSize: 100 }),
-          schema.arrayOf(schema.number(), { maxSize: 100 }),
-        ], {
-          meta: { description: 'Values to include.' },
-        }),
+        values: schema.oneOf(
+          [
+            schema.arrayOf(schema.string(), { maxSize: 100 }),
+            schema.arrayOf(schema.number(), { maxSize: 100 }),
+          ],
+          {
+            meta: { description: 'Values to include.' },
+          }
+        ),
         as_regex: schema.maybe(
           schema.boolean({
             meta: {
@@ -251,12 +254,15 @@ export const bucketTermsOperationSchema = schema.object(
      */
     excludes: schema.maybe(
       schema.object({
-        values: schema.oneOf([
-          schema.arrayOf(schema.string(), { maxSize: 100 }),
-          schema.arrayOf(schema.number(), { maxSize: 100 }),
-        ], {
-          meta: { description: 'Values to exclude.' },
-        }),
+        values: schema.oneOf(
+          [
+            schema.arrayOf(schema.string(), { maxSize: 100 }),
+            schema.arrayOf(schema.number(), { maxSize: 100 }),
+          ],
+          {
+            meta: { description: 'Values to exclude.' },
+          }
+        ),
         as_regex: schema.maybe(
           schema.boolean({
             meta: {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
@@ -230,14 +230,13 @@ export const bucketTermsOperationSchema = schema.object(
      */
     includes: schema.maybe(
       schema.object({
-        values: schema.arrayOf(
-          schema.string({
-            meta: {
-              description: 'Values to include.',
-            },
-          }),
-          { maxSize: 100 }
-        ),
+        // A terms field is either string- or number-typed, so values are homogeneous.
+        values: schema.oneOf([
+          schema.arrayOf(schema.string(), { maxSize: 100 }),
+          schema.arrayOf(schema.number(), { maxSize: 100 }),
+        ], {
+          meta: { description: 'Values to include.' },
+        }),
         as_regex: schema.maybe(
           schema.boolean({
             meta: {
@@ -252,14 +251,12 @@ export const bucketTermsOperationSchema = schema.object(
      */
     excludes: schema.maybe(
       schema.object({
-        values: schema.arrayOf(
-          schema.string({
-            meta: {
-              description: 'Values to exclude.',
-            },
-          }),
-          { maxSize: 100 }
-        ),
+        values: schema.oneOf([
+          schema.arrayOf(schema.string(), { maxSize: 100 }),
+          schema.arrayOf(schema.number(), { maxSize: 100 }),
+        ], {
+          meta: { description: 'Values to exclude.' },
+        }),
         as_regex: schema.maybe(
           schema.boolean({
             meta: {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.test.ts
@@ -102,6 +102,20 @@ describe('Top Values Transforms', () => {
       expect(result.params.excludeIsRegex).toBe(false);
     });
 
+    it('should preserve numeric includes and excludes verbatim', () => {
+      const input: LensApiTermsOperation = {
+        operation: 'terms',
+        fields: ['destination.port'],
+        limit: 5,
+        includes: { as_regex: false, values: [443] },
+        excludes: { as_regex: false, values: [22, 23, 53] },
+      };
+
+      const result = fromTermsLensApiToLensState(input, getMetricColumnIdByIndex);
+      expect(result.params.include).toEqual([443]);
+      expect(result.params.exclude).toEqual([22, 23, 53]);
+    });
+
     it('should handle orderBy column type', () => {
       const input: LensApiTermsOperation = {
         operation: 'terms',
@@ -358,6 +372,35 @@ describe('Top Values Transforms', () => {
         as_regex: false,
         values: ['inactive'],
       });
+    });
+
+    it('should emit numeric includes and excludes without stringifying them', () => {
+      const input: TermsIndexPatternColumn = {
+        operationType: 'terms',
+        sourceField: 'destination.port',
+        customLabel: false,
+        label: 'Top 5 values for destination.port',
+        isBucketed: true,
+        dataType: 'number',
+        params: {
+          secondaryFields: [],
+          size: 5,
+          accuracyMode: false,
+          include: [443],
+          includeIsRegex: false,
+          exclude: [22, 23, 53],
+          excludeIsRegex: false,
+          otherBucket: false,
+          missingBucket: false,
+          orderBy: { type: 'alphabetical' },
+          orderDirection: 'asc',
+          parentFormat: { id: 'terms' },
+        },
+      };
+
+      const result = fromTermsLensStateToAPI(input, columns);
+      expect(result.includes).toEqual({ as_regex: false, values: [443] });
+      expect(result.excludes).toEqual({ as_regex: false, values: [22, 23, 53] });
     });
 
     it('should handle orderBy column type', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/top_values.ts
@@ -116,13 +116,10 @@ export function fromTermsLensApiToLensState(
       size: limit, // it cannot be 0 (zero)
       ...(increase_accuracy != null ? { accuracyMode: increase_accuracy } : {}),
       ...(includes?.values
-        ? { include: includes?.values, includeIsRegex: includes?.as_regex ?? false }
+        ? { include: includes.values, includeIsRegex: includes?.as_regex ?? false }
         : {}),
       ...(excludes?.values
-        ? {
-            exclude: excludes.values,
-            excludeIsRegex: excludes?.as_regex ?? false,
-          }
+        ? { exclude: excludes.values, excludeIsRegex: excludes?.as_regex ?? false }
         : {}),
       ...(other_bucket != null ? { otherBucket: true } : {}),
       ...(other_bucket?.include_documents_without_field != null
@@ -286,7 +283,10 @@ export function fromTermsLensStateToAPI(
       ? {
           includes: {
             as_regex: column.params.includeIsRegex,
-            values: column.params.include?.map((value) => String(value)) || [],
+            // Preserve the value type verbatim: numeric fields store numbers and the runtime terms
+            // agg drops stringified numbers at render (`migrateIncludeExcludeFormat` filters with
+            // `Number.isFinite`), so coercing to strings would silently lose the include filter.
+            values: column.params.include ?? [],
           },
         }
       : {}),
@@ -294,7 +294,10 @@ export function fromTermsLensStateToAPI(
       ? {
           excludes: {
             as_regex: column.params.excludeIsRegex,
-            values: column.params.exclude?.map((value) => String(value)) || [],
+            // Preserve the value type verbatim: numeric fields store numbers and the runtime terms
+            // agg drops stringified numbers at render (`migrateIncludeExcludeFormat` filters with
+            // `Number.isFinite`), so coercing to strings would silently lose the exclude filter.
+            values: column.params.exclude ?? [],
           },
         }
       : {}),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Lens as code] Fix bucket terms operation schema to support both string and numeric values in `includes`/`excludes` (#282752)](https://github.com/elastic/kibana/pull/282752)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"andreana.malama@elastic.co"},"sourceCommit":{"committedDate":"2026-08-05T10:05:50Z","message":"[Lens as code] Fix bucket terms operation schema to support both string and numeric values in `includes`/`excludes` (#282752)\n\nPart of #282534\n\n## Summary\nTerms includes / excludes values were string-only in the API schema and\ncould be stringified on round-trip. Numeric fields (e.g. ports) then\nfailed at render because finite numbers were dropped.\n\n## Changes\n\n- Schema: `includes.values` / `excludes.values` accept `string[]` or\n`number[]` (homogeneous).\n- Transform: pass values through verbatim both ways.\n- Unit tests for numeric include/exclude preserve + emit.\n\nNot a breaking change: existing `string` arrays remain valid. This only\nwidens the schema (additive union) and stops coercing numbers to strings\n— no previously accepted payload is rejected, and string-field callers\nare unchanged.\n\n## Release Notes\n\nFixed Lens as-code terms include/exclude to preserve numeric values\ninstead of stringifying them.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore: \n\n<img width=\"2541\" height=\"1201\" alt=\"Screenshot 2026-08-04 at 7 09\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/00aaaa33-7c3d-4866-9cac-2e5b4e6601e3\"\n/>\n\n\nAfter:\n\n<img width=\"2546\" height=\"1195\" alt=\"Screenshot 2026-08-04 at 7 01\n04 PM\"\nsrc=\"https://github.com/user-attachments/assets/206684c9-bfc7-4a2e-ae4a-0a12b477a159\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d2d328edd788da8ff6ac8dd00d16dc24af20ad5c","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:version","v9.6.0","v9.5.1"],"title":"[Lens as code] Fix bucket terms operation schema to support both string and numeric values in `includes`/`excludes`","number":282752,"url":"https://github.com/elastic/kibana/pull/282752","mergeCommit":{"message":"[Lens as code] Fix bucket terms operation schema to support both string and numeric values in `includes`/`excludes` (#282752)\n\nPart of #282534\n\n## Summary\nTerms includes / excludes values were string-only in the API schema and\ncould be stringified on round-trip. Numeric fields (e.g. ports) then\nfailed at render because finite numbers were dropped.\n\n## Changes\n\n- Schema: `includes.values` / `excludes.values` accept `string[]` or\n`number[]` (homogeneous).\n- Transform: pass values through verbatim both ways.\n- Unit tests for numeric include/exclude preserve + emit.\n\nNot a breaking change: existing `string` arrays remain valid. This only\nwidens the schema (additive union) and stops coercing numbers to strings\n— no previously accepted payload is rejected, and string-field callers\nare unchanged.\n\n## Release Notes\n\nFixed Lens as-code terms include/exclude to preserve numeric values\ninstead of stringifying them.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore: \n\n<img width=\"2541\" height=\"1201\" alt=\"Screenshot 2026-08-04 at 7 09\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/00aaaa33-7c3d-4866-9cac-2e5b4e6601e3\"\n/>\n\n\nAfter:\n\n<img width=\"2546\" height=\"1195\" alt=\"Screenshot 2026-08-04 at 7 01\n04 PM\"\nsrc=\"https://github.com/user-attachments/assets/206684c9-bfc7-4a2e-ae4a-0a12b477a159\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d2d328edd788da8ff6ac8dd00d16dc24af20ad5c"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282752","number":282752,"mergeCommit":{"message":"[Lens as code] Fix bucket terms operation schema to support both string and numeric values in `includes`/`excludes` (#282752)\n\nPart of #282534\n\n## Summary\nTerms includes / excludes values were string-only in the API schema and\ncould be stringified on round-trip. Numeric fields (e.g. ports) then\nfailed at render because finite numbers were dropped.\n\n## Changes\n\n- Schema: `includes.values` / `excludes.values` accept `string[]` or\n`number[]` (homogeneous).\n- Transform: pass values through verbatim both ways.\n- Unit tests for numeric include/exclude preserve + emit.\n\nNot a breaking change: existing `string` arrays remain valid. This only\nwidens the schema (additive union) and stops coercing numbers to strings\n— no previously accepted payload is rejected, and string-field callers\nare unchanged.\n\n## Release Notes\n\nFixed Lens as-code terms include/exclude to preserve numeric values\ninstead of stringifying them.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore: \n\n<img width=\"2541\" height=\"1201\" alt=\"Screenshot 2026-08-04 at 7 09\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/00aaaa33-7c3d-4866-9cac-2e5b4e6601e3\"\n/>\n\n\nAfter:\n\n<img width=\"2546\" height=\"1195\" alt=\"Screenshot 2026-08-04 at 7 01\n04 PM\"\nsrc=\"https://github.com/user-attachments/assets/206684c9-bfc7-4a2e-ae4a-0a12b477a159\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d2d328edd788da8ff6ac8dd00d16dc24af20ad5c"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->