### PR TITLE
[Rules] Log Threshold rule type throwing validation exception on agg results

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/format_search_response_error.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/format_search_response_error.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GroupedSearchQueryResponseRT } from '../../../../common/alerting/logs/log_threshold';
+import { isLeft } from 'fp-ts/Either';
+import { formatLogThresholdSearchResponseError } from './format_search_response_error';
+
+const baseSearchResponse = {
+  _shards: {
+    total: 1,
+    successful: 1,
+    skipped: 0,
+    failed: 0,
+  },
+  timed_out: false,
+  took: 1,
+  hits: {
+    total: {
+      value: 0,
+      relation: 'eq' as const,
+    },
+    hits: [],
+  },
+};
+
+describe('formatLogThresholdSearchResponseError', () => {
+  it('returns a helpful message when grouped aggregations are missing', () => {
+    const searchResponse = {
+      ...baseSearchResponse,
+      aggregations: undefined,
+    };
+
+    const decoded = GroupedSearchQueryResponseRT.decode(searchResponse);
+    expect(isLeft(decoded)).toBe(true);
+
+    if (!isLeft(decoded)) {
+      throw new Error('Expected grouped search response validation to fail');
+    }
+
+    const message = formatLogThresholdSearchResponseError({
+      searchResponse,
+      validationErrors: decoded.left,
+      responseType: 'grouped',
+      errorContext: {
+        indexPattern: 'logs-*',
+        groupBy: ['host.name', 'service.name'],
+      },
+    });
+
+    expect(message).toContain('logs-*');
+    expect(message).toContain('observability:logSources');
+    expect(message).toContain('host.name, service.name');
+    expect(message).not.toContain('does not match expected type');
+  });
+
+  it('returns validation details for other grouped response validation failures', () => {
+    const searchResponse = {
+      ...baseSearchResponse,
+      aggregations: {
+        groups: {
+          buckets: 'invalid',
+        },
+      },
+    };
+
+    const decoded = GroupedSearchQueryResponseRT.decode(searchResponse);
+    expect(isLeft(decoded)).toBe(true);
+
+    if (!isLeft(decoded)) {
+      throw new Error('Expected grouped search response validation to fail');
+    }
+
+    const message = formatLogThresholdSearchResponseError({
+      searchResponse,
+      validationErrors: decoded.left,
+      responseType: 'grouped',
+      errorContext: {
+        indexPattern: 'logs-*',
+      },
+    });
+
+    expect(message).toContain('Failed to parse grouped search response');
+  });
+
+  it('returns a shard failure message when shards fail', () => {
+    const searchResponse = {
+      ...baseSearchResponse,
+      _shards: {
+        ...baseSearchResponse._shards,
+        failed: 2,
+      },
+      aggregations: {
+        groups: {
+          buckets: [],
+        },
+      },
+    };
+
+    const message = formatLogThresholdSearchResponseError({
+      searchResponse,
+      validationErrors: [],
+      responseType: 'grouped',
+      errorContext: {
+        indexPattern: 'logs-*',
+      },
+    });
+
+    expect(message).toContain('2 failed shards');
+    expect(message).toContain('observability:logSources');
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/format_search_response_error.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/format_search_response_error.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import { i18n } from '@kbn/i18n';
+import { formatErrors } from '@kbn/securitysolution-io-ts-utils';
+import type * as t from 'io-ts';
+
+export interface LogThresholdSearchResponseErrorContext {
+  indexPattern?: string | string[];
+  groupBy?: string[];
+}
+
+export interface LogThresholdSearchResponseForErrorFormatting {
+  aggregations?: unknown;
+  _shards?: {
+    failed?: number;
+  };
+}
+
+export const getSearchResponseErrorContext = (
+  query: object,
+  errorContext: LogThresholdSearchResponseErrorContext = {}
+): LogThresholdSearchResponseErrorContext => {
+  const indexPattern =
+    errorContext.indexPattern ?? (query as estypes.SearchRequest).index ?? undefined;
+
+  return {
+    ...errorContext,
+    indexPattern,
+  };
+};
+
+const formatIndexPattern = (indexPattern: string | string[] | undefined): string => {
+  if (!indexPattern) {
+    return i18n.translate('xpack.infra.logs.alerting.searchResponseError.unknownIndexPattern', {
+      defaultMessage: 'unknown',
+    });
+  }
+
+  return Array.isArray(indexPattern) ? indexPattern.join(', ') : indexPattern;
+};
+
+const getMissingAggregationsMessage = ({
+  indexPattern,
+  groupBy,
+}: LogThresholdSearchResponseErrorContext): string => {
+  const formattedIndexPattern = formatIndexPattern(indexPattern);
+
+  if (groupBy && groupBy.length > 0) {
+    return i18n.translate(
+      'xpack.infra.logs.alerting.searchResponseError.missingGroupedAggregations',
+      {
+        defaultMessage:
+          'Elasticsearch returned no aggregation results for index pattern "{indexPattern}". This can happen when log sources have changed (Advanced Settings > observability:logSources), the index pattern no longer matches any indices, or group-by fields ({groupByFields}) are missing from the index mapping.',
+        values: {
+          indexPattern: formattedIndexPattern,
+          groupByFields: groupBy.join(', '),
+        },
+      }
+    );
+  }
+
+  return i18n.translate(
+    'xpack.infra.logs.alerting.searchResponseError.missingUngroupedAggregations',
+    {
+      defaultMessage:
+        'Elasticsearch returned no aggregation results for index pattern "{indexPattern}". This can happen when log sources have changed (Advanced Settings > observability:logSources) or the index pattern no longer matches any indices.',
+      values: {
+        indexPattern: formattedIndexPattern,
+      },
+    }
+  );
+};
+
+const getShardFailureMessage = ({
+  indexPattern,
+  failedShards,
+}: LogThresholdSearchResponseErrorContext & { failedShards: number }): string => {
+  return i18n.translate('xpack.infra.logs.alerting.searchResponseError.shardFailures', {
+    defaultMessage:
+      'Elasticsearch returned shard failures while querying index pattern "{indexPattern}" ({failedShards} failed shards). Check that log sources (Advanced Settings > observability:logSources) and group-by fields match the index mapping.',
+    values: {
+      indexPattern: formatIndexPattern(indexPattern),
+      failedShards,
+    },
+  });
+};
+
+export const formatLogThresholdSearchResponseError = ({
+  searchResponse,
+  validationErrors,
+  responseType,
+  errorContext = {},
+}: {
+  searchResponse: LogThresholdSearchResponseForErrorFormatting;
+  validationErrors: t.Errors;
+  responseType: 'grouped' | 'ungrouped';
+  errorContext?: LogThresholdSearchResponseErrorContext;
+}): string => {
+  if (responseType === 'grouped' && searchResponse.aggregations === undefined) {
+    return getMissingAggregationsMessage(errorContext);
+  }
+
+  const failedShards = searchResponse._shards?.failed ?? 0;
+  if (failedShards > 0) {
+    return getShardFailureMessage({ ...errorContext, failedShards });
+  }
+
+  const errorMessages = formatErrors(validationErrors);
+  const responseLabel =
+    responseType === 'grouped'
+      ? i18n.translate('xpack.infra.logs.alerting.searchResponseError.groupedResponseLabel', {
+          defaultMessage: 'grouped',
+        })
+      : i18n.translate('xpack.infra.logs.alerting.searchResponseError.ungroupedResponseLabel', {
+          defaultMessage: 'ungrouped',
+        });
+
+  return i18n.translate('xpack.infra.logs.alerting.searchResponseError.validationFailed', {
+    defaultMessage: 'Failed to parse {responseType} search response: {details}',
+    values: {
+      responseType: responseLabel,
+      details: errorMessages.join(', '),
+    },
+  });
+};

--- a/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_chart_preview.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_chart_preview.ts
@@ -7,8 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 import type { ResolvedLogView } from '@kbn/logs-shared-plugin/common';
-import { decodeOrThrow } from '@kbn/io-ts-utils';
 import type { estypes } from '@elastic/elasticsearch';
+import { isLeft } from 'fp-ts/Either';
 import type {
   ExecutionTimeRange,
   GroupedSearchQueryResponse,
@@ -28,6 +28,11 @@ import type { InfraPluginRequestHandlerContext } from '../../../types';
 import type { KibanaFramework } from '../../adapters/framework/kibana_framework_adapter';
 import { buildFiltersFromCriteria } from '../../../../common/alerting/logs/log_threshold/query_helpers';
 import { getGroupedESQuery, getUngroupedESQuery } from './log_threshold_executor';
+import {
+  formatLogThresholdSearchResponseError,
+  getSearchResponseErrorContext,
+  type LogThresholdSearchResponseErrorContext,
+} from './format_search_response_error';
 
 const COMPOSITE_GROUP_SIZE = 40;
 
@@ -84,9 +89,16 @@ export async function getChartPreviewData(
   );
 
   const series = isGrouped
-    ? processGroupedResults(await getGroupedResults(expandedQuery, requestContext, callWithRequest))
+    ? processGroupedResults(
+        await getGroupedResults(expandedQuery, requestContext, callWithRequest, {
+          indexPattern: indices,
+          groupBy,
+        })
+      )
     : processUngroupedResults(
-        await getUngroupedResults(expandedQuery, requestContext, callWithRequest)
+        await getUngroupedResults(expandedQuery, requestContext, callWithRequest, {
+          indexPattern: indices,
+        })
       );
 
   return { series };
@@ -166,27 +178,55 @@ export const addHistogramAggregationToQuery = (
 const getUngroupedResults = async (
   query: object,
   requestContext: InfraPluginRequestHandlerContext,
-  callWithRequest: KibanaFramework['callWithRequest']
+  callWithRequest: KibanaFramework['callWithRequest'],
+  errorContext: LogThresholdSearchResponseErrorContext = {}
 ) => {
-  return decodeOrThrow(UngroupedSearchQueryResponseRT)(
-    await callWithRequest(requestContext, 'search', query)
-  );
+  const searchResponse = await callWithRequest(requestContext, 'search', query);
+  const decoded = UngroupedSearchQueryResponseRT.decode(searchResponse);
+
+  if (isLeft(decoded)) {
+    throw new Error(
+      formatLogThresholdSearchResponseError({
+        searchResponse,
+        validationErrors: decoded.left,
+        responseType: 'ungrouped',
+        errorContext: getSearchResponseErrorContext(query, errorContext),
+      })
+    );
+  }
+
+  return decoded.right;
 };
 
 const getGroupedResults = async (
   query: object,
   requestContext: InfraPluginRequestHandlerContext,
-  callWithRequest: KibanaFramework['callWithRequest']
+  callWithRequest: KibanaFramework['callWithRequest'],
+  errorContext: LogThresholdSearchResponseErrorContext = {}
 ) => {
   let compositeGroupBuckets: GroupedSearchQueryResponse['aggregations']['groups']['buckets'] = [];
   let lastAfterKey: GroupedSearchQueryResponse['aggregations']['groups']['after_key'] | undefined;
+  const resolvedErrorContext = getSearchResponseErrorContext(query, errorContext);
 
   while (true) {
     const queryWithAfterKey: any = { ...query };
     queryWithAfterKey.aggregations.groups.composite.after = lastAfterKey;
-    const groupResponse: GroupedSearchQueryResponse = decodeOrThrow(GroupedSearchQueryResponseRT)(
-      await callWithRequest(requestContext, 'search', queryWithAfterKey)
-    );
+    const searchResponse = await callWithRequest(requestContext, 'search', queryWithAfterKey);
+    const decoded = GroupedSearchQueryResponseRT.decode(searchResponse);
+
+    if (isLeft(decoded)) {
+      throw new Error(
+        formatLogThresholdSearchResponseError({
+          searchResponse,
+          validationErrors: decoded.left,
+          responseType: 'grouped',
+          errorContext: resolvedErrorContext,
+        })
+      );
+    }
+
+    const groupResponse = decoded.right;
+
     compositeGroupBuckets = [
       ...compositeGroupBuckets,
       ...groupResponse.aggregations.groups.buckets,

--- a/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
@@ -44,6 +44,11 @@ import { unflattenObject } from '@kbn/object-utils';
 import { ecsFieldMap } from '@kbn/rule-registry-plugin/common/assets/field_maps/ecs_field_map';
 import { formatErrors } from '@kbn/securitysolution-io-ts-utils';
 import { isLeft } from 'fp-ts/Either';
+import {
+  formatLogThresholdSearchResponseError,
+  getSearchResponseErrorContext,
+  type LogThresholdSearchResponseErrorContext,
+} from './format_search_response_error';
 import { getChartGroupNames } from '../../../../common/utils/get_chart_group_names';
 import type {
   RuleParams,
@@ -264,7 +269,7 @@ export const createLogThresholdExecutor =
         validatedParams,
       });
     } catch (e) {
-      throw new Error(e);
+      throw e instanceof Error ? e : new Error(String(e));
     }
 
     return { state: {} };
@@ -299,14 +304,17 @@ export async function executeAlert(
 
   if (hasGroupBy(ruleParams)) {
     processGroupByResults(
-      await getGroupedResults(query, esClient),
+      await getGroupedResults(query, esClient, {
+        indexPattern,
+        groupBy: ruleParams.groupBy,
+      }),
       ruleParams,
       alertReporter,
       alertsClient
     );
   } else {
     processUngroupedResults(
-      await getUngroupedResults(query, esClient),
+      await getUngroupedResults(query, esClient, { indexPattern }),
       ruleParams,
       alertReporter,
       alertsClient
@@ -360,9 +368,13 @@ export async function executeRatioAlert(
   }
 
   if (hasGroupBy(ruleParams)) {
+    const groupedErrorContext = {
+      indexPattern,
+      groupBy: ruleParams.groupBy,
+    };
     const [numeratorGroupedResults, denominatorGroupedResults] = await Promise.all([
-      getGroupedResults(numeratorQuery, esClient),
-      getGroupedResults(denominatorQuery, esClient),
+      getGroupedResults(numeratorQuery, esClient, groupedErrorContext),
+      getGroupedResults(denominatorQuery, esClient, groupedErrorContext),
     ]);
     processGroupByRatioResults(
       numeratorGroupedResults,
@@ -373,8 +385,8 @@ export async function executeRatioAlert(
     );
   } else {
     const [numeratorUngroupedResults, denominatorUngroupedResults] = await Promise.all([
-      getUngroupedResults(numeratorQuery, esClient),
-      getUngroupedResults(denominatorQuery, esClient),
+      getUngroupedResults(numeratorQuery, esClient, { indexPattern }),
+      getUngroupedResults(denominatorQuery, esClient, { indexPattern }),
     ]);
     processUngroupedRatioResults(
       numeratorUngroupedResults,
@@ -867,21 +879,36 @@ export const getUngroupedESQuery = (
   };
 };
 
-const getUngroupedResults = async (query: object, esClient: ElasticsearchClient) => {
+const getUngroupedResults = async (
+  query: object,
+  esClient: ElasticsearchClient,
+  errorContext: LogThresholdSearchResponseErrorContext = {}
+) => {
   const searchResponse = await esClient.search(query);
   const decoded = UngroupedSearchQueryResponseRT.decode(searchResponse);
 
   if (isLeft(decoded)) {
-    const errorMessages = formatErrors(decoded.left);
-    throw new Error(`Failed to parse ungrouped search response: ${errorMessages.join(', ')}`);
+    throw new Error(
+      formatLogThresholdSearchResponseError({
+        searchResponse,
+        validationErrors: decoded.left,
+        responseType: 'ungrouped',
+        errorContext: getSearchResponseErrorContext(query, errorContext),
+      })
+    );
   }
 
   return decoded.right;
 };
 
-const getGroupedResults = async (query: object, esClient: ElasticsearchClient) => {
+const getGroupedResults = async (
+  query: object,
+  esClient: ElasticsearchClient,
+  errorContext: LogThresholdSearchResponseErrorContext = {}
+) => {
   let compositeGroupBuckets: GroupedSearchQueryResponse['aggregations']['groups']['buckets'] = [];
   let lastAfterKey: GroupedSearchQueryResponse['aggregations']['groups']['after_key'] | undefined;
+  const resolvedErrorContext = getSearchResponseErrorContext(query, errorContext);
 
   while (true) {
     const queryWithAfterKey: any = { ...query };
@@ -891,8 +918,14 @@ const getGroupedResults = async (query: object, esClient: ElasticsearchClient) =
     const decoded = GroupedSearchQueryResponseRT.decode(searchResponse);
 
     if (isLeft(decoded)) {
-      const errorMessages = formatErrors(decoded.left);
-      throw new Error(`Failed to parse grouped search response: ${errorMessages.join(', ')}`);
+      throw new Error(
+        formatLogThresholdSearchResponseError({
+          searchResponse,
+          validationErrors: decoded.left,
+          responseType: 'grouped',
+          errorContext: resolvedErrorContext,
+        })
+      );
     }
 
     const groupResponse = decoded.right;


### PR DESCRIPTION
Improves Log Threshold rule error messages when Elasticsearch returns no aggregation results — a case that often happens after observability:logSources changes or when group-by fields are missing from the index mapping.

Instead of a raw io-ts validation error (Failed to validate: in /1/aggregations: undefined does not match expected type…), grouped rules now show a clear message that includes the index pattern, log sources setting, and group-by fields.

Also applies the same formatting to chart preview queries and fixes error re-throwing in the executor.

Closes #237538 

## Test plan

- [x] Unit tests for `formatLogThresholdSearchResponseError`(missing aggregations, shard failures, other validation errors)
- [x] Existing `log_threshold_executor `tests pass
- [x] Infra plugin type check passes
- [x] Manual: grouped Log Threshold rule with invalid `observability:logSources` shows the new error message; restoring `logs-* `makes the rule succeed again