### PR TITLE
[Fleet] Add OAS tags to api/fleet/space_settings API endpoints

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -42409,7 +42409,8 @@ paths:
                   - item
           description: Successful response
       summary: Get space settings
-      tags: []
+      tags:
+        - Fleet internals
       x-state: Generally available
       x-metaTags:
         - content: Kibana, Elastic Cloud Serverless
@@ -42484,7 +42485,8 @@ paths:
                   - item
           description: Successful response
       summary: Create space settings
-      tags: []
+      tags:
+        - Fleet internals
       x-state: Generally available
       x-metaTags:
         - content: Kibana, Elastic Cloud Serverless

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -46184,7 +46184,8 @@ paths:
                   - item
           description: Successful response
       summary: Get space settings
-      tags: []
+      tags:
+        - Fleet internals
       x-state: Generally available; added in 9.1.0
       x-metaTags:
         - content: Kibana
@@ -46259,7 +46260,8 @@ paths:
                   - item
           description: Successful response
       summary: Create space settings
-      tags: []
+      tags:
+        - Fleet internals
       x-state: Generally available; added in 9.1.0
       x-metaTags:
         - content: Kibana

--- a/x-pack/platform/plugins/shared/fleet/server/routes/settings/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/settings/index.ts
@@ -57,6 +57,7 @@ export const registerRoutes = (
             since: '9.1.0',
             stability: 'stable',
           },
+          tags: ['oas-tag:Fleet internals'],
         },
       })
       .addVersion(
@@ -93,6 +94,7 @@ export const registerRoutes = (
             since: '9.1.0',
             stability: 'stable',
           },
+          tags: ['oas-tag:Fleet internals'],
         },
       })
       .addVersion(


### PR DESCRIPTION
## Summary

 `GET /api/fleet/space_settings` and `PUT /api/fleet/space_settings` are currently not documented and therefore hard for a user to know about. This PR adds OAS tags so they are documented under https://www.elastic.co/docs/api/doc/kibana/group/endpoint-fleet-internals.

### Checklist

- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Minimal: adding OAS tags to existing API endpoints so they show up in the Kibana API reference.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.3","9.4","9.5"]} ONMERGE-->