### PR TITLE
[Security Solution][Data View] Relocate useSignalHelpers out of sourcerer folder and avoid duplicate useDataView call on alerts page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
@@ -57,6 +57,14 @@ export const useDataView = (
         // this is due to the fact that many of our tests mock kibana hook and do not provide proper
         // double for dataViews service
         const currDv = await dataViews?.get(dataViewId);
+
+        // In production the dataViews service is always present, so `get` resolves to a DataView.
+        // The only way `currDv` is falsy is an incomplete Kibana mock in tests; bail rather than
+        // store `undefined` so the hook's non-null `DataView` contract stays truthful.
+        if (!currDv) {
+          return;
+        }
+
         if (!loadedForTheFirstTimeRef.current) {
           loadedForTheFirstTimeRef.current = true;
         }

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.test.tsx
@@ -14,12 +14,10 @@ import {
   Wrapper,
 } from './wrapper';
 import { TestProviders } from '../../../common/mock';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
-import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DataView } from '@kbn/data-views-plugin/public';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 
 jest.mock('../../../common/hooks/use_experimental_features');
-jest.mock('../../../data_view_manager/hooks/use_data_view');
 jest.mock('./content', () => ({
   AlertsPageContent: () => <div data-test-subj={'alerts-page-content'} />,
 }));
