### PR TITLE
[Synthetics] Fix back navigation under the new chrome header

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.test.tsx
@@ -75,4 +75,25 @@ describe('WrappedPageTemplate', () => {
 
     expect(pageHeaders[0]?.breadcrumbs).toBeUndefined();
   });
+
+  it('keeps the in-page breadcrumbs when chrome is missing from services', () => {
+    const receivedPageHeaders: Array<EuiPageHeaderProps | undefined> = [];
+    const PageTemplate = ({ pageHeader }: { pageHeader?: EuiPageHeaderProps }) => {
+      receivedPageHeaders.push(pageHeader);
+      return null;
+    };
+
+    render(
+      <WrappedPageTemplate
+        pageHeader={{ pageTitle: 'Monitor name', breadcrumbs: inPageBreadcrumbs }}
+      />,
+      {
+        core: {
+          observabilityShared: { navigation: { PageTemplate } },
+        } as any,
+      }
+    );
+
+    expect(receivedPageHeaders.at(-1)?.breadcrumbs).toEqual(inPageBreadcrumbs);
+  });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.test.tsx
@@ -12,6 +12,7 @@ import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import type { EuiPageHeaderProps } from '@elastic/eui';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { render as rtlRender } from '@testing-library/react';
+import type { LazyObservabilityPageTemplateProps } from '@kbn/observability-shared-plugin/public';
 import { render } from '../../../utils/testing';
 import { WrappedPageTemplate } from './synthetics_page_template';
 import type { ClientPluginsStart } from '../../../../../plugin';
