### PR TITLE
[Scout][cspm] Migrate cloud connector super select to page.components.superSelect, drop deep import

### DIFF
--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/cspm_integration_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/cspm_integration_page.ts
@@ -6,7 +6,6 @@
  */
 
 import type { ScoutPage } from '@kbn/scout';
-import { EuiSuperSelectWrapper } from '@kbn/scout/src/playwright/eui_components/super_select';
 
 /**
  * CSPM / Fleet UI `data-test-subj` values are duplicated here on purpose so
@@ -107,19 +106,8 @@ export class CspmIntegrationPage {
         ? AWS_CLOUD_CONNECTOR_SUPER_SELECT_TEST_SUBJ
         : AZURE_CLOUD_CONNECTOR_SUPER_SELECT_TEST_SUBJ;
 
-    // Use EUI wrapper for reliable super select interaction
-    const superSelect = new EuiSuperSelectWrapper(this.page, { dataTestSubj: selectTestSubj });
-
-    // Open the dropdown
-    await superSelect.toggleDropdown();
-
-    // Find and click the option by visible text (connector names are dynamic)
-    const dropdown = this.page.locator('[role="listbox"]');
-    await dropdown.waitFor({ state: 'visible' });
-    await dropdown.locator(`[role="option"]`).filter({ hasText: connectorName }).click();
-
-    // Wait for dropdown to close
-    await dropdown.waitFor({ state: 'detached' });
+    // Connector names are dynamic, so select by visible label.
+    await this.page.components.superSelect(selectTestSubj).selectOptionByLabel(connectorName);
   }
 
   async fillIntegrationName(name: string) {


### PR DESCRIPTION
## Summary

Migrates the cloud connector super select to page.components.superSelect(...).selectOptionByLabel() (replacing hand-rolled option clicks) and removes the deep-path import of kbn-scout internals. Note: the cspm Scout suite only runs via a conditional CI step; the umbrella carried ci:all-ui-test-suites to exercise it.

**Stacked on https://github.com/elastic/kibana/pull/283398 (the helpers PR) — review only the last commit until it merges, then this branch gets rebased onto main.**

The exact change was pre-validated locally and in full CI (first-attempt results audited) in the umbrella draft https://github.com/elastic/kibana/pull/282596.

Part of https://github.com/elastic/apps-dx/issues/56 (epic https://github.com/elastic/apps-dx/issues/43).