### PR TITLE
[9.5] [Lens as code] Fix duration `format` schema  (#282815)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -77495,6 +77495,12 @@ components:
       additionalProperties: false
       description: Duration format between time units.
       properties:
+        compact:
+          description: When `true`, uses short unit suffixes (for example, `ms` instead of `Milliseconds`). Defaults to `true`. Ignored for `auto-approximate`.
+          type: boolean
+        decimals:
+          description: Number of decimal places to display. Defaults to `0`. Ignored for `auto-approximate`.
+          type: number
         from:
           description: Source time unit of the raw field value, including fine-grained units (`ps`, `ns`, `us`) in addition to standard units. This describes how the stored data is encoded, not a query duration literal.
           enum:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -90569,6 +90569,12 @@ components:
       additionalProperties: false
       description: Duration format between time units.
       properties:
+        compact:
+          description: When `true`, uses short unit suffixes (for example, `ms` instead of `Milliseconds`). Defaults to `true`. Ignored for `auto-approximate`.
+          type: boolean
+        decimals:
+          description: Number of decimal places to display. Defaults to `0`. Ignored for `auto-approximate`.
+          type: number
         from:
           description: Source time unit of the raw field value, including fine-grained units (`ps`, `ns`, `us`) in addition to standard units. This describes how the stored data is encoded, not a query duration literal.
           enum:

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/constants.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/constants.ts
@@ -20,6 +20,9 @@ export const LENS_TERMS_MISSING_BUCKET_DEFAULT = false;
 export const LENS_FORMAT_NUMBER_DECIMALS_DEFAULT = 2;
 export const LENS_FORMAT_COMPACT_DEFAULT = false;
 
+export const LENS_FORMAT_DURATION_DECIMALS_DEFAULT = 0;
+export const LENS_FORMAT_DURATION_COMPACT_DEFAULT = true;
+
 /** Default source unit in Lens as code API (`from`). */
 export const LENS_DURATION_API_INPUT_UNIT_DEFAULT = 's';
 /** Default display unit in Lens as code API (`to`). */

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/duration_units.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/duration_units.test.ts
@@ -15,13 +15,14 @@ type LegacyDurationFormat = TypeOf<typeof legacyDurationFormatSchema>;
 
 describe('Duration unit schemas', () => {
   describe('durationFormatSchema (GA)', () => {
-    it('validates fine-grained input units', () => {
+    it('validates fine-grained input units without inventing decimals/compact', () => {
       const input = {
         type: 'duration',
         from: 'us',
         to: 'auto-approximate',
       } satisfies DurationFormat;
 
+      // Approximate: decimals/compact are optional and must stay absent (transform omits them).
       expect(durationFormatSchema.validate(input)).toEqual(input);
     });
 
@@ -32,6 +33,7 @@ describe('Duration unit schemas', () => {
         to: 'auto',
       } satisfies DurationFormat;
 
+      // Precise: schema does not default; complete-out is the transform's job.
       expect(durationFormatSchema.validate(input)).toEqual(input);
     });
 
@@ -40,6 +42,30 @@ describe('Duration unit schemas', () => {
         type: 'duration',
         from: 'mo',
         to: 'auto',
+      } satisfies DurationFormat;
+
+      expect(durationFormatSchema.validate(input)).toEqual(input);
+    });
+
+    it('preserves explicit decimals and compact', () => {
+      const input = {
+        type: 'duration',
+        from: 'ms',
+        to: 'auto',
+        decimals: 0,
+        compact: true,
+      } satisfies DurationFormat;
+
+      expect(durationFormatSchema.validate(input)).toEqual(input);
+    });
+
+    it('accepts decimals/compact on approximate without requiring them', () => {
+      const input = {
+        type: 'duration',
+        from: 's',
+        to: 'auto-approximate',
+        decimals: 7,
+        compact: true,
       } satisfies DurationFormat;
 
       expect(durationFormatSchema.validate(input)).toEqual(input);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/duration_units.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/duration_units.ts
@@ -42,6 +42,23 @@ const durationFormatSuffixSchema = schema.maybe(
     },
   })
 );
+const durationFormatDecimalsSchema = schema.maybe(
+  schema.number({
+    meta: {
+      description:
+        'Number of decimal places to display. Defaults to `0`. Ignored for `auto-approximate`.',
+    },
+  })
+);
+
+const durationFormatCompactSchema = schema.maybe(
+  schema.boolean({
+    meta: {
+      description:
+        'When `true`, uses short unit suffixes (for example, `ms` instead of `Milliseconds`). Defaults to `true`. Ignored for `auto-approximate`.',
+    },
+  })
+);
 
 export const durationFormatSchema = schema.object(
   {
@@ -58,6 +75,8 @@ export const durationFormatSchema = schema.object(
           'Display time unit: `auto` (precise), `auto-approximate`, or a fixed conversion unit.',
       },
     }),
+    decimals: durationFormatDecimalsSchema,
+    compact: durationFormatCompactSchema,
     suffix: durationFormatSuffixSchema,
   },
   {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/format.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/format.test.ts
@@ -105,9 +105,29 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            decimals: 0,
+            compact: true,
             fromUnit: 'milliseconds',
             toUnit: 'asSeconds',
+          },
+        });
+      });
+
+      it('should preserve explicit decimals and compact', () => {
+        const input = {
+          type: 'duration',
+          from: 'ms',
+          to: 'auto',
+          decimals: 3,
+          compact: false,
+        } satisfies ApiFormat;
+        expect(fromFormatAPIToLensState(input)).toEqual({
+          id: 'duration',
+          params: {
+            decimals: 3,
+            fromUnit: 'milliseconds',
+            toUnit: 'humanizePrecise',
+            compact: false,
           },
         });
       });
