### PR TITLE
[Streams] [SigEvents] Knowledge indicators card uplift

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events_app/public/components/knowledge_indicators_panel/knowledge_indicators_panel.test.tsx
+++ b/x-pack/platform/plugins/shared/significant_events_app/public/components/knowledge_indicators_panel/knowledge_indicators_panel.test.tsx
@@ -94,16 +94,22 @@ describe('KnowledgeIndicatorsPanel', () => {
     ).toHaveTextContent('query');
   });
 
-  it('links to the knowledge indicators tab with the stream pre-filtered', () => {
+  it('renders a View all link to the knowledge indicators tab with the stream pre-filtered', () => {
     renderWithI18n(<KnowledgeIndicatorsPanel streamName={definition.stream.name} />);
 
     expect(link).toHaveBeenCalledWith('/{tab}', {
       path: { tab: 'knowledge_indicators' },
       query: { stream: definition.stream.name },
     });
-    expect(screen.getByTestId('significantEventsAppKnowledgeIndicatorsPanelLink')).toHaveAttribute(
+    const viewAllLink = screen.getByTestId('significantEventsAppKnowledgeIndicatorsPanelLink');
+    expect(viewAllLink).toHaveTextContent('View all');
+    expect(viewAllLink).toHaveAttribute(
       'href',
       '/app/significant_events/knowledge_indicators?stream=logs'
+    );
+    expect(viewAllLink).toHaveAttribute(
+      'aria-label',
+      `View all knowledge indicators for ${definition.stream.name}: 2 features, 8 queries`
     );
   });
 
@@ -125,7 +131,7 @@ describe('KnowledgeIndicatorsPanel', () => {
     expect(screen.getAllByTestId('knowledgeIndicatorsCountLoading')).toHaveLength(2);
     expect(screen.getByTestId('significantEventsAppKnowledgeIndicatorsPanelLink')).toHaveAttribute(
       'aria-label',
-      `View knowledge indicators for ${definition.stream.name}: loading counts`
+      `View all knowledge indicators for ${definition.stream.name}: loading counts`
     );
   });
 

--- a/x-pack/platform/plugins/shared/significant_events_app/public/components/knowledge_indicators_panel/knowledge_indicators_panel.tsx
+++ b/x-pack/platform/plugins/shared/significant_events_app/public/components/knowledge_indicators_panel/knowledge_indicators_panel.tsx
@@ -130,61 +130,68 @@ export function KnowledgeIndicatorsPanel({ streamName }: KnowledgeIndicatorsPane
     }
   );
 
-  const ariaLabel =
+  const viewAllAriaLabel =
     featuresIsLoading || queriesIsLoading
       ? i18n.translate('xpack.significantEventsApp.knowledgeIndicatorsPanel.linkAriaLabelLoading', {
-          defaultMessage: 'View knowledge indicators for {streamName}: loading counts',
+          defaultMessage: 'View all knowledge indicators for {streamName}: loading counts',
           values: { streamName },
         })
       : i18n.translate('xpack.significantEventsApp.knowledgeIndicatorsPanel.linkAriaLabel', {
           defaultMessage:
-            'View knowledge indicators for {streamName}: {featuresCount, plural, one {# feature} other {# features}}, {queriesCount, plural, one {# query} other {# queries}}',
+            'View all knowledge indicators for {streamName}: {featuresCount, plural, one {# feature} other {# features}}, {queriesCount, plural, one {# query} other {# queries}}',
           values: { streamName, featuresCount, queriesCount: queriesCount ?? 0 },
         });
 
   return (
-    <EuiLink
-      href={href}
-      data-test-subj="significantEventsAppKnowledgeIndicatorsPanelLink"
-      aria-label={ariaLabel}
-      css={css`
-        text-decoration: none;
-
-        &:hover,
-        &:focus {
-          text-decoration: none;
-        }
-      `}
+    <EuiPanel
+      hasBorder
+      hasShadow={false}
+      paddingSize="m"
+      data-test-subj="significantEventsAppKnowledgeIndicatorsPanel"
     >
-      <EuiPanel hasBorder hasShadow={false} paddingSize="m">
-        <EuiTitle size="xs">
-          <h2>
-            {i18n.translate('xpack.significantEventsApp.knowledgeIndicatorsPanel.title', {
-              defaultMessage: 'Knowledge indicators',
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xs">
+            <h2>
+              {i18n.translate('xpack.significantEventsApp.knowledgeIndicatorsPanel.title', {
+                defaultMessage: 'Knowledge indicators',
+              })}
+            </h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem />
+        <EuiFlexItem grow={false}>
+          <EuiLink
+            href={href}
+            data-test-subj="significantEventsAppKnowledgeIndicatorsPanelLink"
+            aria-label={viewAllAriaLabel}
+          >
+            {i18n.translate('xpack.significantEventsApp.knowledgeIndicatorsPanel.viewAll', {
+              defaultMessage: 'View all',
             })}
-          </h2>
-        </EuiTitle>
+          </EuiLink>
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
-        <EuiSpacer size="m" />
+      <EuiSpacer size="m" />
 
-        <EuiFlexGroup gutterSize="l" responsive={false}>
-          <KnowledgeIndicatorCount
-            count={featuresError || featuresIsLoading ? undefined : featuresCount}
-            isLoading={featuresIsLoading}
-            isError={!!featuresError}
-            label={featuresLabel}
-            data-test-subj="significantEventsAppKnowledgeIndicatorsFeaturesCount"
-          />
-          <KnowledgeIndicatorCount
-            count={queriesError || queriesCount === undefined ? undefined : queriesCount}
-            isLoading={queriesIsLoading}
-            isFetching={queriesFetching}
-            isError={queriesError}
-            label={queriesLabel}
-            data-test-subj="significantEventsAppKnowledgeIndicatorsQueriesCount"
-          />
-        </EuiFlexGroup>
-      </EuiPanel>
-    </EuiLink>
+      <EuiFlexGroup gutterSize="l" responsive={false}>
+        <KnowledgeIndicatorCount
+          count={featuresError || featuresIsLoading ? undefined : featuresCount}
+          isLoading={featuresIsLoading}
+          isError={!!featuresError}
+          label={featuresLabel}
+          data-test-subj="significantEventsAppKnowledgeIndicatorsFeaturesCount"
+        />
+        <KnowledgeIndicatorCount
+          count={queriesError || queriesCount === undefined ? undefined : queriesCount}
+          isLoading={queriesIsLoading}
+          isFetching={queriesFetching}
+          isError={queriesError}
+          label={queriesLabel}
+          data-test-subj="significantEventsAppKnowledgeIndicatorsQueriesCount"
+        />
+      </EuiFlexGroup>
+    </EuiPanel>
   );
 }


### PR DESCRIPTION
## Summary

Simple PR for improving the KI panel in Streams to be based on the design patterns and structure. Basically showing a link on the top right, instead of clicking on the whole card.


Before
<img width="3360" height="1872" alt="image" src="https://github.com/user-attachments/assets/b8500704-829d-43c3-b3c5-0e5e4b0e457b" />

After
<img width="3360" height="1872" alt="image" src="https://github.com/user-attachments/assets/dc325532-74b4-4621-9267-32e40ff6b16e" />
