### PR TITLE
[9.4] [Kibana Management] Add max length constraints to route validation strings (CodeQL unbounded-string) (#281262)

### DIFF
--- a/src/platform/plugins/shared/console/server/routes/api/console/proxy/route_validation.test.ts
+++ b/src/platform/plugins/shared/console/server/routes/api/console/proxy/route_validation.test.ts
@@ -20,8 +20,21 @@ describe('Proxy route validation', () => {
       it('mixed case http verbs', () => {
         expect(query.validate({ method: 'hEaD', path: 'test' }));
       });
+      it('host value', () => {
+        expect(query.validate({ method: 'GET', path: 'test', host: 'https://localhost:9200' }));
+      });
     });
     describe('throws for', () => {
+      it('overlong path value', () => {
+        expect(() => {
+          query.validate({ method: 'GET', path: 'a'.repeat(4097) });
+        }).toThrow('maximum length of [4096]');
+      });
+      it('overlong host value', () => {
+        expect(() => {
+          query.validate({ method: 'GET', path: 'test', host: 'a'.repeat(4097) });
+        }).toThrow('maximum length of [4096]');
+      });
       it('empty query method value', () => {
         expect(() => {
           query.validate({ method: '', path: 'test' });

--- a/src/platform/plugins/shared/console/server/routes/api/console/proxy/validation_config.ts
+++ b/src/platform/plugins/shared/console/server/routes/api/console/proxy/validation_config.ts
@@ -14,6 +14,7 @@ export type Query = TypeOf<typeof routeValidationConfig.query>;
 export type Body = TypeOf<typeof routeValidationConfig.body>;
 
 export const acceptedHttpVerb = schema.string({
+  maxLength: 64,
   validate: (method) => {
     return ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'PATCH'].some(
       (verb) => verb.toLowerCase() === method.toLowerCase()
@@ -24,6 +25,7 @@ export const acceptedHttpVerb = schema.string({
 });
 
 export const nonEmptyString = schema.string({
+  maxLength: 4096,
   validate: (s) => (s === '' ? 'Expected non-empty string' : undefined),
 });
 
@@ -32,7 +34,7 @@ export const routeValidationConfig = {
     method: acceptedHttpVerb,
     path: nonEmptyString,
     withProductOrigin: schema.maybe(schema.boolean()),
-    host: schema.maybe(schema.string()),
+    host: schema.maybe(schema.string({ maxLength: 4096 })),
   }),
   body: schema.stream(),
 };

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_delete_route.ts
@@ -19,7 +19,7 @@ export const registerDeleteRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.delete(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_get_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_get_route.ts
@@ -20,7 +20,7 @@ export const registerGetRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.get(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_pause_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_pause_route.ts
@@ -18,7 +18,7 @@ export const registerPauseRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.post(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_resume_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_resume_route.ts
@@ -18,7 +18,7 @@ export const registerResumeRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.post(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_update_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/auto_follow_pattern/register_update_route.ts
@@ -25,9 +25,9 @@ export const registerUpdateRoute = ({
 
   const bodySchema = schema.object({
     active: schema.boolean(),
-    remoteCluster: schema.string(),
-    leaderIndexPatterns: schema.arrayOf(schema.string(), { maxSize: 1000 }),
-    followIndexPattern: schema.string(),
+    remoteCluster: schema.string({ maxLength: 1000 }),
+    leaderIndexPatterns: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
+    followIndexPattern: schema.string({ maxLength: 1000 }),
   });
 
   router.put(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_get_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_get_route.ts
@@ -19,7 +19,7 @@ export const registerGetRoute = ({
   lib: { handleEsError },
 }: RouteDependencies) => {
   const paramsSchema = schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
   });
 
   router.get(

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_pause_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_pause_route.ts
@@ -17,7 +17,7 @@ export const registerPauseRoute = ({
   license,
   lib: { handleEsError },
 }: RouteDependencies) => {
-  const paramsSchema = schema.object({ id: schema.string() });
+  const paramsSchema = schema.object({ id: schema.string({ maxLength: 1000 }) });
 
   router.put(
     {

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_resume_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_resume_route.ts
@@ -17,7 +17,7 @@ export const registerResumeRoute = ({
   license,
   lib: { handleEsError },
 }: RouteDependencies) => {
-  const paramsSchema = schema.object({ id: schema.string() });
+  const paramsSchema = schema.object({ id: schema.string({ maxLength: 1000 }) });
 
   router.put(
     {

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_unfollow_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_unfollow_route.ts
@@ -17,7 +17,7 @@ export const registerUnfollowRoute = ({
   license,
   lib: { handleEsError },
 }: RouteDependencies) => {
-  const paramsSchema = schema.object({ id: schema.string() });
+  const paramsSchema = schema.object({ id: schema.string({ maxLength: 1000 }) });
 
   router.put(
     {

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_update_route.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/routes/api/follower_index/register_update_route.ts
@@ -20,19 +20,19 @@ export const registerUpdateRoute = ({
   license,
   lib: { handleEsError },
 }: RouteDependencies) => {
-  const paramsSchema = schema.object({ id: schema.string() });
+  const paramsSchema = schema.object({ id: schema.string({ maxLength: 1000 }) });
 
   const bodySchema = schema.object({
     maxReadRequestOperationCount: schema.maybe(schema.number()),
     maxOutstandingReadRequests: schema.maybe(schema.number()),
-    maxReadRequestSize: schema.maybe(schema.string()), // byte value
+    maxReadRequestSize: schema.maybe(schema.string({ maxLength: 64 })), // byte value
     maxWriteRequestOperationCount: schema.maybe(schema.number()),
-    maxWriteRequestSize: schema.maybe(schema.string()), // byte value
+    maxWriteRequestSize: schema.maybe(schema.string({ maxLength: 64 })), // byte value
     maxOutstandingWriteRequests: schema.maybe(schema.number()),
     maxWriteBufferCount: schema.maybe(schema.number()),
-    maxWriteBufferSize: schema.maybe(schema.string()), // byte value
-    maxRetryDelay: schema.maybe(schema.string()), // time value
-    readPollTimeout: schema.maybe(schema.string()), // time value
+    maxWriteBufferSize: schema.maybe(schema.string({ maxLength: 64 })), // byte value
+    maxRetryDelay: schema.maybe(schema.string({ maxLength: 64 })), // time value
+    readPollTimeout: schema.maybe(schema.string({ maxLength: 64 })), // time value
   });
 
   router.put(

--- a/x-pack/platform/plugins/private/data_usage/server/routes/internal/usage_metrics.ts
+++ b/x-pack/platform/plugins/private/data_usage/server/routes/internal/usage_metrics.ts
@@ -45,6 +45,7 @@ export const registerUsageMetricsRoute = (
 };
 
 const DateSchema = schema.string({
+  maxLength: 64,
   minLength: 1,
   validate: (v) => (v.trim().length ? undefined : 'Date ISO string must not be empty'),
 });
@@ -52,7 +53,7 @@ const DateSchema = schema.string({
 export const UsageMetricsRequestSchema = schema.object({
   from: DateSchema,
   to: DateSchema,
-  metricTypes: schema.arrayOf(schema.string(), {
+  metricTypes: schema.arrayOf(schema.string({ maxLength: 1000 }), {
     minSize: 1,
     maxSize: 1000,
     validate: (values) => {
@@ -64,7 +65,7 @@ export const UsageMetricsRequestSchema = schema.object({
       }
     },
   }),
-  dataStreams: schema.arrayOf(schema.string(), {
+  dataStreams: schema.arrayOf(schema.string({ maxLength: 1000 }), {
     maxSize: 1000,
     validate: (values) => {
       if (values.map((v) => v.trim()).some((v) => !v.length)) {

--- a/x-pack/platform/plugins/private/grokdebugger/server/routes/api/grokdebugger/register_grok_simulate_route.ts
+++ b/x-pack/platform/plugins/private/grokdebugger/server/routes/api/grokdebugger/register_grok_simulate_route.ts
@@ -16,10 +16,14 @@ import { handleEsError } from '../../../shared_imports';
 import type { KibanaFramework } from '../../../lib/kibana_framework';
 
 export const requestBodySchema = schema.object({
-  pattern: schema.string(),
-  rawEvent: schema.string(),
+  pattern: schema.string({ maxLength: 10000 }),
+  rawEvent: schema.string({ maxLength: 100000 }),
   // Dynamic pattern-name keys with string definitions, e.g. { POSTFIX_QUEUEID: '[0-9A-F]{10,11}' }
-  customPatterns: schema.recordOf(schema.string(), schema.string(), { defaultValue: {} }),
+  customPatterns: schema.recordOf(
+    schema.string({ maxLength: 1000 }),
+    schema.string({ maxLength: 10000 }),
+    { defaultValue: {} }
+  ),
 });
 
 export function registerGrokSimulateRoute(framework: KibanaFramework) {

--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/index/register_add_policy_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/index/register_add_policy_route.ts
@@ -28,9 +28,9 @@ async function addLifecyclePolicy(
 }
 
 const bodySchema = schema.object({
-  indexName: schema.string(),
-  policyName: schema.string(),
-  alias: schema.maybe(schema.string()),
+  indexName: schema.string({ maxLength: 1000 }),
+  policyName: schema.string({ maxLength: 1000 }),
+  alias: schema.maybe(schema.string({ maxLength: 1000 })),
 });
 
 export function registerAddPolicyRoute({

--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/nodes/register_details_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/nodes/register_details_route.ts
@@ -27,7 +27,7 @@ function findMatchingNodes(stats: any, nodeAttrs: string): any {
 }
 
 const paramsSchema = schema.object({
-  nodeAttrs: schema.string(),
+  nodeAttrs: schema.string({ maxLength: 1000 }),
 });
 
 export function registerDetailsRoute({

--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/policies/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/policies/register_delete_route.ts
@@ -21,7 +21,7 @@ async function deletePolicies(client: ElasticsearchClient, policyName: string): 
 }
 
 const paramsSchema = schema.object({
-  policyNames: schema.string(),
+  policyNames: schema.string({ maxLength: 10000 }),
 });
 
 export function registerDeleteRoute({

--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/templates/register_add_policy_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/templates/register_add_policy_route.ts
@@ -91,9 +91,9 @@ async function updateIndexTemplate(
 }
 
 const bodySchema = schema.object({
-  templateName: schema.string(),
-  policyName: schema.string(),
-  aliasName: schema.maybe(schema.string()),
+  templateName: schema.string({ maxLength: 1000 }),
+  policyName: schema.string({ maxLength: 1000 }),
+  aliasName: schema.maybe(schema.string({ maxLength: 1000 })),
 });
 
 const querySchema = schema.object({

--- a/x-pack/platform/plugins/private/painless_lab/server/routes/api/execute.ts
+++ b/x-pack/platform/plugins/private/painless_lab/server/routes/api/execute.ts
@@ -11,7 +11,7 @@ import { API_BASE_PATH } from '../../../common/constants';
 import type { RouteDependencies } from '../../types';
 import { handleEsError } from '../../shared_imports';
 
-const bodySchema = schema.string();
+const bodySchema = schema.string({ maxLength: 100000 });
 
 export function registerExecuteRoute({ router, license }: RouteDependencies) {
   router.post(

--- a/x-pack/platform/plugins/private/reindex_service/server/src/routes/reindex_indices.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/src/routes/reindex_indices.ts
@@ -13,8 +13,8 @@ import type { RouteDependencies } from '../../types';
 import { mapAnyErrorToKibanaHttpResponse } from './map_any_error_to_kibana_http_response';
 
 export const reindexSchema = schema.object({
-  indexName: schema.string(),
-  newIndexName: schema.string(),
+  indexName: schema.string({ maxLength: 1000 }),
+  newIndexName: schema.string({ maxLength: 1000 }),
   reindexOptions: schema.maybe(
     schema.object({
       enqueue: schema.maybe(schema.boolean()),
@@ -94,7 +94,7 @@ export function registerReindexIndicesRoutes({ router, getReindexService }: Rout
       },
       validate: {
         params: schema.object({
-          indexName: schema.string(),
+          indexName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -135,7 +135,7 @@ export function registerReindexIndicesRoutes({ router, getReindexService }: Rout
       },
       validate: {
         params: schema.object({
-          indexName: schema.string(),
+          indexName: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/remote_clusters/server/routes/api/delete_route.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/server/routes/api/delete_route.ts
@@ -18,7 +18,7 @@ import { doesClusterExist } from '../../lib/does_cluster_exist';
 import { licensePreRoutingFactory } from '../../lib/license_pre_routing_factory';
 
 const paramsValidation = schema.object({
-  nameOrNames: schema.string(),
+  nameOrNames: schema.string({ maxLength: 10000 }),
 });
 
 type RouteParams = TypeOf<typeof paramsValidation>;

--- a/x-pack/platform/plugins/private/remote_clusters/server/routes/api/update_route.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/server/routes/api/update_route.ts
@@ -20,16 +20,16 @@ import { licensePreRoutingFactory } from '../../lib/license_pre_routing_factory'
 const bodyValidation = schema.object({
   skipUnavailable: schema.boolean(),
   mode: schema.oneOf([schema.literal(PROXY_MODE), schema.literal(SNIFF_MODE)]),
-  seeds: schema.nullable(schema.arrayOf(schema.string(), { maxSize: 1000 })),
+  seeds: schema.nullable(schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 })),
   nodeConnections: schema.nullable(schema.number()),
-  proxyAddress: schema.nullable(schema.string()),
+  proxyAddress: schema.nullable(schema.string({ maxLength: 1000 })),
   proxySocketConnections: schema.nullable(schema.number()),
-  serverName: schema.nullable(schema.string()),
+  serverName: schema.nullable(schema.string({ maxLength: 1000 })),
   hasDeprecatedProxySetting: schema.maybe(schema.boolean()),
 });
 
 const paramsValidation = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 type RouteParams = TypeOf<typeof paramsValidation>;

--- a/x-pack/platform/plugins/private/rollup/server/routes/api/indices/register_validate_index_pattern_route.ts
+++ b/x-pack/platform/plugins/private/rollup/server/routes/api/indices/register_validate_index_pattern_route.ts
@@ -68,7 +68,7 @@ export const registerValidateIndexPatternRoute = ({
       },
       validate: {
         params: schema.object({
-          indexPattern: schema.string(),
+          indexPattern: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_delete_route.ts
@@ -25,7 +25,7 @@ export const registerDeleteRoute = ({
       },
       validate: {
         body: schema.object({
-          jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          jobIds: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_start_route.ts
+++ b/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_start_route.ts
@@ -25,11 +25,11 @@ export const registerStartRoute = ({
       },
       validate: {
         body: schema.object({
-          jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          jobIds: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
         query: schema.maybe(
           schema.object({
-            waitForCompletion: schema.maybe(schema.string()),
+            waitForCompletion: schema.maybe(schema.string({ maxLength: 64 })),
           })
         ),
       },

--- a/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_stop_route.ts
+++ b/x-pack/platform/plugins/private/rollup/server/routes/api/jobs/register_stop_route.ts
@@ -25,10 +25,10 @@ export const registerStopRoute = ({
       },
       validate: {
         body: schema.object({
-          jobIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          jobIds: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
         query: schema.object({
-          waitForCompletion: schema.maybe(schema.string()),
+          waitForCompletion: schema.maybe(schema.string({ maxLength: 64 })),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/policy.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/policy.ts
@@ -344,7 +344,9 @@ export function registerPolicyRoutes({
   );
 
   // Update retention settings
-  const retentionSettingsSchema = schema.object({ retentionSchedule: schema.string() });
+  const retentionSettingsSchema = schema.object({
+    retentionSchedule: schema.string({ maxLength: 256 }),
+  });
 
   router.put(
     {

--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/snapshots.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/snapshots.ts
@@ -216,8 +216,8 @@ export function registerSnapshotsRoutes({
   );
 
   const getOneParamsSchema = schema.object({
-    repository: schema.string(),
-    snapshot: schema.string(),
+    repository: schema.string({ maxLength: 1000 }),
+    snapshot: schema.string({ maxLength: 1000 }),
   });
 
   // GET one snapshot
@@ -280,8 +280,8 @@ export function registerSnapshotsRoutes({
 
   const deleteSchema = schema.arrayOf(
     schema.object({
-      repository: schema.string(),
-      snapshot: schema.string(),
+      repository: schema.string({ maxLength: 1000 }),
+      snapshot: schema.string({ maxLength: 1000 }),
     }),
     { maxSize: 1000 }
   );

--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/validate_schemas.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/validate_schemas.ts
@@ -57,7 +57,7 @@ export const snapshotListSchema = schema.object({
       schema.literal('state'),
     ])
   ),
-  searchValue: schema.maybe(schema.string()),
+  searchValue: schema.maybe(schema.string({ maxLength: 1024 })),
   searchMatch: schema.maybe(schema.oneOf([schema.literal('must'), schema.literal('must_not')])),
   searchOperator: schema.maybe(schema.oneOf([schema.literal('eq'), schema.literal('exact')])),
 });

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/audit_messages.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/audit_messages.ts
@@ -16,7 +16,7 @@ export interface GetTransformsAuditMessagesResponseSchema {
 }
 
 export const getTransformAuditMessagesQuerySchema = schema.object({
-  sortField: schema.string(),
+  sortField: schema.string({ maxLength: 1000 }),
   sortDirection: schema.oneOf([schema.literal('asc'), schema.literal('desc')]),
 });
 

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/common.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/common.ts
@@ -33,7 +33,7 @@ export const transformStateSchema = schema.oneOf([
 
 export const dataViewTitleSchema = schema.object({
   /** Title of the data view for which to return stats. */
-  dataViewTitle: schema.string(),
+  dataViewTitle: schema.string({ maxLength: 1000 }),
 });
 
 export type DataViewTitleSchema = TypeOf<typeof dataViewTitleSchema>;

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/delete_transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/delete_transforms.ts
@@ -18,7 +18,7 @@ export const deleteTransformsRequestSchema = schema.object({
    */
   transformsInfo: schema.arrayOf(
     schema.object({
-      id: schema.string(),
+      id: schema.string({ maxLength: 1000 }),
       state: transformStateSchema,
     }),
     { maxSize: 1000 }

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/reset_transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/reset_transforms.ts
@@ -17,7 +17,7 @@ export const resetTransformsRequestSchema = schema.object({
    */
   transformsInfo: schema.arrayOf(
     schema.object({
-      id: schema.string(),
+      id: schema.string({ maxLength: 1000 }),
       state: transformStateSchema,
     }),
     { maxSize: 1000 }

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/stop_transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/stop_transforms.ts
@@ -13,7 +13,7 @@ import { transformStateSchema } from './common';
 
 export const stopTransformsRequestSchema = schema.arrayOf(
   schema.object({
-    id: schema.string(),
+    id: schema.string({ maxLength: 1000 }),
     state: transformStateSchema,
   }),
   { maxSize: 1000 }

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/update_transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/update_transforms.ts
@@ -14,15 +14,15 @@ import { retentionPolicySchema, settingsSchema, sourceSchema, syncSchema } from 
 
 // POST _transform/{transform_id}/_update
 export const postTransformsUpdateRequestSchema = schema.object({
-  description: schema.maybe(schema.string()),
+  description: schema.maybe(schema.string({ maxLength: 1000 })),
   // we cannot reuse `destSchema` because `index` is optional for the update request
   dest: schema.maybe(
     schema.object({
-      index: schema.string(),
-      pipeline: schema.maybe(schema.string()),
+      index: schema.string({ maxLength: 1000 }),
+      pipeline: schema.maybe(schema.string({ maxLength: 1000 })),
     })
   ),
-  frequency: schema.maybe(schema.string()),
+  frequency: schema.maybe(schema.string({ maxLength: 64 })),
   // maybe: If not set, any existing `retention_policy` config will not be updated.
   // nullable: If set to `null`, any existing `retention_policy` will be removed.
   retention_policy: schema.maybe(schema.nullable(retentionPolicySchema)),

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/cloud_stack_versions.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/cloud_stack_versions.ts
@@ -359,7 +359,7 @@ export function registerCloudStackVersionsRoute(deps: RouteDependencies) {
       },
       validate: {
         params: schema.object({
-          currentVersion: schema.string(),
+          currentVersion: schema.string({ maxLength: 64 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/cluster_settings.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/cluster_settings.ts
@@ -26,7 +26,7 @@ export function registerClusterSettingsRoute({
       },
       validate: {
         body: schema.object({
-          settings: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          settings: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/deprecation_logging.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/deprecation_logging.ts
@@ -91,7 +91,7 @@ export function registerDeprecationLoggingRoutes({
       },
       validate: {
         query: schema.object({
-          from: schema.string(),
+          from: schema.string({ maxLength: 64 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/migrate_data_streams/data_stream_routes.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/migrate_data_streams/data_stream_routes.ts
@@ -38,7 +38,7 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -89,7 +89,7 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -138,7 +138,7 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -181,7 +181,7 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -236,10 +236,10 @@ export function registerMigrateDataStreamRoutes({
       },
       validate: {
         body: schema.object({
-          indices: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+          indices: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
         }),
         params: schema.object({
-          dataStreamName: schema.string(),
+          dataStreamName: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/ml_snapshots.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/ml_snapshots.ts
@@ -155,8 +155,8 @@ export function registerMlSnapshotRoutes({
       },
       validate: {
         body: schema.object({
-          snapshotId: schema.string(),
-          jobId: schema.string(),
+          snapshotId: schema.string({ maxLength: 1000 }),
+          jobId: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -211,8 +211,8 @@ export function registerMlSnapshotRoutes({
       },
       validate: {
         params: schema.object({
-          snapshotId: schema.string(),
-          jobId: schema.string(),
+          snapshotId: schema.string({ maxLength: 1000 }),
+          jobId: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -403,8 +403,8 @@ export function registerMlSnapshotRoutes({
       },
       validate: {
         params: schema.object({
-          snapshotId: schema.string(),
-          jobId: schema.string(),
+          snapshotId: schema.string({ maxLength: 1000 }),
+          jobId: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.ts
@@ -41,7 +41,7 @@ export function registerUpgradeStatusRoute({
       },
       validate: {
         query: schema.object({
-          targetVersion: schema.maybe(schema.string()),
+          targetVersion: schema.maybe(schema.string({ maxLength: 64 })),
         }),
       },
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/update_index_settings.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/update_index_settings.ts
@@ -22,7 +22,7 @@ export function registerUpdateSettingsRoute({ router, current }: RouteDependenci
       },
       validate: {
         params: schema.object({
-          indexName: schema.string(),
+          indexName: schema.string({ maxLength: 1000 }),
         }),
         body: schema.object({
           settings: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/indices/register_get_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/indices/register_get_route.ts
@@ -11,7 +11,10 @@ import type { IScopedClusterClient } from '@kbn/core/server';
 import { reduce, size } from 'lodash';
 import type { RouteDependencies } from '../../../types';
 
-const bodySchema = schema.object({ pattern: schema.string() }, { unknowns: 'allow' });
+const bodySchema = schema.object(
+  { pattern: schema.string({ maxLength: 1000 }) },
+  { unknowns: 'allow' }
+);
 
 function getIndexNamesFromAliasesResponse(json: Record<string, any>) {
   return reduce(

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/register_load_history_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/register_load_history_route.ts
@@ -14,7 +14,7 @@ import type { RouteDependencies } from '../../types';
 import { WatchHistoryItem } from '../../models/watch_history_item';
 
 const paramsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: 1000 }),
 });
 
 function fetchHistoryItem(dataClient: IScopedClusterClient, watchHistoryItemId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/action/register_acknowledge_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/action/register_acknowledge_route.ts
@@ -16,8 +16,8 @@ import {
 import type { RouteDependencies } from '../../../../types';
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
-  actionId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
+  actionId: schema.string({ maxLength: 1000 }),
 });
 
 function acknowledgeAction(dataClient: IScopedClusterClient, watchId: string, actionId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_activate_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_activate_route.ts
@@ -22,7 +22,7 @@ function activateWatch(dataClient: IScopedClusterClient, watchId: string) {
 }
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
 });
 
 export function registerActivateRoute({

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_deactivate_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_deactivate_route.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../models/watch_status_model';
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
 });
 
 function deactivateWatch(dataClient: IScopedClusterClient, watchId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_delete_route.ts
@@ -10,7 +10,7 @@ import type { IScopedClusterClient } from '@kbn/core/server';
 import type { RouteDependencies } from '../../../types';
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
 });
 
 function deleteWatch(dataClient: IScopedClusterClient, watchId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_history_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_history_route.ts
@@ -15,11 +15,11 @@ import type { RouteDependencies } from '../../../types';
 import { WatchHistoryItem } from '../../../models/watch_history_item';
 
 const paramsSchema = schema.object({
-  watchId: schema.string(),
+  watchId: schema.string({ maxLength: 1000 }),
 });
 
 const querySchema = schema.object({
-  startTime: schema.string(),
+  startTime: schema.string({ maxLength: 64 }),
 });
 
 function fetchHistoryItems(dataClient: IScopedClusterClient, watchId: any, startTime: any) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_load_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watch/register_load_route.ts
@@ -13,7 +13,7 @@ import { Watch } from '../../../models/watch';
 import type { RouteDependencies } from '../../../types';
 
 const paramsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: 1000 }),
 });
 
 function fetchWatch(dataClient: IScopedClusterClient, watchId: string) {

--- a/x-pack/platform/plugins/private/watcher/server/routes/api/watches/register_delete_route.ts
+++ b/x-pack/platform/plugins/private/watcher/server/routes/api/watches/register_delete_route.ts
@@ -11,7 +11,7 @@ import type { IScopedClusterClient } from '@kbn/core/server';
 import type { RouteDependencies } from '../../../types';
 
 const bodySchema = schema.object({
-  watchIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+  watchIds: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
 });
 
 type DeleteWatchPromiseArray = Promise<{

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.ts
@@ -18,7 +18,7 @@ import { createStorageService } from '../lib/create_storage_service';
 import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 const bodySchema = schema.object({
-  apiKey: schema.string({ minLength: 1 }),
+  apiKey: schema.string({ minLength: 1, maxLength: 1000 }),
 });
 
 interface CloudConnectedStartDeps {

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.ts
@@ -208,7 +208,7 @@ export const registerClustersRoute = ({
       validate: {
         body: schema.object({
           services: schema.recordOf(
-            schema.string(),
+            schema.string({ maxLength: 256 }),
             schema.object({
               enabled: schema.boolean(),
             })

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_datastream_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_datastream_route.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../../../types';
 import { addBasePath } from '..';
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 async function getDatastreamsForComponentTemplate(

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_delete_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_delete_route.ts
@@ -11,7 +11,7 @@ import type { RouteDependencies } from '../../../types';
 import { addBasePath } from '..';
 
 const paramsSchema = schema.object({
-  names: schema.string(),
+  names: schema.string({ maxLength: 10000 }),
 });
 
 export const registerDeleteRoute = ({

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_get_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_get_route.ts
@@ -16,7 +16,7 @@ import type { RouteDependencies } from '../../../types';
 import { addBasePath } from '..';
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export function registerGetAllRoute({ router, lib: { handleEsError } }: RouteDependencies) {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_update_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_update_route.ts
@@ -15,7 +15,7 @@ import { addBasePath } from '..';
 import { componentTemplateSchema } from './schema_validation';
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export const registerUpdateRoute = ({

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/data_streams/register_get_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/data_streams/register_get_route.ts
@@ -208,7 +208,7 @@ export function registerGetAllRoute({ router, lib: { handleEsError }, config }: 
 
 export function registerGetOneRoute({ router, lib: { handleEsError }, config }: RouteDependencies) {
   const paramsSchema = schema.object({
-    name: schema.string(),
+    name: schema.string({ maxLength: 1000 }),
   });
   router.get(
     {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/data_streams/register_post_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/data_streams/register_post_route.ts
@@ -25,7 +25,7 @@ export function registerPostOneApplyLatestMappings({
   config,
 }: RouteDependencies) {
   const paramsSchema = schema.object({
-    name: schema.string(),
+    name: schema.string({ maxLength: 1000 }),
   });
   router.post(
     {
@@ -81,7 +81,7 @@ export function registerPostOneRollover({
   config,
 }: RouteDependencies) {
   const paramsSchema = schema.object({
-    name: schema.string(),
+    name: schema.string({ maxLength: 1000 }),
   });
   router.post(
     {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/enrich_policies/register_delete_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/enrich_policies/register_delete_route.ts
@@ -13,7 +13,7 @@ import { addInternalBasePath } from '..';
 import { enrichPoliciesActions } from '../../../lib/enrich_policies';
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export function registerDeleteRoute({ router, lib: { handleEsError } }: RouteDependencies) {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/enrich_policies/register_execute_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/enrich_policies/register_execute_route.ts
@@ -13,7 +13,7 @@ import { addInternalBasePath } from '..';
 import { enrichPoliciesActions } from '../../../lib/enrich_policies';
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export function registerExecuteRoute({ router, lib: { handleEsError } }: RouteDependencies) {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.ts
@@ -26,7 +26,7 @@ export function registerDocumentsSampleRoute({
       },
       validate: {
         params: schema.object({
-          indexName: schema.string(),
+          indexName: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_get_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_get_route.ts
@@ -29,7 +29,7 @@ export function registerGetRoute({
       },
       validate: {
         params: schema.object({
-          indexName: schema.string(),
+          indexName: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_user_status_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_user_status_route.ts
@@ -12,7 +12,7 @@ import { addBasePath } from '..';
 import { fetchUserStartPrivileges } from '../../../lib/fetch_indices_status';
 
 const paramsSchema = schema.object({
-  indexName: schema.string(),
+  indexName: schema.string({ maxLength: 1000 }),
 });
 
 export function registerUserStatusPrivilegeRoutes({

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/mapping/register_mapping_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/mapping/register_mapping_route.ts
@@ -11,7 +11,7 @@ import type { RouteDependencies } from '../../../types';
 import { addBasePath } from '..';
 
 const paramsSchema = schema.object({
-  indexName: schema.string(),
+  indexName: schema.string({ maxLength: 1000 }),
 });
 
 function formatHit(hit: { [key: string]: { mappings: any } }, indexName: string) {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/mapping/register_update_mapping_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/mapping/register_update_mapping_route.ts
@@ -11,7 +11,7 @@ import type { RouteDependencies } from '../../../types';
 import { addBasePath } from '..';
 
 const paramsSchema = schema.object({
-  indexName: schema.string(),
+  indexName: schema.string({ maxLength: 1000 }),
 });
 
 export function registerUpdateMappingRoute({ router, lib: { handleEsError } }: RouteDependencies) {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/settings/register_load_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/settings/register_load_route.ts
@@ -11,7 +11,7 @@ import type { RouteDependencies } from '../../../types';
 import { addBasePath } from '..';
 
 const paramsSchema = schema.object({
-  indexName: schema.string(),
+  indexName: schema.string({ maxLength: 1000 }),
 });
 
 // response comes back as { [indexName]: { ... }}

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/settings/register_update_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/settings/register_update_route.ts
@@ -13,7 +13,7 @@ import { addBasePath } from '..';
 const bodySchema = schema.any();
 
 const paramsSchema = schema.object({
-  indexName: schema.string(),
+  indexName: schema.string({ maxLength: 1000 }),
 });
 
 export function registerUpdateRoute({ router, lib: { handleEsError } }: RouteDependencies) {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/stats/register_stats_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/stats/register_stats_route.ts
@@ -12,7 +12,7 @@ import type { RouteDependencies } from '../../../types';
 import { addBasePath } from '..';
 
 const paramsSchema = schema.object({
-  indexName: schema.string(),
+  indexName: schema.string({ maxLength: 1000 }),
 });
 
 interface Hit {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_delete_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_delete_route.ts
@@ -16,9 +16,9 @@ import type { TemplateDeserialized } from '../../../../common';
 const bodySchema = schema.object({
   templates: schema.arrayOf(
     schema.object({
-      name: schema.string(),
+      name: schema.string({ maxLength: 1000 }),
       isLegacy: schema.maybe(schema.boolean()),
-      type: schema.maybe(schema.string()),
+      type: schema.maybe(schema.string({ maxLength: 1000 })),
     }),
     { maxSize: 1000 }
   ),

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_get_routes.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_get_routes.ts
@@ -71,7 +71,7 @@ export function registerGetAllRoute({ router, config, lib: { handleEsError } }: 
 }
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 // Require the template format version (V1 or V2) to be provided as Query param

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_simulate_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_simulate_route.ts
@@ -25,7 +25,7 @@ export function registerSimulateRoute({ router, lib: { handleEsError } }: RouteD
       },
       validate: {
         body: schema.nullable(bodySchema),
-        params: schema.object({ templateName: schema.maybe(schema.string()) }),
+        params: schema.object({ templateName: schema.maybe(schema.string({ maxLength: 1000 })) }),
       },
     },
     async (context, request, response) => {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_update_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_update_route.ts
@@ -15,7 +15,7 @@ import { saveTemplate, doesTemplateExist, getTemplateDataStreamOptions } from '.
 
 const bodySchema = templateSchema;
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export function registerUpdateRoute({ router, lib: { handleEsError } }: RouteDependencies) {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/database/delete.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/database/delete.ts
@@ -10,7 +10,7 @@ import type { RouteDependencies } from '../../../types';
 import { API_BASE_PATH } from '../../../../common/constants';
 
 const paramsSchema = schema.object({
-  database_id: schema.string(),
+  database_id: schema.string({ maxLength: 1000 }),
 });
 
 export const registerDeleteDatabaseRoute = ({

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/delete.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/delete.ts
@@ -11,7 +11,7 @@ import { API_BASE_PATH } from '../../../common/constants';
 import type { RouteDependencies } from '../../types';
 
 const paramsSchema = schema.object({
-  names: schema.string(),
+  names: schema.string({ maxLength: 10000 }),
 });
 
 export const registerDeleteRoute = ({ router }: RouteDependencies): void => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/documents.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/documents.ts
@@ -11,8 +11,8 @@ import { API_BASE_PATH } from '../../../common/constants';
 import type { RouteDependencies } from '../../types';
 
 const paramsSchema = schema.object({
-  index: schema.string(),
-  id: schema.string(),
+  index: schema.string({ maxLength: 1000 }),
+  id: schema.string({ maxLength: 1000 }),
 });
 
 export const registerDocumentsRoute = ({

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/get.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/get.ts
@@ -13,7 +13,7 @@ import { API_BASE_PATH } from '../../../common/constants';
 import type { RouteDependencies } from '../../types';
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export const registerGetRoutes = ({ router, lib: { handleEsError } }: RouteDependencies): void => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/parse_csv.test.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/parse_csv.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parseCsvBodySchema, parseCsvMaxFileBytes } from './parse_csv';
+
+describe('parse_csv body schema', () => {
+  it('accepts a CSV payload', () => {
+    expect(() =>
+      parseCsvBodySchema.validate({ file: 'source,copy\nfoo,bar', copyAction: 'copy' })
+    ).not.toThrow();
+  });
+
+  it('bounds the file to a modest ceiling well below the global payload limit', () => {
+    // A mapping CSV is small; keep the cap tight since the privilege check runs only after
+    // the body is buffered. 10MB is plenty for any real CSV but avoids large allocations by
+    // unprivileged callers.
+    expect(parseCsvMaxFileBytes).toBe(10 * 1024 * 1024);
+
+    // A file at that limit is too large to build as a string in a test, so assert the
+    // schema's declared max length matches the constant instead.
+    const fileSchema = parseCsvBodySchema.getSchema().describe().keys?.file;
+    const metas: Array<Record<string, unknown>> = fileSchema?.metas ?? [];
+    const maxLengthMeta = metas.find((meta) => 'x-oas-max-length' in meta);
+    expect(maxLengthMeta?.['x-oas-max-length']).toBe(parseCsvMaxFileBytes);
+  });
+
+  it('rejects a file larger than the ceiling', () => {
+    const tooLarge = 'a'.repeat(parseCsvMaxFileBytes + 1);
+    expect(() => parseCsvBodySchema.validate({ file: tooLarge, copyAction: 'copy' })).toThrow(
+      /maximum length/
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/parse_csv.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/parse_csv.ts
@@ -13,12 +13,20 @@ import type { FieldCopyAction } from '../../../common/types';
 import { csvToIngestPipeline } from '../../lib';
 import type { RouteDependencies } from '../../types';
 
-const bodySchema = schema.object({
-  file: schema.string(),
-  copyAction: schema.string() as Type<FieldCopyAction>,
+// This route parses a CSV that *describes* field mappings for a pipeline (not a data file), so
+// even a very large mapping only amounts to a few MB. Cap the body well below the global
+// `server.maxPayload`-vs-file-upload ceilings: authorization here is a manual ES privilege
+// check inside the handler (`authz.enabled: false`), which runs only after the body has been
+// buffered and parsed. A tight limit prevents an authenticated-but-unprivileged caller from
+// forcing large allocations before that check runs, while staying generous for any real CSV.
+export const parseCsvMaxFileBytes = 10 * 1024 * 1024; // 10MB
+
+export const parseCsvBodySchema = schema.object({
+  file: schema.string({ maxLength: parseCsvMaxFileBytes }),
+  copyAction: schema.string({ maxLength: 64 }) as Type<FieldCopyAction>,
 });
 
-type ReqBody = TypeOf<typeof bodySchema>;
+type ReqBody = TypeOf<typeof parseCsvBodySchema>;
 
 export const registerParseCsvRoute = ({ router }: RouteDependencies): void => {
   router.post<void, void, ReqBody>(
@@ -30,8 +38,13 @@ export const registerParseCsvRoute = ({ router }: RouteDependencies): void => {
           reason: 'Manually implements ES priv check to match mgmt app',
         },
       },
+      options: {
+        body: {
+          maxBytes: parseCsvMaxFileBytes,
+        },
+      },
       validate: {
-        body: bodySchema,
+        body: parseCsvBodySchema,
       },
     },
     async (contxt, req, res) => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/simulate.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/simulate.ts
@@ -13,7 +13,9 @@ import { pipelineSchema } from './shared';
 
 const bodySchema = schema.object({
   pipeline: schema.object(pipelineSchema),
-  documents: schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 1000 }),
+  documents: schema.arrayOf(schema.recordOf(schema.string({ maxLength: 1000 }), schema.any()), {
+    maxSize: 1000,
+  }),
   verbose: schema.maybe(schema.boolean()),
 });
 

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/update.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/update.ts
@@ -14,7 +14,7 @@ import { pipelineSchema } from './shared';
 const bodySchema = schema.object(pipelineSchema);
 
 const paramsSchema = schema.object({
-  name: schema.string(),
+  name: schema.string({ maxLength: 1000 }),
 });
 
 export const registerUpdateRoute = ({

--- a/x-pack/platform/plugins/shared/license_management/server/routes/api/license/register_license_route.ts
+++ b/x-pack/platform/plugins/shared/license_management/server/routes/api/license/register_license_route.ts
@@ -25,7 +25,7 @@ export function registerLicenseRoute({
         },
       },
       validate: {
-        query: schema.object({ acknowledge: schema.string() }),
+        query: schema.object({ acknowledge: schema.string({ maxLength: 64 }) }),
         body: schema.object({
           license: schema.object({}, { unknowns: 'allow' }),
         }),

--- a/x-pack/platform/plugins/shared/license_management/server/routes/api/license/register_start_basic_route.ts
+++ b/x-pack/platform/plugins/shared/license_management/server/routes/api/license/register_start_basic_route.ts
@@ -24,7 +24,7 @@ export function registerStartBasicRoute({
           reason: 'Relies on es client for authorization',
         },
       },
-      validate: { query: schema.object({ acknowledge: schema.string() }) },
+      validate: { query: schema.object({ acknowledge: schema.string({ maxLength: 64 }) }) },
     },
     async (ctx, req, res) => {
       const { client } = (await ctx.core).elasticsearch;

--- a/x-pack/platform/plugins/shared/query_activity/server/routes/cancel.ts
+++ b/x-pack/platform/plugins/shared/query_activity/server/routes/cancel.ts
@@ -20,7 +20,7 @@ export const registerCancelRoute = ({ router, logger }: RouteOptions) => {
       },
       validate: {
         body: schema.object({
-          taskId: schema.string({ minLength: 1 }),
+          taskId: schema.string({ minLength: 1, maxLength: 1000 }),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/searchprofiler/server/routes/profile.ts
+++ b/x-pack/platform/plugins/shared/searchprofiler/server/routes/profile.ts
@@ -23,7 +23,7 @@ export const register = ({ router, getLicenseStatus, log }: RouteDependencies) =
       validate: {
         body: schema.object({
           query: schema.object({}, { unknowns: 'allow' }),
-          index: schema.string(),
+          index: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/lifecycle/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/lifecycle/route.ts
@@ -160,8 +160,8 @@ const lifecycleIlmPoliciesRoute = createServerRoute({
 });
 
 const ilmPhaseSchema = z.looseObject({
-  min_age: z.string().optional(),
-  actions: z.record(z.string(), z.any()).optional(),
+  min_age: z.string().max(64).optional(),
+  actions: z.record(z.string().max(1000), z.any()).optional(),
 });
 
 const lifecycleIlmPoliciesUpdateRoute = createServerRoute({
@@ -176,7 +176,7 @@ const lifecycleIlmPoliciesUpdateRoute = createServerRoute({
   },
   params: z.object({
     body: z.object({
-      name: z.string(),
+      name: z.string().max(1000),
       phases: z.object({
         hot: ilmPhaseSchema.optional(),
         warm: ilmPhaseSchema.optional(),
@@ -184,9 +184,9 @@ const lifecycleIlmPoliciesUpdateRoute = createServerRoute({
         frozen: ilmPhaseSchema.optional(),
         delete: ilmPhaseSchema.optional(),
       }),
-      meta: z.record(z.string(), z.any()).optional(),
+      meta: z.record(z.string().max(1000), z.any()).optional(),
       deprecated: z.boolean().optional(),
-      source_policy_name: z.string().optional(),
+      source_policy_name: z.string().max(1000).optional(),
     }),
     query: z.object({
       allow_overwrite: BooleanFromString.optional().default(false),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Kibana Management] Add max length constraints to route validation strings (CodeQL unbounded-string) (#281262)](https://github.com/elastic/kibana/pull/281262)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-04T09:59:59Z","message":"[Kibana Management] Add max length constraints to route validation strings (CodeQL unbounded-string) (#281262)\n\n## Summary\n\nAdds a maximum length to every `schema.string()` / `z.string()` flagged\nby CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) across all\nkibana-management-owned plugins — clears **137 alerts** in 20 plugins.\nWithout a length bound, an attacker can send arbitrarily large strings\nthat the server buffers, validates, and forwards to Elasticsearch\n(CWE-400 / CWE-770).\n\nOnly a maximum length is added (no `minLength`/regex changes), so\nexisting legitimate values keep validating.","sha":"5f8dc1a1c3eee14e1e02605a36d0b2e8c5b358c7","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Feature:Watcher","Feature:License","Feature:Index Management","Feature:CCR and Remote Clusters","Feature:ILM","Team:Kibana Management","release_note:skip","Feature:Rollups","Feature:Upgrade Assistant","Feature:Snapshot and Restore","Feature:Transforms","Feature:Search Profiler","Feature:Painless Lab","Feature:Grok Debugger","Feature:Ingest Node Pipelines","backport:all-open","Feature:Streams","Feature:Data Usage","Feature:Cloud Connect","Feature: Query activity","reviewer:scout","v9.6.0","v9.5.1"],"title":"[Kibana Management] Add max length constraints to route validation strings (CodeQL unbounded-string)","number":281262,"url":"https://github.com/elastic/kibana/pull/281262","mergeCommit":{"message":"[Kibana Management] Add max length constraints to route validation strings (CodeQL unbounded-string) (#281262)\n\n## Summary\n\nAdds a maximum length to every `schema.string()` / `z.string()` flagged\nby CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) across all\nkibana-management-owned plugins — clears **137 alerts** in 20 plugins.\nWithout a length bound, an attacker can send arbitrarily large strings\nthat the server buffers, validates, and forwards to Elasticsearch\n(CWE-400 / CWE-770).\n\nOnly a maximum length is added (no `minLength`/regex changes), so\nexisting legitimate values keep validating.","sha":"5f8dc1a1c3eee14e1e02605a36d0b2e8c5b358c7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281262","number":281262,"mergeCommit":{"message":"[Kibana Management] Add max length constraints to route validation strings (CodeQL unbounded-string) (#281262)\n\n## Summary\n\nAdds a maximum length to every `schema.string()` / `z.string()` flagged\nby CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) across all\nkibana-management-owned plugins — clears **137 alerts** in 20 plugins.\nWithout a length bound, an attacker can send arbitrarily large strings\nthat the server buffers, validates, and forwards to Elasticsearch\n(CWE-400 / CWE-770).\n\nOnly a maximum length is added (no `minLength`/regex changes), so\nexisting legitimate values keep validating.","sha":"5f8dc1a1c3eee14e1e02605a36d0b2e8c5b358c7"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/282555","number":282555,"state":"MERGED","mergeCommit":{"sha":"a41299a69362f90a0fa622b7c5dacf166e553bbb","message":"[9.5] [Kibana Management] Add max length constraints to route validation strings (CodeQL unbounded-string) (#281262) (#282555)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Kibana Management] Add max length constraints to route validation\nstrings (CodeQL unbounded-string)\n(#281262)](https://github.com/elastic/kibana/pull/281262)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}}]}] BACKPORT-->