### PR TITLE
[9.5] [Security Solution][Attacks Page] Prevent chips from being hard-clipped in the entity summary (#282759)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/attack_discovery_markdown_parser/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/attack_discovery_markdown_parser/helpers.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { ParsedField } from '../types';
+
 const iconLookup: Record<string, string> = {
   'host.name': 'desktop',
   'user.name': 'user',
@@ -24,3 +26,19 @@ const iconLookup: Record<string, string> = {
 export const getIconFromFieldName = (fieldName: string): string => {
   return iconLookup[fieldName] || '';
 };
+
+/**
+ * Matches every `{{ fieldName value }}` token in a string.
+ * Capture group 1 = field name, capture group 2 = field value.
+ */
+export const FIELD_TOKEN_REGEX = /\{\{\s*(\S+)\s+(.*?)\s*\}\}/g;
+
+/**
+ * Constructs a `ParsedField` from the two capture groups of `FIELD_TOKEN_REGEX`.
+ */
+export const parseFieldToken = (fieldName: string, fieldValue: string): ParsedField => ({
+  name: fieldName,
+  icon: getIconFromFieldName(fieldName),
+  operator: ':',
+  value: fieldValue,
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/attack_discovery_markdown_parser/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/attack_discovery_markdown_parser/index.tsx
@@ -8,8 +8,7 @@
 import type { Plugin } from 'unified';
 import type { RemarkTokenizer } from '@elastic/eui';
 
-import { getIconFromFieldName } from './helpers';
-import type { ParsedField } from '../types';
+import { parseFieldToken } from './helpers';
 
 export const AttackDiscoveryMarkdownParser: Plugin = function () {
   // NOTE: the use of `this.Parse` and the other idioms below required by the Remark `Plugin` should NOT be replicated outside this file
@@ -39,17 +38,10 @@ export const AttackDiscoveryMarkdownParser: Plugin = function () {
       return true;
     }
 
-    const parsedField: ParsedField = {
-      name: fieldName,
-      icon: getIconFromFieldName(fieldName),
-      operator: ':',
-      value: fieldValue,
-    };
-
     // must consume the exact & entire match string
     return eat(`${START_DELIMITER}${rawContent}${END_DELIMITER}`)({
       type: 'fieldPlugin',
-      ...parsedField,
+      ...parseFieldToken(fieldName, fieldValue),
     });
   };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx
@@ -12,7 +12,6 @@ import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 import { useBulkGetUserProfiles } from '../../../../../common/components/user_profiles/use_bulk_get_user_profiles';
 import { getSummaryPlainText, Subtitle } from './subtitle';
 import { getMockAttackDiscoveryAlerts } from '../../../../../attack_discovery/pages/mock/mock_attack_discovery_alerts';
-
 import { getFormattedDate } from '../../../../../attack_discovery/pages/loading_callout/loading_messages/get_formatted_time';
 
 jest.mock(
@@ -29,16 +28,34 @@ jest.mock('../../../../../common/lib/kibana', () => ({
 jest.mock(
   '../../../../../attack_discovery/pages/results/attack_discovery_markdown_formatter',
   () => ({
-    AttackDiscoveryMarkdownFormatter: jest.fn(({ markdown, alertIds }) => (
-      <div data-test-subj="mock-markdown-formatter" data-alert-ids={JSON.stringify(alertIds)}>
-        {markdown}
-      </div>
-    )),
+    AttackDiscoveryMarkdownFormatter: jest.fn(
+      ({
+        markdown,
+        alertIds,
+        disableActions,
+      }: {
+        markdown: string;
+        alertIds?: string[];
+        disableActions?: boolean;
+      }) => (
+        <div
+          data-test-subj="mock-markdown-formatter"
+          data-alert-ids={JSON.stringify(alertIds)}
+          data-disable-actions={String(disableActions)}
+        >
+          {markdown}
+        </div>
+      )
+    ),
   })
 );
 
 jest.mock('../../../../../common/components/user_profiles/use_bulk_get_user_profiles', () => ({
   useBulkGetUserProfiles: jest.fn(),
+}));
+
+jest.mock('../../../../../attack_discovery/helpers', () => ({
+  getOriginalAlertIds: jest.fn((alertIds: string[]) => alertIds),
 }));
 
 const mockAttack = getMockAttackDiscoveryAlerts()[0];
@@ -70,9 +87,7 @@ describe('Subtitle', () => {
     const scheduledAttack = { ...mockAttack, alertRuleUuid: 'some_other_rule_id' };
     const { getByTestId } = render(<Subtitle attack={scheduledAttack} />);
 
-    expect(getByTestId('attack-subtitle')).toHaveTextContent(
-      'Detected on 2023-10-27 10:00:00|Malware and credential theft detected on {{ host.name SRVMAC08 }} by {{ user.name james }}.'
-    );
+    expect(getByTestId('attack-subtitle')).toHaveTextContent('Detected on 2023-10-27 10:00:00');
     expect(getByTestId('mock-markdown-formatter')).toHaveTextContent(
       'Malware and credential theft detected on {{ host.name SRVMAC08 }} by {{ user.name james }}.'
     );
@@ -83,7 +98,7 @@ describe('Subtitle', () => {
     const scheduledAttack = { ...mockAttack, alertRuleUuid: 'some_other_rule_id' };
     render(<Subtitle attack={scheduledAttack} />);
 
-    await user.hover(screen.getByTestId('mock-markdown-formatter'));
+    await user.hover(screen.getByTestId('attack-subtitle-summary-text'));
 
     expect(await screen.findByRole('tooltip')).toHaveTextContent(
       'Malware and credential theft detected on SRVMAC08 by james.'
@@ -99,8 +114,8 @@ describe('Subtitle', () => {
     const { getByTestId, queryByTestId } = render(<Subtitle attack={attackWithoutSummary} />);
 
     expect(getByTestId('attack-subtitle')).toHaveTextContent('Detected on 2023-10-27 10:00:00');
-    expect(queryByTestId('mock-markdown-formatter')).not.toBeInTheDocument();
     expect(queryByTestId('attack-subtitle-summary')).not.toBeInTheDocument();
+    expect(queryByTestId('attack-subtitle-summary-text')).not.toBeInTheDocument();
   });
 
   it('should render anonymized summary when showAnonymized is true', () => {
@@ -202,7 +217,14 @@ describe('Subtitle', () => {
 
     expect(getByTestId('mock-markdown-formatter')).toHaveAttribute(
       'data-alert-ids',
-      JSON.stringify(['original-1', 'alert-2'])
+      JSON.stringify(['alert-1', 'alert-2'])
     );
+  });
+
+  it('should pass disableActions=true to AttackDiscoveryMarkdownFormatter when showAnonymized', () => {
+    const scheduledAttack = { ...mockAttack, alertRuleUuid: 'some_other_rule_id' };
+    const { getByTestId } = render(<Subtitle attack={scheduledAttack} showAnonymized={true} />);
+
+    expect(getByTestId('mock-markdown-formatter')).toHaveAttribute('data-disable-actions', 'true');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.tsx
@@ -19,6 +19,7 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import { UserAvatar } from '@kbn/user-profile-components';
 import { useBulkGetUserProfiles } from '../../../../../common/components/user_profiles/use_bulk_get_user_profiles';
 import { getOriginalAlertIds } from '../../../../../attack_discovery/helpers';
+import { FIELD_TOKEN_REGEX } from '../../../../../attack_discovery/pages/results/attack_discovery_markdown_formatter/attack_discovery_markdown_parser/helpers';
 import { getFormattedDate } from '../../../../../attack_discovery/pages/loading_callout/loading_messages/get_formatted_time';
 import { useDateFormat } from '../../../../../common/lib/kibana';
 import { AttackDiscoveryMarkdownFormatter } from '../../../../../attack_discovery/pages/results/attack_discovery_markdown_formatter';
@@ -47,17 +48,21 @@ export const UNKNOWN_USER_LABEL = i18n.translate(
  * Converts attack discovery field markdown (`{{ field.value }}`) to plain text for tooltips.
  */
 export const getSummaryPlainText = (markdown: string): string =>
-  markdown.replace(/\{\{\s*\S+\s+(.*?)\s*\}\}/g, '$1');
+  markdown.replace(FIELD_TOKEN_REGEX, '$2');
 
-const truncatedSummaryCss = css`
+/**
+ * Constrains the entity summary to a single truncated line.
+ * The gradient fade on the right edge prevents any chip from being hard-clipped.
+ */
+const summaryCss = css`
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  mask-image: linear-gradient(to right, black calc(100% - 2rem), transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 2rem), transparent 100%);
 
   .euiMarkdownFormat {
     overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
 
     > * {
@@ -190,7 +195,7 @@ export const Subtitle = React.memo<SubtitleProps>(({ attack, showAnonymized = fa
             data-test-subj="attack-subtitle-summary"
           >
             <EuiToolTip content={summaryPlainText} display="block" anchorClassName="eui-fullWidth">
-              <div css={truncatedSummaryCss}>
+              <div css={summaryCss} data-test-subj="attack-subtitle-summary-text" tabIndex={0}>
                 <AttackDiscoveryMarkdownFormatter
                   scopeId={TableId.alertsOnAttacksPage}
                   disableActions={showAnonymized}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Security Solution][Attacks Page] Prevent chips from being hard-clipped in the entity summary (#282759)](https://github.com/elastic/kibana/pull/282759)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-05T16:20:49Z","message":"[Security Solution][Attacks Page] Prevent chips from being hard-clipped in the entity summary (#282759)\n\n## Summary\n\nTwo focused changes to the Attacks table subtitle.\n\n### 1. Prevent chips from being hard-clipped in the entity summary\n\nThe `truncatedSummaryCss` block used `text-overflow: ellipsis` to\ntruncate the entity summary line. Because chips are not text, the\nbrowser clips them mid-render rather than truncating cleanly at a word\nboundary.\n\nReplaces `text-overflow: ellipsis` with a CSS gradient mask on the\nwrapper `div`. Any chip that would overflow the container fades out\ngracefully at the right edge instead of being hard-clipped. The tooltip\non hover still shows the full plain-text summary.\n\n### 2. Single source of truth for `{{ field value }}` token parsing\n\nThe `{{ fieldName value }}` token regex and `ParsedField` construction\nwere duplicated between `subtitle.tsx` and the Remark plugin in\n`AttackDiscoveryMarkdownParser`.\n\nExtracts `FIELD_TOKEN_REGEX` and `parseFieldToken` to\n`attack_discovery_markdown_parser/helpers.ts`. Both `subtitle.tsx`\n(`getSummaryPlainText`) and the Remark plugin now import from there\ninstead of defining their own copies.\n\nAddresses https://github.com/elastic/security-team/issues/18686\n\nBefore:\n\n<img width=\"1954\" height=\"582\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/191879dc-c408-4799-ab07-c9beb7360824\"\n/>\n\n\nAfter:\n<img width=\"1416\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/11637d2e-7da9-414f-86fb-dec943f37772\"\n/>\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"9dde841ac49b58b300e56ab1529e2a5b0f5adbfa","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","backport:version","v9.5.0","v9.6.0","v9.5.1"],"title":"[Security Solution][Attacks Page] Prevent chips from being hard-clipped in the entity summary","number":282759,"url":"https://github.com/elastic/kibana/pull/282759","mergeCommit":{"message":"[Security Solution][Attacks Page] Prevent chips from being hard-clipped in the entity summary (#282759)\n\n## Summary\n\nTwo focused changes to the Attacks table subtitle.\n\n### 1. Prevent chips from being hard-clipped in the entity summary\n\nThe `truncatedSummaryCss` block used `text-overflow: ellipsis` to\ntruncate the entity summary line. Because chips are not text, the\nbrowser clips them mid-render rather than truncating cleanly at a word\nboundary.\n\nReplaces `text-overflow: ellipsis` with a CSS gradient mask on the\nwrapper `div`. Any chip that would overflow the container fades out\ngracefully at the right edge instead of being hard-clipped. The tooltip\non hover still shows the full plain-text summary.\n\n### 2. Single source of truth for `{{ field value }}` token parsing\n\nThe `{{ fieldName value }}` token regex and `ParsedField` construction\nwere duplicated between `subtitle.tsx` and the Remark plugin in\n`AttackDiscoveryMarkdownParser`.\n\nExtracts `FIELD_TOKEN_REGEX` and `parseFieldToken` to\n`attack_discovery_markdown_parser/helpers.ts`. Both `subtitle.tsx`\n(`getSummaryPlainText`) and the Remark plugin now import from there\ninstead of defining their own copies.\n\nAddresses https://github.com/elastic/security-team/issues/18686\n\nBefore:\n\n<img width=\"1954\" height=\"582\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/191879dc-c408-4799-ab07-c9beb7360824\"\n/>\n\n\nAfter:\n<img width=\"1416\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/11637d2e-7da9-414f-86fb-dec943f37772\"\n/>\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"9dde841ac49b58b300e56ab1529e2a5b0f5adbfa"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282759","number":282759,"mergeCommit":{"message":"[Security Solution][Attacks Page] Prevent chips from being hard-clipped in the entity summary (#282759)\n\n## Summary\n\nTwo focused changes to the Attacks table subtitle.\n\n### 1. Prevent chips from being hard-clipped in the entity summary\n\nThe `truncatedSummaryCss` block used `text-overflow: ellipsis` to\ntruncate the entity summary line. Because chips are not text, the\nbrowser clips them mid-render rather than truncating cleanly at a word\nboundary.\n\nReplaces `text-overflow: ellipsis` with a CSS gradient mask on the\nwrapper `div`. Any chip that would overflow the container fades out\ngracefully at the right edge instead of being hard-clipped. The tooltip\non hover still shows the full plain-text summary.\n\n### 2. Single source of truth for `{{ field value }}` token parsing\n\nThe `{{ fieldName value }}` token regex and `ParsedField` construction\nwere duplicated between `subtitle.tsx` and the Remark plugin in\n`AttackDiscoveryMarkdownParser`.\n\nExtracts `FIELD_TOKEN_REGEX` and `parseFieldToken` to\n`attack_discovery_markdown_parser/helpers.ts`. Both `subtitle.tsx`\n(`getSummaryPlainText`) and the Remark plugin now import from there\ninstead of defining their own copies.\n\nAddresses https://github.com/elastic/security-team/issues/18686\n\nBefore:\n\n<img width=\"1954\" height=\"582\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/191879dc-c408-4799-ab07-c9beb7360824\"\n/>\n\n\nAfter:\n<img width=\"1416\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/11637d2e-7da9-414f-86fb-dec943f37772\"\n/>\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"9dde841ac49b58b300e56ab1529e2a5b0f5adbfa"}}]}] BACKPORT-->