### PR TITLE
[ResponseOps] Fix accessibility in rule form.

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/rule_settings/rule_settings_flapping_title_tooltip.test.tsx
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/rule_settings/rule_settings_flapping_title_tooltip.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { RuleSettingsFlappingTitleTooltip } from './rule_settings_flapping_title_tooltip';
+
+describe('RuleSettingsFlappingTitleTooltip', () => {
+  it('announces the info button with a descriptive accessible name', () => {
+    render(
+      <I18nProvider>
+        <RuleSettingsFlappingTitleTooltip isOpen={false} setIsPopoverOpen={jest.fn()} />
+      </I18nProvider>
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'More information about alert flapping detection' })
+    ).toBeInTheDocument();
+  });
+
+  it('uses the alert flapping detection title for the open popover', () => {
+    render(
+      <I18nProvider>
+        <RuleSettingsFlappingTitleTooltip isOpen={true} setIsPopoverOpen={jest.fn()} />
+      </I18nProvider>
+    );
+
+    expect(screen.getByTestId('ruleSettingsFlappingTooltipTitle')).toHaveTextContent(
+      'Alert flapping detection'
+    );
+  });
+});

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/rule_settings/rule_settings_flapping_title_tooltip.tsx
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/rule_settings/rule_settings_flapping_title_tooltip.tsx
@@ -66,7 +66,7 @@ const flappingOffContentSettings = i18n.translate(
 const alertFlappingTitleInfo = i18n.translate(
   'alertsUIShared.ruleSettingsFlappingTitleTooltip.alertFlappingTitleInfo',
   {
-    defaultMessage: 'Rule settings flapping title info',
+    defaultMessage: 'More information about alert flapping detection',
   }
 );
 
@@ -85,13 +85,13 @@ export const RuleSettingsFlappingTitleTooltip = (props: RuleSettingsFlappingTitl
         repositionOnScroll
         isOpen={isOpen}
         anchorPosition={anchorPosition}
-        aria-label={alertFlappingTitleInfo}
+        aria-label={tooltipTitle}
         panelStyle={{
           width: 500,
         }}
         closePopover={() => setIsPopoverOpen(false)}
         button={
-          <EuiToolTip content={alertFlappingTitleInfo} disableScreenReaderOutput>
+          <EuiToolTip content={tooltipTitle} disableScreenReaderOutput>
             <EuiButtonIcon
               data-test-subj="ruleSettingsFlappingTitleTooltipButton"
               display="empty"

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout.test.tsx
@@ -100,6 +100,8 @@ describe('ruleFlyout', () => {
     expect(screen.getByText(RULE_FORM_PAGE_RULE_DEFINITION_TITLE_SHORT)).toBeInTheDocument();
     expect(screen.getByText(RULE_FORM_PAGE_RULE_ACTIONS_TITLE)).toBeInTheDocument();
     expect(screen.getByText(RULE_FORM_PAGE_RULE_DETAILS_TITLE_SHORT)).toBeInTheDocument();
+    expect(screen.getByTestId('ruleFlyoutCreateSteps')).toBeInTheDocument();
+    expect(screen.getByLabelText('Create rule steps')).toBeInTheDocument();
 
     expect(screen.getByTestId('ruleFlyoutFooterCancelButton')).toBeInTheDocument();
     expect(screen.getByTestId('ruleFlyoutFooterNextStepButton')).toBeInTheDocument();

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_body.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_body.tsx
@@ -22,6 +22,7 @@ import {
   DISABLED_ACTIONS_WARNING_TITLE,
   RULE_FLYOUT_HEADER_CREATE_TITLE,
   RULE_FLYOUT_HEADER_EDIT_TITLE,
+  RULE_FLYOUT_STEPS_ARIA_LABEL,
 } from '../translations';
 import type { RuleFormData, RuleFormState } from '../types';
 import { hasRuleErrors } from '../validation';
@@ -149,10 +150,21 @@ export const RuleFlyoutBody = ({
             {isEdit ? RULE_FLYOUT_HEADER_EDIT_TITLE : RULE_FLYOUT_HEADER_CREATE_TITLE}
           </h3>
         </EuiTitle>
-        {isEdit && <RuleFlyoutEditTabs steps={steps} />}
+        {isEdit ? (
+          <RuleFlyoutEditTabs steps={steps} />
+        ) : (
+          <>
+            <EuiSpacer size="m" />
+            <EuiStepsHorizontal
+              size="xs"
+              steps={steps}
+              aria-label={RULE_FLYOUT_STEPS_ARIA_LABEL}
+              data-test-subj="ruleFlyoutCreateSteps"
+            />
+          </>
+        )}
       </EuiFlyoutHeader>
       <EuiFlyoutBody onClick={onInteraction} onKeyDown={onInteraction}>
-        {!isEdit && <EuiStepsHorizontal size="xs" steps={steps} />}
         {hasActionsDisabled && (
           <>
             <EuiCallOut

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/translations.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/translations.ts
@@ -402,6 +402,13 @@ export const RULE_FLYOUT_HEADER_CREATE_TITLE = i18n.translate(
   }
 );
 
+export const RULE_FLYOUT_STEPS_ARIA_LABEL = i18n.translate(
+  'responseOpsRuleForm.ruleForm.ruleFlyoutHeader.stepsAriaLabel',
+  {
+    defaultMessage: 'Create rule steps',
+  }
+);
+
 export const RULE_FLYOUT_HEADER_EDIT_TITLE = i18n.translate(
   'responseOpsRuleForm.ruleForm.ruleFlyoutHeader.editTitle',
   {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/240756

## Summary

- Fixes VoiceOver announcing the flapping help control as “Rule settings flapping title info” by giving it a descriptive name tied to Alert flapping detection.
- Moves create-rule horizontal steps from `EuiFlyoutBody` into `EuiFlyoutHeader` (with a named steps list) so VO no longer groups Definition with the form and announces “and 23 more items”.

<img width="1302" height="466" alt="Screenshot 2026-08-06 at 13 43 33" src="https://github.com/user-attachments/assets/cdf3e109-87a2-4e8f-acce-620750a3fd14" />


## Testing

- Open Discover > Alerts > Create search and threshold rule (create-rule flyout)
- With VoiceOver: focus the Definition step and confirm you hear the step name and remaining steps only (e.g. “and 2 more items”), not an extra large “and N more items” count from the form
- Expand Advanced options > focus the Alert flapping detection info (?) button and confirm it announces “More information about alert flapping detection” (not “Rule settings flapping title info”)