@@ -29,10 +30,15 @@ describe('WrappedPageTemplate', () => {
     const defaultChrome = coreMock.createStart().chrome;
     const receivedPageHeaders: Array<EuiPageHeaderProps | undefined> = [];
 
-    const PageTemplate = ({ pageHeader }: { pageHeader?: EuiPageHeaderProps }) => {
-      receivedPageHeaders.push(pageHeader);
-      return null;
+    const PageTemplate = (props: LazyObservabilityPageTemplateProps) => {
+      receivedPageHeaders.push(props.pageHeader);
+      return <div />;
     };
+    const observabilityShared = {
+      navigation: { PageTemplate, registerSections: jest.fn() },
+      locators: {} as unknown as ClientPluginsStart['observabilityShared']['locators'],
+      updateGlobalNavigation: jest.fn(),
+    } as unknown as ClientPluginsStart['observabilityShared'];
 
     render<Pick<ClientPluginsStart, 'observabilityShared'>>(
       <WrappedPageTemplate
@@ -46,7 +52,7 @@ describe('WrappedPageTemplate', () => {
             getChromeStyle$: () => new BehaviorSubject<ChromeStyle>(chromeStyle).asObservable(),
             next: { ...defaultChrome.next, isEnabled: isNextChromeEnabled },
           },
-          observabilityShared: { navigation: { PageTemplate } },
+          observabilityShared,
         },
       }
     );
@@ -81,13 +87,22 @@ describe('WrappedPageTemplate', () => {
 
   it('keeps the in-page breadcrumbs when chrome is missing from services', () => {
     const receivedPageHeaders: Array<EuiPageHeaderProps | undefined> = [];
-    const PageTemplate = ({ pageHeader }: { pageHeader?: EuiPageHeaderProps }) => {
-      receivedPageHeaders.push(pageHeader);
-      return null;
+    const PageTemplate = (props: LazyObservabilityPageTemplateProps) => {
+      receivedPageHeaders.push(props.pageHeader);
+      return <div />;
     };
+    const observabilityShared = {
+      navigation: { PageTemplate, registerSections: jest.fn() },
+      locators: {} as unknown as ClientPluginsStart['observabilityShared']['locators'],
+      updateGlobalNavigation: jest.fn(),
+    } as unknown as ClientPluginsStart['observabilityShared'];
 
     rtlRender(
-      <KibanaContextProvider services={{ observabilityShared: { navigation: { PageTemplate } } }}>
+      <KibanaContextProvider
+        services={{
+          observabilityShared,
+        }}
+      >
         <WrappedPageTemplate
           pageHeader={{ pageTitle: 'Monitor name', breadcrumbs: inPageBreadcrumbs }}
         />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.test.tsx
@@ -10,8 +10,11 @@ import { BehaviorSubject } from 'rxjs';
 import { coreMock } from '@kbn/core/public/mocks';
 import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import type { EuiPageHeaderProps } from '@elastic/eui';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { render as rtlRender } from '@testing-library/react';
 import { render } from '../../../utils/testing';
 import { WrappedPageTemplate } from './synthetics_page_template';
+import type { ClientPluginsStart } from '../../../../../plugin';
 
 describe('WrappedPageTemplate', () => {
   const inPageBreadcrumbs = [{ text: 'Monitors', href: '/app/synthetics/monitors' }];
@@ -31,7 +34,7 @@ describe('WrappedPageTemplate', () => {
       return null;
     };
 
-    render(
+    render<Pick<ClientPluginsStart, 'observabilityShared'>>(
       <WrappedPageTemplate
         pageHeader={{ pageTitle: 'Monitor name', breadcrumbs: inPageBreadcrumbs }}
       />,
@@ -44,7 +47,7 @@ describe('WrappedPageTemplate', () => {
             next: { ...defaultChrome.next, isEnabled: isNextChromeEnabled },
           },
           observabilityShared: { navigation: { PageTemplate } },
-        } as any,
+        },
       }
     );
 
@@ -83,15 +86,12 @@ describe('WrappedPageTemplate', () => {
       return null;
     };
 
-    render(
-      <WrappedPageTemplate
-        pageHeader={{ pageTitle: 'Monitor name', breadcrumbs: inPageBreadcrumbs }}
-      />,
-      {
-        core: {
-          observabilityShared: { navigation: { PageTemplate } },
-        } as any,
-      }
+    rtlRender(
+      <KibanaContextProvider services={{ observabilityShared: { navigation: { PageTemplate } } }}>
+        <WrappedPageTemplate
+          pageHeader={{ pageTitle: 'Monitor name', breadcrumbs: inPageBreadcrumbs }}
+        />
+      </KibanaContextProvider>
     );
 
     expect(receivedPageHeaders.at(-1)?.breadcrumbs).toEqual(inPageBreadcrumbs);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { BehaviorSubject } from 'rxjs';
+import { coreMock } from '@kbn/core/public/mocks';
+import type { ChromeStyle } from '@kbn/core-chrome-browser';
+import type { EuiPageHeaderProps } from '@elastic/eui';
+import { render } from '../../../utils/testing';
+import { WrappedPageTemplate } from './synthetics_page_template';
+
+describe('WrappedPageTemplate', () => {
+  const inPageBreadcrumbs = [{ text: 'Monitors', href: '/app/synthetics/monitors' }];
+
+  const renderTemplate = ({
+    chromeStyle,
+    isNextChromeEnabled,
+  }: {
+    chromeStyle: ChromeStyle;
+    isNextChromeEnabled: boolean;
+  }) => {
+    const defaultChrome = coreMock.createStart().chrome;
+    const receivedPageHeaders: Array<EuiPageHeaderProps | undefined> = [];
+
+    const PageTemplate = ({ pageHeader }: { pageHeader?: EuiPageHeaderProps }) => {
+      receivedPageHeaders.push(pageHeader);
+      return null;
+    };
+
+    render(
+      <WrappedPageTemplate
+        pageHeader={{ pageTitle: 'Monitor name', breadcrumbs: inPageBreadcrumbs }}
+      />,
+      {
+        core: {
+          chrome: {
+            ...defaultChrome,
+            getChromeStyle: () => chromeStyle,
+            getChromeStyle$: () => new BehaviorSubject<ChromeStyle>(chromeStyle).asObservable(),
+            next: { ...defaultChrome.next, isEnabled: isNextChromeEnabled },
+          },
+          observabilityShared: { navigation: { PageTemplate } },
+        } as any,
+      }
+    );
+
+    return receivedPageHeaders;
+  };
+
+  it('keeps the in-page breadcrumbs in classic chrome', () => {
+    const pageHeaders = renderTemplate({ chromeStyle: 'classic', isNextChromeEnabled: false });
+
+    expect(pageHeaders.at(-1)?.breadcrumbs).toEqual(inPageBreadcrumbs);
+  });
+
+  it('keeps the in-page breadcrumbs in solution view while the new chrome is disabled', () => {
+    const pageHeaders = renderTemplate({ chromeStyle: 'project', isNextChromeEnabled: false });
+
+    expect(pageHeaders.at(-1)?.breadcrumbs).toEqual(inPageBreadcrumbs);
+  });
+
+  it('drops the in-page breadcrumbs when the new chrome header renders its own back button', () => {
+    const pageHeaders = renderTemplate({ chromeStyle: 'project', isNextChromeEnabled: true });
+
+    expect(pageHeaders.at(-1)?.breadcrumbs).toBeUndefined();
+    expect(pageHeaders.at(-1)?.pageTitle).toEqual('Monitor name');
+  });
+
+  it('drops the in-page breadcrumbs on the very first render', () => {
+    const pageHeaders = renderTemplate({ chromeStyle: 'project', isNextChromeEnabled: true });
+
+    expect(pageHeaders[0]?.breadcrumbs).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.tsx
@@ -6,17 +6,37 @@
  */
 
 import type { LazyObservabilityPageTemplateProps } from '@kbn/observability-shared-plugin/public';
-import React from 'react';
+import React, { useMemo } from 'react';
+import { of } from 'rxjs';
+import useObservable from 'react-use/lib/useObservable';
+import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 
 import type { ClientPluginsStart } from '../../../../../plugin';
 
 export const WrappedPageTemplate = (props: LazyObservabilityPageTemplateProps) => {
-  const { observabilityShared } = useKibana<ClientPluginsStart>().services;
+  const { chrome, observabilityShared } = useKibana<ClientPluginsStart>().services;
   const PageTemplateComponent = observabilityShared.navigation.PageTemplate;
 
-  return <PageTemplateComponent {...props} />;
+  const chromeStyle$ = useMemo(
+    () => chrome?.getChromeStyle$() ?? of<ChromeStyle>('classic'),
+    [chrome]
+  );
+  // Seeded synchronously, otherwise the breadcrumbs paint once before the subscription drops them.
+  const chromeStyle = useObservable<ChromeStyle>(
+    chromeStyle$,
+    chrome?.getChromeStyle() ?? 'classic'
+  );
+
+  // The chrome header renders its own back button, so in-page breadcrumbs would duplicate it.
+  const hasChromeBackButton = Boolean(chrome?.next.isEnabled) && chromeStyle === 'project';
+  const pageHeader =
+    hasChromeBackButton && props.pageHeader
+      ? { ...props.pageHeader, breadcrumbs: undefined }
+      : props.pageHeader;
+
+  return <PageTemplateComponent {...props} pageHeader={pageHeader} />;
 };
 
 export const SyntheticsPageTemplateComponent = euiStyled(WrappedPageTemplate)`

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.tsx
@@ -23,14 +23,14 @@ export const WrappedPageTemplate = (props: LazyObservabilityPageTemplateProps) =
     () => chrome?.getChromeStyle$() ?? of<ChromeStyle>('classic'),
     [chrome]
   );
-  // Seeded synchronously, otherwise the breadcrumbs paint once before the subscription drops them.
+  // Seed synchronously to avoid a one-frame breadcrumb flicker.
   const chromeStyle = useObservable<ChromeStyle>(
     chromeStyle$,
     chrome?.getChromeStyle() ?? 'classic'
   );
 
   // The chrome header renders its own back button, so in-page breadcrumbs would duplicate it.
-  const hasChromeBackButton = Boolean(chrome?.next.isEnabled) && chromeStyle === 'project';
+  const hasChromeBackButton = Boolean(chrome?.next?.isEnabled) && chromeStyle === 'project';
   const pageHeader =
     hasChromeBackButton && props.pageHeader
       ? { ...props.pageHeader, breadcrumbs: undefined }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/page_template/synthetics_page_template.tsx
@@ -23,7 +23,7 @@ export const WrappedPageTemplate = (props: LazyObservabilityPageTemplateProps) =
     () => chrome?.getChromeStyle$() ?? of<ChromeStyle>('classic'),
     [chrome]
   );
-  // Seed synchronously to avoid a one-frame breadcrumb flicker.
+
   const chromeStyle = useObservable<ChromeStyle>(
     chromeStyle$,
     chrome?.getChromeStyle() ?? 'classic'

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/edit_monitor_not_found.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/edit_monitor_not_found.tsx
@@ -11,14 +11,14 @@ import { useFetcher } from '@kbn/observability-shared-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useGetUrlParams, useUrlParams } from '../../hooks';
 import { deletePackagePolicy } from '../../state/monitor_management/api';
-import { MonitorNotFoundPage } from '../monitor_details/monitor_not_found_page';
+import { MonitorNotFoundPrompt } from '../monitor_details/monitor_not_found_page';
 
 export const EditMonitorNotFound: React.FC = () => {
   return (
     <>
       <LeftoverIntegrationFound />
       <EuiSpacer size="m" />
-      <MonitorNotFoundPage />
+      <MonitorNotFoundPrompt />
     </>
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
@@ -59,7 +59,6 @@ export const MonitorEditPage: React.FC = () => {
 
   const monitorNotFoundError = useMonitorNotFound(error, data?.id);
 
-  // Own the breadcrumbs for the whole edit route, including the not-found state.
   useMonitorAddEditBreadcrumbs(true, { monitorNotFound: Boolean(monitorNotFoundError) });
 
   const canUsePublicLocations = useCanUsePublicLocations(data?.[ConfigKey.LOCATIONS]);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
@@ -40,7 +40,6 @@ export const MonitorEditPage: React.FC = () => {
   useTrackPageview({ app: 'synthetics', path: 'edit-monitor', delay: 15000 });
   const { monitorId } = useParams<{ monitorId: string }>();
   const { spaceId } = useGetUrlParams();
-  useMonitorAddEditBreadcrumbs(true);
   const dispatch = useDispatch();
   const { locationsLoaded, error: locationsError } = useSelector(selectServiceLocationsState);
 
@@ -59,6 +58,9 @@ export const MonitorEditPage: React.FC = () => {
   }, [dispatch, monitorId, spaceId]);
 
   const monitorNotFoundError = useMonitorNotFound(error, data?.id);
+
+  // Own the breadcrumbs for the whole edit route, including the not-found state.
+  useMonitorAddEditBreadcrumbs(true, { monitorNotFound: Boolean(monitorNotFoundError) });
 
   const canUsePublicLocations = useCanUsePublicLocations(data?.[ConfigKey.LOCATIONS]);
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.test.tsx
@@ -7,16 +7,17 @@
 
 import React from 'react';
 import { createMemoryHistory } from 'history';
-import { BehaviorSubject } from 'rxjs';
-import { coreMock } from '@kbn/core/public/mocks';
-import type { ChromeBreadcrumb } from '@kbn/core/public';
-import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import { Route } from '@kbn/shared-ux-router';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { render } from '../../utils/testing';
 import { SyntheticsSettingsContext } from '../../contexts';
 import { MONITOR_EDIT_ROUTE } from '../../../../../common/constants';
 import { useMonitorAddEditBreadcrumbs } from './use_breadcrumbs';
+import type { CoreStart } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
+import type { ChromeBreadcrumb } from '@kbn/core/public';
+import { BehaviorSubject } from 'rxjs';
+import type { ChromeStyle } from '@kbn/core-chrome-browser';
 
 describe('useMonitorAddEditBreadcrumbs', () => {
   const renderEditRoute = ({
@@ -32,7 +33,7 @@ describe('useMonitorAddEditBreadcrumbs', () => {
     remoteName?: string;
     monitorNotFound?: boolean;
   }) => {
-    const [getBreadcrumbs, core] = mockCore();
+    const { core, getBreadcrumbs } = createBreadcrumbsCore();
 
     const Component = () => {
       useMonitorAddEditBreadcrumbs(true, { monitorNotFound });
@@ -147,24 +148,28 @@ describe('useMonitorAddEditBreadcrumbs', () => {
   });
 });
 
-const mockCore: () => [() => ChromeBreadcrumb[], any] = () => {
+const createBreadcrumbsCore = (): {
+  core: Pick<CoreStart, 'application' | 'chrome'>;
+  getBreadcrumbs: () => ChromeBreadcrumb[];
+} => {
   let breadcrumbs: ChromeBreadcrumb[] = [];
   const defaultCoreMock = coreMock.createStart();
 
-  const core = {
-    application: {
-      getUrlForApp: (app: string) =>
-        app === 'synthetics' ? '/app/synthetics' : '/app/observability',
-      navigateToUrl: jest.fn(),
-    },
-    chrome: {
-      ...defaultCoreMock.chrome,
-      getChromeStyle$: () => new BehaviorSubject<ChromeStyle>('classic').asObservable(),
-      setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => {
-        breadcrumbs = newBreadcrumbs;
+  return {
+    getBreadcrumbs: () => breadcrumbs,
+    core: {
+      application: {
+        getUrlForApp: (app: string) =>
+          app === 'synthetics' ? '/app/synthetics' : '/app/observability',
+        navigateToUrl: jest.fn(),
+      } as unknown as CoreStart['application'],
+      chrome: {
+        ...defaultCoreMock.chrome,
+        getChromeStyle$: () => new BehaviorSubject<ChromeStyle>('classic').asObservable(),
+        setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => {
+          breadcrumbs = newBreadcrumbs;
+        },
       },
     },
   };
-
-  return [() => breadcrumbs, core];
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { createMemoryHistory } from 'history';
+import { BehaviorSubject } from 'rxjs';
+import { coreMock } from '@kbn/core/public/mocks';
+import type { ChromeBreadcrumb } from '@kbn/core/public';
+import type { ChromeStyle } from '@kbn/core-chrome-browser';
+import { Route } from '@kbn/shared-ux-router';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { render } from '../../utils/testing';
+import { SyntheticsSettingsContext } from '../../contexts';
+import { MONITOR_EDIT_ROUTE } from '../../../../../common/constants';
+import { useMonitorAddEditBreadcrumbs } from './use_breadcrumbs';
+
+describe('useMonitorAddEditBreadcrumbs', () => {
+  const renderEditRoute = ({
+    loadedMonitorId,
+    routeMonitorId,
+    locationId,
+    remoteName,
+    monitorNotFound,
+  }: {
+    loadedMonitorId?: string;
+    routeMonitorId: string;
+    locationId?: string;
+    remoteName?: string;
+    monitorNotFound?: boolean;
+  }) => {
+    const [getBreadcrumbs, core] = mockCore();
+
+    const Component = () => {
+      useMonitorAddEditBreadcrumbs(true, { monitorNotFound });
+      return null;
+    };
+
+    render(
+      <KibanaContextProvider services={{ ...core }}>
+        <Route path={MONITOR_EDIT_ROUTE}>
+          <SyntheticsSettingsContext.Provider
+            value={{
+              darkMode: false,
+              basePath: '/app/synthetics',
+              canSave: true,
+              dateRangeStart: '',
+              dateRangeEnd: '',
+              isApmAvailable: true,
+              setBreadcrumbs: core.chrome.setBreadcrumbs,
+              isInfraAvailable: false,
+              isLogsAvailable: false,
+              canManagePrivateLocations: false,
+            }}
+          >
+            <Component />
+          </SyntheticsSettingsContext.Provider>
+        </Route>
+      </KibanaContextProvider>,
+      {
+        history: createMemoryHistory({
+          initialEntries: [
+            (() => {
+              const search = new URLSearchParams({
+                ...(locationId ? { locationId } : {}),
+                ...(remoteName ? { remoteName } : {}),
+              }).toString();
+
+              return `/edit-monitor/${routeMonitorId}${search ? `?${search}` : ''}`;
+            })(),
+          ],
+        }),
+        state: loadedMonitorId
+          ? {
+              monitorDetails: {
+                syntheticsMonitor: {
+                  config_id: loadedMonitorId,
+                  name: `Monitor ${loadedMonitorId}`,
+                },
+              },
+            }
+          : undefined,
+      }
+    );
+
+    return () => getBreadcrumbs().map(({ text, href }) => ({ text, href }));
+  };
+
+  it('links the monitor being edited when the loaded monitor matches the route', () => {
+    const getCrumbs = renderEditRoute({
+      loadedMonitorId: 'monitor-a',
+      routeMonitorId: 'monitor-a',
+    });
+
+    expect(getCrumbs()).toEqual(
+      expect.arrayContaining([
+        { text: 'Monitor monitor-a', href: '/app/synthetics/monitor/monitor-a' },
+        { text: 'Edit monitor', href: undefined },
+      ])
+    );
+  });
+
+  it('preserves locationId and remoteName in the monitor crumb href', () => {
+    const getCrumbs = renderEditRoute({
+      loadedMonitorId: 'monitor-a',
+      routeMonitorId: 'monitor-a',
+      locationId: 'location-1',
+      remoteName: 'remote-ccs',
+    });
+
+    expect(getCrumbs()).toEqual(
+      expect.arrayContaining([
+        {
+          text: 'Monitor monitor-a',
+          href: '/app/synthetics/monitor/monitor-a?locationId=location-1&remoteName=remote-ccs',
+        },
+      ])
+    );
+  });
+
+  it('omits the monitor crumb while the store still holds the previously edited monitor', () => {
+    const getCrumbs = renderEditRoute({
+      loadedMonitorId: 'monitor-a',
+      routeMonitorId: 'monitor-b',
+    });
+
+    const crumbs = getCrumbs();
+
+    expect(crumbs).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ text: 'Monitor monitor-a' })])
+    );
+    expect(crumbs[crumbs.length - 1]).toEqual({ text: 'Edit monitor', href: undefined });
+  });
+
+  it('ends the trail with "Monitor not found" when the monitor could not be loaded', () => {
+    const getCrumbs = renderEditRoute({ routeMonitorId: 'monitor-b', monitorNotFound: true });
+
+    const crumbs = getCrumbs();
+
+    expect(crumbs[crumbs.length - 1]).toEqual({ text: 'Monitor not found', href: undefined });
+    expect(crumbs).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ text: 'Edit monitor' })])
+    );
+  });
+});
+
+const mockCore: () => [() => ChromeBreadcrumb[], any] = () => {
+  let breadcrumbs: ChromeBreadcrumb[] = [];
+  const defaultCoreMock = coreMock.createStart();
+
+  const core = {
+    application: {
+      getUrlForApp: (app: string) =>
+        app === 'synthetics' ? '/app/synthetics' : '/app/observability',
+      navigateToUrl: jest.fn(),
+    },
+    chrome: {
+      ...defaultCoreMock.chrome,
+      getChromeStyle$: () => new BehaviorSubject<ChromeStyle>('classic').asObservable(),
+      setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => {
+        breadcrumbs = newBreadcrumbs;
+      },
+    },
+  };
+
+  return [() => breadcrumbs, core];
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.ts
@@ -4,28 +4,58 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
+import { useSelector } from 'react-redux-v7';
+import type { ChromeBreadcrumb } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
-import { MONITOR_ADD_ROUTE, MONITOR_EDIT_ROUTE } from '../../../../../common/constants';
+import { useUrlSpaceId } from '../../hooks/use_url_space_id';
+import { buildMonitorParamsSearch } from '../../utils/url_params';
+import { selectSyntheticsMonitor } from '../../state';
+import { ConfigKey } from '../../../../../common/runtime_types';
+import { MONITOR_ROUTE, MONITORS_ROUTE } from '../../../../../common/constants';
 import { PLUGIN } from '../../../../../common/constants/plugin';
 
 export const useMonitorAddEditBreadcrumbs = (isEdit?: boolean) => {
   const kibana = useKibana();
   const appPath = kibana.services.application?.getUrlForApp(PLUGIN.SYNTHETICS_PLUGIN_ID) ?? '';
+  const spaceId = useUrlSpaceId();
+  const monitor = useSelector(selectSyntheticsMonitor);
+  const configId = monitor?.[ConfigKey.CONFIG_ID];
+  const monitorName = monitor?.name;
 
-  const config = isEdit
-    ? {
-        text: EDIT_MONITOR_CRUMB,
-        href: `${appPath}/${MONITOR_EDIT_ROUTE}`,
-      }
-    : {
-        text: ADD_MONITOR_CRUMB,
-        href: `${appPath}/${MONITOR_ADD_ROUTE}`,
-      };
+  const crumbs = useMemo<ChromeBreadcrumb[]>(() => {
+    if (!isEdit) {
+      return [{ text: ADD_MONITOR_CRUMB }];
+    }
 
-  useBreadcrumbs([config]);
+    const monitorsCrumb = { text: MONITORS_CRUMB, href: `${appPath}${MONITORS_ROUTE}` };
+    const editCrumb = { text: EDIT_MONITOR_CRUMB };
+
+    if (!configId || !monitorName) {
+      return [monitorsCrumb, editCrumb];
+    }
+
+    return [
+      monitorsCrumb,
+      {
+        text: monitorName,
+        href: `${appPath}${monitorDetailPath(configId)}${buildMonitorParamsSearch({ spaceId })}`,
+      },
+      editCrumb,
+    ];
+  }, [appPath, configId, isEdit, monitorName, spaceId]);
+
+  useBreadcrumbs(crumbs);
 };
+
+// The `?` belongs to the optional param token; leaving it behind collides with the query string.
+const monitorDetailPath = (configId: string) => MONITOR_ROUTE.replace(':monitorId?', configId);
+
+const MONITORS_CRUMB = i18n.translate('xpack.synthetics.monitorsPage.monitorsMCrumb', {
+  defaultMessage: 'Monitors',
+});
 
 export const ADD_MONITOR_CRUMB = i18n.translate(
   'xpack.synthetics.monitorManagement.addMonitorCrumb',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.ts
@@ -7,20 +7,33 @@
 import { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useSelector } from 'react-redux-v7';
+import { useParams } from 'react-router-dom';
 import type { ChromeBreadcrumb } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
+import { useGetUrlParams } from '../../hooks';
 import { useUrlSpaceId } from '../../hooks/use_url_space_id';
 import { buildMonitorParamsSearch } from '../../utils/url_params';
 import { selectSyntheticsMonitor } from '../../state';
+import { MONITOR_NOT_FOUND_TITLE } from '../monitor_details/monitor_not_found_page';
 import { ConfigKey } from '../../../../../common/runtime_types';
 import { MONITOR_ROUTE, MONITORS_ROUTE } from '../../../../../common/constants';
 import { PLUGIN } from '../../../../../common/constants/plugin';
 
-export const useMonitorAddEditBreadcrumbs = (isEdit?: boolean) => {
+interface MonitorAddEditBreadcrumbOptions {
+  monitorNotFound?: boolean;
+}
+
+export const useMonitorAddEditBreadcrumbs = (
+  isEdit?: boolean,
+  { monitorNotFound }: MonitorAddEditBreadcrumbOptions = {}
+) => {
   const kibana = useKibana();
   const appPath = kibana.services.application?.getUrlForApp(PLUGIN.SYNTHETICS_PLUGIN_ID) ?? '';
   const spaceId = useUrlSpaceId();
+  // Read from the URL; avoid hooks that write `locationId` back into it.
+  const { locationId, remoteName } = useGetUrlParams();
+  const { monitorId } = useParams<{ monitorId?: string }>();
   const monitor = useSelector(selectSyntheticsMonitor);
   const configId = monitor?.[ConfigKey.CONFIG_ID];
   const monitorName = monitor?.name;
@@ -31,9 +44,14 @@ export const useMonitorAddEditBreadcrumbs = (isEdit?: boolean) => {
     }
 
     const monitorsCrumb = { text: MONITORS_CRUMB, href: `${appPath}${MONITORS_ROUTE}` };
+
+    if (monitorNotFound) {
+      return [monitorsCrumb, { text: MONITOR_NOT_FOUND_TITLE }];
+    }
+
     const editCrumb = { text: EDIT_MONITOR_CRUMB };
 
-    if (!configId || !monitorName) {
+    if (!configId || !monitorName || configId !== monitorId) {
       return [monitorsCrumb, editCrumb];
     }
 
@@ -41,16 +59,30 @@ export const useMonitorAddEditBreadcrumbs = (isEdit?: boolean) => {
       monitorsCrumb,
       {
         text: monitorName,
-        href: `${appPath}${monitorDetailPath(configId)}${buildMonitorParamsSearch({ spaceId })}`,
+        href: `${appPath}${monitorDetailPath(configId)}${buildMonitorParamsSearch({
+          locationId,
+          spaceId,
+          remoteName,
+        })}`,
       },
       editCrumb,
     ];
-  }, [appPath, configId, isEdit, monitorName, spaceId]);
+  }, [
+    appPath,
+    configId,
+    isEdit,
+    locationId,
+    monitorId,
+    monitorName,
+    monitorNotFound,
+    remoteName,
+    spaceId,
+  ]);
 
   useBreadcrumbs(crumbs);
 };
 
-// The `?` belongs to the optional param token; leaving it behind collides with the query string.
+// Replace the full optional token (`:monitorId?`), otherwise `?` collides with the query string.
 const monitorDetailPath = (configId: string) => MONITOR_ROUTE.replace(':monitorId?', configId);
 
 const MONITORS_CRUMB = i18n.translate('xpack.synthetics.monitorsPage.monitorsMCrumb', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_alerts/monitor_detail_alerts.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_alerts/monitor_detail_alerts.tsx
@@ -15,6 +15,7 @@ import { useRefreshedRangeFromUrl } from '../../../hooks';
 import { SyntheticsDatePicker } from '../../common/date_picker/synthetics_date_picker';
 import { useSelectedLocation } from '../hooks/use_selected_location';
 import { useMonitorAttachmentConfig } from '../hooks/use_monitor_attachment_config';
+import { useMonitorDetailsPage } from '../use_monitor_details_page';
 
 export const MONITOR_ALERTS_TABLE_ID = 'xpack.synthetics.monitor.alertTable';
 
@@ -29,6 +30,11 @@ export function MonitorDetailsAlerts() {
 
   // Configure the agent builder flyout with the monitor details
   useMonitorAttachmentConfig();
+
+  const redirect = useMonitorDetailsPage();
+  if (redirect) {
+    return redirect;
+  }
 
   if (!selectedLocation) {
     return <EuiLoadingSpinner size="xl" />;

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_not_found_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_not_found_page.tsx
@@ -18,14 +18,19 @@ import { PLUGIN } from '../../../../../common/constants/plugin';
 import type { ClientPluginsStart } from '../../../../plugin';
 
 export const MonitorNotFoundPage: React.FC = () => {
+  useMonitorListBreadcrumbs([{ text: MONITOR_NOT_FOUND_TITLE }]);
+
+  return <MonitorNotFoundPrompt />;
+};
+
+// Kept separate so the edit route can render it without owning breadcrumbs.
+export const MonitorNotFoundPrompt: React.FC = () => {
   const { application } = useKibana<ClientPluginsStart>().services;
   const { monitorId } = useParams<{ monitorId: string }>();
 
-  useMonitorListBreadcrumbs([{ text: NOT_FOUND_TITLE }]);
-
   return (
     <NotFoundPrompt
-      title={NOT_FOUND_TITLE}
+      title={MONITOR_NOT_FOUND_TITLE}
       body={
         <FormattedMessage
           id="xpack.synthetics.prompt.errors.notFound.body"
@@ -52,6 +57,9 @@ export const MonitorNotFoundPage: React.FC = () => {
   );
 };
 
-const NOT_FOUND_TITLE = i18n.translate('xpack.synthetics.prompt.errors.notFound.title', {
-  defaultMessage: 'Monitor not found',
-});
+export const MONITOR_NOT_FOUND_TITLE = i18n.translate(
+  'xpack.synthetics.prompt.errors.notFound.title',
+  {
+    defaultMessage: 'Monitor not found',
+  }
+);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_not_found_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_not_found_page.tsx
@@ -13,12 +13,15 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useParams } from 'react-router-dom';
 import { CreateMonitorButton } from '../monitors_page/create_monitor_button';
+import { useMonitorListBreadcrumbs } from '../monitors_page/hooks/use_breadcrumbs';
 import { PLUGIN } from '../../../../../common/constants/plugin';
 import type { ClientPluginsStart } from '../../../../plugin';
 
 export const MonitorNotFoundPage: React.FC = () => {
   const { application } = useKibana<ClientPluginsStart>().services;
   const { monitorId } = useParams<{ monitorId: string }>();
+
+  useMonitorListBreadcrumbs([{ text: NOT_FOUND_TITLE }]);
 
   return (
     <NotFoundPrompt

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_not_found_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_not_found_page.tsx
@@ -23,7 +23,6 @@ export const MonitorNotFoundPage: React.FC = () => {
   return <MonitorNotFoundPrompt />;
 };
 
-// Kept separate so the edit route can render it without owning breadcrumbs.
 export const MonitorNotFoundPrompt: React.FC = () => {
   const { application } = useKibana<ClientPluginsStart>().services;
   const { monitorId } = useParams<{ monitorId: string }>();

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_details_breadcrumbs.ts
@@ -38,7 +38,7 @@ export const useStepDetailsBreadcrumbs = (extraCrumbs?: Array<{ text: string; hr
   useTestRunDetailsBreadcrumbs([
     {
       text: data ? moment(data.details?.timestamp).format('LLL') : '',
-      href: `${appPath}/${generatePath(TEST_RUN_DETAILS_ROUTE, params)}${testRunSearch}`,
+      href: `${appPath}${generatePath(TEST_RUN_DETAILS_ROUTE, params)}${testRunSearch}`,
     },
 
     {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
@@ -45,7 +45,7 @@ export const useTestRunDetailsBreadcrumbs = (
           {
             text: monitor?.name ?? '',
             href: `${appPath}${MONITOR_ROUTE.replace(
-              ':monitorId',
+              ':monitorId?',
               monitor?.[ConfigKey.CONFIG_ID] ?? ''
             )}${monitorSearch}`,
           },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_breadcrumbs.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_breadcrumbs.test.tsx
@@ -6,12 +6,13 @@
  */
 
 import { coreMock } from '@kbn/core/public/mocks';
+import { createMemoryHistory } from 'history';
 import type { ChromeBreadcrumb } from '@kbn/core/public';
 import { render } from '../utils/testing';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { Route } from '@kbn/shared-ux-router';
-import { OVERVIEW_ROUTE } from '../../../../common/constants';
+import { MONITORS_ROUTE, OVERVIEW_ROUTE } from '../../../../common/constants';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { SyntheticsUrlParams } from '../utils/url_params/get_supported_url_params';
 import { getSupportedUrlParams } from '../utils/url_params/get_supported_url_params';
@@ -21,21 +22,21 @@ import { BehaviorSubject } from 'rxjs';
 import type { ChromeStyle } from '@kbn/core-chrome-browser';
 
 describe('useBreadcrumbs', () => {
-  it('sets the given breadcrumbs', () => {
-    const [getBreadcrumbs, core] = mockCore();
+  const expectedCrumbs: ChromeBreadcrumb[] = [
+    {
+      text: 'Crumb: ',
+      'data-test-subj': 'http://href.example.net',
+      href: 'http://href.example.net',
+    },
+    {
+      text: 'Crumb II: Son of Crumb',
+      'data-test-subj': 'http://href2.example.net',
+      href: 'http://href2.example.net',
+    },
+  ];
 
-    const expectedCrumbs: ChromeBreadcrumb[] = [
-      {
-        text: 'Crumb: ',
-        'data-test-subj': 'http://href.example.net',
-        href: 'http://href.example.net',
-      },
-      {
-        text: 'Crumb II: Son of Crumb',
-        'data-test-subj': 'http://href2.example.net',
-        href: 'http://href2.example.net',
-      },
-    ];
+  const renderAtRoute = (route: string, url: string = route) => {
+    const [getBreadcrumbs, core] = mockCore();
 
     const Component = () => {
       useBreadcrumbs(expectedCrumbs);
@@ -50,7 +51,7 @@ describe('useBreadcrumbs', () => {
 
     render(
       <KibanaContextProvider services={{ ...core }}>
-        <Route path={OVERVIEW_ROUTE}>
+        <Route path={route}>
           <SyntheticsSettingsContext.Provider
             value={{
               darkMode: false,
@@ -68,8 +69,21 @@ describe('useBreadcrumbs', () => {
             <Component />
           </SyntheticsSettingsContext.Provider>
         </Route>
-      </KibanaContextProvider>
+      </KibanaContextProvider>,
+      { history: createMemoryHistory({ initialEntries: [url] }) }
     );
+
+    return getBreadcrumbs;
+  };
+
+  const getSyntheticsCrumb = (breadcrumbs: ChromeBreadcrumb[]) =>
+    breadcrumbs.find(
+      (crumb) =>
+        (crumb as { 'data-test-subj'?: string })['data-test-subj'] === 'syntheticsPathBreadcrumb'
+    );
+
+  it('sets the given breadcrumbs', () => {
+    const getBreadcrumbs = renderAtRoute(MONITORS_ROUTE);
 
     const urlParams: SyntheticsUrlParams = getSupportedUrlParams({});
     expect(JSON.stringify(getBreadcrumbs())).toEqual(
@@ -80,6 +94,24 @@ describe('useBreadcrumbs', () => {
         ].concat(expectedCrumbs)
       )
     );
+  });
+
+  it('does not link the Synthetics crumb on the app root, where it would point at the current page', () => {
+    const getBreadcrumbs = renderAtRoute(OVERVIEW_ROUTE);
+
+    const syntheticsCrumb = getSyntheticsCrumb(getBreadcrumbs());
+
+    expect(syntheticsCrumb).toBeDefined();
+    expect(syntheticsCrumb?.href).toBeUndefined();
+  });
+
+  it('does not link the Synthetics crumb when the root has an empty pathname', () => {
+    const getBreadcrumbs = renderAtRoute(OVERVIEW_ROUTE, '');
+
+    const syntheticsCrumb = getSyntheticsCrumb(getBreadcrumbs());
+
+    expect(syntheticsCrumb).toBeDefined();
+    expect(syntheticsCrumb?.href).toBeUndefined();
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_breadcrumbs.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_breadcrumbs.test.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { coreMock } from '@kbn/core/public/mocks';
 import { createMemoryHistory } from 'history';
 import type { ChromeBreadcrumb } from '@kbn/core/public';
 import { render } from '../utils/testing';
@@ -18,6 +17,8 @@ import type { SyntheticsUrlParams } from '../utils/url_params/get_supported_url_
 import { getSupportedUrlParams } from '../utils/url_params/get_supported_url_params';
 import { makeBaseBreadcrumb, useBreadcrumbs } from './use_breadcrumbs';
 import { SyntheticsSettingsContext } from '../contexts';
+import type { CoreStart } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
 import { BehaviorSubject } from 'rxjs';
 import type { ChromeStyle } from '@kbn/core-chrome-browser';
 
@@ -36,7 +37,7 @@ describe('useBreadcrumbs', () => {
   ];
 
   const renderAtRoute = (route: string, url: string = route) => {
-    const [getBreadcrumbs, core] = mockCore();
+    const { core, getBreadcrumbs } = createBreadcrumbsCore();
 
     const Component = () => {
       useBreadcrumbs(expectedCrumbs);
@@ -115,27 +116,28 @@ describe('useBreadcrumbs', () => {
   });
 });
 
-const mockCore: () => [() => ChromeBreadcrumb[], any] = () => {
+const createBreadcrumbsCore = (): {
+  core: Pick<CoreStart, 'application' | 'chrome'>;
+  getBreadcrumbs: () => ChromeBreadcrumb[];
+} => {
   let breadcrumbObj: ChromeBreadcrumb[] = [];
-  const get = () => {
-    return breadcrumbObj;
-  };
   const defaultCoreMock = coreMock.createStart();
 
-  const core = {
-    application: {
-      getUrlForApp: (app: string) =>
-        app === 'synthetics' ? '/app/synthetics' : '/app/observability',
-      navigateToUrl: jest.fn(),
-    },
-    chrome: {
-      ...defaultCoreMock.chrome,
-      getChromeStyle$: () => new BehaviorSubject<ChromeStyle>('classic').asObservable(),
-      setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => {
-        breadcrumbObj = newBreadcrumbs;
+  return {
+    getBreadcrumbs: () => breadcrumbObj,
+    core: {
+      application: {
+        getUrlForApp: (app: string) =>
+          app === 'synthetics' ? '/app/synthetics' : '/app/observability',
+        navigateToUrl: jest.fn(),
+      } as unknown as CoreStart['application'],
+      chrome: {
+        ...defaultCoreMock.chrome,
+        getChromeStyle$: () => new BehaviorSubject<ChromeStyle>('classic').asObservable(),
+        setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => {
+          breadcrumbObj = newBreadcrumbs;
+        },
       },
     },
   };
-
-  return [get, core];
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_breadcrumbs.ts
@@ -8,6 +8,7 @@
 import type { ChromeBreadcrumb } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import type { EuiBreadcrumb } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useBreadcrumbs as useObservabilityBreadcrumbs } from '@kbn/observability-shared-plugin/public';
@@ -15,13 +16,15 @@ import type { ClientPluginsStart } from '../../../plugin';
 import type { SyntheticsUrlParams } from '../utils/url_params';
 import { stringifyUrlParams } from '../utils/url_params';
 import { useUrlParams } from './use_url_params';
+import { OVERVIEW_ROUTE } from '../../../../common/constants';
 import { PLUGIN } from '../../../../common/constants/plugin';
 
 const EMPTY_QUERY = '?';
 
 export const makeBaseBreadcrumb = (
   uptimePath: string,
-  params?: SyntheticsUrlParams
+  params?: SyntheticsUrlParams,
+  options?: { isRootRoute?: boolean }
 ): EuiBreadcrumb[] => {
   if (params) {
     const crumbParams: Partial<SyntheticsUrlParams> = { ...params };
@@ -37,7 +40,8 @@ export const makeBaseBreadcrumb = (
     text: i18n.translate('xpack.synthetics.breadcrumbs.overviewBreadcrumbText', {
       defaultMessage: 'Synthetics',
     }),
-    href: uptimePath,
+    // A clickable crumb on the root turns into a back button pointing at the current page.
+    ...(options?.isRootRoute ? {} : { href: uptimePath }),
     'data-test-subj': 'syntheticsPathBreadcrumb',
   });
 
@@ -46,12 +50,15 @@ export const makeBaseBreadcrumb = (
 
 export const useBreadcrumbs = (extraCrumbs: ChromeBreadcrumb[]) => {
   const params = useUrlParams()[0]();
+  const { pathname } = useLocation();
   const kibana = useKibana<ClientPluginsStart>();
   const syntheticsPath =
     kibana.services.application?.getUrlForApp(PLUGIN.SYNTHETICS_PLUGIN_ID) ?? '';
+  // The scoped history reports the app root as '/' or '', depending on how the URL was entered.
+  const isRootRoute = pathname === OVERVIEW_ROUTE || pathname === '';
   const breadcrumbs = useMemo(() => {
-    return makeBaseBreadcrumb(syntheticsPath, params).concat(extraCrumbs);
-  }, [extraCrumbs, params, syntheticsPath]);
+    return makeBaseBreadcrumb(syntheticsPath, params, { isRootRoute }).concat(extraCrumbs);
+  }, [extraCrumbs, isRootRoute, params, syntheticsPath]);
 
   useObservabilityBreadcrumbs(breadcrumbs, { serverless: kibana.services.serverless });
 };


### PR DESCRIPTION
Closes: #283103

## Summary

Fixes back navigation in Synthetics when `core.chrome.next` is enabled in solution view.

Synthetics has not migrated to `AppHeader`, so it gets the compatibility header, which
derives its back button from the breadcrumb trail the app registers. Our trails were
written for the classic breadcrumb bar, where the last crumb renders as plain text and
its `href` is never used. Once the trail started driving a real navigation control, three
problems surfaced.

**The back button on Overview pointed at the page you were already on.** It did not show
up on a clean load, but as soon as the URL carried state — after picking a date range, or
by opening a shared link — a "Back to Synthetics" button appeared and clicking it left you
exactly where you were. The root crumb was always clickable, and core only suppresses the
button when the crumb URL matches the current one exactly, query string included.

**Pages ended up with two stacked back controls.** Synthetics already had its own in-page
back link, and the new arrow does not replace it, it sits above it. On monitor detail both
led to the same place, so it was just redundant. On Edit monitor they disagreed: the
in-page link went back to the monitor you were editing, the arrow went to the Synthetics
root, and the monitor was not even in the arrow's menu.

**Monitor not found had no back target at all.** It never registered chrome breadcrumbs,
so once the in-page link is hidden the page has no way back other than the browser button.

## Changes

| Page | Before | After |
|---|---|---|
| Overview | Back button pointing at the current page whenever the URL had parameters | No back button |
| Monitor detail, History, Errors, Alerts | Header arrow plus an in-page `‹ Monitors` link | Header arrow only |
| Edit monitor | Arrow to the Synthetics root, in-page link to the monitor | Arrow to the monitor, then Monitors, then Synthetics |
| Monitor not found | No chrome trail | Arrow to Monitors |
| Test run details, Step details | Header arrow plus an in-page link | Header arrow only |

## Also fixed

Two malformed breadcrumb URLs found while sweeping the routes in the browser. Both are
pre-existing and were harmless in the classic bar, since these hrefs were never followed.

- `use_test_run_details_breadcrumbs.ts` replaced `:monitorId` in a route constant that is
  actually `/monitor/:monitorId?`, leaving the trailing `?` in place. Concatenating the
  query string then produced `/monitor/<id>??locationId=...`, and `locationId` was lost
  because the parameter ended up named `?locationId`. This hook is also reused by Step
  details and Error details, so the fix covers three pages.
- `use_step_details_breadcrumbs.ts` prefixed `generatePath()` with a slash, but the result
  already starts with one, producing `/app/synthetics//monitor/...`.

## Videos

Before/after clips (Chrome Next, solution view).

Overview self-back loop

Before

https://github.com/user-attachments/assets/65a115e0-48d7-4866-ac2f-c37e29832c56

After

https://github.com/user-attachments/assets/d9e8e153-9b06-4a27-a001-33cd01c414cd

Alerts tab back disappears on reload

Before

https://github.com/user-attachments/assets/a196dc7f-bd80-409e-8c2f-d7fb353b2036

After

https://github.com/user-attachments/assets/5f185b39-b057-45e3-a2ee-2828d7d8aa11

Edit monitor back skips the monitor being edited

Before

https://github.com/user-attachments/assets/dcf136c4-826a-4c49-8ffc-40ce78728cb5

After

https://github.com/user-attachments/assets/116fe01b-6155-4c8f-9f7d-a8f9af254694

Duplicate back controls (header back + in-page `‹ Monitors`)

After

https://github.com/user-attachments/assets/dbb5ac10-2c55-4439-9198-b80d2b03489f

## Testing

To reproduce locally:

```yaml
# config/kibana.dev.yml
feature_flags.overrides:
  core.chrome.next: true
```

with the space set to the Observability solution. The devbar toggle can be used to flip
the flag per session and compare both shells.

--- 

## Classic view

Classic view keeps the breadcrumb bar, so nothing here is meant to change for it. The
in-page links are only dropped when the new header actually renders a back button, and the
richer trails are equally valid in the bar. Swept in a classic space to confirm:

| Page | Trail in classic |
|---|---|
| Overview | `Observability > Synthetics > Overview`, with `Synthetics` now plain text instead of a link to the page you are on |
| Monitor detail | `Observability > Synthetics > Monitors > Google Homepage`, in-page `‹ Monitors` link still rendered |
| Edit monitor | `Observability > Synthetics > Monitors > Google Homepage > Edit monitor`, the monitor crumb navigates to it |
| Monitor not found | `Observability > Synthetics > Monitors > Monitor not found` |
| Test run details | Monitor crumb resolves to `/monitor/<id>?locationId=...`, previously `??locationId=...` |

Breadcrumb bar and in-page links intact

https://github.com/user-attachments/assets/a97793b5-8c9e-4262-aee4-b6860b6ceb50

Edit monitor trail names the monitor

https://github.com/user-attachments/assets/c3bbcf81-c703-4fce-97c0-a084bfcd05cf

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



