### PR TITLE
[Stack Management] Unskip Scout section-visibility tests and fix ECH/local expectations

### DIFF
--- a/src/platform/plugins/shared/management/test/scout/.meta/ui/parallel.json
+++ b/src/platform/plugins/shared/management/test/scout/.meta/ui/parallel.json
@@ -8,57 +8,56 @@
     {
       "id": "a85e30db18dd980-231d31d916345e0",
       "title": "Stack Management — data section transform_user sees only transform in the data section",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts",
-        "line": 18,
-        "column": 7
+        "line": 14,
+        "column": 24
       }
     },
     {
       "id": "a85e30db18dd980-062ac9da8baab63",
       "title": "Stack Management — data section manage_ilm sees index_lifecycle_management in the data section",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts",
-        "line": 43,
-        "column": 7
+        "line": 38,
+        "column": 11
       }
     },
     {
       "id": "a85e30db18dd980-1b731d7876730e0",
       "title": "Stack Management — data section ccr_user sees cross_cluster_replication and the full cluster:manage data section",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic"
+        "@local-stateful-classic"
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts",
-        "line": 68,
-        "column": 7
+        "line": 65,
+        "column": 9
       }
     },
     {
       "id": "a85e30db18dd980-94855b8ec67dddd",
       "title": "Stack Management — data section index_management_user sees index_management and transform in the data section",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts",
-        "line": 110,
-        "column": 7
+        "line": 120,
+        "column": 16
       }
     },
     {
@@ -71,8 +70,8 @@
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/nav_access.spec.ts",
-        "line": 18,
-        "column": 7
+        "line": 16,
+        "column": 14
       }
     },
     {
@@ -85,50 +84,49 @@
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/nav_access.spec.ts",
-        "line": 63,
-        "column": 7
+        "line": 81,
+        "column": 3
       }
     },
     {
       "id": "bad08ef0cbf2e37-6fecfa373f1b9b3",
       "title": "Stack Management — ingest, security, and stack sections logstash_read_user sees only the ingest section with pipelines",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts",
-        "line": 21,
-        "column": 9
+        "line": 14,
+        "column": 24
       }
     },
     {
       "id": "bad08ef0cbf2e37-dd7cc6062509486",
       "title": "Stack Management — ingest, security, and stack sections manage_security sees only the security section with all four links",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts",
-        "line": 47,
+        "line": 39,
         "column": 9
       }
     },
     {
       "id": "bad08ef0cbf2e37-d579dbac266af75",
       "title": "Stack Management — ingest, security, and stack sections cluster:manage surfaces ingest, data (incl. remote_clusters) and stack (license_management) sections",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic"
+        "@local-stateful-classic"
       ],
       "location": {
         "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts",
-        "line": 72,
-        "column": 9
+        "line": 71,
+        "column": 5
       }
     }
   ]

--- a/src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts
+++ b/src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts
@@ -11,119 +11,121 @@
 
 import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
-import { test, CUSTOM_ROLES } from '../fixtures';
+import { CUSTOM_ROLES, test } from '../fixtures';
 
