### PR TITLE
[Inference] Do not send null content for assistant tool-call messages

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.test.ts
@@ -190,7 +190,9 @@ describe('messagesToOpenAI', () => {
     ]);
   });
 
-  it('converts an assistant tool call', () => {
+  it('converts an assistant tool call, using an empty string for null content', () => {
+    // Elasticsearch's UnifiedCompletionRequest parser rejects `content: null`, so
+    // a null/absent text content must be serialized as an empty string instead.
     expect(
       messagesToOpenAI({
         messages: [
@@ -212,7 +214,7 @@ describe('messagesToOpenAI', () => {
     ).toEqual([
       {
         role: 'assistant',
-        content: null,
+        content: '',
         tool_calls: [
           {
             function: {
@@ -358,6 +360,35 @@ describe('messagesToOpenAI', () => {
       });
 
       expect(result).toHaveLength(3);
+    });
+
+    it('merges consecutive assistant messages with null content into an empty string, not null', () => {
+      const result = messagesToOpenAI({
+        messages: [
+          {
+            role: MessageRole.Assistant,
+            content: null,
+            toolCalls: [
+              { toolCallId: 'call-1', function: { name: 'tool_a', arguments: { x: 1 } } },
+            ],
+          },
+          {
+            role: MessageRole.Assistant,
+            content: null,
+            toolCalls: [
+              { toolCallId: 'call-2', function: { name: 'tool_b', arguments: { y: 2 } } },
+            ],
+          },
+        ],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: '',
+        })
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/to_openai.ts
@@ -136,7 +136,10 @@ export function messagesToOpenAI({
       case MessageRole.Assistant:
         const assistantMessage: ChatCompletionAssistantMessageParam = {
           role: 'assistant',
-          content: message.content || null,
+          // Elasticsearch's UnifiedCompletionRequest parser rejects `content: null`
+          // (unlike the OpenAI API, which allows it when `tool_calls` is set), so an
+          // empty string is sent instead when there is no text content.
+          content: message.content || '',
           tool_calls: message.toolCalls?.map((toolCall) => {
             return {
               function: {
@@ -215,8 +218,9 @@ function mergeConsecutiveMessages(
       } else if (message.role === 'assistant' && previous.role === 'assistant') {
         const prevContent = (previous as ChatCompletionAssistantMessageParam).content ?? '';
         const curContent = (message as ChatCompletionAssistantMessageParam).content ?? '';
-        (previous as ChatCompletionAssistantMessageParam).content =
-          [prevContent, curContent].filter(Boolean).join('\n') || null;
+        (previous as ChatCompletionAssistantMessageParam).content = [prevContent, curContent]
+          .filter(Boolean)
+          .join('\n');
         const prevCalls = (previous as ChatCompletionAssistantMessageParam).tool_calls;
         const curCalls = (message as ChatCompletionAssistantMessageParam).tool_calls;
         if (curCalls?.length) {


### PR DESCRIPTION
## Summary

Elasticsearch's `UnifiedCompletionRequest` parser rejects `content: null` on `assistant` messages, even though the OpenAI API itself allows a `null` content when `tool_calls` is present. Kibana's OpenAI-shaped request adapter (used by both the `.inference` connector's unified-completion path and by direct Elasticsearch inference-endpoint calls) sends `content: null` whenever the model replies with a tool call and no accompanying text.

In practice, this causes **intermittent** `500`s from Agent Builder (and any other unified-completion caller) of the form:

```
[UnifiedCompletionRequest] failed to parse field [messages]
```

The failure rate depends entirely on whether the model happens to emit some text before invoking a tool on a given turn — with the same model, prompt, and connector, some responses have `content: null` (tool call only) and fail, while others have non-empty text content and succeed. This makes it look like a routing/connector-resolution bug at first ("only fails on the default connector, not when I explicitly pick a model"), when it's actually pure request-shape non-determinism from the LLM's own token generation.

### Root cause, confirmed via direct reproduction against Elasticsearch

Posting directly to `_inference/chat_completion/<id>/_stream`:
- `messages: [..., { role: "assistant", content: null, tool_calls: [...] }, ...]` → `400 x_content_parse_exception`: `[UnifiedCompletionRequest] failed to parse field [messages]` (the exact error users see surfaced through Agent Builder).
- Same request with `content: ""` instead of `null` → parses fine (progresses past the `messages` field entirely).

### Fix

Send an empty string instead of `null` when there is no text content, in both:
- `messagesToOpenAI` (the initial per-message conversion)
- `mergeConsecutiveMessages` (which also produced `null` when merging two content-less consecutive assistant messages)

### Note on prior work

This overlaps with elastic/kibana#281546 (merged, then reverted in elastic/kibana#282883 due to an unrelated CI/Jest-config issue introduced by a concurrent merge, not because the fix itself was incorrect — see the discussion on that PR). This PR is a minimal, independently-diagnosed and reproduced fix scoped to only the `content: null` issue, so it doesn't touch the token-counting files that were implicated in that CI failure.

## Reproduction / verification

- Reproduced the `500` live against a running Kibana + Elasticsearch by sending repeated identical Agent Builder `write_todos` tool-call requests: roughly 30-70% failed with the exact reported error, purely as a function of whether the model's response included leading text.
- Isolated the cause with a minimal direct call to Elasticsearch's `_inference/chat_completion/{id}/_stream` (see above).
- Verified the fix resolves it: 15/15 consecutive live Agent Builder tool-call rounds succeeded with the fix applied (previously failing at a high rate).

## Test plan

- [x] Added/updated unit tests in `to_openai.test.ts` covering both the direct conversion and the message-merging path.
- [x] `node scripts/jest x-pack/platform/plugins/shared/inference/server` — 429/429 passing.
- [x] Manually verified against a live Kibana + Elasticsearch instance (see above).

### Identify risks

Low risk: this only changes what string value is sent for `content` when it would otherwise be `null`/empty, which is valid input for OpenAI-compatible APIs (including Elasticsearch's own inference endpoints) and for the actual OpenAI API.

Made with [Cursor](https://cursor.com)