### PR TITLE
[9.5] [Cases] Apply global field defaults to cases created via the API and workflow steps (#283185)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
@@ -315,6 +315,47 @@ describe('customFields → extended_fields adapter utilities', () => {
 
       expect(result).toEqual({ x_as_keyword: 'v' });
     });
+
+    it('does NOT fill a key whose existing value is the empty string (deliberate clear preserved)', () => {
+      // The v2 UI persists '' both for untouched fields and for fields the user explicitly
+      // cleared, and the migration runs asynchronously — field definitions become visible
+      // before a space's backfill completes, so a '' observed at backfill time may be a
+      // deliberate clear. It is ambiguous, so it must never be overwritten with the stale
+      // legacy value.
+      const result = buildExtendedFieldsBackfill(
+        [{ key: 'priority', type: 'text', value: 'low' }],
+        {
+          priority_as_keyword: '',
+        }
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('fills a key whose existing value is null', () => {
+      const result = buildExtendedFieldsBackfill(
+        [{ key: 'priority', type: 'text', value: 'low' }],
+        {
+          priority_as_keyword: null,
+        }
+      );
+
+      expect(result).toEqual({ priority_as_keyword: 'low' });
+    });
+
+    it('does not fill a key whose existing value is a non-empty string', () => {
+      const result = buildExtendedFieldsBackfill(
+        [
+          { key: 'kept', type: 'text', value: 'legacy' },
+          { key: 'zero', type: 'number', value: 1 },
+          { key: 'flag', type: 'toggle', value: true },
+        ],
+        { kept_as_keyword: 'v2-value', zero_as_integer: '0', flag_as_boolean: 'false' }
+      );
+
+      // '0' and 'false' are real (falsy-looking) v2 values and must win over the legacy mirror.
+      expect(result).toEqual({});
+    });
   });
 
   describe('mergeCustomFieldsIntoExtendedFields', () => {

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
@@ -191,17 +191,36 @@ export const getV2FieldType = (legacyType: string): 'integer' | 'boolean' | 'key
 };
 
 /**
+ * Whether an `extended_fields` entry counts as "no v2 value" for backfill purposes: the key is
+ * absent, or holds `null`/`undefined` (which no user-facing write path produces — the API and
+ * UI only write strings — so a `null` can only come from synthetic/hand-inserted data).
+ *
+ * The empty string is deliberately NOT included. The v2 UI persists `''` both for fields the
+ * user never touched AND for fields the user explicitly cleared (see `sanitizeExistingValue` /
+ * the create-form serialization), and the migration task runs asynchronously: field definitions
+ * become visible (phase 1, or the configure mirror hook) before a space's case backfill
+ * (phase 2) completes, so a user can clear a value while the space is still unflagged. A `''`
+ * observed at backfill time is therefore ambiguous, and filling it could silently restore a
+ * stale legacy value over a deliberate clear — so it is always preserved.
+ */
+const isEmptyExtendedFieldValue = (value: unknown): boolean => value == null;
+
+/**
  * Computes the `extended_fields` entries to add to a case from its legacy `customFields`.
  *
- * Semantics — **existing wins, nulls skipped**:
- * - A key already present in `existingExtendedFields` is left as-is (a value set through the v2
- *   system takes precedence over the legacy mirror).
+ * Semantics — **any existing entry wins (including `''`), nulls filled, absent filled**:
+ * - A key present in `existingExtendedFields` with a string value — including the empty
+ *   string — is left as-is: a value (or explicit clear) written through the v2 system takes
+ *   precedence over the legacy mirror. See {@link isEmptyExtendedFieldValue} for why `''`
+ *   must never be treated as fillable.
+ * - A key that is absent or `null` counts as "no v2 value" and is filled from the legacy
+ *   custom field.
  * - A `customFields` entry whose value is `null` or `undefined` is skipped — the case left the
  *   field empty; the v2 field then renders empty rather than being forced to a value.
  *
- * Returns only the *additions* (keys not yet present). Callers are responsible for spreading the
- * result over the existing map; see {@link mergeCustomFieldsIntoExtendedFields} for the combined
- * helper.
+ * Returns only the entries to write (keys missing or empty). Callers are responsible for
+ * spreading the result over the existing map; see {@link mergeCustomFieldsIntoExtendedFields}
+ * for the combined helper.
  */
 export const buildExtendedFieldsBackfill = (
   customFields: LegacyCaseCustomField[] | undefined,
@@ -214,7 +233,7 @@ export const buildExtendedFieldsBackfill = (
     const hasValue = cf.value !== null && cf.value !== undefined;
     if (hasValue) {
       const snakeKey = getFieldSnakeKey(cf.key, getV2FieldType(cf.type));
-      if (!(snakeKey in existing)) {
+      if (isEmptyExtendedFieldValue(existing[snakeKey])) {
         additions[snakeKey] = String(cf.value);
       }
     }

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
@@ -1507,4 +1507,307 @@ describe('create', () => {
       expect(clientArgs.services.templatesService.getTemplate).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('server-side global field defaults', () => {
+    const makeGlobalDef = (
+      name: string,
+      defaultValue?: unknown,
+      { required = false }: { required?: boolean } = {}
+    ) => ({
+      fieldDefinitionId: `fd-${name}`,
+      name,
+      owner: SECURITY_SOLUTION_OWNER,
+      description: '',
+      isGlobal: true,
+      definition: yamlStringify({
+        name,
+        type: 'keyword',
+        control: 'INPUT_TEXT',
+        label: name,
+        ...(required ? { validation: { required: true } } : {}),
+        ...(defaultValue !== undefined ? { metadata: { default: defaultValue } } : {}),
+      }),
+    });
+
+    const createClientArgs = ({ templatesEnabled = true } = {}) => {
+      const clientArgs = createCasesClientMockArgs();
+      clientArgs.config = { ...clientArgs.config, templates: { enabled: templatesEnabled } };
+      clientArgs.services.caseService.createCase.mockResolvedValue(caseSO);
+      clientArgs.services.licensingService.isAtLeastPlatinum.mockResolvedValue(true);
+      return clientArgs;
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('applies global field defaults when the request has no extended_fields', async () => {
+      // FAILURE SCENARIO (before fix): the create-case UI injects global-field defaults
+      // client-side, so only UI-created cases persisted them — API / workflow-step creation
+      // left every global field empty.
+      const clientArgs = createClientArgs();
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [makeGlobalDef('risk_score', 'high'), makeGlobalDef('notes')],
+        total: 2,
+      });
+
+      await create(theCase, clientArgs, casesClientMock);
+
+      const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+      // Only fields that declare a YAML default are injected. A field without one would
+      // produce '' — a value-free key that (for required fields) would fail its own
+      // validation — so `notes` must not appear.
+      expect(createArgs.attributes.extended_fields).toEqual({
+        risk_score_as_keyword: 'high',
+      });
+      expect(clientArgs.services.fieldDefinitionsService.getFieldDefinitions).toHaveBeenCalledWith(
+        SECURITY_SOLUTION_OWNER,
+        { isGlobal: true }
+      );
+      // Parity with UI-created cases: without a template no extended_fields user action
+      // is emitted (that audit path is template-scoped).
+      expect(
+        clientArgs.services.userActionService.creator.bulkCreateUserAction
+      ).not.toHaveBeenCalled();
+    });
+
+    it('caller-sent values win over global defaults', async () => {
+      const clientArgs = createClientArgs();
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [makeGlobalDef('risk_score', 'high')],
+        total: 1,
+      });
+
+      await create(
+        { ...theCase, extended_fields: { risk_score_as_keyword: 'low' } },
+        clientArgs,
+        casesClientMock
+      );
+
+      const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+      expect(createArgs.attributes.extended_fields).toEqual({ risk_score_as_keyword: 'low' });
+    });
+
+    it('a caller-sent empty string wins over a global default', async () => {
+      // An explicit empty value is a caller decision — the default must not resurrect it.
+      const clientArgs = createClientArgs();
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [makeGlobalDef('risk_score', 'high')],
+        total: 1,
+      });
+
+      await create(
+        { ...theCase, extended_fields: { risk_score_as_keyword: '' } },
+        clientArgs,
+        casesClientMock
+      );
+
+      const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+      expect(createArgs.attributes.extended_fields).toEqual({ risk_score_as_keyword: '' });
+    });
+
+    it('global defaults win over template defaults on a storage-key collision; caller wins over both', async () => {
+      // The global definition is authoritative on a storage-key collision (see
+      // resolveApplicableFields), mirroring the create form, which preserves global values
+      // over a selected template's defaults.
+      const clientArgs = createClientArgs();
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [makeGlobalDef('priority', 'global-default')],
+        total: 1,
+      });
+      clientArgs.services.templatesService.getTemplate.mockResolvedValue({
+        id: 'so-tpl',
+        type: 'cases-templates',
+        references: [],
+        attributes: {
+          templateId: 'tmpl-collision',
+          name: 'Collision Template',
+          owner: SECURITY_SOLUTION_OWNER,
+          definition: yamlStringify({
+            name: 'Collision Template',
+            fields: [
+              {
+                name: 'priority',
+                type: 'keyword',
+                control: 'INPUT_TEXT',
+                label: 'Priority',
+                metadata: { default: 'template-default' },
+              },
+              {
+                name: 'summary',
+                type: 'keyword',
+                control: 'INPUT_TEXT',
+                label: 'Summary',
+                metadata: { default: 'template-summary' },
+              },
+            ],
+          }),
+          templateVersion: 1,
+          deletedAt: null,
+          isLatest: true,
+        },
+      });
+
+      const minimalRequest = omit(theCase, ['severity', 'assignees']);
+
+      await create(
+        { ...minimalRequest, template: { id: 'tmpl-collision', version: 1 } },
+        clientArgs,
+        casesClientMock
+      );
+
+      const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+      expect(createArgs.attributes.extended_fields).toEqual({
+        priority_as_keyword: 'global-default',
+        summary_as_keyword: 'template-summary',
+      });
+
+      jest.clearAllMocks();
+      clientArgs.services.caseService.createCase.mockResolvedValue(caseSO);
+
+      await create(
+        {
+          ...minimalRequest,
+          template: { id: 'tmpl-collision', version: 1 },
+          extended_fields: { priority_as_keyword: 'caller-value' },
+        },
+        clientArgs,
+        casesClientMock
+      );
+
+      const [[secondCreateArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+      expect(secondCreateArgs.attributes.extended_fields).toEqual({
+        priority_as_keyword: 'caller-value',
+        summary_as_keyword: 'template-summary',
+      });
+    });
+
+    it('does not write extended_fields when no global field definitions exist', async () => {
+      // Guard: the injection must not materialize an empty extended_fields map.
+      const clientArgs = createClientArgs();
+
+      await create(theCase, clientArgs, casesClientMock);
+
+      const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+      expect(createArgs.attributes.extended_fields).toBeUndefined();
+    });
+
+    it('does not fetch or apply global defaults when the templates feature is disabled', async () => {
+      const clientArgs = createClientArgs({ templatesEnabled: false });
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [makeGlobalDef('risk_score', 'high')],
+        total: 1,
+      });
+
+      await create(theCase, clientArgs, casesClientMock);
+
+      const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+      expect(createArgs.attributes.extended_fields).toBeUndefined();
+      expect(
+        clientArgs.services.fieldDefinitionsService.getFieldDefinitions
+      ).not.toHaveBeenCalled();
+    });
+
+    describe('required global fields', () => {
+      // Defaults injection must be invisible to callers that never engaged with
+      // extended_fields: a request without extended_fields that succeeded before injection
+      // existed must keep succeeding after it, even when a REQUIRED global field has no
+      // default (required stays a UI submit-time gate there, exactly like v1 required
+      // customFields). Full create-time `required` enforcement only applies when the caller —
+      // or a pinned template — actually produced an extended_fields map, which is the
+      // pre-injection behavior. These tests lock both sides in so the inject/validate steps
+      // can't silently become a breaking change (or silently drop the existing enforcement).
+      it('creates the case when a required global field has no default and no caller value (no extended_fields sent)', async () => {
+        // Regression guard for the v1 mirror: required legacy customFields are mirrored into
+        // required global definitions with no default, so rejecting here would 400 every
+        // customFields-only create in such a space.
+        const clientArgs = createClientArgs();
+        clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+          fieldDefinitions: [makeGlobalDef('risk_score', undefined, { required: true })],
+          total: 1,
+        });
+
+        await create(theCase, clientArgs, casesClientMock);
+
+        const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+        // Nothing to inject (no default) — the field is simply left unset.
+        expect(createArgs.attributes.extended_fields).toBeUndefined();
+      });
+
+      it('injected defaults do not trigger required enforcement of other global fields', async () => {
+        // The injection materializes an extended_fields map the caller never sent; validating
+        // that map with full create semantics would enforce `required` on the no-default field
+        // and reject a request that succeeded before injection existed.
+        const clientArgs = createClientArgs();
+        clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+          fieldDefinitions: [
+            makeGlobalDef('notes', 'default notes'),
+            makeGlobalDef('risk_score', undefined, { required: true }),
+          ],
+          total: 2,
+        });
+
+        await create(theCase, clientArgs, casesClientMock);
+
+        const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+        expect(createArgs.attributes.extended_fields).toEqual({
+          notes_as_keyword: 'default notes',
+        });
+      });
+
+      it('still rejects when the caller sends extended_fields but omits a required global field', async () => {
+        // Pre-injection behavior preserved: a caller that engages with extended_fields gets
+        // full create-time validation, including `required` on absent fields.
+        const clientArgs = createClientArgs();
+        clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+          fieldDefinitions: [
+            makeGlobalDef('risk_score', undefined, { required: true }),
+            makeGlobalDef('notes'),
+          ],
+          total: 2,
+        });
+
+        await expect(
+          create(
+            { ...theCase, extended_fields: { notes_as_keyword: 'some notes' } },
+            clientArgs,
+            casesClientMock
+          )
+        ).rejects.toThrow('Field "risk_score" is required');
+        expect(clientArgs.services.caseService.createCase).not.toHaveBeenCalled();
+      });
+
+      it('creates the case when a required global field has a default', async () => {
+        const clientArgs = createClientArgs();
+        clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+          fieldDefinitions: [makeGlobalDef('risk_score', 'high', { required: true })],
+          total: 1,
+        });
+
+        await create(theCase, clientArgs, casesClientMock);
+
+        const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+        expect(createArgs.attributes.extended_fields).toEqual({ risk_score_as_keyword: 'high' });
+      });
+
+      it('creates the case when the caller sends a value for a required global field without a default', async () => {
+        const clientArgs = createClientArgs();
+        clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+          fieldDefinitions: [makeGlobalDef('risk_score', undefined, { required: true })],
+          total: 1,
+        });
+
+        await create(
+          { ...theCase, extended_fields: { risk_score_as_keyword: 'caller-value' } },
+          clientArgs,
+          casesClientMock
+        );
+
+        const [[createArgs]] = clientArgs.services.caseService.createCase.mock.calls;
+        expect(createArgs.attributes.extended_fields).toEqual({
+          risk_score_as_keyword: 'caller-value',
+        });
+      });
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
@@ -26,9 +26,13 @@ import {
   validateCaseExtendedFields,
 } from './validators';
 import type { CreateUserAction, CommonUserActionArgs } from '../../services/user_actions/types';
