### PR TITLE
Fail when the Rspack optimizer cannot load

### DIFF
--- a/packages/kbn-cli-dev-mode/src/optimizer.test.ts
+++ b/packages/kbn-cli-dev-mode/src/optimizer.test.ts
@@ -405,7 +405,7 @@ describe('rspack path', () => {
     expect(runComplete).toHaveBeenCalled();
   });
 
-  it('falls back to webpack when dynamic import of @kbn/rspack-optimizer fails', async () => {
+  it('fails when dynamic import of @kbn/rspack-optimizer fails', async () => {
     rspackTestState.importShouldFail = true;
     jest.resetModules();
 
@@ -430,17 +430,13 @@ describe('rspack path', () => {
       ...defaultOptions,
     });
 
-    subscriptions.push(
-      optimizer.run$.subscribe({
-        error: (error) => {
-          throw error;
-        },
-      })
-    );
+    const error = jest.fn();
+    subscriptions.push(optimizer.run$.subscribe({ error }));
 
     await flushPromises();
 
-    expect(kbnOptimizer.runOptimizer).toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(new Error('Failed to load @kbn/rspack-optimizer'));
+    expect(kbnOptimizer.runOptimizer).not.toHaveBeenCalled();
     expect(RspackOptimizerMock).not.toHaveBeenCalled();
 
     rspackTestState.importShouldFail = false;

--- a/packages/kbn-cli-dev-mode/src/optimizer.ts
+++ b/packages/kbn-cli-dev-mode/src/optimizer.ts
@@ -165,10 +165,7 @@ export class Optimizer {
         })
         .catch((error) => {
           log.error(`Failed to load @kbn/rspack-optimizer: ${error.message}`);
-          log.warning('Falling back to @kbn/optimizer...');
-
-          // Fallback to webpack optimizer
-          this.createWebpackRun$(options).subscribe(subscriber);
+          subscriber.error(error);
         });
 
       // Cleanup when run$ completes or is unsubscribed (e.g., on SIGINT)

--- a/packages/kbn-rspack-optimizer/src/run_build.ts
+++ b/packages/kbn-rspack-optimizer/src/run_build.ts
@@ -481,17 +481,9 @@ function processStats(
       assets: false,
       modules: false,
     });
-    const lines = warningOutput
-      .split('\n')
-      .filter(
-        (line) => !line.includes('rspack.persistentCache') && !line.includes('BuildDependencies')
-      )
-      .slice(0, 20);
-    if (lines.length > 0) {
-      log.warning('Build warnings (first 20):');
-      for (const line of lines) {
-        log.warning(line);
-      }
+
+    if (warningOutput.trim()) {
+      log.warning(warningOutput);
     }
   }
 


### PR DESCRIPTION
- propagate Rspack optimizer loading failures instead of falling back to webpack
- verify the webpack optimizer is not started after a Rspack loading failure
- preserve complete multiline Rspack warning output

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->