### PR TITLE
[SigEvents] Rename agents to Nightshift Triager and Investigator

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/discovery/discovery.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/discovery/discovery.spec.ts
@@ -49,7 +49,7 @@ const TRUST_UPSTREAM = process.env.SIGEVENTS_TRUST_UPSTREAM === 'true';
 const SIGNIFICANT_EVENTS_EVENTS_DATA_STREAM = '.significant_events-events';
 
 evaluate.describe(
-  'Significant Events Discovery - Discovery Agent',
+  'Nightshift Triager - Discovery Agent',
   { tag: tags.serverless.observability.complete },
   () => {
     const activeDatasets = getActiveDatasets();

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/discovery.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/discovery.ts
@@ -16,7 +16,7 @@ export const SIGNIFICANT_EVENTS_DISCOVERY_AGENT_TYPE_ID = 'platform.sig_events.d
 
 export const discoveryAgentType = {
   id: SIGNIFICANT_EVENTS_DISCOVERY_AGENT_TYPE_ID,
-  name: 'Significant Events Discovery',
+  name: 'Nightshift Triager',
   description:
     'Correlates related detections into significant events using shared infrastructure, temporal proximity, and causal plausibility, verifies current state, and writes final event records with status, calibrated severity, and supporting evidence.',
   avatar_icon: 'logoElastic',

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/install_discovery_agents.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/install_discovery_agents.test.ts
@@ -28,10 +28,10 @@ describe('installDiscoveryAgents', () => {
       agent: {
         id: SIGNIFICANT_EVENTS_DISCOVERY_AGENT_ID,
         type: SIGNIFICANT_EVENTS_DISCOVERY_AGENT_TYPE_ID,
-        name: 'Significant Events Discovery',
+        name: 'Nightshift Triager',
         description: discoveryAgentType.description,
         labels: ['observability', 'streams', 'significant-events', 'discovery'],
-        avatar_symbol: 'SD',
+        avatar_symbol: 'NT',
         access_control: { access_mode: AgentAccessControlMode.Public },
         configuration: {
           tools: [],

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/install_discovery_agents.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/install_discovery_agents.ts
@@ -33,10 +33,10 @@ export const installDiscoveryAgents = async ({
     agent: {
       id: SIGNIFICANT_EVENTS_DISCOVERY_AGENT_ID,
       type: SIGNIFICANT_EVENTS_DISCOVERY_AGENT_TYPE_ID,
-      name: 'Significant Events Discovery',
+      name: 'Nightshift Triager',
       description: discoveryAgentType.description,
       labels: ['observability', 'streams', 'significant-events', 'discovery'],
-      avatar_symbol: 'SD',
+      avatar_symbol: 'NT',
       access_control: { access_mode: AgentAccessControlMode.Public },
       configuration: {
         tools: [],

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/index.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/agents/investigation/index.ts
@@ -26,7 +26,7 @@ export const SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_TYPE_ID =
 
 export const investigationAgentType = {
   id: SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_TYPE_ID,
-  name: 'Streams Investigator',
+  name: 'Nightshift Investigator',
   description:
     'Investigates an observability issue by querying available signals (logs, traces, metrics), ' +
     'reasoning about causality direction, and producing a contributing-factors conclusion with supporting evidence.',

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/investigation/install_investigation_agent.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/investigation/install_investigation_agent.test.ts
@@ -26,10 +26,10 @@ describe('installInvestigationAgent', () => {
       agent: {
         id: SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_ID,
         type: SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_TYPE_ID,
-        name: 'Streams Investigator',
+        name: 'Nightshift Investigator',
         description: expect.any(String),
         labels: ['observability', 'streams', 'significant-events', 'investigation', 'root-cause'],
-        avatar_symbol: 'SI',
+        avatar_symbol: 'NI',
         access_control: { access_mode: AgentAccessControlMode.Public },
         configuration: {
           tools: [],

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/investigation/install_investigation_agent.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/investigation/install_investigation_agent.ts
@@ -28,12 +28,12 @@ export const installInvestigationAgent = async ({
     agent: {
       id: SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_ID,
       type: SIGNIFICANT_EVENTS_INVESTIGATION_AGENT_TYPE_ID,
-      name: 'Streams Investigator',
+      name: 'Nightshift Investigator',
       description:
         'Investigates an observability issue by querying available signals (logs, traces, metrics), ' +
         'reasoning about causality direction, and producing a contributing-factors conclusion with supporting evidence.',
       labels: ['observability', 'streams', 'significant-events', 'investigation', 'root-cause'],
-      avatar_symbol: 'SI',
+      avatar_symbol: 'NI',
       access_control: { access_mode: AgentAccessControlMode.Public },
       configuration: {
         tools: [],


### PR DESCRIPTION
## Summary

Renames the Significant Events Agent Builder agents to match Nightshift product naming and their current roles after folding judge into discovery:

- `Significant Events Discovery` → **Nightshift Triager**
- `Streams Investigator` → **Nightshift Investigator**

Also updates avatar symbols (`SD`→`NT`, `SI`→`NI`) and the discovery eval suite title.

`agents.ensure` does not overwrite existing installed profiles, so local/dev environments that already installed these agents keep the old display names until those profiles are deleted (along with any leftover Judge agents).

## Test plan

- [ ] Confirm agent type + install unit tests for discovery/investigation still pass
- [ ] On a fresh Significant Events enablement, confirm Agent Builder lists **Nightshift Triager** and **Nightshift Investigator**
- [ ] On an environment with old profiles, delete stale agents / Judge leftovers and confirm the new names appear after reinstall