### PR TITLE
[One Workflow] Clarify read-only state and link connectors

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
@@ -124,11 +124,6 @@ export const selectIsExecutionsTab = createSelector(
   selectActiveTab,
   (activeTab): activeTab is 'executions' => activeTab === 'executions'
 );
-export const selectIsWorkflowEditorReadOnly = createSelector(
-  selectIsExecutionsTab,
-  selectWorkflow,
-  (isExecutionsTab, workflow): boolean => isExecutionsTab || workflow?.managed === true
-);
 export const selectIsWorkflowTab = createSelector(
   selectActiveTab,
   (activeTab): activeTab is 'workflow' => activeTab === 'workflow'
@@ -139,7 +134,7 @@ export const selectIsWorkflowTab = createSelector(
  * These selectors are used to get the correct data for the editor based on the active tab (current workflow or previous execution).
  */
 
-const selectIsEditorExecutionYaml = createSelector(
+export const selectIsEditorExecutionYaml = createSelector(
   selectIsExecutionsTab,
   selectExecution,
   (isExecutionsTab, execution) => Boolean(isExecutionsTab && execution?.yaml)

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
@@ -124,6 +124,11 @@ export const selectIsExecutionsTab = createSelector(
   selectActiveTab,
   (activeTab): activeTab is 'executions' => activeTab === 'executions'
 );
+export const selectIsWorkflowEditorReadOnly = createSelector(
+  selectIsExecutionsTab,
+  selectWorkflow,
+  (isExecutionsTab, workflow): boolean => isExecutionsTab || workflow?.managed === true
+);
 export const selectIsWorkflowTab = createSelector(
   selectActiveTab,
   (activeTab): activeTab is 'workflow' => activeTab === 'workflow'

--- a/src/platform/plugins/shared/workflows_management/public/hooks/use_workflow_editor_read_only.ts
+++ b/src/platform/plugins/shared/workflows_management/public/hooks/use_workflow_editor_read_only.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useSelector } from 'react-redux-v7';
+import { useParams } from 'react-router-dom';
+import { useWorkflowsCapabilities } from '@kbn/workflows-ui';
+import { useWorkflowUrlState } from './use_workflow_url_state';
+import {
+  selectIsEditorExecutionYaml,
+  selectWorkflow,
+} from '../entities/workflows/store/workflow_detail/selectors';
+
+export const useWorkflowEditorReadOnly = (): boolean => {
+  const { id: workflowId } = useParams<{ id?: string }>();
+  const workflow = useSelector(selectWorkflow);
+  const isExecutionYaml = useSelector(selectIsEditorExecutionYaml);
+  const { selectedExecutionId } = useWorkflowUrlState();
+  const { canCreateWorkflow, canUpdateWorkflow } = useWorkflowsCapabilities();
+  const canEditWorkflow = workflowId ? canUpdateWorkflow : canCreateWorkflow;
+
+  return (
+    Boolean(selectedExecutionId) ||
+    isExecutionYaml ||
+    workflow?.managed === true ||
+    !canEditWorkflow
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.test.tsx
@@ -17,6 +17,7 @@ import {
   selectFocusedStepId,
   selectFocusedTriggerId,
   selectIsExecutionsTab,
+  selectIsWorkflowEditorReadOnly,
   selectWorkflowId,
   selectYamlString as selectYamlStringSelector,
 } from '../../../entities/workflows/store/workflow_detail/selectors';
@@ -137,6 +138,7 @@ describe('WorkflowDetailEditor', () => {
   // Named base implementation so tests can extend it without creating infinite recursion
   const baseUseSelectorImpl = (selector: any) => {
     if (selector === selectIsExecutionsTab) return false;
+    if (selector === selectIsWorkflowEditorReadOnly) return false;
     if (selector === selectYamlStringSelector) return mockYaml;
     if (selector === selectWorkflowId) return 'workflow-1';
     if (selector === selectFocusedStepId) return undefined;
@@ -239,6 +241,32 @@ describe('WorkflowDetailEditor', () => {
     it('should pass highlightDiff prop to YAML editor', () => {
       const { getByTestId } = renderEditor({ highlightDiff: true });
       expect(getByTestId('highlight-diff-indicator')).toBeInTheDocument();
+    });
+
+    it('does not show the read-only badge for editable workflows', () => {
+      const { queryByTestId } = renderEditor();
+      expect(queryByTestId('workflowEditorReadOnlyBadge')).not.toBeInTheDocument();
+    });
+
+    it('shows the read-only badge on the executions tab', () => {
+      mockUseSelector.mockImplementation((selector: any) => {
+        if (selector === selectIsExecutionsTab) return true;
+        if (selector === selectIsWorkflowEditorReadOnly) return true;
+        return baseUseSelectorImpl(selector);
+      });
+
+      const { getByTestId } = renderEditor();
+      expect(getByTestId('workflowEditorReadOnlyBadge')).toHaveTextContent('Read only');
+    });
+
+    it('shows the read-only badge for managed workflows', () => {
+      mockUseSelector.mockImplementation((selector: any) => {
+        if (selector === selectIsWorkflowEditorReadOnly) return true;
+        return baseUseSelectorImpl(selector);
+      });
+
+      const { getByTestId } = renderEditor();
+      expect(getByTestId('workflowEditorReadOnlyBadge')).toHaveTextContent('Read only');
     });
   });
 
@@ -343,7 +371,7 @@ describe('WorkflowDetailEditor', () => {
       expect(yamlEditor.querySelector('[data-test-subj="workflow-visual-editor"]')).toBeNull();
     });
 
-    it('renders visual editor as a peer (sibling), not nested inside YAML editor, in graph view', async () => {
+    it('renders the visual editor and read-only badge in graph view', async () => {
       (useWorkflowsExperimentalUiSetting as jest.Mock).mockReturnValue(true);
       mockUseWorkflowUrlState.mockReturnValue({
         activeTab: 'workflow',
@@ -362,8 +390,12 @@ describe('WorkflowDetailEditor', () => {
         updateUrlState: jest.fn(),
         clearResumeParam: jest.fn(),
       });
+      mockUseSelector.mockImplementation((selector: any) => {
+        if (selector === selectIsWorkflowEditorReadOnly) return true;
+        return baseUseSelectorImpl(selector);
+      });
 
-      const { findByTestId } = renderEditor();
+      const { findByTestId, getByTestId } = renderEditor();
       const yamlEditor = await findByTestId('workflow-yaml-editor');
       const visualEditor = await findByTestId('workflow-visual-editor');
 
@@ -373,6 +405,7 @@ describe('WorkflowDetailEditor', () => {
 
       // Visual editor must NOT be a descendant of the YAML editor (peer rendering)
       expect(yamlEditor.contains(visualEditor)).toBe(false);
+      expect(getByTestId('workflowEditorReadOnlyBadge')).toHaveTextContent('Read only');
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.test.tsx
@@ -16,8 +16,9 @@ import {
   selectEditorWorkflowDefinition,
   selectFocusedStepId,
   selectFocusedTriggerId,
+  selectIsEditorExecutionYaml,
   selectIsExecutionsTab,
-  selectIsWorkflowEditorReadOnly,
+  selectWorkflow,
   selectWorkflowId,
   selectYamlString as selectYamlStringSelector,
 } from '../../../entities/workflows/store/workflow_detail/selectors';
@@ -36,6 +37,7 @@ const mockUseUiSetting$ = jest.fn();
 const mockUseWorkflowUrlState = jest.fn();
 const mockUseWorkflowActions = jest.fn();
 const mockUseSelector = jest.fn();
+const mockUseParams = jest.fn();
 
 jest.mock('@kbn/kibana-react-plugin/public', () => ({
   useKibana: () => mockUseKibana(),
@@ -43,6 +45,10 @@ jest.mock('@kbn/kibana-react-plugin/public', () => ({
 }));
 jest.mock('../../../hooks/use_workflow_url_state', () => ({
   useWorkflowUrlState: () => mockUseWorkflowUrlState(),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => mockUseParams(),
 }));
 jest.mock('../../../entities/workflows/model/use_workflow_actions', () => ({
   useWorkflowActions: () => mockUseWorkflowActions(),
@@ -137,8 +143,9 @@ describe('WorkflowDetailEditor', () => {
 
   // Named base implementation so tests can extend it without creating infinite recursion
   const baseUseSelectorImpl = (selector: any) => {
+    if (selector === selectIsEditorExecutionYaml) return false;
     if (selector === selectIsExecutionsTab) return false;
-    if (selector === selectIsWorkflowEditorReadOnly) return false;
+    if (selector === selectWorkflow) return { managed: false };
     if (selector === selectYamlStringSelector) return mockYaml;
     if (selector === selectWorkflowId) return 'workflow-1';
     if (selector === selectFocusedStepId) return undefined;
@@ -191,6 +198,7 @@ describe('WorkflowDetailEditor', () => {
     jest.clearAllMocks();
 
     mockUseWorkflowsCapabilities.mockReturnValue(mockWorkflowsManagementCapabilities);
+    mockUseParams.mockReturnValue({ id: 'workflow-1' });
 
     mockUseKibana.mockReturnValue({
       services: {
@@ -248,11 +256,21 @@ describe('WorkflowDetailEditor', () => {
       expect(queryByTestId('workflowEditorReadOnlyBadge')).not.toBeInTheDocument();
     });
 
-    it('shows the read-only badge on the executions tab', () => {
+    it('does not show the read-only badge on the executions tab without a selection', () => {
       mockUseSelector.mockImplementation((selector: any) => {
         if (selector === selectIsExecutionsTab) return true;
-        if (selector === selectIsWorkflowEditorReadOnly) return true;
         return baseUseSelectorImpl(selector);
+      });
+
+      const { queryByTestId } = renderEditor();
+      expect(queryByTestId('workflowEditorReadOnlyBadge')).not.toBeInTheDocument();
+    });
+
+    it('shows the read-only badge when an execution is selected', () => {
+      mockUseWorkflowUrlState.mockReturnValue({
+        ...mockUseWorkflowUrlState(),
+        activeTab: 'executions',
+        selectedExecutionId: 'execution-1',
       });
 
       const { getByTestId } = renderEditor();
@@ -261,8 +279,29 @@ describe('WorkflowDetailEditor', () => {
 
     it('shows the read-only badge for managed workflows', () => {
       mockUseSelector.mockImplementation((selector: any) => {
-        if (selector === selectIsWorkflowEditorReadOnly) return true;
+        if (selector === selectWorkflow) return { managed: true };
         return baseUseSelectorImpl(selector);
+      });
+
+      const { getByTestId } = renderEditor();
+      expect(getByTestId('workflowEditorReadOnlyBadge')).toHaveTextContent('Read only');
+    });
+
+    it('shows the read-only badge without update privileges', () => {
+      mockUseWorkflowsCapabilities.mockReturnValue({
+        ...mockWorkflowsManagementCapabilities,
+        canUpdateWorkflow: false,
+      });
+
+      const { getByTestId } = renderEditor();
+      expect(getByTestId('workflowEditorReadOnlyBadge')).toHaveTextContent('Read only');
+    });
+
+    it('shows the read-only badge without create privileges for a new workflow', () => {
+      mockUseParams.mockReturnValue({});
+      mockUseWorkflowsCapabilities.mockReturnValue({
+        ...mockWorkflowsManagementCapabilities,
+        canCreateWorkflow: false,
       });
 
       const { getByTestId } = renderEditor();
@@ -391,7 +430,7 @@ describe('WorkflowDetailEditor', () => {
         clearResumeParam: jest.fn(),
       });
       mockUseSelector.mockImplementation((selector: any) => {
-        if (selector === selectIsWorkflowEditorReadOnly) return true;
+        if (selector === selectWorkflow) return { managed: true };
         return baseUseSelectorImpl(selector);
       });
 

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.tsx
@@ -46,7 +46,6 @@ import {
   selectFocusedTriggerId,
   selectIsExecutionsTab,
   selectIsSavingYaml,
-  selectIsWorkflowEditorReadOnly,
   selectIsYamlSyntaxValid,
   selectWorkflowId,
   selectYamlString,
@@ -58,6 +57,7 @@ import {
 } from '../../../entities/workflows/store/workflow_detail/slice';
 import { ExecutionGraph } from '../../../features/debug_graph/execution_graph';
 import { useKibana } from '../../../hooks/use_kibana';
+import { useWorkflowEditorReadOnly } from '../../../hooks/use_workflow_editor_read_only';
 import { useWorkflowUrlState } from '../../../hooks/use_workflow_url_state';
 import { useWorkflowsExperimentalUiSetting } from '../../../hooks/use_workflows_experimental_ui_setting';
 import { getTestRunTooltipContent } from '../../../shared/ui';
@@ -109,7 +109,7 @@ export const WorkflowDetailEditor = React.memo<WorkflowDetailEditorProps>(({ hig
   const workflowYaml = useSelector(selectYamlString) ?? '';
   const workflowId = useSelector(selectWorkflowId);
   const isExecutionsTab = useSelector(selectIsExecutionsTab);
-  const isReadOnly = useSelector(selectIsWorkflowEditorReadOnly);
+  const isReadOnly = useWorkflowEditorReadOnly();
   const isSyntaxValid = useSelector(selectIsYamlSyntaxValid);
   const isSaving = useSelector(selectIsSavingYaml);
   const getContextOverrideData = useContextOverrideData();

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.tsx
@@ -9,12 +9,14 @@
 
 import type { UseEuiTheme } from '@elastic/eui';
 import {
+  EuiBadge,
   EuiButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
   EuiToolTip,
+  useEuiShadow,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { Viewport } from '@xyflow/react';
@@ -44,6 +46,7 @@ import {
   selectFocusedTriggerId,
   selectIsExecutionsTab,
   selectIsSavingYaml,
+  selectIsWorkflowEditorReadOnly,
   selectIsYamlSyntaxValid,
   selectWorkflowId,
   selectYamlString,
@@ -79,6 +82,7 @@ interface WorkflowDetailEditorProps {
 
 export const WorkflowDetailEditor = React.memo<WorkflowDetailEditorProps>(({ highlightDiff }) => {
   const styles = useMemoCss(componentStyles);
+  const readOnlyBadgeShadow = useEuiShadow('xl');
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const openActionsRef = useRef<(() => void) | null>(null);
   // Saved graph viewport — survives the YAML↔graph remount because this
@@ -105,6 +109,7 @@ export const WorkflowDetailEditor = React.memo<WorkflowDetailEditorProps>(({ hig
   const workflowYaml = useSelector(selectYamlString) ?? '';
   const workflowId = useSelector(selectWorkflowId);
   const isExecutionsTab = useSelector(selectIsExecutionsTab);
+  const isReadOnly = useSelector(selectIsWorkflowEditorReadOnly);
   const isSyntaxValid = useSelector(selectIsYamlSyntaxValid);
   const isSaving = useSelector(selectIsSavingYaml);
   const getContextOverrideData = useContextOverrideData();
@@ -384,6 +389,17 @@ export const WorkflowDetailEditor = React.memo<WorkflowDetailEditorProps>(({ hig
               </React.Suspense>
             </div>
           )}
+          {isReadOnly && (
+            <EuiBadge
+              color="warning"
+              css={[styles.readOnlyBadge, css(readOnlyBadgeShadow)]}
+              data-test-subj="workflowEditorReadOnlyBadge"
+            >
+              {i18n.translate('workflows.workflowDetailEditor.readOnlyBadge', {
+                defaultMessage: 'Read only',
+              })}
+            </EuiBadge>
+          )}
           {isVisualEditorEnabled && (
             <WorkflowDetailBottomBar
               editorView={editorView}
@@ -440,6 +456,15 @@ const componentStyles = {
     transform: 'scale(0.985)',
     pointerEvents: 'none',
   }),
+  readOnlyBadge: ({ euiTheme }: UseEuiTheme) =>
+    css({
+      position: 'absolute',
+      insetBlockStart: euiTheme.size.base,
+      insetInlineStart: '50%',
+      transform: 'translateX(-50%)',
+      zIndex: 2,
+      paddingInline: euiTheme.size.l,
+    }),
   visualEditor: ({ euiTheme }: UseEuiTheme) =>
     css({
       flex: 1,

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
@@ -10,6 +10,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { of } from 'rxjs';
+import { openAppMenuOverflow } from '@kbn/app-header/test_helpers';
 import { ChangeHistoryModalContext } from '@kbn/change-history-ui';
 import { useWorkflowsCapabilities, type WorkflowsManagementCapabilities } from '@kbn/workflows-ui';
 import { createMockWorkflowsCapabilities } from '@kbn/workflows-ui/mocks';
@@ -157,9 +158,21 @@ describe('WorkflowDetailHeader', () => {
     mockUseKibana.mockReturnValue({
       services: {
         application: {
+          capabilities: {
+            management: {
+              insightsAndAlerting: {
+                triggersActionsConnectors: true,
+              },
+            },
+          },
           navigateToApp: mockNavigateToApp,
           getUrlForApp: jest.fn(
-            (appId: string, options?: { path?: string }) => `/app/${appId}${options?.path ?? ''}`
+            (appId: string, options?: { deepLinkId?: string; path?: string }) => {
+              const deepLinkPath = options?.deepLinkId
+                ? `/insightsAndAlerting/${options.deepLinkId}`
+                : '';
+              return `/app/${appId}${deepLinkPath}${options?.path ?? ''}`;
+            }
           ),
           applications$: of(
             new Map([['context_engine', { id: 'context_engine', title: 'Context Engine' }]])
@@ -197,6 +210,7 @@ describe('WorkflowDetailHeader', () => {
     mockUseKibana.mockReturnValue({
       services: {
         application: {
+          capabilities: {},
           navigateToApp: jest.fn(),
           getUrlForApp: jest.fn(),
           applications$: of(new Map()),
@@ -223,6 +237,18 @@ describe('WorkflowDetailHeader', () => {
   it('should render', () => {
     const { getAllByText } = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />);
     expect(getAllByText('Test Workflow').length).toBeGreaterThan(0);
+  });
+
+  it('links to connector management from the overflow menu', async () => {
+    const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />);
+
+    await openAppMenuOverflow();
+
+    expect(await result.findByTestId('workflowAddConnectorsLink')).toHaveAttribute(
+      'href',
+      '/app/management/insightsAndAlerting/triggersActionsConnectors/connectors'
+    );
+    expect(result.queryByText('Add integrations')).not.toBeInTheDocument();
   });
 
   it('navigates back to the workflows list with the stored list search params', () => {
@@ -585,7 +611,7 @@ describe('WorkflowDetailHeader', () => {
     });
   });
 
-  it('exposes the change history entry point on the workflow tab when a workflow id is present', () => {
+  it('exposes the change history entry point on the workflow tab when a workflow id is present', async () => {
     const changeHistoryModal = {
       isOpen: false,
       openModal: jest.fn(),
@@ -598,7 +624,7 @@ describe('WorkflowDetailHeader', () => {
     );
 
     // History lives in the overflow ("More") menu, so open it before locating the entry point.
-    fireEvent.click(getByTestId('app-menu-overflow-button'));
+    await openAppMenuOverflow();
 
     const historyItem = getByTestId('workflowDetailHistoryButton');
     expect(historyItem).toBeInTheDocument();

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -39,6 +39,7 @@ import { useKibana } from '../../../hooks/use_kibana';
 import { useWorkflowUrlState } from '../../../hooks/use_workflow_url_state';
 import { useWorkflowsExperimentalUiSetting } from '../../../hooks/use_workflows_experimental_ui_setting';
 import { getSaveWorkflowTooltipContent, getTestRunTooltipContent } from '../../../shared/ui';
+import { getAddConnectorsMenuItem } from '../../../shared/ui/get_add_connectors_menu_item';
 import {
   getReturnDestinationFromSearch,
   navigateToWorkflowsList,
@@ -116,6 +117,7 @@ export interface WorkflowDetailHeaderProps {
 export const WorkflowDetailHeader = React.memo(
   ({ isLoading, highlightDiff, setHighlightDiff }: WorkflowDetailHeaderProps) => {
     const { id: workflowId } = useParams<{ id?: string }>();
+    const { application } = useKibana().services;
     const back = useWorkflowDetailHeaderBack();
     const styles = useMemoCss(componentStyles);
     const dispatch = useDispatch();
@@ -334,6 +336,10 @@ export const WorkflowDetailHeader = React.memo(
     ]);
 
     const { handleRunClick, runConfirmationModal } = useRunWorkflowWithConfirmation(openTestModal);
+    const addConnectorsMenuItem = useMemo(
+      () => getAddConnectorsMenuItem(application),
+      [application]
+    );
 
     const badges = useMemo<AppHeaderBadge[]>(() => {
       const result: AppHeaderBadge[] = [];
@@ -406,6 +412,9 @@ export const WorkflowDetailHeader = React.memo(
       if (historyItem) {
         items.push(historyItem);
       }
+      if (addConnectorsMenuItem) {
+        items.push(addConnectorsMenuItem);
+      }
 
       return {
         primaryActionItem: {
@@ -435,6 +444,7 @@ export const WorkflowDetailHeader = React.memo(
       workflowId,
       executionsToggleItem,
       historyItem,
+      addConnectorsMenuItem,
       enabledSwitchConfig,
       isVisualEditorEnabled,
       handleSaveWorkflow,
@@ -460,7 +470,6 @@ export const WorkflowDetailHeader = React.memo(
             badges={badges}
             menu={appMenu}
             docLink={WORKFLOWS_DOCUMENTATION_URL}
-            showAddIntegrations
           />
         </EuiPageTemplate>
         {runConfirmationModal}

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflows/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflows/index.tsx
@@ -17,7 +17,7 @@ import {
 import React, { useCallback, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AppHeader } from '@kbn/app-header';
-import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
+import type { AppMenuConfig, AppMenuItemType } from '@kbn/core-chrome-app-menu-components';
 import { i18n } from '@kbn/i18n';
 import type { WorkflowsSearchParams } from '@kbn/workflows';
 import { WORKFLOW_EXECUTION_STATS_BAR_SETTING_ID } from '@kbn/workflows/common/constants';
@@ -38,6 +38,7 @@ import { WorkflowExecutionStatsBar } from '../../features/workflow_executions_st
 import { WorkflowList } from '../../features/workflow_list';
 import { useKibana } from '../../hooks/use_kibana';
 import { useWorkflowsBreadcrumbs } from '../../hooks/use_workflow_breadcrumbs/use_workflow_breadcrumbs';
+import { getAddConnectorsMenuItem } from '../../shared/ui/get_add_connectors_menu_item';
 import { shouldShowWorkflowsEmptyState } from '../../shared/utils/workflow_utils';
 import { WorkflowsFilterPopover } from '../../widgets/workflow_filter_popover/workflow_filter_popover';
 import { WorkflowSearchField } from '../../widgets/workflow_search_field/ui/workflow_search_field';
@@ -137,6 +138,7 @@ export function WorkflowsPage() {
 
   /** Import uses bulk APIs that require both create and update; gate UI to match server authz. */
   const canImportWorkflows = Boolean(canCreateWorkflow && canUpdateWorkflow);
+  const addConnectorsMenuItem = useMemo(() => getAddConnectorsMenuItem(application), [application]);
   const isExecutionStatsBarEnabled = featureFlags?.getBooleanValue(
     WORKFLOW_EXECUTION_STATS_BAR_SETTING_ID,
     false
@@ -146,8 +148,26 @@ export function WorkflowsPage() {
   const shouldShowEmptyState = shouldShowWorkflowsEmptyState(workflows, search);
   const shouldShowFilters = !shouldShowEmptyState || showManagedWorkflowsFilter;
 
-  const appMenu = useMemo<AppMenuConfig>(
-    () => ({
+  const appMenu = useMemo<AppMenuConfig>(() => {
+    const items: AppMenuItemType[] = [];
+    if (canImportWorkflows) {
+      items.push({
+        id: 'importWorkflows',
+        order: 1,
+        label: i18n.translate('workflows.importWorkflowsButton', {
+          defaultMessage: 'Import',
+        }),
+        iconType: 'download',
+        overflow: true,
+        run: () => setShowImportFlyout(true),
+        testId: 'importWorkflowsButton',
+      });
+    }
+    if (addConnectorsMenuItem) {
+      items.push(addConnectorsMenuItem);
+    }
+
+    return {
       primaryActionItem: canCreateWorkflow
         ? {
             id: 'createWorkflow',
@@ -159,24 +179,9 @@ export function WorkflowsPage() {
             testId: 'createWorkflowButton',
           }
         : undefined,
-      items: canImportWorkflows
-        ? [
-            {
-              id: 'importWorkflows',
-              order: 1,
-              label: i18n.translate('workflows.importWorkflowsButton', {
-                defaultMessage: 'Import',
-              }),
-              iconType: 'download',
-              overflow: true,
-              run: () => setShowImportFlyout(true),
-              testId: 'importWorkflowsButton',
-            },
-          ]
-        : [],
-    }),
-    [canCreateWorkflow, canImportWorkflows, navigateToCreateWorkflow]
-  );
+      items,
+    };
+  }, [addConnectorsMenuItem, canCreateWorkflow, canImportWorkflows, navigateToCreateWorkflow]);
 
   return (
     <EuiPageTemplate
@@ -188,7 +193,6 @@ export function WorkflowsPage() {
         title={i18n.translate('workflows.pageTitle', { defaultMessage: 'Workflows' })}
         menu={appMenu}
         docLink={WORKFLOWS_DOCUMENTATION_URL}
-        showAddIntegrations
       />
       <EuiPageTemplate.Section restrictWidth={false}>
         {shouldShowFilters ? (

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflows/workflows_page.authorization.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflows/workflows_page.authorization.test.tsx
@@ -10,6 +10,7 @@
 import { EuiProvider } from '@elastic/eui';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import { openAppMenuOverflow } from '@kbn/app-header/test_helpers';
 import { I18nProvider } from '@kbn/i18n-react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useShowManagedWorkflowsSetting, useWorkflows } from '@kbn/workflows-ui';
@@ -99,9 +100,11 @@ function mockCapabilities(
   {
     readWorkflow = true,
     readManagedWorkflow = true,
+    manageConnectors = true,
   }: {
     readWorkflow?: boolean;
     readManagedWorkflow?: boolean;
+    manageConnectors?: boolean;
   } = {}
 ): void {
   mockNavigateToApp = jest.fn();
@@ -115,7 +118,18 @@ function mockCapabilities(
             readManagedWorkflow,
             updateWorkflow,
           },
+          management: {
+            insightsAndAlerting: {
+              triggersActionsConnectors: manageConnectors,
+            },
+          },
         },
+        getUrlForApp: jest.fn((appId: string, options?: { deepLinkId?: string; path?: string }) => {
+          const deepLinkPath = options?.deepLinkId
+            ? `/insightsAndAlerting/${options.deepLinkId}`
+            : '';
+          return `/app/${appId}${deepLinkPath}${options?.path ?? ''}`;
+        }),
         navigateToApp: mockNavigateToApp,
       },
       featureFlags: {
@@ -182,7 +196,7 @@ describe('WorkflowsPage authorization', () => {
 
       if (expectImport) {
         // Import is an overflow menu item; open the overflow popover to reveal it.
-        fireEvent.click(await screen.findByTestId('app-menu-overflow-button'));
+        await openAppMenuOverflow();
         expect(await screen.findByTestId('importWorkflowsButton')).toBeInTheDocument();
       } else {
         expect(screen.queryByTestId('importWorkflowsButton')).not.toBeInTheDocument();
@@ -205,6 +219,28 @@ describe('WorkflowsPage authorization', () => {
       path: '?query=security',
       replace: true,
     });
+  });
+
+  it('links to connector management from the overflow menu', async () => {
+    mockCapabilities(true, true);
+
+    renderPage();
+
+    await openAppMenuOverflow();
+    expect(await screen.findByTestId('workflowAddConnectorsLink')).toHaveAttribute(
+      'href',
+      '/app/management/insightsAndAlerting/triggersActionsConnectors/connectors'
+    );
+    expect(screen.queryByText('Add integrations')).not.toBeInTheDocument();
+  });
+
+  it('hides connector management when the capability is missing', async () => {
+    mockCapabilities(true, true, { manageConnectors: false });
+
+    renderPage();
+
+    await openAppMenuOverflow();
+    expect(screen.queryByTestId('workflowAddConnectorsLink')).not.toBeInTheDocument();
   });
 
   it('hides the managed filter when the setting is disabled', () => {

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/get_add_connectors_menu_item.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/get_add_connectors_menu_item.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CoreStart } from '@kbn/core/public';
+import type { AppMenuItemType } from '@kbn/core-chrome-app-menu-components';
+import { i18n } from '@kbn/i18n';
+
+export const getAddConnectorsMenuItem = (
+  application: CoreStart['application']
+): AppMenuItemType | undefined => {
+  if (
+    application.capabilities.management?.insightsAndAlerting?.triggersActionsConnectors !== true
+  ) {
+    return undefined;
+  }
+
+  return {
+    id: 'addConnectors',
+    order: Number.MAX_SAFE_INTEGER,
+    label: i18n.translate('workflows.addConnectorsMenuItemLabel', {
+      defaultMessage: 'Add connectors',
+    }),
+    iconType: 'plugs',
+    href: application.getUrlForApp('management', {
+      deepLinkId: 'triggersActionsConnectors',
+      path: '/connectors',
+    }),
+    overflow: true,
+    testId: 'workflowAddConnectorsLink',
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { kqlPluginMock } from '@kbn/kql/public/mocks';
 import { monaco, YAML_LANG_ID } from '@kbn/monaco';
+import { useWorkflowsCapabilities } from '@kbn/workflows-ui';
 import type { WorkflowYAMLEditorProps } from './workflow_yaml_editor';
 import { WorkflowYAMLEditor } from './workflow_yaml_editor';
 import { useSaveYaml } from '../../../entities/workflows/model/use_save_yaml';
@@ -23,7 +24,9 @@ import {
 } from '../../../entities/workflows/store';
 import { createMockStore } from '../../../entities/workflows/store/__mocks__/store.mock';
 import { saveYamlThunk } from '../../../entities/workflows/store/workflow_detail/thunks/save_yaml_thunk';
+import { mockWorkflowsManagementCapabilities } from '../../../hooks/__mocks__/use_workflows_capabilities';
 import { getTestProvider } from '../../../shared/mocks/test_providers';
+import { createMockWorkflowExecutionDto } from '../../../shared/test_utils/mock_workflow_factories';
 import type { YamlEditorProps } from '../../../shared/ui';
 import { getCompletionItemProvider } from '../lib/autocomplete/get_completion_item_provider';
 
@@ -83,10 +86,15 @@ jest.mock('../../../entities/connectors/model/use_available_connectors', () => (
 
 const mockSaveYaml = jest.fn();
 const mockUseSaveYaml = useSaveYaml as jest.MockedFunction<typeof useSaveYaml>;
+const mockUseParams = jest.fn();
 
 // Mock the useSaveYaml hook - now returns just the function, not an array
 jest.mock('../../../entities/workflows/model/use_save_yaml', () => ({
   useSaveYaml: jest.fn(),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => mockUseParams(),
 }));
 
 const mockKqlStart = kqlPluginMock.createStartContract();
@@ -167,8 +175,13 @@ jest.mock('../styles/use_workflow_editor_styles', () => ({
 
 jest.mock('@kbn/workflows-ui', () => ({
   ...jest.requireActual('@kbn/workflows-ui'),
+  useWorkflowsCapabilities: jest.fn(),
   useWorkflowsMonacoTheme: jest.fn(),
 }));
+
+const mockUseWorkflowsCapabilities = useWorkflowsCapabilities as jest.MockedFunction<
+  typeof useWorkflowsCapabilities
+>;
 
 jest.mock('../styles/use_dynamic_type_icons', () => ({
   useDynamicTypeIcons: jest.fn(),
@@ -264,9 +277,10 @@ describe('WorkflowYAMLEditor', () => {
 
   const renderWithProviders = (
     component: React.ReactElement,
-    store?: ReturnType<typeof createMockStore>
+    store?: ReturnType<typeof createMockStore>,
+    initialEntries?: string[]
   ) => {
-    return render(component, { wrapper: getTestProvider({ store }) });
+    return render(component, { wrapper: getTestProvider({ store, initialEntries }) });
   };
 
   beforeEach(() => {
@@ -275,6 +289,8 @@ describe('WorkflowYAMLEditor', () => {
     mockSaveYaml.mockResolvedValue(undefined);
     // useSaveYaml now returns just the function, not an array
     mockUseSaveYaml.mockReturnValue(mockSaveYaml);
+    mockUseWorkflowsCapabilities.mockReturnValue(mockWorkflowsManagementCapabilities);
+    mockUseParams.mockReturnValue({ id: 'test-123' });
   });
 
   it('renders without crashing', async () => {
@@ -336,6 +352,62 @@ describe('WorkflowYAMLEditor', () => {
     });
   });
 
+  it('renders workflow YAML as read-only without update privileges', async () => {
+    const store = createMockStore();
+    store.dispatch(setWorkflow(mockWorkflow));
+    mockUseWorkflowsCapabilities.mockReturnValue({
+      ...mockWorkflowsManagementCapabilities,
+      canUpdateWorkflow: false,
+    });
+
+    renderWithProviders(<WorkflowYAMLEditor {...defaultProps} />, store);
+
+    await waitFor(() => {
+      const textarea = document.querySelector(
+        '[data-testid="yaml-textarea"]'
+      ) as HTMLTextAreaElement;
+      expect(textarea.readOnly).toBe(true);
+    });
+  });
+
+  it('keeps workflow YAML editable on the executions tab without a selection', async () => {
+    const store = createMockStore();
+    store.dispatch(setWorkflow(mockWorkflow));
+    store.dispatch(setActiveTab('executions'));
+
+    renderWithProviders(<WorkflowYAMLEditor {...defaultProps} />, store, ['/?tab=executions']);
+
+    await waitFor(() => {
+      const textarea = document.querySelector(
+        '[data-testid="yaml-textarea"]'
+      ) as HTMLTextAreaElement;
+      expect(textarea.readOnly).toBe(false);
+    });
+  });
+
+  it('keeps cached execution YAML read-only while the selection is cleared', async () => {
+    const store = createMockStore();
+    store.dispatch(setWorkflow(mockWorkflow));
+    store.dispatch(setActiveTab('executions'));
+    store.dispatch(
+      setExecution(
+        createMockWorkflowExecutionDto({
+          id: 'test-execution-id',
+          yaml: mockWorkflow.yaml,
+        })
+      )
+    );
+
+    renderWithProviders(<WorkflowYAMLEditor {...defaultProps} />, store, ['/?tab=executions']);
+
+    await waitFor(() => {
+      const textarea = document.querySelector(
+        '[data-testid="yaml-textarea"]'
+      ) as HTMLTextAreaElement;
+      expect(textarea.readOnly).toBe(true);
+    });
+  });
+
   describe('alert trigger decorations', () => {
     const yamlWithAlertTrigger = `
 version: "1"
@@ -362,21 +434,27 @@ steps:
       });
     });
 
-    it('renders in readOnly mode when isExecutionYaml is true', async () => {
+    it('renders selected execution YAML as read-only', async () => {
       const store = createMockStore();
       store.dispatch(setActiveTab('executions'));
       store.dispatch(
-        setExecution({
-          id: 'test-execution-id',
-          yaml: yamlWithAlertTrigger,
-        } as any)
+        setExecution(
+          createMockWorkflowExecutionDto({
+            id: 'test-execution-id',
+            yaml: yamlWithAlertTrigger,
+          })
+        )
       );
 
-      renderWithProviders(<WorkflowYAMLEditor {...defaultProps} />, store);
+      renderWithProviders(<WorkflowYAMLEditor {...defaultProps} />, store, [
+        '/?tab=executions&executionId=test-execution-id',
+      ]);
 
-      // Wait for async state updates (setTimeout in handleEditorDidMount)
       await waitFor(() => {
-        expect(document.querySelector('[data-testid="yaml-editor"]')).toBeInTheDocument();
+        const textarea = document.querySelector(
+          '[data-testid="yaml-textarea"]'
+        ) as HTMLTextAreaElement;
+        expect(textarea.readOnly).toBe(true);
       });
     });
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -60,7 +60,6 @@ import {
   selectHighlightedStepId,
   selectIsExecutionsTab,
   selectIsSavingYaml,
-  selectIsWorkflowEditorReadOnly,
   selectStepExecutions,
   selectWorkflow,
   selectWorkflowDefinition,
@@ -81,6 +80,7 @@ import { useYamlValidation } from '../../../features/validate_workflow_yaml/lib/
 import type { YamlValidationResult } from '../../../features/validate_workflow_yaml/model/types';
 import { useWorkflowJsonSchema } from '../../../features/validate_workflow_yaml/model/use_workflow_json_schema';
 import { useKibana } from '../../../hooks/use_kibana';
+import { useWorkflowEditorReadOnly } from '../../../hooks/use_workflow_editor_read_only';
 import { useWorkflowsExperimentalUiSetting } from '../../../hooks/use_workflows_experimental_ui_setting';
 import { UnsavedChangesPrompt, YamlEditor } from '../../../shared/ui';
 import { triggerSchemas } from '../../../trigger_schemas';
@@ -194,7 +194,7 @@ export const WorkflowYAMLEditor = ({
   const dispatch = useDispatch();
   const workflow = useSelector(selectWorkflow);
   const isExecutionYaml = useSelector(selectIsExecutionsTab);
-  const isReadOnlyYaml = useSelector(selectIsWorkflowEditorReadOnly);
+  const isReadOnlyYaml = useWorkflowEditorReadOnly();
   const isReadOnlyYamlRef = useRef(isReadOnlyYaml);
   isReadOnlyYamlRef.current = isReadOnlyYaml;
   const onChange = useCallback(

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -60,6 +60,7 @@ import {
   selectHighlightedStepId,
   selectIsExecutionsTab,
   selectIsSavingYaml,
+  selectIsWorkflowEditorReadOnly,
   selectStepExecutions,
   selectWorkflow,
   selectWorkflowDefinition,
@@ -193,8 +194,7 @@ export const WorkflowYAMLEditor = ({
   const dispatch = useDispatch();
   const workflow = useSelector(selectWorkflow);
   const isExecutionYaml = useSelector(selectIsExecutionsTab);
-  const isManagedWorkflow = workflow?.managed === true;
-  const isReadOnlyYaml = isExecutionYaml || isManagedWorkflow;
+  const isReadOnlyYaml = useSelector(selectIsWorkflowEditorReadOnly);
   const isReadOnlyYamlRef = useRef(isReadOnlyYaml);
   isReadOnlyYamlRef.current = isReadOnlyYaml;
   const onChange = useCallback(


### PR DESCRIPTION
## Summary
- show a prominent read-only pill for managed workflows and historical execution views
- replace the Workflows "Add integrations" menu entry with a capability-gated "Add connectors" link
- keep the read-only policy centralized and cover YAML, graph, and header menu behavior

<img width="5000" height="2576" alt="CleanShot 2026-08-05 at 17 10 48@2x" src="https://github.com/user-attachments/assets/372dc545-f30e-49f8-a31a-9aefea842fe7" />
<img width="5000" height="2576" alt="CleanShot 2026-08-05 at 17 14 59@2x" src="https://github.com/user-attachments/assets/e9189c18-5be2-4601-bb49-d65ad1dda66e" />



Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->