### PR TITLE
[8.19] [js-yaml to yaml migration] @elastic/appex-qa (#282904)

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -40,11 +40,6 @@ const exactFilePathMatcher = (relativePath) =>
  */
 const JS_YAML_LEGACY_CONSUMERS = [
   'src/platform/packages/private/kbn-gen-ai-functional-testing/src/connectors.ts',
-  'src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts',
-  'src/platform/packages/shared/kbn-scout/src/servers/configs/discovery/search_configs.ts',
-  'src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts',
-  'src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.ts',
-  'src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts',
   'src/platform/plugins/private/interactive_setup/server/kibana_config_writer.ts',
   'x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_eis_gateway_config.ts',
   'x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_service_configuration.ts',

--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
@@ -25,7 +25,7 @@ import {
   testChannels,
 } from '@kbn/scout-info';
 import { type ScoutTestConfig, ScoutTestConfigStats, testConfigs } from '@kbn/scout-reporting';
-import yaml from 'js-yaml';
+import { parse } from 'yaml';
 import CliTable3 from 'cli-table3';
 import dedent from 'dedent';
 import type { TestTrackLoad } from '../execution/test_track';
@@ -59,7 +59,7 @@ export interface ScoutCIConfig {
 
 function loadScoutCIConfig(): ScoutCIConfig {
   try {
-    return yaml.load(readFileSync(SCOUT_CI_CONFIG_PATH, 'utf-8')) as ScoutCIConfig;
+    return parse(readFileSync(SCOUT_CI_CONFIG_PATH, 'utf-8')) as ScoutCIConfig;
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     throw createFlagError(`Failed to load Scout CI config: ${message}`);

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/discovery/search_configs.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/discovery/search_configs.ts
@@ -12,7 +12,7 @@ import path from 'path';
 import { ToolingLog } from '@kbn/tooling-log';
 import { REPO_ROOT } from '@kbn/repo-info';
 import fs from 'fs';
-import yaml from 'js-yaml';
+import { parse } from 'yaml';
 import { createFailError } from '@kbn/dev-cli-errors';
 
 export const DEFAULT_TEST_PATH_PATTERNS = [
@@ -136,7 +136,7 @@ export const validateWithScoutCiConfig = (
 ) => {
   const scoutCiConfigRelPath = path.join('.buildkite', 'scout_ci_config.yml');
   const scoutCiConfigPath = path.resolve(REPO_ROOT, scoutCiConfigRelPath);
-  const ciConfig = yaml.load(fs.readFileSync(scoutCiConfigPath, 'utf8')) as {
+  const ciConfig = parse(fs.readFileSync(scoutCiConfigPath, 'utf8')) as {
     plugins: {
       enabled?: string[];
       disabled?: string[];

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts
@@ -9,7 +9,7 @@
 
 import { ToolingLog } from '@kbn/tooling-log';
 import fs from 'fs';
-import yaml from 'js-yaml';
+import { stringify } from 'yaml';
 import type { ModuleDiscoveryInfo } from './types';
 
 jest.mock('@kbn/repo-info', () => ({
@@ -18,7 +18,6 @@ jest.mock('@kbn/repo-info', () => ({
 
 jest.mock('fs');
 jest.mock('fast-glob');
-jest.mock('js-yaml');
 
 import { filterModulesByScoutCiConfig } from './search_configs';
 
@@ -38,8 +37,7 @@ describe('filterModulesByScoutCiConfig', () => {
   beforeEach(() => {
     mockLog = new ToolingLog({ level: 'verbose', writeTo: process.stdout });
     jest.spyOn(mockLog, 'warning').mockImplementation(jest.fn());
-    (fs.readFileSync as jest.Mock).mockReturnValue('mock yaml content');
-    (yaml.load as jest.Mock).mockReturnValue(mockScoutCiConfig);
+    (fs.readFileSync as jest.Mock).mockReturnValue(stringify(mockScoutCiConfig));
   });
 
   afterEach(() => {

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.ts
@@ -11,7 +11,7 @@ import { createFailError } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/repo-info';
 import type { ToolingLog } from '@kbn/tooling-log';
 import fs from 'fs';
-import yaml from 'js-yaml';
+import { parse } from 'yaml';
 import path from 'path';
 import type { ModuleDiscoveryInfo } from './types';
 
@@ -30,7 +30,7 @@ interface ScoutCiConfig {
 const readScoutCiConfig = (): ScoutCiConfig => {
   const scoutCiConfigRelPath = path.join('.buildkite', 'scout_ci_config.yml');
   const scoutCiConfigPath = path.resolve(REPO_ROOT, scoutCiConfigRelPath);
-  return yaml.load(fs.readFileSync(scoutCiConfigPath, 'utf8')) as ScoutCiConfig;
+  return parse(fs.readFileSync(scoutCiConfigPath, 'utf8')) as ScoutCiConfig;
 };
 
 export const getScoutCiExcludedConfigs = (): string[] => {

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts
@@ -11,7 +11,7 @@ import Path from 'path';
 import Fs from 'fs';
 
 import { REPO_ROOT } from '@kbn/repo-info';
-import JsYaml from 'js-yaml';
+import { parse } from 'yaml';
 
 interface FtrConfigWithOptions {
   [configPath: string]: {
@@ -45,7 +45,7 @@ export const getAllFtrConfigsAndManifests = () => {
   const ftrConfigEntries = new Map<string, string[]>();
 
   for (const manifestRelPath of manifestPaths.all) {
-    const manifest = JsYaml.load(
+    const manifest = parse(
       Fs.readFileSync(Path.resolve(REPO_ROOT, manifestRelPath), 'utf8')
     ) as FtrConfigsManifest;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[js-yaml to yaml migration] @elastic/appex-qa (#282904)](https://github.com/elastic/kibana/pull/282904)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-08-05T12:19:37Z","message":"[js-yaml to yaml migration] @elastic/appex-qa (#282904)\n\n## Summary\n\nMigrates 5 files owned by @elastic/appex-qa from `js-yaml` to the `yaml`\npackage (YAML 1.2 core schema) as part of the incremental `js-yaml`\ndependency removal initiative tracked in `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\nCloses #267877\n\n### Files migrated\n\n| File | Change |\n|---|---|\n| `src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/agent_builder_smoke/stateful/classic.stateful.config.ts`\n| `import { load as loadYaml } from 'js-yaml'` → `import { parse } from\n'yaml'`; `loadYaml(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts`\n| Drops `jest.mock('js-yaml')` + `yaml.load` stub; `fs.readFileSync`\nmock now returns real YAML built with `stringify` from `yaml`, removing\nthe parser-library coupling |\n|\n`src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts`\n| `import JsYaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`JsYaml.load(...)` → `parse(...)` |\n\n5 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`. 22 entries remain after this\nPR.\n\n### Why `import { parse } from 'yaml'` (not `loadYaml` from\n`@kbn/kbn-yaml-loader`)\n\n`loadYaml` from `src/platform/packages/shared/kbn-yaml-loader` is a\ndynamic (lazy) loader designed for browser bundles to avoid pulling the\nfull `yaml` library into the initial chunk. All 5 files here are\nNode-side CLI / test / FTR tooling — a plain static import is correct\nand matches the pattern used in every prior migration PR.\n\n### Parser parity\n\n`js-yaml@4.load` and `yaml.parse` differ mainly in how they handle\nunquoted ISO date strings (`js-yaml` coerces them to `Date` objects;\n`yaml` yields strings per the YAML 1.2 core schema). All 11 YAML files\nconsumed by these code paths (`.buildkite/scout_ci_config.yml` plus the\n10 FTR manifests) were parsed with both libraries before this PR: **0\ndivergences**. Additionally, Kibana's own config loader\n(`src/platform/packages/shared/kbn-config/src/raw/read_config.ts`)\nalready uses `parse` from `yaml` to read the same `kibana.dev.yml` that\n`classic.stateful.config.ts` reads, so this change increases parity with\nproduction behavior.\n\n## Test plan\n\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (verifies\nallowlist edit is correct and no leftover `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-scout/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-test/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts`\n— ✅ 4/4 passed\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts`\n— ✅ 33/33 passed\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"14461973ee59390c6f712532afbeccf3d50144c1","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:QA","release_note:skip","backport:all-open","dependency-reduction","reviewer:scout","v9.6.0"],"title":"[js-yaml to yaml migration] @elastic/appex-qa","number":282904,"url":"https://github.com/elastic/kibana/pull/282904","mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/appex-qa (#282904)\n\n## Summary\n\nMigrates 5 files owned by @elastic/appex-qa from `js-yaml` to the `yaml`\npackage (YAML 1.2 core schema) as part of the incremental `js-yaml`\ndependency removal initiative tracked in `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\nCloses #267877\n\n### Files migrated\n\n| File | Change |\n|---|---|\n| `src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/agent_builder_smoke/stateful/classic.stateful.config.ts`\n| `import { load as loadYaml } from 'js-yaml'` → `import { parse } from\n'yaml'`; `loadYaml(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts`\n| Drops `jest.mock('js-yaml')` + `yaml.load` stub; `fs.readFileSync`\nmock now returns real YAML built with `stringify` from `yaml`, removing\nthe parser-library coupling |\n|\n`src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts`\n| `import JsYaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`JsYaml.load(...)` → `parse(...)` |\n\n5 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`. 22 entries remain after this\nPR.\n\n### Why `import { parse } from 'yaml'` (not `loadYaml` from\n`@kbn/kbn-yaml-loader`)\n\n`loadYaml` from `src/platform/packages/shared/kbn-yaml-loader` is a\ndynamic (lazy) loader designed for browser bundles to avoid pulling the\nfull `yaml` library into the initial chunk. All 5 files here are\nNode-side CLI / test / FTR tooling — a plain static import is correct\nand matches the pattern used in every prior migration PR.\n\n### Parser parity\n\n`js-yaml@4.load` and `yaml.parse` differ mainly in how they handle\nunquoted ISO date strings (`js-yaml` coerces them to `Date` objects;\n`yaml` yields strings per the YAML 1.2 core schema). All 11 YAML files\nconsumed by these code paths (`.buildkite/scout_ci_config.yml` plus the\n10 FTR manifests) were parsed with both libraries before this PR: **0\ndivergences**. Additionally, Kibana's own config loader\n(`src/platform/packages/shared/kbn-config/src/raw/read_config.ts`)\nalready uses `parse` from `yaml` to read the same `kibana.dev.yml` that\n`classic.stateful.config.ts` reads, so this change increases parity with\nproduction behavior.\n\n## Test plan\n\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (verifies\nallowlist edit is correct and no leftover `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-scout/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-test/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts`\n— ✅ 4/4 passed\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts`\n— ✅ 33/33 passed\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"14461973ee59390c6f712532afbeccf3d50144c1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282904","number":282904,"mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/appex-qa (#282904)\n\n## Summary\n\nMigrates 5 files owned by @elastic/appex-qa from `js-yaml` to the `yaml`\npackage (YAML 1.2 core schema) as part of the incremental `js-yaml`\ndependency removal initiative tracked in `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\nCloses #267877\n\n### Files migrated\n\n| File | Change |\n|---|---|\n| `src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/agent_builder_smoke/stateful/classic.stateful.config.ts`\n| `import { load as loadYaml } from 'js-yaml'` → `import { parse } from\n'yaml'`; `loadYaml(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts`\n| Drops `jest.mock('js-yaml')` + `yaml.load` stub; `fs.readFileSync`\nmock now returns real YAML built with `stringify` from `yaml`, removing\nthe parser-library coupling |\n|\n`src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts`\n| `import JsYaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`JsYaml.load(...)` → `parse(...)` |\n\n5 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`. 22 entries remain after this\nPR.\n\n### Why `import { parse } from 'yaml'` (not `loadYaml` from\n`@kbn/kbn-yaml-loader`)\n\n`loadYaml` from `src/platform/packages/shared/kbn-yaml-loader` is a\ndynamic (lazy) loader designed for browser bundles to avoid pulling the\nfull `yaml` library into the initial chunk. All 5 files here are\nNode-side CLI / test / FTR tooling — a plain static import is correct\nand matches the pattern used in every prior migration PR.\n\n### Parser parity\n\n`js-yaml@4.load` and `yaml.parse` differ mainly in how they handle\nunquoted ISO date strings (`js-yaml` coerces them to `Date` objects;\n`yaml` yields strings per the YAML 1.2 core schema). All 11 YAML files\nconsumed by these code paths (`.buildkite/scout_ci_config.yml` plus the\n10 FTR manifests) were parsed with both libraries before this PR: **0\ndivergences**. Additionally, Kibana's own config loader\n(`src/platform/packages/shared/kbn-config/src/raw/read_config.ts`)\nalready uses `parse` from `yaml` to read the same `kibana.dev.yml` that\n`classic.stateful.config.ts` reads, so this change increases parity with\nproduction behavior.\n\n## Test plan\n\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (verifies\nallowlist edit is correct and no leftover `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-scout/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-test/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-scout/src/tests_discovery/search_configs.test.ts`\n— ✅ 4/4 passed\n- [x] `node scripts/jest\nsrc/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts`\n— ✅ 33/33 passed\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"14461973ee59390c6f712532afbeccf3d50144c1"}}]}] BACKPORT-->