### PR TITLE
[CCR] Run with-data Scout spec on local stateful classic only

### DIFF
--- a/x-pack/platform/plugins/private/cross_cluster_replication/test/scout/ui/tests/cross_cluster_replication_with_data.spec.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/test/scout/ui/tests/cross_cluster_replication_with_data.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-// Runs stateful classic only: CCR is not available on Cloud deployments.
+// Runs local stateful classic only: the CCR resource setup requires a local
+// Elasticsearch transport endpoint for the self-referential remote cluster.
 //
 // Restores the "with data" accessibility scenarios from the deleted CCR a11y FTR
 // (follower index table + detail flyout, auto-follow pattern table + detail
@@ -14,7 +15,6 @@
 // address) is used, mirroring the original FTR's `localhost:9300` seed.
 
 import type { EsClient } from '@kbn/scout';
-import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { test, CUSTOM_ROLES } from '../fixtures';
 
@@ -85,7 +85,7 @@ const cleanupCcrResources = async (esClient: EsClient): Promise<void> => {
   }
 };
 
-test.describe('Cross-Cluster Replication - with data', { tag: tags.stateful.classic }, () => {
+test.describe('Cross-Cluster Replication - with data', { tag: '@local-stateful-classic' }, () => {
   test.beforeAll(async ({ esClient }) => {
     await cleanupCcrResources(esClient);
 


### PR DESCRIPTION
## Summary

Closes #272968

The `cross_cluster_replication_with_data.spec.ts` Scout spec failed deterministically on every `cloud-stateful-classic` run (82 failures): its `beforeAll` seeds a self-referential remote cluster and waits for it to connect, which cannot work on Elastic Cloud Hosted deployments.

`tags.stateful.classic` expands to both `@local-stateful-classic` and `@cloud-stateful-classic` (`getPlaywrightTagsFor('stateful', 'classic')` with no location filter), so the spec was selected for ECH runs despite the file header documenting local-only intent. This PR gates the describe block to `@local-stateful-classic` and updates the header comment to match.

The sibling specs (`cross_cluster_replication_home.spec.ts`, `feature_controls.spec.ts`) keep the broad tag intentionally: they never provision CCR resources, so they pass on Cloud and preserve navigation/feature-control coverage there.

The stale `.meta/ui/standard.json` entry is regenerated by the daily `kibana / scout / update-metadata` pipeline and is not updated here.

## Test plan

- [ ] `node scripts/scout run-tests --arch stateful --domain classic --config x-pack/platform/plugins/private/cross_cluster_replication/test/scout/ui/playwright.config.ts` passes locally (spec still selected via `@local-stateful-classic`)
- [ ] CI `cloud-stateful-classic` Scout run no longer includes this spec

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3","9.4","9.5"]} ONMERGE-->