### PR TITLE
[9.5] [SecuritySolution][Flyout] full rule preview parity (#282811)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.test.tsx
@@ -29,6 +29,9 @@ import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('../../../hooks/use_is_new_flyout_enabled');
 jest.mock('../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../hooks/use_space_id', () => ({
+  useSpaceId: () => 'default',
+}));
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
   const original = jest.requireActual('react-redux');
@@ -225,6 +228,48 @@ describe('RowAction', () => {
       scopeId: TableId.hostsPageEvents,
       alertsTableRef: undefined,
     });
+  });
+
+  test('should open the pattern-based flyout for rule preview alerts, converting the backing index to its alias', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+    const backingIndex = '.internal.preview.alerts-security.alerts-default';
+    const aliasIndex = '.preview.alerts-security.alerts-default';
+
+    const rulePreviewProps: RowActionProps = {
+      ...defaultProps,
+      tableId: TableId.rulePreview,
+      data: {
+        _id: '1',
+        _index: backingIndex,
+        data: [],
+        ecs: { _id: '1' },
+      },
+      esHitRecord: {
+        _id: '1',
+        _index: backingIndex,
+        _source: {},
+      },
+    };
+
+    const wrapper = render(
+      <TestProviders>
+        <RowAction {...rulePreviewProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(wrapper.getByTestId('expand-event'));
+
+    // Rule preview must NOT use the index-based wrapper (which searches via a data view
+    // pattern and cannot find preview backing indices); it must use the pattern-based
+    // wrapper, which resolves the document via useTimelineEventsDetails directly.
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+    expect(flyoutApi.openDocumentFlyoutFromPattern).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: '1',
+        indexName: aliasIndex,
+      })
+    );
   });
 
   describe('notes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -17,8 +17,13 @@ import {
   SECURITY_CELL_ACTIONS_DETAILS_FLYOUT,
 } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
