### PR TITLE
[APM UI][Chrome Next] Add AppHeader contract to ApmMainTemplate

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm/moon.yml
@@ -176,6 +176,7 @@ dependsOn:
   - '@kbn/storybook'
   - '@kbn/lens-embeddable-utils'
   - '@kbn/apm-shared'
+  - '@kbn/app-header'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/home/page_template.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/home/page_template.tsx
@@ -20,7 +20,6 @@ export function page<
   children,
   title,
   searchBar,
-  showServiceGroupSaveButton = false,
   params,
 }: {
   path: TPath;
@@ -28,7 +27,6 @@ export function page<
   children?: TChildren;
   title: string;
   searchBar?: React.ReactNode;
-  showServiceGroupSaveButton?: boolean;
   params?: TParams;
 }): Record<
   TPath,
@@ -41,11 +39,7 @@ export function page<
     [path]: {
       element: (
         <Breadcrumb title={title} href={path} omitOnServerless>
-          <ApmMainTemplate
-            pageTitle={title}
-            searchBar={searchBar}
-            showServiceGroupSaveButton={showServiceGroupSaveButton}
-          >
+          <ApmMainTemplate header={{ title }} searchBar={searchBar}>
             {element}
           </ApmMainTemplate>
         </Breadcrumb>

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/home/storage_explorer.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/home/storage_explorer.tsx
@@ -32,9 +32,8 @@ export const storageExplorer = {
       >
         <ApmMainTemplate
           searchBar={<SearchBar />}
-          pageHeader={{
-            alignItems: 'center',
-            pageTitle: i18n.translate('xpack.apm.views.storageExplorer.title', {
+          header={{
+            title: i18n.translate('xpack.apm.views.storageExplorer.title', {
               defaultMessage: 'Storage explorer',
             }),
           }}

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_main_template/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_main_template/index.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
+import { MockAppHeaderProvider } from '@kbn/app-header/mocks';
+import { createMemoryHistory } from 'history';
+import { Router } from '@kbn/shared-ux-router';
+import { ApmMainTemplate } from '.';
+
+const mockPageTemplate = jest.fn(
+  ({ children, pageHeader }: { children: React.ReactNode; pageHeader?: unknown }) => (
+    <div data-test-subj="mockObservabilityPageTemplate">
+      {pageHeader ? <div data-test-subj="legacyPageHeader" /> : null}
+      {children}
+    </div>
+  )
+);
+
+jest.mock('../../../../hooks/use_fetcher', () => ({
+  FETCH_STATUS: {
+    LOADING: 'loading',
+    SUCCESS: 'success',
+    FAILURE: 'failure',
+    NOT_INITIATED: 'not_initiated',
+  },
+  useFetcher: () => ({ data: { hasData: true }, status: 'success' }),
+}));
+
+jest.mock('../../../../hooks/use_default_ai_assistant_starter_prompts_for_apm', () => ({
+  useDefaultAiAssistantStarterPromptsForAPM: () => {},
+}));
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => ({
+    services: {
+      docLinks: { links: { observability: { guide: 'https://example.com' } } },
+      observabilityShared: {
+        navigation: { PageTemplate: mockPageTemplate },
+      },
+      application: { capabilities: { savedObjectsManagement: { edit: false } } },
+      share: { url: { locators: { get: () => undefined } } },
+    },
+  }),
+}));
+
+function renderTemplate(ui: React.ReactElement) {
+  const history = createMemoryHistory({ initialEntries: ['/services'] });
+  return render(
+    <MockAppHeaderProvider>
+      <Router history={history}>{ui}</Router>
+    </MockAppHeaderProvider>
+  );
+}
+
+describe('ApmMainTemplate', () => {
+  beforeEach(() => {
+    mockPageTemplate.mockClear();
+  });
+
+  it('renders AppHeader without a legacy pageHeader when header prop is set', () => {
+    renderTemplate(
+      <ApmMainTemplate header={{ title: 'Service inventory' }} searchBar={<div>search</div>}>
+        <div>body</div>
+      </ApmMainTemplate>
+    );
+
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.title)).toHaveTextContent(
+      'Service inventory'
+    );
+    expect(screen.getByText('search')).toBeInTheDocument();
+    expect(screen.getByText('body')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacyPageHeader')).not.toBeInTheDocument();
+
+    expect(mockPageTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageSectionProps: expect.objectContaining({ paddingSize: 'none' }),
+      }),
+      expect.anything()
+    );
+  });
+
+  it('keeps the legacy pageHeader path when header prop is omitted', () => {
+    renderTemplate(
+      <ApmMainTemplate pageTitle="Legacy title">
+        <div>body</div>
+      </ApmMainTemplate>
+    );
+
+    expect(screen.getByTestId('legacyPageHeader')).toBeInTheDocument();
+    expect(screen.queryByTestId(APP_HEADER_TEST_SUBJECTS.title)).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_main_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_main_template/index.tsx
@@ -7,8 +7,17 @@
 
 import React from 'react';
 import { css } from '@emotion/react';
-import type { EuiPageHeaderProps } from '@elastic/eui';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
+import type { EuiPageHeaderProps, EuiPageSectionProps } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPageSection,
+  EuiSpacer,
+  EuiTab,
+  EuiTabs,
+} from '@elastic/eui';
+import type { AppHeaderProps } from '@kbn/app-header';
+import { AppHeader } from '@kbn/app-header';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { ObservabilityPageTemplateProps } from '@kbn/observability-shared-plugin/public';
 import type { KibanaPageTemplateProps } from '@kbn/shared-ux-page-kibana-template';
@@ -25,37 +34,62 @@ import { getNoDataConfig } from '../no_data_config';
 // Paths that must skip the no data screen
 const bypassNoDataScreenPaths = ['/settings', '/diagnostics'];
 
-// Garantee's responsiveness of the header content
+// Guarantee's responsiveness of the header content
 const headerContentStyles = css`
   contain: inline-size;
 `;
 
+/**
+ * Preferred AppHeader contract for ApmMainTemplate (kibana-team#3549 / #282981).
+ * Search bars stay outside AppHeader via the template `searchBar` prop.
+ */
+export type ApmMainTemplateHeaderProps = AppHeaderProps;
+
+export type ApmMainTemplateProps = {
+  children: React.ReactNode;
+  searchBar?: React.ReactNode;
+  /**
+   * Inline AppHeader props. When set, the legacy `pageHeader` / `pageTitle` path is not used
+   * and only AppHeader renders (no double header).
+   */
+  header?: ApmMainTemplateHeaderProps;
+  /** @deprecated Prefer `header={{ title }}` (AppHeader contract). */
+  pageTitle?: React.ReactNode;
+  /** @deprecated Prefer `header` (AppHeader contract). */
+  pageHeader?: EuiPageHeaderProps;
+  /**
+   * Legacy only: injects ActionsMenu into the page header title row.
+   * With `header`, pass actions via `header.menu` instead.
+   */
+  showActionsMenu?: boolean;
+  /**
+   * Legacy only: injects ServiceGroupSaveButton into the page header title row.
+   * With `header`, pass actions via `header.menu` instead.
+   */
+  showServiceGroupSaveButton?: boolean;
+} & KibanaPageTemplateProps &
+  Pick<ObservabilityPageTemplateProps, 'pageSectionProps'>;
+
 /*
  * This template contains:
- *  - The Shared Observability Nav (https://github.com/elastic/kibana/blob/f7698bd8aa8787d683c728300ba4ca52b202369c/x-pack/plugins/observability/public/components/shared/page_template/README.md)
- *  - The APM Header Action Menu
- *  - Page title
+ *  - The Shared Observability Nav
+ *  - Page header via AppHeader (`header`) or legacy ObservabilityPageTemplate pageHeader
+ *  - Optional search bar below the header
  *
- *  Optionally:
- *   - ServiceGroupSaveButton
+ * Optionally (legacy header path only):
+ *   - ServiceGroupSaveButton / ActionsMenu in the title row
  */
 export function ApmMainTemplate({
+  header,
   pageTitle,
   pageHeader,
   children,
   searchBar,
   showActionsMenu = false,
   showServiceGroupSaveButton = false,
+  pageSectionProps,
   ...pageTemplateProps
-}: {
-  pageTitle?: React.ReactNode;
-  pageHeader?: EuiPageHeaderProps;
-  children: React.ReactNode;
-  searchBar?: React.ReactNode;
-  showActionsMenu?: boolean;
-  showServiceGroupSaveButton?: boolean;
-} & KibanaPageTemplateProps &
-  Pick<ObservabilityPageTemplateProps, 'pageSectionProps'>) {
+}: ApmMainTemplateProps) {
   const location = useLocation();
 
   const { services } = useKibana<ApmPluginStartDeps>();
@@ -116,6 +150,39 @@ export function ApmMainTemplate({
     noDataConfig,
   });
 
+  const sharedTemplateProps = {
+    noDataConfig: shouldBypassNoDataScreen ? undefined : noDataConfig,
+    isPageDataLoaded: isLoading === false,
+    ...pageTemplateProps,
+  };
+
+  if (header) {
+    return (
+      <ObservabilityPageTemplate
+        {...sharedTemplateProps}
+        pageSectionProps={{
+          ...pageSectionProps,
+          paddingSize: 'none',
+        }}
+      >
+        <AppHeader spacing="standard" {...header} />
+        <EuiPageSection
+          paddingSize="m"
+          restrictWidth={false}
+          {...omitPaddingSize(pageSectionProps)}
+        >
+          {searchBar && (
+            <div css={headerContentStyles}>
+              {searchBar}
+              <EuiSpacer size="s" />
+            </div>
+          )}
+          {children}
+        </EuiPageSection>
+      </ObservabilityPageTemplate>
+    );
+  }
+
   const rightSideItems = [
     ...(pageHeader?.rightSideItems ?? []),
     ...(showServiceGroupSaveButton ? [<ServiceGroupSaveButton />] : []),
@@ -166,8 +233,8 @@ export function ApmMainTemplate({
 
   return (
     <ObservabilityPageTemplate
-      noDataConfig={shouldBypassNoDataScreen ? undefined : noDataConfig}
-      isPageDataLoaded={isLoading === false}
+      {...sharedTemplateProps}
+      pageSectionProps={pageSectionProps}
       pageHeader={{
         ...pageHeader,
         color: 'subdued' as unknown as EuiPageHeaderProps['color'],
@@ -176,9 +243,18 @@ export function ApmMainTemplate({
         pageTitle: titleWithActions,
         children: headerChildren,
       }}
-      {...pageTemplateProps}
     >
       {children}
     </ObservabilityPageTemplate>
   );
+}
+
+function omitPaddingSize(
+  props: EuiPageSectionProps | undefined
+): Omit<EuiPageSectionProps, 'paddingSize'> | undefined {
+  if (!props) {
+    return undefined;
+  }
+  const { paddingSize: _paddingSize, ...rest } = props;
+  return rest;
 }

--- a/x-pack/solutions/observability/plugins/apm/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/apm/tsconfig.json
@@ -176,7 +176,8 @@
     "@kbn/apm-common",
     "@kbn/storybook",
     "@kbn/lens-embeddable-utils",
-    "@kbn/apm-shared"
+    "@kbn/apm-shared",
+    "@kbn/app-header"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
Closes #282981

## Summary

Adds an optional `header` prop to `ApmMainTemplate` for inline `AppHeader` ([kibana-team#3549](https://github.com/elastic/kibana-team/issues/3549)): no `core.chrome.next` gate, search bar stays below the header, and the legacy `pageHeader` path remains for unmigrated routes. Dependencies inventory and Storage explorer use the new contract as the first simple call sites.

BEFORE

<img width="1451" height="788" alt="image" src="https://github.com/user-attachments/assets/860236fa-f5f1-4c8c-9b34-93a139775c7e" />

AFTER

(feature flag off: `core.chrome.next: false`)

<img width="1268" height="789" alt="image" src="https://github.com/user-attachments/assets/43ae64cf-87d3-4a3b-9b36-efbd9a88a8a7" />

(feature flag on: `core.chrome.next: true`)

<img width="1268" height="789" alt="image" src="https://github.com/user-attachments/assets/97e6f259-a31f-4304-82f9-5b573f33e3e5" />

## Not in this PR

| Page | Why not in this PR |
|---|---|
| **Service inventory** | Uses `ServiceGroupTemplate` — tabs, group back crumb, save button → #282983 |
| **Traces** | Title plus “Explore traces” as free-form `rightSideItems` → needs `AppMenuConfig.primaryActionItem` → #282989 |
| **User experience** | Separate Observability app (RUM/UX), not APM’s `ApmMainTemplate` / #280342 scope |

Service detail, mobile, settings, diagnostics, etc. also stay on the legacy path until their sub-issues.

## Test plan

- [ ] **With `core.chrome.next: true`:** open `/app/apm/dependencies/inventory` and `/app/apm/storage-explorer` — exactly one AppHeader, correct title, search bar below header, no double header.
- [ ] **With `core.chrome.next: false`:** same two routes — still one AppHeader (not gated), search below header; classic chrome breadcrumbs/action menu placement may differ (expected until #282982).
- [ ] Spot-check an unmigrated page (e.g. Service inventory or service detail) — legacy header still works.
