### PR TITLE
[Nightshift] Show the app in the project side nav

### DIFF
--- a/x-pack/solutions/observability/plugins/nightshift/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/plugin.ts
@@ -96,7 +96,9 @@ export class NightshiftPlugin
         distinctUntilChanged(),
         map(
           (isAvailable): AppUpdater =>
-            () => ({ visibleIn: isAvailable ? ['globalSearch'] : [] })
+            () => ({
+              visibleIn: isAvailable ? ['globalSearch', 'projectSideNav'] : [],
+            })
         )
       )
       .subscribe(this.appUpdater$);


### PR DESCRIPTION
## Summary

Closes #283334

The Nightshift app never showed up as a navigation item.

- The feature-flag driven `AppUpdater` in `public/plugin.ts` set `visibleIn: ['globalSearch']`, so the app was only reachable through global search.
- Adds `projectSideNav` to `visibleIn` so the app renders in the side nav when the `streams.significantEventsAvailable` flag is on, and stays fully hidden when it is off.

