### PR TITLE
[9.4] [Security Solution] fix openai connector PKI authentication issue (#282843)

### DIFF
--- a/src/platform/packages/shared/kbn-connector-schemas/openai/schemas/v1.test.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/openai/schemas/v1.test.ts
@@ -104,6 +104,28 @@ describe('OpenAI Schema', () => {
       ).not.toThrow();
     });
 
+    it('does not default verificationMode when omitted for Other provider', () => {
+      const result = ConfigSchema.parse({
+        apiProvider: 'Other',
+        apiUrl: 'https://custom-api.example.com',
+        defaultModel: 'custom-model',
+      });
+      // A PKI-off save must not persist verificationMode, otherwise the UI
+      // re-derives the "Enable PKI Authentication" toggle as ON on reopen.
+      expect(result).not.toHaveProperty('verificationMode');
+      expect((result as { verificationMode?: string }).verificationMode).toBeUndefined();
+    });
+
+    it('preserves an explicitly provided verificationMode for Other provider', () => {
+      const result = ConfigSchema.parse({
+        apiProvider: 'Other',
+        apiUrl: 'https://custom-api.example.com',
+        defaultModel: 'custom-model',
+        verificationMode: 'full',
+      });
+      expect((result as { verificationMode?: string }).verificationMode).toBe('full');
+    });
+
     it('throws on invalid apiProvider', () => {
       expect(() =>
         ConfigSchema.parse({

--- a/src/platform/packages/shared/kbn-connector-schemas/openai/schemas/v1.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/openai/schemas/v1.ts
@@ -47,7 +47,7 @@ export const ConfigSchema = z.discriminatedUnion(
         apiProvider: z.enum([OpenAiProviderType.Other]),
         apiUrl: z.string(),
         defaultModel: z.string(),
-        verificationMode: z.enum(['full', 'certificate', 'none']).default('full').optional(),
+        verificationMode: z.enum(['full', 'certificate', 'none']).optional(),
         headers: z.record(z.string(), z.string()).optional(),
         contextWindowLength: z.coerce.number().optional(),
         temperature: z.coerce.number().optional(),

--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -1060,7 +1060,6 @@ Object {
           "type": "number",
         },
         "verificationMode": Object {
-          "default": "full",
           "enum": Array [
             "full",
             "certificate",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution] fix openai connector PKI authentication issue (#282843)](https://github.com/elastic/kibana/pull/282843)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-08-05T15:19:42Z","message":"[Security Solution] fix openai connector PKI authentication issue (#282843)\n\n## Summary\n\nFixes the \"Other\" (OpenAI-compatible) connector re-enabling **PKI\nAuthentication** on its own after every save.\n\nWhen creating/editing an OpenAI connector with `apiProvider: \"Other\"`\nand the **Enable PKI Authentication** toggle **off**, the connector\nstill persisted `config.verificationMode: \"full\"`. Because the UI\nderives the toggle state from `!!config.verificationMode`, the toggle\nflipped back **on** on every reopen, and the client cert/key fields then\nbecame required — so users without PKI could not cleanly save.\n\n### Root cause\n\nThe `verificationMode` field in the \"Other\" provider config schema was\ndeclared as:\n\n```ts\nverificationMode: z.enum(['full', 'certificate', 'none']).default('full').optional(),\n```\n\nUnder **Zod v4** (upgraded in #252702), `.default('full')` is applied\neven though the field is `.optional()`, so a PKI-off save persisted\n`verificationMode: 'full'`. The field was originally introduced with the\n\"Other\" connector PKI support in #219984.\n\n### Fix\n\nDrop the default so the field is purely optional:\n\n```ts\nverificationMode: z.enum(['full', 'certificate', 'none']).optional(),\n```\n\nNow a PKI-off save stores no `verificationMode`, and the toggle\ncorrectly stays off on reopen. This is safe because:\n- The server never takes the PKI/mTLS path unless a cert/key **secret**\nis also present, so `verificationMode` alone was never functional.\n- When PKI is actually enabled, the UI still supplies its own `'full'`\ndefault for the `config.verificationMode` select, so real PKI setups are\nunaffected.\n\n\nhttps://github.com/user-attachments/assets/ea12c01a-267b-4aa7-90c4-457a25249df3\n\n### Known limitation\n\nConnectors saved **before** this fix still have `verificationMode:\n'full'` stored and will show the toggle on until re-saved. This change\nonly prevents new PKI-off saves from persisting the value; it does not\nmigrate existing saved objects.\n\n## Testing\n\n- Added regression tests to\n`kbn-connector-schemas/openai/schemas/v1.test.ts`:\n  - `verificationMode` is absent when omitted for the \"Other\" provider.\n  - An explicitly provided `verificationMode` is preserved.\n- Manual repro (before/after) using a local \"Other (OpenAI Compatible\nService)\"\nconnector: create with PKI off → reopen → toggle stays off after the\nfix.\n\n## Backport\n\n- Affected branches carry the Zod v4 upgrade: `main`, `9.5`, `9.4`.\n- `9.3` and earlier are on Zod v3 and are **not** affected — no backport\nneeded there.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"341464fbc010f9d45b94542c19552aca77e8f2fa","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","backport:version","v9.6.0","v9.4.5","v9.5.1"],"title":"[Security Solution] fix openai connector PKI authentication issue","number":282843,"url":"https://github.com/elastic/kibana/pull/282843","mergeCommit":{"message":"[Security Solution] fix openai connector PKI authentication issue (#282843)\n\n## Summary\n\nFixes the \"Other\" (OpenAI-compatible) connector re-enabling **PKI\nAuthentication** on its own after every save.\n\nWhen creating/editing an OpenAI connector with `apiProvider: \"Other\"`\nand the **Enable PKI Authentication** toggle **off**, the connector\nstill persisted `config.verificationMode: \"full\"`. Because the UI\nderives the toggle state from `!!config.verificationMode`, the toggle\nflipped back **on** on every reopen, and the client cert/key fields then\nbecame required — so users without PKI could not cleanly save.\n\n### Root cause\n\nThe `verificationMode` field in the \"Other\" provider config schema was\ndeclared as:\n\n```ts\nverificationMode: z.enum(['full', 'certificate', 'none']).default('full').optional(),\n```\n\nUnder **Zod v4** (upgraded in #252702), `.default('full')` is applied\neven though the field is `.optional()`, so a PKI-off save persisted\n`verificationMode: 'full'`. The field was originally introduced with the\n\"Other\" connector PKI support in #219984.\n\n### Fix\n\nDrop the default so the field is purely optional:\n\n```ts\nverificationMode: z.enum(['full', 'certificate', 'none']).optional(),\n```\n\nNow a PKI-off save stores no `verificationMode`, and the toggle\ncorrectly stays off on reopen. This is safe because:\n- The server never takes the PKI/mTLS path unless a cert/key **secret**\nis also present, so `verificationMode` alone was never functional.\n- When PKI is actually enabled, the UI still supplies its own `'full'`\ndefault for the `config.verificationMode` select, so real PKI setups are\nunaffected.\n\n\nhttps://github.com/user-attachments/assets/ea12c01a-267b-4aa7-90c4-457a25249df3\n\n### Known limitation\n\nConnectors saved **before** this fix still have `verificationMode:\n'full'` stored and will show the toggle on until re-saved. This change\nonly prevents new PKI-off saves from persisting the value; it does not\nmigrate existing saved objects.\n\n## Testing\n\n- Added regression tests to\n`kbn-connector-schemas/openai/schemas/v1.test.ts`:\n  - `verificationMode` is absent when omitted for the \"Other\" provider.\n  - An explicitly provided `verificationMode` is preserved.\n- Manual repro (before/after) using a local \"Other (OpenAI Compatible\nService)\"\nconnector: create with PKI off → reopen → toggle stays off after the\nfix.\n\n## Backport\n\n- Affected branches carry the Zod v4 upgrade: `main`, `9.5`, `9.4`.\n- `9.3` and earlier are on Zod v3 and are **not** affected — no backport\nneeded there.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"341464fbc010f9d45b94542c19552aca77e8f2fa"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282843","number":282843,"mergeCommit":{"message":"[Security Solution] fix openai connector PKI authentication issue (#282843)\n\n## Summary\n\nFixes the \"Other\" (OpenAI-compatible) connector re-enabling **PKI\nAuthentication** on its own after every save.\n\nWhen creating/editing an OpenAI connector with `apiProvider: \"Other\"`\nand the **Enable PKI Authentication** toggle **off**, the connector\nstill persisted `config.verificationMode: \"full\"`. Because the UI\nderives the toggle state from `!!config.verificationMode`, the toggle\nflipped back **on** on every reopen, and the client cert/key fields then\nbecame required — so users without PKI could not cleanly save.\n\n### Root cause\n\nThe `verificationMode` field in the \"Other\" provider config schema was\ndeclared as:\n\n```ts\nverificationMode: z.enum(['full', 'certificate', 'none']).default('full').optional(),\n```\n\nUnder **Zod v4** (upgraded in #252702), `.default('full')` is applied\neven though the field is `.optional()`, so a PKI-off save persisted\n`verificationMode: 'full'`. The field was originally introduced with the\n\"Other\" connector PKI support in #219984.\n\n### Fix\n\nDrop the default so the field is purely optional:\n\n```ts\nverificationMode: z.enum(['full', 'certificate', 'none']).optional(),\n```\n\nNow a PKI-off save stores no `verificationMode`, and the toggle\ncorrectly stays off on reopen. This is safe because:\n- The server never takes the PKI/mTLS path unless a cert/key **secret**\nis also present, so `verificationMode` alone was never functional.\n- When PKI is actually enabled, the UI still supplies its own `'full'`\ndefault for the `config.verificationMode` select, so real PKI setups are\nunaffected.\n\n\nhttps://github.com/user-attachments/assets/ea12c01a-267b-4aa7-90c4-457a25249df3\n\n### Known limitation\n\nConnectors saved **before** this fix still have `verificationMode:\n'full'` stored and will show the toggle on until re-saved. This change\nonly prevents new PKI-off saves from persisting the value; it does not\nmigrate existing saved objects.\n\n## Testing\n\n- Added regression tests to\n`kbn-connector-schemas/openai/schemas/v1.test.ts`:\n  - `verificationMode` is absent when omitted for the \"Other\" provider.\n  - An explicitly provided `verificationMode` is preserved.\n- Manual repro (before/after) using a local \"Other (OpenAI Compatible\nService)\"\nconnector: create with PKI off → reopen → toggle stays off after the\nfix.\n\n## Backport\n\n- Affected branches carry the Zod v4 upgrade: `main`, `9.5`, `9.4`.\n- `9.3` and earlier are on Zod v3 and are **not** affected — no backport\nneeded there.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"341464fbc010f9d45b94542c19552aca77e8f2fa"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->