### PR TITLE
[9.5] [Security Solution][Flyout] add ability to open source event from the table tab (#282346)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/constants/field_names.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/constants/field_names.ts
@@ -20,3 +20,4 @@ const GROUP_LEADER = `${PROCESS}.group_leader`;
 export const GROUP_LEADER_WORKING_DIRECTORY = `${GROUP_LEADER}.working_directory`;
 
 export const ANCESTOR_INDEX = 'kibana.alert.ancestors.index';
+export const LEGACY_ANCESTOR_INDEX = 'signal.ancestors.index';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.test.tsx
@@ -8,16 +8,41 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
+import { ALERT_RULE_TYPE } from '@kbn/rule-data-utils';
+import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
-import { DocumentFlyout, JSON_TAB_TEST_ID, OVERVIEW_TAB_TEST_ID, TABLE_TAB_TEST_ID } from '.';
+import {
+  EVENT_SOURCE_FIELD_NAME,
+  LEGACY_EVENT_SOURCE_FIELD_NAME,
+} from '../../../timelines/components/timeline/body/renderers/constants';
+import {
+  DocumentFlyout,
+  JSON_TAB_TEST_ID,
+  OVERVIEW_TAB_TEST_ID,
+  TABLE_TAB_SOURCE_EVENT_LINK_TEST_ID,
+  TABLE_TAB_TEST_ID,
+} from '.';
+import { ANCESTOR_INDEX } from './constants/field_names';
+import { getTimelineEventsDetailsFromRecord } from './utils/get_timeline_events_details_from_record';
+import type { OpenFlyoutLinkRenderer } from '../../shared/components/open_flyout_link';
 import { TestProviders } from '../../../common/mock';
 import { createStartServicesMock } from '../../../common/lib/kibana/kibana_react.mock';
 
 jest.mock('../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
 jest.mock('../../../common/hooks/is_in_security_app');
+jest.mock('./utils/get_timeline_events_details_from_record', () => ({
+  getTimelineEventsDetailsFromRecord: jest.fn(() => []),
+}));
+// The Table tab is mocked, but it captures the `renderFlyoutLink` prop so the source event link
+// behavior (built in DocumentFlyout) can be exercised in isolation.
+const mockTableTab = jest.fn(
+  (_props: { renderFlyoutLink?: OpenFlyoutLinkRenderer }): JSX.Element => (
+    <div data-test-subj="mock-table-tab" />
+  )
+);
 jest.mock('./tabs/table_tab', () => ({
-  TableTab: () => <div data-test-subj="mock-table-tab" />,
+  TableTab: (props: { renderFlyoutLink?: OpenFlyoutLinkRenderer }) => mockTableTab(props),
 }));
 jest.mock('./tabs/json_tab', () => ({
   JsonTab: () => <div data-test-subj="mock-json-tab" />,
@@ -278,6 +303,165 @@ describe('<DocumentFlyout />', () => {
           'This alert originates from a remote cluster. Some features may not be available.'
         )
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Table tab source event link', () => {
+    const buildDetails = (items: Array<[string, string[]]>): TimelineEventsDetailsItem[] =>
+      items.map(([field, values]) => ({ field, values, isObjectArray: false }));
+
+    // Renders the flyout, switches to the (mocked) Table tab, and returns the `renderFlyoutLink`
+    // it was given so the source event link behavior can be exercised directly.
+    const renderAndGetRenderFlyoutLink = (): OpenFlyoutLinkRenderer => {
+      const { getByTestId } = render(
+        <TestProviders startServices={startServices}>
+          <DocumentFlyout
+            hit={createAlertHit()}
+            renderCellActions={jest.fn()}
+            onAlertUpdated={jest.fn()}
+          />
+        </TestProviders>
+      );
+      fireEvent.click(getByTestId(TABLE_TAB_TEST_ID));
+      const { calls } = mockTableTab.mock;
+      return calls[calls.length - 1][0].renderFlyoutLink as OpenFlyoutLinkRenderer;
+    };
+
+    beforeEach(() => {
+      (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
+      jest.mocked(getTimelineEventsDetailsFromRecord).mockReturnValue([]);
+    });
+
+    it('opens the ancestor document in a new flyout when a source event value is clicked', () => {
+      const openSystemFlyout = jest.fn(() => ({ onClose: Promise.resolve(), close: jest.fn() }));
+      startServices.overlays = { ...startServices.overlays, openSystemFlyout };
+      jest.mocked(getTimelineEventsDetailsFromRecord).mockReturnValue(
+        buildDetails([
+          [EVENT_SOURCE_FIELD_NAME, ['ancestor-1']],
+          [ANCESTOR_INDEX, ['.ds-logs-source-1']],
+        ])
+      );
+
+      const renderFlyoutLink = renderAndGetRenderFlyoutLink();
+
+      const { getByTestId } = render(
+        <TestProviders startServices={startServices}>
+          {renderFlyoutLink({
+            field: EVENT_SOURCE_FIELD_NAME,
+            value: 'ancestor-1',
+            children: <span>{'ancestor-1'}</span>,
+          })}
+        </TestProviders>
+      );
+
+      fireEvent.click(getByTestId(TABLE_TAB_SOURCE_EVENT_LINK_TEST_ID));
+
+      expect(openSystemFlyout).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ session: 'start' })
+      );
+    });
+
+    it('opens the ancestor document for the legacy signal.ancestors.id field', () => {
+      const openSystemFlyout = jest.fn(() => ({ onClose: Promise.resolve(), close: jest.fn() }));
+      startServices.overlays = { ...startServices.overlays, openSystemFlyout };
+      jest.mocked(getTimelineEventsDetailsFromRecord).mockReturnValue(
+        buildDetails([
+          [LEGACY_EVENT_SOURCE_FIELD_NAME, ['ancestor-1']],
+          ['signal.ancestors.index', ['.ds-logs-source-1']],
+        ])
+      );
+
+      const renderFlyoutLink = renderAndGetRenderFlyoutLink();
+
+      const { getByTestId } = render(
+        <TestProviders startServices={startServices}>
+          {renderFlyoutLink({
+            field: LEGACY_EVENT_SOURCE_FIELD_NAME,
+            value: 'ancestor-1',
+            children: <span>{'ancestor-1'}</span>,
+          })}
+        </TestProviders>
+      );
+
+      fireEvent.click(getByTestId(TABLE_TAB_SOURCE_EVENT_LINK_TEST_ID));
+
+      expect(openSystemFlyout).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ session: 'start' })
+      );
+    });
+
+    it('aligns each ancestor value with its own index', () => {
+      const openSystemFlyout = jest.fn(() => ({ onClose: Promise.resolve(), close: jest.fn() }));
+      startServices.overlays = { ...startServices.overlays, openSystemFlyout };
+      jest.mocked(getTimelineEventsDetailsFromRecord).mockReturnValue(
+        buildDetails([
+          [EVENT_SOURCE_FIELD_NAME, ['ancestor-1', 'ancestor-2']],
+          [ANCESTOR_INDEX, ['.ds-logs-source-1', '.internal.alerts-security.alerts-default']],
+        ])
+      );
+
+      const renderFlyoutLink = renderAndGetRenderFlyoutLink();
+
+      const { getByTestId } = render(
+        <TestProviders startServices={startServices}>
+          {renderFlyoutLink({
+            field: EVENT_SOURCE_FIELD_NAME,
+            value: 'ancestor-2',
+            children: <span>{'ancestor-2'}</span>,
+          })}
+        </TestProviders>
+      );
+
+      fireEvent.click(getByTestId(TABLE_TAB_SOURCE_EVENT_LINK_TEST_ID));
+
+      expect(openSystemFlyout).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a source event value as plain text when its index cannot be resolved', () => {
+      jest
+        .mocked(getTimelineEventsDetailsFromRecord)
+        .mockReturnValue(buildDetails([[EVENT_SOURCE_FIELD_NAME, ['ancestor-1']]]));
+
+      const renderFlyoutLink = renderAndGetRenderFlyoutLink();
+
+      const { queryByTestId, getByText } = render(
+        <TestProviders>
+          {renderFlyoutLink({
+            field: EVENT_SOURCE_FIELD_NAME,
+            value: 'ancestor-1',
+            children: <span>{'ancestor-1'}</span>,
+          })}
+        </TestProviders>
+      );
+
+      expect(queryByTestId(TABLE_TAB_SOURCE_EVENT_LINK_TEST_ID)).toBeNull();
+      expect(getByText('ancestor-1')).toBeInTheDocument();
+    });
+
+    it('does not link source event values for threshold rules', () => {
+      jest.mocked(getTimelineEventsDetailsFromRecord).mockReturnValue(
+        buildDetails([
+          [ALERT_RULE_TYPE, ['threshold']],
+          [EVENT_SOURCE_FIELD_NAME, ['fake-ancestor']],
+          [ANCESTOR_INDEX, ['.ds-logs-source-1']],
+        ])
+      );
+
+      const renderFlyoutLink = renderAndGetRenderFlyoutLink();
+
+      const { queryByTestId } = render(
+        <TestProviders>
+          {renderFlyoutLink({
+            field: EVENT_SOURCE_FIELD_NAME,
+            value: 'fake-ancestor',
+            children: <span>{'fake-ancestor'}</span>,
+          })}
+        </TestProviders>
+      );
+
+      expect(queryByTestId(TABLE_TAB_SOURCE_EVENT_LINK_TEST_ID)).toBeNull();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
@@ -10,6 +10,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiLink,
   EuiSpacer,
   EuiTab,
   EuiTabs,
@@ -36,10 +37,14 @@ import type { OpenFlyoutLinkProps } from '../../shared/components/open_flyout_li
 import { OpenFlyoutLink } from '../../shared/components/open_flyout_link';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import {
+  EVENT_SOURCE_FIELD_NAME,
+  LEGACY_EVENT_SOURCE_FIELD_NAME,
   LEGACY_SIGNAL_RULE_NAME_FIELD_NAME,
   SIGNAL_RULE_NAME_FIELD_NAME,
 } from '../../../timelines/components/timeline/body/renderers/constants';
 import { RemoteDocumentCallout } from './components/remote_document_callout';
+import { getTimelineEventsDetailsFromRecord } from './utils/get_timeline_events_details_from_record';
+import { getAncestorsIndexById } from './utils/get_ancestors_index_by_id';
 import { FLYOUT_ORIGIN, FLYOUT_TYPE } from '../../../common/lib/telemetry';
 import { isRulePreviewDocument } from '../../shared/utils/is_rule_preview_document';
 
@@ -62,6 +67,8 @@ const VALID_TAB_IDS: DocumentFlyoutTabId[] = ['overview', 'table', 'json'];
 export const OVERVIEW_TAB_TEST_ID = 'securitySolutionDocumentDetailsFlyoutOverviewTab';
 export const TABLE_TAB_TEST_ID = 'securitySolutionDocumentDetailsFlyoutTableTab';
 export const JSON_TAB_TEST_ID = 'securitySolutionDocumentDetailsFlyoutJsonTab';
+export const TABLE_TAB_SOURCE_EVENT_LINK_TEST_ID =
+  'securitySolutionDocumentDetailsFlyoutTableTabSourceEventLink';
 
 const OVERVIEW_TAB_LABEL = i18n.translate(
   'xpack.securitySolution.flyout.document.overviewTabLabel',
@@ -96,7 +103,7 @@ export interface DocumentFlyoutProps {
  */
 export const DocumentFlyout = memo(
   ({ hit, onAlertUpdated, renderCellActions }: DocumentFlyoutProps) => {
-    const { openNotes } = useFlyoutApi();
+    const { openNotes, openDocumentFlyoutFromIndex } = useFlyoutApi();
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
       [hit]
@@ -124,10 +131,45 @@ export const DocumentFlyout = memo(
       [hit]
     );
 
+    // Maps each ancestor document id to the index it lives in, so a Source event value in the Table
+    // tab can open that specific ancestor document. Threshold rules are excluded (see helper).
+    const ancestorsIndexById = useMemo(
+      () => getAncestorsIndexById(getTimelineEventsDetailsFromRecord(hit)),
+      [hit]
+    );
+
     // Opens the relevant system flyout (host, ip, rule) when a supported value is clicked in the
     // Table tab. Mirrors the Highlighted Fields behavior in the Overview tab.
     const renderFlyoutLink = useCallback(
       (props: OpenFlyoutLinkProps) => {
+        // Source event: the raw `kibana.alert.ancestors.id` field (or its legacy `signal.ancestors.id`
+        // equivalent) can list several ancestor documents, so each value is matched to its own index
+        // and opened in a new flyout (the same open method used by the sibling host/user/rule links).
+        // Values without a resolved index (e.g. a threshold rule's synthetic ancestor) render as
+        // plain text.
+        if (
+          props.field === EVENT_SOURCE_FIELD_NAME ||
+          props.field === LEGACY_EVENT_SOURCE_FIELD_NAME
+        ) {
+          const indexName = ancestorsIndexById[props.value];
+          if (!indexName) {
+            return <>{props.children}</>;
+          }
+          return (
+            <EuiLink
+              onClick={() =>
+                openDocumentFlyoutFromIndex({
+                  documentId: props.value,
+                  indexName,
+                  origin: FLYOUT_ORIGIN.FLYOUT_FIELD_LINK,
+                })
+              }
+              data-test-subj={TABLE_TAB_SOURCE_EVENT_LINK_TEST_ID}
+            >
+              {props.children}
+            </EuiLink>
+          );
+        }
         // Rule name fields: substitute the rule UUID as the link target (the flyout is keyed by
         // UUID) while keeping the rule name as the displayed text. When no UUID is available,
         // or when in rule preview (the rule doesn't exist yet), render plain text.
@@ -142,7 +184,7 @@ export const DocumentFlyout = memo(
         }
         return <OpenFlyoutLink {...props} />;
       },
-      [ruleId, isRulePreview]
+      [ruleId, ancestorsIndexById, isRulePreview, openDocumentFlyoutFromIndex]
     );
 
     const onShowNotesFromHeader = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_ancestors_index_by_id.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_ancestors_index_by_id.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALERT_RULE_TYPE } from '@kbn/rule-data-utils';
+import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import {
+  EVENT_SOURCE_FIELD_NAME,
+  LEGACY_EVENT_SOURCE_FIELD_NAME,
+} from '../../../../timelines/components/timeline/body/renderers/constants';
+import { ANCESTOR_INDEX, LEGACY_ANCESTOR_INDEX } from '../constants/field_names';
+import { getAncestorsIndexById } from './get_ancestors_index_by_id';
+
+const item = (field: string, values: string[]): TimelineEventsDetailsItem => ({
+  field,
+  values,
+  isObjectArray: false,
+});
+
+describe('getAncestorsIndexById', () => {
+  it('maps a single ancestor id to its index', () => {
+    const data = [
+      item(EVENT_SOURCE_FIELD_NAME, ['ancestor-1']),
+      item(ANCESTOR_INDEX, ['.ds-logs-source-1']),
+    ];
+
+    expect(getAncestorsIndexById(data)).toEqual({ 'ancestor-1': '.ds-logs-source-1' });
+  });
+
+  it('aligns multiple ancestor ids with their indices by position', () => {
+    const data = [
+      item(EVENT_SOURCE_FIELD_NAME, ['ancestor-1', 'ancestor-2']),
+      item(ANCESTOR_INDEX, ['.ds-logs-source-1', '.internal.alerts-security.alerts-default']),
+    ];
+
+    expect(getAncestorsIndexById(data)).toEqual({
+      'ancestor-1': '.ds-logs-source-1',
+      'ancestor-2': '.internal.alerts-security.alerts-default',
+    });
+  });
+
+  it('maps ancestor ids from the legacy signal.ancestors.* fields', () => {
+    const data = [
+      item(LEGACY_EVENT_SOURCE_FIELD_NAME, ['ancestor-1']),
+      item(LEGACY_ANCESTOR_INDEX, ['.ds-logs-source-1']),
+    ];
+
+    expect(getAncestorsIndexById(data)).toEqual({ 'ancestor-1': '.ds-logs-source-1' });
+  });
+
+  it('merges ancestor ids from both the current and legacy fields', () => {
+    const data = [
+      item(EVENT_SOURCE_FIELD_NAME, ['ancestor-1']),
+      item(ANCESTOR_INDEX, ['.ds-logs-source-1']),
+      item(LEGACY_EVENT_SOURCE_FIELD_NAME, ['ancestor-2']),
+      item(LEGACY_ANCESTOR_INDEX, ['.ds-logs-source-2']),
+    ];
+
+    expect(getAncestorsIndexById(data)).toEqual({
+      'ancestor-1': '.ds-logs-source-1',
+      'ancestor-2': '.ds-logs-source-2',
+    });
+  });
+
+  it('returns an empty map for threshold rules to avoid linking the synthetic ancestor', () => {
+    const data = [
+      item(ALERT_RULE_TYPE, ['threshold']),
+      item(EVENT_SOURCE_FIELD_NAME, ['fake-ancestor']),
+      item(ANCESTOR_INDEX, ['.ds-logs-source-1']),
+    ];
+
+    expect(getAncestorsIndexById(data)).toEqual({});
+  });
+
+  it('skips ancestor ids that have no aligned index', () => {
+    const data = [
+      item(EVENT_SOURCE_FIELD_NAME, ['ancestor-1', 'ancestor-2']),
+      item(ANCESTOR_INDEX, ['.ds-logs-source-1']),
+    ];
+
+    expect(getAncestorsIndexById(data)).toEqual({ 'ancestor-1': '.ds-logs-source-1' });
+  });
+
+  it('returns an empty map when there are no ancestor ids', () => {
+    expect(getAncestorsIndexById([item(ANCESTOR_INDEX, ['.ds-logs-source-1'])])).toEqual({});
+    expect(getAncestorsIndexById([])).toEqual({});
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_ancestors_index_by_id.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_ancestors_index_by_id.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALERT_RULE_TYPE } from '@kbn/rule-data-utils';
+import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import {
+  EVENT_SOURCE_FIELD_NAME,
+  LEGACY_EVENT_SOURCE_FIELD_NAME,
+} from '../../../../timelines/components/timeline/body/renderers/constants';
+import { ANCESTOR_INDEX, LEGACY_ANCESTOR_INDEX } from '../constants/field_names';
+
+// The ancestor id/index arrays are parallel, and both the current (`kibana.alert.ancestors.*`) and
+// legacy (`signal.ancestors.*`) field names may be present depending on the alert's schema version.
+const ANCESTOR_ID_INDEX_FIELD_PAIRS: ReadonlyArray<readonly [idField: string, indexField: string]> =
+  [
+    [EVENT_SOURCE_FIELD_NAME, ANCESTOR_INDEX],
+    [LEGACY_EVENT_SOURCE_FIELD_NAME, LEGACY_ANCESTOR_INDEX],
+  ];
+
+/**
+ * Builds a map from each ancestor document id (`kibana.alert.ancestors.id`, or the legacy
+ * `signal.ancestors.id`) to the index that document lives in (`kibana.alert.ancestors.index` /
+ * `signal.ancestors.index`), by aligning the two parallel arrays by position. This lets the Table
+ * tab turn each "Source event" value into a link that opens the correct ancestor document, even for
+ * alert-on-alert cases where several ancestors (at different depths) are listed in the same field.
+ *
+ * Threshold rules are intentionally excluded: they synthesize a fake ancestor id to represent the
+ * aggregation bucket, and that id does not correspond to a real document — clicking it would return
+ * a 500 from the server (see https://github.com/elastic/kibana/issues/238019). Returning an empty
+ * map for those keeps the values rendered as plain text.
+ */
+export const getAncestorsIndexById = (
+  dataFormattedForFieldBrowser: TimelineEventsDetailsItem[]
+): Record<string, string> => {
+  const ruleType = dataFormattedForFieldBrowser.find((item) => item.field === ALERT_RULE_TYPE)
+    ?.values?.[0];
+
+  if (ruleType === 'threshold') {
+    return {};
+  }
+
+  return ANCESTOR_ID_INDEX_FIELD_PAIRS.reduce<Record<string, string>>(
+    (acc, [idField, indexField]) => {
+      const ids = dataFormattedForFieldBrowser.find((item) => item.field === idField)?.values ?? [];
+      const indices =
+        dataFormattedForFieldBrowser.find((item) => item.field === indexField)?.values ?? [];
+
+      ids.forEach((id, i) => {
+        const indexName = indices[i];
+        if (id && indexName) {
+          acc[id] = indexName;
+        }
+      });
+      return acc;
+    },
+    {}
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/constants.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/constants.tsx
@@ -27,3 +27,4 @@ export const QUARANTINED_PATH_FIELD_NAME = 'quarantined.path';
 export const REASON_FIELD_NAME = 'kibana.alert.reason';
 export const EVENT_SUMMARY_FIELD_NAME = 'eventSummary';
 export const EVENT_SOURCE_FIELD_NAME = 'kibana.alert.ancestors.id';
+export const LEGACY_EVENT_SOURCE_FIELD_NAME = 'signal.ancestors.id';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Security Solution][Flyout] add ability to open source event from the table tab (#282346)](https://github.com/elastic/kibana/pull/282346)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-08-05T15:21:01Z","message":"[Security Solution][Flyout] add ability to open source event from the table tab (#282346)\n\n## Summary\n\nThis PR makes a small addition to the new document flyout Table tab that\nallows users to open the source event from the\n`kibana.alert.ancestors.id` and `signal.ancestors.id` fields.\n\nOn `main` this is not feasible\n\n\nhttps://github.com/user-attachments/assets/4592b692-577a-4d32-915e-6b97c1a7df9a\n\nBut on this branch, the behavior no mimics what we do in the\n`Highlighted Fields` section of the `Overview` tab\n\n\nhttps://github.com/user-attachments/assets/34e266e6-578b-489d-9b68-f2b07b0e3ccc\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"19cb6c63f26b9c97247b70ae6d7df633609c6ac8","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting","backport:version","OneDiscover","v9.6.0","v9.5.1"],"title":"[Security Solution][Flyout] add ability to open source event from the table tab","number":282346,"url":"https://github.com/elastic/kibana/pull/282346","mergeCommit":{"message":"[Security Solution][Flyout] add ability to open source event from the table tab (#282346)\n\n## Summary\n\nThis PR makes a small addition to the new document flyout Table tab that\nallows users to open the source event from the\n`kibana.alert.ancestors.id` and `signal.ancestors.id` fields.\n\nOn `main` this is not feasible\n\n\nhttps://github.com/user-attachments/assets/4592b692-577a-4d32-915e-6b97c1a7df9a\n\nBut on this branch, the behavior no mimics what we do in the\n`Highlighted Fields` section of the `Overview` tab\n\n\nhttps://github.com/user-attachments/assets/34e266e6-578b-489d-9b68-f2b07b0e3ccc\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"19cb6c63f26b9c97247b70ae6d7df633609c6ac8"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282346","number":282346,"mergeCommit":{"message":"[Security Solution][Flyout] add ability to open source event from the table tab (#282346)\n\n## Summary\n\nThis PR makes a small addition to the new document flyout Table tab that\nallows users to open the source event from the\n`kibana.alert.ancestors.id` and `signal.ancestors.id` fields.\n\nOn `main` this is not feasible\n\n\nhttps://github.com/user-attachments/assets/4592b692-577a-4d32-915e-6b97c1a7df9a\n\nBut on this branch, the behavior no mimics what we do in the\n`Highlighted Fields` section of the `Overview` tab\n\n\nhttps://github.com/user-attachments/assets/34e266e6-578b-489d-9b68-f2b07b0e3ccc\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"19cb6c63f26b9c97247b70ae6d7df633609c6ac8"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->