### PR TITLE
[Security Solution][Attack] fix redirect url

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/routes.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/routes.test.tsx
@@ -10,6 +10,11 @@ import { render, screen } from '@testing-library/react';
 import { Redirect, type RouteComponentProps } from 'react-router-dom';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 
+import {
+  ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX,
+  ATTACK_DISCOVERY_ADHOC_ALERTS_COMMON_INDEX_PREFIX,
+} from '@kbn/elastic-assistant-common';
+
 import { AttackDiscoveryRoutes } from './routes';
 import { useIsAlertsAndAttacksAlignmentEnabled } from '../common/hooks/use_is_alerts_and_attacks_alignment_enabled';
 import { useSpaceId } from '../common/hooks/use_space_id';
@@ -91,16 +96,42 @@ describe('AttackDiscoveryRoutes', () => {
     expect(Redirect).not.toHaveBeenCalled();
   });
 
-  // The legacy `/attack_discovery` -> Attacks redirect is intentionally disabled
-  // (see ENABLE_LEGACY_ATTACK_DISCOVERY_REDIRECT in routes.tsx), so the route never redirects
-  // even when the URL contains attack ids.
-  it('does not redirect even when the URL contains attack ids', () => {
+  // Legacy `/attack_discovery?id=<id>` deep links (e.g. the generated `kibana.alert.url`) must
+  // redirect to the new Attacks page with the attack flyout open when alignment is enabled.
+  it('redirects to the attack flyout when alignment is enabled and the URL contains an attack id', () => {
     (useIsAlertsAndAttacksAlignmentEnabled as jest.Mock).mockReturnValue(true);
+    (useSpaceId as jest.Mock).mockReturnValue('default');
     (useIdsFromUrl as jest.Mock).mockReturnValue({ ids: ['attack-id-1', 'attack-id-2'] });
 
     render(<AttackDiscoveryRoutes {...mockRouteProps} />);
 
-    expect(screen.getByTestId('mock-attack-discovery-moved-page')).toBeInTheDocument();
+    expect(buildAttackDetailPath).toHaveBeenCalledWith({
+      attackId: 'attack-id-1',
+      index: `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-default,${ATTACK_DISCOVERY_ADHOC_ALERTS_COMMON_INDEX_PREFIX}-default`,
+      timestamp: null,
+    });
+    expect(Redirect).toHaveBeenCalled();
+    expect(screen.queryByTestId('mock-attack-discovery-moved-page')).not.toBeInTheDocument();
+  });
+
+  it('waits for the space id to resolve before redirecting', () => {
+    (useIsAlertsAndAttacksAlignmentEnabled as jest.Mock).mockReturnValue(true);
+    (useSpaceId as jest.Mock).mockReturnValue(undefined);
+    (useIdsFromUrl as jest.Mock).mockReturnValue({ ids: ['attack-id-1'] });
+
+    render(<AttackDiscoveryRoutes {...mockRouteProps} />);
+
+    expect(Redirect).not.toHaveBeenCalled();
+    expect(buildAttackDetailPath).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when alignment is disabled even if the URL contains an attack id', () => {
+    (useIsAlertsAndAttacksAlignmentEnabled as jest.Mock).mockReturnValue(false);
+    (useIdsFromUrl as jest.Mock).mockReturnValue({ ids: ['attack-id-1'] });
+
+    render(<AttackDiscoveryRoutes {...mockRouteProps} />);
+
+    expect(screen.getByTestId('mock-attack-discovery-page')).toBeInTheDocument();
     expect(Redirect).not.toHaveBeenCalled();
     expect(buildAttackDetailPath).not.toHaveBeenCalled();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/routes.tsx
@@ -18,21 +18,12 @@ import { AttackDiscoveryMovedPage } from './pages/attack_discovery_moved';
 
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
-import { ATTACKS_PATH, ATTACK_DISCOVERY_PATH } from '../../common/constants';
+import { ATTACK_DISCOVERY_PATH } from '../../common/constants';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
 import { useSpaceId } from '../common/hooks/use_space_id';
 import { useIdsFromUrl } from './pages/results/history/use_ids_from_url';
 import { useIsAlertsAndAttacksAlignmentEnabled } from '../common/hooks/use_is_alerts_and_attacks_alignment_enabled';
-
-/**
- * The legacy `/attack_discovery` → Attacks redirect (introduced when the Attacks page went
- * GA) is intentionally retained but disabled. Attack Discovery is now a permanent top-level
- * page that stays visible regardless of the alerts-and-attacks alignment setting, so the
- * redirect must not fire. We keep the logic behind this flag rather than deleting it so it
- * can be quickly restored if we later decide to fully retire the Attack Discovery page.
- */
-const ENABLE_LEGACY_ATTACK_DISCOVERY_REDIRECT = false;
 
 export const AttackDiscoveryRoutes = React.memo((props: RouteComponentProps) => {
   const enableAlertsAndAttacksAlignment = useIsAlertsAndAttacksAlignmentEnabled();
@@ -41,23 +32,23 @@ export const AttackDiscoveryRoutes = React.memo((props: RouteComponentProps) => 
   const { ids } = useIdsFromUrl();
   const [searchParams] = useSearchParams();
 
-  if (ENABLE_LEGACY_ATTACK_DISCOVERY_REDIRECT && enableAlertsAndAttacksAlignment) {
-    if (ids.length > 0) {
-      if (spaceId === undefined) {
-        return null; // Wait for spaceId to be resolved before redirecting
-      }
-
-      const attackId = ids[0]; // if multiple, open the first one
-      const timestamp = searchParams.get('timestamp');
-      const index = [
-        `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-${spaceId}`,
-        `${ATTACK_DISCOVERY_ADHOC_ALERTS_COMMON_INDEX_PREFIX}-${spaceId}`,
-      ].join(',');
-
-      return <Redirect to={buildAttackDetailPath({ attackId, index, timestamp })} />;
+  // When alignment is enabled, legacy `/attack_discovery?id=<id>` deep links (e.g. the
+  // `kibana.alert.url` generated for scheduled/manual Attack Discovery runs) must resolve to the
+  // new Attacks page with the attack flyout open. Direct navigation without an `id` still renders
+  // the "moved" empty-state below, so the Attack Discovery page never disappears.
+  if (enableAlertsAndAttacksAlignment && ids.length > 0) {
+    if (spaceId === undefined) {
+      return null; // Wait for spaceId to be resolved before redirecting
     }
 
-    return <Redirect to={ATTACKS_PATH} />;
+    const attackId = ids[0]; // if multiple, open the first one
+    const timestamp = searchParams.get('timestamp');
+    const index = [
+      `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-${spaceId}`,
+      `${ATTACK_DISCOVERY_ADHOC_ALERTS_COMMON_INDEX_PREFIX}-${spaceId}`,
+    ].join(',');
+
+    return <Redirect to={buildAttackDetailPath({ attackId, index, timestamp })} />;
   }
 
   return (


### PR DESCRIPTION
## Summary

This PR enables the redirect from the Attack Discovery page to the new Attacks page, now that we're not showing any content in the legacy Attack Discover page anymore, other than a empty prompt pointing the users to the new Attacks page.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->