-import { createCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
+import {
+  createCellActionRenderer,
+  rulePreviewCellActionRenderer,
+} from '../../../../flyout_v2/shared/components/cell_actions';
 import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { getAlertIndexAlias } from '../../../../flyout/document_details/shared/hooks/use_event_details';
+import { useSpaceId } from '../../../hooks/use_space_id';
 import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
 import { useKibana } from '../../../lib/kibana';
 import { useIsNewFlyoutEnabled } from '../../../hooks/use_is_new_flyout_enabled';
@@ -95,10 +100,11 @@ const RowActionComponent = ({
   );
 
   const { telemetry } = useKibana().services;
+  const spaceId = useSpaceId();
 
   const { openFlyout } = useExpandableFlyoutApi();
   const enableNewFlyout = useIsNewFlyoutEnabled();
-  const { openDocumentFlyoutFromIndex, openNotes } = useFlyoutApi();
+  const { openDocumentFlyoutFromIndex, openDocumentFlyoutFromPattern, openNotes } = useFlyoutApi();
 
   const columnValues = useMemo(
     () =>
@@ -150,14 +156,31 @@ const RowActionComponent = ({
 
   const handleOnEventDetailPanelOpened = useCallback(() => {
     if (enableNewFlyout && hit) {
-      openDocumentFlyoutFromIndex({
-        documentId: eventId,
-        indexName: indexName ?? undefined,
-        renderCellActions: documentFlyoutCellActionRenderer,
-        onAlertUpdated: handleAlertUpdated,
-        origin: FLYOUT_ORIGIN.ALERTS_TABLE,
-        title: getDocumentHistoryTitle(hit),
-      });
+      if (tableId === TableId.rulePreview) {
+        // Rule preview alert rows reference their backing .internal.preview. index, which is
+        // not included in any data view pattern. Convert to the alias and resolve via the
+        // pattern-based wrapper.
+        const resolvedIndex = indexName
+          ? getAlertIndexAlias(indexName, spaceId) ?? indexName
+          : undefined;
+        openDocumentFlyoutFromPattern({
+          documentId: eventId,
+          indexName: resolvedIndex,
+          renderCellActions: rulePreviewCellActionRenderer,
+          onAlertUpdated: handleAlertUpdated,
+          origin: FLYOUT_ORIGIN.ALERTS_TABLE,
+          title: getDocumentHistoryTitle(hit),
+        });
+      } else {
+        openDocumentFlyoutFromIndex({
+          documentId: eventId,
+          indexName: indexName ?? undefined,
+          renderCellActions: documentFlyoutCellActionRenderer,
+          onAlertUpdated: handleAlertUpdated,
+          origin: FLYOUT_ORIGIN.ALERTS_TABLE,
+          title: getDocumentHistoryTitle(hit),
+        });
+      }
     } else {
       openFlyout({
         right: {
@@ -177,13 +200,15 @@ const RowActionComponent = ({
   }, [
     enableNewFlyout,
     hit,
+    tableId,
+    spaceId,
+    indexName,
+    openDocumentFlyoutFromPattern,
     openDocumentFlyoutFromIndex,
     documentFlyoutCellActionRenderer,
     eventId,
-    indexName,
     handleAlertUpdated,
     openFlyout,
-    tableId,
     telemetry,
   ]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.test.tsx
@@ -19,15 +19,10 @@ jest.mock('@kbn/expandable-flyout');
 jest.mock(
   '../../../../flyout_v2/document/tools/correlations/components/correlations_details_view',
   () => ({
-    CorrelationsDetailsView: ({
-      scopeId,
-      isRulePreview,
-      onShowAttack,
-    }: CorrelationsDetailsProps) => (
+    CorrelationsDetailsView: ({ scopeId, onShowAttack }: CorrelationsDetailsProps) => (
       <div
         data-test-subj="correlationsDetailsV2Mock"
         data-scope-id={scopeId}
-        data-is-rule-preview={String(isRulePreview)}
         data-has-on-show-attack={String(typeof onShowAttack === 'function')}
       />
     ),
@@ -57,7 +52,6 @@ describe('CorrelationsDetails', () => {
     const el = getByTestId('correlationsDetailsV2Mock');
     expect(el).toBeInTheDocument();
     expect(el).toHaveAttribute('data-scope-id', mockContextValue.scopeId);
-    expect(el).toHaveAttribute('data-is-rule-preview', String(mockContextValue.isRulePreview));
   });
 
   it('passes onShowAttack callback to CorrelationsDetailsV2', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.tsx
@@ -21,7 +21,7 @@ export const CORRELATIONS_TAB_ID = 'correlations';
  * Correlations displayed in the document details expandable flyout left section under the Insights tab
  */
 export const CorrelationsDetails: React.FC = () => {
-  const { scopeId, isRulePreview, searchHit } = useDocumentDetailsContext();
+  const { scopeId, searchHit } = useDocumentDetailsContext();
   const { openPreviewPanel } = useExpandableFlyoutApi();
 
   const onShowAlert = useCallback(
@@ -48,7 +48,6 @@ export const CorrelationsDetails: React.FC = () => {
     <CorrelationsDetailsView
       hit={hit}
       scopeId={scopeId}
-      isRulePreview={isRulePreview}
       onShowAlert={onShowAlert}
       onShowAttack={onShowAttack}
       useLegacyExpandableFlyout

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs.tsx
@@ -70,12 +70,12 @@ export const investigationTab: LeftPanelTabType = {
 };
 
 const ResponseTab = () => {
-  const { searchHit, isRulePreview } = useDocumentDetailsContext();
+  const { searchHit } = useDocumentDetailsContext();
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
 
   return (
     <EuiPanel data-test-subj={RESPONSE_TAB_CONTENT_TEST_ID} hasShadow={false}>
-      <ResponseDetailsContent hit={hit} isRulePreview={isRulePreview} />
+      <ResponseDetailsContent hit={hit} />
     </EuiPanel>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
@@ -6,21 +6,18 @@
  */
 
 import React, { memo, useCallback, useMemo } from 'react';
-import { isEmpty } from 'lodash';
 import {
   buildDataTableRecord,
   type DataTableRecord,
   type EsHitRecord,
   getFieldValue,
 } from '@kbn/discover-utils';
-import { isNonLocalIndexName } from '@kbn/es-query';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FLYOUT_STORAGE_KEYS } from '../../../../flyout_v2/document/main/constants/local_storage';
 import { ExpandableSection } from '../../../../flyout_v2/shared/components/expandable_section';
 import { useExpandSection } from '../../../../flyout_v2/shared/hooks/use_expand_section';
 import { RULE_PREVIEW_BANNER, RulePreviewPanelKey } from '../../../rule_details/right';
 import { useKibana } from '../../../../common/lib/kibana';
-import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useBasicDataFromDetailsData } from '../../shared/hooks/use_basic_data_from_details_data';
 import { EventKind } from '../../../../flyout_v2/document/main/constants/event_kinds';
 import { useDocumentDetailsContext } from '../../shared/context';
@@ -46,25 +43,16 @@ const KEY = 'about';
  */
 export const AboutSection = memo(() => {
   const { telemetry } = useKibana().services;
-  const {
-    dataAsNestedObject,
-    dataFormattedForFieldBrowser,
-    indexName,
-    isRulePreview,
-    scopeId,
-    searchHit,
-  } = useDocumentDetailsContext();
-  const canReadRules = useUserPrivileges().rulesPrivileges.rules.read;
+  const { dataAsNestedObject, dataFormattedForFieldBrowser, scopeId, searchHit } =
+    useDocumentDetailsContext();
   const { openPreviewPanel } = useExpandableFlyoutApi();
 
-  const { ruleId, ruleName } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
+  const { ruleId } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
 
   const hit: DataTableRecord = useMemo(
     () => buildDataTableRecord(searchHit as EsHitRecord),
     [searchHit]
   );
-
-  const isRemoteDocument = useMemo(() => isNonLocalIndexName(indexName), [indexName]);
 
   const eventKind = useMemo(() => getFieldValue(hit, 'event.kind') as string, [hit]);
   const eventKindInECS = eventKind && isEcsAllowedValue('event.kind', eventKind);
@@ -74,12 +62,6 @@ export const AboutSection = memo(() => {
     title: KEY,
     defaultValue: true,
   });
-
-  const ruleSummaryDisabled = useMemo(
-    () =>
-      isEmpty(ruleName) || isEmpty(ruleId) || isRulePreview || !canReadRules || isRemoteDocument,
-    [canReadRules, isRemoteDocument, isRulePreview, ruleId, ruleName]
-  );
 
   const openRulePreview = useCallback(() => {
     openPreviewPanel({
@@ -99,11 +81,7 @@ export const AboutSection = memo(() => {
   const content =
     eventKind === EventKind.signal ? (
       <>
-        <AlertDescription
-          hit={hit}
-          onShowRuleSummary={openRulePreview}
-          ruleSummaryDisabled={ruleSummaryDisabled}
-        />
+        <AlertDescription hit={hit} onShowRuleSummary={openRulePreview} />
         <AlertReason hit={hit} />
         <MitreAttack hit={hit} />
         <AlertStatus hit={hit} />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_section.tsx
@@ -35,7 +35,7 @@ const KEY = 'insights';
  * Insights section under overview tab. It contains entities, threat intelligence, prevalence and correlations.
  */
 export const InsightsSection = memo(() => {
-  const { getFieldsData, investigationFields, isPreviewMode, searchHit, scopeId, isRulePreview } =
+  const { getFieldsData, investigationFields, isPreviewMode, searchHit, scopeId } =
     useDocumentDetailsContext();
   const eventKind = getField(getFieldsData('event.kind'));
 
@@ -110,7 +110,6 @@ export const InsightsSection = memo(() => {
       <CorrelationsOverview
         hit={hit}
         scopeId={scopeId}
-        isRulePreview={isRulePreview}
         showIcon={!isPreviewMode}
         onShowCorrelationsDetails={goToCorrelationsTab}
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
@@ -16,19 +16,13 @@ import { ResponseSectionContent } from '../../../../flyout_v2/document/main/comp
  * Response section adapter for the legacy expandable flyout overview tab.
  */
 export const ResponseSection = memo(() => {
-  const { isRulePreview, searchHit } = useDocumentDetailsContext();
+  const { searchHit } = useDocumentDetailsContext();
   const goToResponseTab = useNavigateToLeftPanel({
     tab: LeftPanelResponseTab,
   });
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
 
-  return (
-    <ResponseSectionContent
-      hit={hit}
-      isRulePreview={isRulePreview}
-      onShowResponseDetails={goToResponseTab}
-    />
-  );
+  return <ResponseSectionContent hit={hit} onShowResponseDetails={goToResponseTab} />;
 });
 
 ResponseSection.displayName = 'ResponseSection';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/tabs.tsx
@@ -45,15 +45,10 @@ const detailsFlyoutCellActionRenderer: CellActionRenderer = ({ field, value, chi
  * `flyout_v2`; this component only reads the context and forwards the values as props.
  */
 const TableTabContent = memo(() => {
-  const { searchHit, scopeId, isRulePreview } = useDocumentDetailsContext();
+  const { searchHit, scopeId } = useDocumentDetailsContext();
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
   return (
-    <TableTab
-      hit={hit}
-      scopeId={scopeId}
-      isRulePreview={isRulePreview}
-      renderCellActions={detailsFlyoutCellActionRenderer}
-    />
+    <TableTab hit={hit} scopeId={scopeId} renderCellActions={detailsFlyoutCellActionRenderer} />
   );
 });
 TableTabContent.displayName = 'TableTabContent';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs/asset_document.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs/asset_document.tsx
@@ -60,14 +60,7 @@ export const AssetDocumentTab: FC<Partial<AssetDocumentPanelProps>> = memo(() =>
             defaultMessage="Table"
           />
         ),
-        content: (
-          <TableTab
-            hit={hit}
-            scopeId={scopeId}
-            isRulePreview={isRulePreview}
-            renderCellActions={cellActionRenderer}
-          />
-        ),
+        content: <TableTab hit={hit} scopeId={scopeId} renderCellActions={cellActionRenderer} />,
       },
       {
         id: JSON_TAB_TEST_ID,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/alert_description.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/alert_description.test.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { initialUserPrivilegesState } from '../../../../common/components/user_privileges/user_privileges_context';
 import { AlertDescription } from './alert_description';
 import {
   ALERT_DESCRIPTION_DETAILS_TEST_ID,
@@ -16,13 +18,18 @@ import {
   RULE_SUMMARY_BUTTON_TEST_ID,
 } from './test_ids';
 
-const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
+jest.mock('../../../../common/components/user_privileges');
+
+const createMockHit = (flattened: DataTableRecord['flattened'], index = ''): DataTableRecord =>
   ({
     id: '1',
-    raw: {},
+    raw: { _index: index },
     flattened,
     isAnchor: false,
   } as DataTableRecord);
+
+const PREVIEW_INDEX = '.preview.alerts-security.alerts-default';
+const REMOTE_INDEX = 'remote_cluster:alerts';
 
 const alertHitWithDescription = createMockHit({
   'event.kind': 'signal',
@@ -41,6 +48,16 @@ const documentHit = createMockHit({
   'some.other.field': 'value',
 });
 
+const previewAlertHit = createMockHit(
+  { 'event.kind': 'signal', 'kibana.alert.rule.uuid': '123' },
+  PREVIEW_INDEX
+);
+
+const remoteAlertHit = createMockHit(
+  { 'event.kind': 'signal', 'kibana.alert.rule.uuid': '123' },
+  REMOTE_INDEX
+);
+
 const renderDescription = (props: Parameters<typeof AlertDescription>[0]) =>
   render(
     <IntlProvider locale="en">
@@ -51,6 +68,16 @@ const renderDescription = (props: Parameters<typeof AlertDescription>[0]) =>
 const NO_DATA_MESSAGE = "There's no description for this rule.";
 
 describe('<AlertDescription />', () => {
+  beforeEach(() => {
+    jest.mocked(useUserPrivileges).mockReturnValue({
+      ...initialUserPrivilegesState(),
+      rulesPrivileges: {
+        ...initialUserPrivilegesState().rulesPrivileges,
+        rules: { read: true, edit: false },
+      },
+    });
+  });
+
   it('should render rule title and description when hit is an alert with description', () => {
     const { getByTestId } = renderDescription({ hit: alertHitWithDescription });
 
@@ -84,11 +111,38 @@ describe('<AlertDescription />', () => {
     expect(onShowRuleSummary).toHaveBeenCalledTimes(1);
   });
 
-  it('should render rule summary button as disabled when ruleSummaryDisabled is true', () => {
+  it('should render rule summary button as disabled for a rule preview document', () => {
+    const { getByTestId } = renderDescription({
+      hit: previewAlertHit,
+      onShowRuleSummary: jest.fn(),
+    });
+
+    expect(getByTestId(RULE_SUMMARY_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(RULE_SUMMARY_BUTTON_TEST_ID)).toHaveAttribute('disabled');
+  });
+
+  it('should render rule summary button as disabled when user cannot read rules', () => {
+    jest.mocked(useUserPrivileges).mockReturnValue({
+      ...initialUserPrivilegesState(),
+      rulesPrivileges: {
+        ...initialUserPrivilegesState().rulesPrivileges,
+        rules: { read: false, edit: false },
+      },
+    });
+
     const { getByTestId } = renderDescription({
       hit: alertHitWithDescription,
       onShowRuleSummary: jest.fn(),
-      ruleSummaryDisabled: true,
+    });
+
+    expect(getByTestId(RULE_SUMMARY_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(RULE_SUMMARY_BUTTON_TEST_ID)).toHaveAttribute('disabled');
+  });
+
+  it('should render rule summary button as disabled for a remote document', () => {
+    const { getByTestId } = renderDescription({
+      hit: remoteAlertHit,
+      onShowRuleSummary: jest.fn(),
     });
 
     expect(getByTestId(RULE_SUMMARY_BUTTON_TEST_ID)).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/alert_description.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/alert_description.tsx
@@ -8,12 +8,15 @@
 import { css } from '@emotion/react';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { EventKind } from '../constants/event_kinds';
+import { isRulePreviewDocument } from '../../../shared/utils/is_rule_preview_document';
 import {
   ALERT_DESCRIPTION_DETAILS_TEST_ID,
   ALERT_DESCRIPTION_TITLE_TEST_ID,
@@ -29,20 +32,19 @@ export interface AlertDescriptionProps {
    * Callback to show the rule summary flyout when the "Show rule summary" button is clicked. If not provided, the button won't be rendered.
    */
   onShowRuleSummary?: () => void;
-  /**
-   * Boolean to disable the "Show rule summary" button. This is used when the rule summary is loading or when there's an error loading it.
-   */
-  ruleSummaryDisabled?: boolean;
 }
 
 /**
  * Displays the rule description of a signal document.
  */
-export const AlertDescription: FC<AlertDescriptionProps> = ({
-  hit,
-  onShowRuleSummary,
-  ruleSummaryDisabled,
-}) => {
+export const AlertDescription: FC<AlertDescriptionProps> = ({ hit, onShowRuleSummary }) => {
+  const canReadRules = useUserPrivileges().rulesPrivileges.rules.read;
+  const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
+  const isRemoteDocument = useMemo(
+    () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+    [hit]
+  );
+  const ruleSummaryDisabled = isRulePreview || !canReadRules || isRemoteDocument;
   const isAlert = useMemo(
     () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
     [hit]

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/correlations_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/correlations_overview.test.tsx
@@ -92,7 +92,6 @@ const mockHit: DataTableRecord = {
 const defaultProps: CorrelationsOverviewProps = {
   hit: mockHit,
   scopeId: 'scopeId',
-  isRulePreview: false,
   showIcon: true,
   onShowCorrelationsDetails: jest.fn(),
 };
@@ -224,7 +223,6 @@ describe('<CorrelationsOverview />', () => {
         <CorrelationsOverview
           hit={mockHit}
           scopeId="scopeId"
-          isRulePreview={false}
           showIcon={true}
           onShowCorrelationsDetails={mockNavigateToLeftPanel}
         />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/correlations_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/correlations_overview.tsx
@@ -36,10 +36,6 @@ export interface CorrelationsOverviewProps {
    */
   scopeId: string;
   /**
-   * Boolean indicating if the flyout is open in rule preview
-   */
-  isRulePreview: boolean;
-  /**
    * Whether to show the arrow icon in the panel header
    */
   showIcon: boolean;
@@ -55,18 +51,11 @@ export interface CorrelationsOverviewProps {
  * and the SummaryPanel component for data rendering.
  */
 export const CorrelationsOverview = memo(
-  ({
-    hit,
-    scopeId,
-    isRulePreview,
-    showIcon,
-    onShowCorrelationsDetails,
-  }: CorrelationsOverviewProps) => {
+  ({ hit, scopeId, showIcon, onShowCorrelationsDetails }: CorrelationsOverviewProps) => {
     const documentId = useMemo(() => hit.raw._id || '', [hit.raw._id]);
 
     const { show: showAlertsByAncestry, ancestryDocumentId } = useShowRelatedAlertsByAncestry({
       hit,
-      isRulePreview,
     });
     const { show: showSameSourceAlerts, originalEventId } = useShowRelatedAlertsBySameSourceEvent({
       hit,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
@@ -113,7 +113,6 @@ export const InsightsSection = memo(
         openDocumentCorrelations({
           hit,
           scopeId: '',
-          isRulePreview: false,
           onShowAlert,
           onShowAttack,
           origin: FLYOUT_ORIGIN.INSIGHTS_CORRELATIONS,
@@ -156,7 +155,6 @@ export const InsightsSection = memo(
         <CorrelationsOverview
           hit={hit}
           scopeId=""
-          isRulePreview={false}
           showIcon={false}
           onShowCorrelationsDetails={onShowCorrelationsDetails}
         />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../../../timelines/components/timeline/body/renderers/constants';
 import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
 import { INVESTIGATION_SECTION_TITLE } from '../../../shared/constants/flyout_titles';
+import { isRulePreviewDocument } from '../../../shared/utils/is_rule_preview_document';
 
 export const INVESTIGATION_SECTION_TEST_ID = `${PREFIX}InvestigationSection` as const;
 
@@ -64,6 +65,7 @@ export const InvestigationSection = memo(
       () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
       [hit]
     );
+    const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
     const ruleId = useMemo(
       () =>
         (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal
@@ -118,19 +120,19 @@ export const InvestigationSection = memo(
         }
         // Rule name fields: substitute the rule UUID as the link target (the flyout is keyed by
         // UUID) while keeping the rule name as the displayed text. When no UUID is available,
-        // render plain text to avoid opening the rule flyout with an invalid id.
+        // or when in rule preview (the rule doesn't exist yet), render plain text.
         if (
           props.field === SIGNAL_RULE_NAME_FIELD_NAME ||
           props.field === LEGACY_SIGNAL_RULE_NAME_FIELD_NAME
         ) {
-          if (!ruleId) {
+          if (!ruleId || isRulePreview) {
             return <>{props.children}</>;
           }
           return <OpenFlyoutLink {...props} value={ruleId} />;
         }
         return <OpenFlyoutLink {...props} />;
       },
-      [ruleId, ancestorsIndexName, openDocumentFlyoutFromIndex]
+      [ruleId, isRulePreview, ancestorsIndexName, openDocumentFlyoutFromIndex]
     );
 
     return (
@@ -145,7 +147,7 @@ export const InvestigationSection = memo(
         {isAlert && !isRemoteDocument ? (
           <InvestigationGuide
             hit={hit}
-            isAvailable={true}
+            isAvailable={!isRulePreview}
             onShowInvestigationGuide={onShowInvestigationGuide}
           />
         ) : null}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section.test.tsx
@@ -56,11 +56,11 @@ const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord
 
 const alertMockHit = createMockHit({ 'event.kind': 'signal' });
 
-const renderResponseSection = ({ isRulePreview = false }: { isRulePreview?: boolean } = {}) =>
+const renderResponseSection = () =>
   render(
     <Provider store={store}>
       <Router history={history}>
-        <ResponseSection hit={alertMockHit} isRulePreview={isRulePreview} />
+        <ResponseSection hit={alertMockHit} />
       </Router>
     </Provider>
   );
@@ -84,13 +84,12 @@ describe('<ResponseSection />', () => {
     } as unknown as ReturnType<typeof useKibana>);
   });
 
-  it('forwards hit and isRulePreview to ResponseSectionContent', () => {
-    renderResponseSection({ isRulePreview: true });
+  it('forwards hit and onShowResponseDetails to ResponseSectionContent', () => {
+    renderResponseSection();
 
     expect(mockResponseSectionContent).toHaveBeenCalledWith(
       expect.objectContaining({
         hit: alertMockHit,
-        isRulePreview: true,
         onShowResponseDetails: expect.any(Function),
       }),
       {}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section.tsx
@@ -16,30 +16,20 @@ export interface ResponseSectionProps {
    * Document to display in the overview tab.
    */
   hit: DataTableRecord;
-  /**
-   * Whether the flyout is opened in rule preview mode.
-   */
-  isRulePreview?: boolean;
 }
 
 /**
  * Most bottom section of the overview tab. It contains a summary of the response tab.
  * Constructs the v2 tools flyout callback and forwards rendering to {@link ResponseSectionContent}.
  */
-export const ResponseSection = memo<ResponseSectionProps>(({ hit, isRulePreview = false }) => {
+export const ResponseSection = memo<ResponseSectionProps>(({ hit }) => {
   const { openDocumentResponse } = useFlyoutApi();
 
   const onShowResponseDetails = useCallback(() => {
     openDocumentResponse({ hit, origin: FLYOUT_ORIGIN.RESPONSE_SECTION });
   }, [openDocumentResponse, hit]);
 
-  return (
-    <ResponseSectionContent
-      hit={hit}
-      isRulePreview={isRulePreview}
-      onShowResponseDetails={onShowResponseDetails}
-    />
-  );
+  return <ResponseSectionContent hit={hit} onShowResponseDetails={onShowResponseDetails} />;
 });
 
 ResponseSection.displayName = 'ResponseSection';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section_content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section_content.test.tsx
@@ -50,20 +50,15 @@ const remoteAlertMockHit = createMockHit(
   { _index: 'remote-cluster:index-name' }
 );
 
-const renderResponseSectionContent = ({
-  hit = alertMockHit,
-  isRulePreview = false,
-}: {
-  hit?: DataTableRecord;
-  isRulePreview?: boolean;
-} = {}) =>
+const previewAlertMockHit = createMockHit(
+  { 'event.kind': 'signal' },
+  { _index: '.preview.alerts-security.alerts-default' }
+);
+
+const renderResponseSectionContent = ({ hit = alertMockHit }: { hit?: DataTableRecord } = {}) =>
   render(
     <IntlProvider locale="en">
-      <ResponseSectionContent
-        hit={hit}
-        isRulePreview={isRulePreview}
-        onShowResponseDetails={onShowResponseDetails}
-      />
+      <ResponseSectionContent hit={hit} onShowResponseDetails={onShowResponseDetails} />
     </IntlProvider>
   );
 
@@ -107,8 +102,8 @@ describe('<ResponseSectionContent />', () => {
     expect(onShowResponseDetails).toHaveBeenCalledTimes(1);
   });
 
-  it('should render preview message if flyout is in preview', () => {
-    const { getByTestId } = renderResponseSectionContent({ isRulePreview: true });
+  it('should render preview message for a rule preview document', () => {
+    const { getByTestId } = renderResponseSectionContent({ hit: previewAlertMockHit });
     expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toHaveTextContent(PREVIEW_MESSAGE);
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section_content.tsx
@@ -17,6 +17,7 @@ import { useExpandSection } from '../../../shared/hooks/use_expand_section';
 import { ExpandableSection } from '../../../shared/components/expandable_section';
 import { EventKind } from '../constants/event_kinds';
 import { RESPONSE_BUTTON_TEST_ID, RESPONSE_SECTION_TEST_ID } from './test_ids';
+import { isRulePreviewDocument } from '../../../shared/utils/is_rule_preview_document';
 
 const KEY = 'response';
 
@@ -26,23 +27,17 @@ export interface ResponseSectionContentProps {
    */
   hit: DataTableRecord;
   /**
-   * Whether the flyout is opened in rule preview mode.
-   */
-  isRulePreview?: boolean;
-  /**
-   * Callback to show Response details. The host (Flyout v2 or legacy expandable flyout)
-   * decides whether this opens a tools flyout or navigates to the legacy left panel.
+   * Callback to show Response details.
    */
   onShowResponseDetails: () => void;
 }
 
 /**
- * Renders the Response overview section. Host-agnostic: takes an `onShowResponseDetails`
- * callback so it can be reused in both Flyout v2 and the legacy expandable flyout
- * without constructing a v2 tools flyout when not needed.
+ * Renders the Response overview section.
  */
 export const ResponseSectionContent = memo<ResponseSectionContentProps>(
-  ({ hit, isRulePreview = false, onShowResponseDetails }) => {
+  ({ hit, onShowResponseDetails }) => {
+    const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
     const indexName = useMemo(
       () => hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? '',
       [hit]

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/status.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/status.tsx
@@ -19,6 +19,7 @@ import {
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { StatusPopoverButton, type StatusPopoverButtonFieldInfo } from './status_popover_button';
 import { STATUS_TITLE_TEST_ID } from './test_ids';
+import { isRulePreviewDocument } from '../../../shared/utils/is_rule_preview_document';
 
 const WORKFLOW_STATUS_FIELD_DATA = {
   field: ALERT_WORKFLOW_STATUS,
@@ -48,12 +49,15 @@ interface StatusProps {
  */
 export const Status = memo(
   ({ hit, renderCellActions = noopCellActionRenderer, onAlertUpdated }: StatusProps) => {
+    const isPreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
     const eventId = hit.raw._id as string;
     const isRemoteDocument = useMemo(
       () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
       [hit]
     );
     const statusFieldInfo = useMemo<StatusPopoverButtonFieldInfo | null>(() => {
+      if (isPreview) return null;
+
       const workflowStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS);
       const statusValue = Array.isArray(workflowStatus)
         ? (workflowStatus[0] as string)
@@ -67,7 +71,7 @@ export const Status = memo(
         data: WORKFLOW_STATUS_FIELD_DATA,
         values: [statusValue],
       };
-    }, [eventId, hit]);
+    }, [isPreview, eventId, hit]);
 
     return (
       <FlyoutHeaderBlock

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/visualizations_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/visualizations_section.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useFlyoutApi } from '../../../use_flyout_api';
 import type { CellActionRenderer } from '../../../shared/components/cell_actions';
@@ -20,6 +20,7 @@ import { useGraphPreview } from '../hooks/use_graph_preview';
 import { useSessionViewConfig } from '../../tools/session_view/hooks/use_session_view_config';
 import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
 import { VISUALIZATION_SECTION_TITLE } from '../../../shared/constants/flyout_titles';
+import { isRulePreviewDocument } from '../../../shared/utils/is_rule_preview_document';
 
 export const VISUALIZATION_SECTION_TEST_ID = `${PREFIX}Visualizations` as const;
 
@@ -49,6 +50,7 @@ export const VisualizationsSection = memo(
     const { openAnalyzer, openSessionView, openDocumentGraph } = useFlyoutApi();
     const sessionViewConfig = useSessionViewConfig(hit);
     const { hasGraphData } = useGraphPreview({ hit });
+    const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
 
     const expanded = useExpandSection({
       storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
@@ -108,20 +110,24 @@ export const VisualizationsSection = memo(
         title={VISUALIZATION_SECTION_TITLE}
       >
         <SessionPreviewContainer
-          disableNavigation={false}
+          disableNavigation={isRulePreview}
           hit={hit}
           onShowSessionView={onShowSessionView}
           showIcon={false}
         />
         <AnalyzerPreviewContainer
-          disableNavigation={false}
+          disableNavigation={isRulePreview}
           hit={hit}
           onShowAnalyzer={onShowAnalyzer}
-          shouldUseAncestor={false}
+          shouldUseAncestor={isRulePreview}
           showIcon={false}
         />
         {hasGraphData && (
-          <GraphPreviewContainer hit={hit} onShowGraph={onShowGraph} showIcon={false} />
+          <GraphPreviewContainer
+            hit={hit}
+            onShowGraph={isRulePreview ? undefined : onShowGraph}
+            showIcon={false}
+          />
         )}
       </ExpandableSection>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/header.tsx
@@ -31,6 +31,7 @@ import { noopCellActionRenderer } from '../../shared/components/cell_actions';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { ShareUrlIconButton } from '../../shared/components/share_url_icon_button';
 import { useGetFlyoutLink } from '../../../flyout/document_details/right/hooks/use_get_flyout_link';
+import { isRulePreviewDocument } from '../../shared/utils/is_rule_preview_document';
 
 const SHARE_ALERT_LABEL = i18n.translate(
   'xpack.securitySolution.flyoutV2.document.header.shareAlertLabel',
@@ -79,6 +80,7 @@ export const Header: FC<HeaderProps> = memo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
       [hit]
     );
+    const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
 
     const alertDetailsLink = useGetFlyoutLink({
       eventId: hit.raw._id ?? '',
@@ -104,7 +106,7 @@ export const Header: FC<HeaderProps> = memo(
         </EuiText>
         <EuiSpacer size="xs" />
 
-        <Title hit={hit} hideLink={!canReadRules} />
+        <Title hit={hit} hideLink={!canReadRules || isRulePreview} />
         {isAlert && (
           <>
             <EuiSpacer size="m" />
@@ -132,10 +134,18 @@ export const Header: FC<HeaderProps> = memo(
               <EuiFlexItem css={flyoutHeaderBlockStyles}>
                 <EuiFlexGroup direction="row" gutterSize="s" responsive={false} alignItems="center">
                   <EuiFlexItem>
-                    <Assignees hit={hit} onAlertUpdated={onAlertUpdated} />
+                    <Assignees
+                      hit={hit}
+                      onAlertUpdated={onAlertUpdated}
+                      showAssignees={!isRulePreview}
+                    />
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <Notes documentId={hit.raw._id ?? ''} onShowNotes={onShowNotes} />
+                    <Notes
+                      documentId={hit.raw._id ?? ''}
+                      onShowNotes={onShowNotes}
+                      disabled={isRulePreview}
+                    />
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../../timelines/components/timeline/body/renderers/constants';
 import { RemoteDocumentCallout } from './components/remote_document_callout';
 import { FLYOUT_ORIGIN, FLYOUT_TYPE } from '../../../common/lib/telemetry';
+import { isRulePreviewDocument } from '../../shared/utils/is_rule_preview_document';
 
 const footerStyles = css`
   @media (max-width: 767px) {
@@ -100,13 +101,13 @@ export const DocumentFlyout = memo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
       [hit]
     );
+    const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
     const isSecurityApp = useIsInSecurityApp();
     const { hasAlertsRead, loading } = useAlertsPrivileges();
     const missingAlertsPrivilege = !loading && !hasAlertsRead && isAlert;
 
     // The Table and JSON tabs are only available in Security Solution, not in Discover.
-    // The selected tab is persisted to localStorage, sharing the key with the legacy
-    // document flyout so the user's preference carries across both implementations.
+    // The selected tab is persisted to localStorage.
     const { selectedTabId, setSelectedTabId } = useTabs<DocumentFlyoutTabId>({
       validTabIds: VALID_TAB_IDS,
       storageKey: FLYOUT_STORAGE_KEYS.SELECTED_TAB,
@@ -129,19 +130,19 @@ export const DocumentFlyout = memo(
       (props: OpenFlyoutLinkProps) => {
         // Rule name fields: substitute the rule UUID as the link target (the flyout is keyed by
         // UUID) while keeping the rule name as the displayed text. When no UUID is available,
-        // render plain text to avoid opening the rule flyout with an invalid id.
+        // or when in rule preview (the rule doesn't exist yet), render plain text.
         if (
           props.field === SIGNAL_RULE_NAME_FIELD_NAME ||
           props.field === LEGACY_SIGNAL_RULE_NAME_FIELD_NAME
         ) {
-          if (!ruleId) {
+          if (!ruleId || isRulePreview) {
             return <>{props.children}</>;
           }
           return <OpenFlyoutLink {...props} value={ruleId} displayValue={props.value} asParent />;
         }
         return <OpenFlyoutLink {...props} />;
       },
-      [ruleId]
+      [ruleId, isRulePreview]
     );
 
     const onShowNotesFromHeader = useCallback(() => {
@@ -207,7 +208,7 @@ export const DocumentFlyout = memo(
               renderFlyoutLink={renderFlyoutLink}
             />
           ) : isSecurityApp && selectedTabId === 'json' ? (
-            <JsonTab hit={hit} />
+            <JsonTab hit={hit} isRulePreview={isRulePreview} />
           ) : (
             <OverviewTab
               hit={hit}
@@ -216,9 +217,11 @@ export const DocumentFlyout = memo(
             />
           )}
         </EuiFlyoutBody>
-        <EuiFlyoutFooter css={footerStyles}>
-          <Footer hit={hit} onAlertUpdated={onAlertUpdated} onShowNotes={onShowNotesFromFooter} />
-        </EuiFlyoutFooter>
+        {!isRulePreview && (
+          <EuiFlyoutFooter css={footerStyles}>
+            <Footer hit={hit} onAlertUpdated={onAlertUpdated} onShowNotes={onShowNotesFromFooter} />
+          </EuiFlyoutFooter>
+        )}
       </>
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/tabs/table_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/tabs/table_tab.tsx
@@ -122,18 +122,13 @@ export interface TableTabProps {
    */
   scopeId?: string;
   /**
-   * Whether the flyout is opened in rule preview
-   */
-  isRulePreview?: boolean;
-  /**
    * Wraps each value cell with cell actions (filter for/out, copy, etc.). The caller decides
    * what to inject (real security cell actions in Security Solution, no-op elsewhere).
    */
   renderCellActions: CellActionRenderer;
   /**
    * Optional wrapper that turns supported field values (host, ip, rule) into links that open the
-   * relevant system flyout. Injected by the new flyout; when omitted (legacy expandable flyout),
-   * the value cell keeps using the `PreviewLink` preview panel.
+   * relevant system flyout. When omitted, the value cell falls back to the `PreviewLink` preview panel.
    */
   renderFlyoutLink?: OpenFlyoutLinkRenderer;
 }
@@ -142,13 +137,7 @@ export interface TableTabProps {
  * Table view displayed in the document details flyout Table tab
  */
 export const TableTab = memo(
-  ({
-    hit,
-    scopeId = '',
-    isRulePreview = false,
-    renderCellActions,
-    renderFlyoutLink,
-  }: TableTabProps) => {
+  ({ hit, scopeId = '', renderCellActions, renderFlyoutLink }: TableTabProps) => {
     const smallFontSize = useEuiFontSize('xs').fontSize;
     const { euiTheme } = useEuiTheme();
     const {
@@ -367,7 +356,6 @@ export const TableTab = memo(
           scopeId,
           getLinkValue,
           ruleId,
-          isRulePreview,
           onTogglePinned,
           entityId,
           renderCellActions,
@@ -381,7 +369,6 @@ export const TableTab = memo(
         scopeId,
         getLinkValue,
         ruleId,
-        isRulePreview,
         onTogglePinned,
         renderCellActions,
         hit,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/table_tab_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/table_tab_columns.tsx
@@ -51,10 +51,6 @@ export type ColumnsProvider = (providerOptions: {
    */
   ruleId: string;
   /**
-   * Whether the preview link is in preview mode
-   */
-  isRulePreview: boolean;
-  /**
    * Value of the link field if it exists. Allows to navigate to other pages like host, user, network...
    */
   getLinkValue: (field: string) => string | null;
@@ -77,8 +73,7 @@ export type ColumnsProvider = (providerOptions: {
   hit: DataTableRecord;
   /**
    * Optional wrapper that renders a preview link for supported field types (host, ip, rule).
-   * Injected by the caller: the new flyout passes `OpenFlyoutLink`, the legacy flyout omits it
-   * so the value cell keeps using the expandable-flyout `PreviewLink`.
+   * When omitted, the value cell falls back to the `PreviewLink` preview panel.
    */
   renderFlyoutLink?: OpenFlyoutLinkRenderer;
 }) => Array<EuiBasicTableColumn<TimelineEventsDetailsItem>>;
@@ -92,7 +87,6 @@ export const getTableTabColumns: ColumnsProvider = ({
   scopeId,
   getLinkValue,
   ruleId,
-  isRulePreview,
   onTogglePinned,
   entityId,
   renderCellActions,
@@ -154,7 +148,6 @@ export const getTableTabColumns: ColumnsProvider = ({
             fieldFromBrowserField={fieldFromBrowserField}
             getLinkValue={getLinkValue}
             ruleId={ruleId}
-            isRulePreview={isRulePreview}
             values={values}
             entityId={entityId}
             hit={hit}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/correlations_details_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/correlations_details_view.test.tsx
@@ -60,17 +60,12 @@ const mockHit: DataTableRecord = {
 
 const mockOnShowAlert = jest.fn();
 
-const renderCorrelationsDetailsView = ({
-  isRulePreview = false,
-}: {
-  isRulePreview?: boolean;
-} = {}) =>
+const renderCorrelationsDetailsView = () =>
   render(
     <TestProviders>
       <CorrelationsDetailsView
         hit={mockHit}
         scopeId="test-scope"
-        isRulePreview={isRulePreview}
         onShowAlert={mockOnShowAlert}
         useLegacyExpandableFlyout={false}
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/correlations_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/correlations_details_view.tsx
@@ -22,6 +22,7 @@ import { RelatedAlertsBySameSourceEvent } from './related_alerts_by_same_source_
 import { RelatedAlertsBySession } from './related_alerts_by_session';
 import { RelatedAlertsByAncestry } from './related_alerts_by_ancestry';
 import { RelatedAttacks } from './related_attacks';
+import { isRulePreviewDocument } from '../../../../shared/utils/is_rule_preview_document';
 
 export interface CorrelationsDetailsViewProps {
   /**
@@ -33,10 +34,6 @@ export interface CorrelationsDetailsViewProps {
    */
   scopeId: string;
   /**
-   * Whether the document is being displayed in a rule preview
-   */
-  isRulePreview: boolean;
-  /**
    * Callback to open an alert preview when clicking the preview button in the correlations table
    */
   onShowAlert: (id: string, indexName: string, title?: string) => void;
@@ -46,7 +43,7 @@ export interface CorrelationsDetailsViewProps {
    */
   onShowAttack?: (id: string, indexName: string, title?: string) => void;
   /**
-   * Whether to render rule links as PreviewLink (legacy expandable flyout) instead of OpenFlyoutLink (new flyout system)
+   * Whether to render rule links as PreviewLink instead of OpenFlyoutLink
    */
   useLegacyExpandableFlyout: boolean;
 }
@@ -59,11 +56,11 @@ export const CorrelationsDetailsView = memo(
   ({
     hit,
     scopeId,
-    isRulePreview,
     onShowAlert,
     onShowAttack,
     useLegacyExpandableFlyout,
   }: CorrelationsDetailsViewProps) => {
+    const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
     const eventId = hit.raw._id ?? '';
     const ecsData = useMemo<Ecs>(
       () => ({
@@ -76,7 +73,6 @@ export const CorrelationsDetailsView = memo(
 
     const { show: showAlertsByAncestry, ancestryDocumentId } = useShowRelatedAlertsByAncestry({
       hit,
-      isRulePreview,
     });
     const { show: showSameSourceAlerts, originalEventId } = useShowRelatedAlertsBySameSourceEvent({
       hit,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/hooks/use_show_related_alerts_by_ancestry.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/hooks/use_show_related_alerts_by_ancestry.test.tsx
@@ -45,6 +45,13 @@ const hitWithAncestors: DataTableRecord = {
   isAnchor: false,
 } as unknown as DataTableRecord;
 
+const hitWithAncestorsPreview: DataTableRecord = {
+  id: 'event-id',
+  raw: { _id: 'event-id', _index: '.preview.alerts-security.alerts-default' },
+  flattened: { [ALERT_ANCESTORS_ID]: 'ancestors-id' },
+  isAnchor: false,
+} as unknown as DataTableRecord;
+
 describe('useShowRelatedAlertsByAncestry', () => {
   let hookResult: RenderHookResult<
     UseShowRelatedAlertsByAncestryResult,
@@ -57,7 +64,6 @@ describe('useShowRelatedAlertsByAncestry', () => {
     hookResult = renderHook(() =>
       useShowRelatedAlertsByAncestry({
         hit: hitWithoutAncestors,
-        isRulePreview: false,
       })
     );
 
@@ -72,7 +78,6 @@ describe('useShowRelatedAlertsByAncestry', () => {
     hookResult = renderHook(() =>
       useShowRelatedAlertsByAncestry({
         hit: hitWithAncestors,
-        isRulePreview: false,
       })
     );
 
@@ -88,7 +93,6 @@ describe('useShowRelatedAlertsByAncestry', () => {
     hookResult = renderHook(() =>
       useShowRelatedAlertsByAncestry({
         hit: hitWithAncestors,
-        isRulePreview: false,
       })
     );
 
@@ -103,8 +107,7 @@ describe('useShowRelatedAlertsByAncestry', () => {
     licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
     hookResult = renderHook(() =>
       useShowRelatedAlertsByAncestry({
-        hit: hitWithAncestors,
-        isRulePreview: true,
+        hit: hitWithAncestorsPreview,
       })
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/hooks/use_show_related_alerts_by_ancestry.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/hooks/use_show_related_alerts_by_ancestry.ts
@@ -10,16 +10,13 @@ import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
 import { ALERT_ANCESTORS_ID } from '../../../../../../common/field_maps/field_names';
 import { useIsAnalyzerEnabled } from '../../../../../detections/hooks/use_is_analyzer_enabled';
 import { useLicense } from '../../../../../common/hooks/use_license';
+import { isRulePreviewDocument } from '../../../../shared/utils/is_rule_preview_document';
 
 export interface UseShowRelatedAlertsByAncestryParams {
   /**
    * The alert or event document
    */
   hit: DataTableRecord;
-  /**
-   * Boolean indicating if the flyout is open in preview
-   */
-  isRulePreview: boolean;
 }
 
 export interface UseShowRelatedAlertsByAncestryResult {
@@ -34,13 +31,14 @@ export interface UseShowRelatedAlertsByAncestryResult {
 }
 
 /**
- * Returns true if the user has at least platinum privilege, and if the document has ancestry data
+ * Returns true if the user has at least platinum privilege, and if the document has ancestry data.
+ * For rule preview documents the ancestry document id is the ancestor's id rather than the hit id.
  */
 export const useShowRelatedAlertsByAncestry = ({
   hit,
-  isRulePreview,
 }: UseShowRelatedAlertsByAncestryParams): UseShowRelatedAlertsByAncestryResult => {
   const hasProcessEntityInfo = useIsAnalyzerEnabled(hit);
+  const isRulePreview = isRulePreviewDocument(hit);
 
   const ancestorId = (getFieldValue(hit, ALERT_ANCESTORS_ID) as string) ?? '';
   const ancestryDocumentId = isRulePreview ? ancestorId : hit.raw._id ?? '';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/index.test.tsx
@@ -63,12 +63,7 @@ const mockOnShowAlert = jest.fn();
 const renderCorrelationsDetails = () =>
   render(
     <TestProviders>
-      <CorrelationsDetails
-        hit={mockHit}
-        scopeId="test-scope"
-        isRulePreview={false}
-        onShowAlert={mockOnShowAlert}
-      />
+      <CorrelationsDetails hit={mockHit} scopeId="test-scope" onShowAlert={mockOnShowAlert} />
     </TestProviders>
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/index.tsx
@@ -23,10 +23,6 @@ export interface CorrelationsDetailsProps {
    */
   scopeId: string;
   /**
-   * Whether the document is being displayed in a rule preview
-   */
-  isRulePreview: boolean;
-  /**
    * Callback to open an alert preview when clicking the preview button in the correlations table
    */
   onShowAlert: (id: string, indexName: string, title?: string) => void;
@@ -42,7 +38,7 @@ export interface CorrelationsDetailsProps {
  * This component is meant to be used in a tools flyout, with the new EUI flyout system.
  */
 export const CorrelationsDetails = memo(
-  ({ hit, scopeId, isRulePreview, onShowAlert, onShowAttack }: CorrelationsDetailsProps) => {
+  ({ hit, scopeId, onShowAlert, onShowAttack }: CorrelationsDetailsProps) => {
     const { euiTheme } = useEuiTheme();
 
     return (
@@ -59,7 +55,6 @@ export const CorrelationsDetails = memo(
           <CorrelationsDetailsView
             hit={hit}
             scopeId={scopeId}
-            isRulePreview={isRulePreview}
             onShowAlert={onShowAlert}
             onShowAttack={onShowAttack}
             useLegacyExpandableFlyout={false}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/entities/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/entities/index.tsx
@@ -20,6 +20,7 @@ import { useGetFieldsData } from '../../../../flyout/document_details/shared/hoo
 import { EntitiesDetails } from '../../../../flyout/document_details/left/components/entities_details';
 import type { SearchHit } from '../../../../../common/search_strategy';
 import { ENTITIES_TOOL_TEST_ID } from './test_ids';
+import { isRulePreviewDocument } from '../../../shared/utils/is_rule_preview_document';
 
 export interface EntityDetailsProps {
   /**
@@ -53,6 +54,8 @@ export const EntityDetails = memo(
 
     const dataAsNestedObject = useMemo(() => hit.raw._source as unknown as Ecs, [hit.raw._source]);
 
+    const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
+
     const contextValue = useMemo(
       () => ({
         eventId: hit.id,
@@ -65,10 +68,10 @@ export const EntityDetails = memo(
         investigationFields: [],
         refetchFlyoutData: NOOP_REFETCH,
         getFieldsData,
-        isRulePreview: false,
+        isRulePreview,
         isPreviewMode: false,
       }),
-      [hit.id, hit.raw, scopeId, dataAsNestedObject, getFieldsData]
+      [hit.id, hit.raw, scopeId, dataAsNestedObject, getFieldsData, isRulePreview]
     );
 
     const overrideBuilders = useEntityFlyoutOverrides({ scopeId, hit });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/response/components/response_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/response/components/response_details.test.tsx
@@ -72,6 +72,13 @@ const defaultContextValue = {
   hit: buildDataTableRecord(rawEventData as EsHitRecord),
 };
 
+const previewContextValue = {
+  hit: buildDataTableRecord({
+    ...rawEventData,
+    _index: '.preview.alerts-security.alerts-default',
+  } as EsHitRecord),
+};
+
 const contextWithResponseActions = {
   ...defaultContextValue,
   hit: buildDataTableRecord({
@@ -140,7 +147,7 @@ describe('<ResponseDetails />', () => {
   });
 
   it('should render preview message if flyout is in preview', () => {
-    const wrapper = renderResponseDetails({ ...defaultContextValue, isRulePreview: true });
+    const wrapper = renderResponseDetails(previewContextValue);
     expect(wrapper.getByTestId(RESPONSE_DETAILS_TEST_ID)).toBeInTheDocument();
     expect(wrapper.getByTestId(RESPONSE_DETAILS_TEST_ID)).toHaveTextContent(PREVIEW_MESSAGE);
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/response/components/response_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/response/components/response_details.tsx
@@ -5,31 +5,26 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { RESPONSE_DETAILS_TEST_ID } from './test_ids';
 import { useResponseActionsView } from '../hooks/use_response_actions_view';
+import { isRulePreviewDocument } from '../../../../shared/utils/is_rule_preview_document';
 
 export interface ResponseDetailsContentProps {
   /**
    * Alert document used to fetch and display response actions.
    */
   hit: DataTableRecord;
-  /**
-   * Whether the flyout is opened in rule preview mode.
-   */
-  isRulePreview?: boolean;
 }
 
 /**
  * Automated response actions results.
  */
-export const ResponseDetailsContent: React.FC<ResponseDetailsContentProps> = ({
-  hit,
-  isRulePreview = false,
-}) => {
+export const ResponseDetailsContent: React.FC<ResponseDetailsContentProps> = ({ hit }) => {
+  const isRulePreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
   const responseActionsView = useResponseActionsView({
     hit,
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
@@ -208,7 +208,6 @@ describe('useDocumentFlyoutApi', () => {
     result.current.openDocumentCorrelations({
       hit,
       scopeId: '',
-      isRulePreview: false,
       onShowAlert: jest.fn(),
     });
 
@@ -395,7 +394,6 @@ describe('useDocumentFlyoutApi', () => {
       result.current.openDocumentCorrelations({
         hit,
         scopeId: 'scope-1',
-        isRulePreview: false,
         onShowAlert: jest.fn(),
       });
 
@@ -405,7 +403,6 @@ describe('useDocumentFlyoutApi', () => {
           documentId: 'doc-id',
           indexName: 'doc-index',
           scopeId: 'scope-1',
-          isRulePreview: false,
         })
       );
       expect(mockBuildOnClose).toHaveBeenCalledWith(null);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -152,8 +152,6 @@ export interface OpenDocumentCorrelationsParams {
   hit: DataTableRecord;
   /** Scope id for the document. */
   scopeId: string;
-  /** Whether the document is being displayed in a rule preview. */
-  isRulePreview: boolean;
   /** Callback to open one of the correlated alerts. */
   onShowAlert: (id: string, indexName: string, title?: string) => void;
   /** Optional callback to open a correlated attack; when omitted the attack column is hidden. */
@@ -253,10 +251,6 @@ export interface DocumentFlyoutApi {
  * (`flyoutProviders` + `overlays.openSystemFlyout`, via `useOpenFlyout`) and the per-tool flyout
  * properties so call sites don't have to repeat them. `useOpenFlyout` also reports open/close
  * telemetry for every method below.
- *
- * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
- * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
- * legacy flyout when it is off.
  *
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
@@ -543,21 +537,13 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
   );
 
   const openDocumentCorrelations = useCallback(
-    ({
-      hit,
-      scopeId,
-      isRulePreview,
-      onShowAlert,
-      onShowAttack,
-      origin,
-    }: OpenDocumentCorrelationsParams) => {
+    ({ hit, scopeId, onShowAlert, onShowAttack, origin }: OpenDocumentCorrelationsParams) => {
       const { documentId, indexName } = documentIdsFromHit(hit);
       writeOnOpen({
         kind: FLYOUT_DESCRIPTOR_KIND.documentCorrelations,
         documentId,
         indexName,
         scopeId,
-        isRulePreview,
       });
       // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
       // the document is not persisted alongside it. Closing the tool therefore clears the param
@@ -567,7 +553,6 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         <CorrelationsDetails
           hit={hit}
           scopeId={scopeId}
-          isRulePreview={isRulePreview}
           onShowAlert={onShowAlert}
           onShowAttack={onShowAttack}
         />,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
@@ -17,6 +17,7 @@ import {
   CellActionsMode,
   SecurityCellActions,
 } from '../../../common/components/cell_actions';
+import { SecurityCellActionType } from '../../../app/actions/constants';
 import { getSourcererScopeId } from '../../../helpers';
 
 export interface CellActionRendererProps {
@@ -43,7 +44,7 @@ export interface CreateCellActionRendererOptions {
   triggerId?: string;
   /**
    * Number of actions shown before the overflow menu. Defaults to `5` (the default trigger's action
-   * count); the details-flyout trigger uses `6` to match the legacy flyout.
+   * count); the details-flyout trigger uses `6`.
    */
   visibleCellActions?: number;
   /**
@@ -51,6 +52,12 @@ export interface CreateCellActionRendererOptions {
    * "Toggle column in table" action can add/remove columns on the imperatively-controlled alerts table.
    */
   alertsTableRef?: RefObject<AlertsTableImperativeApi>;
+  /**
+   * Action types that should be hidden from the cell action menu. Used in contexts where certain
+   * actions are meaningless, e.g. Filter-for/out and Toggle-column are disabled in rule preview
+   * because the alerts are transient and not backed by a persistent data view.
+   */
+  disabledActionTypes?: SecurityCellActionType[];
 }
 
 /**
@@ -71,6 +78,7 @@ export const createCellActionRenderer = (
     triggerId = SECURITY_CELL_ACTIONS_DEFAULT,
     visibleCellActions = 5,
     alertsTableRef,
+    disabledActionTypes = [],
   }: CreateCellActionRendererOptions = {}
 ): CellActionRenderer => {
   const boundCellActionRenderer: CellActionRenderer = ({
@@ -91,6 +99,7 @@ export const createCellActionRenderer = (
         visibleCellActions={visibleCellActions}
         sourcererScopeId={getSourcererScopeId(effectiveScopeId)}
         metadata={{ scopeId: effectiveScopeId, alertsTableRef }}
+        disabledActionTypes={disabledActionTypes}
       >
         {children}
       </SecurityCellActions>
@@ -100,14 +109,20 @@ export const createCellActionRenderer = (
 };
 
 /**
- * Default cell action renderer for Security Solution. This component is used to render cell actions for fields in Security Solution.
- * This is used in the expandable flyout and in the new flyout (though only when used in Security Solution).
+ * Default cell action renderer for Security Solution.
  */
 export const cellActionRenderer: CellActionRenderer = createCellActionRenderer('');
 
 /**
+ * Cell action renderer for rule preview contexts. Disables Filter-for/Filter-out and
+ * Toggle-column because those actions are meaningless against transient preview alerts.
+ */
+export const rulePreviewCellActionRenderer: CellActionRenderer = createCellActionRenderer('', {
+  disabledActionTypes: [SecurityCellActionType.FILTER, SecurityCellActionType.TOGGLE_COLUMN],
+});
+
+/**
  * Cell action renderer for Cases.
- * This is used in the expandable flyout and in the new flyout (though only when used in Security Solution).
  */
 export const casesCellActionRenderer: CellActionRenderer = createCellActionRenderer('', {
   triggerId: SECURITY_CELL_ACTIONS_CASE_EVENTS,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/table_field_value_cell.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/table_field_value_cell.test.tsx
@@ -81,7 +81,6 @@ describe('TableFieldValueCell', () => {
               eventId={eventId}
               values={hostIpValues}
               ruleId="ruleId"
-              isRulePreview={false}
             />
           </DocumentDetailsContext.Provider>
         </TestProviders>
@@ -105,7 +104,6 @@ describe('TableFieldValueCell', () => {
               fieldFromBrowserField={undefined} // <-- no metadata
               values={hostIpValues}
               ruleId="ruleId"
-              isRulePreview={false}
             />
           </DocumentDetailsContext.Provider>
         </TestProviders>
@@ -153,7 +151,6 @@ describe('TableFieldValueCell', () => {
               fieldFromBrowserField={messageFieldFromBrowserField}
               values={messageValues}
               ruleId="ruleId"
-              isRulePreview={false}
             />
           </DocumentDetailsContext.Provider>
         </TestProviders>
@@ -191,7 +188,6 @@ describe('TableFieldValueCell', () => {
               fieldFromBrowserField={hostIpFieldFromBrowserField} // <-- metadata
               values={hostIpValues}
               ruleId="ruleId"
-              isRulePreview={false}
             />
           </DocumentDetailsContext.Provider>
         </TestProviders>
@@ -256,7 +252,6 @@ describe('TableFieldValueCell', () => {
               fieldFromBrowserField={hostIpFieldFromBrowserField}
               values={hostIpValues}
               ruleId="ruleId"
-              isRulePreview={false}
               renderFlyoutLink={renderFlyoutLink}
             />
           </DocumentDetailsContext.Provider>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/table_field_value_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/table_field_value_cell.tsx
@@ -41,10 +41,6 @@ export interface FieldValueCellProps {
    */
   ruleId: string;
   /**
-   * Whether the preview link is in rule preview
-   */
-  isRulePreview: boolean;
-  /**
    * Value of the link field if it exists. Allows to navigate to other pages like host, user, network...
    */
   getLinkValue?: (field: string) => string | null;
@@ -62,8 +58,7 @@ export interface FieldValueCellProps {
   hit?: DataTableRecord;
   /**
    * Optional wrapper that renders a preview link for supported field types (host, ip, rule).
-   * Injected by the caller so each flyout context controls its own navigation. When provided
-   * (new flyout), it is used instead of the legacy expandable-flyout `PreviewLink`.
+   * When omitted, falls back to the `PreviewLink` preview panel.
    */
   renderFlyoutLink?: OpenFlyoutLinkRenderer;
 }
@@ -80,7 +75,6 @@ export const TableFieldValueCell = memo(
     ruleId,
     getLinkValue,
     values,
-    isRulePreview,
     entityId,
     hit,
     renderFlyoutLink: RenderFlyoutLink,
@@ -108,7 +102,7 @@ export const TableFieldValueCell = memo(
           if (data.field === MESSAGE_FIELD_NAME) {
             content = <OverflowField value={value} />;
           } else if (isLink && !RenderFlyoutLink) {
-            // Legacy expandable flyout: open the preview panel.
+            // No renderFlyoutLink provided: open the preview panel.
             content = (
               <PreviewLink
                 field={data.field}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.tsx
@@ -49,7 +49,7 @@ export interface ToolsFlyoutHeaderProps {
 export const ToolsFlyoutHeader: FC<ToolsFlyoutHeaderProps> = memo(
   ({ title, onTitleClick, label, iconType, badge, timestamp }) => {
     const { euiTheme } = useEuiTheme();
-    const showSourceContext = !!onTitleClick && !!label && !!iconType;
+    const showSourceContext = !!label && !!iconType;
 
     // When the flyout menu renders a back button, the header is pushed onto its own row and no
     // longer overlaps the close button, so we only reserve room for the close button otherwise.

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.tsx
@@ -8,14 +8,16 @@
 import type { FC } from 'react';
 import React, { memo } from 'react';
 import type { IconType } from '@elastic/eui';
-import { EuiButtonEmpty, EuiIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { EuiButtonEmpty, EuiIcon, EuiText, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { TOOLS_FLYOUT_HEADER_TITLE_TEST_ID } from './test_ids';
 
 export interface ToolsFlyoutTitleProps {
   /**
-   * Callback invoked when the title is clicked.
+   * Callback invoked when the title is clicked. When omitted the title renders as plain text
+   * (no expand icon, no button) — used in rule preview contexts where the source document
+   * cannot be re-opened.
    */
-  onTitleClick: () => void;
+  onTitleClick?: () => void;
   /**
    * Text label displayed in the title.
    */
@@ -27,41 +29,57 @@ export interface ToolsFlyoutTitleProps {
 }
 
 /**
- * Clickable title used in tools flyout headers. Renders an expand icon followed by a
- * context icon and label. Clicking opens the originating document or entity flyout.
+ * Title used in tools flyout headers. When `onTitleClick` is provided, renders a clickable
+ * button with an expand icon that opens the originating document or entity flyout. When
+ * omitted (rule preview), renders as plain text so the label and badge remain visible without
+ * creating a broken link to a transient document.
  */
 export const ToolsFlyoutTitle: FC<ToolsFlyoutTitleProps> = memo(
   ({ onTitleClick, label, iconType }) => {
     const { euiTheme } = useEuiTheme();
 
+    const inner = (
+      <span css={{ alignItems: 'center', display: 'flex', maxWidth: '100%', minWidth: 0 }}>
+        <EuiIcon
+          type={iconType}
+          size="m"
+          aria-hidden={true}
+          css={{ flexShrink: 0, marginRight: euiTheme.size.xs }}
+        />
+        <span
+          css={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </span>
+      </span>
+    );
+
     return (
       <EuiToolTip content={label}>
-        <EuiButtonEmpty
-          onClick={onTitleClick}
-          iconType="expand"
-          size="xs"
-          flush="left"
-          css={{ maxWidth: '100%', minWidth: 0 }}
-          data-test-subj={TOOLS_FLYOUT_HEADER_TITLE_TEST_ID}
-        >
-          <span css={{ alignItems: 'center', display: 'flex', maxWidth: '100%', minWidth: 0 }}>
-            <EuiIcon
-              type={iconType}
-              size="m"
-              aria-hidden={true}
-              css={{ flexShrink: 0, marginRight: euiTheme.size.xs }}
-            />
-            <span
-              css={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {label}
-            </span>
-          </span>
-        </EuiButtonEmpty>
+        {onTitleClick ? (
+          <EuiButtonEmpty
+            onClick={onTitleClick}
+            iconType="expand"
+            size="xs"
+            flush="left"
+            css={{ maxWidth: '100%', minWidth: 0 }}
+            data-test-subj={TOOLS_FLYOUT_HEADER_TITLE_TEST_ID}
+          >
+            {inner}
+          </EuiButtonEmpty>
+        ) : (
+          <EuiText
+            size="xs"
+            css={{ maxWidth: '100%', minWidth: 0 }}
+            data-test-subj={TOOLS_FLYOUT_HEADER_TITLE_TEST_ID}
+          >
+            {inner}
+          </EuiText>
+        )}
       </EuiToolTip>
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.test.tsx
@@ -82,7 +82,7 @@ describe('useDocumentFlyoutTitle', () => {
     const { result } = renderHook(() => useDocumentFlyoutTitle({ hit: alertHit }));
 
     act(() => {
-      result.current.onTitleClick();
+      result.current.onTitleClick?.();
     });
 
     expect(openDocumentFlyoutFromIndexAsChild).toHaveBeenCalledTimes(1);
@@ -100,7 +100,7 @@ describe('useDocumentFlyoutTitle', () => {
     const { result } = renderHook(() => useDocumentFlyoutTitle({ hit: attackHit }));
 
     act(() => {
-      result.current.onTitleClick();
+      result.current.onTitleClick?.();
     });
 
     expect(openAttackFlyoutAsChild).toHaveBeenCalledTimes(1);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
@@ -24,6 +24,7 @@ import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
 import { DocumentSeverity } from '../../document/main/components/severity';
 import { Timestamp } from '../components/timestamp';
 import { useFlyoutApi } from '../../use_flyout_api';
+import { isRulePreviewDocument } from '../utils/is_rule_preview_document';
 
 export interface UseDocumentFlyoutTitleOptions {
   /** The source document to derive display values from. */
@@ -42,8 +43,12 @@ export interface DocumentFlyoutTitleResult {
    * documents.
    */
   iconType: string;
-  /** Opens the source document as a child flyout (the attack flyout for attack documents). */
-  onTitleClick: () => void;
+  /**
+   * Opens the source document as a child flyout (the attack flyout for attack documents).
+   * Undefined for rule preview documents — the source document is transient and cannot be
+   * re-opened; callers should render the title as plain text instead.
+   */
+  onTitleClick: (() => void) | undefined;
   /** Severity badge for the document. */
   badge: React.ReactNode;
   /** Formatted timestamp for the document. */
@@ -64,6 +69,7 @@ export const useDocumentFlyoutTitle = ({
   // rule type id first — they'd otherwise match the generic alert branch below.
   const isAttack = useMemo(() => isAttackDocument(hit), [hit]);
   const attackTitle = useMemo(() => getAttackTitleValue(hit), [hit]);
+  const isPreview = useMemo(() => isRulePreviewDocument(hit), [hit]);
 
   const isAlert = useMemo(
     () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
@@ -87,7 +93,10 @@ export const useDocumentFlyoutTitle = ({
   // must be opened with openAttackFlyoutAsChild (which fetches via useTimelineEventsDetails against
   // the specific index). openDocumentFlyoutFromIndexAsChild uses useEsDocSearch against the default
   // data view and returns NotFound for attack documents.
-  const onTitleClick = useCallback(() => {
+  //
+  // Rule preview documents are transient and cannot be re-opened, so no click handler is
+  // provided — callers render the title as plain text in that case.
+  const onTitleClickImpl = useCallback(() => {
     if (isAttack) {
       openAttackFlyoutAsChild({
         attackId: hit.raw._id ?? '',
@@ -115,6 +124,8 @@ export const useDocumentFlyoutTitle = ({
     onAlertUpdated,
     sessionTitle,
   ]);
+
+  const onTitleClick = isPreview ? undefined : onTitleClickImpl;
 
   const badge = <DocumentSeverity hit={hit} />;
   const timestamp = <Timestamp hit={hit} size="xs" />;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.ts
@@ -135,7 +135,6 @@ export interface DocumentCorrelationsDescriptor {
   documentId: string;
   indexName: string;
   scopeId: string;
-  isRulePreview: boolean;
 }
 
 export interface DocumentPrevalenceDescriptor {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_expandable_flyout_url_interop.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_expandable_flyout_url_interop.test.ts
@@ -249,7 +249,6 @@ describe('translateLegacyStateToDescriptors', () => {
           documentId: 'doc-7',
           indexName: 'idx',
           scopeId: 'sc',
-          isRulePreview: false,
         },
         { kind: 'document', documentId: 'doc-7', indexName: 'idx' },
       ]);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_expandable_flyout_url_interop.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_expandable_flyout_url_interop.ts
@@ -294,7 +294,6 @@ const docLeftToToolDescriptor = (
           documentId,
           indexName,
           scopeId: scopeId ?? '',
-          isRulePreview: false,
         };
       // 'entity' or no subTab → entities
       return { kind: 'documentEntities', documentId, indexName, scopeId };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.test.tsx
@@ -572,7 +572,6 @@ describe('useFlyoutV2RestoreFromUrl', () => {
           documentId: 'doc-1',
           indexName: 'i',
           scopeId: 's',
-          isRulePreview: false,
         },
       ])
     );
@@ -583,7 +582,6 @@ describe('useFlyoutV2RestoreFromUrl', () => {
       expect.objectContaining({
         hit: expect.objectContaining({ id: 'doc-1' }),
         scopeId: 's',
-        isRulePreview: false,
         onShowAlert: expect.any(Function),
       })
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.ts
@@ -60,6 +60,7 @@ import type {
 } from './flyout_v2_url_param';
 import { decodeFlyoutV2UrlParam } from './flyout_v2_url_param';
 import { subscribeToFlyoutV2Navigation } from './flyout_v2_navigation';
+import { DEFAULT_PREVIEW_INDEX } from '../../../../common/constants';
 
 // ---------------------------------------------------------------------------
 // Constants — which descriptor kinds require an async data fetch
@@ -223,7 +224,6 @@ export const openDescriptorAsStart = (
         api.openDocumentCorrelations({
           hit: ctx.docHit,
           scopeId: d.scopeId,
-          isRulePreview: d.isRulePreview,
           ...originParams,
           // Provide a default onShowAlert that opens the alert as a child flyout.
           onShowAlert: (alertId, indexName) =>
@@ -701,10 +701,21 @@ export const useFlyoutV2RestoreFromUrl = (urlParamKey: string): void => {
   const hasRestoredRef = useRef(false);
 
   // Read URL param exactly once (useState initializer runs on the first render only).
+  // Rule preview documents are stored in a transient index that no longer exists after the page
+  // is reloaded, so attempting to restore them reproduces the "Cannot find document" error.
+  // Drop descriptors whose indexName is a preview index before restoring.
   const [descriptors] = useState<FlyoutV2UrlParamValue | null>(() => {
     if (!isNewFlyoutEnabled) return null;
     const raw = new URLSearchParams(history.location.search).get(urlParamKey);
-    return decodeFlyoutV2UrlParam(raw);
+    const decoded = decodeFlyoutV2UrlParam(raw);
+    if (!decoded) return null;
+    const filtered = decoded.filter(
+      (d) =>
+        !(
+          'indexName' in d && (d as { indexName: string }).indexName.includes(DEFAULT_PREVIEW_INDEX)
+        )
+    ) as FlyoutV2UrlParamValue;
+    return filtered.length > 0 ? filtered : null;
   });
 
   // Detect a malformed param (raw present but decode failed) to strip it.

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/utils/is_rule_preview_document.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/utils/is_rule_preview_document.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getFieldValue } from '@kbn/discover-utils';
+import { DEFAULT_PREVIEW_INDEX } from '../../../../common/constants';
+
+/**
+ * Returns true when the document lives in a preview alerts index.
+ *
+ * Preview alerts are created transiently while the user is editing a rule and
+ * are stored under `.internal.preview.alerts-security.alerts-<space>` (accessed
+ * via the `.preview.alerts-security.alerts-<space>` alias). Either form is
+ * matched because `DEFAULT_PREVIEW_INDEX` (`.preview.alerts-security.alerts`)
+ * is a substring of both.
+ *
+ */
+export const isRulePreviewDocument = (hit: DataTableRecord): boolean =>
+  ((hit.raw._index as string) ?? (getFieldValue(hit, '_index') as string) ?? '').includes(
+    DEFAULT_PREVIEW_INDEX
+  );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[SecuritySolution][Flyout] full rule preview parity (#282811)](https://github.com/elastic/kibana/pull/282811)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-05T16:47:01Z","message":"[SecuritySolution][Flyout] full rule preview parity (#282811)\n\n## Summary\n\nImplements full v1 rule-preview parity in flyout v2. Flyout v2 never\ncomputed the rule-preview flag, so every preview guard was dead.\n\n**Reported symptoms:**\n- The \"Preview Rule\" title linked to a non-existent rule\n- Take Action / AI actions / Notes were available on transient alerts\n- Opening a document from the rule preview table showed \"Cannot find\ndocument. No documents match that ID.\"\n- Tool flyout header title tried to navigate to a non-resolvable\ndocument (link instead of plain text)\n- Status was editable on an alert that doesn't persist\n- After a page refresh, the flyout re-opened and showed \"Cannot find\ndocument\"\n\n## Approach\n\nDerive the flag from the document rather than threading it as a prop.\nEvery v2 component already receives `hit`, so a single utility\n`isRulePreviewDocument(hit)` — checking `hit.raw._index` for\n`DEFAULT_PREVIEW_INDEX` (substring of both the alias and `.internal.`\nbacking index forms) — is called locally wherever needed. No new props,\nno API changes, no URL-state schema changes.\n\nThis is equivalent to v1's `scopeId === TableId.rulePreview` because the\nrule preview table is hardwired to query\n`${DEFAULT_PREVIEW_INDEX}-${spaceId}`, so every document it surfaces\ncarries that index. The index-based check is more robust: it works in\ntool flyouts (which don't inherit the table's scopeId) and in the\nURL-restore path (which fires before any context is set up).\n\n## Changes\n\n### New utility\n- `flyout_v2/shared/utils/is_rule_preview_document.ts` — returns true\nwhen `hit.raw._index` contains `DEFAULT_PREVIEW_INDEX`\n\n### Flyout v2 gating (mirrors v1)\n\n| Area | Change |\n|---|---|\n| **Header** | Rule-title link hidden; Status shows dash with border\npreserved (preview gating moved into `Status` itself); Assignees and\nNotes disabled |\n| **Footer** | Entire `EuiFlyoutFooter` hidden (Take Action, AI actions,\nadd-to-case, investigate-in-timeline, add exception, isolate host,\nosquery) |\n| **Rule-name links** | `renderFlyoutLink` returns plain text for\nrule-name fields in preview |\n| **Investigation guide** | `isAvailable={false}` → shows \"not available\nin alert preview\" callout |\n| **Session / Analyzer** | `disableNavigation`, `shouldUseAncestor`,\n`onShowGraph` disabled |\n| **Response** | Shows \"Response is not available in alert preview.\" |\n| **Correlations** | Ancestry uses ancestor ID; investigate-in-timeline\nhidden |\n| **Cell actions** | `FILTER` and `TOGGLE_COLUMN` disabled via\n`rulePreviewCellActionRenderer` |\n| **Tool flyout title** | `onTitleClick` returns `undefined` for preview\ndocs → plain text, no broken navigation |\n\n### URL restore\nPreview descriptors filtered from the decoded URL param before the\nrestore effect fires, preventing \"Cannot find document\" after page\nrefresh.\n\n### Dead prop cleanup\nRemoved the stale `isRulePreview` prop chain that was hardcoded to\n`false` everywhere: `TableFieldValueCell`, `TableTab`,\n`ColumnsProvider`, `CorrelationsDetailsView`, `CorrelationsDetails`,\n`ResponseDetailsContent`, `OpenDocumentCorrelationsParams`,\n`DocumentCorrelationsDescriptor`.\n\n### v1 shared-component callers\nUpdated four v1 files that import shared v2 components to remove the\nnow-deleted `isRulePreview` props:\n`flyout/document_details/right/tabs.tsx`, `left/tabs.tsx`,\n`left/components/correlations_details.tsx`,\n`entity_details/user_details_left/tabs/asset_document.tsx`.\n\n### Testing\n**Manual (flyout v2 enabled):** Rules → create/edit a rule → Preview →\nexpand a preview alert:\n- No footer / Take action\n- Notes block disabled, assignees empty state\n- Status shows a dash with border\n- Rule title is plain text (no broken link)\n- Investigation guide shows \"not available\" callout\n- Response shows \"not available\" callout\n- Session / analyzer navigation disabled\n- Open Correlations tool → header title is plain text but still shows\nlabel, severity badge, and timestamp\n- Refresh → no \"Cannot find document\" error\n\nVideo: \n\n\nhttps://github.com/user-attachments/assets/25587a1c-5a7b-4832-b034-b9f1678f6912\n\n\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"aa5bfb1e242beea5a9c39fb56ff193a4a0344735","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","backport:version","v9.5.0","v9.6.0","v9.5.1"],"title":"[SecuritySolution][Flyout] full rule preview parity","number":282811,"url":"https://github.com/elastic/kibana/pull/282811","mergeCommit":{"message":"[SecuritySolution][Flyout] full rule preview parity (#282811)\n\n## Summary\n\nImplements full v1 rule-preview parity in flyout v2. Flyout v2 never\ncomputed the rule-preview flag, so every preview guard was dead.\n\n**Reported symptoms:**\n- The \"Preview Rule\" title linked to a non-existent rule\n- Take Action / AI actions / Notes were available on transient alerts\n- Opening a document from the rule preview table showed \"Cannot find\ndocument. No documents match that ID.\"\n- Tool flyout header title tried to navigate to a non-resolvable\ndocument (link instead of plain text)\n- Status was editable on an alert that doesn't persist\n- After a page refresh, the flyout re-opened and showed \"Cannot find\ndocument\"\n\n## Approach\n\nDerive the flag from the document rather than threading it as a prop.\nEvery v2 component already receives `hit`, so a single utility\n`isRulePreviewDocument(hit)` — checking `hit.raw._index` for\n`DEFAULT_PREVIEW_INDEX` (substring of both the alias and `.internal.`\nbacking index forms) — is called locally wherever needed. No new props,\nno API changes, no URL-state schema changes.\n\nThis is equivalent to v1's `scopeId === TableId.rulePreview` because the\nrule preview table is hardwired to query\n`${DEFAULT_PREVIEW_INDEX}-${spaceId}`, so every document it surfaces\ncarries that index. The index-based check is more robust: it works in\ntool flyouts (which don't inherit the table's scopeId) and in the\nURL-restore path (which fires before any context is set up).\n\n## Changes\n\n### New utility\n- `flyout_v2/shared/utils/is_rule_preview_document.ts` — returns true\nwhen `hit.raw._index` contains `DEFAULT_PREVIEW_INDEX`\n\n### Flyout v2 gating (mirrors v1)\n\n| Area | Change |\n|---|---|\n| **Header** | Rule-title link hidden; Status shows dash with border\npreserved (preview gating moved into `Status` itself); Assignees and\nNotes disabled |\n| **Footer** | Entire `EuiFlyoutFooter` hidden (Take Action, AI actions,\nadd-to-case, investigate-in-timeline, add exception, isolate host,\nosquery) |\n| **Rule-name links** | `renderFlyoutLink` returns plain text for\nrule-name fields in preview |\n| **Investigation guide** | `isAvailable={false}` → shows \"not available\nin alert preview\" callout |\n| **Session / Analyzer** | `disableNavigation`, `shouldUseAncestor`,\n`onShowGraph` disabled |\n| **Response** | Shows \"Response is not available in alert preview.\" |\n| **Correlations** | Ancestry uses ancestor ID; investigate-in-timeline\nhidden |\n| **Cell actions** | `FILTER` and `TOGGLE_COLUMN` disabled via\n`rulePreviewCellActionRenderer` |\n| **Tool flyout title** | `onTitleClick` returns `undefined` for preview\ndocs → plain text, no broken navigation |\n\n### URL restore\nPreview descriptors filtered from the decoded URL param before the\nrestore effect fires, preventing \"Cannot find document\" after page\nrefresh.\n\n### Dead prop cleanup\nRemoved the stale `isRulePreview` prop chain that was hardcoded to\n`false` everywhere: `TableFieldValueCell`, `TableTab`,\n`ColumnsProvider`, `CorrelationsDetailsView`, `CorrelationsDetails`,\n`ResponseDetailsContent`, `OpenDocumentCorrelationsParams`,\n`DocumentCorrelationsDescriptor`.\n\n### v1 shared-component callers\nUpdated four v1 files that import shared v2 components to remove the\nnow-deleted `isRulePreview` props:\n`flyout/document_details/right/tabs.tsx`, `left/tabs.tsx`,\n`left/components/correlations_details.tsx`,\n`entity_details/user_details_left/tabs/asset_document.tsx`.\n\n### Testing\n**Manual (flyout v2 enabled):** Rules → create/edit a rule → Preview →\nexpand a preview alert:\n- No footer / Take action\n- Notes block disabled, assignees empty state\n- Status shows a dash with border\n- Rule title is plain text (no broken link)\n- Investigation guide shows \"not available\" callout\n- Response shows \"not available\" callout\n- Session / analyzer navigation disabled\n- Open Correlations tool → header title is plain text but still shows\nlabel, severity badge, and timestamp\n- Refresh → no \"Cannot find document\" error\n\nVideo: \n\n\nhttps://github.com/user-attachments/assets/25587a1c-5a7b-4832-b034-b9f1678f6912\n\n\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"aa5bfb1e242beea5a9c39fb56ff193a4a0344735"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282811","number":282811,"mergeCommit":{"message":"[SecuritySolution][Flyout] full rule preview parity (#282811)\n\n## Summary\n\nImplements full v1 rule-preview parity in flyout v2. Flyout v2 never\ncomputed the rule-preview flag, so every preview guard was dead.\n\n**Reported symptoms:**\n- The \"Preview Rule\" title linked to a non-existent rule\n- Take Action / AI actions / Notes were available on transient alerts\n- Opening a document from the rule preview table showed \"Cannot find\ndocument. No documents match that ID.\"\n- Tool flyout header title tried to navigate to a non-resolvable\ndocument (link instead of plain text)\n- Status was editable on an alert that doesn't persist\n- After a page refresh, the flyout re-opened and showed \"Cannot find\ndocument\"\n\n## Approach\n\nDerive the flag from the document rather than threading it as a prop.\nEvery v2 component already receives `hit`, so a single utility\n`isRulePreviewDocument(hit)` — checking `hit.raw._index` for\n`DEFAULT_PREVIEW_INDEX` (substring of both the alias and `.internal.`\nbacking index forms) — is called locally wherever needed. No new props,\nno API changes, no URL-state schema changes.\n\nThis is equivalent to v1's `scopeId === TableId.rulePreview` because the\nrule preview table is hardwired to query\n`${DEFAULT_PREVIEW_INDEX}-${spaceId}`, so every document it surfaces\ncarries that index. The index-based check is more robust: it works in\ntool flyouts (which don't inherit the table's scopeId) and in the\nURL-restore path (which fires before any context is set up).\n\n## Changes\n\n### New utility\n- `flyout_v2/shared/utils/is_rule_preview_document.ts` — returns true\nwhen `hit.raw._index` contains `DEFAULT_PREVIEW_INDEX`\n\n### Flyout v2 gating (mirrors v1)\n\n| Area | Change |\n|---|---|\n| **Header** | Rule-title link hidden; Status shows dash with border\npreserved (preview gating moved into `Status` itself); Assignees and\nNotes disabled |\n| **Footer** | Entire `EuiFlyoutFooter` hidden (Take Action, AI actions,\nadd-to-case, investigate-in-timeline, add exception, isolate host,\nosquery) |\n| **Rule-name links** | `renderFlyoutLink` returns plain text for\nrule-name fields in preview |\n| **Investigation guide** | `isAvailable={false}` → shows \"not available\nin alert preview\" callout |\n| **Session / Analyzer** | `disableNavigation`, `shouldUseAncestor`,\n`onShowGraph` disabled |\n| **Response** | Shows \"Response is not available in alert preview.\" |\n| **Correlations** | Ancestry uses ancestor ID; investigate-in-timeline\nhidden |\n| **Cell actions** | `FILTER` and `TOGGLE_COLUMN` disabled via\n`rulePreviewCellActionRenderer` |\n| **Tool flyout title** | `onTitleClick` returns `undefined` for preview\ndocs → plain text, no broken navigation |\n\n### URL restore\nPreview descriptors filtered from the decoded URL param before the\nrestore effect fires, preventing \"Cannot find document\" after page\nrefresh.\n\n### Dead prop cleanup\nRemoved the stale `isRulePreview` prop chain that was hardcoded to\n`false` everywhere: `TableFieldValueCell`, `TableTab`,\n`ColumnsProvider`, `CorrelationsDetailsView`, `CorrelationsDetails`,\n`ResponseDetailsContent`, `OpenDocumentCorrelationsParams`,\n`DocumentCorrelationsDescriptor`.\n\n### v1 shared-component callers\nUpdated four v1 files that import shared v2 components to remove the\nnow-deleted `isRulePreview` props:\n`flyout/document_details/right/tabs.tsx`, `left/tabs.tsx`,\n`left/components/correlations_details.tsx`,\n`entity_details/user_details_left/tabs/asset_document.tsx`.\n\n### Testing\n**Manual (flyout v2 enabled):** Rules → create/edit a rule → Preview →\nexpand a preview alert:\n- No footer / Take action\n- Notes block disabled, assignees empty state\n- Status shows a dash with border\n- Rule title is plain text (no broken link)\n- Investigation guide shows \"not available\" callout\n- Response shows \"not available\" callout\n- Session / analyzer navigation disabled\n- Open Correlations tool → header title is plain text but still shows\nlabel, severity badge, and timestamp\n- Refresh → no \"Cannot find document\" error\n\nVideo: \n\n\nhttps://github.com/user-attachments/assets/25587a1c-5a7b-4832-b034-b9f1678f6912\n\n\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"aa5bfb1e242beea5a9c39fb56ff193a4a0344735"}}]}] BACKPORT-->