### PR TITLE
[9.5] [Lens as code] Fix histogram granularity  (#283058)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -81892,8 +81892,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -76630,8 +76630,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -87453,8 +87452,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -92094,8 +92092,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -92324,8 +92321,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -96536,8 +96532,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -98005,8 +98000,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -101849,8 +101843,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -102699,8 +102692,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -105217,8 +105209,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -107608,8 +107599,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -109611,8 +109601,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -89704,8 +89704,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -100527,8 +100526,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -105168,8 +105166,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -105398,8 +105395,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -109610,8 +109606,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -111079,8 +111074,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -114923,8 +114917,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -115773,8 +115766,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -118291,8 +118283,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -120682,8 +120673,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:
@@ -122685,8 +122675,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -94966,8 +94966,7 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_formatType'
         granularity:
           anyOf:
-            - description: Granularity of the histogram.
-              maximum: 7
+            - description: Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.
               minimum: 1
               type: number
             - enum:

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.test.ts
@@ -280,7 +280,7 @@ describe('Bucket Operation Schemas', () => {
       });
     });
 
-    it('enforces granularity limits', () => {
+    it('enforces the minimum granularity but leaves the ceiling to the runtime', () => {
       expect(() =>
         bucketHistogramOperationSchema.validate({
           operation: 'histogram',
@@ -289,13 +289,15 @@ describe('Bucket Operation Schemas', () => {
         })
       ).toThrow();
 
-      expect(() =>
-        bucketHistogramOperationSchema.validate({
-          operation: 'histogram',
-          field: 'price',
-          granularity: 8,
-        })
-      ).toThrow();
+      // No upper bound is enforced: the real ceiling is the deployment-configurable
+      // `histogram:maxBars` advanced setting, so large values are accepted here and
+      // clamped at render time rather than rejected during validation.
+      const aboveDefaultCeiling = bucketHistogramOperationSchema.validate({
+        operation: 'histogram',
+        field: 'price',
+        granularity: 5000,
+      });
+      expect(aboveDefaultCeiling.granularity).toBe(5000);
     });
   });
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
@@ -427,7 +427,8 @@ export const bucketHistogramOperationSchema = schema.object(
         schema.number({
           min: LENS_HISTOGRAM_GRANULARITY_MIN,
           meta: {
-            description: 'Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.',
+            description:
+              'Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.',
           },
         }),
         schema.literal('auto'),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
@@ -13,7 +13,6 @@ import { filterWithLabelSchema } from './filter';
 import {
   LENS_HISTOGRAM_EMPTY_ROWS_DEFAULT,
   LENS_HISTOGRAM_GRANULARITY_DEFAULT_VALUE,
-  LENS_HISTOGRAM_GRANULARITY_MAX,
   LENS_HISTOGRAM_GRANULARITY_MIN,
   LENS_TERMS_LIMIT_DEFAULT,
   LENS_DATE_HISTOGRAM_EMPTY_ROWS_DEFAULT,
@@ -415,16 +414,21 @@ export const bucketHistogramOperationSchema = schema.object(
       },
     }),
     /**
-     * Granularity of the histogram
+     * Granularity of the histogram: the target number of buckets (bars). This maps directly to the
+     * Lens `maxBars` value and controls how finely the field is divided into evenly spaced,
+     * "nice"-valued intervals. It is a target, not a guarantee: the effective ceiling is the
+     * `histogram:maxBars` advanced setting (default 1000), which is deployment-configurable and can
+     * be raised or lowered by an admin. Because that ceiling is only known at render time, no upper
+     * bound is enforced here — values above the configured ceiling are clamped when the chart runs.
+     * Use `'auto'` (the default) to let Lens pick the granularity.
      */
     granularity: schema.oneOf(
       [
         schema.number({
-          meta: {
-            description: 'Granularity of the histogram.',
-          },
           min: LENS_HISTOGRAM_GRANULARITY_MIN,
-          max: LENS_HISTOGRAM_GRANULARITY_MAX,
+          meta: {
+            description: 'Target number of histogram buckets (bars). The maximum is controlled by the `histogram:maxBars` advanced setting, which defaults to 1000.',
+          },
         }),
         schema.literal('auto'),
       ],

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/constants.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/constants.ts
@@ -8,9 +8,7 @@
  */
 
 // @TODO: move it to shared type/values package
-export const LENS_HISTOGRAM_GRANULARITY_DEFAULT_NUMERIC_VALUE = 5;
 export const LENS_HISTOGRAM_GRANULARITY_MIN = 1;
-export const LENS_HISTOGRAM_GRANULARITY_MAX = 7;
 export const LENS_HISTOGRAM_GRANULARITY_DEFAULT_VALUE = 'auto';
 export const LENS_HISTOGRAM_EMPTY_ROWS_DEFAULT = true;
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/range.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/range.test.ts
@@ -151,12 +151,87 @@ describe('Range Transforms', () => {
       const expected: LensApiHistogramOperation = {
         operation: 'histogram',
         field: 'price',
-        granularity: 'auto',
+        granularity: 10,
         include_empty_rows: true,
         format: { type: 'number', decimals: 0, compact: false },
       };
 
       expect(fromRangeOrHistogramLensStateToAPI(input)).toEqual(expected);
+    });
+
+    it(`should persist a max-slider maxBars value (1000) without clamping to "auto"`, () => {
+      const input: RangeIndexPatternColumn = {
+        operationType: 'range',
+        dataType: 'number',
+        sourceField: 'price',
+        customLabel: false,
+        label: 'price',
+        isBucketed: true,
+        params: {
+          type: 'histogram',
+          maxBars: 1000,
+          ranges: [],
+          includeEmptyRows: false,
+        },
+      };
+
+      expect(fromRangeOrHistogramLensStateToAPI(input)).toEqual({
+        operation: 'histogram',
+        field: 'price',
+        granularity: 1000,
+        include_empty_rows: false,
+      });
+    });
+
+    it(`should pass a fractional maxBars through verbatim`, () => {
+      // The Lens editor persists a fractional default of `(histogram:maxBars - 1) / 2` (499.5 for
+      // the default ceiling of 1000). The out-transform must not round or reject it, otherwise the
+      // round-trip mutates the stored bar target.
+      const input: RangeIndexPatternColumn = {
+        operationType: 'range',
+        dataType: 'number',
+        sourceField: 'price',
+        customLabel: false,
+        label: 'price',
+        isBucketed: true,
+        params: {
+          type: 'histogram',
+          maxBars: 499.5,
+          ranges: [],
+          includeEmptyRows: false,
+        },
+      };
+
+      expect(fromRangeOrHistogramLensStateToAPI(input)).toEqual({
+        operation: 'histogram',
+        field: 'price',
+        granularity: 499.5,
+        include_empty_rows: false,
+      });
+    });
+
+    it(`should pass "auto" maxBars through as "auto" granularity`, () => {
+      const input: RangeIndexPatternColumn = {
+        operationType: 'range',
+        dataType: 'number',
+        sourceField: 'price',
+        customLabel: false,
+        label: 'price',
+        isBucketed: true,
+        params: {
+          type: 'histogram',
+          maxBars: LENS_HISTOGRAM_GRANULARITY_DEFAULT_VALUE,
+          ranges: [],
+          includeEmptyRows: true,
+        },
+      };
+
+      expect(fromRangeOrHistogramLensStateToAPI(input)).toEqual({
+        operation: 'histogram',
+        field: 'price',
+        granularity: LENS_HISTOGRAM_GRANULARITY_DEFAULT_VALUE,
+        include_empty_rows: true,
+      });
     });
 
     it('should handle custom labels', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/range.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/range.ts
@@ -9,11 +9,7 @@
 
 import type { RangeIndexPatternColumn } from '@kbn/lens-common';
 import type { LensApiRangeOperation, LensApiHistogramOperation } from '../../schema/bucket_ops';
-import {
-  LENS_HISTOGRAM_GRANULARITY_DEFAULT_VALUE,
-  LENS_HISTOGRAM_GRANULARITY_MAX,
-  LENS_RANGE_DEFAULT_INTERVAL,
-} from '../../schema/constants';
+import { LENS_RANGE_DEFAULT_INTERVAL } from '../../schema/constants';
 import { getLensAPIBucketSharedProps, getLensStateBucketSharedProps } from './utils';
 import { fromFormatAPIToLensState, fromFormatLensStateToAPI } from './format';
 
@@ -46,6 +42,7 @@ export function fromRangeOrHistogramLensApiToLensState(
     ...getLensStateBucketSharedProps(options),
     params: {
       type: 'histogram',
+      // `granularity` is the raw target bar count Lens stores as `maxBars` (1..histogram:maxBars | 'auto').
       maxBars: options.granularity,
       ranges: [],
       format: fromFormatAPIToLensState(options.format),
@@ -74,11 +71,8 @@ export function fromRangeOrHistogramLensStateToAPI(
   return {
     operation: 'histogram',
     include_empty_rows: Boolean(column.params.includeEmptyRows),
-    granularity:
-      column.params?.maxBars !== LENS_HISTOGRAM_GRANULARITY_DEFAULT_VALUE &&
-      column.params?.maxBars > LENS_HISTOGRAM_GRANULARITY_MAX
-        ? 'auto'
-        : column.params?.maxBars,
+    // Pass `maxBars` through verbatim
+    granularity: column.params?.maxBars,
     ...getLensAPIBucketSharedProps(column),
     ...(column.params?.format ? { format: fromFormatLensStateToAPI(column.params.format) } : {}),
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Lens as code] Fix histogram granularity  (#283058)](https://github.com/elastic/kibana/pull/283058)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"andreana.malama@elastic.co"},"sourceCommit":{"committedDate":"2026-08-06T08:40:32Z","message":"[Lens as code] Fix histogram granularity  (#283058)\n\nPart of #282534\n\n## Summary\n\nHistogram granularity was wrongly treated as a `1..7` slider index: the\nschema capped at `7`, and SO→API clamped any `maxBars > 7` to `'auto'`.\nThat broke panels saved at the Lens slider max (`maxBars: 1000`) — after\nround-trip they became `'auto'` and reopened at mid-slider.\n\n`granularity` is the target number of bars (SO `maxBars`), not a 1–7\nstep. The real ceiling is the deployment-configurable\n`histogram:maxBars` advanced setting (default `1000`), applied at render\ntime.\n\n## Changes\n\n- Schema: \n  - keep `min: 1` \n  - remove the upper bound (no fixed `1000` or `7` in validation)\n- Transform: emit `maxBars` as `granularity` verbatim (drop t`he > MAX →\n'auto'` clamp).\n- Remove unused `LENS_HISTOGRAM_GRANULARITY_MAX` (and unused default\nnumeric constant).\n\n### Why not keep granularity as the 7 UI slider steps?\nThe editor only exposes 7 stops, but each stop persists a concrete\n`maxBars`, and that ceiling comes from `histogram:maxBars`. Mapping API\n1…7 ↔ `maxBars` through the current setting would break SOs configured\nunder a previous setting: e.g. slider-max saved as `1000` under default\n`histogram:maxBars`, then an admin raises/lowers the setting —\nround-trip would rematerialize a different `maxBars` instead of\npreserving what was stored. Persisting the raw bar count stays stable\nacross setting changes, while render still clamps to the live ceiling.\n\n_**Not a breaking change:**_ existing 1..7 and `'auto'` stay valid.\nPreviously rejected/clamped high values (e.g. `1000`) now round-trip,\noversize values are accepted by the API and handled at render like Lens\nalready does for `maxBars`.\n\n## Release Notes \nFixed Lens as-code histogram `granularity` to preserve the target bar\ncount on round-trip instead of clamping values above `7` to `auto`. The\nAPI no longer enforces a fixed upper bound; the effective ceiling\nremains the `histogram:maxBars` advanced setting at render time.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore:\n\n- everything `> 7 -> 'auto'`\n\n<img width=\"2548\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 3 53\n13 PM\"\nsrc=\"https://github.com/user-attachments/assets/fc979e69-4fb4-4a53-bcf0-3596163c2098\"\n/>\n\n<img width=\"2543\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 3 53\n51 PM\"\nsrc=\"https://github.com/user-attachments/assets/6d79581a-542d-410c-9a12-c1ba0d10d16a\"\n/>\n\nAfter:\n\n\n<img width=\"2543\" height=\"1198\" alt=\"Screenshot 2026-08-05 at 2 07\n11 PM\"\nsrc=\"https://github.com/user-attachments/assets/9c1790d1-c060-4a7c-954c-fbfedab33c5a\"\n/>\n\n<img width=\"2546\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 2 06\n41 PM\"\nsrc=\"https://github.com/user-attachments/assets/7c4e204e-c36a-47d4-b5d0-c713074b594c\"\n/>\n\n## Dashboard SO to use for transformation Testing\n\n\n[histogram_granularity.ndjson.zip](https://github.com/user-attachments/files/30743881/histogram_granularity.ndjson.zip)\n\n## Request to use for API Testing\n```\nPOST kbn:/api/dashboards\n{\n  \"title\": \"Histogram granularity — round-trip cases\",\n  \"panels\": [\n    {\n      \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: \\\"auto\\\"\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": \"auto\" },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 0, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 5000 (> histogram:maxBars, clamped at render)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 5000 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 0, \"y\": 15, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 750 (> mid-slider default)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 750 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 15, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 100 (< mid-slider default)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 100 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    }\n  ]\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c69a85994f1d9a576691f1be7e01538f04a6ecdc","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:version","v9.6.0","v9.5.1"],"title":"[Lens as code] Fix histogram granularity ","number":283058,"url":"https://github.com/elastic/kibana/pull/283058","mergeCommit":{"message":"[Lens as code] Fix histogram granularity  (#283058)\n\nPart of #282534\n\n## Summary\n\nHistogram granularity was wrongly treated as a `1..7` slider index: the\nschema capped at `7`, and SO→API clamped any `maxBars > 7` to `'auto'`.\nThat broke panels saved at the Lens slider max (`maxBars: 1000`) — after\nround-trip they became `'auto'` and reopened at mid-slider.\n\n`granularity` is the target number of bars (SO `maxBars`), not a 1–7\nstep. The real ceiling is the deployment-configurable\n`histogram:maxBars` advanced setting (default `1000`), applied at render\ntime.\n\n## Changes\n\n- Schema: \n  - keep `min: 1` \n  - remove the upper bound (no fixed `1000` or `7` in validation)\n- Transform: emit `maxBars` as `granularity` verbatim (drop t`he > MAX →\n'auto'` clamp).\n- Remove unused `LENS_HISTOGRAM_GRANULARITY_MAX` (and unused default\nnumeric constant).\n\n### Why not keep granularity as the 7 UI slider steps?\nThe editor only exposes 7 stops, but each stop persists a concrete\n`maxBars`, and that ceiling comes from `histogram:maxBars`. Mapping API\n1…7 ↔ `maxBars` through the current setting would break SOs configured\nunder a previous setting: e.g. slider-max saved as `1000` under default\n`histogram:maxBars`, then an admin raises/lowers the setting —\nround-trip would rematerialize a different `maxBars` instead of\npreserving what was stored. Persisting the raw bar count stays stable\nacross setting changes, while render still clamps to the live ceiling.\n\n_**Not a breaking change:**_ existing 1..7 and `'auto'` stay valid.\nPreviously rejected/clamped high values (e.g. `1000`) now round-trip,\noversize values are accepted by the API and handled at render like Lens\nalready does for `maxBars`.\n\n## Release Notes \nFixed Lens as-code histogram `granularity` to preserve the target bar\ncount on round-trip instead of clamping values above `7` to `auto`. The\nAPI no longer enforces a fixed upper bound; the effective ceiling\nremains the `histogram:maxBars` advanced setting at render time.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore:\n\n- everything `> 7 -> 'auto'`\n\n<img width=\"2548\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 3 53\n13 PM\"\nsrc=\"https://github.com/user-attachments/assets/fc979e69-4fb4-4a53-bcf0-3596163c2098\"\n/>\n\n<img width=\"2543\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 3 53\n51 PM\"\nsrc=\"https://github.com/user-attachments/assets/6d79581a-542d-410c-9a12-c1ba0d10d16a\"\n/>\n\nAfter:\n\n\n<img width=\"2543\" height=\"1198\" alt=\"Screenshot 2026-08-05 at 2 07\n11 PM\"\nsrc=\"https://github.com/user-attachments/assets/9c1790d1-c060-4a7c-954c-fbfedab33c5a\"\n/>\n\n<img width=\"2546\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 2 06\n41 PM\"\nsrc=\"https://github.com/user-attachments/assets/7c4e204e-c36a-47d4-b5d0-c713074b594c\"\n/>\n\n## Dashboard SO to use for transformation Testing\n\n\n[histogram_granularity.ndjson.zip](https://github.com/user-attachments/files/30743881/histogram_granularity.ndjson.zip)\n\n## Request to use for API Testing\n```\nPOST kbn:/api/dashboards\n{\n  \"title\": \"Histogram granularity — round-trip cases\",\n  \"panels\": [\n    {\n      \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: \\\"auto\\\"\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": \"auto\" },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 0, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 5000 (> histogram:maxBars, clamped at render)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 5000 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 0, \"y\": 15, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 750 (> mid-slider default)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 750 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 15, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 100 (< mid-slider default)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 100 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    }\n  ]\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c69a85994f1d9a576691f1be7e01538f04a6ecdc"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283058","number":283058,"mergeCommit":{"message":"[Lens as code] Fix histogram granularity  (#283058)\n\nPart of #282534\n\n## Summary\n\nHistogram granularity was wrongly treated as a `1..7` slider index: the\nschema capped at `7`, and SO→API clamped any `maxBars > 7` to `'auto'`.\nThat broke panels saved at the Lens slider max (`maxBars: 1000`) — after\nround-trip they became `'auto'` and reopened at mid-slider.\n\n`granularity` is the target number of bars (SO `maxBars`), not a 1–7\nstep. The real ceiling is the deployment-configurable\n`histogram:maxBars` advanced setting (default `1000`), applied at render\ntime.\n\n## Changes\n\n- Schema: \n  - keep `min: 1` \n  - remove the upper bound (no fixed `1000` or `7` in validation)\n- Transform: emit `maxBars` as `granularity` verbatim (drop t`he > MAX →\n'auto'` clamp).\n- Remove unused `LENS_HISTOGRAM_GRANULARITY_MAX` (and unused default\nnumeric constant).\n\n### Why not keep granularity as the 7 UI slider steps?\nThe editor only exposes 7 stops, but each stop persists a concrete\n`maxBars`, and that ceiling comes from `histogram:maxBars`. Mapping API\n1…7 ↔ `maxBars` through the current setting would break SOs configured\nunder a previous setting: e.g. slider-max saved as `1000` under default\n`histogram:maxBars`, then an admin raises/lowers the setting —\nround-trip would rematerialize a different `maxBars` instead of\npreserving what was stored. Persisting the raw bar count stays stable\nacross setting changes, while render still clamps to the live ceiling.\n\n_**Not a breaking change:**_ existing 1..7 and `'auto'` stay valid.\nPreviously rejected/clamped high values (e.g. `1000`) now round-trip,\noversize values are accepted by the API and handled at render like Lens\nalready does for `maxBars`.\n\n## Release Notes \nFixed Lens as-code histogram `granularity` to preserve the target bar\ncount on round-trip instead of clamping values above `7` to `auto`. The\nAPI no longer enforces a fixed upper bound; the effective ceiling\nremains the `histogram:maxBars` advanced setting at render time.\n\n## Screenshots\n\n- Left: api flag off\n- Right: api flag on\n\nBefore:\n\n- everything `> 7 -> 'auto'`\n\n<img width=\"2548\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 3 53\n13 PM\"\nsrc=\"https://github.com/user-attachments/assets/fc979e69-4fb4-4a53-bcf0-3596163c2098\"\n/>\n\n<img width=\"2543\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 3 53\n51 PM\"\nsrc=\"https://github.com/user-attachments/assets/6d79581a-542d-410c-9a12-c1ba0d10d16a\"\n/>\n\nAfter:\n\n\n<img width=\"2543\" height=\"1198\" alt=\"Screenshot 2026-08-05 at 2 07\n11 PM\"\nsrc=\"https://github.com/user-attachments/assets/9c1790d1-c060-4a7c-954c-fbfedab33c5a\"\n/>\n\n<img width=\"2546\" height=\"1200\" alt=\"Screenshot 2026-08-05 at 2 06\n41 PM\"\nsrc=\"https://github.com/user-attachments/assets/7c4e204e-c36a-47d4-b5d0-c713074b594c\"\n/>\n\n## Dashboard SO to use for transformation Testing\n\n\n[histogram_granularity.ndjson.zip](https://github.com/user-attachments/files/30743881/histogram_granularity.ndjson.zip)\n\n## Request to use for API Testing\n```\nPOST kbn:/api/dashboards\n{\n  \"title\": \"Histogram granularity — round-trip cases\",\n  \"panels\": [\n    {\n      \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: \\\"auto\\\"\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": \"auto\" },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 0, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 5000 (> histogram:maxBars, clamped at render)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 5000 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 0, \"y\": 15, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 750 (> mid-slider default)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 750 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    },\n    {\n      \"grid\": { \"x\": 24, \"y\": 15, \"w\": 24, \"h\": 15 },\n      \"type\": \"vis\",\n      \"config\": {\n        \"type\": \"xy\",\n        \"title\": \"granularity: 100 (< mid-slider default)\",\n        \"layers\": [\n          {\n            \"type\": \"bar\",\n            \"data_source\": {\n              \"type\": \"data_view_spec\",\n              \"index_pattern\": \"kibana_sample_data_logs\",\n              \"time_field\": \"timestamp\"\n            },\n            \"x\": { \"operation\": \"histogram\", \"field\": \"bytes\", \"granularity\": 100 },\n            \"y\": [{ \"operation\": \"count\" }]\n          }\n        ]\n      }\n    }\n  ]\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c69a85994f1d9a576691f1be7e01538f04a6ecdc"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->