-// Failing: See https://github.com/elastic/kibana/issues/272032
-test.describe.skip('Stack Management — data section', { tag: tags.stateful.classic }, () => {
-  test('transform_user sees only transform in the data section', async ({
-    browserAuth,
-    pageObjects,
-  }) => {
-    await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_transform_user);
+test.describe('Stack Management — data section', () => {
+  test(
+    'transform_user sees only transform in the data section',
+    { tag: tags.stateful.classic },
+    async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_transform_user);
 
-    await test.step('navigate to management and assert nav link + sidebar', async () => {
-      await pageObjects.management.goto();
-      const navLinks = await pageObjects.collapsibleNav.getNavLinks();
-      expect(navLinks).toContain('Stack Management');
+      await test.step('navigate to management and assert nav link + sidebar', async () => {
+        await pageObjects.management.goto();
+        const navLinks = await pageObjects.collapsibleNav.getNavLinks();
+        expect(navLinks).toContain('Stack Management');
 
-      const sections = await pageObjects.management.readSidebarSections();
-      // kibana section with 'settings' appears because advancedSettings:read is granted
-      expect(sections).toHaveLength(2);
-      expect(sections[0]).toStrictEqual({
-        sectionId: 'data',
-        sectionLinks: ['transform'],
+        const sections = await pageObjects.management.readSidebarSections();
+        // kibana section with 'settings' appears because advancedSettings:read is granted
+        expect(sections).toHaveLength(2);
+        expect(sections[0]).toStrictEqual({
+          sectionId: 'data',
+          sectionLinks: ['transform'],
+        });
+        expect(sections[1]).toStrictEqual({
+          sectionId: 'kibana',
+          sectionLinks: ['settings'],
+        });
       });
-      expect(sections[1]).toStrictEqual({
-        sectionId: 'kibana',
-        sectionLinks: ['settings'],
+    }
+  );
+
+  test(
+    'manage_ilm sees index_lifecycle_management in the data section',
+    { tag: tags.stateful.classic },
+    async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_manage_ilm);
+
+      await test.step('navigate to management and assert nav link + sidebar', async () => {
+        await pageObjects.management.goto();
+        const navLinks = await pageObjects.collapsibleNav.getNavLinks();
+        expect(navLinks).toContain('Stack Management');
+
+        const sections = await pageObjects.management.readSidebarSections();
+        // kibana section with 'settings' appears because advancedSettings:read is granted
+        expect(sections).toHaveLength(2);
+        expect(sections[0]).toStrictEqual({
+          sectionId: 'data',
+          sectionLinks: ['index_lifecycle_management'],
+        });
+        expect(sections[1]).toStrictEqual({
+          sectionId: 'kibana',
+          sectionLinks: ['settings'],
+        });
       });
-    });
-  });
+    }
+  );
 
-  test('manage_ilm sees index_lifecycle_management in the data section', async ({
-    browserAuth,
-    pageObjects,
-  }) => {
-    await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_manage_ilm);
+  test(
+    'ccr_user sees cross_cluster_replication and the full cluster:manage data section',
+    { tag: '@local-stateful-classic' },
+    async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_ccr_user);
 
-    await test.step('navigate to management and assert nav link + sidebar', async () => {
-      await pageObjects.management.goto();
-      const navLinks = await pageObjects.collapsibleNav.getNavLinks();
-      expect(navLinks).toContain('Stack Management');
+      await test.step('navigate to management and assert nav link + sidebar', async () => {
+        await pageObjects.management.goto();
+        const navLinks = await pageObjects.collapsibleNav.getNavLinks();
+        expect(navLinks).toContain('Stack Management');
 
-      const sections = await pageObjects.management.readSidebarSections();
-      // kibana section with 'settings' appears because advancedSettings:read is granted
-      expect(sections).toHaveLength(2);
-      expect(sections[0]).toStrictEqual({
-        sectionId: 'data',
-        sectionLinks: ['index_lifecycle_management'],
+        const sections = await pageObjects.management.readSidebarSections();
+        // cluster:manage also surfaces ingest (ingest_pipelines + logstash pipelines) and stack (license_management)
+        expect(sections).toHaveLength(4);
+        expect(sections[0]).toStrictEqual({
+          sectionId: 'ingest',
+          sectionLinks: ['ingest_pipelines', 'pipelines'],
+        });
+        expect(sections[1]).toStrictEqual({
+          sectionId: 'data',
+          sectionLinks: [
+            'index_management',
+            'index_lifecycle_management',
+            'snapshot_restore',
+            'rollup_jobs',
+            'transform',
+            'cross_cluster_replication',
+            'remote_clusters',
+          ],
+        });
+        expect(sections[2]).toStrictEqual({
+          sectionId: 'kibana',
+          sectionLinks: ['settings'],
+        });
+        expect(sections[3]).toStrictEqual({
+          sectionId: 'stack',
+          sectionLinks: ['license_management'],
+        });
       });
-      expect(sections[1]).toStrictEqual({
-        sectionId: 'kibana',
-        sectionLinks: ['settings'],
-      });
-    });
-  });
+    }
+  );
 
-  test('ccr_user sees cross_cluster_replication and the full cluster:manage data section', async ({
-    browserAuth,
-    pageObjects,
-  }) => {
-    await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_ccr_user);
+  test(
+    'index_management_user sees index_management and transform in the data section',
+    { tag: tags.stateful.classic },
+    async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_index_management);
 
-    await test.step('navigate to management and assert nav link + sidebar', async () => {
-      await pageObjects.management.goto();
-      const navLinks = await pageObjects.collapsibleNav.getNavLinks();
-      expect(navLinks).toContain('Stack Management');
+      await test.step('navigate to management and assert nav link + sidebar', async () => {
+        await pageObjects.management.goto();
+        const navLinks = await pageObjects.collapsibleNav.getNavLinks();
+        expect(navLinks).toContain('Stack Management');
 
-      const sections = await pageObjects.management.readSidebarSections();
-      // cluster:manage also surfaces ingest (ingest_pipelines + logstash pipelines) and stack (license_management)
-      expect(sections).toHaveLength(4);
-      expect(sections[0]).toStrictEqual({
-        sectionId: 'ingest',
-        sectionLinks: ['ingest_pipelines', 'pipelines'],
+        const sections = await pageObjects.management.readSidebarSections();
+        expect(sections).toHaveLength(2);
+        expect(sections[0]).toStrictEqual({
+          sectionId: 'data',
+          sectionLinks: ['index_management', 'transform'],
+        });
       });
-      expect(sections[1]).toStrictEqual({
-        sectionId: 'data',
-        sectionLinks: [
-          'index_management',
-          'index_lifecycle_management',
-          'data_federation',
-          'snapshot_restore',
-          'rollup_jobs',
-          'transform',
-          'cross_cluster_replication',
-          'remote_clusters',
-        ],
-      });
-      expect(sections[2]).toStrictEqual({
-        sectionId: 'kibana',
-        sectionLinks: ['settings'],
-      });
-      expect(sections[3]).toStrictEqual({
-        sectionId: 'stack',
-        sectionLinks: ['license_management'],
-      });
-    });
-  });
-
-  test('index_management_user sees index_management and transform in the data section', async ({
-    browserAuth,
-    pageObjects,
-  }) => {
-    await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_index_management);
-
-    await test.step('navigate to management and assert nav link + sidebar', async () => {
-      await pageObjects.management.goto();
-      const navLinks = await pageObjects.collapsibleNav.getNavLinks();
-      expect(navLinks).toContain('Stack Management');
-
-      const sections = await pageObjects.management.readSidebarSections();
-      expect(sections).toHaveLength(2);
-      expect(sections[0]).toStrictEqual({
-        sectionId: 'data',
-        sectionLinks: ['index_management', 'transform'],
-      });
-    });
-  });
+    }
+  );
 });

