### PR TITLE
[Chrome Next] Add title and app menu loading state

### DIFF
--- a/src/core/packages/chrome/app-header/README.md
+++ b/src/core/packages/chrome/app-header/README.md
@@ -92,9 +92,14 @@ regions with defaults that match a typical title + overflow + primary header:
 
 `back` still renders when provided. Once data arrives, replace it with the real `AppHeader`.
 
+The fully supported swap is a **single-row** header: title (optional back) plus the app menu.
+`AppHeaderLoading` does not skeleton tabs, description, metadata, or title actions. Swapping from
+the loading placeholder to a multi-row `AppHeader` will change the header height.
+
 The menu skeleton can be customized later if the loaded header will not look like the default
 (for example two icon buttons and no primary). `buttonCount` is clamped to AppMenu's
-`APP_MENU_ITEM_LIMIT` (3); the primary action is separate and does not count toward that limit:
+`APP_MENU_ITEM_LIMIT` (3); the primary action is separate and does not count toward that limit.
+The menu uses the same responsive collapsed / minimal / expanded layouts as `AppMenu`.
 
 ```tsx
 <AppHeaderLoading menu={{ buttonCount: 2, hasPrimary: false }} />

--- a/src/core/packages/chrome/app-header/README.md
+++ b/src/core/packages/chrome/app-header/README.md
@@ -23,7 +23,8 @@ that bar. Keep new regions flat until they earn a folder; don't pre-folder simpl
 ## Which API should I use?
 
 Use `AppHeader` when the page can render its header inline. This is the preferred model for pages
-that own their title, back target, tabs, badges, and app menu locally.
+that own their title, back target, tabs, badges, and app menu locally. Use `AppHeaderLoading` in
+the same slot while that content is not ready yet.
 
 Use `ChromeAppHeaderRegistration` when Chrome should own the top-bar slot. This keeps migration
 small for pages with sticky or shared top-nav constraints while still using the shared header view.
@@ -78,6 +79,27 @@ the title. This is a Discover-specific layout exception; other apps should use t
 `tabs` or `badges` props on `AppHeader`. The public header components discard undeclared props, so
 this internal title slot cannot be forced through a type suppression. When the tabs bar is present,
 it owns the bottom separator and title actions remain visible without hovering.
+
+## Loading skeleton
+
+When the page title and menu are not ready yet, mount `AppHeaderLoading` instead of gating the
+whole page behind a spinner. It claims the same inline slot as `AppHeader` and skeletons both
+regions with defaults that match a typical title + overflow + primary header:
+
+```tsx
+<AppHeaderLoading />
+```
+
+`back` still renders when provided. Once data arrives, replace it with the real `AppHeader`.
+
+The menu skeleton can be customized later if the loaded header will not look like the default
+(for example two icon buttons and no primary). `buttonCount` is clamped to AppMenu's
+`APP_MENU_ITEM_LIMIT` (3); the primary action is separate and does not count toward that limit:
+
+```tsx
+<AppHeaderLoading menu={{ buttonCount: 2, hasPrimary: false }} />
+<AppHeaderLoading back="/app/my-app" />
+```
 
 ## Editable titles
 

--- a/src/core/packages/chrome/app-header/index.ts
+++ b/src/core/packages/chrome/app-header/index.ts
@@ -10,6 +10,8 @@
 export { AppHeader } from './src';
 export {
   AppHeaderView,
+  AppHeaderLoading,
+  AppHeaderLoadingView,
   ChromeAppHeaderRegistration,
   useChromeAppHeaderRegistration,
   SuppressChromeBackButton,
@@ -23,6 +25,8 @@ export {
 export type { AppHeaderViewProps, AppHeaderConfig, ChromeAppHeaderConfig } from './src';
 export type {
   AppHeaderProps,
+  AppHeaderLoadingProps,
+  AppHeaderLoadingMenu,
   AppHeaderBack,
   AppHeaderBadge,
   AppHeaderBadgeItem,

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, type ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { css } from '@emotion/react';
@@ -300,6 +300,172 @@ export const LoadingWithBack: Story = {
         story:
           '`AppHeaderLoading` with a back button. The title and menu stay skeletoned; only the ' +
           'known back target renders.',
+      },
+    },
+  },
+};
+
+const defaultLoadedMenu: AppMenuConfig = {
+  items: [
+    {
+      id: 'settings',
+      order: 0,
+      label: 'Settings',
+      iconType: 'gear',
+      overflow: true,
+      run: action('settings'),
+    },
+  ],
+  primaryActionItem: {
+    id: 'save',
+    label: 'Save',
+    iconType: 'save',
+    run: action('save'),
+  },
+};
+
+const twoIconMenu: AppMenuConfig = {
+  items: [
+    {
+      id: 'settings',
+      order: 0,
+      label: 'Settings',
+      iconType: 'gear',
+      run: action('settings'),
+    },
+    {
+      id: 'share',
+      order: 1,
+      label: 'Share',
+      iconType: 'share',
+      run: action('share'),
+    },
+  ],
+};
+
+const comparisonBack: AppHeaderBack = { href: '/app/management', label: 'Stack Management' };
+
+const loadingSwapCases: Array<{
+  name: string;
+  note?: string;
+  loading: {
+    back?: AppHeaderBack;
+    menu?: AppHeaderLoadingMenu;
+    spacing?: AppHeaderSpacing;
+  };
+  loaded: ComponentProps<typeof AppHeaderView>;
+}> = [
+  {
+    name: 'Default (title + overflow + primary)',
+    loading: {},
+    loaded: { title: 'System Shells via Services', menu: defaultLoadedMenu, sticky: false },
+  },
+  {
+    name: 'With back',
+    loading: { back: comparisonBack },
+    loaded: {
+      title: 'System Shells via Services',
+      back: comparisonBack,
+      menu: defaultLoadedMenu,
+      sticky: false,
+    },
+  },
+  {
+    name: 'Title only',
+    loading: { menu: { buttonCount: 0, hasPrimary: false } },
+    loaded: { title: 'System Shells via Services', sticky: false },
+  },
+  {
+    name: 'Custom menu (2 icons, no primary)',
+    loading: { menu: { buttonCount: 2, hasPrimary: false } },
+    loaded: { title: 'System Shells via Services', menu: twoIconMenu, sticky: false },
+  },
+  {
+    name: 'Compact spacing',
+    loading: { spacing: 'compact' },
+    loaded: {
+      title: 'System Shells via Services',
+      menu: defaultLoadedMenu,
+      spacing: 'compact',
+      sticky: false,
+    },
+  },
+  {
+    name: 'Multi-row (tabs + metadata) — expected height shift',
+    note: 'AppHeaderLoading only skeletons the primary row. Tabs and metadata add a second row.',
+    loading: {},
+    loaded: {
+      title: 'System Shells via Services',
+      menu: defaultLoadedMenu,
+      tabs,
+      metadata,
+      sticky: false,
+    },
+  },
+];
+
+const comparisonGrid = css`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 900px;
+`;
+
+const comparisonPair = css`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: start;
+`;
+
+const comparisonLabel = css`
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 8px;
+`;
+
+const comparisonNote = css`
+  font-size: 12px;
+  opacity: 0.7;
+  margin: 0 0 8px;
+`;
+
+const LoadingToLoadedComparison = () => {
+  const chrome = useMemo(() => createChromeStorybookStart(), []);
+
+  return (
+    <ChromeServiceProvider value={{ chrome }}>
+      <div css={comparisonGrid}>
+        {loadingSwapCases.map((swapCase) => (
+          <section key={swapCase.name}>
+            <div css={comparisonLabel}>{swapCase.name}</div>
+            {swapCase.note ? <p css={comparisonNote}>{swapCase.note}</p> : null}
+            <div css={comparisonPair}>
+              <div>
+                <div css={comparisonLabel}>Loading</div>
+                <AppHeaderLoadingView {...swapCase.loading} sticky={false} />
+              </div>
+              <div>
+                <div css={comparisonLabel}>Loaded</div>
+                <AppHeaderView {...swapCase.loaded} />
+              </div>
+            </div>
+          </section>
+        ))}
+      </div>
+    </ChromeServiceProvider>
+  );
+};
+
+export const LoadingToLoaded: Story = {
+  render: () => <LoadingToLoadedComparison />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Side-by-side loading vs loaded for typical single-row combinations. Height and the ' +
+          'trailing menu width should match closely; title width is a fixed skeleton. Multi-row ' +
+          'headers (tabs, description, metadata) are not fully supported and will shift height.',
       },
     },
   },

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
@@ -20,8 +20,9 @@ import type {
   AppHeaderTab,
 } from '@kbn/core-chrome-browser';
 import type { AppMenuConfig } from '@kbn/app-menu';
-import type { AppHeaderSpacing } from '../types';
+import type { AppHeaderBack, AppHeaderSpacing } from '../types';
 import { AppHeaderView } from './app_header';
+import { AppHeaderLoadingView, type AppHeaderLoadingMenu } from './app_header_loading';
 
 interface ComposedHeaderStoryProps {
   title: string;
@@ -241,5 +242,65 @@ export const WithoutTabs: Story = {
 export const NonEditableTitle: Story = {
   args: {
     editable: false,
+  },
+};
+
+const LoadingHeader = ({
+  menuSkeleton,
+  back,
+}: {
+  menuSkeleton?: AppHeaderLoadingMenu;
+  back?: AppHeaderBack;
+}) => {
+  const chrome = useMemo(() => createChromeStorybookStart(), []);
+
+  return (
+    <ChromeServiceProvider value={{ chrome }}>
+      <div
+        css={css`
+          width: 900px;
+        `}
+      >
+        <AppHeaderLoadingView menu={menuSkeleton} back={back} sticky={false} />
+      </div>
+    </ChromeServiceProvider>
+  );
+};
+
+export const Loading: Story = {
+  render: () => <LoadingHeader />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default `AppHeaderLoading`: title skeleton plus overflow and primary-action placeholders.',
+      },
+    },
+  },
+};
+
+export const LoadingCustomMenu: Story = {
+  render: () => <LoadingHeader menuSkeleton={{ buttonCount: 2, hasPrimary: false }} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Customized menu skeleton (`buttonCount: 2`, no primary) for headers that will not look ' +
+          'like the default overflow + primary layout.',
+      },
+    },
+  },
+};
+
+export const LoadingWithBack: Story = {
+  render: () => <LoadingHeader back={{ href: '/app/management', label: 'Stack Management' }} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`AppHeaderLoading` with a back button. The title and menu stay skeletoned; only the ' +
+          'known back target renders.',
+      },
+    },
   },
 };

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
@@ -8,11 +8,15 @@
  */
 
 import type { ReactNode } from 'react';
-import React, { useLayoutEffect } from 'react';
+import React from 'react';
 import type { DistributiveOmit } from '@elastic/eui';
-import { useChromeService } from '@kbn/core-chrome-browser-context';
 import type { AppHeaderBack, AppHeaderConfig, AppHeaderSpacing, AppHeaderTitle } from '../types';
-import { useHasLegacyActionMenu } from './hooks/chrome';
+import {
+  useCanAccessIntegrations,
+  useHasLegacyActionMenu,
+  useInlineAppHeader,
+  useResolvedBadges,
+} from './hooks';
 import { AppHeaderShell } from './app_header_shell';
 import { AppBadges } from './app_badges';
 import { AppTabs } from './app_tabs';
@@ -22,7 +26,6 @@ import { AppMenu } from './app_menu';
 import { AppHeaderMetadata } from './app_header_metadata';
 import { AppHeaderDescription } from './app_header_description';
 import { APP_HEADER_TEST_SUBJECTS } from './test_subjects';
-import { useCanAccessIntegrations, useResolvedBadges } from './hooks';
 
 export type AppHeaderViewProps = DistributiveOmit<AppHeaderConfig, 'back' | 'spacing'> & {
   back?: AppHeaderBack | AppHeaderBack[];
@@ -180,21 +183,14 @@ export const AppHeaderView = React.memo<AppHeaderViewProps>((props) => {
 
 AppHeaderView.displayName = 'AppHeaderView';
 
-export type AppHeaderProps = AppHeaderViewProps & {
-  title: AppHeaderTitle;
-};
+export type AppHeaderProps = AppHeaderViewProps & { title: AppHeaderTitle };
 
 type InlineAppHeaderProps = AppHeaderViewInternalProps & {
   title: AppHeaderTitle;
 };
 
 const InlineAppHeader = React.memo<InlineAppHeaderProps>((props) => {
-  const chrome = useChromeService();
-  useLayoutEffect(() => {
-    chrome.next.inlineAppHeader.set(true);
-    return () => chrome.next.inlineAppHeader.set(false);
-  }, [chrome]);
-
+  useInlineAppHeader();
   return <AppHeaderViewInternal {...props} />;
 });
 

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_loading.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_loading.test.tsx
@@ -10,11 +10,15 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { APP_MENU_ITEM_LIMIT } from '@kbn/app-menu';
+import { APP_MENU_TEST_SUBJECTS } from '@kbn/app-menu';
 import { ChromeServiceProvider } from '@kbn/core-chrome-browser-context';
 import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
 import { AppHeaderLoading, AppHeaderLoadingView } from './app_header_loading';
 import { APP_HEADER_TEST_SUBJECTS } from './test_subjects';
+
+jest.mock('@kbn/ui-chrome-layout-utils', () => ({
+  useCurrentChromeApplicationBreakpoint: () => 'xl',
+}));
 
 const renderLoading = (
   ui: React.ReactElement,
@@ -26,19 +30,16 @@ const renderLoading = (
   };
 };
 
-const menuRectangles = (): NodeListOf<Element> =>
-  screen
-    .getByTestId(APP_HEADER_TEST_SUBJECTS.skeletonMenu)
-    .querySelectorAll('.euiSkeletonRectangle');
-
 describe('AppHeaderLoadingView', () => {
   it('skeletons the title and the default overflow + primary menu', () => {
     renderLoading(<AppHeaderLoadingView />);
 
     expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.root)).toBeInTheDocument();
     expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.skeleton)).toBeInTheDocument();
-    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.skeletonMenu)).toBeInTheDocument();
-    expect(menuRectangles()).toHaveLength(2);
+    expect(screen.getByTestId(APP_MENU_TEST_SUBJECTS.loading)).toBeInTheDocument();
+    expect(
+      screen.getByTestId(APP_MENU_TEST_SUBJECTS.loading).querySelectorAll('.euiSkeletonRectangle')
+    ).toHaveLength(2);
   });
 
   it('keeps the back button next to the title skeleton', () => {
@@ -54,13 +55,15 @@ describe('AppHeaderLoadingView', () => {
   it('customizes the menu skeleton', () => {
     renderLoading(<AppHeaderLoadingView menu={{ buttonCount: 2, hasPrimary: false }} />);
 
-    expect(menuRectangles()).toHaveLength(2);
+    expect(
+      screen.getByTestId(APP_MENU_TEST_SUBJECTS.loading).querySelectorAll('.euiSkeletonRectangle')
+    ).toHaveLength(2);
   });
 
-  it('clamps buttonCount to APP_MENU_ITEM_LIMIT', () => {
-    renderLoading(<AppHeaderLoadingView menu={{ buttonCount: 99 }} />);
+  it('omits the menu when nothing is requested', () => {
+    renderLoading(<AppHeaderLoadingView menu={{ buttonCount: 0, hasPrimary: false }} />);
 
-    expect(menuRectangles()).toHaveLength(APP_MENU_ITEM_LIMIT + 1);
+    expect(screen.queryByTestId(APP_MENU_TEST_SUBJECTS.loading)).not.toBeInTheDocument();
   });
 });
 

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_loading.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_loading.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { APP_MENU_ITEM_LIMIT } from '@kbn/app-menu';
+import { ChromeServiceProvider } from '@kbn/core-chrome-browser-context';
+import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
+import { AppHeaderLoading, AppHeaderLoadingView } from './app_header_loading';
+import { APP_HEADER_TEST_SUBJECTS } from './test_subjects';
+
+const renderLoading = (
+  ui: React.ReactElement,
+  chrome = chromeServiceMock.createStartContract()
+) => {
+  return {
+    chrome,
+    ...render(<ChromeServiceProvider value={{ chrome }}>{ui}</ChromeServiceProvider>),
+  };
+};
+
+const menuRectangles = (): NodeListOf<Element> =>
+  screen
+    .getByTestId(APP_HEADER_TEST_SUBJECTS.skeletonMenu)
+    .querySelectorAll('.euiSkeletonRectangle');
+
+describe('AppHeaderLoadingView', () => {
+  it('skeletons the title and the default overflow + primary menu', () => {
+    renderLoading(<AppHeaderLoadingView />);
+
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.root)).toBeInTheDocument();
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.skeleton)).toBeInTheDocument();
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.skeletonMenu)).toBeInTheDocument();
+    expect(menuRectangles()).toHaveLength(2);
+  });
+
+  it('keeps the back button next to the title skeleton', () => {
+    renderLoading(<AppHeaderLoadingView back="/app/my-app" />);
+
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.back)).toHaveAttribute(
+      'href',
+      '/app/my-app'
+    );
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.skeleton)).toBeInTheDocument();
+  });
+
+  it('customizes the menu skeleton', () => {
+    renderLoading(<AppHeaderLoadingView menu={{ buttonCount: 2, hasPrimary: false }} />);
+
+    expect(menuRectangles()).toHaveLength(2);
+  });
+
+  it('clamps buttonCount to APP_MENU_ITEM_LIMIT', () => {
+    renderLoading(<AppHeaderLoadingView menu={{ buttonCount: 99 }} />);
+
+    expect(menuRectangles()).toHaveLength(APP_MENU_ITEM_LIMIT + 1);
+  });
+});
+
+describe('AppHeaderLoading', () => {
+  it('claims the inline app-header slot and releases it on unmount', () => {
+    const chrome = chromeServiceMock.createStartContract();
+    const { unmount } = renderLoading(<AppHeaderLoading />, chrome);
+
+    expect(chrome.next.inlineAppHeader.set).toHaveBeenCalledWith(true);
+
+    unmount();
+
+    expect(chrome.next.inlineAppHeader.set).toHaveBeenCalledWith(false);
+  });
+
+  it('does not claim the slot when only the view is rendered', () => {
+    const chrome = chromeServiceMock.createStartContract();
+    renderLoading(<AppHeaderLoadingView />, chrome);
+
+    expect(chrome.next.inlineAppHeader.set).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_loading.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_loading.tsx
@@ -8,11 +8,12 @@
  */
 
 import React from 'react';
+import { AppMenuLoading } from '@kbn/app-menu';
 import type { AppHeaderBack, AppHeaderSpacing } from '../types';
 import { useInlineAppHeader } from './hooks';
 import { AppHeaderShell } from './app_header_shell';
 import { TitleArea } from './title_area';
-import { AppHeaderSkeletonMenu, AppHeaderSkeletonTitle } from './app_header_skeleton';
+import { AppHeaderSkeletonTitle } from './app_header_skeleton';
 
 /**
  * Optional menu-skeleton customization. Omit the whole `menu` prop to get the default
@@ -53,15 +54,8 @@ export const AppHeaderLoadingView = React.memo<AppHeaderLoadingProps>(
 
     return (
       <AppHeaderShell
-        title={
-          <>
-            {back !== undefined ? <TitleArea back={back} size={titleSize} /> : null}
-            <AppHeaderSkeletonTitle />
-          </>
-        }
-        trailing={
-          <AppHeaderSkeletonMenu buttonCount={menu?.buttonCount} hasPrimary={menu?.hasPrimary} />
-        }
+        title={<TitleArea back={back} size={titleSize} placeholder={<AppHeaderSkeletonTitle />} />}
+        trailing={<AppMenuLoading buttonCount={menu?.buttonCount} hasPrimary={menu?.hasPrimary} />}
         sticky={sticky}
         spacing={spacing}
       />

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_loading.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_loading.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { AppHeaderBack, AppHeaderSpacing } from '../types';
+import { useInlineAppHeader } from './hooks';
+import { AppHeaderShell } from './app_header_shell';
+import { TitleArea } from './title_area';
+import { AppHeaderSkeletonMenu, AppHeaderSkeletonTitle } from './app_header_skeleton';
+
+/**
+ * Optional menu-skeleton customization. Omit the whole `menu` prop to get the default
+ * overflow + primary placeholders.
+ */
+export interface AppHeaderLoadingMenu {
+  /**
+   * App menu button placeholders on the left (overflow / secondary actions).
+   * Defaults to 1. Clamped to `APP_MENU_ITEM_LIMIT` (3) from `@kbn/app-menu` —
+   * the max visible left-side slots. The primary action does not count toward this.
+   */
+  buttonCount?: number;
+  /** Primary-action app menu button. Defaults to `true`. */
+  hasPrimary?: boolean;
+}
+
+export interface AppHeaderLoadingProps {
+  back?: AppHeaderBack | AppHeaderBack[];
+  menu?: AppHeaderLoadingMenu;
+  /**
+   * Defaults to `true`. Set to `false` only when the surrounding full-page layout
+   * provides its own sticky-header mechanism for the correct scrolling container.
+   */
+  sticky?: boolean;
+  /**
+   * Controls the horizontal inset. Defaults to `standard` so the skeleton matches a
+   * typical title + app menu header.
+   */
+  spacing?: AppHeaderSpacing;
+}
+
+/**
+ * Loading-state header view without claiming the inline slot. Prefer {@link AppHeaderLoading}.
+ */
+export const AppHeaderLoadingView = React.memo<AppHeaderLoadingProps>(
+  ({ back, menu, sticky, spacing = 'standard' }) => {
+    const titleSize = spacing === 'compact' ? 'xs' : 's';
+
+    return (
+      <AppHeaderShell
+        title={
+          <>
+            {back !== undefined ? <TitleArea back={back} size={titleSize} /> : null}
+            <AppHeaderSkeletonTitle />
+          </>
+        }
+        trailing={
+          <AppHeaderSkeletonMenu buttonCount={menu?.buttonCount} hasPrimary={menu?.hasPrimary} />
+        }
+        sticky={sticky}
+        spacing={spacing}
+      />
+    );
+  }
+);
+
+AppHeaderLoadingView.displayName = 'AppHeaderLoadingView';
+
+/**
+ * Loading placeholder for {@link AppHeader}. Mounts in the same inline slot and skeletons the
+ * title and app menu with defaults that match a typical title + overflow + primary header.
+ */
+export const AppHeaderLoading = React.memo<AppHeaderLoadingProps>((props) => {
+  useInlineAppHeader();
+  return <AppHeaderLoadingView {...props} />;
+});
+
+AppHeaderLoading.displayName = 'AppHeaderLoading';

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_skeleton.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_skeleton.tsx
@@ -8,34 +8,14 @@
  */
 
 import { EuiSkeletonRectangle, useEuiTheme } from '@elastic/eui';
-import { css } from '@emotion/react';
-import { APP_MENU_ITEM_LIMIT } from '@kbn/app-menu';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { APP_HEADER_TEST_SUBJECTS } from './test_subjects';
 
 /**
- * Approximate the real title line and app-menu controls so the layout does not jump when
- * content arrives:
- * EuiTitle ~24px tall, EuiButtonIcon size="s" square, EuiButton size="s" primary.
+ * Approximate the real title line so the layout does not jump when content arrives.
+ * EuiTitle size s/xs is ~24px tall.
  */
 const TITLE_WIDTH_PX = 200;
-const PRIMARY_WIDTH_PX = 96;
-const DEFAULT_BUTTON_COUNT = 1;
-
-const useSkeletonStyles = () => {
-  const { euiTheme } = useEuiTheme();
-
-  return useMemo(() => {
-    const menu = css`
-      display: flex;
-      flex-shrink: 0;
-      align-items: center;
-      gap: ${euiTheme.size.xs};
-    `;
-
-    return { menu };
-  }, [euiTheme]);
-};
 
 export const AppHeaderSkeletonTitle = React.memo(() => {
   const { euiTheme } = useEuiTheme();
@@ -48,52 +28,3 @@ export const AppHeaderSkeletonTitle = React.memo(() => {
 });
 
 AppHeaderSkeletonTitle.displayName = 'AppHeaderSkeletonTitle';
-
-export interface AppHeaderSkeletonMenuProps {
-  /**
-   * App menu button placeholders on the left (overflow / secondary actions).
-   * Defaults to 1. Clamped to {@link APP_MENU_ITEM_LIMIT}.
-   */
-  buttonCount?: number;
-  /** Primary-action rectangle. Defaults to `true`. */
-  hasPrimary?: boolean;
-}
-
-const resolveButtonCount = (buttonCount: number | undefined): number =>
-  Math.min(Math.max(buttonCount ?? DEFAULT_BUTTON_COUNT, 0), APP_MENU_ITEM_LIMIT);
-
-export const AppHeaderSkeletonMenu = React.memo<AppHeaderSkeletonMenuProps>(
-  ({ buttonCount, hasPrimary = true }) => {
-    const { euiTheme } = useEuiTheme();
-    const styles = useSkeletonStyles();
-    const resolvedButtonCount = resolveButtonCount(buttonCount);
-
-    if (resolvedButtonCount === 0 && !hasPrimary) {
-      return null;
-    }
-
-    return (
-      <div css={styles.menu} data-test-subj={APP_HEADER_TEST_SUBJECTS.skeletonMenu}>
-        {Array.from({ length: resolvedButtonCount }, (_unused, idx) => (
-          <EuiSkeletonRectangle
-            key={idx}
-            width={euiTheme.size.xl}
-            height={euiTheme.size.xl}
-            borderRadius="m"
-            ariaWrapperProps={idx === 0 ? undefined : { 'aria-hidden': true }}
-          />
-        ))}
-        {hasPrimary && (
-          <EuiSkeletonRectangle
-            width={PRIMARY_WIDTH_PX}
-            height={euiTheme.size.xl}
-            borderRadius="m"
-            ariaWrapperProps={resolvedButtonCount === 0 ? undefined : { 'aria-hidden': true }}
-          />
-        )}
-      </div>
-    );
-  }
-);
-
-AppHeaderSkeletonMenu.displayName = 'AppHeaderSkeletonMenu';

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_skeleton.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_skeleton.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiSkeletonRectangle, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { APP_MENU_ITEM_LIMIT } from '@kbn/app-menu';
+import React, { useMemo } from 'react';
+import { APP_HEADER_TEST_SUBJECTS } from './test_subjects';
+
+/**
+ * Approximate the real title line and app-menu controls so the layout does not jump when
+ * content arrives:
+ * EuiTitle ~24px tall, EuiButtonIcon size="s" square, EuiButton size="s" primary.
+ */
+const TITLE_WIDTH_PX = 200;
+const PRIMARY_WIDTH_PX = 96;
+const DEFAULT_BUTTON_COUNT = 1;
+
+const useSkeletonStyles = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return useMemo(() => {
+    const menu = css`
+      display: flex;
+      flex-shrink: 0;
+      align-items: center;
+      gap: ${euiTheme.size.xs};
+    `;
+
+    return { menu };
+  }, [euiTheme]);
+};
+
+export const AppHeaderSkeletonTitle = React.memo(() => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <div data-test-subj={APP_HEADER_TEST_SUBJECTS.skeleton}>
+      <EuiSkeletonRectangle width={TITLE_WIDTH_PX} height={euiTheme.size.l} borderRadius="m" />
+    </div>
+  );
+});
+
+AppHeaderSkeletonTitle.displayName = 'AppHeaderSkeletonTitle';
+
+export interface AppHeaderSkeletonMenuProps {
+  /**
+   * App menu button placeholders on the left (overflow / secondary actions).
+   * Defaults to 1. Clamped to {@link APP_MENU_ITEM_LIMIT}.
+   */
+  buttonCount?: number;
+  /** Primary-action rectangle. Defaults to `true`. */
+  hasPrimary?: boolean;
+}
+
+const resolveButtonCount = (buttonCount: number | undefined): number =>
+  Math.min(Math.max(buttonCount ?? DEFAULT_BUTTON_COUNT, 0), APP_MENU_ITEM_LIMIT);
+
+export const AppHeaderSkeletonMenu = React.memo<AppHeaderSkeletonMenuProps>(
+  ({ buttonCount, hasPrimary = true }) => {
+    const { euiTheme } = useEuiTheme();
+    const styles = useSkeletonStyles();
+    const resolvedButtonCount = resolveButtonCount(buttonCount);
+
+    if (resolvedButtonCount === 0 && !hasPrimary) {
+      return null;
+    }
+
+    return (
+      <div css={styles.menu} data-test-subj={APP_HEADER_TEST_SUBJECTS.skeletonMenu}>
+        {Array.from({ length: resolvedButtonCount }, (_unused, idx) => (
+          <EuiSkeletonRectangle
+            key={idx}
+            width={euiTheme.size.xl}
+            height={euiTheme.size.xl}
+            borderRadius="m"
+            ariaWrapperProps={idx === 0 ? undefined : { 'aria-hidden': true }}
+          />
+        ))}
+        {hasPrimary && (
+          <EuiSkeletonRectangle
+            width={PRIMARY_WIDTH_PX}
+            height={euiTheme.size.xl}
+            borderRadius="m"
+            ariaWrapperProps={resolvedButtonCount === 0 ? undefined : { 'aria-hidden': true }}
+          />
+        )}
+      </div>
+    );
+  }
+);
+
+AppHeaderSkeletonMenu.displayName = 'AppHeaderSkeletonMenu';

--- a/src/core/packages/chrome/app-header/src/app_header/hooks/use_inline_app_header.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/hooks/use_inline_app_header.ts
@@ -7,15 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export {
-  useBasePath,
-  useCanAccessIntegrations,
-  useCapabilities,
-  useLegacyActionMenu,
-  useHasLegacyActionMenu,
-} from './chrome';
-export { useBackNavTargets } from './use_back_navigation';
-export type { BackNavigation } from './use_back_navigation';
-export { useResolvedBadges } from './use_app_badges';
-export { useAppHeaderStaticItems } from './use_app_header_menu';
-export { useInlineAppHeader } from './use_inline_app_header';
+import { useLayoutEffect } from 'react';
+import { useChromeService } from '@kbn/core-chrome-browser-context';
+
+/**
+ * Claims the Chrome Next inline app-header slot so Chrome does not also render a chrome-owned header.
+ */
+export const useInlineAppHeader = (): void => {
+  const chrome = useChromeService();
+  useLayoutEffect(() => {
+    chrome.next.inlineAppHeader.set(true);
+    return () => chrome.next.inlineAppHeader.set(false);
+  }, [chrome]);
+};

--- a/src/core/packages/chrome/app-header/src/app_header/index.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/index.ts
@@ -9,6 +9,8 @@
 
 export { AppHeader, AppHeaderView } from './app_header';
 export type { AppHeaderProps, AppHeaderViewProps } from './app_header';
+export { AppHeaderLoading, AppHeaderLoadingView } from './app_header_loading';
+export type { AppHeaderLoadingProps, AppHeaderLoadingMenu } from './app_header_loading';
 export {
   ChromeAppHeaderRegistration,
   useChromeAppHeaderRegistration,

--- a/src/core/packages/chrome/app-header/src/app_header/test_subjects.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/test_subjects.ts
@@ -29,6 +29,8 @@ export const APP_HEADER_TEST_SUBJECTS = {
   tabs: 'appHeaderTabs',
   badgesOverflow: 'appHeaderBadgesOverflow',
   back: 'appHeaderBack',
+  skeleton: 'appHeaderSkeleton',
+  skeletonMenu: 'appHeaderSkeletonMenu',
   menuDocumentation: 'appHeaderMenuDocumentation',
   menuFeedback: 'appHeaderMenuFeedback',
   menuAddIntegrations: 'appHeaderMenuAddIntegrations',

--- a/src/core/packages/chrome/app-header/src/app_header/test_subjects.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/test_subjects.ts
@@ -30,7 +30,6 @@ export const APP_HEADER_TEST_SUBJECTS = {
   badgesOverflow: 'appHeaderBadgesOverflow',
   back: 'appHeaderBack',
   skeleton: 'appHeaderSkeleton',
-  skeletonMenu: 'appHeaderSkeletonMenu',
   menuDocumentation: 'appHeaderMenuDocumentation',
   menuFeedback: 'appHeaderMenuFeedback',
   menuAddIntegrations: 'appHeaderMenuAddIntegrations',

--- a/src/core/packages/chrome/app-header/src/app_header/title_area/README.md
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/README.md
@@ -5,7 +5,8 @@ title. The title is either a plain string (read-only) or an editable title that 
 user can rename inline.
 
 - `title_area.tsx` — `TitleArea`: thin layout orchestrator (back button + title in a
-  flex row). Holds no edit state.
+  flex row). Holds no edit state. Accepts an optional `placeholder` for the title slot
+  so loading skeletons share the same gap and no-back offset as a real title.
 - `title.tsx` — `Title`: the editable/read-only title itself. All the styling, width
   model, save flow, and a11y live here. Takes a `size` (`xs` | `s`) for the `EuiTitle`.
   Also exports the `isEditableTitle` type guard.

--- a/src/core/packages/chrome/app-header/src/app_header/title_area/title_area.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/title_area.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ChromeServiceProvider } from '@kbn/core-chrome-browser-context';
+import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
+import { TitleArea } from './title_area';
+import { APP_HEADER_TEST_SUBJECTS } from '../test_subjects';
+
+const renderTitleArea = (ui: React.ReactElement) =>
+  render(
+    <ChromeServiceProvider value={{ chrome: chromeServiceMock.createStartContract() }}>
+      {ui}
+    </ChromeServiceProvider>
+  );
+
+describe('TitleArea', () => {
+  it('renders a placeholder in the title slot', () => {
+    renderTitleArea(<TitleArea placeholder={<div data-test-subj="title-placeholder" />} />);
+
+    expect(screen.getByTestId('title-placeholder')).toBeInTheDocument();
+  });
+
+  it('keeps the back button next to the placeholder', () => {
+    renderTitleArea(
+      <TitleArea back="/app/my-app" placeholder={<div data-test-subj="title-placeholder" />} />
+    );
+
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.back)).toHaveAttribute(
+      'href',
+      '/app/my-app'
+    );
+    expect(screen.getByTestId('title-placeholder')).toBeInTheDocument();
+  });
+
+  it('prefers a real title over the placeholder', () => {
+    renderTitleArea(
+      <TitleArea title="Dashboards" placeholder={<div data-test-subj="title-placeholder" />} />
+    );
+
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.title)).toHaveTextContent('Dashboards');
+    expect(screen.queryByTestId('title-placeholder')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no title, back, or placeholder', () => {
+    const { container } = renderTitleArea(<TitleArea />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/core/packages/chrome/app-header/src/app_header/title_area/title_area.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/title_area.tsx
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ReactNode } from 'react';
 import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
@@ -19,34 +20,50 @@ export interface TitleAreaProps {
   title?: string | AppHeaderEditableTitle;
   back?: AppHeaderBack | AppHeaderBack[];
   size?: 'xs' | 's';
+  /**
+   * Rendered in the title slot when no title is provided, so loading placeholders
+   * share the same gap and offset as a real title.
+   */
+  placeholder?: ReactNode;
 }
 
-export const TitleArea = React.memo<TitleAreaProps>(({ title, back, size }) => {
+export const TitleArea = React.memo<TitleAreaProps>(({ title, back, size, placeholder }) => {
   const { euiTheme } = useEuiTheme();
   const backTargets = useBackNavTargets(back);
   const hasBack = backTargets.length > 0;
   const showTitle = !!title && (isEditableTitle(title) || title.length > 0);
+  const showPlaceholder = !showTitle && placeholder != null;
 
-  const wrapper = useMemo(
-    () => css`
+  const styles = useMemo(() => {
+    const wrapper = css`
       display: flex;
       align-items: center;
       gap: ${euiTheme.size.s};
       flex: 0 1 auto;
       min-width: 0;
       max-width: 100%;
-    `,
-    [euiTheme]
-  );
+    `;
 
-  if (!showTitle && !hasBack) {
+    // Same inset `Title` applies when there is no back button, so a lone placeholder
+    // lines up with where the title text sits.
+    const placeholderOffset = css`
+      padding-left: ${euiTheme.size.xs};
+    `;
+
+    return { wrapper, placeholderOffset };
+  }, [euiTheme]);
+
+  if (!showTitle && !hasBack && !showPlaceholder) {
     return null;
   }
 
   return (
-    <div css={wrapper}>
+    <div css={styles.wrapper}>
       {hasBack && <BackButton targets={backTargets} />}
-      {title && <Title title={title} titleOffset={!hasBack} size={size} />}
+      {showTitle && title && <Title title={title} titleOffset={!hasBack} size={size} />}
+      {showPlaceholder && (
+        <div css={!hasBack ? styles.placeholderOffset : undefined}>{placeholder}</div>
+      )}
     </div>
   );
 });

--- a/src/core/packages/chrome/app-header/src/index.ts
+++ b/src/core/packages/chrome/app-header/src/index.ts
@@ -9,6 +9,8 @@
 
 export { AppHeader, AppHeaderView } from './app_header';
 export type { AppHeaderProps, AppHeaderViewProps } from './app_header';
+export { AppHeaderLoading, AppHeaderLoadingView } from './app_header';
+export type { AppHeaderLoadingProps, AppHeaderLoadingMenu } from './app_header';
 export {
   ChromeAppHeaderRegistration,
   useChromeAppHeaderRegistration,

--- a/src/core/packages/chrome/app-menu/app-menu/index.ts
+++ b/src/core/packages/chrome/app-menu/app-menu/index.ts
@@ -8,6 +8,7 @@
  */
 export {
   AppMenuComponent,
+  AppMenuLoading,
   AppMenuItem,
   AppMenuActionButton,
   AppMenuOverflowButton,
@@ -33,6 +34,7 @@ export {
 } from '@kbn/ui-app-menu';
 
 export type {
+  AppMenuLoadingProps,
   AppMenuBreakpointSource,
   AppMenuRunAction,
   AppMenuRunActionParams,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
@@ -10,6 +10,7 @@
 /** @deprecated Import from `@kbn/app-menu` instead. */
 export {
   AppMenuComponent,
+  AppMenuLoading,
   AppMenuItem,
   AppMenuActionButton,
   AppMenuOverflowButton,
@@ -36,6 +37,7 @@ export {
 
 /** @deprecated Import from `@kbn/app-menu` instead. */
 export type {
+  AppMenuLoadingProps,
   AppMenuBreakpointSource,
   AppMenuRunAction,
   AppMenuRunActionParams,

--- a/src/platform/kbn-ui/app-menu/README.md
+++ b/src/platform/kbn-ui/app-menu/README.md
@@ -28,6 +28,20 @@ viewport breakpoint using the previous viewport mapping: `xs` and `s` collapse, 
 the medium layout, and `xl` shows the full menu. Menus that should preserve viewport-based behavior,
 such as the Classic and legacy Project Chrome headers, set `breakpointSource="viewport"`.
 
+## Loading skeleton
+
+`AppMenuLoading` skeletons the same responsive layouts. Mount it in the same slot as
+`AppMenuComponent` while the menu config is not ready. It defaults to one overflow-style
+placeholder plus a primary-action rectangle; `buttonCount` is clamped to `APP_MENU_ITEM_LIMIT`.
+
+```tsx
+<AppMenuLoading />
+<AppMenuLoading buttonCount={2} hasPrimary={false} />
+```
+
+Collapsed breakpoints show only the overflow placeholder (the primary action lives inside that
+menu). Minimal shows overflow + primary. Expanded shows `buttonCount` icon placeholders + primary.
+
 ## Strict props
 
 The public types are the contract. A type assertion can still pass a React node as a `label`, or

--- a/src/platform/kbn-ui/app-menu/app_menu.stories.tsx
+++ b/src/platform/kbn-ui/app-menu/app_menu.stories.tsx
@@ -12,7 +12,7 @@ import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { EuiFlexGroup, EuiHeader, EuiPageTemplate } from '@elastic/eui';
-import { AppMenuComponent } from '.';
+import { AppMenuComponent, AppMenuLoading } from '.';
 import type { AppMenuConfig } from '.';
 
 type AppMenuWrapperProps = ComponentProps<typeof AppMenuComponent>;
@@ -722,5 +722,25 @@ export const ItemDescriptions: Story = {
   name: 'Item descriptions',
   args: {
     config: itemDescriptionsConfig,
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading skeleton',
+  render: () => (
+    <EuiHeader>
+      <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
+        <AppMenuLoading />
+      </EuiFlexGroup>
+    </EuiHeader>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default `AppMenuLoading`: one overflow-style placeholder plus a primary-action rectangle. ' +
+          'Resize the viewport to see the same collapsed / minimal / expanded layouts as the real menu.',
+      },
+    },
   },
 };

--- a/src/platform/kbn-ui/app-menu/index.ts
+++ b/src/platform/kbn-ui/app-menu/index.ts
@@ -8,6 +8,7 @@
  */
 
 export { AppMenuComponent, type AppMenuBreakpointSource } from './src';
+export { AppMenuLoading, type AppMenuLoadingProps } from './src';
 export { AppMenuItem } from './src';
 export { AppMenuActionButton } from './src';
 export { AppMenuOverflowButton } from './src';

--- a/src/platform/kbn-ui/app-menu/src/components/app_menu.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu.tsx
@@ -8,8 +8,6 @@
  */
 
 import React, { useState } from 'react';
-import { EuiHeaderLinks, type EuiBreakpointSize, useCurrentEuiBreakpoint } from '@elastic/eui';
-import { useCurrentChromeApplicationBreakpoint } from '@kbn/ui-chrome-layout-utils';
 import { css } from '@emotion/react';
 import { getAppMenuItems, hasNonGlobalStaticItems, processStaticItems } from '../utils';
 import { AppMenuActionButton } from './app_menu_action_button';
@@ -17,12 +15,19 @@ import { AppMenuItem } from './app_menu_item';
 import { AppMenuOverflowButton } from './app_menu_overflow_button';
 import { AppMenuSwitchComponent } from './app_menu_switch';
 import type { AppMenuConfig, AppMenuStaticItem } from '../types';
-import { APP_MENU_TEST_SUBJECTS } from '../test_subjects';
+import {
+  AppMenuApplicationResponsiveContent,
+  AppMenuViewportResponsiveContent,
+  type AppMenuBreakpointSource,
+  type AppMenuLayout,
+} from './app_menu_responsive';
 
 const secondaryActionsCss = css`
   display: flex;
   align-items: center;
 `;
+
+export type { AppMenuBreakpointSource };
 
 export interface AppMenuItemsProps {
   config?: AppMenuConfig;
@@ -34,78 +39,8 @@ export interface AppMenuItemsProps {
   staticItems?: AppMenuStaticItem[];
 }
 
-export type AppMenuBreakpointSource = 'application' | 'viewport';
-
-type AppMenuLayout = 'collapsed' | 'minimal' | 'expanded';
-
-const APPLICATION_LAYOUTS: Record<EuiBreakpointSize, AppMenuLayout> = {
-  xs: 'collapsed',
-  s: 'minimal',
-  m: 'expanded',
-  l: 'expanded',
-  xl: 'expanded',
-};
-
-const VIEWPORT_LAYOUTS: Record<EuiBreakpointSize, AppMenuLayout> = {
-  xs: 'collapsed',
-  s: 'collapsed',
-  m: 'minimal',
-  l: 'minimal',
-  xl: 'expanded',
-};
-
 const hasNoItems = (config: AppMenuConfig) =>
   !config.items?.length && !config?.primaryActionItem && !config?.switch;
-
-const AppMenuHeaderLinks = ({ children }: { children: React.ReactNode }) => (
-  <EuiHeaderLinks
-    data-test-subj={APP_MENU_TEST_SUBJECTS.root}
-    gutterSize="xs"
-    popoverBreakpoints="none"
-    className="kbnTopNavMenu__wrapper"
-  >
-    {children}
-  </EuiHeaderLinks>
-);
-
-interface AppMenuResponsiveContentProps {
-  content: Record<AppMenuLayout, React.ReactNode>;
-}
-
-type AppMenuResolvedResponsiveContentProps = AppMenuResponsiveContentProps & {
-  breakpoint: EuiBreakpointSize | undefined;
-  source: AppMenuBreakpointSource;
-};
-
-const AppMenuResponsiveContent = ({
-  content,
-  breakpoint,
-  source,
-}: AppMenuResolvedResponsiveContentProps) => {
-  const layouts = source === 'application' ? APPLICATION_LAYOUTS : VIEWPORT_LAYOUTS;
-  const layout = breakpoint ? layouts[breakpoint] : 'collapsed';
-
-  return <AppMenuHeaderLinks>{content[layout]}</AppMenuHeaderLinks>;
-};
-
-const AppMenuApplicationResponsiveContent = (props: AppMenuResponsiveContentProps) => {
-  const applicationBreakpoint = useCurrentChromeApplicationBreakpoint();
-  const viewportBreakpoint = useCurrentEuiBreakpoint();
-
-  return (
-    <AppMenuResponsiveContent
-      {...props}
-      breakpoint={applicationBreakpoint ?? viewportBreakpoint}
-      source={applicationBreakpoint === undefined ? 'viewport' : 'application'}
-    />
-  );
-};
-
-const AppMenuViewportResponsiveContent = (props: AppMenuResponsiveContentProps) => {
-  const breakpoint = useCurrentEuiBreakpoint();
-
-  return <AppMenuResponsiveContent {...props} breakpoint={breakpoint} source="viewport" />;
-};
 
 export const AppMenuComponent = ({
   config,

--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_loading.test.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_loading.test.tsx
@@ -67,6 +67,14 @@ describe('AppMenuLoading', () => {
     expect(menuRectangles()).toHaveLength(1);
   });
 
+  it('collapses a primary-only menu to a single overflow placeholder', () => {
+    mockCurrentBreakpoint = 'xs';
+
+    render(<AppMenuLoading buttonCount={0} hasPrimary />);
+
+    expect(menuRectangles()).toHaveLength(1);
+  });
+
   it('shows overflow + primary at the minimal application breakpoint', () => {
     mockCurrentBreakpoint = 's';
 

--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_loading.test.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_loading.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { EuiBreakpointSize } from '@elastic/eui';
+import { APP_MENU_ITEM_LIMIT } from '../constants';
+import { APP_MENU_TEST_SUBJECTS } from '../test_subjects';
+import { AppMenuLoading } from './app_menu_loading';
+
+let mockCurrentBreakpoint: EuiBreakpointSize | undefined = 'xl';
+let mockViewportBreakpoint: EuiBreakpointSize = 'xl';
+
+jest.mock('@kbn/ui-chrome-layout-utils', () => ({
+  useCurrentChromeApplicationBreakpoint: () => mockCurrentBreakpoint,
+}));
+
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+
+  return {
+    ...actual,
+    useCurrentEuiBreakpoint: () => mockViewportBreakpoint,
+  };
+});
+
+const menuRectangles = (): NodeListOf<Element> =>
+  screen.getByTestId(APP_MENU_TEST_SUBJECTS.loading).querySelectorAll('.euiSkeletonRectangle');
+
+describe('AppMenuLoading', () => {
+  beforeEach(() => {
+    mockCurrentBreakpoint = 'xl';
+    mockViewportBreakpoint = 'xl';
+  });
+
+  it('returns null when there is nothing to skeleton', () => {
+    const { container } = render(<AppMenuLoading buttonCount={0} hasPrimary={false} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('skeletons overflow + primary at the expanded application breakpoint', () => {
+    render(<AppMenuLoading />);
+
+    expect(screen.getByTestId(APP_MENU_TEST_SUBJECTS.loading)).toBeInTheDocument();
+    expect(screen.getByTestId(APP_MENU_TEST_SUBJECTS.root)).toBeInTheDocument();
+    expect(menuRectangles()).toHaveLength(2);
+  });
+
+  it('clamps buttonCount to APP_MENU_ITEM_LIMIT', () => {
+    render(<AppMenuLoading buttonCount={99} />);
+
+    expect(menuRectangles()).toHaveLength(APP_MENU_ITEM_LIMIT + 1);
+  });
+
+  it('collapses to a single overflow placeholder at xs', () => {
+    mockCurrentBreakpoint = 'xs';
+
+    render(<AppMenuLoading buttonCount={2} />);
+
+    expect(menuRectangles()).toHaveLength(1);
+  });
+
+  it('shows overflow + primary at the minimal application breakpoint', () => {
+    mockCurrentBreakpoint = 's';
+
+    render(<AppMenuLoading buttonCount={2} />);
+
+    expect(menuRectangles()).toHaveLength(2);
+  });
+
+  it('shows every requested button at expanded breakpoints', () => {
+    render(<AppMenuLoading buttonCount={2} hasPrimary={false} />);
+
+    expect(menuRectangles()).toHaveLength(2);
+  });
+
+  it('falls back to viewport layouts when application measurement is unavailable', () => {
+    mockCurrentBreakpoint = undefined;
+    mockViewportBreakpoint = 'm';
+
+    render(<AppMenuLoading buttonCount={2} />);
+
+    // Viewport `m` is minimal: overflow + primary, not the two expanded icon slots.
+    expect(menuRectangles()).toHaveLength(2);
+  });
+
+  it('uses viewport mapping when breakpointSource is viewport', () => {
+    mockViewportBreakpoint = 's';
+
+    render(<AppMenuLoading buttonCount={2} breakpointSource="viewport" />);
+
+    expect(menuRectangles()).toHaveLength(1);
+  });
+});

--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_loading.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_loading.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiSkeletonRectangle, useEuiTheme } from '@elastic/eui';
+import React from 'react';
+import { APP_MENU_ITEM_LIMIT } from '../constants';
+import { APP_MENU_TEST_SUBJECTS } from '../test_subjects';
+import {
+  AppMenuApplicationResponsiveContent,
+  AppMenuViewportResponsiveContent,
+  type AppMenuBreakpointSource,
+  type AppMenuLayout,
+} from './app_menu_responsive';
+
+/**
+ * Approximate EuiButton size="s" so the primary placeholder does not jump when the real
+ * action arrives. Icon placeholders use the same 32px square as the header row floor.
+ */
+const PRIMARY_WIDTH_PX = 96;
+const DEFAULT_BUTTON_COUNT = 1;
+
+export interface AppMenuLoadingProps {
+  /**
+   * App menu button placeholders on the left (overflow / secondary actions).
+   * Defaults to 1. Clamped to {@link APP_MENU_ITEM_LIMIT}.
+   */
+  buttonCount?: number;
+  /** Primary-action rectangle. Defaults to `true`. */
+  hasPrimary?: boolean;
+  breakpointSource?: AppMenuBreakpointSource;
+}
+
+const resolveButtonCount = (buttonCount: number | undefined): number =>
+  Math.min(Math.max(buttonCount ?? DEFAULT_BUTTON_COUNT, 0), APP_MENU_ITEM_LIMIT);
+
+const IconSkeleton = ({ announce }: { announce: boolean }) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiSkeletonRectangle
+      width={euiTheme.size.xl}
+      height={euiTheme.size.xl}
+      borderRadius="m"
+      ariaWrapperProps={announce ? undefined : { 'aria-hidden': true }}
+    />
+  );
+};
+
+/**
+ * Loading placeholder for {@link AppMenuComponent}. Uses the same responsive layout
+ * selection so collapsed / minimal / expanded breakpoints match the real menu.
+ */
+export const AppMenuLoading = ({
+  buttonCount,
+  hasPrimary = true,
+  breakpointSource = 'application',
+}: AppMenuLoadingProps): React.ReactElement | null => {
+  const { euiTheme } = useEuiTheme();
+  const resolvedButtonCount = resolveButtonCount(buttonCount);
+
+  if (resolvedButtonCount === 0 && !hasPrimary) {
+    return null;
+  }
+
+  const overflowSkeleton = resolvedButtonCount > 0 ? <IconSkeleton announce /> : null;
+  const primarySkeleton = hasPrimary ? (
+    <EuiSkeletonRectangle
+      width={PRIMARY_WIDTH_PX}
+      height={euiTheme.size.xl}
+      borderRadius="m"
+      ariaWrapperProps={resolvedButtonCount === 0 ? undefined : { 'aria-hidden': true }}
+    />
+  ) : null;
+
+  const expandedButtons = Array.from({ length: resolvedButtonCount }, (_unused, idx) => (
+    <IconSkeleton key={idx} announce={idx === 0} />
+  ));
+
+  const content: Record<AppMenuLayout, React.ReactNode> = {
+    // Primary lives inside the overflow popover when the menu is collapsed.
+    collapsed: overflowSkeleton ?? primarySkeleton,
+    minimal: (
+      <>
+        {overflowSkeleton}
+        {primarySkeleton}
+      </>
+    ),
+    expanded: (
+      <>
+        {expandedButtons}
+        {primarySkeleton}
+      </>
+    ),
+  };
+
+  const ResponsiveContent =
+    breakpointSource === 'application'
+      ? AppMenuApplicationResponsiveContent
+      : AppMenuViewportResponsiveContent;
+
+  return (
+    <div data-test-subj={APP_MENU_TEST_SUBJECTS.loading}>
+      <ResponsiveContent content={content} />
+    </div>
+  );
+};

--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_loading.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_loading.tsx
@@ -83,8 +83,9 @@ export const AppMenuLoading = ({
   ));
 
   const content: Record<AppMenuLayout, React.ReactNode> = {
-    // Primary lives inside the overflow popover when the menu is collapsed.
-    collapsed: overflowSkeleton ?? primarySkeleton,
+    // Collapsed menus always use a single overflow control; primary (if any) lives
+    // inside that popover, so a primary-only menu must not show the 96px rectangle.
+    collapsed: <IconSkeleton announce />,
     minimal: (
       <>
         {overflowSkeleton}

--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_responsive.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_responsive.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiHeaderLinks, type EuiBreakpointSize, useCurrentEuiBreakpoint } from '@elastic/eui';
+import { useCurrentChromeApplicationBreakpoint } from '@kbn/ui-chrome-layout-utils';
+import { APP_MENU_TEST_SUBJECTS } from '../test_subjects';
+
+export type AppMenuBreakpointSource = 'application' | 'viewport';
+
+export type AppMenuLayout = 'collapsed' | 'minimal' | 'expanded';
+
+export const APPLICATION_LAYOUTS: Record<EuiBreakpointSize, AppMenuLayout> = {
+  xs: 'collapsed',
+  s: 'minimal',
+  m: 'expanded',
+  l: 'expanded',
+  xl: 'expanded',
+};
+
+export const VIEWPORT_LAYOUTS: Record<EuiBreakpointSize, AppMenuLayout> = {
+  xs: 'collapsed',
+  s: 'collapsed',
+  m: 'minimal',
+  l: 'minimal',
+  xl: 'expanded',
+};
+
+export const AppMenuHeaderLinks = ({ children }: { children: React.ReactNode }) => (
+  <EuiHeaderLinks
+    data-test-subj={APP_MENU_TEST_SUBJECTS.root}
+    gutterSize="xs"
+    popoverBreakpoints="none"
+    className="kbnTopNavMenu__wrapper"
+  >
+    {children}
+  </EuiHeaderLinks>
+);
+
+export interface AppMenuResponsiveContentProps {
+  content: Record<AppMenuLayout, React.ReactNode>;
+}
+
+type AppMenuResolvedResponsiveContentProps = AppMenuResponsiveContentProps & {
+  breakpoint: EuiBreakpointSize | undefined;
+  source: AppMenuBreakpointSource;
+};
+
+export const AppMenuResponsiveContent = ({
+  content,
+  breakpoint,
+  source,
+}: AppMenuResolvedResponsiveContentProps) => {
+  const layouts = source === 'application' ? APPLICATION_LAYOUTS : VIEWPORT_LAYOUTS;
+  const layout = breakpoint ? layouts[breakpoint] : 'collapsed';
+
+  return <AppMenuHeaderLinks>{content[layout]}</AppMenuHeaderLinks>;
+};
+
+export const AppMenuApplicationResponsiveContent = (props: AppMenuResponsiveContentProps) => {
+  const applicationBreakpoint = useCurrentChromeApplicationBreakpoint();
+  const viewportBreakpoint = useCurrentEuiBreakpoint();
+
+  return (
+    <AppMenuResponsiveContent
+      {...props}
+      breakpoint={applicationBreakpoint ?? viewportBreakpoint}
+      source={applicationBreakpoint === undefined ? 'viewport' : 'application'}
+    />
+  );
+};
+
+export const AppMenuViewportResponsiveContent = (props: AppMenuResponsiveContentProps) => {
+  const breakpoint = useCurrentEuiBreakpoint();
+
+  return <AppMenuResponsiveContent {...props} breakpoint={breakpoint} source="viewport" />;
+};

--- a/src/platform/kbn-ui/app-menu/src/components/index.ts
+++ b/src/platform/kbn-ui/app-menu/src/components/index.ts
@@ -8,6 +8,7 @@
  */
 
 export { AppMenuComponent, type AppMenuBreakpointSource } from './app_menu';
+export { AppMenuLoading, type AppMenuLoadingProps } from './app_menu_loading';
 export { AppMenuItem } from './app_menu_item';
 export { AppMenuActionButton } from './app_menu_action_button';
 export { AppMenuOverflowButton } from './app_menu_overflow_button';

--- a/src/platform/kbn-ui/app-menu/src/index.ts
+++ b/src/platform/kbn-ui/app-menu/src/index.ts
@@ -8,6 +8,7 @@
  */
 
 export { AppMenuComponent, type AppMenuBreakpointSource } from './components';
+export { AppMenuLoading, type AppMenuLoadingProps } from './components';
 export { AppMenuItem } from './components';
 export { AppMenuActionButton } from './components';
 export { AppMenuOverflowButton } from './components';

--- a/src/platform/kbn-ui/app-menu/src/test_subjects.ts
+++ b/src/platform/kbn-ui/app-menu/src/test_subjects.ts
@@ -14,6 +14,7 @@
  */
 export const APP_MENU_TEST_SUBJECTS = {
   root: 'app-menu',
+  loading: 'app-menu-loading',
   overflowButton: 'app-menu-overflow-button',
   popover: 'app-menu-popover',
   switch: 'app-menu-switch',


### PR DESCRIPTION
## Summary

This PR adds `AppHeaderLoading` component that automatically occupies the app header slot. The loading component comes with defaults so it can be used out of the box, but customization (e.g. number of app menu buttons) is allowed.

<img width="1007" height="98" alt="Screenshot 2026-08-18 at 11 00 57" src="https://github.com/user-attachments/assets/27016dfb-31e0-4b94-a8ba-717f28b3e3c4" />

Closes: https://github.com/elastic/kibana-team/issues/3663