### PR TITLE
[Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_create.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_create.test.tsx
@@ -335,14 +335,6 @@ describe('<TemplateCreate />', () => {
 
         await waitFor(() => expect(getFieldsListItems()).toHaveLength(1));
       }, 16000);
-
-      describe('plugin parameters', () => {
-        test('should not render the _size parameter if the mapper size plugin is not installed', async () => {
-          // The mappings editor exposes stable tab test subjects.
-          fireEvent.click(screen.getByTestId('advancedOptionsTab'));
-          expect(screen.queryByTestId('sizeEnabledToggle')).not.toBeInTheDocument();
-        });
-      });
     });
 
     describe('aliases (step 5)', () => {
@@ -369,27 +361,6 @@ describe('<TemplateCreate />', () => {
         expect(await screen.findByText('Invalid JSON format.')).toBeInTheDocument();
       }, 10000);
     });
-  });
-
-  // Isolated test for mapper-size plugin (needs different mock setup)
-  describe('mapper-size plugin', () => {
-    test('should render the _size parameter if the mapper size plugin is installed', async () => {
-      httpRequestsMockHelpers.setLoadNodesPluginsResponse(['mapper-size']);
-      httpRequestsMockHelpers.setLoadComponentTemplatesResponse(componentTemplates);
-
-      await renderTemplateCreate(httpSetup);
-      await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.title);
-
-      // Navigate to mappings step
-      await completeStepOne({ name: TEMPLATE_NAME, indexPatterns: ['index1'] });
-      await completeStepTwo();
-      await completeStepThree('{}');
-
-      // Navigate to advanced tab
-      fireEvent.click(screen.getByTestId('advancedOptionsTab'));
-
-      expect(screen.getByTestId('sizeEnabledToggle')).toBeInTheDocument();
-    }, 10000);
   });
 
   describe('review (step 6)', () => {

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/configuration_form.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/configuration_form.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { docLinksServiceMock } from '@kbn/core/public/mocks';
+
+import { documentationService } from '../../../../services/documentation';
+import { AppContextProvider, type AppDependencies } from '../../../../app_context';
+import { MappingsEditorProvider } from '../../mappings_editor_context';
+import { ConfigurationForm } from './configuration_form';
+
+jest.mock('@kbn/es-ui-shared-plugin/static/forms/components', () => {
+  const original = jest.requireActual('@kbn/es-ui-shared-plugin/static/forms/components');
+  return {
+    ...original,
+    // JsonEditorField pulls in the shared-ux code editor (Monaco) which requires Canvas/Suspense.
+    // For this suite we only care about configuration options, not editor rendering.
+    JsonEditorField: ({ codeEditorProps }: { codeEditorProps?: Record<string, unknown> }) => (
+      <div
+        data-test-subj={(codeEditorProps?.['data-test-subj'] as string) ?? 'mockJsonEditorField'}
+      />
+    ),
+  };
+});
+
+const appDependencies = {
+  config: {
+    enableMappingsSourceFieldSection: true,
+  },
+  hasAtLeastEnterpriseLicense: false,
+} as unknown as AppDependencies;
+
+const setup = (props: Partial<React.ComponentProps<typeof ConfigurationForm>>) =>
+  render(
+    <I18nProvider>
+      <AppContextProvider value={appDependencies}>
+        <MappingsEditorProvider>
+          <ConfigurationForm esNodesPlugins={[]} {...props} />
+        </MappingsEditorProvider>
+      </AppContextProvider>
+    </I18nProvider>
+  );
+
+describe('ConfigurationForm: _size field (mapper-size plugin)', () => {
+  beforeAll(() => {
+    documentationService.setup(docLinksServiceMock.createStartContract());
+  });
+
+  it('renders the _size parameter when the mapper size plugin is installed', () => {
+    setup({ esNodesPlugins: ['mapper-size'] });
+
+    expect(screen.getByTestId('sizeEnabledToggle')).toBeInTheDocument();
+  });
+
+  it("doesn't render the _size parameter when the mapper size plugin is not installed", () => {
+    setup({ esNodesPlugins: ['unrelated-plugin'] });
+
+    expect(screen.queryByTestId('sizeEnabledToggle')).not.toBeInTheDocument();
+  });
+
+  it('renders the _size parameter when the mappings define _size, even without the plugin', () => {
+    setup({ esNodesPlugins: [], value: { _size: { enabled: false } } });
+
+    expect(screen.getByTestId('sizeEnabledToggle')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/mappings_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/mappings_editor.test.tsx
@@ -18,8 +18,7 @@ import { MAJOR_VERSION } from '../../../../common';
 import { useAppContext } from '../../app_context';
 import { MappingsEditor } from './mappings_editor';
 import { MappingsEditorProvider } from './mappings_editor_context';
-import { createKibanaReactContext } from './shared_imports';
-import { UseField } from './shared_imports';
+import { createKibanaReactContext, documentationService, UseField } from './shared_imports';
 import { getFieldConfig } from './lib';
 import { loadSyntheticSourceStatus } from '../../services/api';
 
@@ -171,24 +170,21 @@ const defaultAppContext = {
   hasAtLeastEnterpriseLicense: true,
 };
 
-type MappingsEditorTestProps = Omit<
-  ComponentProps<typeof MappingsEditor>,
-  'docLinks' | 'esNodesPlugins'
->;
+type MappingsEditorTestProps = Omit<ComponentProps<typeof MappingsEditor>, 'docLinks'>;
 
-const renderMappingsEditor = (
+const getMappingsEditorElement = (
   props: Partial<MappingsEditorTestProps>,
   ctx: unknown = defaultAppContext
 ) => {
   mockUseAppContext.mockReturnValue(ctx as unknown as ReturnType<typeof useAppContext>);
-  const { onChange, ...restProps } = props;
+  const { onChange, esNodesPlugins, ...restProps } = props;
   const mergedProps = {
     ...restProps,
     docLinks,
-    esNodesPlugins: [],
+    esNodesPlugins: esNodesPlugins ?? [],
     onChange: onChange ?? (() => undefined),
   } satisfies ComponentProps<typeof MappingsEditor>;
-  return render(
+  return (
     <I18nProvider>
       <KibanaReactContextProvider>
         <MappingsEditorProvider>
@@ -201,7 +197,24 @@ const renderMappingsEditor = (
   );
 };
 
+const renderMappingsEditor = (
+  props: Partial<MappingsEditorTestProps>,
+  ctx: unknown = defaultAppContext
+) => {
+  const rendered = render(getMappingsEditorElement(props, ctx));
+
+  return {
+    ...rendered,
+    rerenderMappingsEditor: (nextProps: Partial<MappingsEditorTestProps>) =>
+      rendered.rerender(getMappingsEditorElement(nextProps, ctx)),
+  };
+};
+
 describe('Mappings editor', () => {
+  beforeAll(() => {
+    documentationService.setup(docLinks);
+  });
+
   describe('core', () => {
     interface TestMappings {
       dynamic?: boolean;
@@ -466,6 +479,48 @@ describe('Mappings editor', () => {
           'Dynamic templates',
           'Advanced options',
         ]);
+      });
+
+      test('passes installed node plugins to the advanced configuration form', async () => {
+        setup({
+          value: defaultMappings,
+          onChange: onChangeHandler,
+          esNodesPlugins: ['mapper-size'],
+        });
+        await screen.findByTestId('mappingsEditor');
+
+        await selectTab('advanced');
+
+        expect(screen.getByTestId('sizeEnabledToggle')).toBeInTheDocument();
+      });
+
+      test("doesn't substitute an installed node plugin when the plugin list is empty", async () => {
+        setup({
+          value: defaultMappings,
+          onChange: onChangeHandler,
+          esNodesPlugins: [],
+        });
+        await screen.findByTestId('mappingsEditor');
+
+        await selectTab('advanced');
+
+        expect(screen.queryByTestId('sizeEnabledToggle')).not.toBeInTheDocument();
+      });
+
+      test('updates the advanced configuration form when node plugins finish loading', async () => {
+        const props = {
+          value: defaultMappings,
+          onChange: onChangeHandler,
+          esNodesPlugins: [],
+        };
+        const { rerenderMappingsEditor } = setup(props);
+        await screen.findByTestId('mappingsEditor');
+        await selectTab('advanced');
+        expect(screen.queryByTestId('sizeEnabledToggle')).not.toBeInTheDocument();
+
+        rerenderMappingsEditor({ ...props, esNodesPlugins: ['mapper-size'] });
+
+        expect(screen.getByTestId('sizeEnabledToggle')).toBeInTheDocument();
       });
 
       const openCreateFieldForm = async () => {

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/shared/components/wizard_steps/step_mappings_container.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/shared/components/wizard_steps/step_mappings_container.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { docLinksServiceMock, httpServiceMock } from '@kbn/core/public/mocks';
+
+import { API_BASE_PATH } from '../../../../../../common/constants';
+import { AppContextProvider, type AppDependencies } from '../../../../app_context';
+import { httpService } from '../../../../services/http';
+import { MappingsEditor } from '../../../mappings_editor';
+import { documentationService } from '../../../mappings_editor/shared_imports';
+import { StepMappingsContainer } from './step_mappings_container';
+
+jest.mock('../../../../../shared_imports', () => {
+  const actual = jest.requireActual('../../../../../shared_imports');
+  return {
+    ...actual,
+    Forms: {
+      useContent: jest.fn(() => ({
+        defaultValue: {},
+        updateContent: jest.fn(),
+        getSingleContentData: jest.fn(),
+      })),
+      useMultiContentContext: jest.fn(() => ({ getData: jest.fn() })),
+    },
+  };
+});
+
+jest.mock('../../../mappings_editor', () => ({
+  LoadMappingsFromJsonButton: jest.fn(() => null),
+  MappingsEditor: jest.fn(() => null),
+}));
+
+const mockMappingsEditor = jest.mocked(MappingsEditor);
+const docLinks = docLinksServiceMock.createStartContract();
+const appDependencies = { docLinks } as AppDependencies;
+let http = httpServiceMock.createSetupContract();
+
+const renderContainer = () =>
+  render(
+    <I18nProvider>
+      <AppContextProvider value={appDependencies}>
+        <StepMappingsContainer esDocsBase="" />
+      </AppContextProvider>
+    </I18nProvider>
+  );
+
+describe('StepMappingsContainer', () => {
+  beforeAll(() => {
+    documentationService.setup(docLinks);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    http = httpServiceMock.createSetupContract();
+    httpService.setup(http);
+  });
+
+  it('loads node plugins and passes them through StepMappings to MappingsEditor', async () => {
+    http.get.mockResolvedValue(['mapper-size']);
+
+    renderContainer();
+
+    await waitFor(() => {
+      expect(mockMappingsEditor).toHaveBeenLastCalledWith(
+        expect.objectContaining({ esNodesPlugins: ['mapper-size'] }),
+        expect.anything()
+      );
+    });
+    expect(http.get).toHaveBeenCalledWith(`${API_BASE_PATH}/nodes/plugins`, expect.anything());
+  });
+
+  it('passes a resolved empty plugin list through StepMappings to MappingsEditor', async () => {
+    http.get.mockResolvedValue([]);
+
+    renderContainer();
+    const callsWhileLoading = mockMappingsEditor.mock.calls.length;
+
+    await waitFor(() => {
+      expect(mockMappingsEditor.mock.calls.length).toBeGreaterThan(callsWhileLoading);
+    });
+    expect(mockMappingsEditor).toHaveBeenLastCalledWith(
+      expect.objectContaining({ esNodesPlugins: [] }),
+      expect.anything()
+    );
+  });
+
+  it('falls back to an empty plugin list while plugins are loading', () => {
+    http.get.mockReturnValue(new Promise(() => {}));
+
+    renderContainer();
+
+    expect(mockMappingsEditor.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ esNodesPlugins: [] })
+    );
+  });
+});


### PR DESCRIPTION
Closes #254224

## Summary

- Removes the two flaky wizard-level mapper-size tests from `template_create.test.tsx`.
- Moves coverage to focused tests for `ConfigurationForm` gating, the real `GET /api/index_management/nodes/plugins` request and propagation through `StepMappings`, and `MappingsEditor` updates after plugin loading.
- Leaves production behavior unchanged.

## Rationale

- The wizard tests synchronously queried UI gated by an async plugin request inside a full template-wizard render, causing intermittent CI timeouts.
- Replacing that heavy setup with focused unit tests retains coverage of the gating and plugin-propagation seams while making the tests faster and deterministic.

## Test Plan

The original timeout scenario is no longer applicable because the heavy wizard integration setup was replaced with focused unit tests using a smaller, faster setup.

- `node scripts/jest .../configuration_form.test.tsx .../mappings_editor.test.tsx .../step_mappings_container.test.tsx` — 34/34 pass
- `node scripts/jest .../index_template_wizard/template_create.test.tsx` — 26/26 pass
- `node scripts/eslint` on the 4 changed test files — clean
- `node scripts/type_check --project x-pack/platform/plugins/shared/index_management/tsconfig.json` — 2 pre-existing errors in `alerting_v2/server/lib/rules_client/rules_client.ts`, none in changed files
- Mutation verification — 15/15 deliberate production breaks failed the intended tests

Assisted with Codex using GPT-5


<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->