### PR TITLE
[8.19] [SecuritySolution][AI Assistant] Prevent index KB entries from bypassing global privilege via users[] (#283195)

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
-import { createKnowledgeBaseEntry } from './create_knowledge_base_entry';
+import {
+  createKnowledgeBaseEntry,
+  transformToCreateSchema,
+  transformToUpdateSchema,
+} from './create_knowledge_base_entry';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { coreMock } from '@kbn/core/server/mocks';
 import { getKnowledgeBaseEntry } from './get_knowledge_base_entry';
@@ -168,5 +172,123 @@ describe('createKnowledgeBaseEntry', () => {
         telemetry,
       })
     ).rejects.toThrowError('Test error');
+  });
+
+  test('it ignores client-provided users when creating a private index entry', async () => {
+    const knowledgeBaseEntry = getCreateKnowledgeBaseEntrySchemaMock({
+      type: 'index',
+      global: false,
+      users: [],
+    });
+    (getKnowledgeBaseEntry as unknown as jest.Mock).mockResolvedValueOnce({
+      ...getKnowledgeBaseEntryMock(),
+      id: 'elastic-id-123',
+    });
+
+    const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
+    esClient.create.mockResponse(
+      // @ts-expect-error not full response interface
+      { _id: 'elastic-id-123' }
+    );
+    await createKnowledgeBaseEntry({
+      esClient,
+      knowledgeBaseIndex: 'index-1',
+      spaceId: 'test',
+      user: authenticatedUser,
+      knowledgeBaseEntry,
+      logger,
+      telemetry,
+    });
+
+    expect(esClient.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.objectContaining({
+          users: [{ id: 'my_profile_uid', name: 'elastic' }],
+        }),
+      })
+    );
+  });
+});
+
+describe('transformToCreateSchema', () => {
+  it('returns the authenticated user as owner when client sends empty users on a private index entry', () => {
+    const result = transformToCreateSchema({
+      createdAt: '2024-01-28T04:20:02.394Z',
+      spaceId: 'test',
+      user: authenticatedUser,
+      entry: getCreateKnowledgeBaseEntrySchemaMock({
+        type: 'index',
+        global: false,
+        users: [],
+      }),
+    });
+
+    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'elastic' }]);
+  });
+
+  it('returns the authenticated user as owner when client spoofs another user id on a private index entry', () => {
+    const result = transformToCreateSchema({
+      createdAt: '2024-01-28T04:20:02.394Z',
+      spaceId: 'test',
+      user: authenticatedUser,
+      entry: getCreateKnowledgeBaseEntrySchemaMock({
+        type: 'index',
+        global: false,
+        users: [{ id: 'other-user', name: 'other' }],
+      }),
+    });
+
+    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'elastic' }]);
+  });
+
+  it('returns empty users for a global index entry', () => {
+    const result = transformToCreateSchema({
+      createdAt: '2024-01-28T04:20:02.394Z',
+      spaceId: 'test',
+      user: authenticatedUser,
+      entry: getCreateKnowledgeBaseEntrySchemaMock({
+        type: 'index',
+        global: true,
+        users: [{ id: 'other-user', name: 'other' }],
+      }),
+    });
+
+    expect(result.users).toEqual([]);
+  });
+});
+
+describe('transformToUpdateSchema', () => {
+  it('returns the authenticated user as owner when client sends empty users on a private index entry', () => {
+    const result = transformToUpdateSchema({
+      updatedAt: '2024-01-28T04:20:02.394Z',
+      user: authenticatedUser,
+      entry: {
+        ...getCreateKnowledgeBaseEntrySchemaMock({
+          type: 'index',
+          global: false,
+          users: [],
+        }),
+        id: 'entry-1',
+      },
+    });
+
+    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'elastic' }]);
+  });
+
+  it('returns the authenticated user as owner when client spoofs another user id on a private index entry', () => {
+    const result = transformToUpdateSchema({
+      updatedAt: '2024-01-28T04:20:02.394Z',
+      user: authenticatedUser,
+      entry: {
+        ...getCreateKnowledgeBaseEntrySchemaMock({
+          type: 'index',
+          global: false,
+          users: [{ id: 'other-user', name: 'other' }],
+        }),
+        id: 'entry-1',
+      },
+    });
+
+    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'elastic' }]);
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.test.ts
@@ -203,7 +203,7 @@ describe('createKnowledgeBaseEntry', () => {
     expect(esClient.create).toHaveBeenCalledWith(
       expect.objectContaining({
         document: expect.objectContaining({
-          users: [{ id: 'my_profile_uid', name: 'elastic' }],
+          users: [{ id: 'my_profile_uid', name: 'my_username' }],
         }),
       })
     );
@@ -223,7 +223,7 @@ describe('transformToCreateSchema', () => {
       }),
     });
 
