### PR TITLE
test: unskip Run workflow Scout suite after alert setup

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/test/scout/workflows/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/workflows/ui/parallel_tests/global.setup.ts
@@ -5,8 +5,11 @@
  * 2.0.
  */
 
-import { globalSetupHook } from '@kbn/scout-security';
+import { globalSetupHook, SECURITY_ARCHIVES } from '@kbn/scout-security';
 
-globalSetupHook('Global setup', async ({ log }) => {
-  log.debug('[setup] no archive ingestion needed for this area');
+globalSetupHook('Ingest archives to Elasticsearch', async ({ esArchiver, log }) => {
+  // CUSTOM_QUERY_RULE matches auditbeat-* documents from 2019. Without this
+  // archive the suite never gets alerts and waitForAlerts times out.
+  log.debug('[setup] loading archives test data (only if indexes do not exist)...');
+  await esArchiver.loadIfNeeded(SECURITY_ARCHIVES.AUDITBEAT);
 });

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/workflows/ui/parallel_tests/run_workflow_action.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/workflows/ui/parallel_tests/run_workflow_action.spec.ts
@@ -8,8 +8,7 @@
 import { spaceTest, tags, CUSTOM_QUERY_RULE, FULL_KIBANA_SECURITY_ROLE } from '@kbn/scout-security';
 import { expect } from '@kbn/scout-security/ui';
 
-// Failing: See https://github.com/elastic/kibana/issues/261392
-spaceTest.describe.skip('Run workflow alert action', { tag: [...tags.stateful.classic] }, () => {
+spaceTest.describe('Run workflow alert action', { tag: [...tags.stateful.classic] }, () => {
   let ruleName: string;
 
   spaceTest.beforeAll(async ({ scoutSpace }) => {
@@ -17,12 +16,22 @@ spaceTest.describe.skip('Run workflow alert action', { tag: [...tags.stateful.cl
     await scoutSpace.uiSettings.set({ 'workflows:ui:enabled': true });
   });
 
-  spaceTest.beforeEach(async ({ browserAuth, apiServices, scoutSpace }) => {
+  spaceTest.beforeEach(async ({ browserAuth, apiServices, scoutSpace }, testInfo) => {
+    // Detection rule first-run can take a while under CI load before an alert lands.
+    // This is for rule execution, not the workflow create API (that cold-start is
+    // covered by StorageIndexAdapter.ensureReady in #283105).
+    testInfo.setTimeout(testInfo.timeout + 90_000);
+
     ruleName = `${CUSTOM_QUERY_RULE.name}_${scoutSpace.id}_${Date.now()}`;
     await apiServices.detectionRule.createCustomQueryRule({
       ...CUSTOM_QUERY_RULE,
       name: ruleName,
     });
+
+    // Wait for the rule to produce an alert before opening the browser. Without this,
+    // navigation races task-manager first-run scheduling and the alerts table never loads.
+    await apiServices.detectionAlerts.waitForAlerts(ruleName, 1, 90_000);
+
     // Use a custom role that includes workflowsManagement privileges (canExecuteWorkflow)
     // in addition to the security index privileges needed to view alerts
     await browserAuth.loginWithCustomRole(FULL_KIBANA_SECURITY_ROLE);
@@ -64,11 +73,16 @@ spaceTest.describe.skip('Run workflow alert action', { tag: [...tags.stateful.cl
           headers: { 'kbn-xsrf': 'true' },
         }
       );
+      if (!createResponse.ok()) {
+        throw new Error(
+          `Failed to create workflow: ${createResponse.status()} ${await createResponse.text()}`
+        );
+      }
       const { id: workflowId } = await createResponse.json();
 
       try {
         await alertsTablePage.navigate();
-        await alertsTablePage.waitForDetectionsAlertsWrapper();
+        await alertsTablePage.waitForRuleAlert(ruleName);
         await alertsTablePage.openAlertContextMenu(ruleName);
         await alertsTablePage.runWorkflowMenuItem.click();
 
@@ -115,7 +129,7 @@ spaceTest.describe.skip('Run workflow alert action', { tag: [...tags.stateful.cl
       const { alertsTablePage } = pageObjects;
 
       await alertsTablePage.navigate();
-      await alertsTablePage.waitForDetectionsAlertsWrapper();
+      await alertsTablePage.waitForRuleAlert(ruleName);
       await alertsTablePage.openAlertContextMenu(ruleName);
 
       await expect(alertsTablePage.runWorkflowMenuItem).toBeVisible();
@@ -133,16 +147,11 @@ spaceTest.describe.skip('Run workflow alert action', { tag: [...tags.stateful.cl
       const { alertsTablePage } = pageObjects;
 
       await alertsTablePage.navigate();
-      await alertsTablePage.waitForDetectionsAlertsWrapper();
+      await alertsTablePage.waitForRuleAlert(ruleName);
 
-      // Select the alert row matching the rule via its checkbox
-      const ruleNameCell = alertsTablePage.alertsTable
-        .getByTestId('ruleName')
-        .filter({ hasText: ruleName });
-      const alertCheckbox = ruleNameCell
-        .locator('xpath=ancestor::div[contains(@class,"euiDataGridRow")]')
-        .locator('.euiCheckbox__input');
-      await alertCheckbox.check();
+      // Prefer the page-object helper: a raw ancestor xpath can match nested
+      // euiDataGridRow nodes and trip Playwright strict mode.
+      await alertsTablePage.checkAlertRowCheckbox(ruleName);
 
       // Open the bulk-actions popover ("N selected" button) before clicking the menu item
       await alertsTablePage.selectedShowBulkActionsButton.click();


### PR DESCRIPTION
## Summary
Follow-up to #283105 / #261392.

#283105 fixes the workflow create cold-start (`ensureReady`). This PR unskips the Run workflow Scout suite by giving it the Scout setup it was missing:

- load `SECURITY_ARCHIVES.AUDITBEAT` in workflows `global.setup` (CUSTOM_QUERY_RULE queries `auditbeat-*`)
- `waitForAlerts` before opening the alerts UI (same pattern as agent_builder Scout)
- extend the Playwright test timeout for rule first-run only (not for create)
- use `waitForRuleAlert` / `checkAlertRowCheckbox` helpers

**Blocked on #283105.** Merge that first so create on a cold CI cluster does not time out again under the 10s action timeout.

## To test
CI Scout lane for `security_solution/test/scout/workflows`. Locally: run the workflows Scout UI config after #283105 is on the branch.

Screenshots: n/a, test-only.

Refs #261392

_PR developed with Cursor + Cursor Grok 4.5_

Made with [Cursor](https://cursor.com)