### PR TITLE
[APM UI][Chrome Next] Fix Back menu self-links from entity breadcrumbs

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/dependency_detail_view/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/dependency_detail_view/index.tsx
@@ -43,20 +43,9 @@ export function DependencyDetailView({ children }: { children: React.ReactChild 
           },
         }),
       },
+      // No href on the current entity — Chrome Next Back would self-link.
       {
         title: dependencyName,
-        href: apmRouter.link('/dependencies', {
-          query: {
-            dependencyName,
-            rangeFrom,
-            rangeTo,
-            refreshInterval,
-            refreshPaused,
-            environment,
-            kuery,
-            comparisonEnabled,
-          },
-        }),
       },
     ],
     [

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/service_detail/apm_service_wrapper.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/service_detail/apm_service_wrapper.tsx
@@ -25,12 +25,10 @@ export function ApmServiceWrapper() {
         title: ServiceInventoryTitle,
         href: router.link('/services', { query }),
       },
+      // No href on the current entity — Chrome Next Back uses linked crumbs except the last
+      // and would otherwise offer a self-navigation target
       {
         title: serviceName,
-        href: router.link('/services/{serviceName}', {
-          query,
-          path: { serviceName },
-        }),
       },
     ],
     [query, router, serviceName],

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/mobile_service_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/mobile_service_template/index.tsx
@@ -96,12 +96,9 @@ function TemplateWithContext({
       },
       ...(selectedTab
         ? [
+            // No href on the current entity — Chrome Next Back would self-link.
             {
               title: serviceName,
-              href: router.link('/mobile-services/{serviceName}', {
-                path: { serviceName },
-                query,
-              }),
             },
             {
               title: selectedTab.label,
@@ -110,7 +107,7 @@ function TemplateWithContext({
           ]
         : []),
     ],
-    [query, router, selectedTab, serviceName, servicesLink],
+    [selectedTab, serviceName, servicesLink],
     {
       omitRootOnServerless: true,
     }

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/service_group_template.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/service_group_template.tsx
@@ -105,9 +105,9 @@ export function ServiceGroupTemplate({
               }),
               href: serviceGroupsLink,
             },
+            // No href on the current entity — Chrome Next Back would self-link.
             {
               title: serviceGroupName,
-              href: router.link('/services', { query: linkQuery }),
             },
             ...(selectedTab
               ? [

--- a/x-pack/solutions/observability/plugins/apm/public/context/breadcrumbs/context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/context/breadcrumbs/context.tsx
@@ -14,7 +14,8 @@ import { useKibana } from '../kibana_context/use_kibana';
 
 export interface Breadcrumb {
   title: string;
-  href: string;
+  /** Omit for the current entity so Chrome Next compatibility Back does not self-link. */
+  href?: string;
 }
 
 interface BreadcrumbApi {
@@ -67,13 +68,10 @@ export function BreadcrumbsContextProvider({ children }: { children: React.React
   const formattedBreadcrumbs: ChromeBreadcrumb[] = api
     .getBreadcrumbs(matches)
     .map((breadcrumb, index, array) => {
+      const isLast = index === array.length - 1;
       return {
         text: breadcrumb.title,
-        ...(index === array.length - 1
-          ? {}
-          : {
-              href: breadcrumb.href,
-            }),
+        ...(!isLast && breadcrumb.href ? { href: breadcrumb.href } : {}),
       };
     });
 


### PR DESCRIPTION
## Summary

Chrome Next builds the compatibility **Back** menu from linked breadcrumbs (all crumbs except the last). APM was giving the current entity (service / mobile service / dependency / service group) an `href`, so Back offered that same entity and navigating it looped back to the page.

This omits `href` on those entity crumbs (same idea as infra #282663). Classic chrome still shows the entity name; it is just not a link.

BEFORE

https://github.com/user-attachments/assets/2e723973-50ad-4548-b336-672cbf2bb506

AFTER

https://github.com/user-attachments/assets/9e387113-0064-4a4c-9b4a-a5db874c154b


## How to test

- [ ] With `core.chrome.next` enabled: open a service detail page → Back menu should show **Service inventory** only (not the service name).
- [ ] Same check for mobile service, dependency detail, and a filtered service group.
- [ ] With Chrome Next off: classic breadcrumbs still look correct (entity name visible).
