### PR TITLE
[9.4] Use stable user id for conversation ownership instead of username alone (#281996)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.test.ts
@@ -32,6 +32,7 @@ jest.mock('./storage', () => ({
 describe('ConversationClient', () => {
   let client: ConversationClient;
 
+  /** Pass `userId: null` to build a legacy document that never stored a `user_id`. */
   const createConversationDocument = ({
     id = 'conversation-1',
     agentId = 'agent-1',
@@ -40,7 +41,7 @@ describe('ConversationClient', () => {
   }: {
     id?: string;
     agentId?: string;
-    userId?: string;
+    userId?: string | null;
     username?: string;
   } = {}): Document =>
     ({
@@ -49,7 +50,7 @@ describe('ConversationClient', () => {
       _primary_term: 1,
       _source: {
         agent_id: agentId,
-        user_id: userId,
+        ...(userId === null ? {} : { user_id: userId }),
         user_name: username,
         space: testSpace,
         title: 'Conversation 1',
@@ -161,6 +162,123 @@ describe('ConversationClient', () => {
           rounds: [],
         })
       ).rejects.toBe(error);
+    });
+  });
+
+  describe('ownership', () => {
+    const createClientForUser = (user: { id?: string; username: string }) =>
+      createClient({
+        space: testSpace,
+        logger: loggerMock.create(),
+        esClient: {} as never,
+        user,
+      });
+
+    it('grants access on a matching user_id', async () => {
+      mockEsClient.search.mockResolvedValue({
+        hits: { hits: [createConversationDocument()] },
+      });
+
+      await expect(client.get('conversation-1')).resolves.toEqual(
+        expect.objectContaining({ id: 'conversation-1' })
+      );
+    });
+
+    it('denies a same-username caller with no id when the conversation stored a user_id', async () => {
+      mockEsClient.search.mockResolvedValue({
+        hits: { hits: [createConversationDocument({ userId: 'owner-profile-uid' })] },
+      });
+
+      const sameUsernameOtherRealm = createClientForUser({ username: 'test-user' });
+
+      await expect(sameUsernameOtherRealm.get('conversation-1')).rejects.toThrow(
+        'Conversation conversation-1 not found'
+      );
+    });
+
+    it('falls back to username when the conversation never stored a user_id', async () => {
+      mockEsClient.search.mockResolvedValue({
+        hits: { hits: [createConversationDocument({ userId: null })] },
+      });
+
+      const legacyOwner = createClientForUser({ username: 'test-user' });
+
+      await expect(legacyOwner.get('conversation-1')).resolves.toEqual(
+        expect.objectContaining({ id: 'conversation-1' })
+      );
+    });
+
+    it('denies a different username on a conversation without a user_id', async () => {
+      mockEsClient.search.mockResolvedValue({
+        hits: { hits: [createConversationDocument({ userId: null, username: 'other-user' })] },
+      });
+
+      const otherUser = createClientForUser({ username: 'test-user' });
+
+      await expect(otherUser.get('conversation-1')).rejects.toThrow(
+        'Conversation conversation-1 not found'
+      );
+    });
+
+    it('lists on user_id, and on username only for documents without a user_id', async () => {
+      mockEsClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+      await client.list();
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            bool: expect.objectContaining({
+              filter: expect.arrayContaining([
+                {
+                  bool: {
+                    should: [
+                      { term: { user_id: 'user-1' } },
+                      {
+                        bool: {
+                          must_not: { exists: { field: 'user_id' } },
+                          filter: { term: { user_name: 'test-user' } },
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              ]),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('omits the user_id clause when the caller has no resolvable id', async () => {
+      mockEsClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+      await createClientForUser({ username: 'test-user' }).list();
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            bool: expect.objectContaining({
+              filter: expect.arrayContaining([
+                {
+                  bool: {
+                    should: [
+                      {
+                        bool: {
+                          must_not: { exists: { field: 'user_id' } },
+                          filter: { term: { user_name: 'test-user' } },
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              ]),
+            }),
+          }),
+        })
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -82,11 +82,9 @@ class ConversationClientImpl implements ConversationClient {
       _source: ['agent_id', 'user_id', 'user_name', 'title', 'created_at', 'updated_at'],
       query: {
         bool: {
-          filter: [createSpaceDslFilter(this.space)],
-          must: [
-            {
-              term: { user_name: this.user.username },
-            },
+          filter: [
+            createSpaceDslFilter(this.space),
+            buildOwnedConversationFilter({ user: this.user }),
             ...(agentId ? [{ term: { agent_id: agentId } }] : []),
           ],
         },
@@ -207,6 +205,38 @@ class ConversationClientImpl implements ConversationClient {
   }
 }
 
+/**
+ * Matches conversations owned by the current user, on `user_id` when the document stored one and on
+ * username only when it did not. Mirrors `hasAccess`.
+ */
+const buildOwnedConversationFilter = ({ user }: { user: UserIdAndName }) => {
+  const shouldClauses: Array<Record<string, unknown>> = [];
+
+  if (user.id !== undefined) {
+    shouldClauses.push({ term: { user_id: user.id } });
+  }
+
+  shouldClauses.push({
+    bool: {
+      must_not: { exists: { field: 'user_id' } },
+      filter: { term: { user_name: user.username } },
+    },
+  });
+
+  return {
+    bool: {
+      should: shouldClauses,
+      minimum_should_match: 1,
+    },
+  };
+};
+
+/**
+ * Checks whether the current user owns the conversation.
+ *
+ * Username matching is limited to documents that never stored a `user_id`, so those owners are not
+ * orphaned. It cannot distinguish same-username principals across authentication realms.
+ */
 const hasAccess = ({
   conversation,
   user,
@@ -214,8 +244,15 @@ const hasAccess = ({
   conversation: Pick<Document, '_source'>;
   user: UserIdAndName;
 }) => {
-  if (user.id && conversation._source!.user_id === user.id) {
-    return true;
+  const { user_id: userId, user_name: userName } = conversation._source!;
+
+  if (userId !== undefined && user.id !== undefined) {
+    return userId === user.id;
   }
-  return conversation._source!.user_name === user.username;
+
+  if (userId === undefined && user.username !== undefined) {
+    return userName === user.username;
+  }
+
+  return false;
 };


### PR DESCRIPTION
# Backport

This is a manual backport of #281996 to `9.4`.

The automatic backport [could not be created](https://github.com/elastic/kibana/pull/281996#issuecomment-5193876981)
because of merge conflicts: `9.4` predates the conversation `access_control/` module
(added in #275533), so none of the four files touched on `main` exist on this branch.
Ownership lives in `hasAccess` and in the `list()` query inside
`conversation/client/client.ts`, so the fix was ported by hand into that file.

Depends on #282840, the manual backport of #280890, which is already merged and
provides `toStableUserId`.

## Summary

Conversation ownership fell back to a bare username comparison whenever either side lacked
an id, and the listing filter matched `user_name` unconditionally. Since usernames are not
unique across Elasticsearch authentication realms, a same-username principal from another
realm could read the full round history, continue, rename, and delete another user's
conversation.

Ownership is the only gate for conversations on this branch — there is no ACL entry list
and no admin bypass.

This PR ports the same two guards:
- `hasAccess` only falls back to username for documents that never stored a `user_id`.
  Previously the fallback fired whenever *either* side lacked an id, so a caller with no
  resolvable principal matched any conversation sharing their username.
- The `list()` query gains an ownership filter that matches `user_id`, with the username
  term guarded by `must_not: { exists: { field: 'user_id' } }`.

## Deviation from the original PR

**The list-query change is larger here.** On `main` the fix was subtractive — a `user_id`
clause already sat beside the username term in `should`, so only the username term needed
guarding. On `9.4` the query filtered on `term: { user_name: this.user.username }` with no
`user_id` clause at all, so the id clause had to be *added*. Without it, `list()` would
have kept matching cross-realm on username while the get/update/delete path was fixed,
leaving the leak half-open.

The `agent_id` term moved from `must` into `filter` since `must` would otherwise be empty.
No test asserts on `must` and the query has no `sort`, so result ordering is unaffected.

**One test was not ported.** The original PR pins that a non-owner writing with
`access: 'converse'` preserves the owner's `user_id`/`user_name`. `9.4`'s `update()` has no
converse-access concept — public conversations arrived in 9.5 — so there is no non-owner
write path to pin on this branch.

## Testing

- 54 unit tests pass (48 existing + 6 new).
- The new tests were confirmed to catch the bug: reverting the `client.ts` change makes
  exactly 3 fail (the same-username-no-id denial and both list-DSL assertions), while the 3
  that pin preserved behaviour — id match, legacy username fallback, different-username
  denial — keep passing.
- `node scripts/eslint` clean; `node scripts/type_check --project .../agent_builder/tsconfig.json` exits 0.