@@ -122,7 +142,8 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            decimals: 0,
+            compact: true,
             fromUnit: 'milliseconds',
             toUnit: 'asSeconds',
             suffix: ' elapsed',
@@ -130,16 +151,19 @@ describe('Format Transforms', () => {
         });
       });
 
-      it('should transform `auto-approximate` to humanize Lens state', () => {
+      it('should transform `auto-approximate` to humanize, ignoring input decimals/compact', () => {
         const input = {
           type: 'duration',
           from: 's',
           to: 'auto-approximate',
+          decimals: 7,
+          compact: true,
         } satisfies ApiFormat;
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            // ValueFormatConfig requires decimals; use shared default (ignored at render).
+            decimals: 0,
             fromUnit: 'seconds',
             toUnit: 'humanize',
           },
@@ -155,7 +179,8 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            decimals: 0,
+            compact: true,
             fromUnit: 'milliseconds',
             toUnit: 'humanizePrecise',
           },
@@ -171,7 +196,7 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            decimals: 0,
             fromUnit: 'minutes',
             toUnit: 'humanize',
           },
@@ -187,7 +212,8 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            decimals: 0,
+            compact: true,
             fromUnit: 'microseconds',
             toUnit: 'asMilliseconds',
           },
@@ -205,7 +231,7 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            decimals: 0,
             fromUnit: 'minutes',
             toUnit: 'humanize',
           },
@@ -221,7 +247,8 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            decimals: 0,
+            compact: true,
             fromUnit: 'milliseconds',
             toUnit: 'humanizePrecise',
           },
@@ -237,7 +264,8 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'duration',
           params: {
-            decimals: 2,
+            decimals: 0,
+            compact: true,
             fromUnit: 'milliseconds',
             toUnit: 'asMinutes',
           },
@@ -254,7 +282,7 @@ describe('Format Transforms', () => {
         expect(fromFormatAPIToLensState(input)).toEqual({
           id: 'custom',
           params: {
-            decimals: 2,
+            decimals: 0,
             pattern: '$0,0.00',
           },
         });
@@ -333,11 +361,32 @@ describe('Format Transforms', () => {
           type: 'duration',
           from: 'ms',
           to: 's',
+          decimals: 2,
+          compact: true,
           suffix: ' elapsed',
         });
       });
 
