### PR TITLE
[VectorDB] Count indexed vectors directly for the home page stat

### DIFF
--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/api_paths.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/api_paths.tsx
@@ -17,7 +17,7 @@ export interface OnboardingApiPaths {
    *  Returns `{ id, name, encoded }` when a new key is created.
    *  Returns `{ id: null, name: null, encoded: null }` when an active onboarding key already exists. */
   apiKey: string;
-  /** GET endpoint returning `{ indicesCount, vectorDocsCount, storeSizeBytes }`. */
+  /** GET endpoint returning `{ indicesCount, vectorCount, storeSizeBytes }`. */
   deploymentStats: string;
 }
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page.tsx
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page.tsx
@@ -69,7 +69,7 @@ export const HomePage = () => {
   const { stats, isLoading } = useDeploymentStats();
   const { agentsCount, isLoading: isAgentsCountLoading } = useAgentsCount();
   const { elasticsearchUrl, apiKey, isLoading: isCredentialsLoading } = useOnboardingCredentials();
-  const hasData = (stats.vectorDocsCount ?? 0) > 0 || (stats.indicesCount ?? 0) > 0;
+  const hasData = (stats.vectorCount ?? 0) > 0 || (stats.indicesCount ?? 0) > 0;
 
   const statTiles = [
     {
@@ -81,7 +81,7 @@ export const HomePage = () => {
     {
       key: 'vectors',
       label: STAT_TILE_LABELS.vectors,
-      value: formatNumber(stats.vectorDocsCount),
+      value: formatNumber(stats.vectorCount),
       isLoading,
     },
     {

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
@@ -15,7 +15,7 @@ interface WorkflowsStats {
 
 interface DeploymentStatsResponse {
   indicesCount: number | null;
-  vectorDocsCount: number | null;
+  vectorCount: number | null;
   storeSizeBytes: number | null;
   dashboardsCount: number | null;
 }
@@ -25,7 +25,7 @@ interface DeploymentStats extends DeploymentStatsResponse {
 
 const initialStats: DeploymentStats = {
   indicesCount: null,
-  vectorDocsCount: null,
+  vectorCount: null,
   storeSizeBytes: null,
   workflowsCount: null,
   dashboardsCount: null,
@@ -46,7 +46,7 @@ export const useDeploymentStats = () => {
 
       return {
         indicesCount: esStats?.indicesCount ?? null,
-        vectorDocsCount: esStats?.vectorDocsCount ?? null,
+        vectorCount: esStats?.vectorCount ?? null,
         storeSizeBytes: esStats?.storeSizeBytes ?? null,
         workflowsCount: workflowsResponse?.workflows
           ? (workflowsResponse.workflows.enabled ?? 0) + (workflowsResponse.workflows.disabled ?? 0)

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
@@ -37,14 +37,15 @@ describe('fetchIndexStats', () => {
     });
   };
 
-  const mockFieldCaps = (fields: Record<string, Record<string, unknown>>) => {
-    client.asCurrentUser.fieldCaps.mockResolvedValue({ indices: [], fields } as any);
-  };
-
-  const mockEsqlCount = (count: number) => {
-    client.asCurrentUser.esql.query.mockResolvedValue({
-      columns: [{ name: 'doc_count', type: 'long' }],
-      values: [[count]],
+  const mockVectorStats = (denseCount: number, sparseCount = 0) => {
+    client.asInternalUser.indices.stats.mockResolvedValue({
+      _all: {
+        primaries: {
+          dense_vector: { value_count: denseCount },
+          sparse_vector: { value_count: sparseCount },
+        },
+      },
+      indices: {},
     } as any);
   };
 
@@ -53,220 +54,56 @@ describe('fetchIndexStats', () => {
       { name: 'products', num_docs: 10, size_in_bytes: 100 },
       { name: '.kibana', num_docs: 999, size_in_bytes: 999 },
     ]);
-    // No vector fields.
-    mockFieldCaps({
-      title: { text: { type: 'text', searchable: true, aggregatable: false, inference: false } },
-    });
+    mockVectorStats(0);
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(result).toEqual({ indicesCount: 1, storeSizeBytes: 100, vectorDocsCount: 0 });
-    expect(client.asCurrentUser.esql.query).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      indicesCount: 1,
+      storeSizeBytes: 100,
+      vectorCount: 0,
+    });
   });
 
-  it('restricts field caps to vector-relevant field types and skips metadata fields', async () => {
+  it('sums dense and sparse vector value_counts from operator indices.stats', async () => {
+    mockMetering([{ name: 'vectordb', num_docs: 20, size_in_bytes: 500 }]);
+    mockVectorStats(100, 25);
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(client.asInternalUser.indices.stats).toHaveBeenCalledWith({
+      index: ['*', '-.*'],
+      expand_wildcards: ['open'],
+      level: 'cluster',
+      metric: ['dense_vector', 'sparse_vector'],
+    });
+    expect(result.vectorCount).toBe(125);
+  });
+
+  it('treats missing dense/sparse stats as zero', async () => {
     mockMetering([{ name: 'products', num_docs: 10, size_in_bytes: 100 }]);
-    mockFieldCaps({});
-
-    await fetchIndexStats(client, logger);
-
-    expect(client.asCurrentUser.fieldCaps).toHaveBeenCalledWith({
-      index: ['products'],
-      fields: '*',
-      // `text` is included because `semantic_text` may be reported as `text` + `inference: true`
-      types: ['dense_vector', 'sparse_vector', 'semantic_text', 'semantic', 'text'],
-      filters: '-metadata',
-      // Required so partially-mapped fields carry an explicit `indices` list.
-      include_unmapped: true,
-    });
-  });
-
-  it('detects semantic_text via the field caps inference flag and counts docs via ES|QL', async () => {
-    // metering over-reports num_docs (20) for the semantic_text index; ES|QL returns the real 10.
-    // `semantic_text` is reported as `text` by field caps, so it is detected via `inference: true`.
-    mockMetering([{ name: 'vectordb', num_docs: 20, size_in_bytes: 500 }]);
-    mockFieldCaps({
-      semantic_content: {
-        text: { type: 'text', searchable: true, aggregatable: false, inference: true },
-      },
-    });
-    mockEsqlCount(10);
+    client.asInternalUser.indices.stats.mockResolvedValue({
+      _all: { primaries: {} },
+      indices: {},
+    } as any);
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(10);
+    expect(result.vectorCount).toBe(0);
   });
 
-  it('detects an inference field reported by its own `type` (no inference flag)', async () => {
-    // In some versions/formats field caps reports `semantic_text` by its own type rather than as
-    // `text` + `inference: true`, so the type set must also catch it.
-    mockMetering([{ name: 'vectordb', num_docs: 20, size_in_bytes: 500 }]);
-    mockFieldCaps({
-      semantic_content: {
-        semantic_text: { type: 'semantic_text', searchable: true, aggregatable: false },
-      },
-    });
-    mockEsqlCount(10);
-
-    const result = await fetchIndexStats(client, logger);
-
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(10);
-  });
-
-  it('detects a `semantic` field by its own reported type', async () => {
+  it('returns a null vectorCount (not 0) when the vector stats call fails', async () => {
     mockMetering([{ name: 'vectordb', num_docs: 10, size_in_bytes: 500 }]);
-    mockFieldCaps({
-      body: {
-        semantic: { type: 'semantic', searchable: true, aggregatable: false },
-      },
-    });
-    mockEsqlCount(10);
+    client.asInternalUser.indices.stats.mockRejectedValue(new Error('boom'));
 
     const result = await fetchIndexStats(client, logger);
 
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(10);
-  });
-
-  it('only queries indices whose field caps report a vector field', async () => {
-    mockMetering([
-      { name: 'vectordb', num_docs: 10, size_in_bytes: 500 },
-      { name: 'plain-text', num_docs: 5, size_in_bytes: 50 },
-    ]);
-    // `embedding` (dense_vector) only exists in `vectordb`, so field caps scopes it via `indices`.
-    mockFieldCaps({
-      embedding: {
-        dense_vector: {
-          type: 'dense_vector',
-          searchable: true,
-          aggregatable: false,
-          inference: false,
-          indices: ['vectordb'],
-        },
-      },
-      title: { text: { type: 'text', searchable: true, aggregatable: false, inference: false } },
+    // index/size counts are still valid; only the vector count is unavailable
+    expect(result).toEqual({
+      indicesCount: 1,
+      storeSizeBytes: 500,
+      vectorCount: null,
     });
-    mockEsqlCount(10);
-
-    await fetchIndexStats(client, logger);
-
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
-    );
-  });
-
-  it('does not classify indices where the vector field is unmapped', async () => {
-    mockMetering([
-      { name: 'test-vector', num_docs: 10, size_in_bytes: 500 },
-      { name: 'test-plain', num_docs: 5000, size_in_bytes: 50 },
-    ]);
-    mockFieldCaps({
-      embedding: {
-        unmapped: {
-          type: 'unmapped',
-          searchable: false,
-          aggregatable: false,
-          inference: false,
-          indices: ['test-plain'],
-        },
-        dense_vector: {
-          type: 'dense_vector',
-          searchable: true,
-          aggregatable: false,
-          inference: false,
-          indices: ['test-vector'],
-        },
-      },
-    });
-    mockEsqlCount(10);
-
-    const result = await fetchIndexStats(client, logger);
-
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "test-vector" | STATS doc_count = COUNT(*)' })
-    );
-    expect(result.vectorDocsCount).toBe(10);
-  });
-
-  it('treats a vector field with no `indices` as present in every requested index', async () => {
-    mockMetering([
-      { name: 'vectordb-a', num_docs: 10, size_in_bytes: 500 },
-      { name: 'vectordb-b', num_docs: 10, size_in_bytes: 500 },
-    ]);
-    // `indices` is omitted when the field is uniform across all requested indices.
-    mockFieldCaps({
-      embedding: {
-        dense_vector: {
-          type: 'dense_vector',
-          searchable: true,
-          aggregatable: false,
-          inference: false,
-        },
-      },
-    });
-    mockEsqlCount(20);
-
-    await fetchIndexStats(client, logger);
-
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: 'FROM "vectordb-a","vectordb-b" | STATS doc_count = COUNT(*)',
-      })
-    );
-  });
-
-  it('batches the ES|QL count when there are more than 500 vector indices', async () => {
-    const indices = Array.from({ length: 501 }, (_, i) => ({
-      name: `vectordb-${i}`,
-      num_docs: 1,
-      size_in_bytes: 10,
-    }));
-    mockMetering(indices);
-    // A uniform vector field means every index is a vector index.
-    mockFieldCaps({
-      embedding: {
-        dense_vector: { type: 'dense_vector', searchable: true, aggregatable: false },
-      },
-    });
-    client.asCurrentUser.esql.query
-      .mockResolvedValueOnce({
-        columns: [{ name: 'doc_count', type: 'long' }],
-        values: [[500]],
-      } as any)
-      .mockResolvedValueOnce({
-        columns: [{ name: 'doc_count', type: 'long' }],
-        values: [[1]],
-      } as any);
-
-    const result = await fetchIndexStats(client, logger);
-
-    expect(client.asCurrentUser.esql.query).toHaveBeenCalledTimes(2);
-    const queries = client.asCurrentUser.esql.query.mock.calls.map(
-      ([request]) => (request as { query: string }).query
-    );
-    expect(queries[0]).toContain('"vectordb-0"');
-    expect(queries[0]).toContain('"vectordb-499"');
-    expect(queries[0]).not.toContain('"vectordb-500"');
-    expect(queries[1]).toBe('FROM "vectordb-500" | STATS doc_count = COUNT(*)');
-    expect(result.vectorDocsCount).toBe(501);
-  });
-
-  it('returns a null vectorDocsCount (not 0) when the vector lookup fails', async () => {
-    mockMetering([{ name: 'vectordb', num_docs: 10, size_in_bytes: 500 }]);
-    client.asCurrentUser.fieldCaps.mockRejectedValue(new Error('boom'));
-
-    const result = await fetchIndexStats(client, logger);
-
-    // index/size counts are still valid; only the vector doc count is unavailable
-    expect(result).toEqual({ indicesCount: 1, storeSizeBytes: 500, vectorDocsCount: null });
     expect(logger.warn).toHaveBeenCalled();
   });
 
@@ -278,9 +115,10 @@ describe('fetchIndexStats', () => {
     expect(result).toEqual({
       indicesCount: null,
       storeSizeBytes: null,
-      vectorDocsCount: null,
+      vectorCount: null,
     });
     expect(logger.warn).toHaveBeenCalled();
+    expect(client.asInternalUser.indices.stats).not.toHaveBeenCalled();
   });
 
   it('skips vector lookups when there are no user indices', async () => {
@@ -289,8 +127,12 @@ describe('fetchIndexStats', () => {
     const result = await fetchIndexStats(client, logger);
 
     // a genuinely empty deployment reports real zeros, not null
-    expect(result).toEqual({ indicesCount: 0, storeSizeBytes: 0, vectorDocsCount: 0 });
-    expect(client.asCurrentUser.fieldCaps).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      indicesCount: 0,
+      storeSizeBytes: 0,
+      vectorCount: 0,
+    });
+    expect(client.asInternalUser.indices.stats).not.toHaveBeenCalled();
   });
 });
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -33,10 +33,36 @@ interface IndexStats {
   vectorCount: number | null;
 }
 
-const INDEX_STATS_UNAVAILABLE: IndexStats = {
+export const INDEX_STATS_UNAVAILABLE: IndexStats = {
   indicesCount: null,
   storeSizeBytes: null,
   vectorCount: null,
+};
+
+const USER_INDICES_PATTERN = ['*', '-.*'];
+
+/**
+ * Whether the caller may see cluster-wide totals. Every source behind `fetchIndexStats` runs with
+ * elevated privileges, so Elasticsearch will not reject an unprivileged caller on its own and the
+ * route has to ask on their behalf. Errors deny access rather than granting it.
+ */
+export const hasIndexManagePrivilege = async (
+  client: IScopedClusterClient,
+  logger: Logger
+): Promise<boolean> => {
+  try {
+    const { has_all_requested: hasAllRequested } =
+      await client.asCurrentUser.security.hasPrivileges({
+        index: [{ names: USER_INDICES_PATTERN, privileges: ['manage'] }],
+      });
+
+    return hasAllRequested;
+  } catch (error) {
+    logger.warn(
+      `Failed to check index privileges for vectordb deployment stats. Denying access: ${error.message}`
+    );
+    return false;
+  }
 };
 
 /**
@@ -48,7 +74,7 @@ const INDEX_STATS_UNAVAILABLE: IndexStats = {
  */
 const countVectors = async (client: IScopedClusterClient): Promise<number> => {
   const stats = await client.asInternalUser.indices.stats({
-    index: ['*', '-.*'],
+    index: USER_INDICES_PATTERN,
     expand_wildcards: ['open'],
     level: 'cluster',
     metric: ['dense_vector', 'sparse_vector'],

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -6,12 +6,6 @@
  */
 
 import type { IScopedClusterClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
-import type { FieldCapsFieldCapability } from '@elastic/elasticsearch/lib/api/types';
-
-// The `inference` flag isn't yet in the Elasticsearch package types.
-type FieldCapability = FieldCapsFieldCapability & {
-  inference?: boolean;
-};
 
 interface MeteringIndexStat {
   name: string;
@@ -24,103 +18,56 @@ interface MeteringStatsResponse {
   indices: MeteringIndexStat[];
 }
 
+interface VectorStats {
+  value_count?: number;
+}
+
+interface IndexStatsWithVectors {
+  dense_vector?: VectorStats;
+  sparse_vector?: VectorStats;
+}
+
 interface IndexStats {
   indicesCount: number | null;
   storeSizeBytes: number | null;
-  vectorDocsCount: number | null;
+  vectorCount: number | null;
 }
 
 const INDEX_STATS_UNAVAILABLE: IndexStats = {
   indicesCount: null,
   storeSizeBytes: null,
-  vectorDocsCount: null,
+  vectorCount: null,
 };
 
-const VECTOR_FIELD_TYPES = new Set(['dense_vector', 'sparse_vector', 'semantic_text', 'semantic']);
-
-// `semantic_text` fields may be reported by field caps as `text` with `inference: true`, so `text`
-// must be requested alongside the vector types.
-const FIELD_CAPS_TYPES = [...VECTOR_FIELD_TYPES, 'text'];
-
 /**
- * Returns which of the given indices contain a vector field. Uses `_field_caps` rather than full
- * mappings as it's far lighter and flattens nested/multi-fields for free.
+ * Counts indexed dense + sparse vectors via `_stats` (operator-only in serverless), aggregated at
+ * the cluster level so no per-index breakdown is returned. Excluding dot indices keeps the total
+ * scoped to the same indices as the metering-derived index and size counts. `open` is already the
+ * default for `expand_wildcards`, but is pinned so hidden indices can't be pulled in by a later
+ * edit.
  */
-const getVectorIndexNames = async (
-  client: IScopedClusterClient,
-  indexNames: string[]
-): Promise<string[]> => {
-  const fieldCaps = await client.asCurrentUser.fieldCaps({
-    index: indexNames,
-    fields: '*',
-    types: FIELD_CAPS_TYPES,
-    filters: '-metadata',
-    // Forces partially-mapped fields to carry an explicit `indices` list. Without it a field mapped
-    // in a subset of indices looks identical to one mapped everywhere, misclassifying all indices.
-    include_unmapped: true,
+const countVectors = async (client: IScopedClusterClient): Promise<number> => {
+  const stats = await client.asInternalUser.indices.stats({
+    index: ['*', '-.*'],
+    expand_wildcards: ['open'],
+    level: 'cluster',
+    metric: ['dense_vector', 'sparse_vector'],
   });
 
-  const vectorIndexNames = new Set<string>();
-
-  for (const capabilitiesByType of Object.values(fieldCaps.fields)) {
-    for (const capability of Object.values(capabilitiesByType) as FieldCapability[]) {
-      // `include_unmapped: true` adds pseudo-entries listing indices where the field is absent.
-      if (capability.type === 'unmapped') continue;
-
-      const isVectorField =
-        VECTOR_FIELD_TYPES.has(capability.type) || capability.inference === true;
-      if (!isVectorField) continue;
-
-      // Absent `indices` means the field is mapped in every requested index.
-      if (capability.indices === undefined) return indexNames;
-
-      const capabilityIndices = Array.isArray(capability.indices)
-        ? capability.indices
-        : [capability.indices];
-      capabilityIndices.forEach((name) => vectorIndexNames.add(name));
-
-      if (vectorIndexNames.size === indexNames.length) return indexNames;
-    }
-  }
-
-  return [...vectorIndexNames];
-};
-
-// Caps indices per ES|QL query so the `FROM` clause can't grow unbounded.
-const ESQL_INDICES_PER_QUERY = 500;
-
-const countTopLevelDocs = async (
-  client: IScopedClusterClient,
-  indexNames: string[]
-): Promise<number> => {
-  let total = 0;
-
-  for (let i = 0; i < indexNames.length; i += ESQL_INDICES_PER_QUERY) {
-    const batch = indexNames.slice(i, i + ESQL_INDICES_PER_QUERY);
-    const esqlResult = await client.asCurrentUser.esql.query({
-      query: `FROM ${batch.map((name) => `"${name}"`).join(',')} | STATS doc_count = COUNT(*)`,
-      allow_partial_results: true,
-    });
-
-    const countColumnIndex = esqlResult.columns.findIndex((col) => col.name === 'doc_count');
-    const [row] = esqlResult.values ?? [];
-    total += (row?.[countColumnIndex] as number) ?? 0;
-  }
-
-  return total;
+  const primaries = stats._all?.primaries as IndexStatsWithVectors | undefined;
+  return (primaries?.dense_vector?.value_count ?? 0) + (primaries?.sparse_vector?.value_count ?? 0);
 };
 
 /**
- * Fetches index-level stats: user index count, aggregate store size, and doc count across indices
- * with a vector field. Failures are logged and surfaced as `null` so callers can
- * distinguish "unavailable" from a genuine `0`.
+ * Fetches index-level stats: user index count, aggregate store size, and indexed dense/sparse
+ * vector count. Failures are logged and surfaced as `null` so callers can distinguish
+ * "unavailable" from a genuine `0`.
  */
 export const fetchIndexStats = async (
   client: IScopedClusterClient,
   logger: Logger
 ): Promise<IndexStats> => {
   try {
-    // Serverless-only `_metering/stats` requires asSecondaryAuthUser.
     const meteringStats = await client.asSecondaryAuthUser.transport.request<MeteringStatsResponse>(
       {
         method: 'GET',
@@ -135,29 +82,21 @@ export const fetchIndexStats = async (
     const indicesCount = userIndices.length;
     const storeSizeBytes = userIndices.reduce((sum, index) => sum + (index.size_in_bytes ?? 0), 0);
 
-    let vectorDocsCount: number | null = 0;
+    let vectorCount: number | null = 0;
+
     if (indicesCount > 0) {
-      const indexNames = userIndices.map((i) => i.name);
-
       try {
-        const vectorIndexNames = await getVectorIndexNames(client, indexNames);
-
-        if (vectorIndexNames.length > 0) {
-          // `_metering/stats` num_docs counts Lucene documents, which includes the nested chunk
-          // documents that `semantic_text` fields generate, inflating the count. Count top-level
-          // documents with ES|QL instead, matching the index management plugin's workaround.
-          vectorDocsCount = await countTopLevelDocs(client, vectorIndexNames);
-        }
+        vectorCount = await countVectors(client);
       } catch (error) {
-        // Index/size counts are still valid; only the vector doc count is unavailable.
+        // Index/size counts are still valid; only the vector count is unavailable.
         logger.warn(
-          `Failed to compute vector doc count for vectordb deployment stats. Returning partial stats: ${error.message}`
+          `Failed to compute vector count for vectordb deployment stats. Returning partial stats: ${error.message}`
         );
-        vectorDocsCount = null;
+        vectorCount = null;
       }
     }
 
-    return { indicesCount, storeSizeBytes, vectorDocsCount };
+    return { indicesCount, storeSizeBytes, vectorCount };
   } catch (error) {
     logger.warn(`Failed to fetch index stats for vectordb deployment stats: ${error.message}`);
     return INDEX_STATS_UNAVAILABLE;

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
@@ -14,7 +14,11 @@ import {
   savedObjectsClientMock,
 } from '@kbn/core/server/mocks';
 import { DEPLOYMENT_STATS_PATH } from '../../common/constants';
-import { fetchDashboardsCount, fetchIndexStats } from '../lib/deployment_stats';
+import {
+  fetchDashboardsCount,
+  fetchIndexStats,
+  hasIndexManagePrivilege,
+} from '../lib/deployment_stats';
 import { registerDeploymentStatsRoute } from './deployment_stats';
 
 jest.mock('../lib/deployment_stats');
@@ -22,6 +26,9 @@ jest.mock('../lib/deployment_stats');
 const mockFetchIndexStats = fetchIndexStats as jest.MockedFunction<typeof fetchIndexStats>;
 const mockFetchDashboardsCount = fetchDashboardsCount as jest.MockedFunction<
   typeof fetchDashboardsCount
+>;
+const mockHasIndexManagePrivilege = hasIndexManagePrivilege as jest.MockedFunction<
+  typeof hasIndexManagePrivilege
 >;
 
 describe('registerDeploymentStatsRoute', () => {
@@ -36,6 +43,7 @@ describe('registerDeploymentStatsRoute', () => {
     logger = loggingSystemMock.createLogger();
     esClient = elasticsearchServiceMock.createScopedClusterClient();
     soClient = savedObjectsClientMock.create();
+    mockHasIndexManagePrivilege.mockResolvedValue(true);
 
     registerDeploymentStatsRoute(router, logger);
   });
@@ -120,6 +128,27 @@ describe('registerDeploymentStatsRoute', () => {
       },
     });
     expect(response.customError).not.toHaveBeenCalled();
+  });
+
+  it('withholds index stats but still returns the dashboard count without the `manage` privilege', async () => {
+    mockHasIndexManagePrivilege.mockResolvedValue(false);
+    mockFetchDashboardsCount.mockResolvedValue(2);
+
+    const request = httpServerMock.createKibanaRequest();
+    const response = httpServerMock.createResponseFactory();
+
+    await getHandler()(createContext(), request, response);
+
+    expect(mockFetchIndexStats).not.toHaveBeenCalled();
+    expect(response.forbidden).not.toHaveBeenCalled();
+    expect(response.ok).toHaveBeenCalledWith({
+      body: {
+        indicesCount: null,
+        storeSizeBytes: null,
+        vectorCount: null,
+        dashboardsCount: 2,
+      },
+    });
   });
 
   it('returns a custom error when resolving the core context throws', async () => {

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
@@ -62,7 +62,7 @@ describe('registerDeploymentStatsRoute', () => {
     mockFetchIndexStats.mockResolvedValue({
       indicesCount: 3,
       storeSizeBytes: 1024,
-      vectorDocsCount: 5,
+      vectorCount: 5,
     });
     mockFetchDashboardsCount.mockResolvedValue(2);
 
@@ -75,7 +75,7 @@ describe('registerDeploymentStatsRoute', () => {
       body: {
         indicesCount: 3,
         storeSizeBytes: 1024,
-        vectorDocsCount: 5,
+        vectorCount: 5,
         dashboardsCount: 2,
       },
     });
@@ -85,7 +85,7 @@ describe('registerDeploymentStatsRoute', () => {
     mockFetchIndexStats.mockResolvedValue({
       indicesCount: 0,
       storeSizeBytes: 0,
-      vectorDocsCount: 0,
+      vectorCount: 0,
     });
     mockFetchDashboardsCount.mockResolvedValue(0);
 
@@ -102,7 +102,7 @@ describe('registerDeploymentStatsRoute', () => {
     mockFetchIndexStats.mockResolvedValue({
       indicesCount: null,
       storeSizeBytes: null,
-      vectorDocsCount: null,
+      vectorCount: null,
     });
     mockFetchDashboardsCount.mockResolvedValue(null);
 
@@ -115,7 +115,7 @@ describe('registerDeploymentStatsRoute', () => {
       body: {
         indicesCount: null,
         storeSizeBytes: null,
-        vectorDocsCount: null,
+        vectorCount: null,
         dashboardsCount: null,
       },
     });

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
@@ -8,7 +8,12 @@
 import type { IRouter, Logger } from '@kbn/core/server';
 import { AuthzDisabled } from '@kbn/core-security-server';
 import { DEPLOYMENT_STATS_PATH } from '../../common/constants';
-import { fetchDashboardsCount, fetchIndexStats } from '../lib/deployment_stats';
+import {
+  INDEX_STATS_UNAVAILABLE,
+  fetchDashboardsCount,
+  fetchIndexStats,
+  hasIndexManagePrivilege,
+} from '../lib/deployment_stats';
 
 export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) => {
   router.get(
@@ -16,7 +21,9 @@ export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) =>
       path: DEPLOYMENT_STATS_PATH,
       validate: false,
       security: {
-        authz: AuthzDisabled.delegateToESClient,
+        authz: AuthzDisabled.fromReason(
+          'Index stats are read with elevated privileges, so the handler checks the caller holds the Elasticsearch `manage` index privilege before returning cluster-wide totals; the dashboard count is authorized by the saved objects client'
+        ),
       },
     },
     async (context, request, response) => {
@@ -26,7 +33,9 @@ export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) =>
         const savedObjectsClient = core.savedObjects.getClient();
 
         const [{ indicesCount, storeSizeBytes, vectorCount }, dashboardsCount] = await Promise.all([
-          fetchIndexStats(client, logger),
+          hasIndexManagePrivilege(client, logger).then((isPrivileged) =>
+            isPrivileged ? fetchIndexStats(client, logger) : INDEX_STATS_UNAVAILABLE
+          ),
           fetchDashboardsCount(savedObjectsClient, logger),
         ]);
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
@@ -25,17 +25,16 @@ export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) =>
         const client = core.elasticsearch.client;
         const savedObjectsClient = core.savedObjects.getClient();
 
-        const [{ indicesCount, storeSizeBytes, vectorDocsCount }, dashboardsCount] =
-          await Promise.all([
-            fetchIndexStats(client, logger),
-            fetchDashboardsCount(savedObjectsClient, logger),
-          ]);
+        const [{ indicesCount, storeSizeBytes, vectorCount }, dashboardsCount] = await Promise.all([
+          fetchIndexStats(client, logger),
+          fetchDashboardsCount(savedObjectsClient, logger),
+        ]);
 
         return response.ok({
           body: {
             indicesCount,
             storeSizeBytes,
-            vectorDocsCount,
+            vectorCount,
             dashboardsCount,
           },
         });


### PR DESCRIPTION
## Summary

The **Total vectors** tile on the VectorDB home page was counting documents containing vectors, not the number of vectors across those documents, so a document with several vector fields was only counted once. 

This change updates the vector count to use the `_stats` API, allowing us to get the `dense_vector` and `sparse_vector` `value_count`s and summing them, giving us a more accurate count in a more straightforward manner.

Since these stats are read with elevated privileges, the route now checks that the caller holds the Elasticsearch `manage` index privilege before returning them.

### Changes

- `fetchIndexStats` now calls `indices.stats` and sums the `value_count`s for `dense_vectors` and `sparse_vectors`. The `_field_caps` classification and the ES|QL batching helper are both removed.
- Added `hasIndexManagePrivilege`, which checks `manage` on `*,-.*` via `security.hasPrivileges` as the current user. A failed check denies rather than grants, and results in the unauthorized stats cards displaying an em dash.
- Renamed `vectorDocsCount` to `vectorCount` across the server lib, the route response body, `useDeploymentStats`, and the home page, so the field name matches what it holds.
- Tests cover the new call shape and the unprivileged path.

### Follow-up

An unprivileged user currently sees an em dash on the **Indices**, **Total vectors**, and **Storage** tiles, which is the same treatment the page gives a stat that failed to load. A future PR will update the home page design to accommodate a viewer role, so those tiles are either hidden or communicate "not available for your role" rather than looking like a failed fetch.

## Testing

To test that the vector count is working as expected, create indices with several variations of vectors and verify the count is correct. Try indices with multiple documents containing:
- Dense vector fields
- Sparse vector fields
- `semantic_text` fields
- Nested vector fields
- Multiple vector fields per document
- Vector fields that aren't populated (an empty field shouldn't be counted)

To test the privilege check, log in as the viewer role and confirm the **Indices**, **Total vectors**, and **Storage** tiles show an em dash while **Dashboards** still shows a real count.

Made with [Cursor](https://cursor.com)