### PR TITLE
chore(deps): bump `fast-uri` from `3.1.4` to `3.1.5`

### DIFF
--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -217,7 +217,7 @@ evp_bytestokey@1.0.3
 extend@3.0.2
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
-fast-uri@3.1.4
+fast-uri@3.1.5
 fastest-levenshtein@1.0.16
 file-selector@0.4.0
 find-root@1.1.0

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
@@ -68,7 +68,7 @@ events@3.3.0
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
 fast-shallow-equal@1.0.0
-fast-uri@3.1.4
+fast-uri@3.1.5
 fastest-stable-stringify@2.0.2
 find-cache-dir@4.0.0
 find-up@6.3.0

--- a/src/platform/packages/shared/kbn-monaco/version_dependencies.txt
+++ b/src/platform/packages/shared/kbn-monaco/version_dependencies.txt
@@ -51,7 +51,7 @@ estraverse@5.3.0
 events@3.3.0
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
-fast-uri@3.1.4
+fast-uri@3.1.5
 find-cache-dir@4.0.0
 find-up@6.3.0
 glob-to-regexp@0.4.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -21470,9 +21470,9 @@ fast-string-width@^3.0.2:
     fast-string-truncated-width "^3.0.2"
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## Summary

Bump `fast-uri` from `3.1.4` to `3.1.5`.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->