### PR TITLE
skip failing disable alerting API suite (#275667)

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/disable.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/disable.ts
@@ -33,7 +33,8 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
   const supertest = getService('supertest');
   const taskManagerUtils = new TaskManagerUtils(es, retry);
 
-  describe('disable', function () {
+  // Failing: See https://github.com/elastic/kibana/issues/275667
+  describe.skip('disable', function () {
     this.tags('skipFIPS');
     const objectRemover = new ObjectRemover(supertestWithoutAuth);
     const ruleUtils = new RuleUtils({ space: Spaces.space1, supertestWithoutAuth });


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/275667

I unskipped the whole suite fixing https://github.com/elastic/kibana/issues/269867, but this one still fails. I'll skip only this one before we skip the whole suite again