-    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'elastic' }]);
+    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'my_username' }]);
   });
 
   it('returns the authenticated user as owner when client spoofs another user id on a private index entry', () => {
@@ -238,7 +238,7 @@ describe('transformToCreateSchema', () => {
       }),
     });
 
-    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'elastic' }]);
+    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'my_username' }]);
   });
 
   it('returns empty users for a global index entry', () => {
@@ -272,7 +272,7 @@ describe('transformToUpdateSchema', () => {
       },
     });
 
-    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'elastic' }]);
+    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'my_username' }]);
   });
 
   it('returns the authenticated user as owner when client spoofs another user id on a private index entry', () => {
@@ -289,6 +289,6 @@ describe('transformToUpdateSchema', () => {
       },
     });
 
-    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'elastic' }]);
+    expect(result.users).toEqual([{ id: 'my_profile_uid', name: 'my_username' }]);
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.test.ts
@@ -202,7 +202,7 @@ describe('createKnowledgeBaseEntry', () => {
 
     expect(esClient.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        document: expect.objectContaining({
+        body: expect.objectContaining({
           users: [{ id: 'my_profile_uid', name: 'my_username' }],
         }),
       })

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.ts
@@ -139,7 +139,8 @@ export const transformToUpdateSchema = ({
     return {
       ...base,
       ...restEntry,
-      users: restEntry.users ?? base.users,
+      // Always server-assign ownership; never trust client-provided users
+      users: base.users,
       query_description: queryDescription,
       input_schema:
         entry.inputSchema?.map((schema) => ({
@@ -208,7 +209,8 @@ export const transformToCreateSchema = ({
     return {
       ...base,
       ...restEntry,
-      users: restEntry.users ?? base.users,
+      // Always server-assign ownership; never trust client-provided users
+      users: base.users,
       query_description: queryDescription,
       input_schema:
         entry.inputSchema?.map((schema) => ({

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/knowledge_base/entries/utils.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/knowledge_base/entries/utils.test.ts
@@ -5,10 +5,53 @@
  * 2.0.
  */
 
-import { AuthenticatedUser } from '@kbn/core-security-common';
-import { getKBUserFilter } from './utils';
+import type { AuthenticatedUser } from '@kbn/core-security-common';
+import { getCreateKnowledgeBaseEntrySchemaMock } from '../../../__mocks__/knowledge_base_entry_schema.mock';
+import { getKBUserFilter, isGlobalEntry } from './utils';
 
 describe('Utils', () => {
+  describe('isGlobalEntry', () => {
+    it('returns true when global is true', () => {
+      expect(
+        isGlobalEntry(
+          getCreateKnowledgeBaseEntrySchemaMock({
+            global: true,
+            users: [{ id: 'u1', name: 'user' }],
+          })
+        )
+      ).toEqual(true);
+    });
+
+    it('returns false when global is false and users is undefined', () => {
+      expect(isGlobalEntry(getCreateKnowledgeBaseEntrySchemaMock({ global: false }))).toEqual(
+        false
+      );
+    });
+
+    it('returns true when global is false but users is an empty array', () => {
+      expect(
+        isGlobalEntry(getCreateKnowledgeBaseEntrySchemaMock({ global: false, users: [] }))
+      ).toEqual(true);
+    });
+
+    it('returns true when global is missing and users is an empty array', () => {
+      const entry = getCreateKnowledgeBaseEntrySchemaMock({ users: [] });
+      delete entry.global;
+      expect(isGlobalEntry(entry)).toEqual(true);
+    });
+
+    it('returns false when global is false and users has an owner', () => {
+      expect(
+        isGlobalEntry(
+          getCreateKnowledgeBaseEntrySchemaMock({
+            global: false,
+            users: [{ id: 'u1', name: 'user' }],
+          })
+        )
+      ).toEqual(false);
+    });
+  });
+
   describe('getKBUserFilter', () => {
     it('should return global filter when user is null', () => {
       const filter = getKBUserFilter(null);

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/knowledge_base/entries/utils.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/knowledge_base/entries/utils.ts
@@ -34,7 +34,7 @@ export const getKBUserFilter = (user: AuthenticatedUser | null) => {
 };
 
 export const isGlobalEntry = (entry: KnowledgeBaseEntryResponse | KnowledgeBaseEntryCreateProps) =>
-  entry.global ?? (isArray(entry.users) && !entry.users.length);
+  Boolean(entry.global) || (isArray(entry.users) && entry.users.length === 0);
 
 export const validateDocumentsModification = async (
   kbDataClient: AIAssistantKnowledgeBaseDataClient | null,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[SecuritySolution][AI Assistant] Prevent index KB entries from bypassing global privilege via users[] (#283195)](https://github.com/elastic/kibana/pull/283195)

<!--- Backport version: 9.6.6 --->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Made with [Cursor](https://cursor.com)