### PR TITLE
[Cases] Fix $ref fields silently dropping local display/validation overrides

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.test.ts
@@ -7,9 +7,11 @@
 
 import {
   ConditionRuleSchema,
+  FieldSchema,
   InputTextFieldSchema,
   MarkdownFieldSchema,
   RadioGroupFieldSchema,
+  RefFieldSchema,
   TextareaFieldSchema,
   ToggleFieldSchema,
 } from './fields';
@@ -290,6 +292,46 @@ describe('ToggleFieldSchema', () => {
       metadata: { default: 'true' },
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe('RefFieldSchema — display/validation overrides', () => {
+  const showWhen = {
+    combine: 'all' as const,
+    rules: [{ field: 'open_tuning_request', operator: 'eq' as const, value: true }],
+  };
+
+  it('preserves a local display.show_when override authored alongside $ref', () => {
+    const result = RefFieldSchema.safeParse({
+      $ref: 'tuning_request_detail',
+      display: { show_when: showWhen },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.display?.show_when).toEqual(showWhen);
+    }
+  });
+
+  it('preserves a local validation.required_when override authored alongside $ref', () => {
+    const result = RefFieldSchema.safeParse({
+      $ref: 'tuning_request_detail',
+      validation: { required_when: showWhen },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.validation?.required_when).toEqual(showWhen);
+    }
+  });
+
+  it('resolves a $ref entry with display through the top-level FieldSchema union', () => {
+    const result = FieldSchema.safeParse({
+      $ref: 'tuning_request_detail',
+      display: { show_when: showWhen },
+    });
+    expect(result.success).toBe(true);
+    if (result.success && '$ref' in result.data) {
+      expect(result.data.display?.show_when).toEqual(showWhen);
+    }
   });
 });
 

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
@@ -258,11 +258,15 @@ export const RadioGroupFieldSchema = BaseFieldSchema.extend({
  * migration emits for a legacy template custom field whose value was explicitly cleared.
  *
  * `display` and `validation` are optional per-template overrides (e.g. `show_when`,
- * `required_when`) — a library field has no inherent visibility/requirement rules of its own in
- * a given template, so when present here they fully replace (not merge with) anything the
- * library field itself declares. Without declaring these here, they would be silently stripped
- * by Zod when a `$ref` entry authored a local `display`/`validation` block, which is what made
- * conditional visibility appear to be broken for `$ref` fields (see `applyRefFieldOverride`).
+ * `required_when`). `display` fully replaces the library field's own `display` when present
+ * (its only key is `show_when`). `validation` is instead merged onto the library field's own
+ * `validation` — a template that only wants to change requiredness keeps the library's format
+ * constraints (`pattern`/`min`/`max`/etc.), though the `required`/`required_when`/
+ * `required_on_close` family is swapped as a unit rather than merged key-by-key (see
+ * `mergeValidationOverride`). Without declaring `display`/`validation` here at all, they would be
+ * silently stripped by Zod when a `$ref` entry authored a local `display`/`validation` block,
+ * which is what made conditional visibility appear to be broken for `$ref` fields (see
+ * `applyRefFieldOverride`).
  */
 export const RefFieldSchema = z.object({
   name: z.string().optional(),

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
@@ -256,6 +256,13 @@ export const RadioGroupFieldSchema = BaseFieldSchema.extend({
  * field" (do not inherit the library default; the field stays empty), whereas an absent
  * `metadata.default` inherits the library field's default. This is what the v1→v2 template
  * migration emits for a legacy template custom field whose value was explicitly cleared.
+ *
+ * `display` and `validation` are optional per-template overrides (e.g. `show_when`,
+ * `required_when`) — a library field has no inherent visibility/requirement rules of its own in
+ * a given template, so when present here they fully replace (not merge with) anything the
+ * library field itself declares. Without declaring these here, they would be silently stripped
+ * by Zod when a `$ref` entry authored a local `display`/`validation` block, which is what made
+ * conditional visibility appear to be broken for `$ref` fields (see `applyRefFieldOverride`).
  */
 export const RefFieldSchema = z.object({
   name: z.string().optional(),
@@ -274,6 +281,8 @@ export const RefFieldSchema = z.object({
         .optional(),
     })
     .optional(),
+  display: DisplaySchema.optional(),
+  validation: ValidationSchema.optional(),
 });
 
 export type RefField = z.infer<typeof RefFieldSchema>;

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
@@ -154,6 +154,33 @@ describe('template field key utils', () => {
       });
       expect(result.metadata?.default).toBeUndefined();
     });
+
+    const showWhen = {
+      combine: 'all' as const,
+      rules: [{ field: 'toggle_field', operator: 'eq' as const, value: true }],
+    };
+
+    it('applies a local display.show_when override onto a $ref field', () => {
+      const result = applyRefFieldOverride(libField, {
+        $ref: 'lib_field',
+        display: { show_when: showWhen },
+      });
+      expect(result.display?.show_when).toEqual(showWhen);
+    });
+
+    it('applies a local validation.required_when override onto a $ref field', () => {
+      const result = applyRefFieldOverride(libField, {
+        $ref: 'lib_field',
+        validation: { required_when: showWhen },
+      });
+      expect(result.validation?.required_when).toEqual(showWhen);
+    });
+
+    it('leaves display/validation untouched when the $ref has no override', () => {
+      const result = applyRefFieldOverride(libField, { $ref: 'lib_field' });
+      expect(result.display).toBeUndefined();
+      expect(result.validation).toBeUndefined();
+    });
   });
 
   describe('resolveTemplateFields', () => {
@@ -201,6 +228,16 @@ describe('template field key utils', () => {
     it('drops a $ref that cannot be resolved in the library', () => {
       const ref: RefField = { $ref: 'unknown' };
       expect(resolveTemplateFields([ref], libDefs)).toEqual([]);
+    });
+
+    it('preserves a local display.show_when authored on a $ref entry (regression: previously silently dropped)', () => {
+      const showWhen = {
+        combine: 'all' as const,
+        rules: [{ field: 'open_tuning_request', operator: 'eq' as const, value: true }],
+      };
+      const ref: RefField = { $ref: 'lib_text', display: { show_when: showWhen } };
+      const [resolved] = resolveTemplateFields([ref], libDefs);
+      expect(resolved.display?.show_when).toEqual(showWhen);
     });
 
     it('produces an empty extended-fields default for a null-cleared $ref', () => {

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
@@ -181,6 +181,69 @@ describe('template field key utils', () => {
       expect(result.display).toBeUndefined();
       expect(result.validation).toBeUndefined();
     });
+
+    describe('validation merge', () => {
+      const libFieldWithValidation: InlineField = {
+        ...libField,
+        validation: {
+          required: true,
+          pattern: { regex: '^[a-z]+$' },
+          min_length: 2,
+          max_length: 10,
+        },
+      };
+
+      it('preserves the library format constraints when the override only sets an unrelated key', () => {
+        const result = applyRefFieldOverride(libFieldWithValidation, {
+          $ref: 'lib_field',
+          validation: { max_length: 20 },
+        });
+        expect(result.validation).toEqual({
+          required: true,
+          pattern: { regex: '^[a-z]+$' },
+          min_length: 2,
+          max_length: 20,
+        });
+      });
+
+      it('drops the library required-family keys when the override defines a different required* key', () => {
+        const result = applyRefFieldOverride(libFieldWithValidation, {
+          $ref: 'lib_field',
+          validation: { required_when: showWhen },
+        });
+        expect(result.validation).toEqual({
+          required_when: showWhen,
+          pattern: { regex: '^[a-z]+$' },
+          min_length: 2,
+          max_length: 10,
+        });
+        expect(result.validation?.required).toBeUndefined();
+      });
+
+      it('drops the library required-family keys even when the override sets required_on_close only', () => {
+        const result = applyRefFieldOverride(libFieldWithValidation, {
+          $ref: 'lib_field',
+          validation: { required_on_close: true },
+        });
+        expect(result.validation?.required).toBeUndefined();
+        expect(result.validation?.required_when).toBeUndefined();
+        expect(result.validation?.required_on_close).toBe(true);
+        expect(result.validation?.pattern).toEqual({ regex: '^[a-z]+$' });
+      });
+
+      it('lets the override redeclare required alongside other required* keys unchanged by it', () => {
+        const result = applyRefFieldOverride(libFieldWithValidation, {
+          $ref: 'lib_field',
+          validation: { required: false },
+        });
+        expect(result.validation).toEqual({
+          required: false,
+          pattern: { regex: '^[a-z]+$' },
+          min_length: 2,
+          max_length: 10,
+        });
+      });
+    });
   });
 
   describe('resolveTemplateFields', () => {

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
@@ -76,6 +76,10 @@ export const getYamlDefaultAsString = (rawDefault: unknown): string => {
  *     - explicit `null`: clear the inherited default so the field stays empty (this is what the
  *       v1→v2 migration emits for a legacy template field whose value was explicitly cleared),
  *     - any other value: use it as the field's default.
+ * - `display` / `validation`, when present on the `$ref` entry, fully replace the library
+ *   field's own `display` / `validation` (e.g. a template-specific `show_when`/`required_when`)
+ *   rather than being merged with it — the library field itself has no template-scoped
+ *   visibility/requirement rules of its own.
  *
  * Shared by `resolveTemplateFields` (server / case-creation) and `useResolvedFields` (editor) so
  * both paths resolve `$ref` overrides identically.
@@ -101,6 +105,14 @@ export const applyRefFieldOverride = (
       ...resolved,
       metadata: { ...(resolved.metadata ?? {}), default: overrideDefault },
     } as InlineField;
+  }
+
+  if (refField.display !== undefined) {
+    resolved = { ...resolved, display: refField.display } as InlineField;
+  }
+
+  if (refField.validation !== undefined) {
+    resolved = { ...resolved, validation: refField.validation } as InlineField;
   }
 
   return resolved;

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
@@ -13,7 +13,7 @@ import {
   isInlineField,
   isRefField,
 } from '../types/domain/template/fields';
-import type { Field, InlineField, RefField } from '../types/domain/template/fields';
+import type { Field, InlineField, RefField, Validation } from '../types/domain/template/fields';
 import type { FieldDefinition } from '../types/domain/field_definition/latest';
 import { CustomFieldTypes } from '../types/domain/custom_field/v1';
 
@@ -69,6 +69,49 @@ export const getYamlDefaultAsString = (rawDefault: unknown): string => {
 };
 
 /**
+ * The requirement-related `Validation` keys. These are mutually exclusive ways of expressing
+ * "when is this field required" — a field is meant to be driven by exactly one of them at a
+ * time. See {@link mergeValidationOverride} for how a `$ref` override interacts with them.
+ */
+const REQUIRED_FAMILY_KEYS = ['required', 'required_when', 'required_on_close'] as const;
+
+/**
+ * Shallow-merges a `$ref` entry's local `validation` onto the library field's own `validation`:
+ * every ordinary key (`pattern`, `min`, `max`, `min_length`, `max_length`) from the library
+ * survives unless the override explicitly redeclares it, so a template that only wants to
+ * change requiredness doesn't silently lose the library's format constraints.
+ *
+ * The requirement keys (`required` / `required_when` / `required_on_close`) are treated as one
+ * family rather than merged individually: if the override declares *any* of them, all three are
+ * taken from the override alone (the library's own requirement keys are dropped), because a
+ * naive per-key merge could otherwise leave e.g. the library's `required: true` sitting next to
+ * a template's `required_when`, with both then applying at once. In other words, whichever
+ * required* key was defined last (the override, when it defines one) wins outright over the
+ * whole family.
+ */
+export const mergeValidationOverride = (
+  libraryValidation: Validation | undefined,
+  refValidation: Validation | undefined
+): Validation | undefined => {
+  if (!refValidation) return libraryValidation;
+  if (!libraryValidation) return refValidation;
+
+  const overridesRequiredFamily = REQUIRED_FAMILY_KEYS.some(
+    (key) => refValidation[key] !== undefined
+  );
+
+  const base = overridesRequiredFamily
+    ? Object.fromEntries(
+        Object.entries(libraryValidation).filter(
+          ([key]) => !(REQUIRED_FAMILY_KEYS as readonly string[]).includes(key)
+        )
+      )
+    : libraryValidation;
+
+  return { ...base, ...refValidation };
+};
+
+/**
  * Applies a `$ref` entry's overrides onto its resolved library (inline) field:
  * - `name` acts as a local alias replacing the library field's name.
  * - `metadata.default` overrides the library default. Three cases:
@@ -76,10 +119,10 @@ export const getYamlDefaultAsString = (rawDefault: unknown): string => {
  *     - explicit `null`: clear the inherited default so the field stays empty (this is what the
  *       v1→v2 migration emits for a legacy template field whose value was explicitly cleared),
  *     - any other value: use it as the field's default.
- * - `display` / `validation`, when present on the `$ref` entry, fully replace the library
- *   field's own `display` / `validation` (e.g. a template-specific `show_when`/`required_when`)
- *   rather than being merged with it — the library field itself has no template-scoped
- *   visibility/requirement rules of its own.
+ * - `display`, when present on the `$ref` entry, fully replaces the library field's own
+ *   `display` (its only key is `show_when`, so there is nothing to preserve from the library).
+ * - `validation`, when present on the `$ref` entry, is merged onto the library field's own
+ *   `validation` — see {@link mergeValidationOverride} for the requirement-family exception.
  *
  * Shared by `resolveTemplateFields` (server / case-creation) and `useResolvedFields` (editor) so
  * both paths resolve `$ref` overrides identically.
@@ -112,7 +155,10 @@ export const applyRefFieldOverride = (
   }
 
   if (refField.validation !== undefined) {
-    resolved = { ...resolved, validation: refField.validation } as InlineField;
+    resolved = {
+      ...resolved,
+      validation: mergeValidationOverride(resolved.validation, refField.validation),
+    } as InlineField;
   }
 
   return resolved;


### PR DESCRIPTION
## What & Why

Template fields in Cases v2 can reference a field-library entry via `$ref` and add a local `display.show_when` (or `validation.required_when`) override on that same entry. That local override was being silently dropped: `RefFieldSchema` didn't declare `display`/`validation`, so Zod stripped those keys during parsing before they ever reached the form renderer. The identical override worked fine on an inline (non-`$ref`) field, which is what made this look like a `$ref`-specific bug. Root-caused with an isolated runtime reproduction of the exact reported YAML shape (pre/post-fix comparison), not just code inspection.

## How to Test

1. In Cases → Settings → Field Library, create two fields: a boolean `TOGGLE` (e.g. `open_tuning_request`) and a `TEXTAREA` (e.g. `tuning_request_detail`), both marked Global.
2. In Cases → Settings → Templates, create a template whose `fields` are two `$ref` entries: one to the toggle, and one to the textarea with a local `display.show_when` checking the toggle equals `true`.
3. In the template preview, toggle the boolean field on/off and confirm the textarea field now correctly shows/hides (previously it never hid).
4. Run the updated unit tests: `node scripts/jest x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.test.ts`.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->