### PR TITLE
[Security Solution][Cases] render rule link as text for linked alerts attached to a case

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.test.tsx
@@ -118,4 +118,35 @@ describe('AlertEvent', () => {
     expect(mockOpenFlyout).not.toHaveBeenCalled();
     expect(flyoutApi.openRuleFlyout).not.toHaveBeenCalled();
   });
+
+  describe('when the alert is a linked/remote (CPS) alert', () => {
+    it('renders the rule name as plain text instead of a clickable link', () => {
+      render(
+        <TestProviders>
+          <AlertEvent {...defaultProps} isRemoteAlert={true} />
+        </TestProviders>
+      );
+
+      // the rule name is still displayed within the user action title
+      expect(screen.getByTestId(`alerts-user-action-${savedObjectId}`)).toHaveTextContent(
+        'My rule'
+      );
+      // but it is no longer rendered as a clickable link
+      expect(screen.queryByTestId(ruleLinkTestId)).not.toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('does not open any flyout when the rule name is clicked', () => {
+      render(
+        <TestProviders>
+          <AlertEvent {...defaultProps} isRemoteAlert={true} />
+        </TestProviders>
+      );
+
+      fireEvent.click(screen.getByTestId(`alerts-user-action-${savedObjectId}`));
+
+      expect(mockOpenFlyout).not.toHaveBeenCalled();
+      expect(flyoutApi.openRuleFlyout).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.tsx
@@ -39,6 +39,12 @@ export interface AlertEventProps {
   rule: AlertAttachmentMetadata['rule'];
   savedObjectId: string;
   totalAlerts: number;
+  /**
+   * Whether the alert originates from a linked/remote (CPS) project. When true,
+   * the rule cannot be resolved from the local project, so the rule name is
+   * rendered as plain text instead of a clickable link that opens the rule flyout.
+   */
+  isRemoteAlert?: boolean;
 }
 
 export const AlertEvent: React.FC<AlertEventProps> = ({
@@ -46,6 +52,7 @@ export const AlertEvent: React.FC<AlertEventProps> = ({
   totalAlerts,
   savedObjectId,
   rule,
+  isRemoteAlert = false,
 }) => {
   const { openFlyout } = useExpandableFlyoutApi();
   const enableNewFlyout = useIsNewFlyoutEnabled();
@@ -111,7 +118,10 @@ export const AlertEvent: React.FC<AlertEventProps> = ({
         label: resolvedRuleName,
         fallbackLabel: i18n.UNKNOWN_RULE,
         dataTestSubj: `alert-rule-link-${savedObjectId}`,
-        onClick: onRuleClick,
+        // Linked/remote (CPS) alerts reference a rule that only exists on the
+        // linked project and cannot be resolved locally, so omit the click
+        // handler to render the rule name as plain text instead of a broken link.
+        onClick: isRemoteAlert ? undefined : onRuleClick,
       }}
       dataTestSubj={`alerts-user-action-${savedObjectId}`}
     />

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Suspense, lazy, type ComponentType } from 'react';
+import React, { type ComponentType, lazy, Suspense } from 'react';
 import { EuiAvatar, EuiLoadingSpinner } from '@elastic/eui';
 import type {
   CommonAttachmentTabViewProps,
@@ -13,13 +13,14 @@ import type {
 } from '@kbn/cases-plugin/public';
 import { defineAttachment } from '@kbn/cases-plugin/public';
 import {
+  type AlertAttachmentMetadata,
   AttachmentActionType,
   CASE_VIEW_PAGE_TABS,
-  SECURITY_ALERT_ATTACHMENT_TYPE,
   getNonEmptyField,
+  SECURITY_ALERT_ATTACHMENT_TYPE,
   toStringArray,
-  type AlertAttachmentMetadata,
 } from '@kbn/cases-plugin/common';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { SecurityAlertAttachmentPayloadSchema } from '../../../../common/cases/attachments/alert';
 import * as i18n from './translations';
 
@@ -58,6 +59,7 @@ const getAttachmentViewObject = (props: SecurityAlertViewProps) => {
   const isSingleAlert = totalAlerts === 1;
   const index = getNonEmptyField(metadata?.index);
   const alertId = getNonEmptyField(alertIds[0]);
+  const isRemoteAlert = isNonLocalIndexName(index ?? '');
   return {
     event: (
       <Suspense fallback={<EuiLoadingSpinner size="m" />}>
@@ -66,6 +68,7 @@ const getAttachmentViewObject = (props: SecurityAlertViewProps) => {
           totalAlerts={totalAlerts}
           savedObjectId={savedObjectId}
           rule={metadata?.rule}
+          isRemoteAlert={isRemoteAlert}
         />
       </Suspense>
     ),


### PR DESCRIPTION
## Summary

This PR makes a small change that renders the Rule link when attaching an alert to a case, as text
<img width="953" height="677" alt="Screenshot 2026-08-05 at 6 45 41 PM" src="https://github.com/user-attachments/assets/d1fbbdad-42fb-4664-a671-b75572f99918" />

instead of as a link that would open the flyout when the alert is linked (CPS) or remote (CCS)
<img width="946" height="686" alt="Screenshot 2026-08-05 at 6 45 11 PM" src="https://github.com/user-attachments/assets/6a08413b-c45a-4141-91a5-f8a728fb7b78" />

This is because we can't render the rule flyout for remote/linked rule at this time.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
