### PR TITLE
Attempt to fix flaky serverless smokescreen test

### DIFF
--- a/x-pack/platform/test/functional/page_objects/lens_page.ts
+++ b/x-pack/platform/test/functional/page_objects/lens_page.ts
@@ -247,6 +247,13 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       }
       if (opts.field) {
         await this.selectOptionFromComboBox('indexPattern-dimension-field', opts.field);
+        if (opts.isPreviousIncompatible) {
+          // Incomplete → field must commit before close, or close discards the transition.
+          await retry.waitFor('incompatible field transition to complete', async () => {
+            const fieldCombo = await testSubjects.find('indexPattern-dimension-field');
+            return await comboBox.isOptionSelected(fieldCombo, opts.field!);
+          });
+        }
       }
 
       if (opts.formula) {


### PR DESCRIPTION
## Summary

Incompatible operation switches only set incomplete state until a new field is chosen; closing early discarded the transition and left `Unique count of ip`.
After selecting the field in `configureDimension`, wait until the field combobox reflects the selection before closing the editor.

Attempt to fix failures such as [this](https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/10303):

Error:
```
Error message
Error: expected 'Unique count of ip' to sort of equal 'Last value of bytes'
    at Assertion.assert (src/platform/packages/shared/kbn-expect/expect.js:100:11)
    at Assertion.eql (src/platform/packages/shared/kbn-expect/expect.js:244:8)
    at Context. (x-pack/platform/test/serverless/functional/test_suites/visualizations/group1/smokescreen.ts:677:90)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at Object.apply (src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/wrap_function.js:74:16) {
  actual: 'Unique count of ip',
  expected: 'Last value of bytes',
  showDiff: true
}
```
<img width="1280" height="1057" alt="image" src="https://github.com/user-attachments/assets/94cb8d49-4c76-419b-961b-60ef4bd7a4e5" />
