### PR TITLE
[discover-scout] Migrate expanded-row data grid and copy-to-clipboard toasts to Component Objects

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/core/ui/parallel_tests/cascade_layout_interactions.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/core/ui/parallel_tests/cascade_layout_interactions.spec.ts
@@ -14,7 +14,6 @@
  * to classic mode) renders the expected layout.
  */
 
-import { EuiDataGridWrapper } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { spaceTest } from '../../../common/ui/fixtures';
 import { runCascadeQuery } from '../../../common/ui/fixtures/helpers';
@@ -88,22 +87,22 @@ spaceTest.describe(
         await spaceTest.step('expanding a row and entering/exiting fullscreen works', async () => {
           await discover.toggleCascadeLayoutRow(firstRowId);
 
-          // Scoped to the expanded row: while scrolled, the sticky pinned group header
-          // renders a `createPortal` duplicate of row content elsewhere in the DOM, so an
-          // unscoped page-wide `discoverDocTable` locator can match the wrong copy. The
-          // locator must resolve to `.euiDataGrid` itself (not its `discoverDocTable`
-          // container) since that's the element EUI toggles the fullscreen class on.
-          const expandedRowGrid = new EuiDataGridWrapper(page, {
-            locator: `[id="${firstRowId}"] [data-test-subj="discoverDocTable"] .euiDataGrid`,
-          });
-          expect(await expandedRowGrid.getRowsCount()).toBeGreaterThan(0);
+          // `docTable` is the subj on the EuiDataGrid itself (the component-type guard
+          // requires that). Scoped to the expanded row: while scrolled, the sticky pinned
+          // group header renders a `createPortal` duplicate of row content elsewhere in
+          // the DOM, so an unscoped page-wide locator can match the wrong copy.
+          const expandedRowGrid = page.components.dataGrid(
+            'docTable',
+            page.locator(`[id="${firstRowId}"]`)
+          );
+          await expect(expandedRowGrid.rows).not.toHaveCount(0);
 
           await expandedRowGrid.openFullScreenMode();
-          expect(await expandedRowGrid.getRowsCount()).toBeGreaterThan(0);
+          await expect(expandedRowGrid.rows).not.toHaveCount(0);
 
           await expandedRowGrid.closeFullScreenMode();
           // Rows are still rendered (the grid didn't unmount/lose its data) after exiting fullscreen.
-          expect(await expandedRowGrid.getRowsCount()).toBeGreaterThan(0);
+          await expect(expandedRowGrid.rows).not.toHaveCount(0);
         });
 
         await spaceTest.step('opting out of grouping shows the flat doc table', async () => {

--- a/src/platform/plugins/shared/discover/test/scout/data_grid/ui/parallel_tests/data_grid_copy_to_clipboard.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/data_grid/ui/parallel_tests/data_grid_copy_to_clipboard.spec.ts
@@ -12,7 +12,7 @@
  */
 
 import type { PageObjects, ScoutPage } from '@kbn/scout';
-import { EuiToastWrapper, spaceTest } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { testData } from '../fixtures';
 
@@ -35,11 +35,11 @@ const clickCopyColumnValues = async (page: ScoutPage, dataGrid: DataGridPage, fi
 };
 
 const expectSingleToastThenDismiss = async (page: ScoutPage) => {
-  const toasts = new EuiToastWrapper(page, { locator: '.euiToast' });
+  const toastList = page.components.toast();
 
-  await expect(toasts.getWrapper()).toHaveCount(1);
+  await expect(toastList.toasts).toHaveCount(1);
 
-  await toasts.closeAllToasts();
+  await toastList.closeAll();
 };
 
 const readClipboard = async (page: ScoutPage): Promise<string> => {


### PR DESCRIPTION
## Summary

Migrates the cascade-layout expanded-row grid to page.components.dataGrid('docTable', rowScope) and the copy-to-clipboard toast assertions to page.components.globalToastList().

**Stacked on https://github.com/elastic/kibana/pull/283398 (the helpers PR) — review only the last commit until it merges, then this branch gets rebased onto main.**

The exact change was pre-validated locally and in full CI (first-attempt results audited) in the umbrella draft https://github.com/elastic/kibana/pull/282596.

Part of https://github.com/elastic/apps-dx/issues/56 (epic https://github.com/elastic/apps-dx/issues/43).