### PR TITLE
[Scout][observability] Migrate alerts data grid to page.components.dataGrid

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_table.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_table.ts
@@ -6,7 +6,7 @@
  */
 
 import { encode } from '@kbn/rison';
-import { EuiDataGridWrapper, type Locator, type ScoutPage } from '@kbn/scout-oblt';
+import type { EuiDataGridObject, Locator, ScoutPage } from '@kbn/scout-oblt';
 import { ALERTS_TABLE_TEST_SUBJECTS as SUBJ, ALERT_TABLE_DATE_RANGE } from '../constants';
 
 /**
@@ -36,7 +36,7 @@ export class AlertsTablePage {
   public readonly createCaseFlyout: Locator;
   public readonly addToExistingCaseModal: Locator;
   public readonly queryInput: Locator;
-  public readonly dataGrid: EuiDataGridWrapper;
+  public readonly dataGrid: EuiDataGridObject;
   public readonly groupSelector: Locator;
   // Alert summary widget (full-size, rendered above the table)
   public readonly summaryWidget: Locator;
@@ -49,7 +49,7 @@ export class AlertsTablePage {
 
   constructor(private readonly page: ScoutPage) {
     this.table = this.page.testSubj.locator(SUBJ.TABLE_LOADED);
-    this.dataGrid = new EuiDataGridWrapper(this.page, SUBJ.TABLE_LOADED);
+    this.dataGrid = this.page.components.dataGrid(SUBJ.TABLE_LOADED);
     this.pageWithData = this.page.testSubj.locator(SUBJ.PAGE_WITH_DATA);
     this.noDataState = this.page.testSubj.locator(SUBJ.TABLE_EMPTY_STATE);
     this.errorPrompt = this.page.testSubj.locator(SUBJ.TABLE_ERROR_PROMPT);

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/overview_page.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/overview_page.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiDataGridWrapper, type Locator, type ScoutPage } from '@kbn/scout-oblt';
+import type { EuiDataGridObject, Locator, ScoutPage } from '@kbn/scout-oblt';
 import { ALERTS_TABLE_TEST_SUBJECTS as SUBJ } from '../constants';
 
 /**
@@ -40,14 +40,14 @@ export class OverviewPage {
   public readonly addDataButton: Locator;
   public readonly alertsSection: Locator;
   public readonly alertsTable: Locator;
-  public readonly alertsDataGrid: EuiDataGridWrapper;
+  public readonly alertsDataGrid: EuiDataGridObject;
 
   constructor(private readonly page: ScoutPage) {
     this.noDataPrompt = this.page.testSubj.locator('obltOverviewNoDataPrompt');
     this.addDataButton = this.page.testSubj.locator('o11yOverviewPageAddDataButton');
     this.alertsSection = this.page.testSubj.locator('accordion-Alerts');
     this.alertsTable = this.page.testSubj.locator(SUBJ.TABLE_LOADED);
-    this.alertsDataGrid = new EuiDataGridWrapper(this.page, SUBJ.TABLE_LOADED);
+    this.alertsDataGrid = this.page.components.dataGrid(SUBJ.TABLE_LOADED);
   }
 
   /** Navigates to the overview using the time window that contains alerts. */
@@ -69,7 +69,7 @@ export class OverviewPage {
 
   /** Returns the number of alert rows rendered in the overview alerts table. */
   async getAlertsRowCount(): Promise<number> {
-    return this.alertsDataGrid.getRowsCount();
+    return this.alertsDataGrid.rows.count();
   }
 
   /** Clicks the empty-state "Add data" CTA that links to onboarding. */

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/alerts_pagination.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/alerts_pagination.spec.ts
@@ -36,12 +36,12 @@ test.describe('Observability alerts - pagination', { tag: [...tags.stateful.clas
 
     await test.step('shows up to 10 rows per page', async () => {
       await alertsTablePage.setPageSize(10);
-      await expect.poll(() => alertsTablePage.dataGrid.getRowsCount()).toBeLessThanOrEqual(10);
+      await expect.poll(() => alertsTablePage.dataGrid.rows.count()).toBeLessThanOrEqual(10);
     });
 
     await test.step('shows up to 20 rows per page', async () => {
       await alertsTablePage.setPageSize(20);
-      await expect.poll(() => alertsTablePage.dataGrid.getRowsCount()).toBeLessThanOrEqual(20);
+      await expect.poll(() => alertsTablePage.dataGrid.rows.count()).toBeLessThanOrEqual(20);
     });
   });
 
@@ -68,17 +68,17 @@ test.describe('Observability alerts - pagination', { tag: [...tags.stateful.clas
 
     await test.step('jumps to a numbered page', async () => {
       await alertsTablePage.goToPage(2);
-      await expect.poll(() => alertsTablePage.dataGrid.getRowsCount()).toBe(PAGE_SIZE);
+      await expect(alertsTablePage.dataGrid.rows).toHaveCount(PAGE_SIZE);
     });
 
     await test.step('moves to the next page', async () => {
       await alertsTablePage.goToNextPage();
-      await expect.poll(() => alertsTablePage.dataGrid.getRowsCount()).toBe(PAGE_SIZE);
+      await expect(alertsTablePage.dataGrid.rows).toHaveCount(PAGE_SIZE);
     });
 
     await test.step('moves back to the previous page', async () => {
       await alertsTablePage.goToPrevPage();
-      await expect.poll(() => alertsTablePage.dataGrid.getRowsCount()).toBe(PAGE_SIZE);
+      await expect(alertsTablePage.dataGrid.rows).toHaveCount(PAGE_SIZE);
     });
   });
 });


### PR DESCRIPTION
## Summary

Migrates the alerts table and overview page objects to page.components.dataGrid. Row-count assertions now use the auto-retrying rows Locator (page-slice semantics unchanged).

**Stacked on https://github.com/elastic/kibana/pull/283398 (the helpers PR) — review only the last commit until it merges, then this branch gets rebased onto main.**

The exact change was pre-validated locally and in full CI (first-attempt results audited) in the umbrella draft https://github.com/elastic/kibana/pull/282596.

Part of https://github.com/elastic/apps-dx/issues/56 (epic https://github.com/elastic/apps-dx/issues/43).