@@ -32,11 +30,9 @@ describe('<Wrapper />', () => {
   });
 
   it('should render a loading skeleton if the dataView status is pristine', async () => {
-    (useDataView as jest.Mock).mockReturnValue({ dataView, status: 'pristine' });
-
     render(
       <TestProviders>
-        <Wrapper />
+        <Wrapper dataView={dataView} status="pristine" />
       </TestProviders>
     );
 
@@ -47,11 +43,9 @@ describe('<Wrapper />', () => {
   });
 
   it('should render a loading skeleton if the dataView status is loading', async () => {
-    (useDataView as jest.Mock).mockReturnValue({ dataView, status: 'loading' });
-
     render(
       <TestProviders>
-        <Wrapper />
+        <Wrapper dataView={dataView} status="loading" />
       </TestProviders>
     );
 
@@ -62,14 +56,9 @@ describe('<Wrapper />', () => {
   });
 
   it('should render an error if the dataView status is error', async () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      dataView: undefined,
-      status: 'error',
-    });
-
     render(
       <TestProviders>
-        <Wrapper />
+        <Wrapper dataView={dataView} status="error" />
       </TestProviders>
     );
 
@@ -80,18 +69,15 @@ describe('<Wrapper />', () => {
   });
 
   it('should render an error if the dataView status is ready but it has no indices', async () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      dataView: {
-        ...dataView,
-        getRuntimeMappings: jest.fn(),
-        hasMatchedIndices: jest.fn().mockReturnValue(false),
-      },
-      status: 'ready',
-    });
+    const invalidDataView = {
+      ...dataView,
+      getRuntimeMappings: jest.fn(),
+      hasMatchedIndices: jest.fn().mockReturnValue(false),
+    } as unknown as DataView;
 
     render(
       <TestProviders>
-        <Wrapper />
+        <Wrapper dataView={invalidDataView} status="ready" />
       </TestProviders>
     );
 
@@ -104,20 +90,17 @@ describe('<Wrapper />', () => {
   });
 
   it('should render the content', async () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      dataView: {
-        ...dataView,
-        id: 'id',
-        getIndexPattern: jest.fn().mockReturnValue('title'),
-        getRuntimeMappings: jest.fn(),
-        hasMatchedIndices: jest.fn().mockReturnValue(true),
-      },
-      status: 'ready',
-    });
+    const validDataView = {
+      ...dataView,
+      id: 'id',
+      getIndexPattern: jest.fn().mockReturnValue('title'),
+      getRuntimeMappings: jest.fn(),
+      hasMatchedIndices: jest.fn().mockReturnValue(true),
+    } as unknown as DataView;
 
     render(
       <TestProviders>
-        <Wrapper />
+        <Wrapper dataView={validDataView} status="ready" />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
@@ -16,9 +16,9 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { PageScope } from '../../../data_view_manager/constants';
+import type { DataView } from '@kbn/data-views-plugin/public';
 import { HeaderPage } from '../../../common/components/header_page';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import type { UseDataViewReturnValue } from '../../../data_view_manager/hooks/use_data_view';
 import { AlertsPageContent } from './content';
 import { PAGE_TITLE } from '../../pages/alerts/translations';
 
@@ -30,14 +30,19 @@ const DATAVIEW_ERROR = i18n.translate('xpack.securitySolution.alertsPage.dataVie
   defaultMessage: 'Unable to retrieve the data view',
 });
 
+interface WrapperProps {
+  /** the alerts data view, retrieved once by the parent via useDataView(PageScope.alerts) */
+  dataView: DataView;
+  /** the status of the alerts data view retrieval */
+  status: UseDataViewReturnValue['status'];
+}
+
 /**
- * Retrieves the dataView for the alerts page then renders the alerts page when the dataView is valid.
+ * Renders the alerts page when the provided dataView is valid.
  * Shows a loading skeleton while retrieving.
  * Shows an error message if the dataView is invalid.
  */
-export const Wrapper = memo(() => {
-  const { dataView, status } = useDataView(PageScope.alerts);
-
+export const Wrapper = memo(({ dataView, status }: WrapperProps) => {
   const isLoading: boolean = useMemo(() => status === 'loading' || status === 'pristine', [status]);
 
   const isDataViewInvalid: boolean = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
@@ -18,7 +18,6 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { HeaderPage } from '../../../common/components/header_page';
-import type { UseDataViewReturnValue } from '../../../data_view_manager/hooks/use_data_view';
 import { AlertsPageContent } from './content';
 import { PAGE_TITLE } from '../../pages/alerts/translations';
 
@@ -34,7 +33,7 @@ interface WrapperProps {
   /** the alerts data view, retrieved once by the parent via useDataView(PageScope.alerts) */
   dataView: DataView;
   /** the status of the alerts data view retrieval */
-  status: UseDataViewReturnValue['status'];
+  status: 'pristine' | 'loading' | 'ready' | 'error';
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_signal_helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_signal_helpers.tsx
@@ -6,18 +6,25 @@
  */
 
 import { useMemo } from 'react';
-import { PageScope } from '../../data_view_manager/constants';
-import { useDataView } from '../../data_view_manager/hooks/use_data_view';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import type { UseDataViewReturnValue } from '../../data_view_manager/hooks/use_data_view';
 import { useSignalIndexName } from '../../data_view_manager/hooks/use_signal_index_name';
 
-export const useSignalHelpers = (): {
+/**
+ * Computes whether the signal index still needs to be initialized for the given alerts data view.
+ * The alerts data view should be retrieved once via the useDataView hook (with PageScope.alerts)
+ * and passed in here, so we avoid an additional useDataView subscription per consumer.
+ */
+export const useSignalHelpers = (
+  dataView: DataView,
+  status: UseDataViewReturnValue['status']
+): {
   /* when true, signal index has been initiated but does not exist yet */
   signalIndexNeedsInit: boolean;
 } => {
-  const { dataView, status } = useDataView(PageScope.alerts);
   const signalIndexName = useSignalIndexName();
 
-  const defaultDataViewPattern = dataView.getIndexPattern() ?? '';
+  const defaultDataViewPattern = dataView?.getIndexPattern() ?? '';
 
   const signalIndexNeedsInit = useMemo(() => {
     if (status === 'pristine') {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_signal_helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_signal_helpers.tsx
@@ -24,7 +24,7 @@ export const useSignalHelpers = (
 } => {
   const signalIndexName = useSignalIndexName();
 
-  const defaultDataViewPattern = dataView?.getIndexPattern() ?? '';
+  const defaultDataViewPattern = dataView.getIndexPattern() ?? '';
 
   const signalIndexNeedsInit = useMemo(() => {
     if (status === 'pristine') {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alerts.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alerts.test.tsx
@@ -11,7 +11,7 @@ import { ALERTS_PAGE_LOADING_TEST_ID, AlertsPage } from './alerts';
 import { useUserData } from '../../components/user_info';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { useListsConfig } from '../../containers/detection_engine/lists/use_lists_config';
-import { useSignalHelpers } from '../../../sourcerer/containers/use_signal_helpers';
+import { useSignalHelpers } from '../../hooks/use_signal_helpers';
 import { TestProviders } from '../../../common/mock';
 import { USER_UNAUTHENTICATED_TEST_ID } from '../../components/alerts/empty_pages/user_unauthenticated_empty_page';
 import { NO_INDEX_TEST_ID } from '../../components/alerts/empty_pages/no_index_empty_page';
@@ -23,7 +23,10 @@ import { useAlertsPrivileges } from '../../containers/detection_engine/alerts/us
 jest.mock('../../components/user_info');
 jest.mock('../../../common/components/user_privileges');
 jest.mock('../../containers/detection_engine/lists/use_lists_config');
-jest.mock('../../../sourcerer/containers/use_signal_helpers');
+jest.mock('../../hooks/use_signal_helpers');
+jest.mock('../../../data_view_manager/hooks/use_data_view', () => ({
+  useDataView: jest.fn().mockReturnValue({ dataView: {}, status: 'ready' }),
+}));
 jest.mock('../../../common/hooks/use_missing_privileges');
 jest.mock('../../containers/detection_engine/alerts/use_alerts_privileges');
 jest.mock('../../components/alerts/wrapper', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alerts.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alerts.tsx
@@ -16,7 +16,9 @@ import { NoIndexEmptyPage } from '../../components/alerts/empty_pages/no_index_e
 import { useListsConfig } from '../../containers/detection_engine/lists/use_lists_config';
 import { UserUnauthenticatedEmptyPage } from '../../components/alerts/empty_pages/user_unauthenticated_empty_page';
 import * as i18n from './translations';
-import { useSignalHelpers } from '../../../sourcerer/containers/use_signal_helpers';
+import { PageScope } from '../../../data_view_manager/constants';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useSignalHelpers } from '../../hooks/use_signal_helpers';
 import { NeedAdminForUpdateRulesCallOut } from '../../../detection_engine/rule_management/components/callouts/need_admin_for_update_rules_callout';
 import { MissingDetectionsPrivilegesCallOut } from '../../components/callouts/missing_detections_privileges_callout';
 import { NoPrivileges } from '../../../common/components/no_privileges';
@@ -34,7 +36,8 @@ export const AlertsPage = memo(() => {
   const { hasAlertsRead: canReadAlerts } = useAlertsPrivileges();
   const { loading: listsConfigLoading, needsConfiguration: needsListsConfiguration } =
     useListsConfig();
-  const { signalIndexNeedsInit } = useSignalHelpers();
+  const { dataView, status } = useDataView(PageScope.alerts);
+  const { signalIndexNeedsInit } = useSignalHelpers(dataView, status);
 
   const loading: boolean = useMemo(
     () => userInfoLoading || listsConfigLoading,
@@ -96,7 +99,7 @@ export const AlertsPage = memo(() => {
           docLinkSelector={(docLinks: DocLinks) => docLinks.siem.privileges}
         />
       ) : (
-        <Wrapper />
+        <Wrapper dataView={dataView} status={status} />
       )}
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/attacks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/attacks.test.tsx
@@ -10,7 +10,7 @@ import { render } from '@testing-library/react';
 import { ATTACKS_PAGE_LOADING_TEST_ID, AttacksPage } from './attacks';
 import { useUserData } from '../../components/user_info';
 import { useListsConfig } from '../../containers/detection_engine/lists/use_lists_config';
-import { useSignalHelpers } from '../../../sourcerer/containers/use_signal_helpers';
+import { useSignalHelpers } from '../../hooks/use_signal_helpers';
 import { TestProviders } from '../../../common/mock';
 import { USER_UNAUTHENTICATED_TEST_ID } from '../../components/alerts/empty_pages/user_unauthenticated_empty_page';
 import { NO_INDEX_TEST_ID } from '../../components/alerts/empty_pages/no_index_empty_page';
@@ -23,7 +23,10 @@ import { useAlertsPrivileges } from '../../containers/detection_engine/alerts/us
 jest.mock('../../components/user_info');
 jest.mock('../../../common/components/user_privileges');
 jest.mock('../../containers/detection_engine/lists/use_lists_config');
-jest.mock('../../../sourcerer/containers/use_signal_helpers');
+jest.mock('../../hooks/use_signal_helpers');
+jest.mock('../../../data_view_manager/hooks/use_data_view', () => ({
+  useDataView: jest.fn().mockReturnValue({ dataView: {}, status: 'ready' }),
+}));
 jest.mock('../../../common/hooks/use_missing_privileges');
 jest.mock('../../containers/detection_engine/alerts/use_alerts_privileges');
 jest.mock('../../components/attacks/wrapper', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/attacks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/attacks.tsx
@@ -16,7 +16,9 @@ import { NoIndexEmptyPage } from '../../components/alerts/empty_pages/no_index_e
 import { useListsConfig } from '../../containers/detection_engine/lists/use_lists_config';
 import { UserUnauthenticatedEmptyPage } from '../../components/alerts/empty_pages/user_unauthenticated_empty_page';
 import * as i18n from './translations';
-import { useSignalHelpers } from '../../../sourcerer/containers/use_signal_helpers';
+import { PageScope } from '../../../data_view_manager/constants';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useSignalHelpers } from '../../hooks/use_signal_helpers';
 import { NeedAdminForUpdateRulesCallOut } from '../../../detection_engine/rule_management/components/callouts/need_admin_for_update_rules_callout';
 import { MissingAttacksPrivilegesCallOut } from '../../components/callouts/missing_attacks_privileges_callout';
 import { NoPrivileges } from '../../../common/components/no_privileges';
@@ -34,7 +36,8 @@ export const AttacksPage = memo(() => {
   const { hasAlertsRead: canReadAlerts } = useAlertsPrivileges();
   const { loading: listsConfigLoading, needsConfiguration: needsListsConfiguration } =
     useListsConfig();
-  const { signalIndexNeedsInit } = useSignalHelpers();
+  const { dataView, status } = useDataView(PageScope.alerts);
+  const { signalIndexNeedsInit } = useSignalHelpers(dataView, status);
 
   const loading: boolean = useMemo(
     () => userInfoLoading || listsConfigLoading,

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/readme.md
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/readme.md
@@ -42,11 +42,6 @@ interface SelectedDataView {
 }
 ```
 
-### `useSignalHelpers`
-
-- called on from detections and timelines scopes
-- `signalIndexNeedsInit` - when true, signal index has been initiated but does not exist yet
-
 ### Adding sourcerer to a new page
 
 - In order for the sourcerer to show up on a page, it needs to be added to the array `sourcererPaths`

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
@@ -47,10 +47,6 @@ jest.mock('../../../fields_browser', () => ({
   useFieldBrowserOptions: jest.fn(),
 }));
 
-jest.mock('../../../../../sourcerer/containers/use_signal_helpers', () => ({
-  useSignalHelpers: () => ({ signalIndexNeedsInit: false }),
-}));
-
 jest.mock('../../../../../common/hooks/use_experimental_features');
 const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
@@ -75,10 +75,6 @@ jest.mock('../../../fields_browser', () => ({
   useFieldBrowserOptions: jest.fn(),
 }));
 
-jest.mock('../../../../../sourcerer/containers/use_signal_helpers', () => ({
-  useSignalHelpers: () => ({ signalIndexNeedsInit: false }),
-}));
-
 jest.mock('../../../../../common/hooks/use_experimental_features');
 
 jest.mock('react-router-dom', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
@@ -45,10 +45,6 @@ jest.mock('../../fields_browser', () => ({
   useFieldBrowserOptions: jest.fn(),
 }));
 
-jest.mock('../../../../sourcerer/containers/use_signal_helpers', () => ({
-  useSignalHelpers: () => ({ signalIndexNeedsInit: false }),
-}));
-
 jest.mock('../../../../common/lib/kuery');
 
 jest.mock('../../../../common/hooks/use_experimental_features');


### PR DESCRIPTION
> [!NOTE]
> This PR is the fifth of a few aiming at removing all dependencies on the legacy sourcerer code. We officially switched to using the data_view_manager code [a couple of months ago](https://github.com/elastic/kibana/pull/238549).

## Summary

`useSignalHelpers` is now a small alerts-only helper consumed only by the detections alerts/attacks pages, so it moves from `sourcerer/containers` to `detections/hooks`.

`useSignalHelpers` previously called `useDataView(PageScope.alerts)` internally, while the alerts page `Wrapper` also called `useDataView(PageScope.alerts)`, resulting in two of the (expensive) fetches for the same scope. `useSignalHelpers` now takes the alerts dataView + status as arguments. The alerts page retrieves the data view once and feeds it to both `useSignalHelpers` and the `Wrapper`. The attacks page still calls `useSignalHelpers` with the alerts scope (for the signal index check) while its `Wrapper` uses the attacks scope.

> [!TIP]
> This PR does not introduce any visual or functional change. All the code removed was dead and unused.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.