### PR TITLE
[Scout][index-management] Replace EuiFieldTextWrapper with native locator fills

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/test/scout/ui/fixtures/page_objects/index_management_page.ts
+++ b/x-pack/platform/plugins/shared/index_management/test/scout/ui/fixtures/page_objects/index_management_page.ts
@@ -7,7 +7,7 @@
 
 /* eslint-disable max-classes-per-file */
 
-import { type Locator, type ScoutPage, EuiFieldTextWrapper, EuiToastWrapper } from '@kbn/scout';
+import type { Locator, ScoutPage } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
 export class AbstractPageObject {
@@ -193,7 +193,7 @@ export class IndexManagement extends AbstractPageObject {
     await expect(this.page.testSubj.locator('editDataLifecycleFlyoutApplyButton')).toBeHidden({
       timeout: 30_000,
     });
-    await new EuiToastWrapper(this.page, { dataTestSubj: 'globalToastList' }).closeAllToasts();
+    await this.page.components.toast().closeAll();
   }
 
   async stopInheritingDataStreamLifecycle() {
@@ -259,23 +259,19 @@ export class IndexManagement extends AbstractPageObject {
 
   indexTemplateWizard = {
     // `nameField` and `indexPatternsField` carry the test subject on their EuiFormRow wrapper, so
-    // the inner input is driven via the EUI field wrapper.
+    // the inner input is driven via a native locator.
     open: async (name: string, indexPattern: string) => {
       await this.page.testSubj.locator('createTemplateButton').click();
-      await new EuiFieldTextWrapper(this.page, { dataTestSubj: 'nameField' }).fill(name);
-      await new EuiFieldTextWrapper(this.page, { dataTestSubj: 'indexPatternsField' }).fill(
-        indexPattern
-      );
+      await this.page.testSubj.locator('nameField').locator('input').fill(name);
+      await this.page.testSubj.locator('indexPatternsField').locator('input').fill(indexPattern);
     },
 
     completeStepOne: async () => {
-      const nameField = new EuiFieldTextWrapper(this.page, { dataTestSubj: 'nameField' });
-      await nameField.fill('test-index-template');
-
-      const indexPatternsField = new EuiFieldTextWrapper(this.page, {
-        dataTestSubj: 'indexPatternsField',
-      });
-      await indexPatternsField.fill('test-index-pattern');
+      await this.page.testSubj.locator('nameField').locator('input').fill('test-index-template');
+      await this.page.testSubj
+        .locator('indexPatternsField')
+        .locator('input')
+        .fill('test-index-pattern');
 
       await this.clickNextButton();
     },

--- a/x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/index_templates/index_template_wizard_mappings.spec.ts
+++ b/x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/index_templates/index_template_wizard_mappings.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFieldTextWrapper, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { test } from '../../fixtures';
 
@@ -18,12 +18,8 @@ test.describe('Index template wizard - Mappings step', { tag: tags.stateful.clas
     await page.testSubj.locator('createTemplateButton').click();
 
     // Fill out required fields using EUI wrapper
-    const nameField = new EuiFieldTextWrapper(page, { dataTestSubj: 'nameField' });
-    await nameField.fill('test-index-template');
-    const indexPatternsField = new EuiFieldTextWrapper(page, {
-      dataTestSubj: 'indexPatternsField',
-    });
-    await indexPatternsField.fill('test-index-pattern');
+    await page.testSubj.locator('nameField').locator('input').fill('test-index-template');
+    await page.testSubj.locator('indexPatternsField').locator('input').fill('test-index-pattern');
 
     // Go to Mappings step
     await page.testSubj.locator('formWizardStep-3').click();

--- a/x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/index_templates/index_template_wizard_preview.spec.ts
+++ b/x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/index_templates/index_template_wizard_preview.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFieldTextWrapper, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { test } from '../../fixtures';
 
@@ -29,14 +29,9 @@ test.describe('Index template wizard - Preview template', { tag: tags.stateful.c
       await expect(page.testSubj.locator('appHeaderTitle')).toHaveText('Create template');
       await expect(page.testSubj.locator('stepTitle')).toHaveText('Logistics');
 
-      const nameField = new EuiFieldTextWrapper(page, { dataTestSubj: 'nameField' });
-      await nameField.fill('a-star');
-      const indexPatternsField = new EuiFieldTextWrapper(page, {
-        dataTestSubj: 'indexPatternsField',
-      });
-      await indexPatternsField.fill('a*');
-      const priorityField = new EuiFieldTextWrapper(page, { dataTestSubj: 'priorityField' });
-      await priorityField.fill('1000');
+      await page.testSubj.locator('nameField').locator('input').fill('a-star');
+      await page.testSubj.locator('indexPatternsField').locator('input').fill('a*');
+      await page.testSubj.locator('priorityField').locator('input').fill('1000');
       await pageObjects.indexManagement.clickNextButton();
     });
 


### PR DESCRIPTION
## Summary

Replaces EuiFieldTextWrapper with native locator fills in the index template wizard (the wrapper only wrapped fill()).

**Stacked on https://github.com/elastic/kibana/pull/283398 (the helpers PR) — review only the last commit until it merges, then this branch gets rebased onto main.**

The exact change was pre-validated locally and in full CI (first-attempt results audited) in the umbrella draft https://github.com/elastic/kibana/pull/282596.

Part of https://github.com/elastic/apps-dx/issues/56 (epic https://github.com/elastic/apps-dx/issues/43).