### PR TITLE
[Scout][apm] Migrate alerts table, toast dismissal and field text to Component Objects / native locators

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiToastWrapper, type ScoutPage } from '@kbn/scout-oblt';
+import type { ScoutPage } from '@kbn/scout-oblt';
 import { EXTENDED_TIMEOUT } from './constants';
 
 /**
@@ -45,6 +45,5 @@ export async function waitForSearchBarReady(page: ScoutPage): Promise<void> {
  * interactions (e.g. Investigate menu) while still visible (#246662 CI flakes).
  */
 export async function dismissGlobalToastsIfPresent(page: ScoutPage): Promise<void> {
-  const toast = new EuiToastWrapper(page, { locator: '.euiToast' });
-  await toast.closeAllToasts();
+  await page.components.toast().closeAll();
 }

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/agent_configurations.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/agent_configurations.ts
@@ -13,7 +13,6 @@
  */
 
 import type { KibanaUrl, ScoutPage } from '@kbn/scout-oblt';
-import { EuiFieldTextWrapper } from '@kbn/scout-oblt';
 import { waitForApmMainContainer } from '../page_helpers';
 
 export class AgentConfigurationsPage {
@@ -79,10 +78,7 @@ export class AgentConfigurationsPage {
   }
 
   async selectSettingValue(settingKey: string, value: string) {
-    const inputField = new EuiFieldTextWrapper(this.page, {
-      dataTestSubj: `row_${settingKey}`,
-    });
-    await inputField.fill(value);
+    await this.page.testSubj.locator(`row_${settingKey}`).locator('input').fill(value);
   }
 
   async clickSaveConfiguration() {

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/service_details/alerts_tab.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/service_details/alerts_tab.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiDataGridWrapper, type KibanaUrl, type Locator, type ScoutPage } from '@kbn/scout-oblt';
+import type { EuiDataGridObject, KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
 import type { ServiceDetailsPageTabName } from './service_details_tab';
 import { ServiceDetailsTab } from './service_details_tab';
 import { EXTENDED_TIMEOUT } from '../../constants';
@@ -18,7 +18,7 @@ export class AlertsTab extends ServiceDetailsTab {
   public readonly alertsTableEmptyState: Locator;
   public readonly controlTitles: Locator;
 
-  public readonly alertsTable: EuiDataGridWrapper;
+  public readonly alertsTable: EuiDataGridObject;
 
   constructor(page: ScoutPage, kbnUrl: KibanaUrl, defaultServiceName: string) {
     super(page, kbnUrl, defaultServiceName);
@@ -27,7 +27,7 @@ export class AlertsTab extends ServiceDetailsTab {
     this.alertsTableEmptyState = this.page.testSubj.locator('alertsTableEmptyState');
     this.controlTitles = this.page.testSubj.locator('control-frame-title');
 
-    this.alertsTable = new EuiDataGridWrapper(this.page, 'alertsTableIsLoaded');
+    this.alertsTable = this.page.components.dataGrid('alertsTableIsLoaded');
   }
 
   protected async waitForTabLoad() {

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts
@@ -76,7 +76,7 @@ function createAlertDisplayTest(alertIndex: string) {
 
     await test.step('verify alert is visible', async () => {
       const ruleCell = serviceDetailsPage.alertsTab.alertsTable
-        .getAllCellLocatorByColId('kibana.alert.rule.name')
+        .cells('kibana.alert.rule.name')
         .filter({ hasText: RULE_NAME });
       await expect(ruleCell).toBeVisible();
     });


### PR DESCRIPTION
## Summary

Migrates the alerts tab table to page.components.dataGrid, toast dismissal to page.components.globalToastList().closeAll(), and the agent configuration field text to a native locator fill.

**Stacked on https://github.com/elastic/kibana/pull/283398 (the helpers PR) — review only the last commit until it merges, then this branch gets rebased onto main.**

The exact change was pre-validated locally and in full CI (first-attempt results audited) in the umbrella draft https://github.com/elastic/kibana/pull/282596.

Part of https://github.com/elastic/apps-dx/issues/56 (epic https://github.com/elastic/apps-dx/issues/43).