### PR TITLE
[Profiling] Chrome next fixes

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/index.tsx
@@ -60,31 +60,14 @@ export function RouteBreadcrumbsContextProvider({ children }: { children: React.
     [breadcrumbs]
   );
 
-  const formattedBreadcrumbs: ChromeBreadcrumb[] = api
-    .getBreadcrumbs(matches)
-    .map((breadcrumb, index, array) => {
-      return {
-        text: breadcrumb.title,
-        ...(index === array.length - 1
-          ? {}
-          : {
-              href: breadcrumb.href,
-            }),
-      };
-    });
-
-  // Filter out the "Universal Profiling" breadcrumb because it is included in the breadcrumbs already in case of the project navigation
-  const projectStyleBreadcrumbs = formattedBreadcrumbs.filter(
-    (breadcrumb) => String(breadcrumb?.text).toLocaleLowerCase() !== 'universal profiling'
-  );
-
-  useBreadcrumbs(projectStyleBreadcrumbs, {
-    absoluteProjectStyleBreadcrumbs: false,
-    classicOnly: false,
+  const formattedBreadcrumbs: ChromeBreadcrumb[] = api.getBreadcrumbs(matches).map((breadcrumb) => {
+    return {
+      text: breadcrumb.title,
+      href: breadcrumb.href,
+    };
   });
 
-  // Keep using breadcrumbs for the Profiling app for classic navigation
-  useBreadcrumbs(formattedBreadcrumbs, { classicOnly: true });
+  useBreadcrumbs(formattedBreadcrumbs);
 
   return (
     <RouteBreadcrumbsContext.Provider value={api}>{children}</RouteBreadcrumbsContext.Provider>

--- a/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/index.tsx
@@ -24,16 +24,6 @@ interface BreadcrumbApi {
 
 export const RouteBreadcrumbsContext = createContext<BreadcrumbApi | undefined>(undefined);
 
-/**
- * Under project navigation, these routes should keep the Chrome Next back button.
- * Breadcrumbs for them keep their hrefs.
- */
-const ROUTES_WITH_BACK_BUTTON = new Set([
-  '/settings',
-  '/add-data-instructions',
-  '/storage-explorer',
-]);
-
 export function RouteBreadcrumbsContextProvider({ children }: { children: React.ReactElement }) {
   const [, forceUpdate] = useState({});
 
@@ -42,7 +32,6 @@ export function RouteBreadcrumbsContextProvider({ children }: { children: React.
   }, []);
 
   const matches: RouteMatch[] = useMatchRoutes();
-  const currentRoute = matches[matches.length - 1]?.match.path ?? '';
 
   const api = useMemo<BreadcrumbApi>(
     () => ({
@@ -78,15 +67,7 @@ export function RouteBreadcrumbsContextProvider({ children }: { children: React.
     };
   });
 
-  const projectStyleBreadcrumbs = ROUTES_WITH_BACK_BUTTON.has(currentRoute)
-    ? formattedBreadcrumbs
-    : formattedBreadcrumbs.map((breadcrumb) => ({
-        ...breadcrumb,
-        href: undefined,
-      }));
-
-  useBreadcrumbs(projectStyleBreadcrumbs);
-  useBreadcrumbs(formattedBreadcrumbs, { classicOnly: true });
+  useBreadcrumbs(formattedBreadcrumbs);
 
   return (
     <RouteBreadcrumbsContext.Provider value={api}>{children}</RouteBreadcrumbsContext.Provider>

--- a/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/index.tsx
@@ -24,6 +24,16 @@ interface BreadcrumbApi {
 
 export const RouteBreadcrumbsContext = createContext<BreadcrumbApi | undefined>(undefined);
 
+/**
+ * Under project navigation, these routes should keep the Chrome Next back button.
+ * Breadcrumbs for them keep their hrefs.
+ */
+const ROUTES_WITH_BACK_BUTTON = new Set([
+  '/settings',
+  '/add-data-instructions',
+  '/storage-explorer',
+]);
+
 export function RouteBreadcrumbsContextProvider({ children }: { children: React.ReactElement }) {
   const [, forceUpdate] = useState({});
 
@@ -32,6 +42,7 @@ export function RouteBreadcrumbsContextProvider({ children }: { children: React.
   }, []);
 
   const matches: RouteMatch[] = useMatchRoutes();
+  const currentRoute = matches[matches.length - 1]?.match.path ?? '';
 
   const api = useMemo<BreadcrumbApi>(
     () => ({
@@ -67,7 +78,15 @@ export function RouteBreadcrumbsContextProvider({ children }: { children: React.
     };
   });
 
-  useBreadcrumbs(formattedBreadcrumbs);
+  const projectStyleBreadcrumbs = ROUTES_WITH_BACK_BUTTON.has(currentRoute)
+    ? formattedBreadcrumbs
+    : formattedBreadcrumbs.map((breadcrumb) => ({
+        ...breadcrumb,
+        href: undefined,
+      }));
+
+  useBreadcrumbs(projectStyleBreadcrumbs);
+  useBreadcrumbs(formattedBreadcrumbs, { classicOnly: true });
 
   return (
     <RouteBreadcrumbsContext.Provider value={api}>{children}</RouteBreadcrumbsContext.Provider>

--- a/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/use_route_breadcrumb.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/use_route_breadcrumb.ts
@@ -10,6 +10,10 @@ import { useContext, useEffect, useRef } from 'react';
 import type { Breadcrumb } from '.';
 import { RouteBreadcrumbsContext } from '.';
 
+/**
+ * Registers a breadcrumb for the current route. The `breadcrumb` value should be
+ * memoised to avoid unnecessary re-registrations on every render.
+ */
 export function useRouteBreadcrumb(breadcrumb: Breadcrumb) {
   const api = useContext(RouteBreadcrumbsContext);
 

--- a/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/use_route_breadcrumb.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/contexts/route_breadcrumbs_context/use_route_breadcrumb.ts
@@ -7,11 +7,10 @@
 
 import { useCurrentRoute } from '@kbn/typed-react-router-config';
 import { useContext, useEffect, useRef } from 'react';
-import { castArray } from 'lodash';
 import type { Breadcrumb } from '.';
 import { RouteBreadcrumbsContext } from '.';
 
-export function useRouteBreadcrumb(breadcrumb: Breadcrumb | Breadcrumb[]) {
+export function useRouteBreadcrumb(breadcrumb: Breadcrumb) {
   const api = useContext(RouteBreadcrumbsContext);
 
   if (!api) {
@@ -30,7 +29,7 @@ export function useRouteBreadcrumb(breadcrumb: Breadcrumb | Breadcrumb[]) {
     matchedRoute.current = match?.route;
 
     if (matchedRoute.current) {
-      api.set(matchedRoute.current, castArray(breadcrumb));
+      api.set(matchedRoute.current, [breadcrumb]);
     }
 
     return () => {
@@ -38,6 +37,5 @@ export function useRouteBreadcrumb(breadcrumb: Breadcrumb | Breadcrumb[]) {
         api.unset(matchedRoute.current);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [matchedRoute.current, match?.route]);
+  }, [match?.route, breadcrumb, api]);
 }

--- a/x-pack/solutions/observability/plugins/profiling/public/routing/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/routing/index.tsx
@@ -17,6 +17,7 @@ import {
 import { createRouter, Outlet } from '@kbn/typed-react-router-config';
 import * as t from 'io-ts';
 import React from 'react';
+import { SuppressChromeBackButton } from '@kbn/app-header';
 import {
   indexLifecyclePhaseRt,
   IndexLifecyclePhaseSelectOption,
@@ -102,16 +103,19 @@ const routes = {
         children: {
           '/stacktraces': {
             element: (
-              <RouteBreadcrumb
-                title={i18n.translate('xpack.profiling.breadcrumb.stacktraces', {
-                  defaultMessage: 'Stacktraces',
-                })}
-                href="/stacktraces"
-              >
-                <StackTracesViewWrapper>
-                  <Outlet />
-                </StackTracesViewWrapper>
-              </RouteBreadcrumb>
+              <>
+                <RouteBreadcrumb
+                  title={i18n.translate('xpack.profiling.breadcrumb.stacktraces', {
+                    defaultMessage: 'Stacktraces',
+                  })}
+                  href="/stacktraces"
+                >
+                  <StackTracesViewWrapper>
+                    <Outlet />
+                  </StackTracesViewWrapper>
+                </RouteBreadcrumb>
+                <SuppressChromeBackButton />
+              </>
             ),
             children: {
               '/stacktraces/{topNType}': {
@@ -146,16 +150,19 @@ const routes = {
           },
           '/flamegraphs': {
             element: (
-              <RouteBreadcrumb
-                title={i18n.translate('xpack.profiling.breadcrumb.flamegraphs', {
-                  defaultMessage: 'Flamegraphs',
-                })}
-                href="/flamegraphs"
-              >
-                <FlameGraphsView>
-                  <Outlet />
-                </FlameGraphsView>
-              </RouteBreadcrumb>
+              <>
+                <RouteBreadcrumb
+                  title={i18n.translate('xpack.profiling.breadcrumb.flamegraphs', {
+                    defaultMessage: 'Flamegraphs',
+                  })}
+                  href="/flamegraphs"
+                >
+                  <FlameGraphsView>
+                    <Outlet />
+                  </FlameGraphsView>
+                </RouteBreadcrumb>
+                <SuppressChromeBackButton />
+              </>
             ),
             children: {
               '/flamegraphs/flamegraph': {
@@ -222,16 +229,19 @@ const routes = {
           },
           '/functions': {
             element: (
-              <RouteBreadcrumb
-                title={i18n.translate('xpack.profiling.breadcrumb.functions', {
-                  defaultMessage: 'Functions',
-                })}
-                href="/functions"
-              >
-                <FunctionsView>
-                  <Outlet />
-                </FunctionsView>
-              </RouteBreadcrumb>
+              <>
+                <RouteBreadcrumb
+                  title={i18n.translate('xpack.profiling.breadcrumb.functions', {
+                    defaultMessage: 'Functions',
+                  })}
+                  href="/functions"
+                >
+                  <FunctionsView>
+                    <Outlet />
+                  </FunctionsView>
+                </RouteBreadcrumb>
+                <SuppressChromeBackButton />
+              </>
             ),
             params: t.type({
               query: t.type({

--- a/x-pack/solutions/observability/plugins/profiling/public/routing/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/routing/index.tsx
@@ -327,7 +327,7 @@ const routes = {
             },
           },
           '/': {
-            element: <RedirectTo pathname="/stacktraces/threads" />,
+            element: <RedirectTo pathname="/stacktraces/executables" />,
           },
         },
         element: <Outlet />,

--- a/x-pack/solutions/observability/plugins/profiling/public/routing/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/routing/index.tsx
@@ -33,7 +33,7 @@ import { DifferentialTopNFunctionsView } from '../views/functions/differential_t
 import { TopNFunctionsView } from '../views/functions/topn';
 import { ProfilingNotEnabledView } from '../views/profiling_not_enabled';
 import { Settings } from '../views/settings';
-import { StackTracesView } from '../views/stack_traces_view';
+import { StackTracesView, StackTracesViewWrapper } from '../views/stack_traces_view';
 import { StorageExplorerView } from '../views/storage_explorer';
 import { RouteBreadcrumb } from './route_breadcrumb';
 
@@ -100,42 +100,62 @@ const routes = {
       },
       '/': {
         children: {
-          '/stacktraces/{topNType}': {
-            element: <StackTracesView />,
-            params: t.type({
-              path: t.type({
-                topNType: t.union([
-                  t.literal(TopNType.Containers),
-                  t.literal(TopNType.Deployments),
-                  t.literal(TopNType.Executables),
-                  t.literal(TopNType.Hosts),
-                  t.literal(TopNType.Threads),
-                  t.literal(TopNType.Traces),
-                ]),
-              }),
-              query: t.type({
-                displayAs: t.union([
-                  t.literal(StackTracesDisplayOption.StackTraces),
-                  t.literal(StackTracesDisplayOption.Percentage),
-                ]),
-                limit: toNumberRt,
-              }),
-            }),
-            defaults: {
-              query: {
-                displayAs: StackTracesDisplayOption.StackTraces,
-                limit: '10',
+          '/stacktraces': {
+            element: (
+              <RouteBreadcrumb
+                title={i18n.translate('xpack.profiling.breadcrumb.stacktraces', {
+                  defaultMessage: 'Stacktraces',
+                })}
+                href="/stacktraces"
+              >
+                <StackTracesViewWrapper>
+                  <Outlet />
+                </StackTracesViewWrapper>
+              </RouteBreadcrumb>
+            ),
+            children: {
+              '/stacktraces/{topNType}': {
+                element: <StackTracesView />,
+                params: t.type({
+                  path: t.type({
+                    topNType: t.union([
+                      t.literal(TopNType.Containers),
+                      t.literal(TopNType.Deployments),
+                      t.literal(TopNType.Executables),
+                      t.literal(TopNType.Hosts),
+                      t.literal(TopNType.Threads),
+                      t.literal(TopNType.Traces),
+                    ]),
+                  }),
+                  query: t.type({
+                    displayAs: t.union([
+                      t.literal(StackTracesDisplayOption.StackTraces),
+                      t.literal(StackTracesDisplayOption.Percentage),
+                    ]),
+                    limit: toNumberRt,
+                  }),
+                }),
+                defaults: {
+                  query: {
+                    displayAs: StackTracesDisplayOption.StackTraces,
+                    limit: '10',
+                  },
+                },
               },
             },
           },
-          '/stacktraces': {
-            element: <RedirectTo pathname="/stacktraces/executables" />,
-          },
           '/flamegraphs': {
             element: (
-              <FlameGraphsView>
-                <Outlet />
-              </FlameGraphsView>
+              <RouteBreadcrumb
+                title={i18n.translate('xpack.profiling.breadcrumb.flamegraphs', {
+                  defaultMessage: 'Flamegraphs',
+                })}
+                href="/flamegraphs"
+              >
+                <FlameGraphsView>
+                  <Outlet />
+                </FlameGraphsView>
+              </RouteBreadcrumb>
             ),
             children: {
               '/flamegraphs/flamegraph': {
@@ -202,9 +222,16 @@ const routes = {
           },
           '/functions': {
             element: (
-              <FunctionsView>
-                <Outlet />
-              </FunctionsView>
+              <RouteBreadcrumb
+                title={i18n.translate('xpack.profiling.breadcrumb.functions', {
+                  defaultMessage: 'Functions',
+                })}
+                href="/functions"
+              >
+                <FunctionsView>
+                  <Outlet />
+                </FunctionsView>
+              </RouteBreadcrumb>
             ),
             params: t.type({
               query: t.type({

--- a/x-pack/solutions/observability/plugins/profiling/public/routing/route_breadcrumb.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/routing/route_breadcrumb.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import type React from 'react';
+import { useMemo } from 'react';
 import { useProfilingDependencies } from '../components/contexts/profiling_dependencies/use_profiling_dependencies';
 import { useRouteBreadcrumb } from '../components/contexts/route_breadcrumbs_context/use_route_breadcrumb';
 
@@ -20,7 +21,15 @@ export const RouteBreadcrumb = ({
   const {
     start: { core },
   } = useProfilingDependencies();
-  useRouteBreadcrumb({ title, href: core.http.basePath.prepend('/app/profiling/' + href) });
+
+  const breadcrumb = useMemo(() => {
+    return {
+      title,
+      href: core.http.basePath.prepend('/app/profiling/' + href),
+    };
+  }, [core.http.basePath, href, title]);
+
+  useRouteBreadcrumb(breadcrumb);
 
   return children;
 };

--- a/x-pack/solutions/observability/plugins/profiling/public/views/stack_traces_view/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/stack_traces_view/index.tsx
@@ -20,6 +20,7 @@ import { RouteBreadcrumb } from '../../routing/route_breadcrumb';
 import { getStackTracesTabs } from './get_stack_traces_tabs';
 import { getTracesViewRouteParams } from './utils';
 import { AsyncStatus } from '../../hooks/use_async';
+import { RedirectTo } from '../../components/redirect_to';
 
 export function StackTracesView() {
   const routePath = useProfilingRoutePath();
@@ -90,6 +91,7 @@ export function StackTracesView() {
       });
     }
   }, [state.status, state.data?.charts.length, onPageReady, rangeFrom, rangeTo]);
+
   return (
     <RouteBreadcrumb title={selectedTab?.label || ''} href={selectedTab?.href || ''}>
       <ProfilingAppPageTemplate
@@ -136,4 +138,14 @@ export function StackTracesView() {
       </ProfilingAppPageTemplate>
     </RouteBreadcrumb>
   );
+}
+
+export function StackTracesViewWrapper({ children }: { children: React.ReactElement }) {
+  const routePath = useProfilingRoutePath();
+
+  if (routePath === '/stacktraces') {
+    return <RedirectTo pathname="/stacktraces/executables" />;
+  }
+
+  return children;
 }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/home.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/home.ts
@@ -13,21 +13,23 @@ export class ProfilingHomePage {
 
   async goto() {
     await this.page.goto(`${this.kbnUrl.app('profiling')}`);
-    await this.waitForThreadsTab();
+    await this.waitForExecutablesTab();
   }
 
   async gotoWithTimeRange(rangeFrom: string, rangeTo: string) {
     await this.page.goto(
       `${this.kbnUrl.app('profiling')}?rangeFrom=${rangeFrom}&rangeTo=${rangeTo}`
     );
-    await this.waitForThreadsTab();
+    await this.waitForExecutablesTab();
   }
 
   /*
-   * Waits for the Threads tab to be visible
+   * Waits for the Executables tab to be visible
    */
-  private async waitForThreadsTab() {
-    await this.page.getByRole('tab', { name: 'Threads' }).waitFor({ timeout: EXTENDED_TIMEOUT });
+  private async waitForExecutablesTab() {
+    await this.page
+      .getByRole('tab', { name: 'Executables' })
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   // Tab navigation methods
@@ -45,7 +47,7 @@ export class ProfilingHomePage {
 
   // Content verification methods
   async expectTopNContent() {
-    await this.page.getByText('Top 46').waitFor({ state: 'visible' });
+    await this.page.getByText('Top 1').waitFor({ state: 'visible' });
   }
 
   async expectUserPrivilegeLimitation() {

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/parallel_tests/home/home.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/parallel_tests/home/home.spec.ts
@@ -33,7 +33,11 @@ test.describe('Home page', { tag: tags.stateful.classic }, () => {
 
   test('navigates through the tabs', async ({ pageObjects: { profilingHomePage }, page }) => {
     await profilingHomePage.gotoWithTimeRange(rangeFrom, rangeTo);
+    await profilingHomePage.expectUrlToInclude('/app/profiling/stacktraces/executables');
+
+    await profilingHomePage.clickTab('Threads');
     await profilingHomePage.expectUrlToInclude('/app/profiling/stacktraces/threads');
+    expect(page.url()).toContain('/app/profiling/stacktraces/threads');
 
     await profilingHomePage.clickTab('Traces');
     await profilingHomePage.expectUrlToInclude('/app/profiling/stacktraces/traces');


### PR DESCRIPTION
## Summary

This PR addresses some minor issues the Chrome Next compatibility navigation included with the profiling plugin. 

The intent is to remove the back button from most profiling plugins minus `Settings`, `Storage Explorer` and the `Add Data` instructions. For that, the project style breadcrumbs are pre-processed to remove the `href` values from all breadcrumbs in the chain. This way, Chrome Next won't render back buttons. The routes mentioned above are excluded from this processing step so that they keep the back buttons as intended 

https://github.com/user-attachments/assets/c7ecd137-1c6e-4723-b315-6f7eaac5405f

https://github.com/user-attachments/assets/9d933b93-7774-4213-be25-ada2e35489f6

