### PR TITLE
[9.5] [Inference] Fix Anthropic stream parsing and Agent Builder empty-response retries (#281616)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/answer_agent_structured.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/answer_agent_structured.ts
@@ -12,7 +12,7 @@ import { createReasoningEvent } from '@kbn/agent-builder-genai-utils/langchain';
 import { wrapJsonSchema } from '@kbn/agent-builder-genai-utils/tools/utils/json_schema';
 import type { Logger } from '@kbn/logging';
 import { convertError, isRecoverableError } from './utils/errors';
-import { errorAction } from './actions';
+import { errorAction, isAgentErrorAction } from './actions';
 import type { PromptFactory } from './prompts';
 import { getRandomAnsweringMessage } from './i18n';
 import { tags } from './constants';
@@ -88,7 +88,9 @@ export const createAnswerAgentStructured = ({
 
       return {
         answerActions: [action],
-        errorCount: 0,
+        // Successful inference calls can still produce recoverable error actions,
+        // which must count toward the retry limit.
+        errorCount: isAgentErrorAction(action) ? state.errorCount + 1 : 0,
       };
     } catch (error) {
       const executionError = convertError(error);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AIMessage } from '@langchain/core/messages';
+import type { Logger } from '@kbn/core/server';
+import type { InferenceChatModel } from '@kbn/inference-langchain';
+import { AgentExecutionErrorCode } from '@kbn/agent-builder-common/agents';
+import type { AgentEventEmitter } from '@kbn/agent-builder-server';
+import type { ToolManager } from '@kbn/agent-builder-server/runner';
+import { AgentActionType } from './actions';
+import { createAgentGraph } from './graph';
+import type { PromptFactory } from './prompts';
+import type { ProcessedConversation } from './utils/prepare_conversation';
+
+jest.mock('@langchain/langgraph/prebuilt', () => ({
+  ToolNode: jest.fn().mockImplementation(() => ({
+    invoke: jest.fn().mockResolvedValue([]),
+  })),
+}));
+
+const createTestGraph = ({ structuredOutput = false }: { structuredOutput?: boolean } = {}) => {
+  const researchInvoke = jest.fn();
+  const structuredInvoke = jest.fn();
+  const chatModel = {
+    bindTools: jest.fn(() => ({
+      withConfig: jest.fn(() => ({ invoke: researchInvoke })),
+    })),
+    withStructuredOutput: jest.fn(() => ({
+      withConfig: jest.fn(() => ({ invoke: structuredInvoke })),
+    })),
+  } as unknown as InferenceChatModel;
+  const toolManager = {
+    list: jest.fn(() => []),
+    recordToolUse: jest.fn(),
+  } as unknown as ToolManager;
+  const promptFactory = {
+    getMainPrompt: jest.fn().mockResolvedValue([]),
+    getStructuredAnswerPrompt: jest.fn().mockResolvedValue([]),
+  } as jest.Mocked<PromptFactory>;
+
+  const graph = createAgentGraph({
+    chatModel,
+    toolManager,
+    configuration: { instructions: '' },
+    capabilities: { visualizations: false },
+    logger: {} as Logger,
+    events: { emit: jest.fn() } as unknown as AgentEventEmitter,
+    structuredOutput,
+    processedConversation: {} as ProcessedConversation,
+    promptFactory,
+    roundId: 'test-round',
+  });
+
+  return { graph, researchInvoke, structuredInvoke, toolManager };
+};
+
+describe('createAgentGraph', () => {
+  it('stops after two retries and surfaces emptyResponse for empty research responses', async () => {
+    const { graph, researchInvoke } = createTestGraph();
+    researchInvoke.mockResolvedValue(new AIMessage({ content: '' }));
+
+    await expect(graph.invoke({ cycleLimit: 10 }, { recursionLimit: 20 })).rejects.toMatchObject({
+      meta: { errCode: AgentExecutionErrorCode.emptyResponse },
+    });
+    expect(researchInvoke).toHaveBeenCalledTimes(3);
+  });
+
+  it('resets the consecutive error counter after a valid research response', async () => {
+    const { graph, researchInvoke } = createTestGraph();
+    researchInvoke
+      .mockResolvedValueOnce(new AIMessage({ content: '' }))
+      .mockResolvedValueOnce(new AIMessage({ content: 'final answer' }));
+
+    const result = await graph.invoke({ cycleLimit: 10 });
+
+    expect(result.errorCount).toBe(0);
+    expect(result.finalAnswer).toBe('final answer');
+    expect(result.mainActions.map(({ type }) => type)).toEqual([
+      AgentActionType.Error,
+      AgentActionType.HandOver,
+    ]);
+  });
+
+  it('preserves valid tool-call and handover behavior', async () => {
+    const { graph, researchInvoke, toolManager } = createTestGraph();
+    researchInvoke
+      .mockResolvedValueOnce(
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call-1', name: 'test-tool', args: {}, type: 'tool_call' }],
+        })
+      )
+      .mockResolvedValueOnce(new AIMessage({ content: 'answer after tool call' }));
+
+    const result = await graph.invoke({ cycleLimit: 10 });
+
+    expect(toolManager.recordToolUse).toHaveBeenCalledWith('test-tool');
+    expect(result.finalAnswer).toBe('answer after tool call');
+    expect(result.errorCount).toBe(0);
+  });
+
+  it('stops after two retries and surfaces emptyResponse for empty structured answers', async () => {
+    const { graph, researchInvoke, structuredInvoke } = createTestGraph({
+      structuredOutput: true,
+    });
+    researchInvoke.mockResolvedValue(new AIMessage({ content: 'research complete' }));
+    structuredInvoke.mockResolvedValue({});
+
+    await expect(graph.invoke({ cycleLimit: 10 }, { recursionLimit: 20 })).rejects.toMatchObject({
+      meta: { errCode: AgentExecutionErrorCode.emptyResponse },
+    });
+    expect(researchInvoke).toHaveBeenCalledTimes(1);
+    expect(structuredInvoke).toHaveBeenCalledTimes(3);
+  });
+
+  it('resets the consecutive error counter after a valid structured answer', async () => {
+    const { graph, researchInvoke, structuredInvoke } = createTestGraph({
+      structuredOutput: true,
+    });
+    researchInvoke.mockResolvedValue(new AIMessage({ content: 'research complete' }));
+    structuredInvoke
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ response: 'structured answer' });
+
+    const result = await graph.invoke({ cycleLimit: 10 });
+
+    expect(result.errorCount).toBe(0);
+    expect(result.finalAnswer).toEqual({ response: 'structured answer' });
+    expect(result.answerActions.map(({ type }) => type)).toEqual([
+      AgentActionType.Error,
+      AgentActionType.StructuredAnswer,
+    ]);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
@@ -127,7 +127,9 @@ export const createAgentGraph = ({
       return {
         mainActions: [action],
         currentCycle,
-        errorCount: 0,
+        // Successful inference calls can still produce recoverable error actions,
+        // which must count toward the retry limit.
+        errorCount: isAgentErrorAction(action) ? state.errorCount + 1 : 0,
       };
     } catch (error) {
       const executionError = convertError(error);

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.test.ts
@@ -45,6 +45,13 @@ function createOpenAIChunk({
   };
 }
 
+const anthropicChunkBase = {
+  id: 'chatcmpl-anthropic',
+  object: null,
+  created: 1753747200,
+  model: 'claude-sonnet-4',
+} as const;
+
 describe('inferenceEndpointAdapter', () => {
   const executorMock: InferenceEndpointExecutor & {
     invoke: jest.MockedFn<InferenceEndpointExecutor['invoke']>;
@@ -97,6 +104,155 @@ describe('inferenceEndpointAdapter', () => {
           type: ChatCompletionEventType.ChatCompletionChunk,
         },
       ]);
+    });
+
+    it('emits Anthropic chunks with a null object', async () => {
+      const source$ = of(
+        {
+          ...anthropicChunkBase,
+          choices: [
+            {
+              index: 0,
+              delta: { content: 'I will search.' },
+              finish_reason: null,
+            },
+          ],
+          usage: null,
+        },
+        {
+          ...anthropicChunkBase,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'toolu_01',
+                    function: { name: 'search', arguments: '{"query":"' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+          usage: null,
+        },
+        {
+          ...anthropicChunkBase,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: { arguments: 'kibana"}' },
+                  },
+                ],
+              },
+              finish_reason: 'tool_use',
+            },
+          ],
+          usage: null,
+        },
+        {
+          ...anthropicChunkBase,
+          choices: [],
+          usage: {
+            completion_tokens: 12,
+            prompt_tokens: 8,
+            total_tokens: 20,
+          },
+        }
+      );
+
+      executorMock.invoke.mockResolvedValue(observableIntoEventSourceStream(source$, logger));
+
+      const response = await lastValueFrom(
+        inferenceEndpointAdapter
+          .chatComplete({
+            ...defaultArgs,
+            messages: [{ role: MessageRole.User, content: 'Search Kibana' }],
+          })
+          .pipe(toArray())
+      );
+
+      expect(response).toEqual([
+        {
+          content: 'I will search.',
+          tool_calls: [],
+          type: ChatCompletionEventType.ChatCompletionChunk,
+        },
+        {
+          content: '',
+          tool_calls: [
+            {
+              function: { name: 'search', arguments: '{"query":"' },
+              index: 0,
+              toolCallId: 'toolu_01',
+            },
+          ],
+          type: ChatCompletionEventType.ChatCompletionChunk,
+        },
+        {
+          content: '',
+          tool_calls: [
+            {
+              function: { name: '', arguments: 'kibana"}' },
+              index: 0,
+              toolCallId: '',
+            },
+          ],
+          type: ChatCompletionEventType.ChatCompletionChunk,
+        },
+        {
+          model: 'claude-sonnet-4',
+          tokens: {
+            completion: 12,
+            prompt: 8,
+            total: 20,
+          },
+          type: ChatCompletionEventType.ChatCompletionTokenCount,
+        },
+      ]);
+    });
+
+    it('ignores null-object events without array choices and unrelated object values', async () => {
+      const source$ = of(
+        {
+          id: 'non-array-choices',
+          object: null,
+          choices: {},
+          usage: {
+            completion_tokens: 1,
+            prompt_tokens: 1,
+            total_tokens: 2,
+          },
+        },
+        {
+          id: 'missing-object',
+          choices: [{ index: 0, delta: { content: 'ignored' }, finish_reason: null }],
+        },
+        {
+          id: 'unrelated-object',
+          object: 'content_block_delta',
+          choices: [{ index: 0, delta: { content: 'ignored' }, finish_reason: null }],
+        }
+      );
+
+      executorMock.invoke.mockResolvedValue(observableIntoEventSourceStream(source$, logger));
+
+      const chunks = await lastValueFrom(
+        inferenceEndpointAdapter
+          .chatComplete({
+            ...defaultArgs,
+            messages: [{ role: MessageRole.User, content: 'Hello' }],
+          })
+          .pipe(filter(isChatCompletionChunkEvent), toArray())
+      );
+
+      expect(chunks).toEqual([]);
     });
 
     it('emits token count event when provided by the response', async () => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.ts
@@ -92,7 +92,8 @@ export const inferenceEndpointAdapter = {
       })
     ).pipe(
       switchMap((stream) => eventSourceStreamIntoObservable(stream)),
-      processOpenAIStream(),
+      // Elasticsearch's Anthropic stream emits valid OpenAI-compatible chunks with `object: null`.
+      processOpenAIStream({ allowNullObjectWithChoices: true }),
       emitTokenCountEstimateIfMissing({ request, logger }),
       useSimulatedFunctionCalling ? parseInlineFunctionCalls({ logger }) : identity
     );

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/process_openai_stream.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/process_openai_stream.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { lastValueFrom, of, toArray } from 'rxjs';
+import { ChatCompletionEventType } from '@kbn/inference-common';
+import { processOpenAIStream } from './process_openai_stream';
+
+describe('processOpenAIStream', () => {
+  it('does not accept null-object chunks by default', async () => {
+    const result = await lastValueFrom(
+      of(
+        JSON.stringify({
+          id: 'null-object',
+          object: null,
+          created: 1753747200,
+          model: 'claude-sonnet-4',
+          choices: [{ index: 0, delta: { content: 'ignored' }, finish_reason: null }],
+        }),
+        JSON.stringify({
+          id: 'canonical',
+          object: 'chat.completion.chunk',
+          created: 1753747200,
+          model: 'gpt-4o',
+          choices: [{ index: 0, delta: { content: 'emitted' }, finish_reason: null }],
+        })
+      ).pipe(processOpenAIStream(), toArray())
+    );
+
+    expect(result).toEqual([
+      {
+        content: 'emitted',
+        tool_calls: [],
+        type: ChatCompletionEventType.ChatCompletionChunk,
+      },
+    ]);
+  });
+
+  it('preserves token-limit errors for accepted null-object chunks', async () => {
+    const result$ = of(
+      JSON.stringify({
+        id: 'null-object',
+        object: null,
+        created: 1753747200,
+        model: 'claude-sonnet-4',
+        choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+      })
+    ).pipe(processOpenAIStream({ allowNullObjectWithChoices: true }), toArray());
+
+    await expect(lastValueFrom(result$)).rejects.toThrow('Token limit reached');
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/process_openai_stream.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/process_openai_stream.ts
@@ -20,7 +20,17 @@ import { tokenCountFromOpenAI, chunkFromOpenAI } from './from_openai';
 import { convertStreamError, type ErrorLine } from './stream_errors';
 import { createTokenLimitReachedError } from '../../../../common/chat_complete/errors';
 
-export function processOpenAIStream(): OperatorFunction<
+interface ProcessOpenAIStreamOptions {
+  allowNullObjectWithChoices?: boolean;
+}
+
+type CompatibleChatCompletionChunk = Omit<OpenAI.ChatCompletionChunk, 'object'> & {
+  object: OpenAI.ChatCompletionChunk['object'] | null;
+};
+
+export function processOpenAIStream({
+  allowNullObjectWithChoices = false,
+}: ProcessOpenAIStreamOptions = {}): OperatorFunction<
   string,
   ChatCompletionChunkEvent | ChatCompletionTokenCountEvent
 > {
@@ -29,7 +39,7 @@ export function processOpenAIStream(): OperatorFunction<
       filter((line) => !!line && line !== '[DONE]'),
       map((line) => {
         try {
-          return JSON.parse(line) as OpenAI.ChatCompletionChunk | ErrorLine;
+          return JSON.parse(line) as CompatibleChatCompletionChunk | ErrorLine;
         } catch (e) {
           throw createInferenceInternalError(`Failed to parse line "${line}": ${e.message}`);
         }
@@ -46,8 +56,18 @@ export function processOpenAIStream(): OperatorFunction<
           throw createTokenLimitReachedError();
         }
       }),
-      filter((line): line is OpenAI.ChatCompletionChunk => {
-        return 'object' in line && line.object === 'chat.completion.chunk';
+      filter((line): line is CompatibleChatCompletionChunk => {
+        return (
+          'object' in line &&
+          (line.object === 'chat.completion.chunk' ||
+            (allowNullObjectWithChoices &&
+              line.object === null &&
+              'choices' in line &&
+              Array.isArray(line.choices)))
+        );
+      }),
+      map((chunk): OpenAI.ChatCompletionChunk => {
+        return { ...chunk, object: 'chat.completion.chunk' };
       }),
       mergeMap((chunk): Observable<ChatCompletionChunkEvent | ChatCompletionTokenCountEvent> => {
         const events: Array<ChatCompletionChunkEvent | ChatCompletionTokenCountEvent> = [];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Inference] Fix Anthropic stream parsing and Agent Builder empty-response retries (#281616)](https://github.com/elastic/kibana/pull/281616)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Melissa Alvarez","email":"melissa.alvarez@elastic.co"},"sourceCommit":{"committedDate":"2026-08-05T17:59:34Z","message":"[Inference] Fix Anthropic stream parsing and Agent Builder empty-response retries (#281616)\n\n## Summary\n\nRelated/follow up to PR: https://github.com/elastic/kibana/pull/281179\nRelated issue: https://github.com/elastic/kibana/issues/278483\n\nThis PR addresses two issues discovered while testing the [temperature\nfix](https://github.com/elastic/kibana/pull/281179) for\n[#278483](https://github.com/elastic/kibana/issues/278483) with\nAnthropic in Agent Builder.\n\n### 1. Empty response retry\nThe chat appeared to hang while silently retrying, consuming significant\ntokens before eventually reaching LangGraph’s recursion limit.\n\nSome providers can return 200 without producing text or tool calls.\nAgent Builder converts this into a recoverable emptyResponse error\naction. However, because the model invocation itself succeeded, the\ngraph reset the consecutive error counter to zero. Because of this,\nempty responses were repeatedly retried until LangGraph reached its\nrecursion limit (125), surfacing GraphRecursionError instead of the\nunderlying emptyResponse.\n\nThis change increments the existing consecutive error counter when a\nsuccessful research or structured-answer invocation produces an error\naction. **After the initial attempt and two retries, Agent Builder now\nstops and surfaces emptyResponse. Valid responses still reset the\ncounter, while existing tool-call, handover, and thrown\nrecoverable-error behavior remains unchanged.**\n\nInstead of hanging for a long time and failing with the limit error, we\nnow get a much more timely error message:\n\n<img width=\"980\" height=\"937\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed6aaf64-dd19-4000-abc1-1005496e6cb3\"\n/>\n\n_I think a follow-up is needed here. We could add dedicated UI handling\nfor emptyResponse errors in RoundError. After retries are exhausted,\nshow a concise, actionable message instead of a generic stack trace. We\nshould keep intermediate retries silent, while recording them through\nlogging or telemetry for diagnostics._\n\n\n### 2. Null object handling\nInvestigation showed that Elasticsearch’s Anthropic inference service\nreturned valid OpenAI-compatible text, tool-call, and usage chunks with\n`\"object\": null`. Kibana only accepted `\"object\":\n\"chat.completion.chunk\"`, so it discarded every chunk and Agent Builder\ntreated the result as an empty response.\n\nThis surfaced after native Anthropic chat_completion support was added\nin May 2026 by [Elasticsearch PR\n#148539](https://github.com/elastic/elasticsearch/pull/148539) for 9.5+\nand Serverless.\n\n**This PR allows the native inference-endpoint adapter to process\n`\"object\": null` only when the event contains a valid choices array.**\nCanonical chunks remain supported, while OpenAI and connector adapters\nretain their existing strict behavior. Agent Builder can now process\nthese Anthropic responses without accepting unrelated events.\n\n**Elasticsearch should ultimately emit the canonical object value**, but\nthis narrow Kibana compatibility fix supports existing affected\ndeployments. (cc @jonathan-buttner)\n\n### 3. Anthropic tool-result incompatibility (known limitation, not\nfixed here)\nAfter fixing the empty-response and `object: null` issues, an underlying\nprovider error became visible:\n`400 invalid_request_error: messages: Unexpected role \"tool\". Allowed\nroles are \"user\" or \"assistant\".`\n\nNative Elasticsearch Anthropic `chat_completion` endpoints currently\nforward unified OpenAI-style `role: \"tool\"` messages directly to\nAnthropic, whose Messages API requires user messages containing\n`tool_result` blocks.\n\nKibana is correctly following Elasticsearch’s unified inference API\ncontract. Provider-specific translation is being addressed by\n[Elasticsearch PR\n#154607](https://github.com/elastic/elasticsearch/pull/154607) for\nnative Anthropic and Google Model Garden Anthropic endpoints.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21ba61caaa1f735775d8698c6962776f29e8dc04","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","Feature: AI Infra","feature:agent-builder","v9.6.0","v9.5.1"],"title":"[Inference] Fix Anthropic stream parsing and Agent Builder empty-response retries","number":281616,"url":"https://github.com/elastic/kibana/pull/281616","mergeCommit":{"message":"[Inference] Fix Anthropic stream parsing and Agent Builder empty-response retries (#281616)\n\n## Summary\n\nRelated/follow up to PR: https://github.com/elastic/kibana/pull/281179\nRelated issue: https://github.com/elastic/kibana/issues/278483\n\nThis PR addresses two issues discovered while testing the [temperature\nfix](https://github.com/elastic/kibana/pull/281179) for\n[#278483](https://github.com/elastic/kibana/issues/278483) with\nAnthropic in Agent Builder.\n\n### 1. Empty response retry\nThe chat appeared to hang while silently retrying, consuming significant\ntokens before eventually reaching LangGraph’s recursion limit.\n\nSome providers can return 200 without producing text or tool calls.\nAgent Builder converts this into a recoverable emptyResponse error\naction. However, because the model invocation itself succeeded, the\ngraph reset the consecutive error counter to zero. Because of this,\nempty responses were repeatedly retried until LangGraph reached its\nrecursion limit (125), surfacing GraphRecursionError instead of the\nunderlying emptyResponse.\n\nThis change increments the existing consecutive error counter when a\nsuccessful research or structured-answer invocation produces an error\naction. **After the initial attempt and two retries, Agent Builder now\nstops and surfaces emptyResponse. Valid responses still reset the\ncounter, while existing tool-call, handover, and thrown\nrecoverable-error behavior remains unchanged.**\n\nInstead of hanging for a long time and failing with the limit error, we\nnow get a much more timely error message:\n\n<img width=\"980\" height=\"937\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed6aaf64-dd19-4000-abc1-1005496e6cb3\"\n/>\n\n_I think a follow-up is needed here. We could add dedicated UI handling\nfor emptyResponse errors in RoundError. After retries are exhausted,\nshow a concise, actionable message instead of a generic stack trace. We\nshould keep intermediate retries silent, while recording them through\nlogging or telemetry for diagnostics._\n\n\n### 2. Null object handling\nInvestigation showed that Elasticsearch’s Anthropic inference service\nreturned valid OpenAI-compatible text, tool-call, and usage chunks with\n`\"object\": null`. Kibana only accepted `\"object\":\n\"chat.completion.chunk\"`, so it discarded every chunk and Agent Builder\ntreated the result as an empty response.\n\nThis surfaced after native Anthropic chat_completion support was added\nin May 2026 by [Elasticsearch PR\n#148539](https://github.com/elastic/elasticsearch/pull/148539) for 9.5+\nand Serverless.\n\n**This PR allows the native inference-endpoint adapter to process\n`\"object\": null` only when the event contains a valid choices array.**\nCanonical chunks remain supported, while OpenAI and connector adapters\nretain their existing strict behavior. Agent Builder can now process\nthese Anthropic responses without accepting unrelated events.\n\n**Elasticsearch should ultimately emit the canonical object value**, but\nthis narrow Kibana compatibility fix supports existing affected\ndeployments. (cc @jonathan-buttner)\n\n### 3. Anthropic tool-result incompatibility (known limitation, not\nfixed here)\nAfter fixing the empty-response and `object: null` issues, an underlying\nprovider error became visible:\n`400 invalid_request_error: messages: Unexpected role \"tool\". Allowed\nroles are \"user\" or \"assistant\".`\n\nNative Elasticsearch Anthropic `chat_completion` endpoints currently\nforward unified OpenAI-style `role: \"tool\"` messages directly to\nAnthropic, whose Messages API requires user messages containing\n`tool_result` blocks.\n\nKibana is correctly following Elasticsearch’s unified inference API\ncontract. Provider-specific translation is being addressed by\n[Elasticsearch PR\n#154607](https://github.com/elastic/elasticsearch/pull/154607) for\nnative Anthropic and Google Model Garden Anthropic endpoints.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21ba61caaa1f735775d8698c6962776f29e8dc04"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281616","number":281616,"mergeCommit":{"message":"[Inference] Fix Anthropic stream parsing and Agent Builder empty-response retries (#281616)\n\n## Summary\n\nRelated/follow up to PR: https://github.com/elastic/kibana/pull/281179\nRelated issue: https://github.com/elastic/kibana/issues/278483\n\nThis PR addresses two issues discovered while testing the [temperature\nfix](https://github.com/elastic/kibana/pull/281179) for\n[#278483](https://github.com/elastic/kibana/issues/278483) with\nAnthropic in Agent Builder.\n\n### 1. Empty response retry\nThe chat appeared to hang while silently retrying, consuming significant\ntokens before eventually reaching LangGraph’s recursion limit.\n\nSome providers can return 200 without producing text or tool calls.\nAgent Builder converts this into a recoverable emptyResponse error\naction. However, because the model invocation itself succeeded, the\ngraph reset the consecutive error counter to zero. Because of this,\nempty responses were repeatedly retried until LangGraph reached its\nrecursion limit (125), surfacing GraphRecursionError instead of the\nunderlying emptyResponse.\n\nThis change increments the existing consecutive error counter when a\nsuccessful research or structured-answer invocation produces an error\naction. **After the initial attempt and two retries, Agent Builder now\nstops and surfaces emptyResponse. Valid responses still reset the\ncounter, while existing tool-call, handover, and thrown\nrecoverable-error behavior remains unchanged.**\n\nInstead of hanging for a long time and failing with the limit error, we\nnow get a much more timely error message:\n\n<img width=\"980\" height=\"937\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed6aaf64-dd19-4000-abc1-1005496e6cb3\"\n/>\n\n_I think a follow-up is needed here. We could add dedicated UI handling\nfor emptyResponse errors in RoundError. After retries are exhausted,\nshow a concise, actionable message instead of a generic stack trace. We\nshould keep intermediate retries silent, while recording them through\nlogging or telemetry for diagnostics._\n\n\n### 2. Null object handling\nInvestigation showed that Elasticsearch’s Anthropic inference service\nreturned valid OpenAI-compatible text, tool-call, and usage chunks with\n`\"object\": null`. Kibana only accepted `\"object\":\n\"chat.completion.chunk\"`, so it discarded every chunk and Agent Builder\ntreated the result as an empty response.\n\nThis surfaced after native Anthropic chat_completion support was added\nin May 2026 by [Elasticsearch PR\n#148539](https://github.com/elastic/elasticsearch/pull/148539) for 9.5+\nand Serverless.\n\n**This PR allows the native inference-endpoint adapter to process\n`\"object\": null` only when the event contains a valid choices array.**\nCanonical chunks remain supported, while OpenAI and connector adapters\nretain their existing strict behavior. Agent Builder can now process\nthese Anthropic responses without accepting unrelated events.\n\n**Elasticsearch should ultimately emit the canonical object value**, but\nthis narrow Kibana compatibility fix supports existing affected\ndeployments. (cc @jonathan-buttner)\n\n### 3. Anthropic tool-result incompatibility (known limitation, not\nfixed here)\nAfter fixing the empty-response and `object: null` issues, an underlying\nprovider error became visible:\n`400 invalid_request_error: messages: Unexpected role \"tool\". Allowed\nroles are \"user\" or \"assistant\".`\n\nNative Elasticsearch Anthropic `chat_completion` endpoints currently\nforward unified OpenAI-style `role: \"tool\"` messages directly to\nAnthropic, whose Messages API requires user messages containing\n`tool_result` blocks.\n\nKibana is correctly following Elasticsearch’s unified inference API\ncontract. Provider-specific translation is being addressed by\n[Elasticsearch PR\n#154607](https://github.com/elastic/elasticsearch/pull/154607) for\nnative Anthropic and Google Model Garden Anthropic endpoints.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21ba61caaa1f735775d8698c6962776f29e8dc04"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->