### PR TITLE
POC: [PND] Pre-built watch settings e2e (user-owned catalogue + take-update)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-pnd-common/impl/schemas/components/watch.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-pnd-common/impl/schemas/components/watch.gen.ts
@@ -206,6 +206,16 @@ export const Watch = lazySchema(() =>
     autonomyLevel: AutonomyLevel,
     metrics: WatchMetrics,
     recentRuns: z.array(WatchRecentRun),
+    /**
+     * POC (watch-settings-e2e-mvp): catalogue has a newer seedContentVersion
+     */
+    updateAvailable: z.boolean().optional(),
+    seedContentVersion: z.number().int().optional(),
+    catalogVersion: z.number().int().optional(),
+    /**
+     * POC: scheduled trigger `with.every` string (e.g. "15m", "1h")
+     */
+    scheduleInterval: z.string().optional(),
   })
 );
 export type Watch = z.infer<typeof Watch>;

--- a/x-pack/solutions/security/plugins/pnd/common/constants.ts
+++ b/x-pack/solutions/security/plugins/pnd/common/constants.ts
@@ -24,3 +24,6 @@ export {
 
 /** API privilege for read-only PND internal routes. */
 export const PND_API_PRIVILEGE_READ = 'pnd_read' as const;
+
+/** POC: write privilege for watch settings / catalogue update routes. */
+export const PND_API_PRIVILEGE_WRITE = 'pnd_write' as const;

--- a/x-pack/solutions/security/plugins/pnd/public/application.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/application.tsx
@@ -78,24 +78,16 @@ export const renderApp = ({ coreStart, startDeps, params, config: _config }: Ren
                   />
                   <Route path="/streams" render={() => <PlaceholderPage title={NAV_STREAMS} />} />
                   <Route
+                    path="/watches/workers"
+                    render={() => <WatchesSectionStubPage section="workers" />}
+                  />
+                  <Route
                     path="/watches/workflows"
-                    render={() => <WatchesSectionStubPage section="workflows" />}
+                    render={() => <WatchesSectionStubPage section="workers" />}
                   />
                   <Route
                     path="/watches/skills"
                     render={() => <WatchesSectionStubPage section="skills" />}
-                  />
-                  <Route
-                    path="/watches/activity"
-                    render={() => <WatchesSectionStubPage section="activity" />}
-                  />
-                  <Route
-                    path="/watches/performance"
-                    render={() => <WatchesSectionStubPage section="performance" />}
-                  />
-                  <Route
-                    path="/watches/guardrails"
-                    render={() => <WatchesSectionStubPage section="guardrails" />}
                   />
                   <Route path="/watches/:watchId" component={WatchDetailPage} />
                   <Route path="/watches" exact component={WatchesPage} />

--- a/x-pack/solutions/security/plugins/pnd/public/hooks/use_watches_api.ts
+++ b/x-pack/solutions/security/plugins/pnd/public/hooks/use_watches_api.ts
@@ -22,6 +22,13 @@ const retryOnTransientError = (failureCount: number, error: unknown): boolean =>
   return true;
 };
 
+export interface UpdateWatchSettingsBody {
+  enabled?: boolean;
+  description?: string;
+  autonomyLevel?: number;
+  scheduleInterval?: string;
+}
+
 export const useWatches = () => {
   const { services } = useKibana();
 
@@ -51,6 +58,68 @@ export const useWatch = (watchId: string | undefined) => {
     },
     enabled: Boolean(watchId),
     retry: retryOnTransientError,
+  });
+};
+
+/** POC: persist settings onto the user-owned workflow document. */
+export const useUpdateWatchSettings = () => {
+  const { services } = useKibana();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      watchId,
+      body,
+    }: {
+      watchId: string;
+      body: UpdateWatchSettingsBody;
+    }): Promise<GetWatchResponse> =>
+      services.http!.patch<GetWatchResponse>(buildWatchUrl(watchId), {
+        version: API_VERSIONS.internal.v1,
+        body: JSON.stringify(body),
+      }),
+    onSuccess: async (data, variables) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.watches.list() });
+      queryClient.setQueryData(queryKeys.watches.detail(variables.watchId), data);
+    },
+  });
+};
+
+/** POC: take a shipped catalogue update, re-applying customer settings. */
+export const useApplyWatchUpdate = () => {
+  const { services } = useKibana();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      watchId,
+      force,
+    }: {
+      watchId: string;
+      force?: boolean;
+    }): Promise<{
+      updated: boolean;
+      conflict?: boolean;
+      fromVersion?: number;
+      toVersion?: number;
+      watch?: GetWatchResponse['watch'];
+    }> =>
+      services.http!.post(`${PND_WATCHES_URL}/${encodeURIComponent(watchId)}/apply_update`, {
+        version: API_VERSIONS.internal.v1,
+        body: JSON.stringify({ force: force ?? false }),
+      }),
+    onSuccess: async (data, variables) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.watches.list() });
+      if (data.watch) {
+        queryClient.setQueryData(queryKeys.watches.detail(variables.watchId), {
+          watch: data.watch,
+        });
+      } else {
+        await queryClient.invalidateQueries({
+          queryKey: queryKeys.watches.detail(variables.watchId),
+        });
+      }
+    },
   });
 };
 

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/agent_capabilities_list.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/agent_capabilities_list.tsx
@@ -22,11 +22,14 @@ import * as i18n from '../translations';
 interface AgentCapabilitiesListProps {
   callables: WatchCallableRef[];
   onToggle?: (callableId: string) => void;
+  /** When false, hide skill/workflow kind badges (section already labels the list). */
+  showKindBadge?: boolean;
 }
 
 export const AgentCapabilitiesList: React.FC<AgentCapabilitiesListProps> = ({
   callables,
   onToggle,
+  showKindBadge = true,
 }) => {
   const { euiTheme } = useEuiTheme();
 
@@ -83,31 +86,37 @@ export const AgentCapabilitiesList: React.FC<AgentCapabilitiesListProps> = ({
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          <EuiFlexGroup
-            gutterSize="s"
-            alignItems="center"
-            responsive={false}
-            css={css`
-              margin-top: ${euiTheme.size.s};
-              flex-wrap: wrap;
-            `}
-          >
-            <EuiFlexItem grow={false}>
-              <EuiBadge color={callable.kind === 'workflow' ? 'accent' : 'primary'}>
-                {callable.kind === 'workflow' ? i18n.KIND_WORKFLOW : i18n.KIND_SKILL}
-              </EuiBadge>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiBadge color="hollow" iconType="bolt">
-                {callable.summary}
-              </EuiBadge>
-            </EuiFlexItem>
-            {callable.gated ? (
-              <EuiFlexItem grow={false}>
-                <EuiBadge color="warning">{i18n.GATED_BADGE}</EuiBadge>
-              </EuiFlexItem>
-            ) : null}
-          </EuiFlexGroup>
+          {callable.summary || callable.gated || showKindBadge ? (
+            <EuiFlexGroup
+              gutterSize="s"
+              alignItems="center"
+              responsive={false}
+              css={css`
+                margin-top: ${euiTheme.size.s};
+                flex-wrap: wrap;
+              `}
+            >
+              {showKindBadge ? (
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color={callable.kind === 'workflow' ? 'accent' : 'primary'}>
+                    {callable.kind === 'workflow' ? i18n.KIND_WORKFLOW : i18n.KIND_SKILL}
+                  </EuiBadge>
+                </EuiFlexItem>
+              ) : null}
+              {callable.summary ? (
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {callable.summary}
+                  </EuiText>
+                </EuiFlexItem>
+              ) : null}
+              {callable.gated ? (
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="warning">{i18n.GATED_BADGE}</EuiBadge>
+                </EuiFlexItem>
+              ) : null}
+            </EuiFlexGroup>
+          ) : null}
         </EuiPanel>
       ))}
     </div>

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/autonomy_slider.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/autonomy_slider.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css } from '@emotion/react';
+import { EuiLink, EuiRange, EuiSpacer, EuiText, useEuiTheme } from '@elastic/eui';
+import * as i18n from '../translations';
+
+export type UiAutonomy = 'manual' | 'assisted' | 'supervised';
+
+const UI_LEVELS: UiAutonomy[] = ['manual', 'assisted', 'supervised'];
+
+const LEVEL_BLURB: Record<UiAutonomy, string> = {
+  manual: i18n.AUTONOMY_BLURB_MANUAL,
+  assisted: i18n.AUTONOMY_BLURB_ASSISTED,
+  supervised: i18n.AUTONOMY_BLURB_SUPERVISED,
+};
+
+interface AutonomySliderProps {
+  value: UiAutonomy;
+  onChange: (next: UiAutonomy) => void;
+  onViewGuardrails?: () => void;
+}
+
+export const AutonomySlider: React.FC<AutonomySliderProps> = ({
+  value,
+  onChange,
+  onViewGuardrails,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const index = Math.max(0, UI_LEVELS.indexOf(value));
+
+  return (
+    <div>
+      <EuiRange
+        min={0}
+        max={2}
+        step={1}
+        value={index}
+        onChange={(e) => {
+          const next = UI_LEVELS[Number(e.currentTarget.value)] ?? 'assisted';
+          onChange(next);
+        }}
+        showTicks
+        ticks={[
+          { label: i18n.AUTONOMY_MANUAL, value: 0 },
+          { label: i18n.AUTONOMY_ASSISTED, value: 1 },
+          { label: i18n.AUTONOMY_SUPERVISED, value: 2 },
+        ]}
+        aria-label={i18n.AUTONOMY_LEVEL}
+        fullWidth
+        data-test-subj="pndWatchAutonomySlider"
+      />
+      <EuiSpacer size="s" />
+      <EuiText size="s">
+        <p>
+          <strong>
+            {value === 'manual'
+              ? i18n.AUTONOMY_MANUAL
+              : value === 'assisted'
+              ? i18n.AUTONOMY_ASSISTED
+              : i18n.AUTONOMY_SUPERVISED}
+          </strong>
+          {' — '}
+          {LEVEL_BLURB[value]}
+        </p>
+      </EuiText>
+      <EuiSpacer size="xs" />
+      <EuiText
+        size="xs"
+        color="subdued"
+        css={css`
+          display: flex;
+          align-items: baseline;
+          gap: ${euiTheme.size.xs};
+          flex-wrap: wrap;
+        `}
+      >
+        <span>{i18n.AUTONOMY_GUARDRAILS_NOTE}</span>
+        {onViewGuardrails ? (
+          <EuiLink onClick={onViewGuardrails}>{i18n.AUTONOMY_VIEW_GUARDRAILS}</EuiLink>
+        ) : null}
+      </EuiText>
+    </div>
+  );
+};

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/pnd_watches_nav.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/pnd_watches_nav.tsx
@@ -5,63 +5,101 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import {
+  EuiBadge,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
+  EuiLoadingSpinner,
+  EuiText,
   EuiTitle,
-  useEuiTheme,
   EuiToolTip,
+  useEuiTheme,
 } from '@elastic/eui';
 import { useHistory } from 'react-router-dom';
+import {
+  compareWatchesForDisplay,
+  WATCH_DARK_TAG,
+  WATCH_DEEP_TAG,
+  type Watch,
+} from '@kbn/pnd-common';
 import { PND_WATCHES_SUBNAV_WIDTH } from '../../../components/layout/constants';
+import { useWatches } from '../../../hooks/use_watches_api';
 import * as i18n from '../translations';
 
-export type WatchesSectionId =
-  | 'watches'
-  | 'workflows'
-  | 'skills'
-  | 'activity'
-  | 'performance'
-  | 'guardrails';
+export type WatchesSectionId = 'watches' | 'workers' | 'skills';
 
-interface NavItem {
-  id: WatchesSectionId;
+interface TopNavItem {
+  id: Exclude<WatchesSectionId, 'watches'>;
   label: string;
   path: string;
-  icon: string;
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { id: 'watches', label: i18n.SUBNAV_WATCHES, path: '/watches', icon: 'eye' },
-  { id: 'workflows', label: i18n.SUBNAV_WORKFLOWS, path: '/watches/workflows', icon: 'branch' },
-  { id: 'skills', label: i18n.SUBNAV_SKILLS, path: '/watches/skills', icon: 'nested' },
-  { id: 'activity', label: i18n.SUBNAV_ACTIVITY, path: '/watches/activity', icon: 'stats' },
-  {
-    id: 'performance',
-    label: i18n.SUBNAV_PERFORMANCE,
-    path: '/watches/performance',
-    icon: 'visLine',
-  },
-  {
-    id: 'guardrails',
-    label: i18n.SUBNAV_GUARDRAILS,
-    path: '/watches/guardrails',
-    icon: 'lock',
-  },
+const TOP_NAV_ITEMS: TopNavItem[] = [
+  { id: 'workers', label: i18n.SUBNAV_WORKERS, path: '/watches/workers' },
+  { id: 'skills', label: i18n.SUBNAV_SKILLS, path: '/watches/skills' },
 ];
+
+const isBetaWatch = (watch: Watch): boolean =>
+  watch.tags.includes(WATCH_DARK_TAG) ||
+  watch.tags.includes(WATCH_DEEP_TAG) ||
+  /dark|deep/i.test(watch.name);
 
 interface PndWatchesNavProps {
   active: WatchesSectionId;
+  /** Highlighted watch when viewing a detail page. */
+  activeWatchId?: string;
   onCollapse: () => void;
 }
 
-export const PndWatchesNav: React.FC<PndWatchesNavProps> = ({ active, onCollapse }) => {
+export const PndWatchesNav: React.FC<PndWatchesNavProps> = ({
+  active,
+  activeWatchId,
+  onCollapse,
+}) => {
   const { euiTheme } = useEuiTheme();
   const history = useHistory();
+  const { data, isLoading } = useWatches();
+
+  const watches = useMemo(() => {
+    if (!data?.watches) return [];
+    return [...data.watches].sort(compareWatchesForDisplay);
+  }, [data]);
+
+  const navButtonCss = (isActive: boolean) => css`
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: ${euiTheme.size.s};
+    width: 100%;
+    padding: ${euiTheme.size.s} ${euiTheme.size.m};
+    border: none;
+    border-radius: ${euiTheme.border.radius.medium};
+    background: ${isActive ? euiTheme.colors.lightShade : 'transparent'};
+    color: ${isActive ? euiTheme.colors.textParagraph : euiTheme.colors.textSubdued};
+    cursor: pointer;
+    font-size: ${euiTheme.size.m};
+    font-weight: ${isActive ? 600 : 500};
+    text-align: left;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 8px;
+      bottom: 8px;
+      width: 3px;
+      border-radius: 0 2px 2px 0;
+      background: ${isActive ? euiTheme.colors.primary : 'transparent'};
+    }
+
+    &:hover {
+      background: ${euiTheme.colors.lightestShade};
+      color: ${euiTheme.colors.textParagraph};
+    }
+  `;
 
   return (
     <aside
@@ -74,6 +112,7 @@ export const PndWatchesNav: React.FC<PndWatchesNavProps> = ({ active, onCollapse
         padding: ${euiTheme.size.m};
         border-right: 1px solid ${euiTheme.border.color};
         background: ${euiTheme.colors.emptyShade};
+        overflow: auto;
       `}
     >
       <EuiFlexGroup
@@ -100,6 +139,74 @@ export const PndWatchesNav: React.FC<PndWatchesNavProps> = ({ active, onCollapse
           </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>
+
+      <EuiText
+        size="xs"
+        color="subdued"
+        css={css`
+          margin-top: ${euiTheme.size.m};
+          margin-bottom: ${euiTheme.size.xs};
+          padding-left: ${euiTheme.size.s};
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+        `}
+      >
+        <p>{i18n.SUBNAV_WATCHES}</p>
+      </EuiText>
+
+      <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+        {isLoading && watches.length === 0 ? (
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup justifyContent="center" css={{ padding: euiTheme.size.m }}>
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner size="m" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        ) : null}
+        {watches.map((watch) => {
+          const isActive = active === 'watches' && activeWatchId === watch.id;
+          return (
+            <EuiFlexItem key={watch.id} grow={false}>
+              <button
+                type="button"
+                aria-current={isActive ? 'page' : undefined}
+                onClick={() => history.push(`/watches/${watch.id}`)}
+                data-test-subj={`pndWatchesSubnav-watch-${watch.id}`}
+                css={navButtonCss(isActive)}
+              >
+                <span
+                  aria-hidden="true"
+                  css={css`
+                    width: 8px;
+                    height: 8px;
+                    border-radius: 50%;
+                    flex-shrink: 0;
+                    background: ${watch.color};
+                  `}
+                />
+                <span
+                  css={css`
+                    flex: 1;
+                    min-width: 0;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  `}
+                >
+                  {watch.name}
+                </span>
+                {isBetaWatch(watch) ? (
+                  <EuiBadge color="hollow" css={{ flexShrink: 0 }}>
+                    {i18n.BETA_BADGE}
+                  </EuiBadge>
+                ) : null}
+              </button>
+            </EuiFlexItem>
+          );
+        })}
+      </EuiFlexGroup>
+
       <EuiFlexGroup
         direction="column"
         gutterSize="xs"
@@ -108,7 +215,7 @@ export const PndWatchesNav: React.FC<PndWatchesNavProps> = ({ active, onCollapse
           margin-top: ${euiTheme.size.m};
         `}
       >
-        {NAV_ITEMS.map((item) => {
+        {TOP_NAV_ITEMS.map((item) => {
           const isActive = item.id === active;
           return (
             <EuiFlexItem key={item.id} grow={false}>
@@ -117,40 +224,8 @@ export const PndWatchesNav: React.FC<PndWatchesNavProps> = ({ active, onCollapse
                 aria-current={isActive ? 'page' : undefined}
                 onClick={() => history.push(item.path)}
                 data-test-subj={`pndWatchesSubnav-${item.id}`}
-                css={css`
-                  position: relative;
-                  display: flex;
-                  align-items: center;
-                  gap: ${euiTheme.size.s};
-                  width: 100%;
-                  padding: ${euiTheme.size.s} ${euiTheme.size.m};
-                  border: none;
-                  border-radius: ${euiTheme.border.radius.medium};
-                  background: ${isActive ? euiTheme.colors.lightShade : 'transparent'};
-                  color: ${isActive ? euiTheme.colors.textParagraph : euiTheme.colors.textSubdued};
-                  cursor: pointer;
-                  font-size: ${euiTheme.size.m};
-                  font-weight: ${isActive ? 600 : 500};
-                  text-align: left;
-
-                  &::before {
-                    content: '';
-                    position: absolute;
-                    left: 0;
-                    top: 8px;
-                    bottom: 8px;
-                    width: 3px;
-                    border-radius: 0 2px 2px 0;
-                    background: ${isActive ? euiTheme.colors.primary : 'transparent'};
-                  }
-
-                  &:hover {
-                    background: ${euiTheme.colors.lightestShade};
-                    color: ${euiTheme.colors.textParagraph};
-                  }
-                `}
+                css={navButtonCss(isActive)}
               >
-                <EuiIcon type={item.icon} size="m" aria-hidden={true} />
                 <span>{item.label}</span>
               </button>
             </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/watch_card.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/watch_card.tsx
@@ -95,15 +95,24 @@ export const WatchCard: React.FC<WatchCardProps> = ({ watch, onSelect }) => {
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          {watch.draft ? (
-            <EuiBadge color="hollow">{i18n.DRAFT_BADGE}</EuiBadge>
-          ) : watch.enabled ? (
-            <EuiText size="xs" color="subdued">
-              {watch.metrics.lastRun ? i18n.lastRunLabel(watch.metrics.lastRun) : i18n.NEVER_RUN}
-            </EuiText>
-          ) : (
-            <EuiBadge color="default">{i18n.PAUSED_BADGE}</EuiBadge>
-          )}
+          <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+            {watch.updateAvailable ? (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="accent">Update</EuiBadge>
+              </EuiFlexItem>
+            ) : null}
+            <EuiFlexItem grow={false}>
+              {watch.draft ? (
+                <EuiBadge color="hollow">{i18n.DRAFT_BADGE}</EuiBadge>
+              ) : watch.enabled ? (
+                <EuiText size="xs" color="subdued">
+                  {watch.metrics.lastRun ? i18n.lastRunLabel(watch.metrics.lastRun) : i18n.NEVER_RUN}
+                </EuiText>
+              ) : (
+                <EuiBadge color="default">{i18n.PAUSED_BADGE}</EuiBadge>
+              )}
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/watches_section_layout.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/components/watches_section_layout.tsx
@@ -61,10 +61,16 @@ export const WatchesSubnavExpandControl: React.FC = () => {
 
 interface WatchesSectionLayoutProps {
   active: WatchesSectionId;
+  /** When on a watch detail page, highlights that watch in the nested nav list. */
+  activeWatchId?: string;
   children: React.ReactNode;
 }
 
-export const WatchesSectionLayout: React.FC<WatchesSectionLayoutProps> = ({ active, children }) => {
+export const WatchesSectionLayout: React.FC<WatchesSectionLayoutProps> = ({
+  active,
+  activeWatchId,
+  children,
+}) => {
   const { euiTheme } = useEuiTheme();
   const [isCollapsed, setIsCollapsed] = useState(readCollapsed);
 
@@ -99,7 +105,11 @@ export const WatchesSectionLayout: React.FC<WatchesSectionLayoutProps> = ({ acti
       >
         {!isCollapsed ? (
           <EuiFlexItem grow={false}>
-            <PndWatchesNav active={active} onCollapse={() => setCollapsed(true)} />
+            <PndWatchesNav
+              active={active}
+              activeWatchId={activeWatchId}
+              onCollapse={() => setCollapsed(true)}
+            />
           </EuiFlexItem>
         ) : null}
         <EuiFlexItem

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/index.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/index.tsx
@@ -5,86 +5,52 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import {
   EuiButton,
-  EuiCallOut,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import { useHistory } from 'react-router-dom';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { compareWatchesForDisplay } from '@kbn/pnd-common';
 import { PndPageSection } from '../../components/layout/pnd_page_section';
-import { PndPageHeader } from '../../components/pnd_page_header';
 import { usePndDocTitle } from '../../hooks/use_pnd_doc_title';
 import { useWatches } from '../../hooks/use_watches_api';
-import { CoverageStrip } from './components/coverage_strip';
-import { WatchCardGrid } from './components/watch_card_grid';
-import {
-  WatchesSectionLayout,
-  WatchesSubnavExpandControl,
-} from './components/watches_section_layout';
+import { WatchesSectionLayout } from './components/watches_section_layout';
 import * as i18n from './translations';
 
+/** Entry route: land on the first catalogue watch (design IA has no grid landing). */
 export const WatchesPage: React.FC = () => {
   const history = useHistory();
-  const { services } = useKibana();
   const { data, isLoading, error, refetch } = useWatches();
   usePndDocTitle(i18n.PAGE_TITLE);
 
-  const onSelectWatch = useCallback(
-    (watchId: string) => {
-      history.push(`/watches/${watchId}`);
-    },
-    [history]
-  );
+  useEffect(() => {
+    if (!data?.watches?.length) return;
+    const sorted = [...data.watches].sort(compareWatchesForDisplay);
+    history.replace(`/watches/${sorted[0].id}`);
+  }, [data, history]);
 
-  const onNewWatch = useCallback(() => {
-    services.notifications?.toasts.addInfo(i18n.POC_STUB_TOAST);
-  }, [services.notifications]);
-
-  const sectionCount = useMemo(() => {
-    if (!data) return '';
-    const active = data.watches.filter((w) => w.enabled && !w.draft).length;
-    const drafts = data.watches.filter((w) => w.draft).length;
-    const paused = data.watches.filter((w) => !w.enabled && !w.draft).length;
-    return i18n.watchesSectionCount(active, drafts, paused);
-  }, [data]);
-
-  return (
-    <WatchesSectionLayout active="watches">
-      <PndPageSection>
-        <PndPageHeader
-          title={i18n.PAGE_TITLE}
-          subtitle={i18n.PAGE_SUBTITLE}
-          leftSideItems={[<WatchesSubnavExpandControl key="subnav-expand" />]}
-          rightSideItems={[
-            <EuiButton
-              key="new-watch"
-              fill
-              iconType="plusInCircle"
-              onClick={onNewWatch}
-              data-test-subj="pndNewWatchButton"
-            >
-              {i18n.NEW_WATCH}
-            </EuiButton>,
-          ]}
-        />
-
-        {isLoading && !data ? (
+  if (isLoading && !data) {
+    return (
+      <WatchesSectionLayout active="watches">
+        <PndPageSection>
           <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: 200 }}>
             <EuiFlexItem grow={false}>
               <EuiLoadingSpinner size="xl" aria-label={i18n.LOADING_WATCHES} />
             </EuiFlexItem>
           </EuiFlexGroup>
-        ) : null}
+        </PndPageSection>
+      </WatchesSectionLayout>
+    );
+  }
 
-        {error && !data ? (
+  if (error && !data) {
+    return (
+      <WatchesSectionLayout active="watches">
+        <PndPageSection>
           <EuiEmptyPrompt
             iconType="error"
             color="danger"
@@ -96,43 +62,38 @@ export const WatchesPage: React.FC = () => {
               </EuiButton>
             }
           />
-        ) : null}
+        </PndPageSection>
+      </WatchesSectionLayout>
+    );
+  }
 
-        {data ? (
-          <>
-            {error ? (
-              <>
-                <EuiCallOut
-                  announceOnMount
-                  color="warning"
-                  iconType="warning"
-                  title={i18n.STALE_DATA_WARNING}
-                />
-                <EuiSpacer size="m" />
-              </>
-            ) : null}
-            <CoverageStrip watches={data.watches} onSelectWatch={onSelectWatch} />
-            <EuiSpacer size="l" />
-            <EuiFlexGroup alignItems="baseline" gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <EuiTitle size="s">
-                  <h2>{i18n.WATCHES_SECTION_TITLE}</h2>
-                </EuiTitle>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText size="xs" color="subdued">
-                  {sectionCount}
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer size="m" />
-            <WatchCardGrid
-              watches={data.watches}
-              onSelectWatch={onSelectWatch}
-              onNewWatch={onNewWatch}
-            />
-          </>
-        ) : null}
+  if (data && data.watches.length === 0) {
+    return (
+      <WatchesSectionLayout active="watches">
+        <PndPageSection>
+          <EuiEmptyPrompt
+            iconType="eye"
+            title={<h2>{i18n.NO_WATCHES_TITLE}</h2>}
+            body={<p>{i18n.NO_WATCHES_BODY}</p>}
+            actions={
+              <EuiButton onClick={() => refetch()} fill>
+                {i18n.RETRY}
+              </EuiButton>
+            }
+          />
+        </PndPageSection>
+      </WatchesSectionLayout>
+    );
+  }
+
+  return (
+    <WatchesSectionLayout active="watches">
+      <PndPageSection>
+        <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: 200 }}>
+          <EuiFlexItem grow={false}>
+            <EuiLoadingSpinner size="xl" aria-label={i18n.LOADING_WATCHES} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </PndPageSection>
     </WatchesSectionLayout>
   );

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/section_stub.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/section_stub.tsx
@@ -25,11 +25,8 @@ const SECTION_COPY: Record<
   Exclude<WatchesSectionId, 'watches'>,
   { title: string; subtitle: string }
 > = {
-  workflows: { title: i18n.SUBNAV_WORKFLOWS, subtitle: i18n.STUB_WORKFLOWS_SUBTITLE },
+  workers: { title: i18n.SUBNAV_WORKERS, subtitle: i18n.STUB_WORKERS_SUBTITLE },
   skills: { title: i18n.SUBNAV_SKILLS, subtitle: i18n.STUB_SKILLS_SUBTITLE },
-  activity: { title: i18n.SUBNAV_ACTIVITY, subtitle: i18n.STUB_ACTIVITY_SUBTITLE },
-  performance: { title: i18n.SUBNAV_PERFORMANCE, subtitle: i18n.STUB_PERFORMANCE_SUBTITLE },
-  guardrails: { title: i18n.SUBNAV_GUARDRAILS, subtitle: i18n.STUB_GUARDRAILS_SUBTITLE },
 };
 
 export const WatchesSectionStubPage: React.FC<WatchesSectionStubPageProps> = ({ section }) => {

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/translations.ts
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/translations.ts
@@ -82,8 +82,16 @@ export const ACTIVE_BADGE = i18n.translate('xpack.pnd.watches.badge.active', {
   defaultMessage: 'Active',
 });
 
+export const ENABLED_BADGE = i18n.translate('xpack.pnd.watches.badge.enabled', {
+  defaultMessage: 'Enabled',
+});
+
 export const PAUSED_BADGE = i18n.translate('xpack.pnd.watches.badge.paused', {
   defaultMessage: 'Paused',
+});
+
+export const BETA_BADGE = i18n.translate('xpack.pnd.watches.badge.beta', {
+  defaultMessage: 'beta',
 });
 
 export const lastRunLabel = (lastRun: string) =>
@@ -212,14 +220,6 @@ export const DELETE_FAILED = i18n.translate('xpack.pnd.watches.detail.deleteFail
   defaultMessage: 'Failed to delete watch',
 });
 
-export const IDENTITY_TITLE = i18n.translate('xpack.pnd.watches.detail.identity.title', {
-  defaultMessage: 'Identity',
-});
-
-export const IDENTITY_SUBTITLE = i18n.translate('xpack.pnd.watches.detail.identity.subtitle', {
-  defaultMessage: 'how this watch appears on cards, briefs & records',
-});
-
 export const DESCRIPTION_LABEL = i18n.translate('xpack.pnd.watches.detail.description', {
   defaultMessage: 'Description',
 });
@@ -236,11 +236,234 @@ export const AUTONOMY_LEVEL = i18n.translate('xpack.pnd.watches.detail.autonomy.
   defaultMessage: 'Level',
 });
 
+export const AUTONOMY_MANUAL = i18n.translate('xpack.pnd.watches.detail.autonomy.manual', {
+  defaultMessage: 'Manual',
+});
+
+export const AUTONOMY_ASSISTED = i18n.translate('xpack.pnd.watches.detail.autonomy.assisted', {
+  defaultMessage: 'Assisted',
+});
+
+export const AUTONOMY_SUPERVISED = i18n.translate('xpack.pnd.watches.detail.autonomy.supervised', {
+  defaultMessage: 'Supervised',
+});
+
+export const AUTONOMY_BLURB_MANUAL = i18n.translate(
+  'xpack.pnd.watches.detail.autonomy.blurb.manual',
+  {
+    defaultMessage: 'No automatic investigation or response.',
+  }
+);
+
+export const AUTONOMY_BLURB_ASSISTED = i18n.translate(
+  'xpack.pnd.watches.detail.autonomy.blurb.assisted',
+  {
+    defaultMessage: 'Automates investigation; consequential response stays human gated.',
+  }
+);
+
+export const AUTONOMY_BLURB_SUPERVISED = i18n.translate(
+  'xpack.pnd.watches.detail.autonomy.blurb.supervised',
+  {
+    defaultMessage:
+      'Handles the lifecycle end-to-end within policy; the analyst reviews and can reverse.',
+  }
+);
+
 export const AUTONOMY_GUARDRAILS_NOTE = i18n.translate(
   'xpack.pnd.watches.detail.autonomy.guardrailsNote',
   {
     defaultMessage:
       'Org guardrails still apply — actions outside the allow-list stay gated at any level.',
+  }
+);
+
+export const AUTONOMY_VIEW_GUARDRAILS = i18n.translate(
+  'xpack.pnd.watches.detail.autonomy.viewGuardrails',
+  {
+    defaultMessage: 'View guardrails',
+  }
+);
+
+export const GENERAL_TITLE = i18n.translate('xpack.pnd.watches.detail.general.title', {
+  defaultMessage: 'General',
+});
+
+export const GENERAL_SUBTITLE = i18n.translate('xpack.pnd.watches.detail.general.subtitle', {
+  defaultMessage: 'identity and top-level state',
+});
+
+export const RUN_AS_IDENTITY_LABEL = i18n.translate(
+  'xpack.pnd.watches.detail.general.runAsIdentity',
+  {
+    defaultMessage: 'Run-as identity',
+  }
+);
+
+export const MVP_SCOPE_TITLE = i18n.translate('xpack.pnd.watches.detail.general.mvpScopeTitle', {
+  defaultMessage: 'MVP scope',
+});
+
+export const MVP_SCOPE_BODY = i18n.translate('xpack.pnd.watches.detail.general.mvpScopeBody', {
+  defaultMessage:
+    'Higher-autonomy controls are out of scope for October. Autonomy inheritance across watches is still an open decision.',
+});
+
+export const TRIGGERS_TITLE = i18n.translate('xpack.pnd.watches.detail.triggers.title', {
+  defaultMessage: 'Triggers',
+});
+
+export const TRIGGERS_SUBTITLE = i18n.translate('xpack.pnd.watches.detail.triggers.subtitle', {
+  defaultMessage: 'owned by the Watch Orchestrator',
+});
+
+export const TRIGGERS_SHARED_AD = i18n.translate('xpack.pnd.watches.detail.triggers.sharedAd', {
+  defaultMessage:
+    'Shared with Attack Discovery — schedule uses the same configuration surface for this watch.',
+});
+
+export const ATTACK_DISCOVERY_SCHEDULE = i18n.translate(
+  'xpack.pnd.watches.detail.triggers.adSchedule',
+  {
+    defaultMessage: 'Attack Discovery schedule',
+  }
+);
+
+export const ALLOW_MANUAL_RUN = i18n.translate('xpack.pnd.watches.detail.triggers.allowManualRun', {
+  defaultMessage: 'Allow manual run',
+});
+
+export const ALLOW_MANUAL_RUN_HELP = i18n.translate(
+  'xpack.pnd.watches.detail.triggers.allowManualRunHelp',
+  {
+    defaultMessage: 'Allow analysts to trigger a run on demand.',
+  }
+);
+
+export const NO_SCHEDULED_TRIGGER = i18n.translate(
+  'xpack.pnd.watches.detail.triggers.noScheduledTrigger',
+  {
+    defaultMessage:
+      'No scheduled trigger on this watch — cadence cannot drive Task Manager here.',
+  }
+);
+
+export const SCOPE_ROUTING_TITLE = i18n.translate('xpack.pnd.watches.detail.scopeRouting.title', {
+  defaultMessage: 'Scope & routing',
+});
+
+export const SCOPE_ROUTING_SUBTITLE = i18n.translate(
+  'xpack.pnd.watches.detail.scopeRouting.subtitle',
+  {
+    defaultMessage: 'what it may read, where work lands',
+  }
+);
+
+export const ALLOWED_DATA_SOURCES = i18n.translate(
+  'xpack.pnd.watches.detail.scopeRouting.dataSources',
+  {
+    defaultMessage: 'Allowed data sources',
+  }
+);
+
+export const DEFAULT_ASSIGNEE_QUEUE = i18n.translate(
+  'xpack.pnd.watches.detail.scopeRouting.assigneeQueue',
+  {
+    defaultMessage: 'Default assignee queue',
+  }
+);
+
+export const ESCALATION_CONTACT = i18n.translate(
+  'xpack.pnd.watches.detail.scopeRouting.escalationContact',
+  {
+    defaultMessage: 'Escalation contact',
+  }
+);
+
+export const WORKERS_SECTION_TITLE = i18n.translate('xpack.pnd.watches.detail.workers.title', {
+  defaultMessage: 'Workers',
+});
+
+export const WORKERS_SECTION_SUBTITLE = i18n.translate(
+  'xpack.pnd.watches.detail.workers.subtitle',
+  {
+    defaultMessage: 'Workers attached to this Watch',
+  }
+);
+
+export const WORKERS_EMPTY = i18n.translate('xpack.pnd.watches.detail.workers.empty', {
+  defaultMessage: 'No workers attached to this watch yet.',
+});
+
+export const SKILLS_SECTION_TITLE = i18n.translate('xpack.pnd.watches.detail.skills.title', {
+  defaultMessage: 'Skills',
+});
+
+export const SKILLS_SECTION_SUBTITLE = i18n.translate('xpack.pnd.watches.detail.skills.subtitle', {
+  defaultMessage: "what this Watch's Workers can use",
+});
+
+export const SKILLS_EMPTY = i18n.translate('xpack.pnd.watches.detail.skills.empty', {
+  defaultMessage: 'No skills attached to this watch yet.',
+});
+
+export const SKILL_DEPENDENCIES_TITLE = i18n.translate(
+  'xpack.pnd.watches.detail.skills.dependenciesTitle',
+  {
+    defaultMessage: 'Skill dependencies',
+  }
+);
+
+export const SKILL_DEPENDENCIES_BODY = i18n.translate(
+  'xpack.pnd.watches.detail.skills.dependenciesBody',
+  {
+    defaultMessage: 'Disabling a skill can degrade or disable dependent workers.',
+  }
+);
+
+export const APPROVAL_GATES_TITLE = i18n.translate(
+  'xpack.pnd.watches.detail.approvalGates.title',
+  {
+    defaultMessage: 'Approval gates',
+  }
+);
+
+export const APPROVAL_GATES_SUBTITLE = i18n.translate(
+  'xpack.pnd.watches.detail.approvalGates.subtitle',
+  {
+    defaultMessage: 'humans stay in control of consequential changes',
+  }
+);
+
+export const APPROVAL_COL_ACTION = i18n.translate(
+  'xpack.pnd.watches.detail.approvalGates.col.action',
+  {
+    defaultMessage: 'Action type',
+  }
+);
+
+export const APPROVAL_COL_REQUIRES = i18n.translate(
+  'xpack.pnd.watches.detail.approvalGates.col.requires',
+  {
+    defaultMessage: 'Requires approval',
+  }
+);
+
+export const APPROVAL_COL_ROLE = i18n.translate('xpack.pnd.watches.detail.approvalGates.col.role', {
+  defaultMessage: 'Approver role',
+});
+
+export const APPROVAL_AUDIT_NOTE = i18n.translate(
+  'xpack.pnd.watches.detail.approvalGates.auditNote',
+  {
+    defaultMessage: 'Every approved action creates an Action Result for the audit trail.',
+  }
+);
+
+export const RECENT_RUNS_SUBTITLE = i18n.translate(
+  'xpack.pnd.watches.detail.recentRuns.subtitle',
+  {
+    defaultMessage: 'ledger for this Watch',
   }
 );
 
@@ -350,59 +573,36 @@ export const SUBNAV_WATCHES = i18n.translate('xpack.pnd.watches.subnav.watches',
   defaultMessage: 'Watches',
 });
 
-export const SUBNAV_WORKFLOWS = i18n.translate('xpack.pnd.watches.subnav.workflows', {
-  defaultMessage: 'Workflows',
+export const SUBNAV_WORKERS = i18n.translate('xpack.pnd.watches.subnav.workers', {
+  defaultMessage: 'Workers',
 });
 
 export const SUBNAV_SKILLS = i18n.translate('xpack.pnd.watches.subnav.skills', {
   defaultMessage: 'Skills',
 });
 
-export const SUBNAV_ACTIVITY = i18n.translate('xpack.pnd.watches.subnav.activity', {
-  defaultMessage: 'Activity',
-});
-
-export const SUBNAV_PERFORMANCE = i18n.translate('xpack.pnd.watches.subnav.performance', {
-  defaultMessage: 'Performance',
-});
-
-export const SUBNAV_GUARDRAILS = i18n.translate('xpack.pnd.watches.subnav.guardrails', {
-  defaultMessage: 'Guardrails',
-});
-
-export const STUB_WORKFLOWS_SUBTITLE = i18n.translate('xpack.pnd.watches.stub.workflows.subtitle', {
-  defaultMessage: 'Triggered runs across watches',
+export const STUB_WORKERS_SUBTITLE = i18n.translate('xpack.pnd.watches.stub.workers.subtitle', {
+  defaultMessage: 'Workers attached across watches',
 });
 
 export const STUB_SKILLS_SUBTITLE = i18n.translate('xpack.pnd.watches.stub.skills.subtitle', {
   defaultMessage: 'Capabilities & connectors',
 });
 
-export const STUB_ACTIVITY_SUBTITLE = i18n.translate('xpack.pnd.watches.stub.activity.subtitle', {
-  defaultMessage: 'Run & trust ledger',
-});
-
-export const STUB_PERFORMANCE_SUBTITLE = i18n.translate(
-  'xpack.pnd.watches.stub.performance.subtitle',
-  {
-    defaultMessage: 'Value, quality & cost',
-  }
-);
-
-export const STUB_GUARDRAILS_SUBTITLE = i18n.translate(
-  'xpack.pnd.watches.stub.guardrails.subtitle',
-  {
-    defaultMessage: 'Autonomy & approvals',
-  }
-);
-
 export const STUB_EMPTY_TITLE = i18n.translate('xpack.pnd.watches.stub.emptyTitle', {
   defaultMessage: 'Coming soon',
 });
 
 export const STUB_EMPTY_BODY = i18n.translate('xpack.pnd.watches.stub.emptyBody', {
-  defaultMessage:
-    'This surface will load live Workflows, Skills, and Activity data once those APIs are wired in.',
+  defaultMessage: 'This surface will load live Workers and Skills data once those APIs are wired in.',
+});
+
+export const NO_WATCHES_TITLE = i18n.translate('xpack.pnd.watches.noWatches.title', {
+  defaultMessage: 'No watches yet',
+});
+
+export const NO_WATCHES_BODY = i18n.translate('xpack.pnd.watches.noWatches.body', {
+  defaultMessage: 'Pre-built watches appear here after the catalogue seeds on first visit.',
 });
 
 export const NEW_WATCH = i18n.translate('xpack.pnd.watches.newWatch', {

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/watch_detail.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/watch_detail.tsx
@@ -11,6 +11,8 @@ import {
   EuiBadge,
   EuiButton,
   EuiButtonEmpty,
+  EuiButtonGroup,
+  EuiCallOut,
   EuiConfirmModal,
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -18,8 +20,9 @@ import {
   EuiFormRow,
   EuiLoadingSpinner,
   EuiPanel,
-  EuiRange,
+  EuiSelect,
   EuiSpacer,
+  EuiSwitch,
   EuiText,
   EuiTextArea,
   EuiTitle,
@@ -30,7 +33,6 @@ import { useHistory, useParams } from 'react-router-dom';
 import { isHttpFetchError } from '@kbn/core-http-browser';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import {
-  AUTONOMY_LABELS,
   coverageFromSchedule,
   type AutonomyLevel,
   type Watch,
@@ -40,7 +42,11 @@ import {
 import { PndPageSection } from '../../components/layout/pnd_page_section';
 import { PndPageHeader } from '../../components/pnd_page_header';
 import { usePndDocTitle } from '../../hooks/use_pnd_doc_title';
-import { useWatch } from '../../hooks/use_watches_api';
+import {
+  useApplyWatchUpdate,
+  useUpdateWatchSettings,
+  useWatch,
+} from '../../hooks/use_watches_api';
 import { AgentCapabilitiesList } from './components/agent_capabilities_list';
 import { AutonomyMeter } from './components/autonomy_meter';
 import { RecentRunsTable } from './components/recent_runs_table';
@@ -58,12 +64,36 @@ const SCOPE_COLOR: Record<string, string> = {
   denied: '#ef4444',
 };
 
+/** POC: three UI levels mapped onto shipped 1–5 AutonomyLevel. */
+type UiAutonomy = 'manual' | 'assisted' | 'supervised';
+
+const UI_AUTONOMY_TO_STORED: Record<UiAutonomy, AutonomyLevel> = {
+  manual: 1,
+  assisted: 3,
+  supervised: 5,
+};
+
+const storedToUiAutonomy = (level: AutonomyLevel): UiAutonomy => {
+  if (level <= 2) return 'manual';
+  if (level === 3) return 'assisted';
+  return 'supervised';
+};
+
+const SCHEDULE_INTERVAL_OPTIONS = [
+  { value: '15m', text: 'Every 15 minutes' },
+  { value: '1h', text: 'Every 1 hour' },
+  { value: '6h', text: 'Every 6 hours' },
+  { value: '1d', text: 'Every day' },
+];
+
 export const WatchDetailPage: React.FC = () => {
   const { euiTheme } = useEuiTheme();
   const history = useHistory();
   const { watchId } = useParams<{ watchId: string }>();
   const { services } = useKibana();
   const { data, isLoading, error, refetch } = useWatch(watchId);
+  const updateSettings = useUpdateWatchSettings();
+  const applyUpdate = useApplyWatchUpdate();
 
   const [localWatch, setLocalWatch] = useState<Watch | null>(null);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
@@ -79,12 +109,8 @@ export const WatchDetailPage: React.FC = () => {
     if (!data?.watch || data.watch.id !== watchId) {
       return;
     }
-    setLocalWatch((prev) => {
-      if (prev == null || prev.id !== data.watch.id) {
-        return data.watch;
-      }
-      return prev;
-    });
+    // Always accept server data after refetch/save so round-trip is visible.
+    setLocalWatch(data.watch);
   }, [data, watchId]);
 
   const stubToast = useCallback(() => {
@@ -108,9 +134,77 @@ export const WatchDetailPage: React.FC = () => {
     );
   }, []);
 
-  const onAutonomyChange = useCallback((level: AutonomyLevel) => {
-    setLocalWatch((prev) => (prev ? { ...prev, autonomyLevel: level } : prev));
+  const onUiAutonomyChange = useCallback((ui: UiAutonomy) => {
+    setLocalWatch((prev) =>
+      prev ? { ...prev, autonomyLevel: UI_AUTONOMY_TO_STORED[ui] } : prev
+    );
   }, []);
+
+  const onSave = useCallback(async () => {
+    if (!localWatch) return;
+    try {
+      const result = await updateSettings.mutateAsync({
+        watchId: localWatch.id,
+        body: {
+          enabled: localWatch.enabled,
+          description: localWatch.description,
+          autonomyLevel: localWatch.autonomyLevel,
+          ...(localWatch.scheduleInterval
+            ? { scheduleInterval: localWatch.scheduleInterval }
+            : {}),
+        },
+      });
+      setLocalWatch(result.watch);
+      services.notifications?.toasts.addSuccess('Watch settings saved');
+    } catch (err) {
+      services.notifications?.toasts.addError(
+        err instanceof Error ? err : new Error(String(err)),
+        { title: 'Failed to save watch settings' }
+      );
+    }
+  }, [localWatch, updateSettings, services.notifications]);
+
+  const onToggleEnabled = useCallback(
+    async (enabled: boolean) => {
+      if (!localWatch) return;
+      setLocalWatch({ ...localWatch, enabled, draft: !enabled ? localWatch.draft : false });
+      try {
+        const result = await updateSettings.mutateAsync({
+          watchId: localWatch.id,
+          body: { enabled },
+        });
+        setLocalWatch(result.watch);
+        services.notifications?.toasts.addSuccess(enabled ? 'Watch enabled' : 'Watch paused');
+      } catch (err) {
+        setLocalWatch(localWatch);
+        services.notifications?.toasts.addError(
+          err instanceof Error ? err : new Error(String(err)),
+          { title: 'Failed to toggle watch' }
+        );
+      }
+    },
+    [localWatch, updateSettings, services.notifications]
+  );
+
+  const onApplyCatalogUpdate = useCallback(async () => {
+    if (!localWatch) return;
+    try {
+      const result = await applyUpdate.mutateAsync({ watchId: localWatch.id });
+      if (result.watch) {
+        setLocalWatch(result.watch);
+      } else {
+        await refetch();
+      }
+      services.notifications?.toasts.addSuccess(
+        `Catalogue update applied (v${result.fromVersion} → v${result.toVersion})`
+      );
+    } catch (err) {
+      services.notifications?.toasts.addError(
+        err instanceof Error ? err : new Error(String(err)),
+        { title: 'Failed to apply catalogue update' }
+      );
+    }
+  }, [localWatch, applyUpdate, refetch, services.notifications]);
 
   const onToggleCallable = useCallback(
     (callableId: string) => {
@@ -208,10 +302,29 @@ export const WatchDetailPage: React.FC = () => {
           leftSideItems={[<WatchesSubnavExpandControl key="subnav-expand" />]}
           backTo={{ path: '/watches', label: i18n.BACK_TO_WATCHES }}
           rightSideItems={[
-            <EuiButton key="save" fill onClick={stubToast}>
+            <EuiSwitch
+              key="enabled"
+              label={watch.enabled ? i18n.ACTIVE_BADGE : i18n.PAUSED_BADGE}
+              checked={watch.enabled}
+              onChange={(e) => onToggleEnabled(e.target.checked)}
+              compressed
+            />,
+            <EuiButton
+              key="save"
+              fill
+              onClick={onSave}
+              isLoading={updateSettings.isLoading}
+              data-test-subj="pndWatchSaveButton"
+            >
               {i18n.SAVE}
             </EuiButton>,
-            <EuiButtonEmpty key="discard" onClick={() => history.push('/watches')}>
+            <EuiButtonEmpty
+              key="discard"
+              onClick={() => {
+                if (data?.watch) setLocalWatch(data.watch);
+                else history.push('/watches');
+              }}
+            >
               {i18n.DISCARD}
             </EuiButtonEmpty>,
             ...(!watch.managed
@@ -232,6 +345,33 @@ export const WatchDetailPage: React.FC = () => {
           <p>{watch.description}</p>
         </EuiText>
         <EuiSpacer size="m" />
+
+        {watch.updateAvailable ? (
+          <>
+            <EuiCallOut
+              title={`Update available (v${watch.seedContentVersion ?? '?'} → v${
+                watch.catalogVersion ?? '?'
+              })`}
+              color="primary"
+              iconType="exportAction"
+            >
+              <p>
+                Elastic shipped an improved definition. Your settings (enabled, autonomy, cadence,
+                description) will be re-applied. Definition-body edits conflict and are warned.
+              </p>
+              <EuiButton
+                size="s"
+                fill
+                onClick={onApplyCatalogUpdate}
+                isLoading={applyUpdate.isLoading}
+                data-test-subj="pndWatchApplyUpdateButton"
+              >
+                Take update
+              </EuiButton>
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        ) : null}
 
         {isDeleteConfirmOpen ? (
           <EuiConfirmModal
@@ -315,7 +455,7 @@ export const WatchDetailPage: React.FC = () => {
 
         <EuiSpacer size="l" />
 
-        {/* Autonomy */}
+        {/* Autonomy — POC: three levels in UI, stored as 1 / 3 / 5 */}
         <SectionHeading title={i18n.AUTONOMY_TITLE} subtitle={i18n.AUTONOMY_SUBTITLE} />
         <EuiPanel hasBorder paddingSize="m">
           <EuiFormRow label={i18n.AUTONOMY_LEVEL} fullWidth>
@@ -326,30 +466,28 @@ export const WatchDetailPage: React.FC = () => {
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiText size="xs" color="subdued">
-                    {watch.autonomyLevel} / 5
+                    stored {watch.autonomyLevel}/5 · UI{' '}
+                    {storedToUiAutonomy(watch.autonomyLevel)}
                   </EuiText>
                 </EuiFlexItem>
               </EuiFlexGroup>
               <EuiSpacer size="s" />
-              <EuiRange
-                min={1}
-                max={5}
-                step={1}
-                value={watch.autonomyLevel}
-                onChange={(e) =>
-                  onAutonomyChange(Number((e.target as HTMLInputElement).value) as AutonomyLevel)
-                }
-                showTicks
-                ticks={AUTONOMY_LABELS.map((label, i) => ({
-                  value: i + 1,
-                  label: i === 0 || i === 4 ? label : '',
-                }))}
-                fullWidth
-                compressed
+              <EuiButtonGroup
+                legend={i18n.AUTONOMY_LEVEL}
+                idSelected={storedToUiAutonomy(watch.autonomyLevel)}
+                onChange={(id) => onUiAutonomyChange(id as UiAutonomy)}
+                options={[
+                  { id: 'manual', label: 'Manual' },
+                  { id: 'assisted', label: 'Assisted' },
+                  { id: 'supervised', label: 'Supervised' },
+                ]}
+                buttonSize="compressed"
+                color="primary"
+                isFullWidth
               />
               <EuiSpacer size="s" />
               <EuiText size="xs" color="subdued">
-                {i18n.AUTONOMY_GUARDRAILS_NOTE}
+                POC maps Manual→1, Assisted→3, Supervised→5 on the shipped 1–5 field.
               </EuiText>
             </div>
           </EuiFormRow>
@@ -359,6 +497,39 @@ export const WatchDetailPage: React.FC = () => {
 
         {/* Schedule */}
         <SectionHeading title={i18n.SCHEDULE_TITLE} subtitle={i18n.SCHEDULE_SUBTITLE} />
+        {watch.scheduleInterval ? (
+          <>
+            <EuiPanel hasBorder paddingSize="m">
+              <EuiFormRow
+                label="Schedule interval (Task Manager)"
+                helpText="Writable cadence for watches with a scheduled trigger. Writes triggers[].with.every."
+                fullWidth
+              >
+                <EuiSelect
+                  options={SCHEDULE_INTERVAL_OPTIONS}
+                  value={watch.scheduleInterval}
+                  onChange={(e) =>
+                    setLocalWatch((prev) =>
+                      prev ? { ...prev, scheduleInterval: e.target.value } : prev
+                    )
+                  }
+                  compressed
+                  fullWidth
+                  data-test-subj="pndWatchScheduleInterval"
+                />
+              </EuiFormRow>
+            </EuiPanel>
+            <EuiSpacer size="s" />
+          </>
+        ) : (
+          <>
+            <EuiCallOut size="s" color="warning" title="No scheduled trigger on this watch">
+              Cadence cannot drive Task Manager here (Floor/Deep are alert/manual). Change interval
+              on Officer or Dark.
+            </EuiCallOut>
+            <EuiSpacer size="s" />
+          </>
+        )}
         <SchedulePanel watch={watch} onScheduleChange={onScheduleChange} />
 
         <EuiSpacer size="l" />

--- a/x-pack/solutions/security/plugins/pnd/public/pages/watches/watch_detail.tsx
+++ b/x-pack/solutions/security/plugins/pnd/public/pages/watches/watch_detail.tsx
@@ -9,11 +9,11 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiBadge,
+  EuiBasicTable,
   EuiButton,
   EuiButtonEmpty,
-  EuiButtonGroup,
   EuiCallOut,
-  EuiConfirmModal,
+  EuiCode,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -27,17 +27,15 @@ import {
   EuiTextArea,
   EuiTitle,
   useEuiTheme,
-  useGeneratedHtmlId,
+  type EuiBasicTableColumn,
 } from '@elastic/eui';
 import { useHistory, useParams } from 'react-router-dom';
 import { isHttpFetchError } from '@kbn/core-http-browser';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import {
-  coverageFromSchedule,
   type AutonomyLevel,
   type Watch,
   type WatchCallableRef,
-  type WatchSchedule,
 } from '@kbn/pnd-common';
 import { PndPageSection } from '../../components/layout/pnd_page_section';
 import { PndPageHeader } from '../../components/pnd_page_header';
@@ -48,10 +46,9 @@ import {
   useWatch,
 } from '../../hooks/use_watches_api';
 import { AgentCapabilitiesList } from './components/agent_capabilities_list';
-import { AutonomyMeter } from './components/autonomy_meter';
+import { AutonomySlider, type UiAutonomy } from './components/autonomy_slider';
 import { RecentRunsTable } from './components/recent_runs_table';
 import { RunSparkline } from './components/run_sparkline';
-import { SchedulePanel } from './components/schedule_panel';
 import {
   WatchesSectionLayout,
   WatchesSubnavExpandControl,
@@ -65,8 +62,6 @@ const SCOPE_COLOR: Record<string, string> = {
 };
 
 /** POC: three UI levels mapped onto shipped 1–5 AutonomyLevel. */
-type UiAutonomy = 'manual' | 'assisted' | 'supervised';
-
 const UI_AUTONOMY_TO_STORED: Record<UiAutonomy, AutonomyLevel> = {
   manual: 1,
   assisted: 3,
@@ -86,6 +81,62 @@ const SCHEDULE_INTERVAL_OPTIONS = [
   { value: '1d', text: 'Every day' },
 ];
 
+const DATA_SOURCE_OPTIONS = [
+  { value: 'alerts-entities-timelines', text: 'Alerts, entities, timelines' },
+];
+
+const ASSIGNEE_OPTIONS = [{ value: 'tier1', text: 'Tier 1 — Alert triage' }];
+
+const ESCALATION_OPTIONS = [{ value: 'soc-lead', text: 'SOC lead on-call' }];
+
+interface ApprovalGateRow {
+  id: string;
+  actionType: string;
+  requires: string;
+  role: string;
+}
+
+const APPROVAL_GATE_ROWS: ApprovalGateRow[] = [
+  {
+    id: 'host-isolation',
+    actionType: 'Host isolation',
+    requires: 'Always',
+    role: 'Incident lead',
+  },
+  {
+    id: 'detection-rule-change',
+    actionType: 'Detection rule change',
+    requires: 'Always',
+    role: 'Detection engineer',
+  },
+  {
+    id: 'new-detection-rule',
+    actionType: 'New detection rule',
+    requires: 'Always',
+    role: 'Detection engineer',
+  },
+  {
+    id: 'hunt-execution',
+    actionType: 'Hunt execution',
+    requires: 'High-impact only',
+    role: 'Threat hunter',
+  },
+  {
+    id: 'evidence-only',
+    actionType: 'Evidence-only investigation',
+    requires: 'Runs in scope',
+    role: '—',
+  },
+];
+
+const runAsIdentityFromWatch = (watch: Watch): string => {
+  const slug = watch.id
+    .replace(/^security-watch-/, '')
+    .replace(/^system-security-watch-/, '')
+    .replace(/_/g, '-');
+  return `svc-watch-${slug}`;
+};
+
 export const WatchDetailPage: React.FC = () => {
   const { euiTheme } = useEuiTheme();
   const history = useHistory();
@@ -96,43 +147,24 @@ export const WatchDetailPage: React.FC = () => {
   const applyUpdate = useApplyWatchUpdate();
 
   const [localWatch, setLocalWatch] = useState<Watch | null>(null);
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const confirmModalTitleId = useGeneratedHtmlId();
+  const [allowManualRun, setAllowManualRun] = useState(true);
   usePndDocTitle(localWatch?.name ?? i18n.PAGE_TITLE);
 
   useEffect(() => {
     setLocalWatch(null);
-    setIsDeleteConfirmOpen(false);
+    setAllowManualRun(true);
   }, [watchId]);
 
   useEffect(() => {
     if (!data?.watch || data.watch.id !== watchId) {
       return;
     }
-    // Always accept server data after refetch/save so round-trip is visible.
     setLocalWatch(data.watch);
   }, [data, watchId]);
 
   const stubToast = useCallback(() => {
     services.notifications?.toasts.addInfo(i18n.POC_STUB_TOAST);
   }, [services.notifications]);
-
-  const onConfirmDelete = useCallback(() => {
-    setIsDeleteConfirmOpen(false);
-    stubToast();
-  }, [stubToast]);
-
-  const onScheduleChange = useCallback((schedule: WatchSchedule) => {
-    setLocalWatch((prev) =>
-      prev
-        ? {
-            ...prev,
-            schedule,
-            coverage: coverageFromSchedule(schedule),
-          }
-        : prev
-    );
-  }, []);
 
   const onUiAutonomyChange = useCallback((ui: UiAutonomy) => {
     setLocalWatch((prev) =>
@@ -220,9 +252,22 @@ export const WatchDetailPage: React.FC = () => {
     [stubToast]
   );
 
-  const callablesOn = useMemo(
-    () => localWatch?.callables.filter((c) => c.enabled).length ?? 0,
+  const workers = useMemo(
+    () => localWatch?.callables.filter((c) => c.kind === 'workflow') ?? [],
     [localWatch]
+  );
+  const skills = useMemo(
+    () => localWatch?.callables.filter((c) => c.kind === 'skill') ?? [],
+    [localWatch]
+  );
+
+  const approvalColumns = useMemo<Array<EuiBasicTableColumn<ApprovalGateRow>>>(
+    () => [
+      { field: 'actionType', name: i18n.APPROVAL_COL_ACTION },
+      { field: 'requires', name: i18n.APPROVAL_COL_REQUIRES, width: '160px' },
+      { field: 'role', name: i18n.APPROVAL_COL_ROLE, width: '180px' },
+    ],
+    []
   );
 
   const hasCurrentWatch = localWatch?.id === watchId;
@@ -232,13 +277,15 @@ export const WatchDetailPage: React.FC = () => {
 
   if (!hasCurrentWatch && isLoading) {
     return (
-      <PndPageSection>
-        <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: 240 }}>
-          <EuiFlexItem grow={false}>
-            <EuiLoadingSpinner size="xl" aria-label={i18n.LOADING_WATCH} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </PndPageSection>
+      <WatchesSectionLayout active="watches" activeWatchId={watchId}>
+        <PndPageSection>
+          <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: 240 }}>
+            <EuiFlexItem grow={false}>
+              <EuiLoadingSpinner size="xl" aria-label={i18n.LOADING_WATCH} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </PndPageSection>
+      </WatchesSectionLayout>
     );
   }
 
@@ -275,7 +322,7 @@ export const WatchDetailPage: React.FC = () => {
   const watch = localWatch;
 
   return (
-    <WatchesSectionLayout active="watches">
+    <WatchesSectionLayout active="watches" activeWatchId={watch.id}>
       <PndPageSection
         contentProps={{
           css: {
@@ -285,26 +332,29 @@ export const WatchDetailPage: React.FC = () => {
       >
         <PndPageHeader
           title={
-            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
               <EuiFlexItem grow={false}>{watch.name}</EuiFlexItem>
               <EuiFlexItem grow={false}>
                 {watch.draft ? (
                   <EuiBadge color="warning">{i18n.DRAFT_BADGE}</EuiBadge>
                 ) : watch.enabled ? (
-                  <EuiBadge color="success">{i18n.ACTIVE_BADGE}</EuiBadge>
+                  <EuiBadge color="success">{i18n.ENABLED_BADGE}</EuiBadge>
                 ) : (
                   <EuiBadge color="default">{i18n.PAUSED_BADGE}</EuiBadge>
                 )}
               </EuiFlexItem>
+              {watch.mandate ? (
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">{watch.mandate}</EuiBadge>
+                </EuiFlexItem>
+              ) : null}
             </EuiFlexGroup>
           }
-          subtitle={watch.mandate}
           leftSideItems={[<WatchesSubnavExpandControl key="subnav-expand" />]}
-          backTo={{ path: '/watches', label: i18n.BACK_TO_WATCHES }}
           rightSideItems={[
             <EuiSwitch
               key="enabled"
-              label={watch.enabled ? i18n.ACTIVE_BADGE : i18n.PAUSED_BADGE}
+              label={i18n.ENABLED_BADGE}
               checked={watch.enabled}
               onChange={(e) => onToggleEnabled(e.target.checked)}
               compressed
@@ -318,26 +368,6 @@ export const WatchDetailPage: React.FC = () => {
             >
               {i18n.SAVE}
             </EuiButton>,
-            <EuiButtonEmpty
-              key="discard"
-              onClick={() => {
-                if (data?.watch) setLocalWatch(data.watch);
-                else history.push('/watches');
-              }}
-            >
-              {i18n.DISCARD}
-            </EuiButtonEmpty>,
-            ...(!watch.managed
-              ? [
-                  <EuiButtonEmpty
-                    key="delete"
-                    color="danger"
-                    onClick={() => setIsDeleteConfirmOpen(true)}
-                  >
-                    {i18n.DELETE}
-                  </EuiButtonEmpty>,
-                ]
-              : []),
           ]}
         />
 
@@ -373,28 +403,12 @@ export const WatchDetailPage: React.FC = () => {
           </>
         ) : null}
 
-        {isDeleteConfirmOpen ? (
-          <EuiConfirmModal
-            aria-labelledby={confirmModalTitleId}
-            title={i18n.DELETE_CONFIRM_TITLE}
-            titleProps={{ id: confirmModalTitleId }}
-            onCancel={() => setIsDeleteConfirmOpen(false)}
-            onConfirm={onConfirmDelete}
-            cancelButtonText={i18n.DELETE_CANCEL}
-            confirmButtonText={i18n.DELETE_CONFIRM_BUTTON}
-            buttonColor="danger"
-            defaultFocusedButton="confirm"
-          >
-            <p>{i18n.deleteConfirmBody(watch.name)}</p>
-          </EuiConfirmModal>
-        ) : null}
-
         <div
           css={css`
             display: grid;
             grid-template-columns: repeat(3, minmax(0, 1fr));
             gap: ${euiTheme.size.m};
-            max-width: 480px;
+            max-width: 520px;
             opacity: ${watch.metrics.runs7d == null ? 0.4 : 1};
           `}
         >
@@ -437,10 +451,28 @@ export const WatchDetailPage: React.FC = () => {
 
         <EuiSpacer size="xl" />
 
-        {/* Identity */}
-        <SectionHeading title={i18n.IDENTITY_TITLE} subtitle={i18n.IDENTITY_SUBTITLE} />
+        <SectionHeading title={i18n.AUTONOMY_TITLE} subtitle={i18n.AUTONOMY_SUBTITLE} />
         <EuiPanel hasBorder paddingSize="m">
-          <EuiFormRow label={i18n.DESCRIPTION_LABEL} fullWidth>
+          <AutonomySlider
+            value={storedToUiAutonomy(watch.autonomyLevel)}
+            onChange={onUiAutonomyChange}
+            onViewGuardrails={stubToast}
+          />
+        </EuiPanel>
+
+        <EuiSpacer size="l" />
+
+        <SectionHeading title={i18n.GENERAL_TITLE} subtitle={i18n.GENERAL_SUBTITLE} />
+        <EuiPanel hasBorder paddingSize="m">
+          <EuiFormRow label={i18n.RUN_AS_IDENTITY_LABEL} fullWidth>
+            <EuiCode>{runAsIdentityFromWatch(watch)}</EuiCode>
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiFormRow
+            label={i18n.DESCRIPTION_LABEL}
+            helpText="POC: persisted on Save with other watch settings."
+            fullWidth
+          >
             <EuiTextArea
               value={watch.description}
               onChange={(e) =>
@@ -451,137 +483,162 @@ export const WatchDetailPage: React.FC = () => {
               compressed
             />
           </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiCallOut title={i18n.MVP_SCOPE_TITLE} color="warning" iconType="iInCircle" size="s">
+            <p>{i18n.MVP_SCOPE_BODY}</p>
+          </EuiCallOut>
         </EuiPanel>
 
         <EuiSpacer size="l" />
 
-        {/* Autonomy — POC: three levels in UI, stored as 1 / 3 / 5 */}
-        <SectionHeading title={i18n.AUTONOMY_TITLE} subtitle={i18n.AUTONOMY_SUBTITLE} />
+        <SectionHeading title={i18n.TRIGGERS_TITLE} subtitle={i18n.TRIGGERS_SUBTITLE} />
         <EuiPanel hasBorder paddingSize="m">
-          <EuiFormRow label={i18n.AUTONOMY_LEVEL} fullWidth>
-            <div>
-              <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s">
-                <EuiFlexItem grow={false}>
-                  <AutonomyMeter level={watch.autonomyLevel} color={watch.color} />
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiText size="xs" color="subdued">
-                    stored {watch.autonomyLevel}/5 · UI{' '}
-                    {storedToUiAutonomy(watch.autonomyLevel)}
-                  </EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiSpacer size="s" />
-              <EuiButtonGroup
-                legend={i18n.AUTONOMY_LEVEL}
-                idSelected={storedToUiAutonomy(watch.autonomyLevel)}
-                onChange={(id) => onUiAutonomyChange(id as UiAutonomy)}
-                options={[
-                  { id: 'manual', label: 'Manual' },
-                  { id: 'assisted', label: 'Assisted' },
-                  { id: 'supervised', label: 'Supervised' },
-                ]}
-                buttonSize="compressed"
-                color="primary"
-                isFullWidth
+          <EuiCallOut color="primary" iconType="iInCircle" size="s" title={i18n.TRIGGERS_SHARED_AD} />
+          <EuiSpacer size="m" />
+          {watch.scheduleInterval ? (
+            <EuiFormRow label={i18n.ATTACK_DISCOVERY_SCHEDULE} fullWidth>
+              <EuiSelect
+                options={SCHEDULE_INTERVAL_OPTIONS}
+                value={watch.scheduleInterval}
+                onChange={(e) =>
+                  setLocalWatch((prev) =>
+                    prev ? { ...prev, scheduleInterval: e.target.value } : prev
+                  )
+                }
+                compressed
+                fullWidth
+                data-test-subj="pndWatchScheduleInterval"
               />
-              <EuiSpacer size="s" />
-              <EuiText size="xs" color="subdued">
-                POC maps Manual→1, Assisted→3, Supervised→5 on the shipped 1–5 field.
-              </EuiText>
-            </div>
+            </EuiFormRow>
+          ) : (
+            <EuiCallOut size="s" color="warning" title={i18n.NO_SCHEDULED_TRIGGER} />
+          )}
+          <EuiSpacer size="m" />
+          <EuiFormRow helpText={i18n.ALLOW_MANUAL_RUN_HELP}>
+            <EuiSwitch
+              label={i18n.ALLOW_MANUAL_RUN}
+              checked={allowManualRun}
+              onChange={(e) => {
+                setAllowManualRun(e.target.checked);
+                stubToast();
+              }}
+              compressed
+            />
           </EuiFormRow>
         </EuiPanel>
 
         <EuiSpacer size="l" />
 
-        {/* Schedule */}
-        <SectionHeading title={i18n.SCHEDULE_TITLE} subtitle={i18n.SCHEDULE_SUBTITLE} />
-        {watch.scheduleInterval ? (
-          <>
-            <EuiPanel hasBorder paddingSize="m">
-              <EuiFormRow
-                label="Schedule interval (Task Manager)"
-                helpText="Writable cadence for watches with a scheduled trigger. Writes triggers[].with.every."
-                fullWidth
-              >
-                <EuiSelect
-                  options={SCHEDULE_INTERVAL_OPTIONS}
-                  value={watch.scheduleInterval}
-                  onChange={(e) =>
-                    setLocalWatch((prev) =>
-                      prev ? { ...prev, scheduleInterval: e.target.value } : prev
-                    )
-                  }
-                  compressed
-                  fullWidth
-                  data-test-subj="pndWatchScheduleInterval"
-                />
-              </EuiFormRow>
-            </EuiPanel>
-            <EuiSpacer size="s" />
-          </>
-        ) : (
-          <>
-            <EuiCallOut size="s" color="warning" title="No scheduled trigger on this watch">
-              Cadence cannot drive Task Manager here (Floor/Deep are alert/manual). Change interval
-              on Officer or Dark.
-            </EuiCallOut>
-            <EuiSpacer size="s" />
-          </>
-        )}
-        <SchedulePanel watch={watch} onScheduleChange={onScheduleChange} />
-
-        <EuiSpacer size="l" />
-
-        {/* Agent capabilities */}
-        <EuiFlexGroup alignItems="baseline" justifyContent="spaceBetween" gutterSize="s">
-          <EuiFlexItem>
-            <SectionHeading
-              title={i18n.AGENT_CAPABILITIES_TITLE}
-              subtitle={i18n.agentCapabilitiesSubtitle(callablesOn, watch.callables.length)}
+        <SectionHeading title={i18n.SCOPE_ROUTING_TITLE} subtitle={i18n.SCOPE_ROUTING_SUBTITLE} />
+        <EuiPanel hasBorder paddingSize="m">
+          <EuiFormRow label={i18n.ALLOWED_DATA_SOURCES} fullWidth>
+            <EuiSelect
+              options={DATA_SOURCE_OPTIONS}
+              value={DATA_SOURCE_OPTIONS[0].value}
+              onChange={() => stubToast()}
+              compressed
+              fullWidth
             />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty size="s" iconType="plusInCircle" onClick={stubToast}>
-              {i18n.ADD_CAPABILITY}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <AgentCapabilitiesList callables={watch.callables} onToggle={onToggleCallable} />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiFormRow label={i18n.DEFAULT_ASSIGNEE_QUEUE} fullWidth>
+            <EuiSelect
+              options={ASSIGNEE_OPTIONS}
+              value={ASSIGNEE_OPTIONS[0].value}
+              onChange={() => stubToast()}
+              compressed
+              fullWidth
+            />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiFormRow label={i18n.ESCALATION_CONTACT} fullWidth>
+            <EuiSelect
+              options={ESCALATION_OPTIONS}
+              value={ESCALATION_OPTIONS[0].value}
+              onChange={() => stubToast()}
+              compressed
+              fullWidth
+            />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiText size="xs" color="subdued">
+            <p>{i18n.DATA_BOUNDARIES_TITLE}</p>
+          </EuiText>
+          <EuiSpacer size="xs" />
+          <EuiFlexGroup gutterSize="s" wrap responsive={false}>
+            {watch.scopes.map((scope) => (
+              <EuiFlexItem grow={false} key={scope.name}>
+                <EuiBadge
+                  color="hollow"
+                  css={css`
+                    border-left: 3px solid ${SCOPE_COLOR[scope.access] ?? euiTheme.colors.lightShade};
+                  `}
+                >
+                  {scope.name}
+                </EuiBadge>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        </EuiPanel>
 
         <EuiSpacer size="l" />
 
-        {/* Data boundaries */}
-        <SectionHeading title={i18n.DATA_BOUNDARIES_TITLE} />
-        <EuiFlexGroup gutterSize="s" wrap responsive={false}>
-          {watch.scopes.map((scope) => (
-            <EuiFlexItem grow={false} key={scope.name}>
-              <EuiBadge
-                color="hollow"
-                css={css`
-                  border-left: 3px solid ${SCOPE_COLOR[scope.access] ?? euiTheme.colors.lightShade};
-                `}
-              >
-                {scope.name} — {scope.label}
-              </EuiBadge>
-            </EuiFlexItem>
-          ))}
-        </EuiFlexGroup>
+        <SectionHeading title={i18n.WORKERS_SECTION_TITLE} subtitle={i18n.WORKERS_SECTION_SUBTITLE} />
+        {workers.length === 0 ? (
+          <EuiText size="s" color="subdued">
+            <p>{i18n.WORKERS_EMPTY}</p>
+          </EuiText>
+        ) : (
+          <AgentCapabilitiesList
+            callables={workers}
+            onToggle={onToggleCallable}
+            showKindBadge={false}
+          />
+        )}
 
         <EuiSpacer size="l" />
 
-        {/* Recent runs */}
-        <EuiFlexGroup alignItems="baseline" justifyContent="spaceBetween" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <SectionHeading title={i18n.RECENT_RUNS_TITLE} />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty size="s" onClick={stubToast}>
-              {i18n.VIEW_ALL_RUNS}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <SectionHeading title={i18n.SKILLS_SECTION_TITLE} subtitle={i18n.SKILLS_SECTION_SUBTITLE} />
+        <EuiCallOut
+          title={i18n.SKILL_DEPENDENCIES_TITLE}
+          color="warning"
+          iconType="warning"
+          size="s"
+        >
+          <p>{i18n.SKILL_DEPENDENCIES_BODY}</p>
+        </EuiCallOut>
+        <EuiSpacer size="s" />
+        {skills.length === 0 ? (
+          <EuiText size="s" color="subdued">
+            <p>{i18n.SKILLS_EMPTY}</p>
+          </EuiText>
+        ) : (
+          <AgentCapabilitiesList
+            callables={skills}
+            onToggle={onToggleCallable}
+            showKindBadge={false}
+          />
+        )}
+
+        <EuiSpacer size="l" />
+
+        <SectionHeading
+          title={i18n.APPROVAL_GATES_TITLE}
+          subtitle={i18n.APPROVAL_GATES_SUBTITLE}
+        />
+        <EuiPanel hasBorder paddingSize="m">
+          <EuiBasicTable
+            items={APPROVAL_GATE_ROWS}
+            columns={approvalColumns}
+            tableCaption={i18n.APPROVAL_GATES_TITLE}
+          />
+          <EuiSpacer size="s" />
+          <EuiCallOut color="primary" iconType="iInCircle" size="s" title={i18n.APPROVAL_AUDIT_NOTE} />
+        </EuiPanel>
+
+        <EuiSpacer size="l" />
+
+        <SectionHeading title={i18n.RECENT_RUNS_TITLE} subtitle={i18n.RECENT_RUNS_SUBTITLE} />
         <EuiPanel hasBorder paddingSize="m">
           <RecentRunsTable runs={watch.recentRuns} />
         </EuiPanel>

--- a/x-pack/solutions/security/plugins/pnd/server/plugin.test.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/plugin.test.ts
@@ -100,7 +100,7 @@ describe('PndPlugin feature-flag gating', () => {
       expect(registerRoutes).toHaveBeenCalled();
     });
 
-    it('installs managed watch workflows during start', () => {
+    it('skips managed watch install during start (POC pre-built catalogue)', () => {
       const plugin = new PndPlugin(createContext(createConfig({ enabled: true })));
       const coreStart = coreMock.createStart();
       const workflowsExtensions = { initManagedWorkflowsClient: jest.fn() };
@@ -110,12 +110,8 @@ describe('PndPlugin feature-flag gating', () => {
         workflowsExtensions,
       } as never);
 
-      expect(installStatic).toHaveBeenCalledWith(
-        expect.objectContaining({
-          enabled: true,
-          workflowsExtensions,
-        })
-      );
+      // POC watch-settings-e2e-mvp: installStatic intentionally skipped.
+      expect(installStatic).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/pnd/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/plugin.ts
@@ -15,7 +15,12 @@ import {
   type PluginInitializerContext,
 } from '@kbn/core/server';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
-import { PND_API_PRIVILEGE_READ, PND_FEATURE_ID, PND_PLUGIN_NAME } from '../common/constants';
+import {
+  PND_API_PRIVILEGE_READ,
+  PND_API_PRIVILEGE_WRITE,
+  PND_FEATURE_ID,
+  PND_PLUGIN_NAME,
+} from '../common/constants';
 import type { PndConfig } from './config';
 import type {
   PndPluginSetup,
@@ -25,7 +30,6 @@ import type {
 } from './types';
 import { registerRoutes } from './routes/register_routes';
 import { registerOwner } from './managed_workflows/register_owner';
-import { installStatic } from './managed_workflows/install_static';
 import type { WatchWorkflowProjectionService } from './services/watches/watch_workflow_projection_service';
 import { WatchWorkflowProjectionService as WatchWorkflowProjectionServiceImpl } from './services/watches/watch_workflow_projection_service';
 import { WatchWorkflowsManagementClientImpl } from './services/watches/watch_workflows_management_client';
@@ -68,7 +72,7 @@ export class PndPlugin
       privileges: {
         all: {
           app: ['kibana', PND_FEATURE_ID],
-          api: [PND_API_PRIVILEGE_READ],
+          api: [PND_API_PRIVILEGE_READ, PND_API_PRIVILEGE_WRITE],
           savedObject: { all: [], read: [] },
           ui: ['show'],
         },
@@ -101,17 +105,13 @@ export class PndPlugin
       return {};
     }
 
-    const installationReady = installStatic({
-      enabled: this.config.enabled,
-      workflowsExtensions: plugins.workflowsExtensions,
-      logger: this.logger,
-    }).catch((error) => {
-      this.logger.error(
-        `PND managed watch installation failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-    });
+    // POC (watch-settings-e2e-mvp): skip managed installStatic so the
+    // pre-built / user-owned catalogue is the only set. Leftover managed
+    // docs are also filtered out of list/get. Re-enable for production.
+    this.logger.info(
+      'POC: skipping PND managed watch installStatic — using first-visit pre-built seed'
+    );
+    const installationReady = Promise.resolve();
 
     if (!this.config.ui.useMockData && this.workflowsManagementApi != null) {
       const managementClient = new WatchWorkflowsManagementClientImpl(this.workflowsManagementApi);

--- a/x-pack/solutions/security/plugins/pnd/server/routes/register_routes.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/routes/register_routes.ts
@@ -11,6 +11,8 @@ import type { PndSpaceIdResolver } from '../types';
 import type { WatchWorkflowProjectionService } from '../services/watches/watch_workflow_projection_service';
 import { registerListWatchesRoute } from './watches/list_watches';
 import { registerGetWatchRoute } from './watches/get_watch';
+import { registerUpdateWatchRoute } from './watches/update_watch';
+import { registerApplyWatchUpdateRoute } from './watches/apply_watch_update';
 import { registerListInvestigationsRoute } from './investigations/list_investigations';
 import { registerGetInvestigationRoute } from './investigations/get_investigation';
 import { registerListInvestigationProposalsRoute } from './investigations/list_proposals';
@@ -26,6 +28,8 @@ export interface RouteDependencies {
 export const registerRoutes = (deps: RouteDependencies): void => {
   registerListWatchesRoute(deps);
   registerGetWatchRoute(deps);
+  registerUpdateWatchRoute(deps);
+  registerApplyWatchUpdateRoute(deps);
   registerListInvestigationsRoute(deps);
   registerGetInvestigationRoute(deps);
   registerListInvestigationProposalsRoute(deps);

--- a/x-pack/solutions/security/plugins/pnd/server/routes/watches/apply_watch_update.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/routes/watches/apply_watch_update.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import {
+  API_VERSIONS,
+  INTERNAL_API_ACCESS,
+  PND_WATCHES_URL,
+} from '@kbn/pnd-common';
+import type { RouteDependencies } from '../register_routes';
+import { getWatchWritePrivileges } from './watch_route_security';
+
+/**
+ * POC: take a shipped catalogue update for a pre-built watch.
+ * Re-applies customer settings; conflicts when the definition body was edited.
+ */
+export const registerApplyWatchUpdateRoute = ({
+  router,
+  logger,
+  config,
+  getSpaceId,
+  getWatchProjection,
+}: RouteDependencies) => {
+  router.versioned
+    .post({
+      path: `${PND_WATCHES_URL}/{watchId}/apply_update`,
+      access: INTERNAL_API_ACCESS,
+      security: {
+        authz: {
+          requiredPrivileges: getWatchWritePrivileges(config.ui.useMockData),
+        },
+      },
+      summary: 'POC: apply shipped catalogue update to a pre-built watch',
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v1,
+        validate: {
+          request: {
+            params: schema.object({
+              watchId: schema.string({ minLength: 1, maxLength: 128 }),
+            }),
+            body: schema.object({
+              force: schema.maybe(schema.boolean()),
+            }),
+          },
+        },
+      },
+      async (_context, request, response) => {
+        try {
+          if (config.ui.useMockData) {
+            return response.customError({
+              statusCode: 501,
+              body: { message: 'Catalogue updates require useMockData: false' },
+            });
+          }
+
+          const projection = getWatchProjection?.();
+          if (!projection) {
+            return response.customError({
+              statusCode: 503,
+              body: { message: 'Watch projection is not available' },
+            });
+          }
+
+          const { watchId } = request.params;
+          const { result, watch } = await projection.applyUpdate(
+            request,
+            watchId,
+            getSpaceId(request),
+            request.body.force
+          );
+
+          if (result.conflict && !result.updated) {
+            return response.customError({
+              statusCode: 409,
+              body: {
+                message: result.conflictReason ?? 'Definition conflict',
+                attributes: result,
+              },
+            });
+          }
+
+          return response.ok({
+            body: {
+              ...result,
+              watch,
+            },
+          });
+        } catch (error) {
+          const statusCode =
+            typeof error === 'object' && error != null && 'statusCode' in error
+              ? Number((error as { statusCode?: number }).statusCode)
+              : undefined;
+          if (statusCode === 404) {
+            return response.notFound({
+              body: { message: error instanceof Error ? error.message : 'Watch not found' },
+            });
+          }
+          if (statusCode === 400) {
+            return response.badRequest({
+              body: { message: error instanceof Error ? error.message : 'Bad request' },
+            });
+          }
+          logger.error(`Failed to apply watch update: ${error}`);
+          return response.customError({
+            statusCode: 500,
+            body: { message: 'Failed to apply watch update' },
+          });
+        }
+      }
+    );
+};

--- a/x-pack/solutions/security/plugins/pnd/server/routes/watches/list_watches.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/routes/watches/list_watches.ts
@@ -48,7 +48,7 @@ export const registerListWatchesRoute = ({
             return response.ok({ body: { watches: [] } });
           }
 
-          const body: ListWatchesResponse = await projection.list(getSpaceId(request));
+          const body: ListWatchesResponse = await projection.list(request, getSpaceId(request));
           return response.ok({ body });
         } catch (error) {
           logger.error(`Failed to list watches: ${error}`);

--- a/x-pack/solutions/security/plugins/pnd/server/routes/watches/update_watch.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/routes/watches/update_watch.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { API_VERSIONS, INTERNAL_API_ACCESS, PND_WATCH_URL_TEMPLATE } from '@kbn/pnd-common';
+import type { RouteDependencies } from '../register_routes';
+import { getWatchWritePrivileges } from './watch_route_security';
+
+/**
+ * POC: PATCH watch settings onto the user-owned workflow document.
+ * Writable: enabled, description, autonomyLevel (1–5), scheduleInterval.
+ */
+export const registerUpdateWatchRoute = ({
+  router,
+  logger,
+  config,
+  getSpaceId,
+  getWatchProjection,
+}: RouteDependencies) => {
+  router.versioned
+    .patch({
+      path: PND_WATCH_URL_TEMPLATE,
+      access: INTERNAL_API_ACCESS,
+      security: {
+        authz: {
+          requiredPrivileges: getWatchWritePrivileges(config.ui.useMockData),
+        },
+      },
+      summary: 'POC: update PND watch settings',
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v1,
+        validate: {
+          request: {
+            params: schema.object({
+              watchId: schema.string({ minLength: 1, maxLength: 128 }),
+            }),
+            body: schema.object({
+              enabled: schema.maybe(schema.boolean()),
+              description: schema.maybe(schema.string({ maxLength: 4000 })),
+              autonomyLevel: schema.maybe(schema.number({ min: 1, max: 5 })),
+              scheduleInterval: schema.maybe(
+                schema.string({
+                  minLength: 2,
+                  maxLength: 16,
+                  validate: (v) =>
+                    /^\d+(m|h|d)$/.test(v) ? undefined : 'must look like 15m, 1h, or 1d',
+                })
+              ),
+            }),
+          },
+        },
+      },
+      async (_context, request, response) => {
+        try {
+          if (config.ui.useMockData) {
+            return response.customError({
+              statusCode: 501,
+              body: { message: 'Watch settings writes require useMockData: false' },
+            });
+          }
+
+          const projection = getWatchProjection?.();
+          if (!projection) {
+            return response.customError({
+              statusCode: 503,
+              body: { message: 'Watch projection is not available' },
+            });
+          }
+
+          const { watchId } = request.params;
+          const body = await projection.updateSettings(
+            request,
+            watchId,
+            getSpaceId(request),
+            request.body
+          );
+          return response.ok({ body });
+        } catch (error) {
+          const statusCode =
+            typeof error === 'object' && error != null && 'statusCode' in error
+              ? Number((error as { statusCode?: number }).statusCode)
+              : undefined;
+          if (statusCode === 404) {
+            return response.notFound({
+              body: { message: error instanceof Error ? error.message : 'Watch not found' },
+            });
+          }
+          if (statusCode === 403) {
+            return response.forbidden({
+              body: { message: error instanceof Error ? error.message : 'Forbidden' },
+            });
+          }
+          logger.error(`Failed to update watch: ${error}`);
+          return response.customError({
+            statusCode: 500,
+            body: { message: 'Failed to update watch' },
+          });
+        }
+      }
+    );
+};

--- a/x-pack/solutions/security/plugins/pnd/server/routes/watches/watch_route_security.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/routes/watches/watch_route_security.ts
@@ -6,7 +6,7 @@
  */
 
 import { WorkflowsManagementApiActions } from '@kbn/workflows';
-import { PND_API_PRIVILEGE_READ } from '../../../common/constants';
+import { PND_API_PRIVILEGE_READ, PND_API_PRIVILEGE_WRITE } from '../../../common/constants';
 
 /**
  * Live watch routes project managed Workflows. Require the same privilege pair
@@ -25,3 +25,14 @@ export const getLiveWatchReadPrivileges = () => [
 
 export const getWatchRoutePrivileges = (useMockData: boolean) =>
   useMockData ? [PND_API_PRIVILEGE_READ] : getLiveWatchReadPrivileges();
+
+/** POC: settings write + catalogue apply_update. */
+export const getLiveWatchWritePrivileges = () => [
+  PND_API_PRIVILEGE_WRITE,
+  WorkflowsManagementApiActions.create,
+  WorkflowsManagementApiActions.update,
+  WorkflowsManagementApiActions.read,
+];
+
+export const getWatchWritePrivileges = (useMockData: boolean) =>
+  useMockData ? [PND_API_PRIVILEGE_WRITE] : getLiveWatchWritePrivileges();

--- a/x-pack/solutions/security/plugins/pnd/server/services/watches/ensure_prebuilt_watches.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/services/watches/ensure_prebuilt_watches.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import { stringifyWorkflowDefinition } from '@kbn/workflows-yaml';
+import {
+  getCatalogYaml,
+  PREBUILT_WATCH_CATALOG,
+  PREBUILT_WATCH_IDS,
+  type PrebuiltWatchId,
+} from './prebuilt_watch_catalog';
+import {
+  parseWorkflowYaml,
+  structuralFingerprint,
+} from './watch_settings_write';
+import type { WatchWorkflowsManagementClient } from './watch_workflows_management_client';
+
+/**
+ * POC: first-visit seed. Creates missing user-owned pre-built watches.
+ * Known gaps (do not "fix"): soft-delete tombstones block re-seed (409);
+ * workflow ids are globally unique across spaces.
+ */
+export const ensurePrebuiltWatches = async ({
+  management,
+  spaceId,
+  request,
+  logger,
+}: {
+  management: WatchWorkflowsManagementClient;
+  spaceId: string;
+  request: KibanaRequest;
+  logger: Logger;
+}): Promise<{ created: PrebuiltWatchId[]; existed: PrebuiltWatchId[]; failed: PrebuiltWatchId[] }> => {
+  const created: PrebuiltWatchId[] = [];
+  const existed: PrebuiltWatchId[] = [];
+  const failed: PrebuiltWatchId[] = [];
+
+  for (const id of PREBUILT_WATCH_IDS) {
+    const existing = await management.getWorkflow(id, spaceId);
+    if (existing) {
+      // Migrate legacy POC structuralHash (raw JSON) to short sha256 hex.
+      const prov = existing.definition?.consts?.watch_provenance as
+        | Record<string, unknown>
+        | undefined;
+      const hash = typeof prov?.structuralHash === 'string' ? prov.structuralHash : '';
+      if (hash && !/^[a-f0-9]{64}$/.test(hash) && existing.yaml) {
+        try {
+          const def = parseWorkflowYaml(existing.yaml);
+          def.consts = {
+            ...def.consts,
+            watch_provenance: {
+              originSeedId: id,
+              seedContentVersion:
+                typeof prov?.seedContentVersion === 'number' ? prov.seedContentVersion : 1,
+              structuralHash: structuralFingerprint(def),
+            },
+          };
+          await management.updateWorkflow(
+            id,
+            {
+              yaml: stringifyWorkflowDefinition(def as unknown as Record<string, unknown>),
+              enabled: existing.enabled,
+            },
+            spaceId,
+            request
+          );
+          logger.info(`POC re-stamped structuralHash for ${id}`);
+        } catch (error) {
+          logger.warn(
+            `POC structuralHash re-stamp failed for ${id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+      existed.push(id);
+      continue;
+    }
+
+    const entry = PREBUILT_WATCH_CATALOG[id];
+    // Stamp structuralHash against the YAML we are about to create so later
+    // apply_update can detect definition-body edits without false conflicts
+    // from engine YAML rewrite on create.
+    const def = parseWorkflowYaml(getCatalogYaml(id, entry.version));
+    def.consts = {
+      ...def.consts,
+      watch_provenance: {
+        ...(typeof def.consts?.watch_provenance === 'object' && def.consts.watch_provenance
+          ? (def.consts.watch_provenance as Record<string, unknown>)
+          : {}),
+        originSeedId: id,
+        seedContentVersion: entry.version,
+        structuralHash: structuralFingerprint(def),
+      },
+    };
+    const yaml = stringifyWorkflowDefinition(def as unknown as Record<string, unknown>);
+
+    try {
+      const createdWorkflow = await management.createWorkflow({ id, yaml }, spaceId, request);
+      // Create path has been observed to return enabled:false despite YAML enabled:true.
+      if (createdWorkflow.enabled !== true) {
+        await management.updateWorkflow(id, { enabled: true }, spaceId, request);
+      }
+
+      // Re-stamp structuralHash from the persisted definition (post-engine normalize).
+      const persisted = await management.getWorkflow(id, spaceId);
+      if (persisted?.definition) {
+        const persistedYaml =
+          persisted.yaml ??
+          stringifyWorkflowDefinition(persisted.definition as unknown as Record<string, unknown>);
+        const persistedDef = parseWorkflowYaml(persistedYaml);
+        const hash = structuralFingerprint(persistedDef);
+        persistedDef.consts = {
+          ...persistedDef.consts,
+          watch_provenance: {
+            originSeedId: id,
+            seedContentVersion: entry.version,
+            structuralHash: hash,
+          },
+        };
+        await management.updateWorkflow(
+          id,
+          {
+            yaml: stringifyWorkflowDefinition(
+              persistedDef as unknown as Record<string, unknown>
+            ),
+            enabled: true,
+          },
+          spaceId,
+          request
+        );
+      }
+
+      created.push(id);
+      logger.info(`POC pre-built watch seeded: ${id} v${entry.version}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Conflict usually means soft-deleted tombstone still owns the id.
+      if (/already exists|conflict|409/i.test(message)) {
+        logger.warn(
+          `POC pre-built watch "${id}" could not be seeded (likely soft-deleted tombstone): ${message}`
+        );
+        existed.push(id);
+      } else {
+        logger.error(`POC pre-built watch seed failed for "${id}": ${message}`);
+        failed.push(id);
+      }
+    }
+  }
+
+  return { created, existed, failed };
+};

--- a/x-pack/solutions/security/plugins/pnd/server/services/watches/prebuilt_watch_catalog.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/services/watches/prebuilt_watch_catalog.ts
@@ -1,0 +1,330 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * POC (watch-settings-e2e-mvp): shipped pre-built watch catalogue.
+ * Experimental — not production. Versions bump here to simulate Elastic shipping an update.
+ */
+
+export const PREBUILT_WATCH_IDS = [
+  'security-watch-floor',
+  'security-watch-officer',
+  'security-watch-dark',
+  'security-watch-deep',
+] as const;
+
+export type PrebuiltWatchId = (typeof PREBUILT_WATCH_IDS)[number];
+
+export interface PrebuiltWatchCatalogEntry {
+  id: PrebuiltWatchId;
+  /** Bump to simulate Elastic shipping an improved definition. */
+  version: number;
+  buildYaml: (version: number) => string;
+}
+
+const provenanceBlock = (id: PrebuiltWatchId, version: number): string => `  watch_provenance:
+    originSeedId: ${id}
+    seedContentVersion: ${version}
+    # POC: customer-editable document — provenance is best-effort, not a sealed stamp
+`;
+
+const floorYaml = (version: number): string => `version: "1"
+name: Watch Floor
+description: >
+  Tier-1 Security Watch Floor. Triages alerts via the alert-analysis skill.
+  ${version > 1 ? 'POC ship v' + version + ': improved triage prompt.' : 'Full Alert Analysis managed-workflow wrap is the next Floor spike.'}
+enabled: true
+tags:
+  - watch
+  - watch-floor
+triggers:
+  - type: alert
+  - type: manual
+consts:
+${provenanceBlock('security-watch-floor', version)}  watch_policy:
+    mandate: Frontline triage
+    autonomyLevel: 3
+    handoff: officer
+    onDemand: false
+    draft: false
+    cadence: stream
+    mode: always
+    ui:
+      color: "#16b3a6"
+      icon: alert
+      order: 10
+    scopeSummary: Security indices · APM · logs
+    scopes:
+      - name: Security indices
+        access: full
+        label: Read
+      - name: APM · logs · SLOs
+        access: full
+        label: Read
+      - name: Finance PII
+        access: masked
+        label: Masked
+    callables:
+      - id: alert-analysis
+        name: Alert analysis
+        kind: skill
+        summary: On alert · classifies FP / TP / inconclusive
+        gated: false
+        enabled: true
+steps:
+  - name: triage_alerts
+    type: ai.agent
+    timeout: "10m"
+    create-conversation: true
+    with:
+      message: >
+        Use the [/alert-analysis](skill://alert-analysis) skill to triage the
+        security alert context below.${
+          version > 1
+            ? ' Prefer precision over recall when evidence is thin. POC_SHIP_MARKER_V' +
+              version +
+              '.'
+            : ' Prefer recall over precision when unsure.'
+        }
+        Return a structured classification.
+
+        Alert / event context:
+        {{ event | json }}
+      schema:
+        type: object
+        properties:
+          classification:
+            type: string
+            enum:
+              - false_positive
+              - true_positive
+              - inconclusive
+          confidence_score:
+            type: number
+            minimum: 0
+            maximum: 1
+          rationale:
+            type: string
+        required:
+          - classification
+          - confidence_score
+          - rationale
+  - name: record_reasoning
+    type: data.set
+    with:
+      reasoning:
+        summary: >-
+          {{ steps.triage_alerts.output.structured_output.rationale
+          | default: "Watch Floor triage completed." }}
+        sections:
+          - title: Classification
+            body: >-
+              {{ steps.triage_alerts.output.structured_output.classification
+              | default: "inconclusive" }}
+`;
+
+const officerYaml = (version: number): string => `version: "1"
+name: Watch Officer
+description: >
+  Tier-2 Security Watch Officer. Escalates criticals, drafts briefs,
+  and stages gated response proposals.${
+    version > 1 ? ' POC ship v' + version + ': adds a scheduled sweep.' : ''
+  }
+enabled: true
+tags:
+  - watch
+  - watch-officer
+triggers:
+  - type: scheduled
+    with:
+      every: "1h"
+  - type: manual
+consts:
+${provenanceBlock('security-watch-officer', version)}  watch_policy:
+    mandate: Escalation & briefs
+    autonomyLevel: 4
+    handoff: oncall
+    onDemand: false
+    draft: false
+    cadence: sweep
+    every: 60
+    mode: always
+    ui:
+      color: "#3b82f6"
+      icon: bell
+      order: 20
+    scopeSummary: Open threads · on-call · deploys
+    scopes:
+      - name: Open threads · cases
+        access: full
+        label: Read
+      - name: On-call schedule
+        access: full
+        label: Read
+      - name: Deploy history
+        access: full
+        label: Read
+    callables: []
+steps:
+  - name: draft_proposal
+    type: data.set
+    with:
+      reasoning:
+        summary: "Watch Officer${
+          version > 1 ? ' v' + version : ''
+        } — staged a gated proposal for review."
+        sections:
+          - title: NEXT
+            body: "Replace with investigation / proposal skills and real evidence."
+  - name: await_approval
+    type: waitForInput
+    with:
+      message: "Approve the Watch Officer draft proposal?"
+      schema:
+        type: object
+        properties:
+          decision:
+            type: string
+            enum: [approve, modify, dismiss]
+        required: [decision]
+`;
+
+const darkYaml = (version: number): string => `version: "1"
+name: Dark Watch
+description: >
+  Dark Watch. Continuous, technology-aware hunting with scheduled sweeps
+  and reviewable findings.${version > 1 ? ' POC ship v' + version + ': tighter hunt stub.' : ''}
+enabled: true
+tags:
+  - watch
+  - watch-dark
+triggers:
+  - type: scheduled
+    with:
+      every: "1h"
+  - type: manual
+consts:
+${provenanceBlock('security-watch-dark', version)}  watch_policy:
+    mandate: Continuous, technology-aware hunting for relevant threats and coverage gaps
+    autonomyLevel: 2
+    handoff: brief
+    onDemand: true
+    draft: false
+    cadence: sweep
+    every: 60
+    from: 22
+    to: 6
+    mode: window
+    ui:
+      color: "#f59e0b"
+      icon: bolt
+      order: 30
+    scopeSummary: Mail · IdP · edge / VPN
+    scopes:
+      - name: Mail · IdP
+        access: full
+        label: Read + monitor
+      - name: Edge / VPN
+        access: full
+        label: Read + monitor
+      - name: Customer data
+        access: denied
+        label: No access
+    callables: []
+steps:
+  - name: hunt_stub
+    type: console
+    with:
+      message: "Dark Watch${
+        version > 1 ? ' v' + version + ' POC_SHIP_MARKER' : ''
+      } skeleton — add ai.agent / skill steps (see Floor)"
+`;
+
+const deepYaml = (version: number): string => `version: "1"
+name: Deep Watch
+description: >
+  Deep Watch. Specialist, on-demand depth — forensics,
+  hunts, and draft-only conclusions under human review.${
+    version > 1 ? ' POC ship v' + version + '.' : ''
+  }
+enabled: true
+tags:
+  - watch
+  - watch-deep
+triggers:
+  - type: manual
+consts:
+${provenanceBlock('security-watch-deep', version)}  watch_policy:
+    mandate: Deep investigation & hunts
+    autonomyLevel: 3
+    handoff: records
+    onDemand: true
+    draft: false
+    cadence: manual
+    from: 8
+    to: 18
+    mode: window
+    ui:
+      color: "#8b5cf6"
+      icon: console
+      order: 40
+    scopeSummary: Security indices · EDR · DNS
+    scopes:
+      - name: Security indices
+        access: full
+        label: Read
+      - name: EDR telemetry
+        access: full
+        label: Read
+      - name: DNS · netflow
+        access: full
+        label: Read
+    callables: []
+steps:
+  - name: specialist_stub
+    type: console
+    with:
+      message: "Deep Watch${
+        version > 1 ? ' v' + version : ''
+      } skeleton — add ai.agent / skill steps (see Floor)"
+`;
+
+/**
+ * Shipped catalogue versions. Bump a single entry to simulate Elastic shipping
+ * an update; restart Kibana (or hot-reload) then take the update from the UI.
+ */
+export const PREBUILT_WATCH_CATALOG: Record<PrebuiltWatchId, PrebuiltWatchCatalogEntry> = {
+  'security-watch-floor': {
+    id: 'security-watch-floor',
+    // Bumped for ship-an-update / conflict probes (seeded at 1; settings-survive at 2).
+    version: 3,
+    buildYaml: floorYaml,
+  },
+  'security-watch-officer': {
+    id: 'security-watch-officer',
+    version: 1,
+    buildYaml: officerYaml,
+  },
+  'security-watch-dark': {
+    id: 'security-watch-dark',
+    version: 1,
+    buildYaml: darkYaml,
+  },
+  'security-watch-deep': {
+    id: 'security-watch-deep',
+    version: 1,
+    buildYaml: deepYaml,
+  },
+};
+
+export const isPrebuiltWatchId = (id: string): id is PrebuiltWatchId =>
+  (PREBUILT_WATCH_IDS as readonly string[]).includes(id);
+
+export const getCatalogYaml = (id: PrebuiltWatchId, version?: number): string => {
+  const entry = PREBUILT_WATCH_CATALOG[id];
+  return entry.buildYaml(version ?? entry.version);
+};

--- a/x-pack/solutions/security/plugins/pnd/server/services/watches/watch_errors.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/services/watches/watch_errors.ts
@@ -9,7 +9,7 @@ export const isWatchNotFoundError = (error: unknown): error is Error =>
   error instanceof Error && error.name === 'WatchNotFoundError';
 
 export const createWatchNotFoundError = (watchId: string): Error => {
-  const error = new Error(`Watch "${watchId}" not found`);
+  const error = Object.assign(new Error(`Watch "${watchId}" not found`), { statusCode: 404 });
   error.name = 'WatchNotFoundError';
   return error;
 };

--- a/x-pack/solutions/security/plugins/pnd/server/services/watches/watch_settings_write.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/services/watches/watch_settings_write.ts
@@ -1,0 +1,344 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * POC (watch-settings-e2e-mvp): one-store settings write path.
+ * Settings live on the user-owned workflow document only — no overlay SO.
+ */
+
+import { createHash } from 'crypto';
+import type { KibanaRequest } from '@kbn/core/server';
+import type { WorkflowDetailDto, WorkflowYaml } from '@kbn/workflows';
+import {
+  parseYamlToJSONWithoutValidation,
+  stringifyWorkflowDefinition,
+} from '@kbn/workflows-yaml';
+import {
+  getCatalogYaml,
+  isPrebuiltWatchId,
+  PREBUILT_WATCH_CATALOG,
+} from './prebuilt_watch_catalog';
+import { createWatchNotFoundError } from './watch_errors';
+import type { WatchWorkflowsManagementClient } from './watch_workflows_management_client';
+
+export interface WatchSettingsPatch {
+  enabled?: boolean;
+  description?: string;
+  /** Stored 1–5; UI maps three levels onto these values. */
+  autonomyLevel?: number;
+  /** Scheduled trigger interval, e.g. "15m" / "1h". */
+  scheduleInterval?: string;
+}
+
+export interface WatchProvenance {
+  originSeedId?: string;
+  seedContentVersion?: number;
+  /** Fingerprint of steps + trigger types at last seed/catalogue apply. */
+  structuralHash?: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const extractProvenance = (
+  definition: WorkflowYaml | null | undefined
+): WatchProvenance | undefined => {
+  const raw = definition?.consts?.watch_provenance;
+  if (!isRecord(raw)) return undefined;
+  return {
+    originSeedId: typeof raw.originSeedId === 'string' ? raw.originSeedId : undefined,
+    seedContentVersion:
+      typeof raw.seedContentVersion === 'number' ? raw.seedContentVersion : undefined,
+    structuralHash: typeof raw.structuralHash === 'string' ? raw.structuralHash : undefined,
+  };
+};
+
+/**
+ * Structural fingerprint — sha256 of steps + trigger types.
+ * Must stay a short hex string: embedding raw JSON into YAML consts breaks parsing
+ * (Floor went valid:false / definition:null in the first seed attempt).
+ */
+export const structuralFingerprint = (definition: WorkflowYaml | null | undefined): string => {
+  if (!definition) return '';
+  const triggers = (definition.triggers ?? []).map((t) => {
+    const rec = t as Record<string, unknown>;
+    return { type: rec.type };
+  });
+  const raw = JSON.stringify({ steps: definition.steps ?? [], triggers });
+  return createHash('sha256').update(raw).digest('hex');
+};
+
+export const parseWorkflowYaml = (yaml: string): WorkflowYaml => {
+  const parsed = parseYamlToJSONWithoutValidation(yaml);
+  if (!parsed.success || !parsed.json) {
+    throw new Error(
+      parsed.success === false
+        ? parsed.error instanceof Error
+          ? parsed.error.message
+          : String(parsed.error)
+        : 'Failed to parse workflow YAML'
+    );
+  }
+  return parsed.json as WorkflowYaml;
+};
+
+const applySettingsToDefinition = (
+  definition: WorkflowYaml,
+  patch: WatchSettingsPatch
+): WorkflowYaml => {
+  const next: WorkflowYaml = {
+    ...definition,
+    consts: { ...(definition.consts ?? {}) },
+  };
+
+  if (patch.description !== undefined) {
+    next.description = patch.description;
+  }
+
+  const policyRaw = isRecord(next.consts?.watch_policy) ? { ...next.consts!.watch_policy } : {};
+  if (patch.autonomyLevel !== undefined) {
+    policyRaw.autonomyLevel = patch.autonomyLevel;
+  }
+  next.consts = {
+    ...next.consts,
+    watch_policy: policyRaw,
+  };
+
+  if (patch.scheduleInterval !== undefined) {
+    const triggers = [...(next.triggers ?? [])];
+    const scheduledIdx = triggers.findIndex((t) => {
+      const type = (t as { type?: string }).type;
+      return type === 'scheduled' || type === 'schedule';
+    });
+    if (scheduledIdx >= 0) {
+      const existing = triggers[scheduledIdx] as Record<string, unknown>;
+      const withBlock = isRecord(existing.with) ? { ...existing.with } : {};
+      // Drop rrule when switching to simple every-interval (POC Dark seed uses every).
+      delete withBlock.rrule;
+      withBlock.every = patch.scheduleInterval;
+      triggers[scheduledIdx] = { ...existing, with: withBlock } as (typeof triggers)[number];
+      next.triggers = triggers;
+
+      const minutes = intervalToMinutes(patch.scheduleInterval);
+      if (minutes != null && isRecord(next.consts.watch_policy)) {
+        next.consts.watch_policy = { ...next.consts.watch_policy, every: minutes };
+      }
+    }
+  }
+
+  return next;
+};
+
+export const intervalToMinutes = (interval: string): number | undefined => {
+  const match = /^(\d+)(m|h|d)$/.exec(interval.trim());
+  if (!match) return undefined;
+  const n = Number(match[1]);
+  if (match[2] === 'm') return n;
+  if (match[2] === 'h') return n * 60;
+  if (match[2] === 'd') return n * 60 * 24;
+  return undefined;
+};
+
+export const extractScheduleInterval = (
+  definition: WorkflowYaml | null | undefined
+): string | undefined => {
+  for (const trigger of definition?.triggers ?? []) {
+    const type = (trigger as { type?: string }).type;
+    if (type !== 'scheduled' && type !== 'schedule') continue;
+    const withBlock = (trigger as { with?: Record<string, unknown> }).with;
+    if (withBlock && typeof withBlock.every === 'string') return withBlock.every;
+  }
+  return undefined;
+};
+
+export const updateWatchSettings = async ({
+  management,
+  watchId,
+  spaceId,
+  request,
+  patch,
+}: {
+  management: WatchWorkflowsManagementClient;
+  watchId: string;
+  spaceId: string;
+  request: KibanaRequest;
+  patch: WatchSettingsPatch;
+}): Promise<WorkflowDetailDto> => {
+  const detail = await management.getWorkflow(watchId, spaceId);
+  if (!detail) {
+    throw createWatchNotFoundError(watchId);
+  }
+  if (detail.managed === true) {
+    throw Object.assign(new Error(`Managed watch "${watchId}" cannot take settings writes`), {
+      statusCode: 403,
+    });
+  }
+
+  const enableOnly =
+    patch.enabled !== undefined &&
+    patch.description === undefined &&
+    patch.autonomyLevel === undefined &&
+    patch.scheduleInterval === undefined;
+
+  if (enableOnly) {
+    await management.updateWorkflow(watchId, { enabled: patch.enabled }, spaceId, request);
+    const refreshedEnabled = await management.getWorkflow(watchId, spaceId);
+    if (!refreshedEnabled) {
+      throw createWatchNotFoundError(watchId);
+    }
+    return refreshedEnabled;
+  }
+
+  const sourceYaml = detail.yaml ?? stringifyWorkflowDefinition(detail.definition ?? {});
+  let definition = parseWorkflowYaml(sourceYaml);
+  definition = applySettingsToDefinition(definition, patch);
+  const yaml = stringifyWorkflowDefinition(definition as unknown as Record<string, unknown>);
+
+  const update: { yaml: string; enabled?: boolean } = { yaml };
+  if (patch.enabled !== undefined) {
+    update.enabled = patch.enabled;
+  }
+
+  await management.updateWorkflow(watchId, update, spaceId, request);
+  const refreshed = await management.getWorkflow(watchId, spaceId);
+  if (!refreshed) {
+    throw createWatchNotFoundError(watchId);
+  }
+  return refreshed;
+};
+
+export interface ApplyCatalogUpdateResult {
+  updated: boolean;
+  conflict?: boolean;
+  conflictReason?: string;
+  fromVersion?: number;
+  toVersion?: number;
+}
+
+/**
+ * Install catalogue YAML at the shipped version, re-applying customer settings.
+ * Refuses (conflict) when the customer edited the definition body vs their seed version.
+ */
+export const applyCatalogUpdate = async ({
+  management,
+  watchId,
+  spaceId,
+  request,
+  force = false,
+}: {
+  management: WatchWorkflowsManagementClient;
+  watchId: string;
+  spaceId: string;
+  request: KibanaRequest;
+  force?: boolean;
+}): Promise<ApplyCatalogUpdateResult> => {
+  if (!isPrebuiltWatchId(watchId)) {
+    throw Object.assign(new Error(`Watch "${watchId}" is not a pre-built catalogue id`), {
+      statusCode: 400,
+    });
+  }
+
+  const detail = await management.getWorkflow(watchId, spaceId);
+  if (!detail) {
+    throw createWatchNotFoundError(watchId);
+  }
+  if (detail.managed === true) {
+    throw Object.assign(new Error(`Managed watch "${watchId}" cannot take catalogue updates`), {
+      statusCode: 403,
+    });
+  }
+
+  const entry = PREBUILT_WATCH_CATALOG[watchId];
+  const provenance = extractProvenance(detail.definition);
+  const fromVersion = provenance?.seedContentVersion ?? 0;
+  const toVersion = entry.version;
+
+  if (fromVersion >= toVersion) {
+    return { updated: false, fromVersion, toVersion };
+  }
+
+  const sourceYaml = detail.yaml ?? stringifyWorkflowDefinition(detail.definition ?? {});
+  const currentDef = parseWorkflowYaml(sourceYaml);
+  const currentFp = structuralFingerprint(currentDef);
+  const expectedFp = provenance?.structuralHash;
+  const conflict =
+    typeof expectedFp === 'string' && expectedFp.length > 0 && currentFp !== expectedFp;
+
+  if (conflict && !force) {
+    return {
+      updated: false,
+      conflict: true,
+      conflictReason:
+        'Customer edited the watch definition body (not just settings). Taking the update would overwrite those edits. Re-submit with force=true to overwrite, or leave as-is.',
+      fromVersion,
+      toVersion,
+    };
+  }
+
+  // Preserve customer settings from the live document.
+  const customerSettings: WatchSettingsPatch = {
+    enabled: detail.enabled,
+    description: detail.description ?? currentDef.description,
+    autonomyLevel: isRecord(currentDef.consts?.watch_policy)
+      ? (currentDef.consts!.watch_policy.autonomyLevel as number | undefined)
+      : undefined,
+    scheduleInterval: extractScheduleInterval(currentDef),
+  };
+
+  let nextDef = parseWorkflowYaml(getCatalogYaml(watchId, toVersion));
+  nextDef = applySettingsToDefinition(nextDef, {
+    description: customerSettings.description,
+    autonomyLevel: customerSettings.autonomyLevel,
+    scheduleInterval: customerSettings.scheduleInterval,
+  });
+
+  // Ensure provenance reflects the new catalogue version + new body hash.
+  nextDef.consts = {
+    ...nextDef.consts,
+    watch_provenance: {
+      originSeedId: watchId,
+      seedContentVersion: toVersion,
+      structuralHash: structuralFingerprint(nextDef),
+    },
+  };
+
+  const yaml = stringifyWorkflowDefinition(nextDef as unknown as Record<string, unknown>);
+  await management.updateWorkflow(
+    watchId,
+    { yaml, enabled: customerSettings.enabled },
+    spaceId,
+    request
+  );
+
+  // Re-stamp structuralHash from whatever the engine persisted.
+  const persisted = await management.getWorkflow(watchId, spaceId);
+  if (persisted) {
+    const persistedYaml =
+      persisted.yaml ??
+      stringifyWorkflowDefinition(persisted.definition as unknown as Record<string, unknown>);
+    const persistedDef = parseWorkflowYaml(persistedYaml);
+    persistedDef.consts = {
+      ...persistedDef.consts,
+      watch_provenance: {
+        originSeedId: watchId,
+        seedContentVersion: toVersion,
+        structuralHash: structuralFingerprint(persistedDef),
+      },
+    };
+    await management.updateWorkflow(
+      watchId,
+      {
+        yaml: stringifyWorkflowDefinition(persistedDef as unknown as Record<string, unknown>),
+        enabled: customerSettings.enabled,
+      },
+      spaceId,
+      request
+    );
+  }
+
+  return { updated: true, conflict: conflict || undefined, fromVersion, toVersion };
+};

--- a/x-pack/solutions/security/plugins/pnd/server/services/watches/watch_workflow_projection_service.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/services/watches/watch_workflow_projection_service.ts
@@ -19,6 +19,18 @@ import {
   normalizeWorkflowTriggerType,
   projectWorkflowToWatch,
 } from './project_watch';
+import { ensurePrebuiltWatches } from './ensure_prebuilt_watches';
+import {
+  isPrebuiltWatchId,
+  PREBUILT_WATCH_CATALOG,
+} from './prebuilt_watch_catalog';
+import {
+  applyCatalogUpdate,
+  extractProvenance,
+  extractScheduleInterval,
+  updateWatchSettings,
+  type WatchSettingsPatch,
+} from './watch_settings_write';
 import { createWatchDeleteForbiddenError, createWatchNotFoundError } from './watch_errors';
 import type { WatchWorkflowsManagementClient } from './watch_workflows_management_client';
 
@@ -38,9 +50,27 @@ export class WatchWorkflowProjectionService {
     return this.management;
   }
 
-  async list(spaceId: string): Promise<ListWatchesResponse> {
+  /**
+   * POC: first-visit seed of the four user-owned pre-built watches.
+   * Must run under a KibanaRequest (createWorkflow requires one).
+   */
+  async ensurePrebuilt(request: KibanaRequest, spaceId: string): Promise<void> {
+    const management = this.requireManagement();
+    await ensurePrebuiltWatches({
+      management,
+      spaceId,
+      request,
+      logger: this.logger,
+    });
+  }
+
+  async list(request: KibanaRequest, spaceId: string): Promise<ListWatchesResponse> {
     await this.installationReady;
     const management = this.requireManagement();
+
+    // POC single-catalogue: seed user-owned pre-builts on first list visit.
+    await this.ensurePrebuilt(request, spaceId);
+
     // Managed catalog watches opt into `selector:watch` visibility; custom
     // unmanaged watches still match via tag `watch` under managedFilter `all`.
     // Default getWorkflows managedFilter is 'unmanaged' — must request 'all'.
@@ -60,9 +90,14 @@ export class WatchWorkflowProjectionService {
     const watches = result.results
       .filter((item) => {
         const tags = item.tags?.length ? item.tags : item.definition?.tags ?? [];
-        return tags.includes(WATCH_TAG);
+        if (!tags.includes(WATCH_TAG)) return false;
+        // POC: hide leftover managed system-* watches so the catalogue is the
+        // four user-owned pre-builts only (installStatic is also skipped).
+        if (item.managed === true) return false;
+        if (String(item.id).startsWith('system-security-watch-')) return false;
+        return true;
       })
-      .map(projectWorkflowToWatch)
+      .map((item) => this.enrichWatchProjection(projectWorkflowToWatch(item), item.definition))
       .sort(compareWatchesForDisplay);
 
     return ListWatchesResponse.parse({ watches });
@@ -78,6 +113,10 @@ export class WatchWorkflowProjectionService {
 
     const tags = detail.definition?.tags ?? [];
     if (!tags.includes(WATCH_TAG)) {
+      return undefined;
+    }
+    // POC: managed leftovers are not part of the pre-built catalogue.
+    if (detail.managed === true || watchId.startsWith('system-security-watch-')) {
       return undefined;
     }
 
@@ -110,7 +149,10 @@ export class WatchWorkflowProjectionService {
         finishedAt: run.finishedAt,
         duration: run.duration,
       }));
-      const watch = projectWorkflowToWatch({ ...listItem, history, tags: detail.definition?.tags });
+      const watch = this.enrichWatchProjection(
+        projectWorkflowToWatch({ ...listItem, history, tags: detail.definition?.tags }),
+        detail.definition
+      );
 
       // Attach step summaries for the latest few runs
       const enrichedRuns = await Promise.all(
@@ -147,8 +189,75 @@ export class WatchWorkflowProjectionService {
           error instanceof Error ? error.message : String(error)
         }`
       );
-      return GetWatchResponse.parse({ watch: projectWorkflowToWatch(listItem) });
+      return GetWatchResponse.parse({
+        watch: this.enrichWatchProjection(projectWorkflowToWatch(listItem), detail.definition),
+      });
     }
+  }
+
+  /** POC: write settings onto the user-owned workflow document (one store). */
+  async updateSettings(
+    request: KibanaRequest,
+    watchId: string,
+    spaceId: string,
+    patch: WatchSettingsPatch
+  ): Promise<GetWatchResponse> {
+    const management = this.requireManagement();
+    await updateWatchSettings({ management, watchId, spaceId, request, patch });
+    const projected = await this.get(watchId, spaceId);
+    if (!projected) {
+      throw createWatchNotFoundError(watchId);
+    }
+    return projected;
+  }
+
+  /** POC: take a shipped catalogue update, re-applying customer settings. */
+  async applyUpdate(
+    request: KibanaRequest,
+    watchId: string,
+    spaceId: string,
+    force?: boolean
+  ): Promise<{ result: Awaited<ReturnType<typeof applyCatalogUpdate>>; watch?: GetWatchResponse }> {
+    const management = this.requireManagement();
+    const result = await applyCatalogUpdate({
+      management,
+      watchId,
+      spaceId,
+      request,
+      force,
+    });
+    if (!result.updated) {
+      return { result };
+    }
+    const watch = await this.get(watchId, spaceId);
+    return { result, watch: watch ?? undefined };
+  }
+
+  private enrichWatchProjection<T extends ReturnType<typeof projectWorkflowToWatch>>(
+    watch: T,
+    definition: Parameters<typeof extractProvenance>[0]
+  ): T & {
+    updateAvailable?: boolean;
+    seedContentVersion?: number;
+    catalogVersion?: number;
+    scheduleInterval?: string;
+  } {
+    const provenance = extractProvenance(definition);
+    const scheduleInterval = extractScheduleInterval(definition);
+    if (!isPrebuiltWatchId(watch.id)) {
+      return scheduleInterval ? { ...watch, scheduleInterval } : watch;
+    }
+    const catalogVersion = PREBUILT_WATCH_CATALOG[watch.id].version;
+    const seedContentVersion = provenance?.seedContentVersion;
+    const updateAvailable =
+      typeof seedContentVersion === 'number' && seedContentVersion < catalogVersion;
+    return {
+      ...watch,
+      updateAvailable,
+      seedContentVersion,
+      catalogVersion,
+      scheduleInterval,
+    };
   }
 
   async createCustom(

--- a/x-pack/solutions/security/plugins/pnd/server/services/watches/watch_workflows_management_client.ts
+++ b/x-pack/solutions/security/plugins/pnd/server/services/watches/watch_workflows_management_client.ts
@@ -45,10 +45,18 @@ export interface WatchWorkflowsManagementClient {
   ): Promise<WorkflowExecutionDto | null>;
 
   createWorkflow(
-    workflow: { yaml: string },
+    workflow: { yaml: string; id?: string },
     spaceId: string,
     request: KibanaRequest
   ): Promise<WorkflowDetailDto>;
+
+  /** POC: ordinary update path (yaml / enabled) for user-owned watches. */
+  updateWorkflow(
+    id: string,
+    workflow: { yaml?: string; enabled?: boolean },
+    spaceId: string,
+    request: KibanaRequest
+  ): Promise<unknown>;
 
   deleteWorkflows(
     workflowIds: string[],
@@ -103,11 +111,20 @@ export class WatchWorkflowsManagementClientImpl implements WatchWorkflowsManagem
   }
 
   createWorkflow(
-    workflow: { yaml: string },
+    workflow: { yaml: string; id?: string },
     spaceId: string,
     request: KibanaRequest
   ): Promise<WorkflowDetailDto> {
     return this.management.createWorkflow(workflow, spaceId, request);
+  }
+
+  updateWorkflow(
+    id: string,
+    workflow: { yaml?: string; enabled?: boolean },
+    spaceId: string,
+    request: KibanaRequest
+  ): Promise<unknown> {
+    return this.management.updateWorkflow(id, workflow, spaceId, request);
   }
 
   deleteWorkflows(


### PR DESCRIPTION
## Summary

Throwaway Common Worker Layer POC for pre-built watches: prove that customer watch settings stick on the workflow document, and that Elastic can still ship an improved catalogue definition without wiping those settings.

- Seeds four **user-owned** watches (`security-watch-{floor,officer,dark,deep}`) on first list visit; skips managed `installStatic` for these IDs
- Persists settings on the workflow document (`consts.watch_policy` + provenance) — enable, 3-level autonomy, schedule interval, description
- Detail page: Save settings + **Take update** when catalogue version is ahead; conflict (409) if the definition body was edited locally
- Live stack verified: settings round-trip, Officer cadence reflected in Task Manager, Floor take-update kept customer settings, body-edit conflict warned

Related pattern discussion: Nightshift mitigation POC [#278554](https://github.com/elastic/kibana/pull/278554) (metadata / product wrapper) — this PR does **not** depend on that branch.

**Not merge-ready.** Experimental probe only; no productization, no full test suite.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [x] **POC / throwaway code** — medium if merged by accident: changes PND watch install model and adds write routes. Mitigation: keep draft; do not merge; discard branch after findings are recorded.