### PR TITLE
[9.4] [maps] fix react warning in TOCEntry "Each child in a list should have a unique key prop" (#282119)

### DIFF
--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/__snapshots__/toc_entry.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/__snapshots__/toc_entry.test.tsx.snap
@@ -36,28 +36,29 @@ exports[`TOCEntry is rendered 1`] = `
       <EuiToolTip
         content="Hide layer"
         disableScreenReaderOutput={true}
+        key="toggleVisiblity"
       >
         <EuiButtonIcon
           aria-label="Hide layer"
           iconType="eyeSlash"
-          key="toggleVisiblity"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Fit to data"
         disableScreenReaderOutput={true}
+        key="fitToBounds"
       >
         <EuiButtonIcon
           aria-label="Fit to data"
           iconType="maximize"
-          key="fitToBounds"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Edit layer settings"
         disableScreenReaderOutput={true}
+        key="settings"
       >
         <EuiButtonIcon
           aria-label="Edit layer settings"
@@ -70,12 +71,12 @@ exports[`TOCEntry is rendered 1`] = `
       <EuiToolTip
         content="Reorder layer"
         disableScreenReaderOutput={true}
+        key="reorder"
       >
         <EuiButtonIcon
           aria-label="Reorder layer"
           className="mapTocEntry__grab"
           iconType="dragVertical"
-          key="reorder"
         />
       </EuiToolTip>
     </div>
@@ -140,28 +141,29 @@ exports[`TOCEntry props Should indent child layer 1`] = `
       <EuiToolTip
         content="Hide layer"
         disableScreenReaderOutput={true}
+        key="toggleVisiblity"
       >
         <EuiButtonIcon
           aria-label="Hide layer"
           iconType="eyeSlash"
-          key="toggleVisiblity"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Fit to data"
         disableScreenReaderOutput={true}
+        key="fitToBounds"
       >
         <EuiButtonIcon
           aria-label="Fit to data"
           iconType="maximize"
-          key="fitToBounds"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Edit layer settings"
         disableScreenReaderOutput={true}
+        key="settings"
       >
         <EuiButtonIcon
           aria-label="Edit layer settings"
@@ -174,12 +176,12 @@ exports[`TOCEntry props Should indent child layer 1`] = `
       <EuiToolTip
         content="Reorder layer"
         disableScreenReaderOutput={true}
+        key="reorder"
       >
         <EuiButtonIcon
           aria-label="Reorder layer"
           className="mapTocEntry__grab"
           iconType="dragVertical"
-          key="reorder"
         />
       </EuiToolTip>
     </div>
@@ -240,28 +242,29 @@ exports[`TOCEntry props Should shade background when not selected layer 1`] = `
       <EuiToolTip
         content="Hide layer"
         disableScreenReaderOutput={true}
+        key="toggleVisiblity"
       >
         <EuiButtonIcon
           aria-label="Hide layer"
           iconType="eyeSlash"
-          key="toggleVisiblity"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Fit to data"
         disableScreenReaderOutput={true}
+        key="fitToBounds"
       >
         <EuiButtonIcon
           aria-label="Fit to data"
           iconType="maximize"
-          key="fitToBounds"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Edit layer settings"
         disableScreenReaderOutput={true}
+        key="settings"
       >
         <EuiButtonIcon
           aria-label="Edit layer settings"
@@ -274,12 +277,12 @@ exports[`TOCEntry props Should shade background when not selected layer 1`] = `
       <EuiToolTip
         content="Reorder layer"
         disableScreenReaderOutput={true}
+        key="reorder"
       >
         <EuiButtonIcon
           aria-label="Reorder layer"
           className="mapTocEntry__grab"
           iconType="dragVertical"
-          key="reorder"
         />
       </EuiToolTip>
     </div>
@@ -340,28 +343,29 @@ exports[`TOCEntry props Should shade background when selected layer 1`] = `
       <EuiToolTip
         content="Hide layer"
         disableScreenReaderOutput={true}
+        key="toggleVisiblity"
       >
         <EuiButtonIcon
           aria-label="Hide layer"
           iconType="eyeSlash"
-          key="toggleVisiblity"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Fit to data"
         disableScreenReaderOutput={true}
+        key="fitToBounds"
       >
         <EuiButtonIcon
           aria-label="Fit to data"
           iconType="maximize"
-          key="fitToBounds"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Edit layer settings"
         disableScreenReaderOutput={true}
+        key="settings"
       >
         <EuiButtonIcon
           aria-label="Edit layer settings"
@@ -374,12 +378,12 @@ exports[`TOCEntry props Should shade background when selected layer 1`] = `
       <EuiToolTip
         content="Reorder layer"
         disableScreenReaderOutput={true}
+        key="reorder"
       >
         <EuiButtonIcon
           aria-label="Reorder layer"
           className="mapTocEntry__grab"
           iconType="dragVertical"
-          key="reorder"
         />
       </EuiToolTip>
     </div>
@@ -440,22 +444,22 @@ exports[`TOCEntry props isReadOnly 1`] = `
       <EuiToolTip
         content="Hide layer"
         disableScreenReaderOutput={true}
+        key="toggleVisiblity"
       >
         <EuiButtonIcon
           aria-label="Hide layer"
           iconType="eyeSlash"
-          key="toggleVisiblity"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Fit to data"
         disableScreenReaderOutput={true}
+        key="fitToBounds"
       >
         <EuiButtonIcon
           aria-label="Fit to data"
           iconType="maximize"
-          key="fitToBounds"
           onClick={[Function]}
         />
       </EuiToolTip>
@@ -517,28 +521,29 @@ exports[`TOCEntry props should display layer details when isLegendDetailsOpen is
       <EuiToolTip
         content="Hide layer"
         disableScreenReaderOutput={true}
+        key="toggleVisiblity"
       >
         <EuiButtonIcon
           aria-label="Hide layer"
           iconType="eyeSlash"
-          key="toggleVisiblity"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Fit to data"
         disableScreenReaderOutput={true}
+        key="fitToBounds"
       >
         <EuiButtonIcon
           aria-label="Fit to data"
           iconType="maximize"
-          key="fitToBounds"
           onClick={[Function]}
         />
       </EuiToolTip>
       <EuiToolTip
         content="Edit layer settings"
         disableScreenReaderOutput={true}
+        key="settings"
       >
         <EuiButtonIcon
           aria-label="Edit layer settings"
@@ -551,12 +556,12 @@ exports[`TOCEntry props should display layer details when isLegendDetailsOpen is
       <EuiToolTip
         content="Reorder layer"
         disableScreenReaderOutput={true}
+        key="reorder"
       >
         <EuiButtonIcon
           aria-label="Reorder layer"
           className="mapTocEntry__grab"
           iconType="dragVertical"
-          key="reorder"
         />
       </EuiToolTip>
     </div>

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry.tsx
@@ -194,11 +194,11 @@ export class TOCEntry extends Component<Props, State> {
   _renderQuickActions() {
     const quickActions = [
       <EuiToolTip
+        key="toggleVisiblity"
         content={getVisibilityToggleLabel(this.props.layer.isVisible())}
         disableScreenReaderOutput
       >
         <EuiButtonIcon
-          key="toggleVisiblity"
           iconType={getVisibilityToggleIcon(this.props.layer.isVisible())}
           aria-label={getVisibilityToggleLabel(this.props.layer.isVisible())}
           onClick={this._toggleVisible}
@@ -208,9 +208,8 @@ export class TOCEntry extends Component<Props, State> {
 
     if (this.state.supportsFitToBounds) {
       quickActions.push(
-        <EuiToolTip content={FIT_TO_DATA_LABEL} disableScreenReaderOutput>
+        <EuiToolTip key="fitToBounds" content={FIT_TO_DATA_LABEL} disableScreenReaderOutput>
           <EuiButtonIcon
-            key="fitToBounds"
             iconType="maximize"
             aria-label={FIT_TO_DATA_LABEL}
             onClick={this._fitToBounds}
@@ -221,7 +220,7 @@ export class TOCEntry extends Component<Props, State> {
 
     if (!this.props.isReadOnly) {
       quickActions.push(
-        <EuiToolTip content={EDIT_LAYER_SETTINGS_LABEL} disableScreenReaderOutput>
+        <EuiToolTip key="settings" content={EDIT_LAYER_SETTINGS_LABEL} disableScreenReaderOutput>
           <EuiButtonIcon
             key="settings"
             isDisabled={this.props.isEditButtonDisabled}
@@ -233,13 +232,13 @@ export class TOCEntry extends Component<Props, State> {
       );
       quickActions.push(
         <EuiToolTip
+          key="reorder"
           content={i18n.translate('xpack.maps.layerControl.tocEntry.grabButtonTitle', {
             defaultMessage: 'Reorder layer',
           })}
           disableScreenReaderOutput
         >
           <EuiButtonIcon
-            key="reorder"
             iconType="dragVertical"
             aria-label={i18n.translate('xpack.maps.layerControl.tocEntry.grabButtonAriaLabel', {
               defaultMessage: 'Reorder layer',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[maps] fix react warning in TOCEntry "Each child in a list should have a unique key prop" (#282119)](https://github.com/elastic/kibana/pull/282119)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2026-08-03T13:37:08Z","message":"[maps] fix react warning in TOCEntry \"Each child in a list should have a unique key prop\" (#282119)\n\nRegression caused by https://github.com/elastic/kibana/pull/271486.\nhttps://github.com/elastic/kibana/pull/271486 wrapped `EuiButtonIcon`\nwith `EuiToolTip` but failed to move `key` up to top level element in\narray\n\n<img width=\"800\" alt=\"Screenshot 2026-07-31 at 11 53 41 AM\"\nsrc=\"https://github.com/user-attachments/assets/96c0e83b-c8b5-4c61-b866-663c63b898df\"\n/>","sha":"63fafd8ed79e5a96c1a2e0cb5c04677d6eaf2c20","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","release_note:skip","backport missing","backport:version","v9.6.0","v9.4.5","v9.5.1"],"title":"[maps] fix react warning in TOCEntry \"Each child in a list should have a unique key prop\"","number":282119,"url":"https://github.com/elastic/kibana/pull/282119","mergeCommit":{"message":"[maps] fix react warning in TOCEntry \"Each child in a list should have a unique key prop\" (#282119)\n\nRegression caused by https://github.com/elastic/kibana/pull/271486.\nhttps://github.com/elastic/kibana/pull/271486 wrapped `EuiButtonIcon`\nwith `EuiToolTip` but failed to move `key` up to top level element in\narray\n\n<img width=\"800\" alt=\"Screenshot 2026-07-31 at 11 53 41 AM\"\nsrc=\"https://github.com/user-attachments/assets/96c0e83b-c8b5-4c61-b866-663c63b898df\"\n/>","sha":"63fafd8ed79e5a96c1a2e0cb5c04677d6eaf2c20"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282119","number":282119,"mergeCommit":{"message":"[maps] fix react warning in TOCEntry \"Each child in a list should have a unique key prop\" (#282119)\n\nRegression caused by https://github.com/elastic/kibana/pull/271486.\nhttps://github.com/elastic/kibana/pull/271486 wrapped `EuiButtonIcon`\nwith `EuiToolTip` but failed to move `key` up to top level element in\narray\n\n<img width=\"800\" alt=\"Screenshot 2026-07-31 at 11 53 41 AM\"\nsrc=\"https://github.com/user-attachments/assets/96c0e83b-c8b5-4c61-b866-663c63b898df\"\n/>","sha":"63fafd8ed79e5a96c1a2e0cb5c04677d6eaf2c20"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->