### PR TITLE
[Alerting V2] Split agent builder skill concepts into granular references

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/matcher_context.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/matcher_context.ts
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import type { z } from '@kbn/zod/v4';
+import type { AlertEpisodeStatus } from './alert_action_schema';
+import type { alertEventSeveritySchema } from './create_alert_event_data_schema';
+
 export interface MatcherContextRule {
   id: string;
   name: string;
@@ -15,8 +19,8 @@ export interface MatcherContext {
   last_event_timestamp: string;
   group_hash: string;
   episode_id: string;
-  episode_status: 'inactive' | 'pending' | 'active' | 'recovering';
-  severity?: 'info' | 'low' | 'medium' | 'high' | 'critical';
+  episode_status: AlertEpisodeStatus;
+  severity?: z.infer<typeof alertEventSeveritySchema>;
   rule?: MatcherContextRule;
   data?: Record<string, unknown>;
 }
@@ -24,16 +28,35 @@ export interface MatcherContext {
 export interface MatcherContextFieldDescriptor {
   path: string;
   type: 'string' | 'boolean' | 'string[]' | 'object';
+  /** Agent/UI-facing description of the matcher context field. */
+  description: string;
 }
 
+/**
+ * Canonical list of KQL matcher context fields. Source of truth for autocomplete
+ * and for Agent Builder skill docs (`generateMatcherContextDoc`).
+ */
 export const MATCHER_CONTEXT_FIELDS: MatcherContextFieldDescriptor[] = [
-  { path: 'episode_id', type: 'string' },
-  { path: 'episode_status', type: 'string' },
-  { path: 'group_hash', type: 'string' },
-  { path: 'last_event_timestamp', type: 'string' },
-  { path: 'severity', type: 'string' },
-  { path: 'rule.id', type: 'string' },
-  { path: 'rule.name', type: 'string' },
-  { path: 'rule.tags', type: 'string[]' },
-  { path: 'data', type: 'object' },
+  { path: 'episode_id', type: 'string', description: 'The episode UUID' },
+  {
+    path: 'episode_status',
+    type: 'string',
+    description: 'Episode lifecycle status',
+  },
+  { path: 'group_hash', type: 'string', description: 'Hash of the grouping fields' },
+  {
+    path: 'last_event_timestamp',
+    type: 'string',
+    description: 'Timestamp of the most recent event',
+  },
+  { path: 'severity', type: 'string', description: 'Episode severity when present' },
+  { path: 'rule.id', type: 'string', description: "The rule's saved object ID" },
+  { path: 'rule.name', type: 'string', description: "The rule's display name" },
+  { path: 'rule.tags', type: 'string[]', description: "The rule's tags array" },
+  {
+    path: 'data',
+    type: 'object',
+    description:
+      'Rule-specific ES|QL output columns (query as `data.*`, e.g. `data.host.name`, `data.error_count`)',
+  },
 ];

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
@@ -112,7 +112,7 @@ Auto-generated from \`groupingModeSchema\` in \`@kbn/alerting-v2-schemas\`.
 - \`all\`: a single notification for all matching episodes
 - \`per_field\`: group by specified \`groupBy\` fields
 
-Throttle strategy must be compatible with the grouping mode — see [throttle-strategies](./throttle-strategies.md)."
+Throttle strategy must be compatible with the grouping mode — see [action-policy-throttle-strategies](./action-policy-throttle-strategies.md)."
 `;
 
 exports[`schema_to_skill_docs generateMatcherContextDoc matches the reviewed skill-doc snapshot 1`] = `
@@ -251,7 +251,7 @@ Auto-generated from \`throttleStrategySchema\` and compatibility sets in \`@kbn/
 - \`time_interval\`: notify at regular intervals regardless of status (default for \`all\` / \`per_field\`)
 - \`every_time\`: notify on every evaluation cycle (high volume)
 
-Compatibility with grouping modes (see [grouping-modes](./grouping-modes.md)):
+Compatibility with grouping modes (see [action-policy-grouping-modes](./action-policy-grouping-modes.md)):
 - For \`per_episode\`: \`on_status_change\`, \`per_status_interval\`, \`every_time\`.
 - For \`all\` / \`per_field\`: \`time_interval\`, \`every_time\`.
 - \`per_status_interval\`, \`time_interval\` require an \`interval\` (e.g. \`\\"5m\\"\`, \`\\"1h\\"\`)."

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
@@ -103,6 +103,40 @@ Rule names: \`{{ inputs.payload.rules[ep.rule_id].name }}\`.
 | \`data\` | object | optional | Data of the alert episode |"
 `;
 
+exports[`schema_to_skill_docs generateGroupingModesDoc matches the reviewed skill-doc snapshot 1`] = `
+"# Grouping Modes
+
+Auto-generated from \`groupingModeSchema\` in \`@kbn/alerting-v2-schemas\`.
+
+- \`per_episode\`: one notification per alert episode lifecycle (default)
+- \`all\`: a single notification for all matching episodes
+- \`per_field\`: group by specified \`groupBy\` fields
+
+Throttle strategy must be compatible with the grouping mode — see [throttle-strategies](./throttle-strategies.md)."
+`;
+
+exports[`schema_to_skill_docs generateMatcherContextDoc matches the reviewed skill-doc snapshot 1`] = `
+"# Matcher Context Fields
+
+Auto-generated from \`MATCHER_CONTEXT_FIELDS\` in \`@kbn/alerting-v2-schemas\`.
+
+When the dispatcher evaluates a policy's KQL matcher, these fields are available:
+
+| Field | Type | Description |
+|---|---|---|
+| \`episode_id\` | string | The episode UUID |
+| \`episode_status\` | \`inactive\`, \`pending\`, \`active\`, \`recovering\` | Episode lifecycle status |
+| \`group_hash\` | string | Hash of the grouping fields |
+| \`last_event_timestamp\` | string | Timestamp of the most recent event |
+| \`severity\` | \`info\`, \`low\`, \`medium\`, \`high\`, \`critical\` | Episode severity when present |
+| \`rule.id\` | string | The rule's saved object ID |
+| \`rule.name\` | string | The rule's display name |
+| \`rule.tags\` | string[] | The rule's tags array |
+| \`data\` | \`data.*\` object | Rule-specific ES\\\\|QL output columns (query as \`data.*\`, e.g. \`data.host.name\`, \`data.error_count\`) |
+
+An empty matcher is a catch-all that matches all episodes in the space. To scope a policy to a single rule, use \`rule.id: \\"<ruleId>\\"\`."
+`;
+
 exports[`schema_to_skill_docs generateRuleOperationsDoc matches the snapshot 1`] = `
 "# Rule Operations Schema Reference
 
@@ -205,4 +239,20 @@ Auto-generated from \`@kbn/alerting-v2-schemas\`. This is the source of truth fo
 | \`breach\` | object | required | Breach detection configuration (required). |
 | \`recovery\` | object | optional | Recovery query. Required when recovery_strategy is \\"query\\". |
 | \`no_data\` | object | optional | No-data detection query. Required when no_data_strategy is not \\"none\\". |"
+`;
+
+exports[`schema_to_skill_docs generateThrottleStrategiesDoc matches the reviewed skill-doc snapshot 1`] = `
+"# Throttle Strategies
+
+Auto-generated from \`throttleStrategySchema\` and compatibility sets in \`@kbn/alerting-v2-schemas\`.
+
+- \`on_status_change\`: notify only on episode status transitions (default for \`per_episode\`)
+- \`per_status_interval\`: notify on transitions and at regular intervals
+- \`time_interval\`: notify at regular intervals regardless of status (default for \`all\` / \`per_field\`)
+- \`every_time\`: notify on every evaluation cycle (high volume)
+
+Compatibility with grouping modes (see [grouping-modes](./grouping-modes.md)):
+- For \`per_episode\`: \`on_status_change\`, \`per_status_interval\`, \`every_time\`.
+- For \`all\` / \`per_field\`: \`time_interval\`, \`every_time\`.
+- \`per_status_interval\`, \`time_interval\` require an \`interval\` (e.g. \`\\"5m\\"\`, \`\\"1h\\"\`)."
 `;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
@@ -65,4 +65,23 @@ describe('createActionPolicyManagementSkill', () => {
     expect(payloadRef?.content).toContain('`rules`');
     expect(payloadRef?.content).toContain('`episode_status`');
   });
+
+  it('exposes granular concept references instead of a monolithic concepts entry', () => {
+    const skill = createActionPolicyManagementSkill(createDeps());
+    const refNames = (skill.referencedContent ?? []).map((entry) => entry.name);
+
+    expect(refNames).toEqual(
+      expect.arrayContaining([
+        'action-policy-overview',
+        'workflows',
+        'connectors',
+        'dispatch-flow',
+      ])
+    );
+    expect(refNames).not.toContain('concepts');
+    expect(skill.content).toContain('./references/action-policy-overview.md');
+    expect(skill.content).toContain('./references/workflows.md');
+    expect(skill.content).toContain('./references/connectors.md');
+    expect(skill.content).toContain('./references/dispatch-flow.md');
+  });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
@@ -71,12 +71,7 @@ describe('createActionPolicyManagementSkill', () => {
     const refNames = (skill.referencedContent ?? []).map((entry) => entry.name);
 
     expect(refNames).toEqual(
-      expect.arrayContaining([
-        'action-policy-overview',
-        'workflows',
-        'connectors',
-        'dispatch-flow',
-      ])
+      expect.arrayContaining(['action-policy-overview', 'workflows', 'connectors', 'dispatch-flow'])
     );
     expect(refNames).not.toContain('concepts');
     expect(skill.content).toContain('./references/action-policy-overview.md');

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
@@ -59,16 +59,16 @@ describe('createActionPolicyManagementSkill', () => {
       (skill.referencedContent ?? []).map((entry) => [entry.name, entry.content])
     );
 
-    expect(byName.matchers).toContain('Auto-generated from `MATCHER_CONTEXT_FIELDS`');
-    expect(byName.matchers).toContain('`episode_status`');
-    expect(byName.matchers).toContain('`rule.id`');
+    expect(byName['action-policy-matchers']).toContain('Auto-generated from `MATCHER_CONTEXT_FIELDS`');
+    expect(byName['action-policy-matchers']).toContain('`episode_status`');
+    expect(byName['action-policy-matchers']).toContain('`rule.id`');
 
-    expect(byName['grouping-modes']).toContain('Auto-generated from `groupingModeSchema`');
-    expect(byName['grouping-modes']).toContain('`per_episode`');
+    expect(byName['action-policy-grouping-modes']).toContain('Auto-generated from `groupingModeSchema`');
+    expect(byName['action-policy-grouping-modes']).toContain('`per_episode`');
 
-    expect(byName['throttle-strategies']).toContain('Auto-generated from `throttleStrategySchema`');
-    expect(byName['throttle-strategies']).toContain('`on_status_change`');
-    expect(byName['throttle-strategies']).toContain('Compatibility with grouping modes');
+    expect(byName['action-policy-throttle-strategies']).toContain('Auto-generated from `throttleStrategySchema`');
+    expect(byName['action-policy-throttle-strategies']).toContain('`on_status_change`');
+    expect(byName['action-policy-throttle-strategies']).toContain('Compatibility with grouping modes');
   });
 
   it('exposes the generated workflow dispatch payload schema as referenced content', () => {
@@ -90,10 +90,10 @@ describe('createActionPolicyManagementSkill', () => {
 
     expect(refNames).toEqual(
       expect.arrayContaining([
-        'matchers',
-        'grouping-modes',
-        'throttle-strategies',
-        'workflows',
+        'action-policy-matchers',
+        'action-policy-grouping-modes',
+        'action-policy-throttle-strategies',
+        'workflow-destinations',
         'dispatch-flow',
       ])
     );
@@ -101,10 +101,10 @@ describe('createActionPolicyManagementSkill', () => {
     expect(refNames).not.toContain('connectors');
     expect(refNames).not.toContain('action-policy-overview');
     expect(skill.content).toContain('space-scoped saved object');
-    expect(skill.content).toContain('./references/matchers.md');
-    expect(skill.content).toContain('./references/grouping-modes.md');
-    expect(skill.content).toContain('./references/throttle-strategies.md');
-    expect(skill.content).toContain('./references/workflows.md');
+    expect(skill.content).toContain('./references/action-policy-matchers.md');
+    expect(skill.content).toContain('./references/action-policy-grouping-modes.md');
+    expect(skill.content).toContain('./references/action-policy-throttle-strategies.md');
+    expect(skill.content).toContain('./references/workflow-destinations.md');
     expect(skill.content).toContain('./references/dispatch-flow.md');
     expect(skill.content).toContain('workflow-authoring');
     expect(skill.description).not.toContain('(notification policies)');

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
@@ -53,6 +53,24 @@ describe('createActionPolicyManagementSkill', () => {
     expect(skill.content).toContain('workflow-authoring');
   });
 
+  it('exposes schema-generated matcher, grouping, and throttle references', () => {
+    const skill = createActionPolicyManagementSkill(createDeps());
+    const byName = Object.fromEntries(
+      (skill.referencedContent ?? []).map((entry) => [entry.name, entry.content])
+    );
+
+    expect(byName.matchers).toContain('Auto-generated from `MATCHER_CONTEXT_FIELDS`');
+    expect(byName.matchers).toContain('`episode_status`');
+    expect(byName.matchers).toContain('`rule.id`');
+
+    expect(byName['grouping-modes']).toContain('Auto-generated from `groupingModeSchema`');
+    expect(byName['grouping-modes']).toContain('`per_episode`');
+
+    expect(byName['throttle-strategies']).toContain('Auto-generated from `throttleStrategySchema`');
+    expect(byName['throttle-strategies']).toContain('`on_status_change`');
+    expect(byName['throttle-strategies']).toContain('Compatibility with grouping modes');
+  });
+
   it('exposes the generated workflow dispatch payload schema as referenced content', () => {
     const skill = createActionPolicyManagementSkill(createDeps());
     const payloadRef = skill.referencedContent?.find(
@@ -71,12 +89,26 @@ describe('createActionPolicyManagementSkill', () => {
     const refNames = (skill.referencedContent ?? []).map((entry) => entry.name);
 
     expect(refNames).toEqual(
-      expect.arrayContaining(['action-policy-overview', 'workflows', 'connectors', 'dispatch-flow'])
+      expect.arrayContaining([
+        'matchers',
+        'grouping-modes',
+        'throttle-strategies',
+        'workflows',
+        'dispatch-flow',
+      ])
     );
     expect(refNames).not.toContain('concepts');
-    expect(skill.content).toContain('./references/action-policy-overview.md');
+    expect(refNames).not.toContain('connectors');
+    expect(refNames).not.toContain('action-policy-overview');
+    expect(skill.content).toContain('space-scoped saved object');
+    expect(skill.content).toContain('./references/matchers.md');
+    expect(skill.content).toContain('./references/grouping-modes.md');
+    expect(skill.content).toContain('./references/throttle-strategies.md');
     expect(skill.content).toContain('./references/workflows.md');
-    expect(skill.content).toContain('./references/connectors.md');
     expect(skill.content).toContain('./references/dispatch-flow.md');
+    expect(skill.content).toContain('workflow-authoring');
+    expect(skill.description).not.toContain('(notification policies)');
+    expect(skill.content).not.toContain('(Notification Policies)');
+    expect(skill.content).not.toContain('also called notification policies');
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
@@ -59,16 +59,24 @@ describe('createActionPolicyManagementSkill', () => {
       (skill.referencedContent ?? []).map((entry) => [entry.name, entry.content])
     );
 
-    expect(byName['action-policy-matchers']).toContain('Auto-generated from `MATCHER_CONTEXT_FIELDS`');
+    expect(byName['action-policy-matchers']).toContain(
+      'Auto-generated from `MATCHER_CONTEXT_FIELDS`'
+    );
     expect(byName['action-policy-matchers']).toContain('`episode_status`');
     expect(byName['action-policy-matchers']).toContain('`rule.id`');
 
-    expect(byName['action-policy-grouping-modes']).toContain('Auto-generated from `groupingModeSchema`');
+    expect(byName['action-policy-grouping-modes']).toContain(
+      'Auto-generated from `groupingModeSchema`'
+    );
     expect(byName['action-policy-grouping-modes']).toContain('`per_episode`');
 
-    expect(byName['action-policy-throttle-strategies']).toContain('Auto-generated from `throttleStrategySchema`');
+    expect(byName['action-policy-throttle-strategies']).toContain(
+      'Auto-generated from `throttleStrategySchema`'
+    );
     expect(byName['action-policy-throttle-strategies']).toContain('`on_status_change`');
-    expect(byName['action-policy-throttle-strategies']).toContain('Compatibility with grouping modes');
+    expect(byName['action-policy-throttle-strategies']).toContain(
+      'Compatibility with grouping modes'
+    );
   });
 
   it('exposes the generated workflow dispatch payload schema as referenced content', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.ts
@@ -30,11 +30,9 @@ export const createActionPolicyManagementSkill = (deps: ManageActionPolicyToolDe
     uiSettingRequired: ALERTING_V2_ENABLED_SETTING_ID,
     referencedContent: [
       {
-        name: 'concepts',
+        name: 'action-policy-overview',
         relativePath: './references',
-        content: `# Action Policy Concepts
-
-## Action Policies (Notification Policies)
+        content: `# Action Policies (Notification Policies)
 
 An action policy is a **space-scoped saved object** that controls how alert episodes are matched, grouped, throttled, and dispatched to workflow destinations.
 
@@ -43,7 +41,7 @@ Key characteristics:
 - **Matcher**: optional KQL query evaluated against episode context. An empty matcher is a catch-all that matches all episodes in the space.
 - **Only processes \`kind: alert\` episodes.** Signal events are excluded from the dispatcher pipeline — they never reach action policy evaluation.
 
-### Matcher Context Fields
+## Matcher Context Fields
 
 When the dispatcher evaluates a policy's KQL matcher, these fields are available:
 
@@ -58,39 +56,42 @@ When the dispatcher evaluates a policy's KQL matcher, these fields are available
 | \`rule.tags\` | The rule's tags array |
 | \`data.*\` | Rule-specific ES|QL output columns (e.g. \`data.host.name\`, \`data.error_count\`) |
 
-### Grouping Modes
+## Grouping Modes
 - \`per_episode\` (default): one notification per alert episode lifecycle.
 - \`all\`: a single notification for all matching episodes.
 - \`per_field\`: group by specified \`groupBy\` fields.
 
-### Throttle Strategies
+## Throttle Strategies
 - \`on_status_change\`: notify only on episode status transitions (default for \`per_episode\`).
 - \`per_status_interval\`: notify on transitions and at regular intervals.
 - \`time_interval\`: notify at regular intervals regardless of status (default for \`all\`/\`per_field\`).
-- \`every_time\`: notify on every evaluation cycle (high volume).
-
----
-
-## Workflows
+- \`every_time\`: notify on every evaluation cycle (high volume).`,
+      },
+      {
+        name: 'workflows',
+        relativePath: './references',
+        content: `# Workflows
 
 A workflow is a **concrete automation defined in YAML** that executes when dispatched by an action policy.
 
 - Workflow steps can use Kibana **connectors** (email, Slack, PagerDuty, etc.) via the \`connector-id\` field on each step.
 - Action policy destinations reference **workflow IDs**, never connector IDs directly.
-- Destination workflows must use **exactly one** \`triggers: - type: manual\` trigger — never \`alert\`.
-
----
-
-## Connectors
+- Destination workflows must use **exactly one** \`triggers: - type: manual\` trigger — never \`alert\`.`,
+      },
+      {
+        name: 'connectors',
+        relativePath: './references',
+        content: `# Connectors
 
 A connector is a **configured integration instance** (e.g., an email server, a Slack webhook) managed under **Stack Management > Connectors**.
 
 - Referenced inside workflow YAML steps via \`connector-id\`, **not** in action policies.
-- The agent **cannot create connectors**. If no suitable connector exists, direct the user to set one up in Stack Management > Connectors.
-
----
-
-## Dispatch Flow
+- The agent **cannot create connectors**. If no suitable connector exists, direct the user to set one up in Stack Management > Connectors.`,
+      },
+      {
+        name: 'dispatch-flow',
+        relativePath: './references',
+        content: `# Dispatch Flow
 
 The end-to-end notification path:
 
@@ -123,7 +124,11 @@ Signal rules (\`kind: signal\`) are excluded at step 2 — the dispatcher query 
     ],
     content: `## Domain Knowledge
 
-For questions about action policies, workflows, connectors, or the dispatch flow — consult the [concepts reference](./references/concepts.md).
+For questions about action policies, workflows, connectors, or the dispatch flow:
+- Action policies (matchers, grouping, throttling) — consult the [action-policy-overview reference](./references/action-policy-overview.md).
+- Workflows — consult the [workflows reference](./references/workflows.md).
+- Connectors — consult the [connectors reference](./references/connectors.md).
+- End-to-end dispatch path — consult the [dispatch-flow reference](./references/dispatch-flow.md).
 
 ---
 
@@ -145,7 +150,7 @@ Do **not** use this skill for:
 
 # Part 1: Action Policies (Notification Policies)
 
-Action policies control how alert episodes are matched, grouped, throttled, and dispatched to workflow destinations.
+Action policies control how alert episodes are matched, grouped, throttled, and dispatched to workflow destinations. See the [action-policy-overview reference](./references/action-policy-overview.md) and [dispatch-flow reference](./references/dispatch-flow.md).
 
 ## Action Policy Discovery
 
@@ -159,17 +164,17 @@ When a user asks about existing action policies:
 
 Build the request for ${ALERTING_TOOL_IDS.manageActionPolicy} as an ordered \`operations\` array. Operations run in sequence.
 
-For a new policy, start with \`set_metadata\` (name required), then \`set_destinations\`.
+For a new policy, start with \`set_metadata\` (name required), then \`set_destinations\`. Destination workflows are covered in the [workflows reference](./references/workflows.md).
 
 For an existing policy, pass the \`actionPolicyAttachmentId\` and only include the operations for the requested changes.
 
-Refer to the [action-policy-operations-schema reference](./references/action-policy-operations-schema.md) for every operation's fields, types, and constraints. Grouping modes and throttle strategies are also summarized in the [concepts reference](./references/concepts.md).
+Refer to the [action-policy-operations-schema reference](./references/action-policy-operations-schema.md) for every operation's fields, types, and constraints. Grouping modes and throttle strategies are also summarized in the [action-policy-overview reference](./references/action-policy-overview.md).
 
-Action policies are always space-scoped: they match alerts from any rule in the space unless the matcher narrows them. To scope a policy to a single rule, set a matcher of \`rule.id: "<ruleId>"\` via \`set_matcher\`. Matcher context fields are listed in the concepts reference.
+Action policies are always space-scoped: they match alerts from any rule in the space unless the matcher narrows them. To scope a policy to a single rule, set a matcher of \`rule.id: "<ruleId>"\` via \`set_matcher\`. Matcher context fields are listed in the [action-policy-overview reference](./references/action-policy-overview.md).
 
 ### Throttle / Grouping Compatibility
 
-The throttle strategy must be compatible with the grouping mode:
+The throttle strategy must be compatible with the grouping mode (see [action-policy-overview reference](./references/action-policy-overview.md)):
 - For \`per_episode\`: \`on_status_change\`, \`per_status_interval\`, \`every_time\`.
 - For \`all\` / \`per_field\`: \`time_interval\`, \`every_time\`.
 - \`per_status_interval\` and \`time_interval\` require an \`interval\` (e.g. \`"5m"\`, \`"1h"\`).
@@ -203,8 +208,8 @@ Action policies only process alert episodes. If the rule is \`kind: signal\`, do
 
 ## Step 1 — Create a Default Workflow
 
-1. Load the \`workflow-authoring\` skill via \`filestore.read\` (path: \`skills/platform/workflows\`).
-2. Call \`platform.workflows.get_connectors\` with \`actionTypeId: ".email"\` to find an available email connector.
+1. Load the \`workflow-authoring\` skill via \`filestore.read\` (path: \`skills/platform/workflows\`). See also the [workflows reference](./references/workflows.md).
+2. Call \`platform.workflows.get_connectors\` with \`actionTypeId: ".email"\` to find an available email connector ([connectors reference](./references/connectors.md)).
    - If no email connector exists, tell the user: "No email connector is configured. You can set one up under Stack Management → Connectors, then come back to add notifications."
 3. Generate a unique \`workflowId\` — a UUID (e.g. \`550e8400-e29b-41d4-a716-446655440000\`). Pass it as the \`workflowId\` parameter when calling \`platform.core.generate_workflow\`. This same ID will be used as the persisted workflow ID and must be referenced in the action policy destination. **Do NOT use a human-readable slug** — it would collide across conversations.
 4. Call \`platform.core.generate_workflow\` with the \`workflowId\` and a natural-language description that includes the YAML template tailored to the rule's query columns (paste the template into the \`query\` or \`instructions\` parameter).
@@ -263,7 +268,7 @@ steps:
 
 ## Step 2 — Create a Default Action Policy
 
-Use ${ALERTING_TOOL_IDS.manageActionPolicy} with these operations in order:
+Use ${ALERTING_TOOL_IDS.manageActionPolicy} with these operations in order (see [action-policy-overview reference](./references/action-policy-overview.md) for matcher, grouping, and throttle details):
 
 1. \`set_metadata\`: name = \`"Notify on <rule-name>"\`, description = \`"Default notification for <rule-name>"\`
 2. \`set_destinations\`: \`[{ type: "workflow", id: "<workflowId-from-step-1>" }]\`
@@ -285,11 +290,13 @@ After rendering all three attachments (rule, workflow, action policy), remind th
 
 > "To activate this alerting setup, please save in order: **Rule → Workflow → Action Policy**. The action policy depends on both the rule and the workflow being saved first."
 
+The end-to-end path from rule evaluation to notification delivery is described in the [dispatch-flow reference](./references/dispatch-flow.md).
+
 ## Customization Hints
 
 After creating the defaults, briefly mention:
-- They can use a different connector type (Slack, PagerDuty, etc.) — offer to use \`platform.workflows.get_connectors\` to explore.
-- They can change the throttle strategy — \`on_status_change\` (default) only notifies on transitions, \`every_time\` notifies on every evaluation cycle.
+- They can use a different connector type (Slack, PagerDuty, etc.) — offer to use \`platform.workflows.get_connectors\` to explore ([connectors reference](./references/connectors.md)).
+- They can change the throttle strategy — \`on_status_change\` (default) only notifies on transitions, \`every_time\` notifies on every evaluation cycle ([action-policy-overview reference](./references/action-policy-overview.md)).
 - They can broaden the policy to cover multiple rules by removing the \`rule.id\` matcher or replacing it with a broader matcher.`,
     getInlineTools: () => [manageActionPolicyTool(deps)],
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.ts
@@ -17,6 +17,9 @@ import {
   generateActionPolicyOperationsDoc,
   generateActionPolicySchemaDoc,
   generateActionPolicyWorkflowPayloadDoc,
+  generateGroupingModesDoc,
+  generateMatcherContextDoc,
+  generateThrottleStrategiesDoc,
 } from './schema_to_skill_docs';
 
 export const createActionPolicyManagementSkill = (deps: ManageActionPolicyToolDeps) =>
@@ -25,47 +28,24 @@ export const createActionPolicyManagementSkill = (deps: ManageActionPolicyToolDe
     name: ACTION_POLICY_MANAGEMENT_SKILL_ID,
     basePath: 'skills/platform/alerting',
     description:
-      'Compose, discover, and modify Alerting V2 action policies (notification policies) within a conversation. Use when the user wants to set up, change, or inspect how alert notifications are matched, grouped, throttled, and dispatched to workflows ("notify me when this rule fires", "set up email notifications for my alert", "create a notification policy", "change my alert to page via PagerDuty", "list my action policies"). Covers workflow destinations, KQL matchers, grouping, and throttling. For composing or editing the underlying alert rules themselves, load the rule-management skill.',
+      'Compose, discover, and modify Alerting V2 action policies within a conversation. Use when the user wants to set up, change, or inspect how alert notifications are matched, grouped, throttled, and dispatched to workflows ("notify me when this rule fires", "set up email notifications for my alert", "create a notification policy", "change my alert to page via PagerDuty", "list my action policies"). Covers workflow destinations, KQL matchers, grouping, and throttling. For composing or editing the underlying alert rules themselves, load the rule-management skill.',
     experimental: true,
     uiSettingRequired: ALERTING_V2_ENABLED_SETTING_ID,
     referencedContent: [
       {
-        name: 'action-policy-overview',
+        name: 'matchers',
         relativePath: './references',
-        content: `# Action Policies (Notification Policies)
-
-An action policy is a **space-scoped saved object** that controls how alert episodes are matched, grouped, throttled, and dispatched to workflow destinations.
-
-Key characteristics:
-- **Not embedded in a rule.** One policy can match episodes from many rules.
-- **Matcher**: optional KQL query evaluated against episode context. An empty matcher is a catch-all that matches all episodes in the space.
-- **Only processes \`kind: alert\` episodes.** Signal events are excluded from the dispatcher pipeline — they never reach action policy evaluation.
-
-## Matcher Context Fields
-
-When the dispatcher evaluates a policy's KQL matcher, these fields are available:
-
-| Field | Description |
-|---|---|
-| \`episode_id\` | The episode UUID |
-| \`episode_status\` | \`inactive\`, \`pending\`, \`active\`, or \`recovering\` |
-| \`group_hash\` | Hash of the grouping fields |
-| \`last_event_timestamp\` | Timestamp of the most recent event |
-| \`rule.id\` | The rule's saved object ID |
-| \`rule.name\` | The rule's display name |
-| \`rule.tags\` | The rule's tags array |
-| \`data.*\` | Rule-specific ES|QL output columns (e.g. \`data.host.name\`, \`data.error_count\`) |
-
-## Grouping Modes
-- \`per_episode\` (default): one notification per alert episode lifecycle.
-- \`all\`: a single notification for all matching episodes.
-- \`per_field\`: group by specified \`groupBy\` fields.
-
-## Throttle Strategies
-- \`on_status_change\`: notify only on episode status transitions (default for \`per_episode\`).
-- \`per_status_interval\`: notify on transitions and at regular intervals.
-- \`time_interval\`: notify at regular intervals regardless of status (default for \`all\`/\`per_field\`).
-- \`every_time\`: notify on every evaluation cycle (high volume).`,
+        content: generateMatcherContextDoc(),
+      },
+      {
+        name: 'grouping-modes',
+        relativePath: './references',
+        content: generateGroupingModesDoc(),
+      },
+      {
+        name: 'throttle-strategies',
+        relativePath: './references',
+        content: generateThrottleStrategiesDoc(),
       },
       {
         name: 'workflows',
@@ -76,17 +56,8 @@ A workflow is a **concrete automation defined in YAML** that executes when dispa
 
 - Workflow steps can use Kibana **connectors** (email, Slack, PagerDuty, etc.) via the \`connector-id\` field on each step.
 - Action policy destinations reference **workflow IDs**, never connector IDs directly.
-- Destination workflows must use **exactly one** \`triggers: - type: manual\` trigger — never \`alert\`.`,
-      },
-      {
-        name: 'connectors',
-        relativePath: './references',
-        content: `# Connectors
-
-A connector is a **configured integration instance** (e.g., an email server, a Slack webhook) managed under **Stack Management > Connectors**.
-
-- Referenced inside workflow YAML steps via \`connector-id\`, **not** in action policies.
-- The agent **cannot create connectors**. If no suitable connector exists, direct the user to set one up in Stack Management > Connectors.`,
+- Destination workflows must use **exactly one** \`triggers: - type: manual\` trigger — never \`alert\`.
+- For deeper connector knowledge (types, \`connector-id\` usage, discovery tools), load the \`workflow-authoring\` skill.`,
       },
       {
         name: 'dispatch-flow',
@@ -122,35 +93,43 @@ Signal rules (\`kind: signal\`) are excluded at step 2 — the dispatcher query 
         content: generateActionPolicyWorkflowPayloadDoc(),
       },
     ],
-    content: `## Domain Knowledge
-
-For questions about action policies, workflows, connectors, or the dispatch flow:
-- Action policies (matchers, grouping, throttling) — consult the [action-policy-overview reference](./references/action-policy-overview.md).
-- Workflows — consult the [workflows reference](./references/workflows.md).
-- Connectors — consult the [connectors reference](./references/connectors.md).
-- End-to-end dispatch path — consult the [dispatch-flow reference](./references/dispatch-flow.md).
-
----
-
-## When to Use This Skill
+    content: `## When to Use This Skill
 
 Use this skill when:
-- A user asks to find, list, inspect, or modify action policies (also called notification policies).
+- A user asks to find, list, inspect, or modify action policies.
 - A user asks to create or configure a new action policy with workflow destinations, matchers, grouping, or throttling.
-- A user wants to set up notifications (email, Slack, PagerDuty, etc.) for an alert rule.
+- A user wants to set up notifications (email, Slack, PagerDuty, etc.) for an alert rule (saved object id: 'alerting_rule').
 - The \`rule-management\` skill has handed off after composing a complete alert rule and the user agreed to set up notifications.
 
 Do **not** use this skill for:
 - Composing or editing alerting V2 rules themselves — load the \`rule-management\` skill for that.
-- Classic (V1) Kibana stack rules or Security detection rules.
+- Notifications for Classic Kibana stack (saved object id: 'alert') rules or Security detection rules.
 - Action connector configuration (connectors are managed separately).
 - Querying or analyzing data — use data exploration skills for that.
 
 ---
 
-# Part 1: Action Policies (Notification Policies)
+## Domain Knowledge
 
-Action policies control how alert episodes are matched, grouped, throttled, and dispatched to workflow destinations. See the [action-policy-overview reference](./references/action-policy-overview.md) and [dispatch-flow reference](./references/dispatch-flow.md).
+For questions about matchers, grouping, throttling, workflows, or the dispatch flow:
+- Matchers — consult the [matchers reference](./references/matchers.md).
+- Grouping modes — consult the [grouping-modes reference](./references/grouping-modes.md).
+- Throttle strategies — consult the [throttle-strategies reference](./references/throttle-strategies.md).
+- Workflows — consult the [workflows reference](./references/workflows.md). For connectors (types, discovery, \`connector-id\` usage), load the \`workflow-authoring\` skill.
+- End-to-end dispatch path — consult the [dispatch-flow reference](./references/dispatch-flow.md).
+
+---
+
+# Part 1: Action Policies
+
+An action policy is a **space-scoped saved object** that controls how alert episodes are matched, grouped, throttled, and dispatched to workflow destinations.
+
+Key characteristics:
+- **Not embedded in a rule.** One policy can match episodes from many rules.
+- **Matcher**: optional KQL query evaluated against episode context. An empty matcher is a catch-all that matches all episodes in the space. See the [matchers reference](./references/matchers.md).
+- **Only processes \`kind: alert\` episodes.** Signal events are excluded from the dispatcher pipeline — they never reach action policy evaluation.
+- Grouping and throttling details: [grouping-modes](./references/grouping-modes.md), [throttle-strategies](./references/throttle-strategies.md).
+- End-to-end path: [dispatch-flow reference](./references/dispatch-flow.md).
 
 ## Action Policy Discovery
 
@@ -168,13 +147,13 @@ For a new policy, start with \`set_metadata\` (name required), then \`set_destin
 
 For an existing policy, pass the \`actionPolicyAttachmentId\` and only include the operations for the requested changes.
 
-Refer to the [action-policy-operations-schema reference](./references/action-policy-operations-schema.md) for every operation's fields, types, and constraints. Grouping modes and throttle strategies are also summarized in the [action-policy-overview reference](./references/action-policy-overview.md).
+Refer to the [action-policy-operations-schema reference](./references/action-policy-operations-schema.md) for every operation's fields, types, and constraints. Grouping modes and throttle strategies are summarized in the [grouping-modes reference](./references/grouping-modes.md) and [throttle-strategies reference](./references/throttle-strategies.md).
 
-Action policies are always space-scoped: they match alerts from any rule in the space unless the matcher narrows them. To scope a policy to a single rule, set a matcher of \`rule.id: "<ruleId>"\` via \`set_matcher\`. Matcher context fields are listed in the [action-policy-overview reference](./references/action-policy-overview.md).
+Action policies are always space-scoped: they match alerts from any rule in the space unless the matcher narrows them. To scope a policy to a single rule, set a matcher of \`rule.id: "<ruleId>"\` via \`set_matcher\`. Matcher context fields are listed in the [matchers reference](./references/matchers.md).
 
 ### Throttle / Grouping Compatibility
 
-The throttle strategy must be compatible with the grouping mode (see [action-policy-overview reference](./references/action-policy-overview.md)):
+The throttle strategy must be compatible with the grouping mode (see [grouping-modes reference](./references/grouping-modes.md) and [throttle-strategies reference](./references/throttle-strategies.md)):
 - For \`per_episode\`: \`on_status_change\`, \`per_status_interval\`, \`every_time\`.
 - For \`all\` / \`per_field\`: \`time_interval\`, \`every_time\`.
 - \`per_status_interval\` and \`time_interval\` require an \`interval\` (e.g. \`"5m"\`, \`"1h"\`).
@@ -206,11 +185,13 @@ When setting up notifications for a complete **alert** rule (has name, query, sc
 
 Action policies only process alert episodes. If the rule is \`kind: signal\`, do not proceed: ask the user (or the rule-management skill) to convert or recreate the rule as \`kind: alert\` first.
 
+The email connector lookup and workflow YAML below are **examples only** for the common case where the user has not named a channel. Prefer the user's requested channel (Slack, PagerDuty, etc.) when they specify one. Adapt \`get_connectors\`, the workflow step type, and the message template accordingly — consult the \`workflow-authoring\` skill for connector details.
+
 ## Step 1 — Create a Default Workflow
 
-1. Load the \`workflow-authoring\` skill via \`filestore.read\` (path: \`skills/platform/workflows\`). See also the [workflows reference](./references/workflows.md).
-2. Call \`platform.workflows.get_connectors\` with \`actionTypeId: ".email"\` to find an available email connector ([connectors reference](./references/connectors.md)).
-   - If no email connector exists, tell the user: "No email connector is configured. You can set one up under Stack Management → Connectors, then come back to add notifications."
+1. Load the \`workflow-authoring\` skill via \`filestore.read\` (path: \`skills/platform/workflows\`). That skill also covers connectors in depth. See also the [workflows reference](./references/workflows.md).
+2. Find an available connector for the chosen channel. **Example** for email: call \`platform.workflows.get_connectors\` with \`actionTypeId: ".email"\`.
+   - If no suitable connector exists, tell the user (example for email): "No email connector is configured. You can set one up under Stack Management → Connectors, then come back to add notifications."
 3. Generate a unique \`workflowId\` — a UUID (e.g. \`550e8400-e29b-41d4-a716-446655440000\`). Pass it as the \`workflowId\` parameter when calling \`platform.core.generate_workflow\`. This same ID will be used as the persisted workflow ID and must be referenced in the action policy destination. **Do NOT use a human-readable slug** — it would collide across conversations.
 4. Call \`platform.core.generate_workflow\` with the \`workflowId\` and a natural-language description that includes the YAML template tailored to the rule's query columns (paste the template into the \`query\` or \`instructions\` parameter).
 
@@ -221,9 +202,7 @@ Those columns are the fields that appear in \`episodes[].data\` when the rule fi
 executor writes each ES|QL result row as \`data: rowDoc\` on alert events.
 If the output columns are unclear, run the rule's ES|QL with \`| LIMIT 0\` to discover column names and types.
 
-For a rule with query: \`FROM logs-* | STATS error_count = COUNT(*) BY host.name | WHERE error_count >= 5\`
-
-Use this template structure:
+**Example** for a rule with query: \`FROM logs-* | STATS error_count = COUNT(*) BY host.name | WHERE error_count >= 5\`, using an email connector:
 
 \`\`\`yaml
 version: '1'
@@ -260,7 +239,7 @@ steps:
 - Reference \`ep.data.*\` from the rule's ES|QL columns; dotted names nest
   (\`ep.data.host.name\`, not \`ep.data["host.name"]\`).
 - Guard empty \`data\` on recovering/inactive (\`| default\` or \`{% if ep.data %}\`).
-
+- Swap the step type / \`with\` fields for other channels — the email step above is an example, not a requirement.
 5. After creating the workflow, render it inline for user review:
    \`<render_attachment id="{attachmentId}" version="{attachmentVersion}"/>\`
    where \`attachmentId\` and \`attachmentVersion\` come from the \`generate_workflow\` tool result.
@@ -268,7 +247,7 @@ steps:
 
 ## Step 2 — Create a Default Action Policy
 
-Use ${ALERTING_TOOL_IDS.manageActionPolicy} with these operations in order (see [action-policy-overview reference](./references/action-policy-overview.md) for matcher, grouping, and throttle details):
+Use ${ALERTING_TOOL_IDS.manageActionPolicy} with these operations in order (see [matchers](./references/matchers.md), [grouping-modes](./references/grouping-modes.md), and [throttle-strategies](./references/throttle-strategies.md) for details):
 
 1. \`set_metadata\`: name = \`"Notify on <rule-name>"\`, description = \`"Default notification for <rule-name>"\`
 2. \`set_destinations\`: \`[{ type: "workflow", id: "<workflowId-from-step-1>" }]\`
@@ -295,8 +274,8 @@ The end-to-end path from rule evaluation to notification delivery is described i
 ## Customization Hints
 
 After creating the defaults, briefly mention:
-- They can use a different connector type (Slack, PagerDuty, etc.) — offer to use \`platform.workflows.get_connectors\` to explore ([connectors reference](./references/connectors.md)).
-- They can change the throttle strategy — \`on_status_change\` (default) only notifies on transitions, \`every_time\` notifies on every evaluation cycle ([action-policy-overview reference](./references/action-policy-overview.md)).
+- They can switch connector type (Slack, PagerDuty, email, etc.) — offer to use \`platform.workflows.get_connectors\` to explore, or consult the \`workflow-authoring\` skill for connector details. The email path above is only an example.
+- They can change the throttle strategy — \`on_status_change\` (default) only notifies on transitions, \`every_time\` notifies on every evaluation cycle ([throttle-strategies reference](./references/throttle-strategies.md)).
 - They can broaden the policy to cover multiple rules by removing the \`rule.id\` matcher or replacing it with a broader matcher.`,
     getInlineTools: () => [manageActionPolicyTool(deps)],
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.ts
@@ -33,22 +33,22 @@ export const createActionPolicyManagementSkill = (deps: ManageActionPolicyToolDe
     uiSettingRequired: ALERTING_V2_ENABLED_SETTING_ID,
     referencedContent: [
       {
-        name: 'matchers',
+        name: 'action-policy-matchers',
         relativePath: './references',
         content: generateMatcherContextDoc(),
       },
       {
-        name: 'grouping-modes',
+        name: 'action-policy-grouping-modes',
         relativePath: './references',
         content: generateGroupingModesDoc(),
       },
       {
-        name: 'throttle-strategies',
+        name: 'action-policy-throttle-strategies',
         relativePath: './references',
         content: generateThrottleStrategiesDoc(),
       },
       {
-        name: 'workflows',
+        name: 'workflow-destinations',
         relativePath: './references',
         content: `# Workflows
 
@@ -112,10 +112,10 @@ Do **not** use this skill for:
 ## Domain Knowledge
 
 For questions about matchers, grouping, throttling, workflows, or the dispatch flow:
-- Matchers — consult the [matchers reference](./references/matchers.md).
-- Grouping modes — consult the [grouping-modes reference](./references/grouping-modes.md).
-- Throttle strategies — consult the [throttle-strategies reference](./references/throttle-strategies.md).
-- Workflows — consult the [workflows reference](./references/workflows.md). For connectors (types, discovery, \`connector-id\` usage), load the \`workflow-authoring\` skill.
+- Matchers — consult the [action-policy-matchers reference](./references/action-policy-matchers.md).
+- Grouping modes — consult the [action-policy-grouping-modes reference](./references/action-policy-grouping-modes.md).
+- Throttle strategies — consult the [action-policy-throttle-strategies reference](./references/action-policy-throttle-strategies.md).
+- Workflows — consult the [workflow-destinations reference](./references/workflow-destinations.md). For connectors (types, discovery, \`connector-id\` usage), load the \`workflow-authoring\` skill.
 - End-to-end dispatch path — consult the [dispatch-flow reference](./references/dispatch-flow.md).
 
 ---
@@ -126,9 +126,9 @@ An action policy is a **space-scoped saved object** that controls how alert epis
 
 Key characteristics:
 - **Not embedded in a rule.** One policy can match episodes from many rules.
-- **Matcher**: optional KQL query evaluated against episode context. An empty matcher is a catch-all that matches all episodes in the space. See the [matchers reference](./references/matchers.md).
+- **Matcher**: optional KQL query evaluated against episode context. An empty matcher is a catch-all that matches all episodes in the space. See the [action-policy-matchers reference](./references/action-policy-matchers.md).
 - **Only processes \`kind: alert\` episodes.** Signal events are excluded from the dispatcher pipeline — they never reach action policy evaluation.
-- Grouping and throttling details: [grouping-modes](./references/grouping-modes.md), [throttle-strategies](./references/throttle-strategies.md).
+- Grouping and throttling details: [action-policy-grouping-modes](./references/action-policy-grouping-modes.md), [action-policy-throttle-strategies](./references/action-policy-throttle-strategies.md).
 - End-to-end path: [dispatch-flow reference](./references/dispatch-flow.md).
 
 ## Action Policy Discovery
@@ -143,17 +143,17 @@ When a user asks about existing action policies:
 
 Build the request for ${ALERTING_TOOL_IDS.manageActionPolicy} as an ordered \`operations\` array. Operations run in sequence.
 
-For a new policy, start with \`set_metadata\` (name required), then \`set_destinations\`. Destination workflows are covered in the [workflows reference](./references/workflows.md).
+For a new policy, start with \`set_metadata\` (name required), then \`set_destinations\`. Destination workflows are covered in the [workflow-destinations reference](./references/workflow-destinations.md).
 
 For an existing policy, pass the \`actionPolicyAttachmentId\` and only include the operations for the requested changes.
 
-Refer to the [action-policy-operations-schema reference](./references/action-policy-operations-schema.md) for every operation's fields, types, and constraints. Grouping modes and throttle strategies are summarized in the [grouping-modes reference](./references/grouping-modes.md) and [throttle-strategies reference](./references/throttle-strategies.md).
+Refer to the [action-policy-operations-schema reference](./references/action-policy-operations-schema.md) for every operation's fields, types, and constraints. Grouping modes and throttle strategies are summarized in the [action-policy-grouping-modes reference](./references/action-policy-grouping-modes.md) and [action-policy-throttle-strategies reference](./references/action-policy-throttle-strategies.md).
 
-Action policies are always space-scoped: they match alerts from any rule in the space unless the matcher narrows them. To scope a policy to a single rule, set a matcher of \`rule.id: "<ruleId>"\` via \`set_matcher\`. Matcher context fields are listed in the [matchers reference](./references/matchers.md).
+Action policies are always space-scoped: they match alerts from any rule in the space unless the matcher narrows them. To scope a policy to a single rule, set a matcher of \`rule.id: "<ruleId>"\` via \`set_matcher\`. Matcher context fields are listed in the [action-policy-matchers reference](./references/action-policy-matchers.md).
 
 ### Throttle / Grouping Compatibility
 
-The throttle strategy must be compatible with the grouping mode (see [grouping-modes reference](./references/grouping-modes.md) and [throttle-strategies reference](./references/throttle-strategies.md)):
+The throttle strategy must be compatible with the grouping mode (see [action-policy-grouping-modes reference](./references/action-policy-grouping-modes.md) and [action-policy-throttle-strategies reference](./references/action-policy-throttle-strategies.md)):
 - For \`per_episode\`: \`on_status_change\`, \`per_status_interval\`, \`every_time\`.
 - For \`all\` / \`per_field\`: \`time_interval\`, \`every_time\`.
 - \`per_status_interval\` and \`time_interval\` require an \`interval\` (e.g. \`"5m"\`, \`"1h"\`).
@@ -189,7 +189,7 @@ The email connector lookup and workflow YAML below are **examples only** for the
 
 ## Step 1 — Create a Default Workflow
 
-1. Load the \`workflow-authoring\` skill via \`filestore.read\` (path: \`skills/platform/workflows\`). That skill also covers connectors in depth. See also the [workflows reference](./references/workflows.md).
+1. Load the \`workflow-authoring\` skill via \`filestore.read\` (path: \`skills/platform/workflows\`). That skill also covers connectors in depth. See also the [workflow-destinations reference](./references/workflow-destinations.md).
 2. Find an available connector for the chosen channel. **Example** for email: call \`platform.workflows.get_connectors\` with \`actionTypeId: ".email"\`.
    - If no suitable connector exists, tell the user (example for email): "No email connector is configured. You can set one up under Stack Management → Connectors, then come back to add notifications."
 3. Generate a unique \`workflowId\` — a UUID (e.g. \`550e8400-e29b-41d4-a716-446655440000\`). Pass it as the \`workflowId\` parameter when calling \`platform.core.generate_workflow\`. This same ID will be used as the persisted workflow ID and must be referenced in the action policy destination. **Do NOT use a human-readable slug** — it would collide across conversations.
@@ -247,7 +247,7 @@ steps:
 
 ## Step 2 — Create a Default Action Policy
 
-Use ${ALERTING_TOOL_IDS.manageActionPolicy} with these operations in order (see [matchers](./references/matchers.md), [grouping-modes](./references/grouping-modes.md), and [throttle-strategies](./references/throttle-strategies.md) for details):
+Use ${ALERTING_TOOL_IDS.manageActionPolicy} with these operations in order (see [action-policy-matchers](./references/action-policy-matchers.md), [action-policy-grouping-modes](./references/action-policy-grouping-modes.md), and [action-policy-throttle-strategies](./references/action-policy-throttle-strategies.md) for details):
 
 1. \`set_metadata\`: name = \`"Notify on <rule-name>"\`, description = \`"Default notification for <rule-name>"\`
 2. \`set_destinations\`: \`[{ type: "workflow", id: "<workflowId-from-step-1>" }]\`
@@ -275,7 +275,7 @@ The end-to-end path from rule evaluation to notification delivery is described i
 
 After creating the defaults, briefly mention:
 - They can switch connector type (Slack, PagerDuty, email, etc.) — offer to use \`platform.workflows.get_connectors\` to explore, or consult the \`workflow-authoring\` skill for connector details. The email path above is only an example.
-- They can change the throttle strategy — \`on_status_change\` (default) only notifies on transitions, \`every_time\` notifies on every evaluation cycle ([throttle-strategies reference](./references/throttle-strategies.md)).
+- They can change the throttle strategy — \`on_status_change\` (default) only notifies on transitions, \`every_time\` notifies on every evaluation cycle ([action-policy-throttle-strategies reference](./references/action-policy-throttle-strategies.md)).
 - They can broaden the policy to cover multiple rules by removing the \`rule.id\` matcher or replacing it with a broader matcher.`,
     getInlineTools: () => [manageActionPolicyTool(deps)],
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.test.ts
@@ -52,4 +52,17 @@ describe('createRuleManagementSkill', () => {
     expect(skill.content).not.toContain('Part 2: Action Policies');
     expect(skill.content).not.toContain('Part 3: Default Notification Setup');
   });
+
+  it('exposes granular concept references instead of a monolithic concepts entry', () => {
+    const skill = createRuleManagementSkill();
+    const refNames = (skill.referencedContent ?? []).map((entry) => entry.name);
+
+    expect(refNames).toEqual(
+      expect.arrayContaining(['rule-kind', 'episode-lifecycle', 'notifications-overview'])
+    );
+    expect(refNames).not.toContain('concepts');
+    expect(skill.content).toContain('./references/rule-kind.md');
+    expect(skill.content).toContain('./references/episode-lifecycle.md');
+    expect(skill.content).toContain('./references/notifications-overview.md');
+  });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -26,34 +26,33 @@ export const createRuleManagementSkill = () =>
     uiSettingRequired: ALERTING_V2_ENABLED_SETTING_ID,
     referencedContent: [
       {
-        name: 'concepts',
+        name: 'rule-kind',
         relativePath: './references',
-        content: `# Alerting V2 Concepts
-
-## Rule Kind: Alert vs Signal
+        content: `# Rule Kind: Alert vs Signal
 
 Rules declare a \`kind\` of \`alert\` or \`signal\`. This is the most important behavioral split in the system.
 
-### Alert (\`kind: alert\`)
+## Alert (\`kind: alert\`)
 - **Stateful alerting** with full episode lifecycle: pending, active, recovering, inactive.
 - Supports state transitions (\`pending_count\` / \`recovering_count\`), recovery detection, and notification dispatch.
 - Produces \`type: 'alert'\` events that participate in the dispatcher pipeline.
 - UI label: **"Alert"**.
 - Use when the user wants to be **notified**, needs **lifecycle tracking**, or wants **recovery detection**.
 
-### Signal (\`kind: signal\`)
+## Signal (\`kind: signal\`)
 - **Stateless detection** (observation-only).
 - Produces \`type: 'signal'\` events but **skips** episode lifecycle and dispatcher processing entirely.
 - No notifications, no recovery, no state transitions.
 - UI label: **"Signal"**.
 - Use for logging or detection without automated action.
 
-### Immutability
-\`kind\` is **immutable on persisted rules** — it can only be set at creation time. The update API rejects changes to \`kind\`. For draft (in-memory) rules, \`set_kind\` can change it freely.
-
----
-
-## Episode Lifecycle
+## Immutability
+\`kind\` is **immutable on persisted rules** — it can only be set at creation time. The update API rejects changes to \`kind\`. For draft (in-memory) rules, \`set_kind\` can change it freely.`,
+      },
+      {
+        name: 'episode-lifecycle',
+        relativePath: './references',
+        content: `# Episode Lifecycle
 
 Episodes are the unit of alert state. Each unique group (by \`group_hash\`) has its own episode.
 
@@ -64,11 +63,12 @@ Episodes are the unit of alert state. Each unique group (by \`group_hash\`) has 
 | \`recovering\` | Breach stopped but not yet fully recovered |
 | \`inactive\` | Fully recovered |
 
-Only \`kind: alert\` rules produce episodes. \`kind: signal\` rules write raw signal events with no episode tracking.
-
----
-
-## Notifications via Action Policies
+Only \`kind: alert\` rules produce episodes. \`kind: signal\` rules write raw signal events with no episode tracking.`,
+      },
+      {
+        name: 'notifications-overview',
+        relativePath: './references',
+        content: `# Notifications via Action Policies
 
 Notifications are not configured on the rule itself. Alert episodes are matched and dispatched by **action policies** (notification policies) — space-scoped saved objects that send matched episodes to workflow destinations.
 
@@ -87,7 +87,10 @@ When the user needs notifications (email, Slack, PagerDuty, etc.), load the \`${
     ],
     content: `## Domain Knowledge
 
-For questions about alerting concepts — rule kinds (alert vs signal), episode lifecycle, or how notifications relate to rules — consult the [concepts reference](./references/concepts.md).
+For questions about alerting concepts:
+- Rule kinds (alert vs signal) — consult the [rule-kind reference](./references/rule-kind.md).
+- Episode lifecycle — consult the [episode-lifecycle reference](./references/episode-lifecycle.md).
+- How notifications relate to rules — consult the [notifications-overview reference](./references/notifications-overview.md).
 
 ---
 
@@ -123,6 +126,7 @@ When a user asks about existing rules:
 Build the request for ${ALERTING_TOOL_IDS.manageRule} as an ordered \`operations\` array. Operations run in sequence.
 
 For a new rule, start with \`set_metadata\` (name required), then \`set_kind\`, \`set_schedule\`, and \`set_query\`.
+See the [rule-kind reference](./references/rule-kind.md) when choosing between \`alert\` and \`signal\`.
 
 For an existing rule, pass the \`ruleAttachmentId\` and only include the operations needed for the changes requested.
 
@@ -147,18 +151,18 @@ For an existing rule, pass the \`ruleAttachmentId\` and only include the operati
 
 ## State Transition
 
-Use \`set_state_transition\` to delay alert firing until the threshold is breached N times in a row. This reduces noise from transient spikes.
+Use \`set_state_transition\` to delay alert firing until the threshold is breached N times in a row. This reduces noise from transient spikes. Episode statuses (\`pending\`, \`active\`, \`recovering\`, \`inactive\`) are explained in the [episode-lifecycle reference](./references/episode-lifecycle.md).
 
 - \`pending_count: N\` — breaches required before transitioning from pending to active (e.g. \`pending_count: 3\` means 3 consecutive breach cycles).
 - \`pending_timeframe\` — optional time window for the pending evaluation (e.g. \`"15m"\`).
 - \`recovering_count: N\` — non-breach cycles required before transitioning from recovering to inactive.
 - \`recovering_timeframe\` — optional time window for the recovering evaluation.
 
-State transition is only allowed on \`kind: alert\` rules. Refer to the [rule-operations-schema reference](./references/rule-operations-schema.md) for the full field schema.
+State transition is only allowed on \`kind: alert\` rules ([rule-kind reference](./references/rule-kind.md)). Refer to the [rule-operations-schema reference](./references/rule-operations-schema.md) for the full field schema.
 
 ## Recovery Strategy
 
-\`recovery_strategy\` is a **top-level rule field** (not inside the query). It controls how episodes transition from active to recovering/inactive. Signal rules (\`kind: signal\`) cannot set \`recovery_strategy\`.
+\`recovery_strategy\` is a **top-level rule field** (not inside the query). It controls how episodes transition from active to recovering/inactive (see [episode-lifecycle reference](./references/episode-lifecycle.md)). Signal rules (\`kind: signal\`) cannot set \`recovery_strategy\` ([rule-kind reference](./references/rule-kind.md)).
 
 When using \`recovery_strategy: 'query'\`, add a \`set_query\` operation that includes a \`recovery\` block alongside \`breach\`:
 - **Composed**: \`recovery: { segment: 'WHERE cpu < 0.5' }\`
@@ -180,7 +184,7 @@ Refer to the [rule-schema reference](./references/rule-schema.md) for allowed va
 When setting \`no_data_strategy\` to anything other than \`'none'\`, add a \`no_data\` block to the standalone query:
 \`no_data: { query: 'FROM heartbeat-* | STATS count = COUNT(*) BY host.name | WHERE count >= 1' }\`. For composed query format, the \`base\` query is used as the data query.
 
-Signal rules cannot set \`no_data_strategy\`.
+Signal rules cannot set \`no_data_strategy\` ([rule-kind reference](./references/rule-kind.md)).
 Refer to the [rule-schema reference](./references/rule-schema.md) for allowed values and constraints.
 
 ## Final Validation
@@ -215,7 +219,7 @@ where \`attachmentId\` is \`ruleAttachment.id\` and \`version\` is \`version\` f
 
 ## Notifications Require Alert Kind
 
-Action policies only process alert episodes. Signal rules (\`kind: signal\`) do not participate in episode lifecycle or notification dispatch.
+Action policies only process alert episodes. Signal rules (\`kind: signal\`) do not participate in episode lifecycle or notification dispatch. See the [rule-kind reference](./references/rule-kind.md), [episode-lifecycle reference](./references/episode-lifecycle.md), and [notifications-overview reference](./references/notifications-overview.md).
 
 When a user asks for notifications on a rule that is currently \`kind: signal\` (or when composing a new rule where the user wants notifications):
 
@@ -234,6 +238,6 @@ After composing a complete **alert** rule (has name, query, schedule, and \`kind
 Do not offer notifications if the rule is still incomplete (missing name, query, or schedule).
 If the rule's kind is \`signal\`, follow the "Notifications Require Alert Kind" guidance above before proceeding.
 
-If the user agrees (or asks for notifications directly), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill via \`filestore.read\` (path: \`skills/platform/alerting/${ACTION_POLICY_MANAGEMENT_SKILL_ID}/SKILL.md\`) and let that skill own the workflow + action policy setup. Do **not** compose action policies or notification workflows from this skill.`,
+If the user agrees (or asks for notifications directly), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill via \`filestore.read\` (path: \`skills/platform/alerting/${ACTION_POLICY_MANAGEMENT_SKILL_ID}/SKILL.md\`) and let that skill own the workflow + action policy setup (see [notifications-overview reference](./references/notifications-overview.md)). Do **not** compose action policies or notification workflows from this skill.`,
     getInlineTools: () => [manageRuleTool()],
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -132,6 +132,7 @@ For questions about alerting concepts:
 - Rule kinds (alert vs signal) — consult the [rule-kind reference](./references/rule-kind.md).
 - Episode lifecycle — consult the [episode-lifecycle reference](./references/episode-lifecycle.md).
 - How notifications relate to rules — consult the [notifications-overview reference](./references/notifications-overview.md).
+- Alert event severity — also covered in the [notifications-overview reference](./references/notifications-overview.md).
 
 ---
 
@@ -188,7 +189,7 @@ State transition is only allowed on \`kind: alert\` rules ([rule-kind reference]
 
 ## Severity
 
-When the user specifies a severity (e.g. "make this a critical alert"), add an \`EVAL severity = "..."\` pipe to the breach query or segment via \`set_query\`. Refer to the [concepts reference](./references/concepts.md) for valid values, the extraction model, and literal vs conditional patterns.
+When the user specifies a severity (e.g. "make this a critical alert"), add an \`EVAL severity = "..."\` pipe to the breach query or segment via \`set_query\`. Refer to the [notifications-overview reference](./references/notifications-overview.md) for valid values, the extraction model, and literal vs conditional patterns.
 
 ## Recovery Strategy
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -13,7 +13,11 @@ import {
   RULE_MANAGEMENT_SKILL_ID,
 } from '@kbn/alerting-v2-constants';
 import { manageRuleTool } from '../tools/manage_rule';
-import { generateRuleSchemaDoc, generateRuleOperationsDoc } from './schema_to_skill_docs';
+import {
+  generateRuleSchemaDoc,
+  generateRuleOperationsDoc,
+  getSeverityValues,
+} from './schema_to_skill_docs';
 
 export const createRuleManagementSkill = () =>
   defineSkillType({
@@ -70,9 +74,31 @@ Only \`kind: alert\` rules produce episodes. \`kind: signal\` rules write raw si
         relativePath: './references',
         content: `# Notifications via Action Policies
 
-Notifications are not configured on the rule itself. Alert episodes are matched and dispatched by **action policies** (notification policies) — space-scoped saved objects that send matched episodes to workflow destinations.
+Notifications are not configured on the rule itself. Alert episodes are matched and dispatched by **action policies** — space-scoped saved objects that send matched episodes to workflow destinations.
 
-When the user needs notifications (email, Slack, PagerDuty, etc.), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill. That skill owns action policy CRUD, workflow destination wiring, and the default notification setup flow.`,
+When the user needs notifications (email, Slack, PagerDuty, etc.), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill. That skill owns action policy CRUD, workflow destination wiring, and the default notification setup flow.
+
+---
+
+## Alert Event Severity
+
+Severity is a per-event property on alert events and episodes, not a rule-level field. It is extracted at execution time from a column named \`severity\` in the ES|QL breach query output.
+
+- **Valid values**: ${getSeverityValues()
+          .map((v) => `\`${v}\``)
+          .join(', ')} (case-insensitive).
+- If the breach query does not produce a \`severity\` column, alert events have no severity.
+- Different groups can produce different severities in the same rule execution (the value comes from each row).
+- Action policies can match on \`severity\` to route high-severity episodes differently (e.g. PagerDuty for critical, email for low).
+
+### Setting Severity in ES|QL
+
+Severity is set by adding a \`severity\` column to the breach query via \`EVAL\`:
+
+- **Literal severity** — all alerts from the rule share the same severity:
+  \`| EVAL severity = "critical"\`
+- **Conditional severity** — severity varies per group based on data:
+  \`| EVAL severity = CASE(cpu > 0.95, "critical", cpu > 0.8, "high", "medium")\``,
       },
       {
         name: 'rule-schema',
@@ -85,16 +111,7 @@ When the user needs notifications (email, Slack, PagerDuty, etc.), load the \`${
         content: generateRuleOperationsDoc(),
       },
     ],
-    content: `## Domain Knowledge
-
-For questions about alerting concepts:
-- Rule kinds (alert vs signal) — consult the [rule-kind reference](./references/rule-kind.md).
-- Episode lifecycle — consult the [episode-lifecycle reference](./references/episode-lifecycle.md).
-- How notifications relate to rules — consult the [notifications-overview reference](./references/notifications-overview.md).
-
----
-
-## When to Use This Skill
+    content: `## When to Use This Skill
 
 Use this skill when:
 - A user asks to find, list, inspect, or modify existing alerting V2 rules.
@@ -102,10 +119,19 @@ Use this skill when:
 - A user asks to change a rule's query, schedule, thresholds, or metadata.
 
 Do **not** use this skill for:
-- Creating, inspecting, or modifying action policies (notification policies) — load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill instead.
+- Creating, inspecting, or modifying action policies — load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill instead.
 - Classic (V1) stack, Observability or Security detection rules.
 - Action connector configuration (connectors are managed separately).
 - Querying or analyzing data — use data exploration skills for that.
+
+---
+
+## Domain Knowledge
+
+For questions about alerting concepts:
+- Rule kinds (alert vs signal) — consult the [rule-kind reference](./references/rule-kind.md).
+- Episode lifecycle — consult the [episode-lifecycle reference](./references/episode-lifecycle.md).
+- How notifications relate to rules — consult the [notifications-overview reference](./references/notifications-overview.md).
 
 ---
 
@@ -159,6 +185,10 @@ Use \`set_state_transition\` to delay alert firing until the threshold is breach
 - \`recovering_timeframe\` — optional time window for the recovering evaluation.
 
 State transition is only allowed on \`kind: alert\` rules ([rule-kind reference](./references/rule-kind.md)). Refer to the [rule-operations-schema reference](./references/rule-operations-schema.md) for the full field schema.
+
+## Severity
+
+When the user specifies a severity (e.g. "make this a critical alert"), add an \`EVAL severity = "..."\` pipe to the breach query or segment via \`set_query\`. Refer to the [concepts reference](./references/concepts.md) for valid values, the extraction model, and literal vs conditional patterns.
 
 ## Recovery Strategy
 
@@ -232,7 +262,8 @@ When a user asks for notifications on a rule that is currently \`kind: signal\` 
 
 ## Offering Notifications After Rule Compose
 
-After composing a complete **alert** rule (has name, query, schedule, and \`kind: alert\`), proactively ask the user:
+After composing a complete **alert** rule (has name, query, schedule, and \`kind: alert\`), proactively ask the user about notifications. Email is only an **example** default channel — use it when the user has not named one. If they already asked for Slack, PagerDuty, etc., offer that channel instead.
+Example offer when no channel was specified:
 **"Would you like to set up email notifications for this rule?"**
 
 Do not offer notifications if the rule is still incomplete (missing name, query, or schedule).

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
@@ -7,14 +7,20 @@
 
 import { z } from '@kbn/zod/v4';
 import type { ActionPolicyWorkflowPayload, AlertEpisode } from '../../lib/dispatcher/types';
+import type { GroupingMode, ThrottleStrategy } from '@kbn/alerting-v2-schemas';
+import { MATCHER_CONTEXT_FIELDS } from '@kbn/alerting-v2-schemas';
 import {
   generateApiSchemaDoc,
   generateOperationsDoc,
   generateRuleSchemaDoc,
   generateRuleOperationsDoc,
   generateActionPolicySchemaDoc,
+  getSeverityValues,
   generateActionPolicyOperationsDoc,
   generateActionPolicyWorkflowPayloadDoc,
+  generateMatcherContextDoc,
+  generateGroupingModesDoc,
+  generateThrottleStrategiesDoc,
 } from './schema_to_skill_docs';
 
 /**
@@ -40,6 +46,21 @@ const episodeKeyGuard: Record<keyof AlertEpisode, true> = {
   episode_status: true,
   severity: true,
   data: true,
+};
+
+/** Drift-guard: new grouping modes must update generateGroupingModesDoc coverage. */
+const groupingModeGuard: Record<GroupingMode, true> = {
+  per_episode: true,
+  all: true,
+  per_field: true,
+};
+
+/** Drift-guard: new throttle strategies must update generateThrottleStrategiesDoc coverage. */
+const throttleStrategyGuard: Record<ThrottleStrategy, true> = {
+  on_status_change: true,
+  per_status_interval: true,
+  time_interval: true,
+  every_time: true,
 };
 
 describe('schema_to_skill_docs', () => {
@@ -198,6 +219,14 @@ describe('schema_to_skill_docs', () => {
     });
   });
 
+  describe('getSeverityValues', () => {
+    it('matches the snapshot', () => {
+      expect(getSeverityValues().join(', ')).toMatchInlineSnapshot(
+        `"info, low, medium, high, critical"`
+      );
+    });
+  });
+
   describe('generateActionPolicySchemaDoc', () => {
     /**
      * Snapshot of the generated skill markdown for the action policy create API
@@ -288,6 +317,54 @@ describe('schema_to_skill_docs', () => {
     it('documents the inputs.payload Liquid access pattern', () => {
       const doc = generateActionPolicyWorkflowPayloadDoc();
       expect(doc).toContain('inputs.payload');
+    });
+  });
+
+  describe('generateMatcherContextDoc', () => {
+    it('matches the reviewed skill-doc snapshot', () => {
+      expect(generateMatcherContextDoc()).toMatchSnapshot();
+    });
+
+    it('documents every MATCHER_CONTEXT_FIELDS path', () => {
+      const doc = generateMatcherContextDoc();
+      for (const { path } of MATCHER_CONTEXT_FIELDS) {
+        expect(doc).toContain(`\`${path}\``);
+      }
+    });
+
+    it('enriches episode_status and severity with schema enums', () => {
+      const doc = generateMatcherContextDoc();
+      expect(doc).toContain('`inactive`');
+      expect(doc).toContain('`recovering`');
+      expect(doc).toContain('`critical`');
+    });
+  });
+
+  describe('generateGroupingModesDoc', () => {
+    it('matches the reviewed skill-doc snapshot', () => {
+      expect(generateGroupingModesDoc()).toMatchSnapshot();
+    });
+
+    it('documents every grouping mode', () => {
+      const doc = generateGroupingModesDoc();
+      for (const mode of Object.keys(groupingModeGuard)) {
+        expect(doc).toContain(`\`${mode}\``);
+      }
+    });
+  });
+
+  describe('generateThrottleStrategiesDoc', () => {
+    it('matches the reviewed skill-doc snapshot', () => {
+      expect(generateThrottleStrategiesDoc()).toMatchSnapshot();
+    });
+
+    it('documents every throttle strategy and compatibility sets', () => {
+      const doc = generateThrottleStrategiesDoc();
+      for (const strategy of Object.keys(throttleStrategyGuard)) {
+        expect(doc).toContain(`\`${strategy}\``);
+      }
+      expect(doc).toContain('per_episode');
+      expect(doc).toContain('interval');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
@@ -370,6 +370,8 @@ export const generateMatcherContextDoc = (): string => {
   return [
     '# Matcher Context Fields',
     '',
+    'Auto-generated from `MATCHER_CONTEXT_FIELDS` in `@kbn/alerting-v2-schemas`.',
+    '',
     "When the dispatcher evaluates a policy's KQL matcher, these fields are available:",
     '',
     '| Field | Type | Description |',
@@ -394,7 +396,7 @@ export const generateGroupingModesDoc = (): string => {
     '',
     ...bullets,
     '',
-    'Throttle strategy must be compatible with the grouping mode — see [throttle-strategies](./throttle-strategies.md).',
+    'Throttle strategy must be compatible with the grouping mode — see [action-policy-throttle-strategies](./action-policy-throttle-strategies.md).',
   ].join('\n');
 };
 
@@ -420,7 +422,7 @@ export const generateThrottleStrategiesDoc = (): string => {
     '',
     ...bullets,
     '',
-    'Compatibility with grouping modes (see [grouping-modes](./grouping-modes.md)):',
+    'Compatibility with grouping modes (see [action-policy-grouping-modes](./action-policy-grouping-modes.md)):',
     `- For \`per_episode\`: ${formatSet(PER_EPISODE_STRATEGIES)}.`,
     `- For \`all\` / \`per_field\`: ${formatSet(AGGREGATE_STRATEGIES)}.`,
     `- ${intervalStrategies} require an \`interval\` (e.g. \`"5m"\`, \`"1h"\`).`,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
@@ -6,7 +6,19 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { createRuleDataBaseSchema, createActionPolicyDataSchema } from '@kbn/alerting-v2-schemas';
+import {
+  createRuleDataBaseSchema,
+  createActionPolicyDataSchema,
+  alertEventSeveritySchema,
+  ALERT_EPISODE_STATUS,
+  MATCHER_CONTEXT_FIELDS,
+  groupingModeSchema,
+  throttleStrategySchema,
+  PER_EPISODE_STRATEGIES,
+  AGGREGATE_STRATEGIES,
+  STRATEGIES_REQUIRING_INTERVAL,
+} from '@kbn/alerting-v2-schemas';
+import type { GroupingMode, ThrottleStrategy } from '@kbn/alerting-v2-schemas';
 import {
   ALERTING_V2_NOTIFICATION_GROUP_INPUT_DEFINITION_ID,
   builtinWorkflowInputDefinitions,
@@ -292,6 +304,8 @@ export const generateRuleOperationsDoc = (): string =>
     schema: ruleOperationSchema,
   });
 
+export const getSeverityValues = (): string[] => alertEventSeveritySchema.options;
+
 /**
  * Generates concise markdown documentation from the create-action-policy Zod schema.
  */
@@ -310,6 +324,108 @@ export const generateActionPolicyOperationsDoc = (): string =>
     source: 'the `manage_action_policy` tool Zod schemas',
     schema: actionPolicyOperationSchema,
   });
+
+/** Agent-facing descriptions keyed by grouping mode — drift-guards new enum values. */
+const GROUPING_MODE_DOC: Record<GroupingMode, string> = {
+  per_episode: 'one notification per alert episode lifecycle (default)',
+  all: 'a single notification for all matching episodes',
+  per_field: 'group by specified `groupBy` fields',
+};
+
+/** Agent-facing descriptions keyed by throttle strategy — drift-guards new enum values. */
+const THROTTLE_STRATEGY_DOC: Record<ThrottleStrategy, string> = {
+  on_status_change: 'notify only on episode status transitions (default for `per_episode`)',
+  per_status_interval: 'notify on transitions and at regular intervals',
+  time_interval:
+    'notify at regular intervals regardless of status (default for `all` / `per_field`)',
+  every_time: 'notify on every evaluation cycle (high volume)',
+};
+
+const EPISODE_STATUS_VALUES = Object.values(ALERT_EPISODE_STATUS);
+const SEVERITY_VALUES = alertEventSeveritySchema.options;
+
+function formatMatcherFieldType(path: string, type: string): string {
+  if (path === 'episode_status') {
+    return EPISODE_STATUS_VALUES.map((v) => `\`${v}\``).join(', ');
+  }
+  if (path === 'severity') {
+    return SEVERITY_VALUES.map((v) => `\`${v}\``).join(', ');
+  }
+  if (path === 'data') {
+    return '`data.*` object';
+  }
+  return type;
+}
+
+/**
+ * Generates markdown for KQL matcher context fields from `MATCHER_CONTEXT_FIELDS`,
+ * enriching enum fields from `ALERT_EPISODE_STATUS` / `alertEventSeveritySchema`.
+ */
+export const generateMatcherContextDoc = (): string => {
+  const rows = MATCHER_CONTEXT_FIELDS.map((field) => {
+    const typeCell = escapeTableCell(formatMatcherFieldType(field.path, field.type));
+    return `| \`${field.path}\` | ${typeCell} | ${escapeTableCell(field.description)} |`;
+  });
+
+  return [
+    '# Matcher Context Fields',
+    '',
+    "When the dispatcher evaluates a policy's KQL matcher, these fields are available:",
+    '',
+    '| Field | Type | Description |',
+    '|---|---|---|',
+    ...rows,
+    '',
+    'An empty matcher is a catch-all that matches all episodes in the space. To scope a policy to a single rule, use `rule.id: "<ruleId>"`.',
+  ].join('\n');
+};
+
+/**
+ * Generates markdown for action-policy grouping modes from `groupingModeSchema`.
+ */
+export const generateGroupingModesDoc = (): string => {
+  const modes = groupingModeSchema.options as GroupingMode[];
+  const bullets = modes.map((mode) => `- \`${mode}\`: ${GROUPING_MODE_DOC[mode]}`);
+
+  return [
+    '# Grouping Modes',
+    '',
+    'Auto-generated from `groupingModeSchema` in `@kbn/alerting-v2-schemas`.',
+    '',
+    ...bullets,
+    '',
+    'Throttle strategy must be compatible with the grouping mode — see [throttle-strategies](./throttle-strategies.md).',
+  ].join('\n');
+};
+
+/**
+ * Generates markdown for throttle strategies and grouping-mode compatibility from
+ * `throttleStrategySchema`, `PER_EPISODE_STRATEGIES`, `AGGREGATE_STRATEGIES`, and
+ * `STRATEGIES_REQUIRING_INTERVAL`.
+ */
+export const generateThrottleStrategiesDoc = (): string => {
+  const strategies = throttleStrategySchema.options as ThrottleStrategy[];
+  const bullets = strategies.map(
+    (strategy) => `- \`${strategy}\`: ${THROTTLE_STRATEGY_DOC[strategy]}`
+  );
+
+  const formatSet = (set: Set<string>) => [...set].map((v) => `\`${v}\``).join(', ');
+
+  const intervalStrategies = formatSet(STRATEGIES_REQUIRING_INTERVAL);
+
+  return [
+    '# Throttle Strategies',
+    '',
+    'Auto-generated from `throttleStrategySchema` and compatibility sets in `@kbn/alerting-v2-schemas`.',
+    '',
+    ...bullets,
+    '',
+    'Compatibility with grouping modes (see [grouping-modes](./grouping-modes.md)):',
+    `- For \`per_episode\`: ${formatSet(PER_EPISODE_STRATEGIES)}.`,
+    `- For \`all\` / \`per_field\`: ${formatSet(AGGREGATE_STRATEGIES)}.`,
+    `- ${intervalStrategies} require an \`interval\` (e.g. \`"5m"\`, \`"1h"\`).`,
+  ].join('\n');
+};
 
 /**
  * Generates concise markdown documentation for the action-policy → workflow dispatch payload.


### PR DESCRIPTION
## Summary
- Split the monolithic `concepts` `referencedContent` in the rule-management and action-policy-management agent builder skills into topic-scoped reference files so the agent can fetch only what it needs.
- Link those concept references from Domain Knowledge and inline where each topic is discussed in the skill instructions.
- Add unit coverage asserting the new granular reference names and that the old `concepts` entry is gone.

## Test plan
- [x] Unit tests for both skills pass
- [ ] Alerting V2 evals run via PR labels (no judge override; default judge)

Made with [Cursor](https://cursor.com)