### PR TITLE
[Scout][response-ops] Migrate rule details alerts table to page.components.dataGrid

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/fixtures/page_objects/rule_details_page.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/fixtures/page_objects/rule_details_page.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiDataGridWrapper, type ScoutPage } from '@kbn/scout';
+import type { EuiDataGridObject, ScoutPage } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { getRuleDetailsRoute } from '@kbn/rule-data-utils';
 import {
@@ -16,10 +16,10 @@ import {
 } from '../constants';
 
 export class RuleDetailsPage {
-  public readonly alertsTable: EuiDataGridWrapper;
+  public readonly alertsTable: EuiDataGridObject;
 
   constructor(private readonly page: ScoutPage) {
-    this.alertsTable = new EuiDataGridWrapper(this.page, 'alertsTableIsLoaded');
+    this.alertsTable = this.page.components.dataGrid('alertsTableIsLoaded');
   }
 
   async gotoById(ruleId: string) {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/per_alert_snooze.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/per_alert_snooze.spec.ts
@@ -149,7 +149,7 @@ test.describe('Per-alert snooze (rule details alerts tab)', { tag: tags.stateful
   }) => {
     await pageObjects.ruleDetailsPage.gotoById(ruleId);
     await pageObjects.ruleDetailsPage.expectAlertsTabLoaded();
-    await pageObjects.ruleDetailsPage.alertsTable.ensureGridVisible();
+    await expect(pageObjects.ruleDetailsPage.alertsTable.locator).toBeVisible();
 
     // Open the row action menu and swap it for the inline snooze panel.
     await pageObjects.ruleDetailsPage.openAlertSnoozePanel();
@@ -172,7 +172,7 @@ test.describe('Per-alert snooze (rule details alerts tab)', { tag: tags.stateful
   }) => {
     await pageObjects.ruleDetailsPage.gotoById(ruleId);
     await pageObjects.ruleDetailsPage.expectAlertsTabLoaded();
-    await pageObjects.ruleDetailsPage.alertsTable.ensureGridVisible();
+    await expect(pageObjects.ruleDetailsPage.alertsTable.locator).toBeVisible();
 
     await pageObjects.ruleDetailsPage.openAlertSnoozePanel();
     await expect(page.testSubj.locator('alertSnoozePanel')).toBeVisible();
@@ -194,7 +194,7 @@ test.describe('Per-alert snooze (rule details alerts tab)', { tag: tags.stateful
   }) => {
     await pageObjects.ruleDetailsPage.gotoById(ruleId);
     await pageObjects.ruleDetailsPage.expectAlertsTabLoaded();
-    await pageObjects.ruleDetailsPage.alertsTable.ensureGridVisible();
+    await expect(pageObjects.ruleDetailsPage.alertsTable.locator).toBeVisible();
 
     await pageObjects.ruleDetailsPage.openAlertSnoozePanel();
     await expect(page.testSubj.locator('alertSnoozePanel')).toBeVisible();
@@ -220,7 +220,7 @@ test.describe('Per-alert snooze (rule details alerts tab)', { tag: tags.stateful
   }) => {
     await pageObjects.ruleDetailsPage.gotoById(ruleId);
     await pageObjects.ruleDetailsPage.expectAlertsTabLoaded();
-    await pageObjects.ruleDetailsPage.alertsTable.ensureGridVisible();
+    await expect(pageObjects.ruleDetailsPage.alertsTable.locator).toBeVisible();
 
     await pageObjects.ruleDetailsPage.openAlertSnoozePanel();
     await expect(page.testSubj.locator('alertSnoozePanel')).toBeVisible();
@@ -256,7 +256,7 @@ test.describe('Per-alert snooze (rule details alerts tab)', { tag: tags.stateful
 
     await pageObjects.ruleDetailsPage.gotoById(ruleId);
     await pageObjects.ruleDetailsPage.expectAlertsTabLoaded();
-    await pageObjects.ruleDetailsPage.alertsTable.ensureGridVisible();
+    await expect(pageObjects.ruleDetailsPage.alertsTable.locator).toBeVisible();
 
     // The badge should already be visible because the rule SO has a snoozed instance.
     await expect(page.testSubj.locator('alertSnoozedBadge')).toBeVisible();

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_alerts_tab.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_alerts_tab.spec.ts
@@ -151,14 +151,12 @@ test.describe.skip('Rule details alerts tab', { tag: tags.stateful.classic }, ()
       await expect(pageObjects.ruleDetailsPage.alertSummaryTotalCount).toHaveText('2');
       await pageObjects.ruleDetailsPage.filterAlertsByKql('kibana.alert.status : "active"');
 
-      await pageObjects.ruleDetailsPage.alertsTable.ensureGridVisible();
-      const ruleNameCells =
-        pageObjects.ruleDetailsPage.alertsTable.getAllCellLocatorByColId(ALERT_RULE_NAME);
+      await expect(pageObjects.ruleDetailsPage.alertsTable.locator).toBeVisible();
+      const ruleNameCells = pageObjects.ruleDetailsPage.alertsTable.cells(ALERT_RULE_NAME);
       await expect(ruleNameCells).toHaveCount(1);
       await expect(ruleNameCells).toContainText(INDEX_THRESHOLD_RULE_NAME);
 
-      const statusCells =
-        pageObjects.ruleDetailsPage.alertsTable.getAllCellLocatorByColId(ALERT_STATUS);
+      const statusCells = pageObjects.ruleDetailsPage.alertsTable.cells(ALERT_STATUS);
       await expect(statusCells).toHaveCount(1);
       await expect(statusCells).toHaveText(/active/i);
 


### PR DESCRIPTION
## Summary

Migrates the rule details alerts table to page.components.dataGrid; ensureGridVisible() becomes a plain toBeVisible() expect in the specs.

**Stacked on https://github.com/elastic/kibana/pull/283398 (the helpers PR) — review only the last commit until it merges, then this branch gets rebased onto main.**

The exact change was pre-validated locally and in full CI (first-attempt results audited) in the umbrella draft https://github.com/elastic/kibana/pull/282596.

Part of https://github.com/elastic/apps-dx/issues/56 (epic https://github.com/elastic/apps-dx/issues/43).