### PR TITLE
[Alerting] Fix broken link on Alert Details page

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_overview/alert_overview.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_overview/alert_overview.tsx
@@ -48,16 +48,17 @@ import { getSources } from '../alert_sources/get_sources';
 import { RULE_DETAILS_PAGE_ID } from '../../pages/rule_details/constants';
 import type { TimeRange } from '../../../common/typings';
 
+export type RuleLinkStatus = 'ok' | 'deleted' | 'disabled' | 'unknown';
+
+export interface AlertOverviewProps {
+  alert: TopAlert;
+  pageId?: string;
+  alertStatus?: AlertStatus;
+  ruleStatus?: RuleLinkStatus;
+}
+
 export const AlertOverview = memo(
-  ({
-    alert,
-    pageId,
-    alertStatus,
-  }: {
-    alert: TopAlert;
-    pageId?: string;
-    alertStatus?: AlertStatus;
-  }) => {
+  ({ alert, pageId, alertStatus, ruleStatus }: AlertOverviewProps) => {
     const {
       http: {
         basePath: { prepend },
@@ -81,7 +82,7 @@ export const AlertOverview = memo(
     );
 
     const linkToRule =
-      canReadAlertRule && pageId !== RULE_DETAILS_PAGE_ID && ruleId
+      canReadAlertRule && pageId !== RULE_DETAILS_PAGE_ID && ruleId && ruleStatus !== 'deleted'
         ? prepend(paths.observability.ruleDetails(ruleId))
         : null;
 

--- a/x-pack/solutions/observability/plugins/observability/public/hooks/use_fetch_rule.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/hooks/use_fetch_rule.ts
@@ -21,11 +21,17 @@ export interface UseFetchRuleResponse {
   isRefetching: boolean;
   isSuccess: boolean;
   isError: boolean;
+  isRuleNotFound: boolean;
   rule: Rule | undefined;
   refetch: <TPageData>(
     options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined
   ) => Promise<QueryObserverResult<Rule | undefined, unknown>>;
 }
+
+const isRuleNotFoundError = (error: unknown): boolean => {
+  const status = (error as IHttpFetchError<{ statusCode?: number }>)?.response?.status;
+  return status === 404;
+};
 
 export function useFetchRule({
   ruleId,
@@ -39,48 +45,48 @@ export function useFetchRule({
     notifications: { toasts },
   } = useKibana().services;
 
-  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery(
-    {
+  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data, refetch, error } =
+    useQuery({
       queryKey: ['fetchRule', ruleId],
       queryFn: async ({ signal }) => {
-        try {
-          if (!ruleId) return;
+        if (!ruleId) return;
 
-          const res = await http.get<AsApiContract<Rule>>(
-            `${INTERNAL_BASE_ALERTING_API_PATH}/rule/${encodeURIComponent(ruleId)}`,
-            {
-              signal,
-            }
-          );
+        const res = await http.get<AsApiContract<Rule>>(
+          `${INTERNAL_BASE_ALERTING_API_PATH}/rule/${encodeURIComponent(ruleId)}`,
+          {
+            signal,
+          }
+        );
 
-          return transformRule(res);
-        } catch (error) {
-          throw error;
-        }
+        return transformRule(res);
       },
       keepPreviousData: true,
       enabled: Boolean(ruleId) && enabled,
       refetchOnWindowFocus: false,
-      retry: (failureCount, error) => {
-        // Don't retry when the user is not authorized to read the rule; a 403
-        // will keep failing and only delays showing the error.
-        const status = (error as IHttpFetchError<{ statusCode?: number }>)?.response?.status;
-        if (status === 403) {
+      retry: (failureCount, retryError) => {
+        const status = (retryError as IHttpFetchError<{ statusCode?: number }>)?.response?.status;
+        if (status === 403 || status === 404) {
           return false;
         }
         return failureCount < 3;
       },
-      onError: (error: Error) => {
-        toasts.addError(error, {
+      onError: (queryError: Error) => {
+        if (isRuleNotFoundError(queryError)) {
+          return;
+        }
+        toasts.addError(queryError, {
           title: i18n.translate('xpack.observability.ruleDetails.ruleLoadError', {
             defaultMessage: 'Unable to load rule',
           }),
           toastMessage:
-            error instanceof Error ? error.message : typeof error === 'string' ? error : '',
+            queryError instanceof Error
+              ? queryError.message
+              : typeof queryError === 'string'
+              ? queryError
+              : '',
         });
       },
-    }
-  );
+    });
 
   return {
     rule: data,
@@ -89,6 +95,7 @@ export function useFetchRule({
     isRefetching,
     isSuccess,
     isError,
+    isRuleNotFound: isError && isRuleNotFoundError(error),
     refetch,
   };
 }

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -134,10 +134,24 @@ export function AlertDetails() {
     refetchRelatedDashboards,
   } = useRelatedDashboards(alertId, { enabled: canReadAlertRule });
 
-  const { rule, refetch } = useFetchRule({
+  const {
+    rule,
+    isLoading: isLoadingRule,
+    isRuleNotFound,
+    refetch,
+  } = useFetchRule({
     ruleId: ruleId || '',
     enabled: canReadAlertRule,
   });
+
+  const ruleStatus =
+    !canReadAlertRule || isLoadingRule
+      ? 'unknown'
+      : isRuleNotFound
+      ? 'deleted'
+      : rule?.enabled === false
+      ? 'disabled'
+      : 'ok';
 
   useAlertDetailsPageViewEbt({ ruleType: rule?.ruleTypeId });
 
@@ -367,7 +381,11 @@ export function AlertDetails() {
           />
         )}
         <EuiSpacer size="l" />
-        <AlertOverview alert={alertDetail.formatted} alertStatus={alertStatus} />
+        <AlertOverview
+          alert={alertDetail.formatted}
+          alertStatus={alertStatus}
+          ruleStatus={ruleStatus}
+        />
       </EuiPanel>
     )
   ) : (
@@ -502,7 +520,7 @@ export function AlertDetails() {
                 </span>
               </EuiToolTip>
               <EuiSpacer size="xs" />
-              <AlertSubtitle alert={alertDetail.formatted} />
+              <AlertSubtitle alert={alertDetail.formatted} ruleStatus={ruleStatus} />
             </>
           ) : (
             <EuiLoadingSpinner />

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/alert_subtitle.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/alert_subtitle.test.tsx
@@ -6,6 +6,8 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
 import { render } from '../../../utils/test_helper';
 import { alert } from '../mock/alert';
 import { useKibana } from '../../../utils/kibana_react';
@@ -31,7 +33,7 @@ const mockKibana = () => {
       ...kibanaStartMock.startContract().services,
       http: {
         basePath: {
-          prepend: jest.fn(),
+          prepend: jest.fn((path: string) => path),
         },
       },
     },
@@ -78,5 +80,40 @@ describe('Alert subtitle', () => {
 
     expect(result.queryByText('View rule')).not.toBeInTheDocument();
     expect(result.queryByTestId('o11yAlertRuleLink')).not.toBeInTheDocument();
+  });
+
+  it('should show deleted rule UI and open modal when rule name is clicked', async () => {
+    const result = renderComponent({ alert, ruleStatus: 'deleted' });
+
+    expect(result.queryByText('View rule')).not.toBeInTheDocument();
+    expect(result.queryByTestId('o11yAlertRuleLink')).not.toBeInTheDocument();
+    expect(result.getByTestId('alertSubtitleRuleUnavailableBadge')).toBeInTheDocument();
+    expect(result.getByTestId('alertSubtitleRuleId')).toHaveTextContent(
+      `Rule ID: ${alert.fields[ALERT_RULE_UUID]}`
+    );
+    expect(result.queryByTestId('ruleDeletedModal')).not.toBeInTheDocument();
+
+    fireEvent.click(result.getByTestId('alertSubtitleRuleNameLink'));
+
+    expect(result.getByTestId('ruleDeletedModal')).toBeInTheDocument();
+  });
+
+  it('should show disabled rule UI with a link to the rule details', async () => {
+    const result = renderComponent({ alert, ruleStatus: 'disabled' });
+
+    expect(result.queryByText('View rule')).not.toBeInTheDocument();
+    expect(result.queryByTestId('o11yAlertRuleLink')).not.toBeInTheDocument();
+    expect(result.getByTestId('alertSubtitleRuleUnavailableBadge')).toBeInTheDocument();
+    expect(result.getByTestId('alertSubtitleRuleId')).toHaveTextContent(
+      `Rule ID: ${alert.fields[ALERT_RULE_UUID]}`
+    );
+    expect(result.getByTestId('alertSubtitleRuleNameLink')).toHaveTextContent(
+      alert.fields[ALERT_RULE_NAME] as string
+    );
+    expect(result.getByTestId('alertSubtitleRuleNameLink')).toHaveAttribute(
+      'href',
+      expect.stringContaining(alert.fields[ALERT_RULE_UUID] as string)
+    );
+    expect(result.queryByTestId('ruleDeletedModal')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/alert_subtitle.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/alert_subtitle.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
-import { EuiFlexGroup, EuiLink, EuiText } from '@elastic/eui';
+import React, { useState } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLink, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
   ALERT_RULE_CATEGORY,
   ALERT_RULE_CONSUMER,
+  ALERT_RULE_NAME,
   ALERT_RULE_TYPE_ID,
   ALERT_RULE_UUID,
 } from '@kbn/rule-data-utils';
@@ -19,16 +20,21 @@ import { paths } from '../../../../common/locators/paths';
 import { useKibana } from '../../../utils/kibana_react';
 import { getAlertSubtitle } from '../../../utils/format_alert_subtitle';
 import { useAuthorizedToReadRuleType } from '../../../hooks/use_authorized_to_read_rule_type';
+import type { RuleLinkStatus } from '../../../components/alert_overview/alert_overview';
+import { RuleDeletedModal } from './rule_deleted_modal';
 
 export interface AlertSubtitleProps {
   alert: TopAlert;
+  ruleStatus?: RuleLinkStatus;
 }
 
-export function AlertSubtitle({ alert }: AlertSubtitleProps) {
+export function AlertSubtitle({ alert, ruleStatus }: AlertSubtitleProps) {
   const { http } = useKibana().services;
   const { authorizedToReadRuleType } = useAuthorizedToReadRuleType();
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const ruleId = alert.fields[ALERT_RULE_UUID];
+  const ruleName = alert.fields[ALERT_RULE_NAME];
   const ruleLink = http.basePath.prepend(paths.observability.ruleDetails(ruleId));
   const ruleTypeBreached = getAlertSubtitle(alert.fields[ALERT_RULE_CATEGORY]);
   const canReadAlertRule = authorizedToReadRuleType(
@@ -36,20 +42,76 @@ export function AlertSubtitle({ alert }: AlertSubtitleProps) {
     alert.fields[ALERT_RULE_CONSUMER]
   );
 
+  const isRuleUnavailable = ruleStatus === 'deleted' || ruleStatus === 'disabled';
+  const showRuleLink = canReadAlertRule && ruleId && !isRuleUnavailable;
+
   return (
-    <EuiFlexGroup gutterSize="s" alignItems="center">
-      <EuiText size="s" color="subdued">
-        {ruleTypeBreached}
-      </EuiText>
-      {canReadAlertRule && ruleId && (
-        <EuiText size="s">
-          <EuiLink data-test-subj="o11yAlertRuleLink" href={ruleLink}>
-            {i18n.translate('xpack.observability.pages.alertDetails.pageTitle.viewRule', {
-              defaultMessage: 'View rule',
-            })}
-          </EuiLink>
-        </EuiText>
-      )}
-    </EuiFlexGroup>
+    <>
+      <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s" color="subdued">
+            {ruleTypeBreached}
+          </EuiText>
+        </EuiFlexItem>
+        {showRuleLink && (
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">
+              <EuiLink data-test-subj="o11yAlertRuleLink" href={ruleLink}>
+                {i18n.translate('xpack.observability.pages.alertDetails.pageTitle.viewRule', {
+                  defaultMessage: 'View rule',
+                })}
+              </EuiLink>
+            </EuiText>
+          </EuiFlexItem>
+        )}
+        {isRuleUnavailable && canReadAlertRule && (
+          <>
+            {ruleName && (
+              <EuiFlexItem grow={false}>
+                <EuiText size="s" data-test-subj="alertSubtitleRuleName">
+                  {i18n.translate('xpack.observability.pages.alertDetails.pageTitle.ruleLabel', {
+                    defaultMessage: 'Rule:',
+                  })}
+                  &nbsp;
+                  {ruleStatus === 'deleted' ? (
+                    <EuiLink
+                      data-test-subj="alertSubtitleRuleNameLink"
+                      onClick={() => setIsModalOpen(true)}
+                    >
+                      {ruleName}
+                    </EuiLink>
+                  ) : (
+                    <EuiLink data-test-subj="alertSubtitleRuleNameLink" href={ruleLink}>
+                      {ruleName}
+                    </EuiLink>
+                  )}
+                </EuiText>
+              </EuiFlexItem>
+            )}
+            {ruleId && (
+              <EuiFlexItem grow={false}>
+                <EuiText size="s" color="subdued" data-test-subj="alertSubtitleRuleId">
+                  {i18n.translate('xpack.observability.pages.alertDetails.pageTitle.ruleIdLabel', {
+                    defaultMessage: 'Rule ID: {ruleId}',
+                    values: { ruleId },
+                  })}
+                </EuiText>
+              </EuiFlexItem>
+            )}
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="warning" data-test-subj="alertSubtitleRuleUnavailableBadge">
+                <EuiIcon type="warning" size="s" aria-hidden={true} />
+                &nbsp;
+                {i18n.translate(
+                  'xpack.observability.pages.alertDetails.pageTitle.ruleUnavailableBadge',
+                  { defaultMessage: 'The rule was deleted or disabled!' }
+                )}
+              </EuiBadge>
+            </EuiFlexItem>
+          </>
+        )}
+      </EuiFlexGroup>
+      {isModalOpen && <RuleDeletedModal ruleId={ruleId} onClose={() => setIsModalOpen(false)} />}
+    </>
   );
 }

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/rule_deleted_modal.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/rule_deleted_modal.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+interface RuleDeletedModalProps {
+  ruleId?: string;
+  onClose: () => void;
+}
+
+export const RuleDeletedModal = ({ ruleId, onClose }: RuleDeletedModalProps) => {
+  const modalTitleId = useGeneratedHtmlId();
+
+  return (
+    <EuiModal onClose={onClose} data-test-subj="ruleDeletedModal" aria-labelledby={modalTitleId}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={modalTitleId}>
+          {i18n.translate('xpack.observability.alertDetails.ruleDeletedModalTitle', {
+            defaultMessage: 'Rule no longer available',
+          })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiText>
+          <p>
+            {i18n.translate('xpack.observability.alertDetails.ruleDeletedModalDescription', {
+              defaultMessage:
+                'The rule that generated this alert has been deleted. The alert data is retained, but the rule can no longer be viewed or edited.',
+            })}
+          </p>
+        </EuiText>
+        {ruleId && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiText size="s" color="subdued">
+              <strong>
+                {i18n.translate('xpack.observability.alertDetails.ruleDeletedModalRuleIdLabel', {
+                  defaultMessage: 'Rule ID:',
+                })}
+              </strong>{' '}
+              {ruleId}
+            </EuiText>
+          </>
+        )}
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton onClick={onClose} fill data-test-subj="ruleDeletedModalCloseButton">
+          {i18n.translate('xpack.observability.alertDetails.ruleDeletedModalCloseButtonLabel', {
+            defaultMessage: 'Close',
+          })}
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};


### PR DESCRIPTION
## Summary

Fixes broken rule link on the Alert Details page when a rule has been deleted or disabled.

Closes #244990

## Changes

- **use_fetch_rule.ts** — suppress 404 toast and retry, expose `isRuleNotFound`
- **alert_details.tsx** — derive `ruleStatus` from the rule fetch result
- **alert_overview.tsx** — guard the "View rule details" link for deleted rules
- **alert_subtitle.tsx** — show rule name, rule ID, and warning badge when the rule is deleted or disabled; clicking the rule name opens a modal instead of navigating to a 404
- **rule_deleted_modal.tsx** — new modal explaining the rule was deleted, showing the rule ID

<img width="1264" height="644" alt="deleted rule modal" src="https://github.com/user-attachments/assets/64dcac6c-9a07-4e42-8d5b-e62a46b1ef7b" />
<img width="1506" height="591" alt="deleted rule" src="https://github.com/user-attachments/assets/e3f77e4c-011c-40b6-b421-44d313773677" />
