### PR TITLE
[ci] Disable sparse checkout plugin on pipeline.emergency.kibana-tests.yaml

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
@@ -20,11 +20,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/quality-gates/emergency/pipeline.emergency.kibana-tests.yaml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/quality-gates/emergency/pipeline.emergency.kibana-tests.yaml
-            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       teams:


### PR DESCRIPTION
https://buildkite.com/elastic/kibana-tests-emergency/builds/157

This pipeline attempts to checkout a short sha, which is only valid if it's available locally.

We can fix this, but for now I need to get the pipeline working on a branch that won't be receiving new commits.