### PR TITLE
[Data Views] Surface field list failures in the data view editor

### DIFF
--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -384,6 +384,7 @@ const IndexPatternEditorFlyoutContentComponent = ({
                   options$={dataViewEditorService.timestampFieldOptions$}
                   isLoadingOptions$={dataViewEditorService.loadingTimestampFields$}
                   matchedIndices$={dataViewEditorService.matchedIndices$}
+                  optionsError$={dataViewEditorService.timestampFieldsError$}
                   disabled={isManaged}
                 />
               </EuiFlexItem>

--- a/src/platform/plugins/shared/data_view_editor/public/components/form_fields/timestamp_field.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/form_fields/timestamp_field.tsx
@@ -12,7 +12,8 @@ import { i18n } from '@kbn/i18n';
 import useObservable from 'react-use/lib/useObservable';
 import type { Observable } from 'rxjs';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
-import { EuiFormRow, EuiComboBox, EuiFormHelpText } from '@elastic/eui';
+import { EuiComboBox, EuiFormHelpText, EuiFormRow, EuiSpacer } from '@elastic/eui';
+import { KbnWarningCallout } from '@kbn/ui-callout';
 import { matchedIndiciesDefault } from '../../data_view_editor_service';
 
 import type { FieldConfig, FieldHook, ValidationConfig } from '../../shared_imports';
@@ -25,6 +26,7 @@ interface Props {
   options$: Observable<TimestampOption[]>;
   isLoadingOptions$: Observable<boolean>;
   matchedIndices$: Observable<MatchedIndicesSet>;
+  optionsError$: Observable<Error | undefined>;
   disabled?: boolean;
 }
 
@@ -72,14 +74,23 @@ const timestampFieldHelp = i18n.translate('indexPatternEditor.editor.form.timeFi
   defaultMessage: 'Select a timestamp field for use with the global time filter.',
 });
 
+const timestampOptionsErrorTitle = i18n.translate(
+  'indexPatternEditor.editor.form.timeFieldsErrorTitle',
+  {
+    defaultMessage: "Couldn't retrieve the list of timestamp fields",
+  }
+);
+
 export const TimestampField = ({
   options$,
   isLoadingOptions$,
   matchedIndices$,
+  optionsError$,
   disabled,
 }: Props) => {
   const options = useObservable<TimestampOption[]>(options$, []);
   const isLoadingOptions = useObservable<boolean>(isLoadingOptions$, false);
+  const optionsError = useObservable<Error | undefined>(optionsError$);
   const hasMatchedIndices = !!useObservable(matchedIndices$, matchedIndiciesDefault)
     .exactMatchedIndices.length;
 
@@ -91,8 +102,12 @@ export const TimestampField = ({
   const timestampConfig = useMemo(() => getTimestampConfig(options), [options]);
   const selectTimestampHelp = options.length ? timestampFieldHelp : '';
 
+  // when the field list request failed the empty list of options is not meaningful,
+  // the callout explains the failure instead
   const timestampNoFieldsHelp =
-    options.length === 0 && !isLoadingOptions && hasMatchedIndices ? noTimestampOptionText : '';
+    options.length === 0 && !isLoadingOptions && hasMatchedIndices && !optionsError
+      ? noTimestampOptionText
+      : '';
 
   return (
     <UseField<EuiComboBoxOptionOption<string>> config={timestampConfig} path="timestampField">
@@ -106,6 +121,7 @@ export const TimestampField = ({
             field={field}
             optionsAsComboBoxOptions={optionsAsComboBoxOptions}
             isLoadingOptions={isLoadingOptions}
+            optionsError={optionsError}
             disabled={disabled}
             timestampNoFieldsHelp={timestampNoFieldsHelp}
             selectTimestampHelp={selectTimestampHelp}
@@ -120,6 +136,7 @@ interface TimestampFieldRendererProps {
   field: FieldHook<EuiComboBoxOptionOption<string>>;
   optionsAsComboBoxOptions: Array<EuiComboBoxOptionOption<string>>;
   isLoadingOptions: boolean;
+  optionsError?: Error;
   disabled?: boolean;
   timestampNoFieldsHelp: string;
   selectTimestampHelp: string;
@@ -129,6 +146,7 @@ const TimestampFieldRenderer = ({
   field,
   optionsAsComboBoxOptions,
   isLoadingOptions,
+  optionsError,
   disabled,
   timestampNoFieldsHelp,
   selectTimestampHelp,
@@ -207,6 +225,17 @@ const TimestampFieldRenderer = ({
           </EuiFormHelpText>
         </>
       </EuiFormRow>
+      {optionsError && (
+        <>
+          <EuiSpacer size="s" />
+          <KbnWarningCallout
+            title={timestampOptionsErrorTitle}
+            text={optionsError.message}
+            size="s"
+            data-test-subj="timestampFieldError"
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/platform/plugins/shared/data_view_editor/public/data_view_editor_service.test.ts
+++ b/src/platform/plugins/shared/data_view_editor/public/data_view_editor_service.test.ts
@@ -7,9 +7,25 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { first, firstValueFrom } from 'rxjs';
 import { DataViewEditorService } from './data_view_editor_service';
 import type { HttpSetup } from '@kbn/core/public';
 import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
+
+const createService = (dataViewsOverrides: Partial<DataViewsServicePublic> = {}) =>
+  new DataViewEditorService({
+    services: {
+      http: { get: jest.fn().mockResolvedValue({}) } as unknown as HttpSetup,
+      dataViews: {
+        getIdsWithTitle: jest.fn().mockResolvedValue([]),
+        getRollupsEnabled: jest.fn().mockReturnValue(false),
+        getIndices: jest.fn().mockResolvedValue([{ name: 'tracks', item: {} }]),
+        getFieldsForWildcard: jest.fn().mockResolvedValue([]),
+        ...dataViewsOverrides,
+      } as unknown as DataViewsServicePublic,
+    },
+    initialValues: {},
+  });
 
 describe('DataViewEditorService', () => {
   it('should check for rollup indices when rolls are enabled', () => {
@@ -43,5 +59,48 @@ describe('DataViewEditorService', () => {
     });
 
     expect(http.get).toHaveBeenCalledTimes(0);
+  });
+
+  describe('timestamp fields', () => {
+    it('should expose the failure when the field list request fails', async () => {
+      const service = createService({
+        getFieldsForWildcard: jest.fn().mockRejectedValue(new Error('Fields API is unavailable')),
+      });
+
+      service.setIndexPattern('tracks*');
+
+      const error = await firstValueFrom(
+        service.timestampFieldsError$.pipe(first((value) => value !== undefined))
+      );
+
+      expect(error?.message).toBe('Fields API is unavailable');
+      expect(await firstValueFrom(service.timestampFieldOptions$)).toEqual([]);
+
+      service.destroy();
+    });
+
+    it('should clear a previous failure once the field list request succeeds', async () => {
+      const service = createService({
+        getFieldsForWildcard: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('Fields API is unavailable'))
+          .mockResolvedValue([{ name: '@timestamp', type: 'date' }]),
+      });
+
+      service.setIndexPattern('tracks*');
+      await firstValueFrom(
+        service.timestampFieldsError$.pipe(first((value) => value !== undefined))
+      );
+
+      service.setIndexPattern('other*');
+      const options = await firstValueFrom(
+        service.timestampFieldOptions$.pipe(first((value) => value.length > 0))
+      );
+
+      expect(options.map(({ fieldName }) => fieldName)).toContain('@timestamp');
+      expect(await firstValueFrom(service.timestampFieldsError$)).toBeUndefined();
+
+      service.destroy();
+    });
   });
 });

--- a/src/platform/plugins/shared/data_view_editor/public/data_view_editor_service.ts
+++ b/src/platform/plugins/shared/data_view_editor/public/data_view_editor_service.ts
@@ -75,6 +75,7 @@ interface DataViewEditorState {
   isLoadingSourcesInternal: boolean;
   loadingTimestampFields: boolean;
   timestampFieldOptions: TimestampOption[];
+  timestampFieldsError?: Error;
   rollupIndexName?: string | null;
   rollupCaps?: RollupIndiciesCapability;
 }
@@ -85,6 +86,7 @@ const defaultDataViewEditorState: DataViewEditorState = {
   isLoadingSourcesInternal: false,
   loadingTimestampFields: false,
   timestampFieldOptions: [],
+  timestampFieldsError: undefined,
   rollupIndexName: undefined,
 };
 
@@ -126,6 +128,7 @@ export class DataViewEditorService {
     this.isLoadingSources$ = stateSelector((state) => state.isLoadingSourcesInternal);
     this.loadingTimestampFields$ = stateSelector((state) => state.loadingTimestampFields);
     this.timestampFieldOptions$ = stateSelector((state) => state.timestampFieldOptions);
+    this.timestampFieldsError$ = stateSelector((state) => state.timestampFieldsError);
     this.rollupIndex$ = stateSelector((state) => state.rollupIndexName);
     this.rollupCaps$ = stateSelector((state) => state.rollupCaps);
 
@@ -177,6 +180,8 @@ export class DataViewEditorService {
   isLoadingSources$: Observable<boolean>;
   loadingTimestampFields$: Observable<boolean>;
   timestampFieldOptions$: Observable<TimestampOption[]>;
+  // error thrown while fetching the field list, so the UI can explain why no timestamp field is selectable
+  timestampFieldsError$: Observable<Error | undefined>;
 
   // current matched rollup index
   rollupIndex$: Observable<string | undefined | null>;
@@ -349,12 +354,8 @@ export class DataViewEditorService {
     getFieldsOptions: GetFieldsOptions,
     requireTimestampField: boolean
   ) => {
-    try {
-      const fields = await ensureMinimumTime(this.dataViews.getFieldsForWildcard(getFieldsOptions));
-      return extractTimeFields(fields as DataViewField[], requireTimestampField);
-    } catch (e) {
-      return [];
-    }
+    const fields = await ensureMinimumTime(this.dataViews.getFieldsForWildcard(getFieldsOptions));
+    return extractTimeFields(fields as DataViewField[], requireTimestampField);
   };
 
   private getTimestampOptionsForWildcardCached = async (
@@ -381,7 +382,11 @@ export class DataViewEditorService {
   private loadTimestampFields = async () => {
     const currentState = this.state$.getValue();
     if (currentState.matchedIndices.exactMatchedIndices.length === 0) {
-      this.updateState({ timestampFieldOptions: [], loadingTimestampFields: false });
+      this.updateState({
+        timestampFieldOptions: [],
+        timestampFieldsError: undefined,
+        loadingTimestampFields: false,
+      });
       return;
     }
     const currentLoadingTimestampFieldsIdx = ++this.currentLoadingTimestampFields;
@@ -398,14 +403,22 @@ export class DataViewEditorService {
     }
 
     let timestampFieldOptions: TimestampOption[] = [];
+    let timestampFieldsError: Error | undefined;
     try {
       timestampFieldOptions = await this.getTimestampOptionsForWildcardCached(
         getFieldsOptions,
         this.requireTimestampField
       );
+    } catch (error) {
+      // keep the error around so the UI can explain why the timestamp field can't be selected
+      timestampFieldsError = error instanceof Error ? error : new Error(String(error));
     } finally {
       if (currentLoadingTimestampFieldsIdx === this.currentLoadingTimestampFields) {
-        this.updateState({ timestampFieldOptions, loadingTimestampFields: false });
+        this.updateState({
+          timestampFieldOptions,
+          timestampFieldsError,
+          loadingTimestampFields: false,
+        });
       }
     }
   };


### PR DESCRIPTION
## Summary

Closes #161690

The create/edit data view flyout swallowed every failure from the fields endpoint and returned an empty list of timestamp options:

```ts
// data_view_editor_service.ts
} catch (e) {
  return [];
}
```

<img width="1133" height="545" alt="CleanShot 2026-08-06 at 12 27 31" src="https://github.com/user-attachments/assets/75d50651-07b1-4b2f-8ba2-244ed44681a7" />


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes — none; the change is client-side only


