### PR TITLE
[CPS] Fix APM client defaulting to 'space' routing when CPS header is missing

### DIFF
--- a/src/platform/packages/shared/kbn-ebt-click/constants.ts
+++ b/src/platform/packages/shared/kbn-ebt-click/constants.ts
@@ -52,6 +52,8 @@ export const EBT_CLICK_ACTIONS = {
   VIEW_ANOMALIES: 'viewAnomalies',
   /** User intends to open an actions menu to explore available actions. */
   OPEN_ACTIONS: 'openActions',
+  /** User intends to add data to their (empty) cluster. Commonly used from empty data prompts and similar components */
+  ADD_DATA: 'addData',
 } as const;
 
 /**

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
@@ -27,6 +27,7 @@ type StreamsDetailAdvancedPageId = 'streams_detail_advanced';
 type StreamsDetailAttachmentsPageId = 'streams_detail_attachments';
 type StreamsDetailReferencesPageId = 'streams_detail_references';
 type SyntheticsPageId = 'synthetics';
+type ObsOverviewPageId = 'observability_overview';
 
 export type Key =
   | `${AlertDetailsPageId}`
@@ -48,6 +49,7 @@ export type Key =
   | `${StreamsDetailAdvancedPageId}`
   | `${StreamsDetailAttachmentsPageId}`
   | `${StreamsDetailReferencesPageId}`
-  | `${SyntheticsPageId}`;
+  | `${SyntheticsPageId}`
+  | `${ObsOverviewPageId}`;
 
 export type DescriptionWithPrefix = `[ttfmp_${Key}] ${string}`;

--- a/src/platform/packages/shared/kbn-edot-collector/src/get_edot_collector_configuration.ts
+++ b/src/platform/packages/shared/kbn-edot-collector/src/get_edot_collector_configuration.ts
@@ -72,6 +72,9 @@ export function getEdotCollectorConfig({
         flush: {
           interval: '1s',
         },
+        tls: {
+          insecure_skip_verify: true,
+        },
       },
     },
     service: {

--- a/src/platform/packages/shared/kbn-edot-collector/src/get_edot_collector_configuration.ts
+++ b/src/platform/packages/shared/kbn-edot-collector/src/get_edot_collector_configuration.ts
@@ -72,9 +72,6 @@ export function getEdotCollectorConfig({
         flush: {
           interval: '1s',
         },
-        tls: {
-          insecure_skip_verify: true,
-        },
       },
     },
     service: {

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_apm_event_client.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_apm_event_client.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, CoreStart } from '@kbn/core/server';
+import type { ClusterClientMock } from '@kbn/core/server/mocks';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { APMIndices } from '@kbn/apm-sources-access-plugin/server';
+import { getApmEventClient } from './get_apm_event_client';
+import type { MinimalAPMRouteHandlerResources } from '../../routes/apm_routes/register_apm_server_routes';
+
+const apmIndices = {
+  transaction: 'traces-apm*',
+  span: 'traces-apm*',
+  metric: 'metrics-apm*',
+  error: 'logs-apm*',
+} as APMIndices;
+
+describe('getApmEventClient', () => {
+  let coreStart: ReturnType<typeof coreMock.createStart>;
+
+  beforeEach(() => {
+    coreStart = coreMock.createStart();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('scopes the Elasticsearch client without space CPS project routing', async () => {
+    // No `x-project-routing` header → getProjectRoutingFromRequest returns undefined
+    const request = httpServerMock.createKibanaRequest({ headers: {} });
+
+    await getApmEventClient({
+      request,
+      context: coreMock.createCustomRequestHandlerContext(
+        {}
+      ) as unknown as MinimalAPMRouteHandlerResources['context'],
+      core: { setup: {} as CoreSetup, start: async () => coreStart as unknown as CoreStart },
+      params: { query: { _inspect: false } },
+      getApmIndices: jest.fn().mockResolvedValue(apmIndices),
+    });
+
+    const { asScoped } = coreStart.elasticsearch.client as ClusterClientMock;
+    expect(asScoped).toHaveBeenCalledTimes(1);
+    expect(asScoped).toHaveBeenCalledWith(request);
+    // Regression guard: no AsScopedOptions second argument
+    expect(asScoped.mock.calls[0]).toHaveLength(1);
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_apm_event_client.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_apm_event_client.ts
@@ -41,15 +41,11 @@ export async function getApmEventClient({
       core.start(),
     ]);
 
-    const headerProjectRouting = getProjectRoutingFromRequest(request);
-    const elasticsearchClusterClient = coreStart.elasticsearch.client;
-    // Rule UIs may omit `x-project-routing`; align with alerting by using the space NPRE when absent.
-    const scopedClusterClient = headerProjectRouting
-      ? elasticsearchClusterClient.asScoped(request)
-      : elasticsearchClusterClient.asScoped(request, { projectRouting: 'space' });
+    const projectRouting = getProjectRoutingFromRequest(request);
+    const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
 
     return new APMEventClient({
-      esClient: scopedClusterClient.asCurrentUser,
+      esClient,
       debug: params.query._inspect,
       request,
       indices,
@@ -57,7 +53,7 @@ export async function getApmEventClient({
         includeFrozen: uiSettings.includeFrozen,
         excludedDataTiers: uiSettings.excludedDataTiers,
         inspectableEsQueriesMap,
-        projectRouting: headerProjectRouting,
+        projectRouting,
       },
     });
   });

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/overview.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/overview.tsx
@@ -25,6 +25,7 @@ import React, { useEffect, useMemo } from 'react';
 import type { ObservabilityOnboardingLocatorParams } from '@kbn/deeplinks-observability';
 import { OBSERVABILITY_ONBOARDING_LOCATOR } from '@kbn/deeplinks-observability';
 import { usePageReady } from '@kbn/ebt-tools';
+import { EBT_CLICK_ACTIONS, getEbtProps } from '@kbn/ebt-click';
 import { LoadingObservability } from '../../components/loading_observability';
 import { useDatePickerContext } from '../../hooks/use_date_picker_context';
 import { useHasData } from '../../hooks/use_has_data';
@@ -232,6 +233,10 @@ export function OverviewPage() {
               color="primary"
               fill
               href={onboardingHref}
+              {...getEbtProps({
+                action: EBT_CLICK_ACTIONS.ADD_DATA,
+                element: 'obsOverviewPageEmptyPrompt',
+              })}
             >
               {i18n.translate('xpack.observability.overview.emptyState.action', {
                 defaultMessage: 'Add data',

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/overview.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/overview.tsx
@@ -159,7 +159,7 @@ export function OverviewPage() {
     },
     customMetrics: {
       key1: 'hasAnyData',
-      value1: hasAnyData ? 0 : 1,
+      value1: hasAnyData ? 1 : 0,
     },
   });
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/overview.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/overview.tsx
@@ -24,6 +24,7 @@ import {
 import React, { useEffect, useMemo } from 'react';
 import type { ObservabilityOnboardingLocatorParams } from '@kbn/deeplinks-observability';
 import { OBSERVABILITY_ONBOARDING_LOCATOR } from '@kbn/deeplinks-observability';
+import { usePageReady } from '@kbn/ebt-tools';
 import { LoadingObservability } from '../../components/loading_observability';
 import { useDatePickerContext } from '../../hooks/use_date_picker_context';
 import { useHasData } from '../../hooks/use_has_data';
@@ -134,7 +135,7 @@ export function OverviewPage() {
     });
   }, [appsWithoutData, hasData, setScreenContext]);
 
-  const { absoluteStart, absoluteEnd } = useDatePickerContext();
+  const { absoluteStart, absoluteEnd, relativeStart, relativeEnd } = useDatePickerContext();
 
   const timeBuckets = useTimeBuckets();
   const bucketSize = useMemo(
@@ -146,6 +147,20 @@ export function OverviewPage() {
       }),
     [absoluteStart, absoluteEnd, timeBuckets]
   );
+
+  usePageReady({
+    isReady: isAllRequestsComplete,
+    isRefreshing: !isAllRequestsComplete,
+    meta: {
+      rangeFrom: relativeStart,
+      rangeTo: relativeEnd,
+      description: '[ttfmp_observability_overview] The Observability Overview page has loaded.',
+    },
+    customMetrics: {
+      key1: 'hasAnyData',
+      value1: hasAnyData ? 0 : 1,
+    },
+  });
 
   if (!hasAnyData && !isAllRequestsComplete) {
     return <LoadingObservability />;


### PR DESCRIPTION
## Summary

Among other things, https://github.com/elastic/kibana/pull/262723 introduced a mechanism for the APM event client to default to `space` project routing when the `X-Project-Routing` header is missing. This was introduced to fix some issues that popped up when APM didn't have proper CPS support. Other apps that were introducing CPS, when using APM data, would see they were unable to query linked project data. This approach worked then because it would force APM to assume it needed to use CPS whenever and wherever it couldn't handle it properly. Now that APM officially supports CPS, this workaround isn't really required anymore.

Nevertheless, the real reason this PR removes it is not that is redundant now but that it actually leads to incorrect behaviour in pages that do not support CPS on purpose. In these cases, the `X-Project-Routing` header is not provided because the page is not CPS aware. Problem is, while the page doesn't support CPS and the CPS selector in the UI would say that only data from the local project is being fetched, the fallback behaviour on the APM client would trigger and it would apply the space NPRE expression. This issue was discovered in the Observability overview page. While the page isn't meant to fetch CPS data, the APM section ("Service inventory" in the UI) would get populated, while other sections would remain hidden as they were only querying local data.

<img width="2560" height="1330" alt="Screenshot 2026-08-05 at 13 05 25" src="https://github.com/user-attachments/assets/17947819-7daf-440a-869c-fcbea456213b" />

After the fix introduced here, because APM now respects the provided `X-Project-Routing` value and won't assume `space` routing anymore, the page now properly avoids linked APM data as intended.

### Page ready metrics

While this breaks the single feature per PR, I've taken the liberty of adding `usePageReady` metrics to the observability overview page. This issue was discovered while I was working on CPS performance testing, so adding this will ensure a single update of the test environment covers both this fix and the required instrumentation for proper performance measurements

## Testing
The problems mentioned in these issues:
- https://github.com/elastic/kibana/issues/262333
- https://github.com/elastic/kibana/issues/256211
- https://github.com/elastic/kibana/issues/256072
- https://github.com/elastic/kibana/issues/256190

Should not be reproducible