--- a/src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts
+++ b/src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts
@@ -11,17 +11,13 @@
 
 import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
-import { test, CUSTOM_ROLES } from '../fixtures';
+import { CUSTOM_ROLES, test } from '../fixtures';
 
-// Failing: See https://github.com/elastic/kibana/issues/272033
-test.describe.skip(
-  'Stack Management — ingest, security, and stack sections',
-  { tag: tags.stateful.classic },
-  () => {
-    test('logstash_read_user sees only the ingest section with pipelines', async ({
-      browserAuth,
-      pageObjects,
-    }) => {
+test.describe('Stack Management — ingest, security, and stack sections', () => {
+  test(
+    'logstash_read_user sees only the ingest section with pipelines',
+    { tag: tags.stateful.classic },
+    async ({ browserAuth, pageObjects }) => {
       await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_logstash);
 
       await test.step('navigate to management and assert nav link + sidebar', async () => {
@@ -41,13 +37,14 @@ test.describe.skip(
           sectionLinks: ['settings'],
         });
       });
-    });
+    }
+  );
 
-    // Pre-migration tag 'skipFIPS'
-    test('manage_security sees only the security section with all four links', async ({
-      browserAuth,
-      pageObjects,
-    }) => {
+  // Pre-migration tag 'skipFIPS'
+  test(
+    'manage_security sees only the security section with all four links',
+    { tag: tags.stateful.classic },
+    async ({ browserAuth, pageObjects }) => {
       await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_manage_security);
 
       await test.step('navigate to management and assert nav link + sidebar', async () => {
@@ -67,12 +64,13 @@ test.describe.skip(
           sectionLinks: ['settings'],
         });
       });
-    });
+    }
+  );
 
-    test('cluster:manage surfaces ingest, data (incl. remote_clusters) and stack (license_management) sections', async ({
-      browserAuth,
-      pageObjects,
-    }) => {
+  test(
+    'cluster:manage surfaces ingest, data (incl. remote_clusters) and stack (license_management) sections',
+    { tag: '@local-stateful-classic' },
+    async ({ browserAuth, pageObjects }) => {
       await browserAuth.loginWithCustomRole(CUSTOM_ROLES.dashboard_read_and_license_management);
 
       await test.step('navigate to management and assert nav link + sidebar', async () => {
@@ -93,7 +91,6 @@ test.describe.skip(
           sectionLinks: [
             'index_management',
             'index_lifecycle_management',
-            'data_federation',
             'snapshot_restore',
             'rollup_jobs',
             'transform',
@@ -109,6 +106,6 @@ test.describe.skip(
           sectionLinks: ['license_management'],
         });
       });
-    });
-  }
-);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Unskips the Scout Stack Management section-visibility tests skipped for #272033 and #272032, and fixes both root causes behind the failures:

- **ECH failure** (`cluster:manage` tests expected a `stack` section that never renders on `cloud-stateful-classic`): ECH hides the License Management UI (`license_management` is the only app registering into `section.stack`), so the tests are now restricted to `@local-stateful-classic`, matching the investigation on the issue.
- **Local failure** (`data_federation` missing from the data section since 2026-07-27): the data_federation plugin is disabled by default since #280968, so it is removed from the expected data-section links in both `cluster:manage` tests.
- Tags moved from describe-level to per-test so only the affected tests change targets; the other tests keep running on both local and cloud.
- `.meta/ui/parallel.json` regenerated via the Scout manifest updater.

Fixes #272033
Fixes #272032

## Test plan

- [x] `node scripts/scout run-tests --arch stateful --domain classic --config src/platform/plugins/shared/management/test/scout/ui/parallel.playwright.config.ts` — 9/9 passed locally
- [ ] `cloud-stateful-classic` leg runs in `appex-qa-stateful-kibana-scout-tests` CI (the two restricted tests no longer target it)

Made with [Cursor](https://cursor.com)