### PR TITLE
[Agent Builder] HITL: Fix custom text field losing focus after radio selection

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/__storybook__/agent_builder_storybook_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/__storybook__/agent_builder_storybook_provider.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { of } from 'rxjs';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import { AgentBuilderServicesContext } from '../context/agent_builder_services_context';
+import { ConversationContext } from '../context/conversation/conversation_context';
+import { StreamingProvider } from '../context/streaming/streaming_context';
+import type { AgentBuilderInternalService } from '../../services/types';
+import type { StartServices } from '../hooks/use_kibana';
+import type { ConversationActions } from '../context/conversation/use_conversation_actions';
+
+const noOp = () => {};
+const noOpAsync = () => Promise.resolve([] as never[]);
+
+const kibanaServices = {
+  analytics: {
+    reportEvent: noOp,
+  },
+  notifications: {
+    toasts: {
+      add: noOp,
+      addSuccess: noOp,
+      addWarning: noOp,
+      addDanger: noOp,
+      addError: noOp,
+      remove: noOp,
+      get$: () => of([]),
+    },
+  },
+  uiSettings: {
+    get: () => undefined,
+    get$: () => of(undefined),
+    getAll: () => ({}),
+    overrideLocalDefault: noOp,
+    isCustom: () => false,
+    isOverridden: () => false,
+    isDeclared: () => false,
+    isDefault: () => true,
+    set: () => Promise.resolve(true),
+    remove: () => Promise.resolve(true),
+  },
+  http: {
+    get: noOpAsync,
+    post: noOpAsync,
+    put: noOpAsync,
+    delete: noOpAsync,
+    patch: noOpAsync,
+    fetch: noOpAsync,
+    basePath: { get: () => '', prepend: (p: string) => p, remove: (p: string) => p },
+  },
+  settings: {
+    client: {
+      get: () => undefined,
+      get$: () => of(undefined),
+      set: () => Promise.resolve(true),
+      getAll: () => ({}),
+    },
+  },
+  application: {
+    capabilities: { management: {}, catalogue: {}, actions: { show: true } },
+    currentAppId$: of('agentBuilder'),
+    currentLocation$: of({ id: 'agentBuilder', state: {} }),
+    navigateToApp: () => Promise.resolve(),
+    getUrlForApp: () => '/',
+    navigateToUrl: () => Promise.resolve(),
+  },
+  appParams: { history: {} },
+  plugins: {},
+} as unknown as StartServices;
+
+const agentBuilderServices = {
+  agentService: {
+    list: () =>
+      Promise.resolve([
+        { id: agentBuilderDefaultAgentId, type: 'chat', name: 'Elastic AI Agent', description: '' },
+      ]),
+    get: () => Promise.resolve(null),
+    create: () => Promise.resolve({}),
+    update: () => Promise.resolve({}),
+    delete: () => Promise.resolve({}),
+  },
+  attachmentsService: { getAttachmentUiDefinition: () => undefined },
+  renderersService: {},
+  chatService: {},
+  conversationsService: {},
+  docLinksService: {},
+  navigationService: {},
+  toolsService: {},
+  skillsService: {},
+  smlService: {},
+  pluginsService: {},
+  oauthClientsService: {},
+  startDependencies: {},
+  accessChecker: {},
+  eventsService: { track: noOp },
+  isEarsEnabled: false,
+  isEarsExperimentalEnabled: false,
+  openSidebarConversation: () => ({}),
+} as unknown as AgentBuilderInternalService;
+
+const defaultQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+export interface AgentBuilderStorybookProviderProps {
+  children: React.ReactNode;
+  /** Provide a stable conversationId for stories that exercise telemetry/context reads. */
+  conversationId?: string;
+  agentId?: string;
+}
+
+export const AgentBuilderStorybookProvider = ({
+  children,
+  conversationId,
+  agentId = agentBuilderDefaultAgentId,
+}: AgentBuilderStorybookProviderProps) => (
+  <QueryClientProvider client={defaultQueryClient}>
+    <KibanaContextProvider services={kibanaServices}>
+      <AgentBuilderServicesContext.Provider value={agentBuilderServices}>
+        <StreamingProvider>
+          <ConversationContext.Provider
+            value={{
+              isEmbeddedContext: false,
+              agentId,
+              conversationId,
+              conversationActions: {} as ConversationActions,
+            }}
+          >
+            {children}
+          </ConversationContext.Provider>
+        </StreamingProvider>
+      </AgentBuilderServicesContext.Provider>
+    </KibanaContextProvider>
+  </QueryClientProvider>
+);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.stories.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.stories.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { AgentBuilderStorybookProvider } from '../../../../__storybook__/agent_builder_storybook_provider';
+import { AskUserQuestionPrompt } from './ask_user_question_prompt';
+
+const meta: Meta<typeof AskUserQuestionPrompt> = {
+  title: 'HITL/Ask User Question Prompt',
+  component: AskUserQuestionPrompt,
+  // Disable auto-action detection to prevent double-logging alongside the explicit action below
+  parameters: { actions: { argTypesRegex: '' } },
+  args: { promptId: 'prompt-1', onSubmit: action('onSubmit') },
+  decorators: [
+    (Story) => (
+      <AgentBuilderStorybookProvider conversationId="story-conversation-1">
+        <div style={{ maxWidth: 600, padding: 24 }}>
+          <Story />
+        </div>
+      </AgentBuilderStorybookProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof AskUserQuestionPrompt>;
+
+export const SingleQuestion: Story = {
+  args: {
+    questions: [
+      {
+        question: 'Which environment are you investigating?',
+        options: [{ label: 'Production' }, { label: 'Staging' }, { label: 'Development' }],
+        multi_select: false,
+      },
+    ],
+  },
+};
+
+export const MultiSelect: Story = {
+  args: {
+    questions: [
+      {
+        question: 'Which log levels should be included?',
+        options: [
+          { label: 'ERROR', description: 'Critical failures only' },
+          { label: 'WARN', description: 'Warnings and errors' },
+          { label: 'INFO', description: 'General operational messages' },
+          { label: 'DEBUG', description: 'Verbose diagnostic output' },
+        ],
+        multi_select: true,
+      },
+    ],
+  },
+};
+
+export const MultiQuestion: Story = {
+  args: {
+    questions: [
+      {
+        question: 'Which environment are you investigating?',
+        options: [{ label: 'Production' }, { label: 'Staging' }],
+        multi_select: false,
+      },
+      {
+        question: 'What is the time range of interest?',
+        options: [{ label: 'Last 15 minutes' }, { label: 'Last hour' }, { label: 'Last 24 hours' }],
+        multi_select: false,
+      },
+      {
+        question: 'Which services are affected?',
+        options: [
+          { label: 'checkout-api' },
+          { label: 'inventory-service' },
+          { label: 'payment-gateway' },
+        ],
+        multi_select: true,
+      },
+    ],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    promptId: 'prompt-1',
+    isLoading: true,
+    questions: [
+      {
+        question: 'Which environment are you investigating?',
+        options: [{ label: 'Production' }, { label: 'Staging' }],
+        multi_select: false,
+      },
+    ],
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    promptId: 'prompt-1',
+    isDisabled: true,
+    questions: [
+      {
+        question: 'Which environment are you investigating?',
+        options: [{ label: 'Production' }, { label: 'Staging' }],
+        multi_select: false,
+      },
+    ],
+  },
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
@@ -161,12 +161,9 @@ export const AskUserQuestionPrompt = (props: AskUserQuestionPromptProps) => {
                 <EuiIcon type="pencil" size="m" color="subdued" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem>
-                {/* Intentional: this field is only ever reached by selecting the custom
-                    option above (or restored on Back) — it must not be a stray Tab stop. */}
-                {/* eslint-disable-next-line @elastic/eui/accessible-interactive-element */}
                 <EuiFieldText
                   inputRef={refs.customInputRef}
-                  tabIndex={-1}
+                  tabIndex={isCustomActive ? 0 : -1}
                   value={currentDraft.custom ?? ''}
                   placeholder={labels.customPlaceholder}
                   onChange={(e) => handlers.handleCustomChange(e.target.value)}


### PR DESCRIPTION
## Summary

**Bug:** In the HITL clarification prompt, clicking the custom answer radio button and then clicking the text field made the text field unresponsive — typing had no effect.

**Root cause:** `EuiCheckableCard` uses the `tabbable` library to detect interactive children. The text field had `tabIndex={-1}`, which `tabbable` ignores, so `EuiCheckableCard` treated the children area as non-interactive and forwarded every click to the radio input — stealing focus from the text field.

**Fix:** Set `tabIndex={0}` when the custom option is active, `-1` when not. Once `tabbable` detects the field as interactive, `EuiCheckableCard` stops forwarding clicks and the field stays focused.


## Demo


https://github.com/user-attachments/assets/55daca35-b2cc-4f63-a2b8-7543bc2195c1


## Storybook

Added a Storybook for the HITL `AskUserQuestionPrompt` component (`yarn storybook agent_builder`).

Also introduced `AgentBuilderStorybookProvider` — a shared wrapper that provides the Kibana context, analytics, and conversation context needed by agent-builder components. Reusable across future stories without mocking individual hooks.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->