-      it('should apply defaults when duration units are missing', () => {
+      it('should preserve decimals and compact for precise output units', () => {
+        const input = {
+          id: 'duration',
+          params: {
+            decimals: 0,
+            compact: true,
+            fromUnit: 'milliseconds',
+            toUnit: 'humanizePrecise',
+          },
+        } satisfies ValueFormatConfig;
+        expect(fromFormatLensStateToAPI(input)).toEqual({
+          type: 'duration',
+          from: 'ms',
+          to: 'auto',
+          decimals: 0,
+          compact: true,
+        });
+      });
+
+      it('should omit decimals/compact when output defaults to approximate', () => {
         const input = {
           id: 'duration',
           params: {
@@ -352,7 +401,7 @@ describe('Format Transforms', () => {
         });
       });
 
-      it('should convert Lens `humanize` state to `auto-approximate`', () => {
+      it('should convert Lens `humanize` state to `auto-approximate` without decimals/compact', () => {
         const input = {
           id: 'duration',
           params: {
@@ -369,7 +418,7 @@ describe('Format Transforms', () => {
         });
       });
 
-      it('should convert Lens `humanizePrecise` state to `auto`', () => {
+      it('should convert Lens `humanizePrecise` state to `auto` with complete-out compact', () => {
         const input = {
           id: 'duration',
           params: {
@@ -382,6 +431,8 @@ describe('Format Transforms', () => {
           type: 'duration',
           from: 'ms',
           to: 'auto',
+          decimals: 2,
+          compact: true,
         });
       });
 
@@ -398,6 +449,8 @@ describe('Format Transforms', () => {
           type: 'duration',
           from: 'min',
           to: 'min',
+          decimals: 2,
+          compact: true,
         });
       });
 
@@ -409,45 +462,41 @@ describe('Format Transforms', () => {
             toUnit: 'humanizePrecise',
           },
         } satisfies ValueFormatConfig;
+        // Explicit decimals:0 preserved; missing compact → editor default true.
         expect(fromFormatLensStateToAPI(input)).toEqual({
           type: 'duration',
           from: 's',
           to: 'auto',
+          decimals: 0,
+          compact: true,
         });
       });
 
-      it('should round-trip GA duration formats', () => {
-        const apiFormat = {
+      it('should preserve editor-persisted decimals 0 and compact true', () => {
+        const input = {
+          id: 'duration',
+          params: {
+            decimals: 0,
+            compact: true,
+            fromUnit: 'milliseconds',
+            toUnit: 'humanizePrecise',
+          },
+        } satisfies ValueFormatConfig;
+        expect(fromFormatLensStateToAPI(input)).toEqual({
           type: 'duration',
-          from: 's',
+          from: 'ms',
           to: 'auto',
-        } satisfies ApiFormat;
-        const lensFormat = fromFormatAPIToLensState(apiFormat);
-        expect(fromFormatLensStateToAPI(lensFormat)).toEqual(apiFormat);
-      });
-
-      it('should normalize legacy input to GA output on round-trip', () => {
-        // Legacy input uses pre-GA names; output always uses GA enum names
-        const legacyApiFormat = {
-          type: 'duration',
-          from: 'm',
-          to: 'humanize',
-        } satisfies ApiFormat;
-        const lensFormat = fromFormatAPIToLensState(legacyApiFormat);
-        expect(fromFormatLensStateToAPI(lensFormat)).toEqual({
-          type: 'duration',
-          from: 'min',
-          to: 'auto-approximate',
+          decimals: 0,
+          compact: true,
         });
       });
     });
-
     describe('custom format', () => {
       it('should transform custom format', () => {
         const input = {
           id: 'custom',
           params: {
-            decimals: 2,
+            decimals: 0,
             pattern: '$0,0.00',
           },
         } satisfies ValueFormatConfig;
@@ -455,6 +504,45 @@ describe('Format Transforms', () => {
           type: 'custom',
           pattern: '$0,0.00',
         });
+      });
+    });
+  });
+
+  describe('roundtrip', () => {
+    it('should round-trip GA duration formats including decimals and compact', () => {
+      const apiFormat = {
+        type: 'duration',
+        from: 's',
+        to: 'auto',
+        decimals: 3,
+        compact: true,
+      } satisfies ApiFormat;
+      const lensFormat = fromFormatAPIToLensState(apiFormat);
+      expect(fromFormatLensStateToAPI(lensFormat)).toEqual(apiFormat);
+    });
+
+    it('should round-trip approximate without decimals/compact', () => {
+      const apiFormat = {
+        type: 'duration',
+        from: 's',
+        to: 'auto-approximate',
+      } satisfies ApiFormat;
+      const lensFormat = fromFormatAPIToLensState(apiFormat);
+      expect(fromFormatLensStateToAPI(lensFormat)).toEqual(apiFormat);
+    });
+
+    it('should normalize legacy input to GA output on round-trip', () => {
+      // Legacy input uses pre-GA names; output always uses GA enum names
+      const legacyApiFormat = {
+        type: 'duration',
+        from: 'm',
+        to: 'humanize',
+      } satisfies ApiFormat;
+      const lensFormat = fromFormatAPIToLensState(legacyApiFormat);
+      expect(fromFormatLensStateToAPI(lensFormat)).toEqual({
+        type: 'duration',
+        from: 'min',
+        to: 'auto-approximate',
       });
     });
   });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/format.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/format.ts
@@ -9,7 +9,16 @@
 
 import type { ValueFormatConfig } from '@kbn/lens-common';
 import type { LensApiMetricOperation } from '../../schema/metric_ops';
+import {
+  LENS_FORMAT_DURATION_COMPACT_DEFAULT,
+  LENS_FORMAT_DURATION_DECIMALS_DEFAULT,
+} from '../../schema/constants';
 import { durationInputUnitCompat, durationOutputUnitCompat } from './duration_units';
+
+/** Approximate duration output ignores decimals/compact (UI hides them; formatter does not use them). */
+function isApproximateDurationApiTo(to: string): boolean {
+  return to === 'auto-approximate';
+}
 
 export function fromFormatAPIToLensState(
   format: LensApiMetricOperation['format']
@@ -37,14 +46,27 @@ export function fromFormatAPIToLensState(
     };
   }
   if (format.type === 'duration') {
+    const toUnit = durationOutputUnitCompat.toState(format.to);
+    // GA `auto-approximate` and legacy `humanize` both map to Lens `humanize`.
+    const approximate = toUnit === 'humanize' || isApproximateDurationApiTo(format.to);
+    // Legacy duration schema has no `decimals`/`compact`; narrow with `in` before reading.
+    const decimals = 'decimals' in format ? format.decimals : undefined;
+    const compact = 'compact' in format ? format.compact : undefined;
+    const suffix = format.suffix ? { suffix: format.suffix } : {};
+    const fromUnit = durationInputUnitCompat.toState(format.from);
+
+    // Approximate: ignore input decimals/compact (not configurable). `decimals` is only
+    // required by ValueFormatConfig; use the shared default. SO→API omits both.
     return {
       id: format.type,
       params: {
-        // doesn't matter, it's will be ignored but want to make TS happy
-        decimals: 2,
-        fromUnit: durationInputUnitCompat.toState(format.from),
-        toUnit: durationOutputUnitCompat.toState(format.to),
-        ...(format.suffix ? { suffix: format.suffix } : {}),
+        decimals: approximate
+          ? LENS_FORMAT_DURATION_DECIMALS_DEFAULT
+          : decimals ?? LENS_FORMAT_DURATION_DECIMALS_DEFAULT,
+        ...(!approximate ? { compact: compact ?? LENS_FORMAT_DURATION_COMPACT_DEFAULT } : {}),
+        fromUnit,
+        toUnit,
+        ...suffix,
       },
     };
   }
@@ -53,7 +75,7 @@ export function fromFormatAPIToLensState(
       id: format.type,
       params: {
         // doesn't matter, it's will be ignored but want to make TS happy
-        decimals: 2,
+        decimals: 0, // match runtime default
         pattern: format.pattern,
       },
     };
@@ -82,10 +104,19 @@ export function fromFormatLensStateToAPI(
     } as LensApiMetricOperation['format'];
   }
   if (format.id === 'duration') {
+    const to = durationOutputUnitCompat.toAPI(format.params?.toUnit);
+    const approximate = isApproximateDurationApiTo(to);
     return {
       type: format.id,
       from: durationInputUnitCompat.toAPI(format.params?.fromUnit),
-      to: durationOutputUnitCompat.toAPI(format.params?.toUnit),
+      to,
+      // Approximate: omit decimals/compact — not configurable and ignored at render.
+      ...(!approximate
+        ? {
+            decimals: format.params?.decimals ?? LENS_FORMAT_DURATION_DECIMALS_DEFAULT,
+            compact: format.params?.compact ?? LENS_FORMAT_DURATION_COMPACT_DEFAULT,
+          }
+        : {}),
       ...(format.params?.suffix ? { suffix: format.params.suffix } : {}),
     };
   }

--- a/x-pack/platform/plugins/shared/lens/common/transforms/ga_schema_validator.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/ga_schema_validator.test.ts
@@ -102,6 +102,24 @@ describe('toLegacyDurationUnits', () => {
     });
   });
 
+  it('strips GA-only `decimals`/`compact` from duration formats (not in the legacy schema)', () => {
+    expect(
+      toLegacyDurationUnits({
+        type: 'duration',
+        from: 'ms',
+        to: 'auto',
+        decimals: 0,
+        compact: true,
+        suffix: ' elapsed',
+      })
+    ).toEqual({
+      type: 'duration',
+      from: 'milliseconds',
+      to: 'humanizePrecise',
+      suffix: ' elapsed',
+    });
+  });
+
   it('leaves non-duration values unchanged', () => {
     expect(toLegacyDurationUnits({ type: 'number', decimals: 2 })).toEqual({
       type: 'number',

--- a/x-pack/platform/plugins/shared/lens/common/transforms/ga_schema_validator.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/ga_schema_validator.ts
@@ -84,8 +84,12 @@ export const toLegacyDurationUnits = <T>(value: T): T => {
   const obj = value as Record<string, unknown>;
 
   if (obj.type === 'duration') {
+    // `decimals`/`compact` are a GA-only addition to the duration format. The deprecated legacy schema
+    // (`legacyDurationFormatSchema`) does not allow them, so leaving them might make the same body fail
+    // request validation.
+    const { decimals, compact, ...rest } = obj;
     return {
-      ...obj,
+      ...rest,
       ...(typeof obj.from === 'string' ? { from: gaDurationInputUnitToLegacyApi(obj.from) } : {}),
       ...(typeof obj.to === 'string' ? { to: gaDurationOutputUnitToLegacyApi(obj.to) } : {}),
     } as unknown as T;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Lens as code] Fix duration `format` schema  (#282815)](https://github.com/elastic/kibana/pull/282815)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"andreana.malama@elastic.co"},"sourceCommit":{"committedDate":"2026-08-06T06:52:38Z","message":"[Lens as code] Fix duration `format` schema  (#282815)\n\nPart of #282534\n\n## Summary\n\nDuration formats did not round-trip `decimals` / `compact`. \n\nThe `humanize` (`auto-approximate`) path indeed ignores them:\n\n<img width=\"430\" height=\"149\" alt=\"Screenshot 2026-08-05 at 12 52 40 PM\"\nsrc=\"https://github.com/user-attachments/assets/2bdac8da-eaa8-4d77-81c9-69389a5235e8\"\n/>\n\nBut the `humanizePrecise` and all the fixed units (`asSeconds`, …) honor\nboth and as a result they should round-trip.\n\n<img width=\"446\" height=\"211\" alt=\"Screenshot 2026-08-05 at 12 52 51 PM\"\nsrc=\"https://github.com/user-attachments/assets/75dc2154-ffd8-4216-8b03-88158d32dee6\"\n/>\n\nSchema/transform now support them with editor-aligned defaults, and omit\nthem for `approximate` output so dashboard schema `parse` cannot default\nunused keys.\n\n## Changes\n\n- Duration format:\n- Schema: optional `decimals` / `compact` on duration (no Zod\n`.default()` — avoids inventing fields on `auto-approximate` via\ndashboard parse-and-replace).\n- Transform complete-out when `to` is not `auto-approximate` (SO\n`humanize`): defaults match Lens editor: `decimals: 0, compact: true`\nexplicit values round-trip\n- When `to` is `auto-approximate`: ignore input `decimals`/`compact`\nAPI→SO and omit both SO→API.\n- GA→legacy validator strips `decimals`/`compact` (not in legacy\nduration schema).\n\n- Custom format:\n- `decimals` set to 0 (runtime default - does not affect rendering but\nhelps with the round-trip of SOs)\n\n_This is not a breaking change_: existing `{ type, from, to }` payloads\nstill validate and the new fields are optional.\n- `auto-approximate` responses stay lean (no invented\n`decimals`/`compact`).\n- Precise/fixed responses may now include complete-out defaults.\n\n## Release Notes \nFixed Lens as-code `duration` format round-trip for `decimals` and\n`compact` when `to` is not `auto-approximate`.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore:\n<img width=\"2544\" height=\"1199\" alt=\"Screenshot 2026-08-05 at 12 56\n57 PM\"\nsrc=\"https://github.com/user-attachments/assets/5134ad74-bc4f-4428-953d-e0af08282e4c\"\n/>\n\n\nAfter:\n<img width=\"2550\" height=\"1196\" alt=\"Screenshot 2026-08-05 at 12 43\n20 PM\"\nsrc=\"https://github.com/user-attachments/assets/c28bab7c-4834-425d-908a-2458b2bc93a8\"\n/>\n\n## Dashboard SO to use for transformation Testing\n\n\n[duration_format_dashboard.ndjson.zip](https://github.com/user-attachments/files/30739030/duration_format_dashboard.ndjson.zip)\n\n## Request to use for API Testing\n```\nPOST kbn:/api/dashboards\n{\n  \"title\": \"Duration format matrix\",\n  \"panels\": [\n    {\n      \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto-approximate without decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"s\",\n              \"to\": \"auto-approximate\"\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 0, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto-approximate with decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"s\",\n              \"to\": \"auto-approximate\",\n              \"decimals\": 4,\n              \"compact\": true\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 0, \"y\": 8, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto without decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"ms\",\n              \"to\": \"auto\"\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 8, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto with decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"ms\",\n              \"to\": \"auto\",\n              \"decimals\": 5,\n              \"compact\": false\n            }\n          }\n        ]\n      }\n    }\n  ]\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6c1d09d8f47c62672d1a002986f600b255df4510","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:version","v9.6.0","v9.5.1"],"title":"[Lens as code] Fix duration `format` schema ","number":282815,"url":"https://github.com/elastic/kibana/pull/282815","mergeCommit":{"message":"[Lens as code] Fix duration `format` schema  (#282815)\n\nPart of #282534\n\n## Summary\n\nDuration formats did not round-trip `decimals` / `compact`. \n\nThe `humanize` (`auto-approximate`) path indeed ignores them:\n\n<img width=\"430\" height=\"149\" alt=\"Screenshot 2026-08-05 at 12 52 40 PM\"\nsrc=\"https://github.com/user-attachments/assets/2bdac8da-eaa8-4d77-81c9-69389a5235e8\"\n/>\n\nBut the `humanizePrecise` and all the fixed units (`asSeconds`, …) honor\nboth and as a result they should round-trip.\n\n<img width=\"446\" height=\"211\" alt=\"Screenshot 2026-08-05 at 12 52 51 PM\"\nsrc=\"https://github.com/user-attachments/assets/75dc2154-ffd8-4216-8b03-88158d32dee6\"\n/>\n\nSchema/transform now support them with editor-aligned defaults, and omit\nthem for `approximate` output so dashboard schema `parse` cannot default\nunused keys.\n\n## Changes\n\n- Duration format:\n- Schema: optional `decimals` / `compact` on duration (no Zod\n`.default()` — avoids inventing fields on `auto-approximate` via\ndashboard parse-and-replace).\n- Transform complete-out when `to` is not `auto-approximate` (SO\n`humanize`): defaults match Lens editor: `decimals: 0, compact: true`\nexplicit values round-trip\n- When `to` is `auto-approximate`: ignore input `decimals`/`compact`\nAPI→SO and omit both SO→API.\n- GA→legacy validator strips `decimals`/`compact` (not in legacy\nduration schema).\n\n- Custom format:\n- `decimals` set to 0 (runtime default - does not affect rendering but\nhelps with the round-trip of SOs)\n\n_This is not a breaking change_: existing `{ type, from, to }` payloads\nstill validate and the new fields are optional.\n- `auto-approximate` responses stay lean (no invented\n`decimals`/`compact`).\n- Precise/fixed responses may now include complete-out defaults.\n\n## Release Notes \nFixed Lens as-code `duration` format round-trip for `decimals` and\n`compact` when `to` is not `auto-approximate`.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore:\n<img width=\"2544\" height=\"1199\" alt=\"Screenshot 2026-08-05 at 12 56\n57 PM\"\nsrc=\"https://github.com/user-attachments/assets/5134ad74-bc4f-4428-953d-e0af08282e4c\"\n/>\n\n\nAfter:\n<img width=\"2550\" height=\"1196\" alt=\"Screenshot 2026-08-05 at 12 43\n20 PM\"\nsrc=\"https://github.com/user-attachments/assets/c28bab7c-4834-425d-908a-2458b2bc93a8\"\n/>\n\n## Dashboard SO to use for transformation Testing\n\n\n[duration_format_dashboard.ndjson.zip](https://github.com/user-attachments/files/30739030/duration_format_dashboard.ndjson.zip)\n\n## Request to use for API Testing\n```\nPOST kbn:/api/dashboards\n{\n  \"title\": \"Duration format matrix\",\n  \"panels\": [\n    {\n      \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto-approximate without decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"s\",\n              \"to\": \"auto-approximate\"\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 0, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto-approximate with decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"s\",\n              \"to\": \"auto-approximate\",\n              \"decimals\": 4,\n              \"compact\": true\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 0, \"y\": 8, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto without decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"ms\",\n              \"to\": \"auto\"\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 8, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto with decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"ms\",\n              \"to\": \"auto\",\n              \"decimals\": 5,\n              \"compact\": false\n            }\n          }\n        ]\n      }\n    }\n  ]\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6c1d09d8f47c62672d1a002986f600b255df4510"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282815","number":282815,"mergeCommit":{"message":"[Lens as code] Fix duration `format` schema  (#282815)\n\nPart of #282534\n\n## Summary\n\nDuration formats did not round-trip `decimals` / `compact`. \n\nThe `humanize` (`auto-approximate`) path indeed ignores them:\n\n<img width=\"430\" height=\"149\" alt=\"Screenshot 2026-08-05 at 12 52 40 PM\"\nsrc=\"https://github.com/user-attachments/assets/2bdac8da-eaa8-4d77-81c9-69389a5235e8\"\n/>\n\nBut the `humanizePrecise` and all the fixed units (`asSeconds`, …) honor\nboth and as a result they should round-trip.\n\n<img width=\"446\" height=\"211\" alt=\"Screenshot 2026-08-05 at 12 52 51 PM\"\nsrc=\"https://github.com/user-attachments/assets/75dc2154-ffd8-4216-8b03-88158d32dee6\"\n/>\n\nSchema/transform now support them with editor-aligned defaults, and omit\nthem for `approximate` output so dashboard schema `parse` cannot default\nunused keys.\n\n## Changes\n\n- Duration format:\n- Schema: optional `decimals` / `compact` on duration (no Zod\n`.default()` — avoids inventing fields on `auto-approximate` via\ndashboard parse-and-replace).\n- Transform complete-out when `to` is not `auto-approximate` (SO\n`humanize`): defaults match Lens editor: `decimals: 0, compact: true`\nexplicit values round-trip\n- When `to` is `auto-approximate`: ignore input `decimals`/`compact`\nAPI→SO and omit both SO→API.\n- GA→legacy validator strips `decimals`/`compact` (not in legacy\nduration schema).\n\n- Custom format:\n- `decimals` set to 0 (runtime default - does not affect rendering but\nhelps with the round-trip of SOs)\n\n_This is not a breaking change_: existing `{ type, from, to }` payloads\nstill validate and the new fields are optional.\n- `auto-approximate` responses stay lean (no invented\n`decimals`/`compact`).\n- Precise/fixed responses may now include complete-out defaults.\n\n## Release Notes \nFixed Lens as-code `duration` format round-trip for `decimals` and\n`compact` when `to` is not `auto-approximate`.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore:\n<img width=\"2544\" height=\"1199\" alt=\"Screenshot 2026-08-05 at 12 56\n57 PM\"\nsrc=\"https://github.com/user-attachments/assets/5134ad74-bc4f-4428-953d-e0af08282e4c\"\n/>\n\n\nAfter:\n<img width=\"2550\" height=\"1196\" alt=\"Screenshot 2026-08-05 at 12 43\n20 PM\"\nsrc=\"https://github.com/user-attachments/assets/c28bab7c-4834-425d-908a-2458b2bc93a8\"\n/>\n\n## Dashboard SO to use for transformation Testing\n\n\n[duration_format_dashboard.ndjson.zip](https://github.com/user-attachments/files/30739030/duration_format_dashboard.ndjson.zip)\n\n## Request to use for API Testing\n```\nPOST kbn:/api/dashboards\n{\n  \"title\": \"Duration format matrix\",\n  \"panels\": [\n    {\n      \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto-approximate without decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"s\",\n              \"to\": \"auto-approximate\"\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 0, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto-approximate with decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"s\",\n              \"to\": \"auto-approximate\",\n              \"decimals\": 4,\n              \"compact\": true\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 0, \"y\": 8, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto without decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"ms\",\n              \"to\": \"auto\"\n            }\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 8, \"w\": 24, \"h\": 8 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"metric\",\n        \"title\": \"Duration to auto with decimals/compact\",\n        \"data_source\": {\n          \"type\": \"data_view_spec\",\n          \"index_pattern\": \"kibana_sample_data_logs\",\n          \"time_field\": \"timestamp\"\n        },\n        \"metrics\": [\n          {\n            \"type\": \"primary\",\n            \"operation\": \"average\",\n            \"field\": \"bytes\",\n            \"format\": {\n              \"type\": \"duration\",\n              \"from\": \"ms\",\n              \"to\": \"auto\",\n              \"decimals\": 5,\n              \"compact\": false\n            }\n          }\n        ]\n      }\n    }\n  ]\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6c1d09d8f47c62672d1a002986f600b255df4510"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->