### PR TITLE
[Scout][streams] Migrate preview data grid, super selects and code block to Component Objects / native locators

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/shared/preview_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/shared/preview_table.tsx
@@ -524,6 +524,7 @@ export function PreviewTable({
 
   return (
     <EuiDataGrid
+      data-test-subj="streamsAppPreviewDataGrid"
       aria-label={i18n.translate('xpack.streams.resultPanel.euiDataGrid.previewLabel', {
         defaultMessage: 'Preview',
       })}

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -9,14 +9,17 @@
 
 import moment from 'moment';
 import type { Locator, ScoutPage } from '@kbn/scout';
-import {
-  EuiCodeBlockWrapper,
-  EuiDataGridWrapper,
-  EuiSuperSelectWrapper,
-  KibanaCodeEditorWrapper,
-} from '@kbn/scout';
+import { KibanaCodeEditorWrapper, type EuiDataGridObject } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import type { FieldTypeOption } from '../../../../../public/components/stream_management/data_management/schema_editor/constants';
+
+interface CellValueExpectation {
+  columnName: string;
+  rowIndex: number;
+  value: string;
+  invertCondition?: boolean;
+  timeout?: number;
+}
 
 const LEGACY_DATE_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
 
@@ -29,7 +32,6 @@ export class StreamsApp {
   public readonly fieldTypeSuperSelect;
   public readonly previewDataGrid;
   public readonly schemaDataGrid;
-  public readonly advancedSettingsCodeBlock;
   public readonly kibanaMonacoEditor;
   public readonly saveRoutingRuleButton;
   public readonly concatFieldInput;
@@ -82,22 +84,12 @@ export class StreamsApp {
     this.dateProcessorFormatsComboBox = this.page.components.comboBox(
       'streamsAppDateProcessorFormatsComboBox'
     );
-    this.fieldTypeSuperSelect = new EuiSuperSelectWrapper(
-      this.page,
-      'streamsAppFieldFormTypeSelect'
-    );
-    // TODO: Make locator more specific when possible
-    this.previewDataGrid = new EuiDataGridWrapper(this.page, { locator: '.euiDataGrid' });
-    this.schemaDataGrid = new EuiDataGridWrapper(
-      this.page,
-      'streamsAppSchemaEditorFieldsTableLoaded'
-    );
-    this.advancedSettingsCodeBlock = new EuiCodeBlockWrapper(this.page, {
-      locator: '.euiCodeBlock',
-    });
+    this.fieldTypeSuperSelect = this.page.components.superSelect('streamsAppFieldFormTypeSelect');
+    this.previewDataGrid = this.page.components.dataGrid('streamsAppPreviewDataGrid');
+    this.schemaDataGrid = this.page.components.dataGrid('streamsAppSchemaEditorFieldsTableLoaded');
     this.kibanaMonacoEditor = new KibanaCodeEditorWrapper(this.page);
     this.saveRoutingRuleButton = this.page.getByTestId('streamsAppStreamDetailRoutingSaveButton');
-    this.concatFieldInput = new EuiSuperSelectWrapper(this.page, 'streamsAppConcatFieldInput');
+    this.concatFieldInput = this.page.components.superSelect('streamsAppConcatFieldInput');
     this.concatLiteralInput = this.page.getByTestId('streamsAppConcatLiteralInput');
     this.createStreamButton = this.page.getByTestId('streamsAppCreateStreamButton');
     this.createQueryStreamButton = this.page.getByTestId('streamsAppCreateQueryStreamButton');
@@ -1063,20 +1055,20 @@ export class StreamsApp {
    * Uses a high default timeout so the simulation preview has time to refresh
    * after transient stale values (e.g. literal "null" from a Set processor).
    */
-  async expectCellValueContains({
-    columnName,
-    rowIndex,
-    value,
-    invertCondition = false,
-    timeout = 30_000,
-  }: {
-    columnName: string;
-    rowIndex: number;
-    value: string;
-    invertCondition?: boolean;
-    timeout?: number;
-  }) {
-    const cellLocator = this.previewDataGrid.getCellLocatorByColId(rowIndex, columnName);
+  async expectCellValueContains(params: CellValueExpectation) {
+    await this.expectGridCellValueContains(this.previewDataGrid, params);
+  }
+
+  /** Same as {@link expectCellValueContains}, against the schema editor fields table. */
+  async expectSchemaEditorCellValueContains(params: CellValueExpectation) {
+    await this.expectGridCellValueContains(this.schemaDataGrid, params);
+  }
+
+  private async expectGridCellValueContains(
+    grid: EuiDataGridObject,
+    { columnName, rowIndex, value, invertCondition = false, timeout = 30_000 }: CellValueExpectation
+  ) {
+    const cellLocator = grid.cell(rowIndex, columnName);
 
     if (invertCondition) {
       await expect(cellLocator).not.toContainText(value, { timeout });
@@ -1448,7 +1440,7 @@ export class StreamsApp {
   }
 
   async fillConcatFieldInput(value: string) {
-    await this.concatFieldInput.selectOption(value);
+    await this.concatFieldInput.selectOptionByValue(value);
   }
 
   async fillConcatLiteralInput(value: string) {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/classic_streams_schema.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/classic_streams_schema.spec.ts
@@ -106,7 +106,7 @@ test.describe(
         { columnName: 'name', rowIndex: 0, value: sourceFieldName },
         { columnName: 'status', rowIndex: 0, value: 'Mapped' },
       ]) {
-        await pageObjects.streams.expectCellValueContains(exp);
+        await pageObjects.streams.expectSchemaEditorCellValueContains(exp);
       }
 
       // Verify copy_to parameter was saved by opening the view flyout
@@ -120,7 +120,7 @@ test.describe(
       }
 
       // Get the code block value and verify it contains copy_to
-      const codeValue = await pageObjects.streams.advancedSettingsCodeBlock.getCodeValue();
+      const codeValue = (await page.locator('code.euiCodeBlock__code').textContent())?.trim() ?? '';
       expect(codeValue).toContain('copy_to');
       expect(codeValue).toContain(targetFieldName);
     });
@@ -145,17 +145,17 @@ test.describe(
       await pageObjects.streams.expectSchemaEditorTableVisible();
 
       await pageObjects.streams.searchFields(fieldName);
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: fieldName,
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'type',
         rowIndex: 0,
         value: 'geo_point',
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'status',
         rowIndex: 0,
         value: 'Mapped',

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/data_mapping.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/data_mapping.spec.ts
@@ -76,7 +76,7 @@ test.describe(
       // Verify the search filters the results
       const rows = await pageObjects.streams.getPreviewTableRows();
       expect(rows).toHaveLength(1);
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: '@timestamp',
@@ -91,12 +91,12 @@ test.describe(
       await pageObjects.streams.searchFields('host');
 
       // Verify the search filters the results
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: 'resource.attributes.host.name',
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 1,
         value: 'host',
@@ -113,7 +113,7 @@ test.describe(
 
       const numberRows = await pageObjects.streams.getPreviewTableRows();
       for (let rowIndex = 0; rowIndex < numberRows.length; rowIndex++) {
-        await pageObjects.streams.expectCellValueContains({
+        await pageObjects.streams.expectSchemaEditorCellValueContains({
           columnName: 'type',
           rowIndex,
           value: 'Number',
@@ -130,7 +130,7 @@ test.describe(
 
       const mappedRows = await pageObjects.streams.getPreviewTableRows();
       for (let rowIndex = 0; rowIndex < mappedRows.length; rowIndex++) {
-        await pageObjects.streams.expectCellValueContains({
+        await pageObjects.streams.expectSchemaEditorCellValueContains({
           columnName: 'status',
           rowIndex,
           value: 'Inherited',
@@ -144,12 +144,12 @@ test.describe(
       // Search specific unmapped field
       await pageObjects.streams.searchFields('resource.attributes.host.ip');
       // Verify the field is unmapped
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: 'resource.attributes.host.ip',
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'status',
         rowIndex: 0,
         value: 'Unmapped',
@@ -168,12 +168,12 @@ test.describe(
       await pageObjects.streams.submitSchemaChanges();
 
       // Verify the field is now mapped
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: 'resource.attributes.host.ip',
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'status',
         rowIndex: 0,
         value: 'Mapped',
@@ -186,12 +186,12 @@ test.describe(
       // Search specific unmapped field
       await pageObjects.streams.searchFields('resource.attributes.host.ip');
       // Verify the field is unmapped
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: 'resource.attributes.host.ip',
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'status',
         rowIndex: 0,
         value: 'Unmapped',
@@ -211,12 +211,12 @@ test.describe(
       await pageObjects.toasts.closeAll();
 
       // Verify the field is now mapped
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: 'resource.attributes.host.ip',
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'status',
         rowIndex: 0,
         value: 'Mapped',
@@ -229,12 +229,12 @@ test.describe(
       await pageObjects.streams.submitSchemaChanges();
 
       // Verify the field is now unmapped
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: 'resource.attributes.host.ip',
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'status',
         rowIndex: 0,
         value: 'Unmapped',
@@ -277,17 +277,17 @@ test.describe(
       await pageObjects.streams.searchFields(fieldName);
 
       // Verify the field was added and is mapped
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: fieldName,
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'type',
         rowIndex: 0,
         value: 'keyword',
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'status',
         rowIndex: 0,
         value: 'Mapped',
@@ -309,7 +309,7 @@ test.describe(
       await pageObjects.streams.confirmChangesInReviewModal();
 
       // Verify the description is visible in the table
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'description',
         rowIndex: 0,
         value: 'The IP address of the host',

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/wired_streams_schema.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/wired_streams_schema.spec.ts
@@ -76,12 +76,12 @@ test.describe(
       await pageObjects.streams.searchFields(parentFieldName);
 
       // Verify the field is shown as inherited
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: parentFieldName,
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'status',
         rowIndex: 0,
         value: 'Inherited',
@@ -108,9 +108,11 @@ test.describe(
 
       // Wait for ECS/Otel recommendation to load - the /fields_metadata call provides type hints
       // Give extra time for the API response to be processed and the UI to update
-      await expect(pageObjects.streams.fieldTypeSuperSelect.valueInputLocator).toHaveValue('ip', {
-        timeout: 30_000,
-      });
+      await expect
+        .poll(() => pageObjects.streams.fieldTypeSuperSelect.getSelectedValue(), {
+          timeout: 30_000,
+        })
+        .toBe('ip');
 
       await page.getByTestId('streamsAppSchemaEditorAddFieldButton').click();
       await expect(
@@ -125,12 +127,12 @@ test.describe(
       await pageObjects.streams.searchFields(ecsFieldName);
 
       // Verify the field was added with IP type
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: ecsFieldName,
       });
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'type',
         rowIndex: 0,
         value: 'ip',
@@ -169,7 +171,7 @@ test.describe(
 
       // Verify the ECS field was created
       await pageObjects.streams.searchFields(ecsFieldName);
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: ecsFieldName,
@@ -177,14 +179,14 @@ test.describe(
 
       // Verify the alias field was automatically created
       await pageObjects.streams.searchFields(aliasFieldName);
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'name',
         rowIndex: 0,
         value: aliasFieldName,
       });
 
       // Verify the Type column shows the alias relationship for the alias field
-      await pageObjects.streams.expectCellValueContains({
+      await pageObjects.streams.expectSchemaEditorCellValueContains({
         columnName: 'type',
         rowIndex: 1,
         value: `Alias for ${ecsFieldName}`,


### PR DESCRIPTION
## Summary

Migrates the preview and schema editor grids to page.components.dataGrid (adds a data-test-subj to the shared PreviewTable grid, which a page-wide .euiDataGrid locator was silently sharing with the schema editor table), the super selects to page.components.superSelect, and the code block read to a native locator.

**Stacked on https://github.com/elastic/kibana/pull/283398 (the helpers PR) — review only the last commit until it merges, then this branch gets rebased onto main.**

The exact change was pre-validated locally and in full CI (first-attempt results audited) in the umbrella draft https://github.com/elastic/kibana/pull/282596.

Part of https://github.com/elastic/apps-dx/issues/56 (epic https://github.com/elastic/apps-dx/issues/43).