+import type { InlineField } from '../../../common/types/domain/template/fields';
 import { emptyCaseAssigneesSanitizer } from './sanitizers';
 import { normalizeCreateCaseRequest, populateAssigneesIdentity } from './utils';
-import { mergeCustomFieldsIntoExtendedFields } from '../../../common/utils/template_fields';
+import {
+  buildExtendedFieldsDefaults,
+  mergeCustomFieldsIntoExtendedFields,
+} from '../../../common/utils/template_fields';
 import {
   applyTemplateDefaultsToCreateRequest,
   ensureTemplateVersionIsPinned,
@@ -137,8 +141,49 @@ export const create = async (
       }
     }
 
+    // Global (isGlobal) field-definition defaults are applied client-side by the create-case UI
+    // before submission, so UI-created cases persist them — but API and workflow-step callers
+    // only send the fields they know about, which left every global field empty on non-UI cases.
+    // Merge the defaults here with the same precedence the UI create form produces: template
+    // defaults, then global defaults (the global definition is authoritative on a storage-key
+    // collision — see resolveApplicableFields), then caller-sent values (caller always wins).
+    // Runs AFTER template expansion so the collision order holds, and BEFORE extended_fields
+    // validation so the merged map is what gets validated.
+    //
+    // Captured before injection: when the map exists only because defaults were injected, the
+    // validation below must run with partial (update) semantics. Full create-time validation
+    // enforces `required` on absent fields, and enforcing it here would 400 requests that
+    // succeeded before defaults injection existed — e.g. every legacy customFields-only create
+    // in a space whose required v1 custom fields are mirrored into required global definitions.
+    const hadExtendedFieldsBeforeDefaults = query.extended_fields !== undefined;
+    let globalFields: InlineField[] | undefined;
+    if (clientArgs.config.templates.enabled) {
+      globalFields = await resolveGlobalFields(query.owner, fieldDefinitionsService);
+      const globalFieldsDefaults = Object.fromEntries(
+        // A field without a default produces '' — writing that adds no information and, for a
+        // required field, would immediately fail its own validation. Only inject real defaults.
+        Object.entries(buildExtendedFieldsDefaults(globalFields)).filter(
+          ([, value]) => value !== ''
+        )
+      );
+      if (Object.keys(globalFieldsDefaults).length > 0) {
+        query = {
+          ...query,
+          extended_fields: {
+            ...(query.extended_fields ?? {}),
+            ...globalFieldsDefaults,
+            // The caller's original extended_fields, NOT query.extended_fields — template
+            // expansion already merged template defaults into the latter, and those must not
+            // shadow a global default on a storage-key collision.
+            ...(rawQuery.extended_fields ?? {}),
+          },
+        };
+      }
+    }
+
     if (query.extended_fields) {
-      const globalFields = await resolveGlobalFields(query.owner, fieldDefinitionsService);
+      globalFields =
+        globalFields ?? (await resolveGlobalFields(query.owner, fieldDefinitionsService));
       await validateCaseExtendedFields({
         extendedFields: query.extended_fields,
         templateId: query.template?.id,
@@ -146,6 +191,10 @@ export const create = async (
         templatesService,
         fieldDefinitionsService,
         owner: query.owner,
+        // Injection-only maps get partial semantics: validate the injected values, but do not
+        // enforce `required` on fields the caller never sent — that keeps creates that
+        // succeeded before defaults injection succeeding after it (see comment above).
+        partial: !hadExtendedFieldsBeforeDefaults,
         preResolvedTemplateFields: resolvedTemplateFields,
       });
     }

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/build_case_extended_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/build_case_extended_fields.test.ts
@@ -52,7 +52,7 @@ describe('buildExtendedFieldsBackfill', () => {
     expect(result).toEqual({ c_as_keyword: 'kept' });
   });
 
-  it('never overwrites a key already present in extended_fields', () => {
+  it('never overwrites a key already present in extended_fields with a non-empty value', () => {
     const result = buildExtendedFieldsBackfill(
       [
         { key: 'summary', type: CustomFieldTypes.TEXT, value: 'from-legacy' },
@@ -61,6 +61,21 @@ describe('buildExtendedFieldsBackfill', () => {
       { summary_as_keyword: 'already-set-in-v2' }
     );
     // summary is left as-is; only the missing key is added
+    expect(result).toEqual({ count_as_integer: '9' });
+  });
+
+  it('never overwrites an empty-string entry (a possible deliberate v2 clear) but fills null', () => {
+    // '' is ambiguous: the v2 UI writes it both for untouched fields and for explicit clears,
+    // and users can clear values while the space's backfill is still pending — so '' always
+    // wins over the legacy mirror. null cannot come from any user-facing write path, so it is
+    // treated as "no v2 value" and filled.
+    const result = buildExtendedFieldsBackfill(
+      [
+        { key: 'summary', type: CustomFieldTypes.TEXT, value: 'from-legacy' },
+        { key: 'count', type: CustomFieldTypes.NUMBER, value: 9 },
+      ],
+      { summary_as_keyword: '', count_as_integer: null }
+    );
     expect(result).toEqual({ count_as_integer: '9' });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/run_case_backfill.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/run_case_backfill.ts
@@ -33,7 +33,7 @@ const safeClosePit = async (
   }
 };
 
-/** Records `legacyCasesMigrated: true` on the space's configure SO once its backfill is complete. */
+/** Records the completion marker on the space's configure SO once its backfill is complete. */
 const setCasesMigratedFlag = async (
   repo: ISavedObjectsRepository,
   so: SavedObject<ConfigurationPersistedAttributes>
@@ -54,9 +54,10 @@ const setCasesMigratedFlag = async (
 /**
  * Backfills one space's cases using an Elasticsearch Point-In-Time cursor (skip-safe, and not
  * subject to the from/size result-window limit that breaks past ~10k docs). Fills only the
- * `extended_fields` keys a case is missing (never overwriting existing values) and stops when the
- * space is exhausted, the per-run scan budget is hit, or the task is cancelled — returning where to
- * resume in each of those cases.
+ * `extended_fields` keys a case does not have at all (absent or `null` — never overwriting any
+ * existing entry, including an explicit `''` clear) and stops when the space is exhausted, the
+ * per-run scan budget is hit, or the task is cancelled — returning where to resume in each of
+ * those cases.
  */
 const backfillCasesForSpace = async (
   repo: ISavedObjectsRepository,
@@ -172,6 +173,12 @@ const backfillCasesForSpace = async (
           attributes: {
             extended_fields: { ...(caseSO.attributes.extended_fields ?? {}), ...additions },
           },
+          // Optimistic concurrency: the merged map above was computed from the PIT snapshot, and
+          // an unguarded write would silently replace a user update that landed between the read
+          // and this write. With the snapshot version a concurrent update turns into a 409, which
+          // lands in the retryable branch below — the space stays unflagged and the next run
+          // recomputes from a fresh read.
+          version: caseSO.version,
           ...(nsOption ? { namespace: nsOption } : {}),
         },
       ];
@@ -184,6 +191,8 @@ const backfillCasesForSpace = async (
         // A 404 means the case can't be resolved for update — it was deleted between the scan and the
         // update, or its stored id/namespace don't line up (e.g. synthetic data inserted straight
         // into ES). Retrying never succeeds, so skip these rather than blocking the space forever.
+        // Everything else — including a 409 version conflict from the optimistic-concurrency guard
+        // above — is retryable: the space stays unflagged and is rescanned fresh on a later run.
         const notRetryable = failed.filter((s) => s.error?.statusCode === 404);
         const retryable = failed.filter((s) => s.error?.statusCode !== 404);
         const distinctReasons = (list: typeof failed) =>
@@ -243,19 +252,26 @@ const backfillCasesForSpace = async (
 };
 
 /**
- * Whether a single space still needs its existing cases backfilled: it has legacy custom fields AND
- * has not yet been flagged `legacyCasesMigrated`. Spaces with no custom fields are never backfilled
- * (there is nothing to derive `extended_fields` from), so they are never "pending".
+ * Whether a single space still needs its existing cases backfilled: it has legacy custom fields
+ * AND it has never been flagged `legacyCasesMigrated`. A flagged space is never rescanned — its
+ * `extended_fields` may have been deliberately edited (including cleared to `''`) since its
+ * migration, and rerunning the backfill would silently restore stale legacy values over those
+ * edits. Spaces with no custom fields are never backfilled (there is nothing to derive
+ * `extended_fields` from), so they are never "pending". Exported so the task runner counts a
+ * space as "skipped" from the same source of truth.
  */
-const configureNeedsCaseBackfill = (so: SavedObject<ConfigurationPersistedAttributes>): boolean =>
-  (so.attributes.customFields?.length ?? 0) > 0 && !so.attributes.legacyCasesMigrated;
+export const configureNeedsCaseBackfill = (
+  so: SavedObject<ConfigurationPersistedAttributes>
+): boolean =>
+  (so.attributes.customFields?.length ?? 0) > 0 && so.attributes.legacyCasesMigrated !== true;
 
 /**
  * Whether ANY space still needs its existing cases backfilled — the exact predicate
  * `runCaseBackfillPhase` uses to build its pending list, exported so the task runner can decide,
  * from the same source of truth, whether a completing run actually finished outstanding backfill
- * work. This is derived purely from the (restart-durable) `legacyCasesMigrated` per-space flags on
- * the freshly-loaded configure SOs, so it is stable across Kibana restarts and multi-run backfills.
+ * work. This is derived purely from the (restart-durable) per-space `legacyCasesMigrated`
+ * completion markers on the freshly-loaded configure SOs, so it is stable across Kibana restarts
+ * and multi-run backfills.
  */
 export const hasPendingCaseBackfill = (
   configures: Array<SavedObject<ConfigurationPersistedAttributes>>

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/templates_migration_task_manager.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/templates_migration_task_manager.test.ts
@@ -401,7 +401,7 @@ describe('TemplatesMigrationTaskManager', () => {
 
     it('migrates a legacy template with a Jira connector into a valid, connector-preserving definition', async () => {
       // Regression guard for the desk-test finding "migration is not picking up connector fields
-      // → preview error". Exercise the full task path and assert the persisted definition (a) is
+      // ? preview error". Exercise the full task path and assert the persisted definition (a) is
       // valid per ParsedTemplateDefinitionSchema (so the template is created, not skipped) and
       // (b) preserves the Jira connector's fields, dropping only the resolved `name`.
       const configSO = buildConfigureSO({
@@ -449,7 +449,7 @@ describe('TemplatesMigrationTaskManager', () => {
       }
     });
 
-    it('fully migrates a fleshed-out v1 template: identity → attributes; connector (all sub-fields), settings & case defaults → definition', async () => {
+    it('fully migrates a fleshed-out v1 template: identity ? attributes; connector (all sub-fields), settings & case defaults ? definition', async () => {
       // The core GA guarantee: a complete legacy template — template identity (name/description/tags),
       // every case default, a fully-populated Jira connector (all sub-fields incl. the free-form
       // otherFields), and both settings — migrates COMPLETELY and losslessly to v2.
@@ -615,7 +615,7 @@ describe('TemplatesMigrationTaskManager', () => {
 
     it('logs a warning when a reused field definition has a mismatched control type', async () => {
       const configSO = buildConfigureSO({
-        customFields: [buildLegacyCustomField('cf_text')], // TEXT → expects INPUT_TEXT
+        customFields: [buildLegacyCustomField('cf_text')], // TEXT ? expects INPUT_TEXT
       });
 
       const existingFieldDef = {
@@ -709,7 +709,7 @@ describe('TemplatesMigrationTaskManager', () => {
 
     it('reuses existing templates by name and does not duplicate', async () => {
       const configSO = buildConfigureSO({
-        // no customFields → skips field-def find; only templates find is made
+        // no customFields ? skips field-def find; only templates find is made
         templates: [buildLegacyTemplate('Existing Template')],
       });
 
@@ -1046,6 +1046,120 @@ describe('TemplatesMigrationTaskManager', () => {
       ]);
     });
 
+    it('preserves a v2 value deliberately cleared while the space was still unflagged', async () => {
+      // Field definitions become visible before a space's backfill completes (phase 1 runs
+      // first, and the configure mirror hook can create them even earlier), so a user can clear
+      // a v2 value ('' write) while legacyCasesMigrated is still unset — including between
+      // backfill retries or across restarts. The '' must win over the stale legacy value.
+      const configSO = buildConfigureSO({
+        customFields: [buildLegacyCustomField('cf_text')],
+        legacyCustomFieldsMigrated: true,
+        legacyTemplatesMigrated: true,
+      });
+      const caseSO = buildCaseSO(
+        'case-1',
+        [{ key: 'cf_text', type: CustomFieldTypes.TEXT, value: 'stale-legacy' }],
+        { cf_text_as_keyword: '' }
+      );
+      mockFindByType(configSO, [caseSO]);
+
+      const manager = await buildAndSchedule();
+      await getTaskRunner(manager).run();
+
+      // Nothing to fill — the cleared value is preserved — and the space still completes.
+      expect(repo.bulkUpdate).not.toHaveBeenCalled();
+      expect(repo.update).toHaveBeenCalledWith(
+        CASE_CONFIGURE_SAVED_OBJECT,
+        configSO.id,
+        { legacyCasesMigrated: true },
+        expect.anything()
+      );
+    });
+
+    it('retries from fresh data when a case changes after the PIT read (409 version conflict)', async () => {
+      // The backfill computes its merged extended_fields map from a PIT snapshot; without the
+      // snapshot version an update landing between the read and the write would be silently
+      // replaced. The write must carry the version, the 409 must not flag the space, and the
+      // retry must recompute from fresh data so the user's value survives.
+      const configSO = buildConfigureSO({
+        customFields: [buildLegacyCustomField('cf_text')],
+        legacyCustomFieldsMigrated: true,
+        legacyTemplatesMigrated: true,
+      });
+      const legacyCustomFields = [
+        { key: 'cf_text', type: CustomFieldTypes.TEXT, value: 'stale-legacy' },
+      ];
+      let scan = 0;
+      repo.find.mockImplementation((opts: { type: string }) => {
+        if (opts.type === CASE_CONFIGURE_SAVED_OBJECT) {
+          return Promise.resolve({ saved_objects: [configSO], total: 1 });
+        }
+        if (opts.type === CASE_SAVED_OBJECT) {
+          scan++;
+          if (scan === 1) {
+            // First scan: the case has no v2 value yet, at version v1.
+            return Promise.resolve({
+              saved_objects: [
+                { ...buildCaseSO('case-1', legacyCustomFields), version: 'v1', sort: [1] },
+              ],
+              total: 1,
+              pit_id: 'pit-1',
+            });
+          }
+          // Retry scan: a user set their own value in the meantime (version bumped).
+          return Promise.resolve({
+            saved_objects: [
+              {
+                ...buildCaseSO('case-1', legacyCustomFields, { cf_text_as_keyword: 'user-value' }),
+                version: 'v2',
+                sort: [1],
+              },
+            ],
+            total: 1,
+            pit_id: 'pit-2',
+          });
+        }
+        return Promise.resolve({ saved_objects: [], total: 0 });
+      });
+      repo.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'case-1',
+            type: CASE_SAVED_OBJECT,
+            error: { statusCode: 409, message: 'version conflict' },
+          },
+        ],
+      });
+
+      const manager = await buildAndSchedule();
+      const first = await getTaskRunner(manager).run();
+
+      // The guarded write carried the snapshot version...
+      expect(repo.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(repo.bulkUpdate.mock.calls[0][0]).toEqual([
+        expect.objectContaining({ id: 'case-1', version: 'v1' }),
+      ]);
+      // ...and the conflict left the space unflagged, rescheduling a retry.
+      expect(repo.update).not.toHaveBeenCalledWith(
+        CASE_CONFIGURE_SAVED_OBJECT,
+        configSO.id,
+        { legacyCasesMigrated: true },
+        expect.anything()
+      );
+      expect(first).toEqual(expect.objectContaining({ runAt: expect.any(Date) }));
+
+      // The retry recomputes from a fresh read: the user's value is present, so nothing is
+      // written over it and the space completes.
+      await getTaskRunner(manager).run();
+      expect(repo.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(repo.update).toHaveBeenCalledWith(
+        CASE_CONFIGURE_SAVED_OBJECT,
+        configSO.id,
+        { legacyCasesMigrated: true },
+        expect.anything()
+      );
+    });
+
     it('does not update cases that already have all their extended_fields', async () => {
       const configSO = buildConfigureSO({ customFields: [buildLegacyCustomField('cf_text')] });
       const caseSO = buildCaseSO(
@@ -1144,6 +1258,35 @@ describe('TemplatesMigrationTaskManager', () => {
       );
     });
 
+    it('never rescans a space already flagged as migrated — a deliberately cleared v2 value is preserved', async () => {
+      // The space completed its one-shot backfill in an earlier release; since then a user
+      // explicitly cleared the v2 mirror key (extended_fields value '') while the legacy
+      // customFields value remains. The backfill must NOT revisit the space — rerunning it
+      // with the ''-fills-as-empty semantics would silently restore the stale legacy value
+      // over the deliberate clear.
+      const configSO = buildConfigureSO({
+        customFields: [buildLegacyCustomField('cf_text')],
+        legacyCustomFieldsMigrated: true,
+        legacyTemplatesMigrated: true,
+        legacyCasesMigrated: true,
+      });
+      const caseSO = buildCaseSO(
+        'case-1',
+        [{ key: 'cf_text', type: CustomFieldTypes.TEXT, value: 'stale-legacy' }],
+        { cf_text_as_keyword: '' }
+      );
+      mockFindByType(configSO, [caseSO]);
+
+      const manager = await buildAndSchedule();
+      await getTaskRunner(manager).run();
+
+      // No case scan, no case writes, no flag rewrites: the cleared '' value stays cleared.
+      const caseFind = repo.find.mock.calls.find((c) => c[0]?.type === CASE_SAVED_OBJECT);
+      expect(caseFind).toBeUndefined();
+      expect(repo.bulkUpdate).not.toHaveBeenCalled();
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
     it('skips the case-backfill phase when the space has no custom fields', async () => {
       const configSO = buildConfigureSO({
         customFields: [],
@@ -1198,7 +1341,7 @@ describe('TemplatesMigrationTaskManager', () => {
     const PAGE_SIZE = 1000;
     const SCAN_BUDGET = 25000;
 
-    // A full page of trivial cases (no customFields → scanned but not updated), reused across finds.
+    // A full page of trivial cases (no customFields ? scanned but not updated), reused across finds.
     const fullPage = (sortValue: number) => ({
       saved_objects: Array.from({ length: PAGE_SIZE }, (_, i) => ({
         id: `case-${sortValue}-${i}`,
@@ -1256,7 +1399,7 @@ describe('TemplatesMigrationTaskManager', () => {
       expect(caseFinds).toHaveLength(2);
       expect(caseFinds[1][0]).toEqual(expect.objectContaining({ searchAfter: [1] }));
 
-      // Exhausted → PIT closed, flag set, task deleted (no reschedule).
+      // Exhausted ? PIT closed, flag set, task deleted (no reschedule).
       expect(repo.closePointInTime).toHaveBeenCalled();
       expect(repo.update).toHaveBeenCalledWith(
         CASE_CONFIGURE_SAVED_OBJECT,
@@ -1297,7 +1440,7 @@ describe('TemplatesMigrationTaskManager', () => {
 
     it('resumes from a persisted cursor without reopening a PIT', async () => {
       const configSO = buildConfigureSO({ customFields: [buildLegacyCustomField('cf_text')] });
-      // Partial page → exhausts immediately once resumed.
+      // Partial page ? exhausts immediately once resumed.
       routeConfigureAndCases(configSO, [{ saved_objects: [], total: 0, pit_id: 'pit-resumed' }]);
 
       const manager = await buildAndSchedule();
@@ -1313,7 +1456,7 @@ describe('TemplatesMigrationTaskManager', () => {
         },
       });
 
-      // Resumed → no new PIT opened, and the scan continues from the saved search_after.
+      // Resumed ? no new PIT opened, and the scan continues from the saved search_after.
       expect(repo.openPointInTimeForType).not.toHaveBeenCalled();
       const caseFind = repo.find.mock.calls.find((c) => c[0]?.type === CASE_SAVED_OBJECT);
       expect(caseFind?.[0]).toEqual(
@@ -1546,7 +1689,7 @@ describe('TemplatesMigrationTaskManager', () => {
     });
 
     it('resets failedRuns after a run that stops only for budget (no failures)', async () => {
-      // 1000-case pages that never fail → the scan budget is what stops the run (a clean pause),
+      // 1000-case pages that never fail ? the scan budget is what stops the run (a clean pause),
       // so a prior failure streak must reset to zero.
       const fullPage = {
         saved_objects: Array.from({ length: 1000 }, (_, i) => ({
@@ -1612,7 +1755,7 @@ describe('TemplatesMigrationTaskManager', () => {
           if (opts.type === CASE_CONFIGURE_SAVED_OBJECT) {
             return Promise.resolve({ saved_objects: [cfg], total: 1 });
           }
-          // No sortField → order by array index (the unique `_shard_doc`-like tiebreaker).
+          // No sortField ? order by array index (the unique `_shard_doc`-like tiebreaker).
           const after = opts.searchAfter ? opts.searchAfter[0] : -1;
           const start = after + 1;
           const pageDocs = docs.slice(start, start + opts.perPage).map((d, i) => ({
@@ -1651,7 +1794,7 @@ describe('TemplatesMigrationTaskManager', () => {
       expect(docs[TOTAL - 1].attributes.extended_fields).toEqual({
         cf_text_as_keyword: `v-${TOTAL - 1}`,
       });
-      // Fully done → task deleted, space flagged.
+      // Fully done ? task deleted, space flagged.
       expect(result).toEqual(expect.objectContaining({ shouldDeleteTask: true }));
       expect(repo.update).toHaveBeenCalledWith(
         CASE_CONFIGURE_SAVED_OBJECT,
@@ -1686,7 +1829,7 @@ describe('TemplatesMigrationTaskManager', () => {
           saved_objects: [buildConfigureSO({ customFields: [buildLegacyCustomField('cf')] })],
           total: 1,
         })
-        // field-def find throws → migrateOneConfigure propagates the error
+        // field-def find throws ? migrateOneConfigure propagates the error
         .mockRejectedValueOnce(new Error('network error'));
 
       await getTaskRunner(
@@ -1869,7 +2012,7 @@ describe('TemplatesMigrationTaskManager', () => {
       mockFindByType(configSO, [
         buildCaseSO('c1', [{ key: 'cf_text', type: CustomFieldTypes.TEXT, value: 'v' }]),
       ]);
-      // Every update fails → resuming one run short of the cap makes this run give up and delete.
+      // Every update fails ? resuming one run short of the cap makes this run give up and delete.
       repo.bulkUpdate.mockResolvedValue({
         saved_objects: [{ id: 'c1', type: CASE_SAVED_OBJECT, error: { message: 'boom' } }],
       });

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/templates_migration_task_manager.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/templates_migration_task_manager.ts
@@ -33,7 +33,11 @@ import {
 } from './types';
 import type { MigrationTaskState } from './types';
 import { findAllConfigurations, migrateOneConfigure } from './migrate_configuration';
-import { hasPendingCaseBackfill, runCaseBackfillPhase } from './run_case_backfill';
+import {
+  configureNeedsCaseBackfill,
+  hasPendingCaseBackfill,
+  runCaseBackfillPhase,
+} from './run_case_backfill';
 
 /**
  * Registers and schedules the one-shot task that migrates legacy (v1) templates and custom fields
@@ -189,7 +193,7 @@ export class TemplatesMigrationTaskManager {
           so.attributes.legacyTemplatesMigrated && so.attributes.legacyCustomFieldsMigrated;
 
         if (fieldsAndTemplatesDone) {
-          if (so.attributes.legacyCasesMigrated) {
+          if (!configureNeedsCaseBackfill(so)) {
             totals.skipped++;
             this.migrationUsageCounter?.incrementCounter({
               counterName: 'configureMigrationSkipped',

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/extended_fields_global.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/extended_fields_global.ts
@@ -7,18 +7,39 @@
 
 import expect from '@kbn/expect';
 import { stringify as yamlStringify } from 'yaml';
+import { CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
 import { CASES_URL, CASE_EXTENDED_FIELDS } from '@kbn/cases-plugin/common/constants';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
-import { deleteAllCaseItems, createCase } from '../../../../common/lib/api';
+import {
+  deleteAllCaseItems,
+  createCase,
+  createConfiguration,
+  getConfigurationRequest,
+} from '../../../../common/lib/api';
 import { getPostCaseRequest } from '../../../../common/lib/mock';
 
 const FIELD_DEFINITIONS_URL = '/internal/cases/field_definitions';
 
-const buildFieldDef = (name: string, type = 'keyword', isGlobal = true) => ({
+const buildFieldDef = (
+  name: string,
+  {
+    type = 'keyword',
+    isGlobal = true,
+    defaultValue,
+    required,
+  }: { type?: string; isGlobal?: boolean; defaultValue?: string; required?: boolean } = {}
+) => ({
   name,
   owner: 'securitySolutionFixture',
   isGlobal,
-  definition: yamlStringify({ name, type, control: 'INPUT_TEXT', label: name }),
+  definition: yamlStringify({
+    name,
+    type,
+    control: 'INPUT_TEXT',
+    label: name,
+    ...(required ? { validation: { required: true } } : {}),
+    ...(defaultValue !== undefined ? { metadata: { default: defaultValue } } : {}),
+  }),
 });
 
 export default ({ getService }: FtrProviderContext): void => {
@@ -94,6 +115,163 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(createdCase[CASE_EXTENDED_FIELDS]).to.eql({
           global_tag_as_keyword: 'security',
           summary_as_keyword: 'hello',
+        });
+      });
+    });
+
+    describe('POST /cases — server-side global field defaults', () => {
+      it('applies global field defaults when the caller sends no extended_fields', async () => {
+        await supertest
+          .post(`${FIELD_DEFINITIONS_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send(buildFieldDef('risk_score', { defaultValue: 'high' }))
+          .expect(200);
+
+        const createdCase = await createCase(supertest, {
+          ...getPostCaseRequest({ owner: 'securitySolutionFixture' }),
+        });
+
+        expect(createdCase[CASE_EXTENDED_FIELDS]).to.eql({ risk_score_as_keyword: 'high' });
+      });
+
+      it('merges template defaults, global defaults, and caller values with caller-wins precedence', async () => {
+        await supertest
+          .post(`${FIELD_DEFINITIONS_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send(buildFieldDef('priority', { defaultValue: 'global-default' }))
+          .expect(200);
+
+        const { body: templateBody } = await supertest
+          .post('/internal/cases/templates')
+          .set('kbn-xsrf', 'true')
+          .send({
+            name: 'Precedence Template',
+            owner: 'securitySolutionFixture',
+            definition: yamlStringify({
+              name: 'Precedence Template',
+              fields: [
+                // Collides with the global definition on the storage key — the global
+                // default must win over the template default.
+                {
+                  name: 'priority',
+                  type: 'keyword',
+                  control: 'INPUT_TEXT',
+                  label: 'Priority',
+                  metadata: { default: 'template-default' },
+                },
+                {
+                  name: 'summary',
+                  type: 'keyword',
+                  control: 'INPUT_TEXT',
+                  label: 'Summary',
+                  metadata: { default: 'template-summary' },
+                },
+              ],
+            }),
+            isEnabled: true,
+          })
+          .expect(200);
+
+        const createdCase = await createCase(supertest, {
+          ...getPostCaseRequest({ owner: 'securitySolutionFixture' }),
+          template: { id: templateBody.templateId, version: templateBody.templateVersion },
+          [CASE_EXTENDED_FIELDS]: { summary_as_keyword: 'caller-summary' },
+        });
+
+        expect(createdCase[CASE_EXTENDED_FIELDS]).to.eql({
+          priority_as_keyword: 'global-default',
+          summary_as_keyword: 'caller-summary',
+        });
+      });
+
+      it('a caller-sent empty string wins over a global default', async () => {
+        await supertest
+          .post(`${FIELD_DEFINITIONS_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send(buildFieldDef('risk_score', { defaultValue: 'high' }))
+          .expect(200);
+
+        const createdCase = await createCase(supertest, {
+          ...getPostCaseRequest({ owner: 'securitySolutionFixture' }),
+          [CASE_EXTENDED_FIELDS]: { risk_score_as_keyword: '' },
+        });
+
+        expect(createdCase[CASE_EXTENDED_FIELDS]).to.eql({ risk_score_as_keyword: '' });
+      });
+
+      it('creates the case when a required global field has no default and no caller value', async () => {
+        // Backward compatibility: defaults injection must be invisible to callers that never
+        // engaged with extended_fields — `required` stays a UI submit-time gate here.
+        await supertest
+          .post(`${FIELD_DEFINITIONS_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send(buildFieldDef('risk_score', { required: true }))
+          .expect(200);
+
+        const createdCase = await createCase(supertest, {
+          ...getPostCaseRequest({ owner: 'securitySolutionFixture' }),
+        });
+
+        expect(createdCase[CASE_EXTENDED_FIELDS]).to.be(undefined);
+      });
+
+      it('rejects when the caller sends extended_fields but omits a required global field', async () => {
+        await supertest
+          .post(`${FIELD_DEFINITIONS_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send(buildFieldDef('risk_score', { required: true }))
+          .expect(200);
+        await supertest
+          .post(`${FIELD_DEFINITIONS_URL}`)
+          .set('kbn-xsrf', 'true')
+          .send(buildFieldDef('notes'))
+          .expect(200);
+
+        await supertest
+          .post(`${CASES_URL}`)
+          .set('kbn-xsrf', 'true')
+          .set('x-elastic-internal-origin', 'foo')
+          .send({
+            ...getPostCaseRequest({ owner: 'securitySolutionFixture' }),
+            [CASE_EXTENDED_FIELDS]: { notes_as_keyword: 'some notes' },
+          })
+          .expect(400);
+      });
+
+      it('legacy customFields-only creates keep succeeding when a required custom field is mirrored into a required global definition', async () => {
+        // Posting a configuration mirrors its custom fields into global field definitions,
+        // preserving `required`. A create that satisfies the field through the legacy
+        // customFields array (or omits it entirely) must not be rejected by the v2 surface.
+        await createConfiguration(
+          supertest,
+          getConfigurationRequest({
+            overrides: {
+              customFields: [
+                {
+                  key: 'test_custom_field',
+                  label: 'text',
+                  type: CustomFieldTypes.TEXT,
+                  required: true,
+                },
+              ],
+            },
+          })
+        );
+
+        const createdCase = await createCase(supertest, {
+          ...getPostCaseRequest({ owner: 'securitySolutionFixture' }),
+          customFields: [
+            {
+              key: 'test_custom_field',
+              type: CustomFieldTypes.TEXT,
+              value: 'legacy value',
+            },
+          ],
+        });
+
+        // The legacy value is mirrored into the v2 surface.
+        expect(createdCase[CASE_EXTENDED_FIELDS]).to.eql({
+          test_custom_field_as_keyword: 'legacy value',
         });
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Cases] Apply global field defaults to cases created via the API and workflow steps (#283185)](https://github.com/elastic/kibana/pull/283185)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michael Olorunnisola","email":"michael.olorunnisola@elastic.co"},"sourceCommit":{"committedDate":"2026-08-06T14:47:33Z","message":"[Cases] Apply global field defaults to cases created via the API and workflow steps (#283185)\n\n## Summary\n\nThis PR does two things:\n\n1. **Fixes missing default values on cases created through the API or\nworkflow steps.** The create-case UI fills in global field defaults in\nthe browser before submitting, so cases created in the UI looked fine.\nBut cases created through `POST /api/cases` or the `cases.create_case`\nworkflow step skipped that client-side step, so every global field came\nback empty.\n2. **Hardens the template migration backfill so it can never overwrite\nuser data.** The backfill now uses version checks on every write, treats\nany existing entry (including an empty string) as untouchable, and never\nre-scans a space that already finished migrating.\n\nTo be clear about what this PR does **not** do: cases that already have\nan empty string stored for a global field keep their old custom field\nvalue stranded. An empty string can mean \"the user never touched this\nfield\" or \"the user cleared it on purpose\", and we have no way to tell\nthem apart, so we leave those values alone. Repairing them would need\nprovenance tracking that doesn't exist today. Data safety wins over\ncompleteness here.\n\n## What changed\n\n**Case creation (API and workflow steps):**\n\n- When a case is created, the server now looks up the global field\ndefinitions for that owner and fills in their default values. The order\nof precedence matches what the UI already does: template defaults are\napplied first, then global field defaults, and anything the caller sends\nalways wins (including an explicit empty string).\n- Only fields that actually have a default get filled in. Fields without\na default are left out entirely instead of being stored as empty\nstrings.\n- Validation behaves exactly like it did before this PR. If a request\nnever included `extended_fields`, adding defaults on the server does not\nmake it stricter — a required field with no default will not suddenly\nreject requests that used to succeed. If the caller (or a chosen\ntemplate) does send `extended_fields`, the same full validation that\nalready existed still runs. In short: no request that worked before will\nstart failing.\n\n**Migration backfill (safety hardening):**\n\n- The backfill only fills in a global field when the case has **no entry\nfor it at all** (the key is absent, or holds a `null` that no\nuser-facing path can produce). Any existing entry — even an empty string\n— is left alone, because an empty string can be a deliberate clear.\nFields with absent keys were already being backfilled before this PR;\nthe change here is making the empty-string rule explicit and safe.\n- Every backfill write now includes the document version it was read at.\nIf someone edits a case between the time the backfill reads it and\nwrites it, the write fails with a conflict instead of silently replacing\nthe user's edit. The space is then retried later with fresh data.\n- Spaces that already finished their migration are never scanned again.\nAn earlier revision of this PR re-scanned them to repair stranded\nvalues; that was removed because it could overwrite values users changed\nor cleared after their migration.\n\n### Known gaps (follow-ups, not addressed here)\n\n- Stranded values behind empty-string entries are not repaired — see the\nnote in the summary. Fixing this properly needs a way to record whether\na field value was ever set by a user.\n- The cases connector (auto-creating cases from alerts) uses a different\ncreation path (`bulkCreate`) that still has the same missing-defaults\ngap. That fix has a different shape and will come separately.\n- Defaults defined on the old v1 custom field configuration still don't\nreach the new global fields at creation time in every code path. The\nbroader v1/v2 reconciliation work covers this.\n\n## Risk\n\n**Low.** No API request that succeeded before this PR will fail after\nit. The backfill can only add values to fields that have no entry, never\nchanges an existing one, uses version checks on every write, and never\ntouches a space that already migrated. No new saved object attributes\nand no schema changes.\n\n## Testing\n\n**Manual:**\n1. With templates enabled, create a global field definition with a\ndefault value, then create a case through `POST /api/cases` (or a\nworkflow with the `cases.create_case` step) without sending\n`extended_fields`. The new case shows the default value.\n2. Send your own value (or an empty string) for that field in the\nrequest. Your value is kept, not the default.\n3. Make a global field required with no default. Creating a case through\nthe API without `extended_fields` still works, with the field left empty\n(same as before this PR). Sending an `extended_fields` object that\nleaves out the required field is still rejected (also same as before).\n4. Clear a global field value on a case while its space's migration is\nstill running, or in a space that already migrated. The field stays\ncleared — the backfill never puts the old custom field value back.\n\n**Automated:**\n- [x] Unit tests: server-side defaults and precedence on create, the\nbackward-compatible required-field behavior, the \"only fill fields with\nno entry\" backfill rules, the version-conflict retry, and the guarantees\nthat cleared values and already-migrated spaces are never touched.\n- [x] API integration tests: defaults applied to API-created cases,\nprecedence (template < global < caller), an explicit empty string\nwinning over a default, both sides of the required-field behavior, and\nold-style `customFields`-only creates continuing to work when a required\ncustom field has been mirrored into a required global field.\n\n## Checklist\n\nCheck the PR satisfies following conditions.\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\n*No breaking changes: requests that succeeded before this PR continue to\nsucceed.*\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes an issue where default values of global case fields were not\napplied to cases created via the API or workflow steps. Also hardens the\ncases template migration backfill: it now uses version checks so\nconcurrent edits are never overwritten, and it never modifies a field\nvalue a user has set or cleared.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"3684393143c642ae145ecf541af0e6d08fa43f5e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","Team:Cases","v9.6.0","v9.5.1"],"title":"[Cases] Apply global field defaults to cases created via the API and workflow steps","number":283185,"url":"https://github.com/elastic/kibana/pull/283185","mergeCommit":{"message":"[Cases] Apply global field defaults to cases created via the API and workflow steps (#283185)\n\n## Summary\n\nThis PR does two things:\n\n1. **Fixes missing default values on cases created through the API or\nworkflow steps.** The create-case UI fills in global field defaults in\nthe browser before submitting, so cases created in the UI looked fine.\nBut cases created through `POST /api/cases` or the `cases.create_case`\nworkflow step skipped that client-side step, so every global field came\nback empty.\n2. **Hardens the template migration backfill so it can never overwrite\nuser data.** The backfill now uses version checks on every write, treats\nany existing entry (including an empty string) as untouchable, and never\nre-scans a space that already finished migrating.\n\nTo be clear about what this PR does **not** do: cases that already have\nan empty string stored for a global field keep their old custom field\nvalue stranded. An empty string can mean \"the user never touched this\nfield\" or \"the user cleared it on purpose\", and we have no way to tell\nthem apart, so we leave those values alone. Repairing them would need\nprovenance tracking that doesn't exist today. Data safety wins over\ncompleteness here.\n\n## What changed\n\n**Case creation (API and workflow steps):**\n\n- When a case is created, the server now looks up the global field\ndefinitions for that owner and fills in their default values. The order\nof precedence matches what the UI already does: template defaults are\napplied first, then global field defaults, and anything the caller sends\nalways wins (including an explicit empty string).\n- Only fields that actually have a default get filled in. Fields without\na default are left out entirely instead of being stored as empty\nstrings.\n- Validation behaves exactly like it did before this PR. If a request\nnever included `extended_fields`, adding defaults on the server does not\nmake it stricter — a required field with no default will not suddenly\nreject requests that used to succeed. If the caller (or a chosen\ntemplate) does send `extended_fields`, the same full validation that\nalready existed still runs. In short: no request that worked before will\nstart failing.\n\n**Migration backfill (safety hardening):**\n\n- The backfill only fills in a global field when the case has **no entry\nfor it at all** (the key is absent, or holds a `null` that no\nuser-facing path can produce). Any existing entry — even an empty string\n— is left alone, because an empty string can be a deliberate clear.\nFields with absent keys were already being backfilled before this PR;\nthe change here is making the empty-string rule explicit and safe.\n- Every backfill write now includes the document version it was read at.\nIf someone edits a case between the time the backfill reads it and\nwrites it, the write fails with a conflict instead of silently replacing\nthe user's edit. The space is then retried later with fresh data.\n- Spaces that already finished their migration are never scanned again.\nAn earlier revision of this PR re-scanned them to repair stranded\nvalues; that was removed because it could overwrite values users changed\nor cleared after their migration.\n\n### Known gaps (follow-ups, not addressed here)\n\n- Stranded values behind empty-string entries are not repaired — see the\nnote in the summary. Fixing this properly needs a way to record whether\na field value was ever set by a user.\n- The cases connector (auto-creating cases from alerts) uses a different\ncreation path (`bulkCreate`) that still has the same missing-defaults\ngap. That fix has a different shape and will come separately.\n- Defaults defined on the old v1 custom field configuration still don't\nreach the new global fields at creation time in every code path. The\nbroader v1/v2 reconciliation work covers this.\n\n## Risk\n\n**Low.** No API request that succeeded before this PR will fail after\nit. The backfill can only add values to fields that have no entry, never\nchanges an existing one, uses version checks on every write, and never\ntouches a space that already migrated. No new saved object attributes\nand no schema changes.\n\n## Testing\n\n**Manual:**\n1. With templates enabled, create a global field definition with a\ndefault value, then create a case through `POST /api/cases` (or a\nworkflow with the `cases.create_case` step) without sending\n`extended_fields`. The new case shows the default value.\n2. Send your own value (or an empty string) for that field in the\nrequest. Your value is kept, not the default.\n3. Make a global field required with no default. Creating a case through\nthe API without `extended_fields` still works, with the field left empty\n(same as before this PR). Sending an `extended_fields` object that\nleaves out the required field is still rejected (also same as before).\n4. Clear a global field value on a case while its space's migration is\nstill running, or in a space that already migrated. The field stays\ncleared — the backfill never puts the old custom field value back.\n\n**Automated:**\n- [x] Unit tests: server-side defaults and precedence on create, the\nbackward-compatible required-field behavior, the \"only fill fields with\nno entry\" backfill rules, the version-conflict retry, and the guarantees\nthat cleared values and already-migrated spaces are never touched.\n- [x] API integration tests: defaults applied to API-created cases,\nprecedence (template < global < caller), an explicit empty string\nwinning over a default, both sides of the required-field behavior, and\nold-style `customFields`-only creates continuing to work when a required\ncustom field has been mirrored into a required global field.\n\n## Checklist\n\nCheck the PR satisfies following conditions.\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\n*No breaking changes: requests that succeeded before this PR continue to\nsucceed.*\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes an issue where default values of global case fields were not\napplied to cases created via the API or workflow steps. Also hardens the\ncases template migration backfill: it now uses version checks so\nconcurrent edits are never overwritten, and it never modifies a field\nvalue a user has set or cleared.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"3684393143c642ae145ecf541af0e6d08fa43f5e"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283185","number":283185,"mergeCommit":{"message":"[Cases] Apply global field defaults to cases created via the API and workflow steps (#283185)\n\n## Summary\n\nThis PR does two things:\n\n1. **Fixes missing default values on cases created through the API or\nworkflow steps.** The create-case UI fills in global field defaults in\nthe browser before submitting, so cases created in the UI looked fine.\nBut cases created through `POST /api/cases` or the `cases.create_case`\nworkflow step skipped that client-side step, so every global field came\nback empty.\n2. **Hardens the template migration backfill so it can never overwrite\nuser data.** The backfill now uses version checks on every write, treats\nany existing entry (including an empty string) as untouchable, and never\nre-scans a space that already finished migrating.\n\nTo be clear about what this PR does **not** do: cases that already have\nan empty string stored for a global field keep their old custom field\nvalue stranded. An empty string can mean \"the user never touched this\nfield\" or \"the user cleared it on purpose\", and we have no way to tell\nthem apart, so we leave those values alone. Repairing them would need\nprovenance tracking that doesn't exist today. Data safety wins over\ncompleteness here.\n\n## What changed\n\n**Case creation (API and workflow steps):**\n\n- When a case is created, the server now looks up the global field\ndefinitions for that owner and fills in their default values. The order\nof precedence matches what the UI already does: template defaults are\napplied first, then global field defaults, and anything the caller sends\nalways wins (including an explicit empty string).\n- Only fields that actually have a default get filled in. Fields without\na default are left out entirely instead of being stored as empty\nstrings.\n- Validation behaves exactly like it did before this PR. If a request\nnever included `extended_fields`, adding defaults on the server does not\nmake it stricter — a required field with no default will not suddenly\nreject requests that used to succeed. If the caller (or a chosen\ntemplate) does send `extended_fields`, the same full validation that\nalready existed still runs. In short: no request that worked before will\nstart failing.\n\n**Migration backfill (safety hardening):**\n\n- The backfill only fills in a global field when the case has **no entry\nfor it at all** (the key is absent, or holds a `null` that no\nuser-facing path can produce). Any existing entry — even an empty string\n— is left alone, because an empty string can be a deliberate clear.\nFields with absent keys were already being backfilled before this PR;\nthe change here is making the empty-string rule explicit and safe.\n- Every backfill write now includes the document version it was read at.\nIf someone edits a case between the time the backfill reads it and\nwrites it, the write fails with a conflict instead of silently replacing\nthe user's edit. The space is then retried later with fresh data.\n- Spaces that already finished their migration are never scanned again.\nAn earlier revision of this PR re-scanned them to repair stranded\nvalues; that was removed because it could overwrite values users changed\nor cleared after their migration.\n\n### Known gaps (follow-ups, not addressed here)\n\n- Stranded values behind empty-string entries are not repaired — see the\nnote in the summary. Fixing this properly needs a way to record whether\na field value was ever set by a user.\n- The cases connector (auto-creating cases from alerts) uses a different\ncreation path (`bulkCreate`) that still has the same missing-defaults\ngap. That fix has a different shape and will come separately.\n- Defaults defined on the old v1 custom field configuration still don't\nreach the new global fields at creation time in every code path. The\nbroader v1/v2 reconciliation work covers this.\n\n## Risk\n\n**Low.** No API request that succeeded before this PR will fail after\nit. The backfill can only add values to fields that have no entry, never\nchanges an existing one, uses version checks on every write, and never\ntouches a space that already migrated. No new saved object attributes\nand no schema changes.\n\n## Testing\n\n**Manual:**\n1. With templates enabled, create a global field definition with a\ndefault value, then create a case through `POST /api/cases` (or a\nworkflow with the `cases.create_case` step) without sending\n`extended_fields`. The new case shows the default value.\n2. Send your own value (or an empty string) for that field in the\nrequest. Your value is kept, not the default.\n3. Make a global field required with no default. Creating a case through\nthe API without `extended_fields` still works, with the field left empty\n(same as before this PR). Sending an `extended_fields` object that\nleaves out the required field is still rejected (also same as before).\n4. Clear a global field value on a case while its space's migration is\nstill running, or in a space that already migrated. The field stays\ncleared — the backfill never puts the old custom field value back.\n\n**Automated:**\n- [x] Unit tests: server-side defaults and precedence on create, the\nbackward-compatible required-field behavior, the \"only fill fields with\nno entry\" backfill rules, the version-conflict retry, and the guarantees\nthat cleared values and already-migrated spaces are never touched.\n- [x] API integration tests: defaults applied to API-created cases,\nprecedence (template < global < caller), an explicit empty string\nwinning over a default, both sides of the required-field behavior, and\nold-style `customFields`-only creates continuing to work when a required\ncustom field has been mirrored into a required global field.\n\n## Checklist\n\nCheck the PR satisfies following conditions.\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\n*No breaking changes: requests that succeeded before this PR continue to\nsucceed.*\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes an issue where default values of global case fields were not\napplied to cases created via the API or workflow steps. Also hardens the\ncases template migration backfill: it now uses version checks so\nconcurrent edits are never overwritten, and it never modifies a field\nvalue a user has set or cleared.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"3684393143c642ae145ecf541af0e6d08fa43f5e"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->