### PR TITLE
[9.5] [Search Inference Endpoints] Add region policy delete toggle to Manage Region Preferences modal (#282769)

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/confirm_delete_region_policy_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/confirm_delete_region_policy_modal.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { ConfirmDeleteRegionPolicyModal } from './confirm_delete_region_policy_modal';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <EuiThemeProvider>
+    <I18nProvider>{children}</I18nProvider>
+  </EuiThemeProvider>
+);
+
+describe('ConfirmDeleteRegionPolicyModal', () => {
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderModal = (overrides: { isDeleting?: boolean } = {}) =>
+    render(
+      <Wrapper>
+        <ConfirmDeleteRegionPolicyModal
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          isDeleting={overrides.isDeleting ?? false}
+        />
+      </Wrapper>
+    );
+
+  it('renders the title, description, checkbox, and buttons', () => {
+    renderModal();
+
+    expect(screen.getByTestId('confirmDeleteRegionPolicyTitle')).toHaveTextContent(
+      'Reset region preferences to default?'
+    );
+    expect(screen.getByTestId('confirmDeleteRegionPolicyDescription')).toHaveTextContent(
+      /Removing your custom region preferences allows inference in all locations/
+    );
+    expect(screen.getByTestId('confirmDeleteRegionPolicyReconfigureNote')).toHaveTextContent(
+      /You'll need to set new region preferences to restrict inference again/
+    );
+    expect(screen.getByTestId('confirmDeleteRegionPolicyAcknowledge')).toBeInTheDocument();
+    expect(screen.getByTestId('confirmModalConfirmButton')).toBeInTheDocument();
+    expect(screen.getByTestId('confirmModalCancelButton')).toBeInTheDocument();
+  });
+
+  it('disables the confirm button until the acknowledge checkbox is checked', () => {
+    renderModal();
+
+    const confirmButton = screen.getByTestId('confirmModalConfirmButton');
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('confirmDeleteRegionPolicyAcknowledge'));
+
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it('does not call onConfirm when confirm is clicked while disabled', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('confirmModalConfirmButton'));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirm when confirm is clicked after acknowledging', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('confirmDeleteRegionPolicyAcknowledge'));
+    fireEvent.click(screen.getByTestId('confirmModalConfirmButton'));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel is clicked', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('confirmModalCancelButton'));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the confirm button disabled while deletion is in flight', () => {
+    renderModal({ isDeleting: true });
+
+    const confirmButton = screen.getByTestId('confirmModalConfirmButton');
+    fireEvent.click(screen.getByTestId('confirmDeleteRegionPolicyAcknowledge'));
+
+    expect(confirmButton).toBeDisabled();
+  });
+});

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/confirm_delete_region_policy_modal.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/confirm_delete_region_policy_modal.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiCheckbox,
+  EuiConfirmModal,
+  EuiSpacer,
+  EuiText,
+  useEuiTheme,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export interface ConfirmDeleteRegionPolicyModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDeleting: boolean;
+}
+
+export const ConfirmDeleteRegionPolicyModal: React.FC<ConfirmDeleteRegionPolicyModalProps> = ({
+  onConfirm,
+  onCancel,
+  isDeleting,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const modalTitleId = useGeneratedHtmlId();
+  const acknowledgeId = useGeneratedHtmlId({ prefix: 'confirmDeleteRegionPolicyAcknowledge' });
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  return (
+    <EuiConfirmModal
+      maxWidth={euiTheme.base * 30}
+      aria-labelledby={modalTitleId}
+      titleProps={{ id: modalTitleId, 'data-test-subj': 'confirmDeleteRegionPolicyTitle' }}
+      title={i18n.translate('xpack.searchInferenceEndpoints.manageRegions.deleteConfirm.title', {
+        defaultMessage: 'Reset region preferences to default?',
+      })}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      cancelButtonText={i18n.translate(
+        'xpack.searchInferenceEndpoints.manageRegions.deleteConfirm.cancelButtonLabel',
+        { defaultMessage: 'Cancel' }
+      )}
+      confirmButtonText={i18n.translate(
+        'xpack.searchInferenceEndpoints.manageRegions.deleteConfirm.confirmButtonLabel',
+        { defaultMessage: 'Reset to default' }
+      )}
+      buttonColor="danger"
+      defaultFocusedButton="cancel"
+      isLoading={isDeleting}
+      confirmButtonDisabled={!acknowledged || isDeleting}
+      data-test-subj="confirmDeleteRegionPolicyModal"
+    >
+      <EuiText size="s">
+        <p data-test-subj="confirmDeleteRegionPolicyDescription">
+          {i18n.translate(
+            'xpack.searchInferenceEndpoints.manageRegions.deleteConfirm.description',
+            {
+              defaultMessage:
+                'Removing your custom region preferences allows inference in all locations. Any new regions Elastic Inference Service adds will be allowed automatically.',
+            }
+          )}
+        </p>
+        <p data-test-subj="confirmDeleteRegionPolicyReconfigureNote">
+          <strong>
+            {i18n.translate(
+              'xpack.searchInferenceEndpoints.manageRegions.deleteConfirm.reconfigureNote',
+              {
+                defaultMessage:
+                  "You'll need to set new region preferences to restrict inference again.",
+              }
+            )}
+          </strong>
+        </p>
+      </EuiText>
+
+      <EuiSpacer size="m" />
+
+      <EuiCheckbox
+        id={acknowledgeId}
+        checked={acknowledged}
+        onChange={(e) => setAcknowledged(e.target.checked)}
+        disabled={isDeleting}
+        data-test-subj="confirmDeleteRegionPolicyAcknowledge"
+        label={i18n.translate(
+          'xpack.searchInferenceEndpoints.manageRegions.deleteConfirm.acknowledgeLabel',
+          { defaultMessage: 'I understand this resets my region preferences' }
+        )}
+      />
+    </EuiConfirmModal>
+  );
+};

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/header.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/header.tsx
@@ -98,7 +98,7 @@ export const ElasticInferenceServiceModelsHeader = ({
               >
                 {i18n.translate(
                   'xpack.searchInferenceEndpoints.eisModelsPage.manageRegionsButton',
-                  { defaultMessage: 'Manage regions' }
+                  { defaultMessage: 'Region preferences' }
                 )}
               </EuiButtonEmpty>,
             ]

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.test.tsx
@@ -6,17 +6,19 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { EuiThemeProvider } from '@elastic/eui';
 import { I18nProvider } from '@kbn/i18n-react';
 import { ManageRegionsModal } from './manage_regions_modal';
 import { useRegionPolicy } from '../../hooks/use_region_policy';
 import { useSaveRegionPolicy } from '../../hooks/use_save_region_policy';
+import { useDeleteRegionPolicy } from '../../hooks/use_delete_region_policy';
 import { useEisModels } from '../../hooks/use_eis_models';
 import * as eisUtils from '../../utils/eis_utils';
 
 jest.mock('../../hooks/use_region_policy');
 jest.mock('../../hooks/use_save_region_policy');
+jest.mock('../../hooks/use_delete_region_policy');
 jest.mock('../../hooks/use_eis_models');
 jest.mock('../../utils/eis_utils', () => ({
   ...jest.requireActual('../../utils/eis_utils'),
@@ -28,9 +30,12 @@ const mockGetAvailableRegions = jest.mocked(eisUtils.getAvailableRegions);
 const mockGetAvailableGeos = jest.mocked(eisUtils.getAvailableGeos);
 const mockUseRegionPolicy = jest.mocked(useRegionPolicy);
 const mockUseSaveRegionPolicy = jest.mocked(useSaveRegionPolicy);
+const mockUseDeleteRegionPolicy = jest.mocked(useDeleteRegionPolicy);
 const mockUseEisModels = jest.mocked(useEisModels);
 
 const mockSaveMutate = jest.fn();
+const mockDeleteMutate = jest.fn();
+let capturedDeleteOnSuccess: (() => void) | undefined;
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <EuiThemeProvider>
@@ -54,6 +59,10 @@ const endpointWithRegions = {
   },
 };
 
+const toggleCustomPolicyOn = () => {
+  fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
+};
+
 describe('ManageRegionsModal', () => {
   const onClose = jest.fn();
 
@@ -68,6 +77,15 @@ describe('ManageRegionsModal', () => {
       mutate: mockSaveMutate,
       isLoading: false,
     } as unknown as ReturnType<typeof useSaveRegionPolicy>);
+
+    capturedDeleteOnSuccess = undefined;
+    mockUseDeleteRegionPolicy.mockImplementation((onSuccess) => {
+      capturedDeleteOnSuccess = onSuccess;
+      return {
+        mutate: mockDeleteMutate,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useDeleteRegionPolicy>;
+    });
 
     // Default hook returns — individual tests override as needed
     mockUseRegionPolicy.mockReturnValue({
@@ -98,6 +116,7 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      expect(screen.getByTestId('manageRegionsCustomPolicyToggle')).toBeDisabled();
       expect(screen.getByTestId('manageGeosLoading')).toBeInTheDocument();
     });
 
@@ -136,12 +155,14 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
       // Default tab is Geo — switch to Regions to see the no-regions warning.
       fireEvent.click(screen.getByTestId('manageRegionsRegionsTab'));
 
       await waitFor(() => {
-        expect(screen.getByTestId('manageRegionsNoRegions')).toBeInTheDocument();
-        expect(screen.getByText('No regions available')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsNoRegions')).toHaveTextContent(
+          'No regions available'
+        );
       });
     });
 
@@ -160,6 +181,7 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
       fireEvent.click(screen.getByTestId('manageRegionsGeoTab'));
 
       await waitFor(() => {
@@ -168,13 +190,75 @@ describe('ManageRegionsModal', () => {
     });
   });
 
-  describe('tabs', () => {
-    it('renders Geo and Regions tabs', () => {
+  describe('custom-policy toggle', () => {
+    it('hides the tabs when the toggle is OFF (no existing policy)', () => {
       render(
         <Wrapper>
           <ManageRegionsModal onClose={onClose} />
         </Wrapper>
       );
+
+      expect(screen.queryByTestId('manageRegionsGeoTab')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('manageRegionsRegionsTab')).not.toBeInTheDocument();
+    });
+
+    it('reveals the tabs when the toggle is clicked ON', () => {
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      toggleCustomPolicyOn();
+
+      expect(screen.getByTestId('manageRegionsGeoTab')).toBeInTheDocument();
+      expect(screen.getByTestId('manageRegionsRegionsTab')).toBeInTheDocument();
+    });
+
+    it('shows the tabs by default when an existing policy is loaded', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      expect(screen.getByTestId('manageRegionsGeoTab')).toBeInTheDocument();
+      expect(screen.getByTestId('manageRegionsRegionsTab')).toBeInTheDocument();
+    });
+
+    it('hides the tabs when the toggle is turned OFF on an existing policy', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
+
+      expect(screen.queryByTestId('manageRegionsGeoTab')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('manageRegionsRegionsTab')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('tabs', () => {
+    it('renders Geo and Regions tabs when the toggle is ON', () => {
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      toggleCustomPolicyOn();
 
       expect(screen.getByTestId('manageRegionsGeoTab')).toBeInTheDocument();
       expect(screen.getByTestId('manageRegionsRegionsTab')).toBeInTheDocument();
@@ -186,6 +270,8 @@ describe('ManageRegionsModal', () => {
           <ManageRegionsModal onClose={onClose} />
         </Wrapper>
       );
+
+      toggleCustomPolicyOn();
 
       await waitFor(() => {
         expect(screen.getByTestId('manageRegionsGeoTab')).toHaveAttribute('aria-selected', 'true');
@@ -199,6 +285,7 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
       fireEvent.click(screen.getByTestId('manageRegionsGeoTab'));
 
       await waitFor(() => {
@@ -237,6 +324,7 @@ describe('ManageRegionsModal', () => {
           <ManageRegionsModal onClose={onClose} />
         </Wrapper>
       );
+      toggleCustomPolicyOn();
       fireEvent.click(screen.getByTestId('manageRegionsGeoTab'));
     };
 
@@ -249,12 +337,12 @@ describe('ManageRegionsModal', () => {
       });
     });
 
-    it('shows all geo zones checked by default when there is no policy', async () => {
+    it('shows no geo zones checked by default when there is no policy', async () => {
       renderWithGeoTab();
 
       await waitFor(() => {
-        expect(screen.getByTestId('geoZoneCheckbox-eu')).toBeChecked();
-        expect(screen.getByTestId('geoZoneCheckbox-us')).toBeChecked();
+        expect(screen.getByTestId('geoZoneCheckbox-eu')).not.toBeChecked();
+        expect(screen.getByTestId('geoZoneCheckbox-us')).not.toBeChecked();
       });
     });
 
@@ -284,20 +372,22 @@ describe('ManageRegionsModal', () => {
         expect(screen.getByTestId('geoZoneCheckbox-eu')).toBeInTheDocument();
       });
 
-      // No policy → starts checked (all routes allowed). Click to uncheck it.
-      expect(screen.getByTestId('geoZoneCheckbox-eu')).toBeChecked();
+      // No policy → starts unchecked. Click to check it.
+      expect(screen.getByTestId('geoZoneCheckbox-eu')).not.toBeChecked();
       fireEvent.click(screen.getByTestId('geoZoneCheckbox-eu'));
 
       await waitFor(() => {
-        expect(screen.getByTestId('geoZoneCheckbox-eu')).not.toBeChecked();
+        expect(screen.getByTestId('geoZoneCheckbox-eu')).toBeChecked();
       });
     });
 
-    it('shows "N of N selected" on the geo toolbar when no policy exists', async () => {
+    it('shows "0 of N selected" on the geo toolbar when no policy exists', async () => {
       renderWithGeoTab();
 
       await waitFor(() => {
-        expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '0 of 2 selected'
+        );
       });
     });
   });
@@ -318,15 +408,14 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
       // Default tab is Geo — switch to Regions to see zone headers.
       fireEvent.click(screen.getByTestId('manageRegionsRegionsTab'));
 
       // us-east-1 → North America zone, europe-west1 → Europe zone
       await waitFor(() => {
-        expect(screen.getByTestId('manageRegionsZone-us')).toBeInTheDocument();
-        expect(screen.getByTestId('manageRegionsZone-eu')).toBeInTheDocument();
-        expect(screen.getByText('North America')).toBeInTheDocument();
-        expect(screen.getByText('Europe')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsZone-us')).toHaveTextContent('North America');
+        expect(screen.getByTestId('manageRegionsZone-eu')).toHaveTextContent('Europe');
       });
     });
 
@@ -345,6 +434,7 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
       fireEvent.click(screen.getByTestId('manageRegionsRegionsTab'));
       await waitFor(() => {
         expect(screen.getByTestId('manageRegionsZoneCountToggle-us')).toBeInTheDocument();
@@ -358,7 +448,7 @@ describe('ManageRegionsModal', () => {
       });
     });
 
-    it('shows "N of N selected" when there is no existing policy', async () => {
+    it('shows "0 of N selected" when there is no existing policy', async () => {
       mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
         typeof useRegionPolicy
       >);
@@ -373,12 +463,15 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
       // Default tab is Geo — switch to Regions to verify the regions toolbar count.
       fireEvent.click(screen.getByTestId('manageRegionsRegionsTab'));
 
-      // No policy → all regions pre-selected (no restrictions)
+      // No policy → nothing pre-selected
       await waitFor(() => {
-        expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '0 of 2 selected'
+        );
       });
     });
 
@@ -407,7 +500,9 @@ describe('ManageRegionsModal', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '2 of 2 selected'
+        );
       });
     });
 
@@ -440,7 +535,7 @@ describe('ManageRegionsModal', () => {
       });
     });
 
-    it('defaults to all regions checked when there is no existing policy', async () => {
+    it('defaults to no regions checked when there is no existing policy', async () => {
       mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
         typeof useRegionPolicy
       >);
@@ -455,6 +550,7 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
       // Default tab is Geo — switch to Regions to inspect individual checkboxes.
       fireEvent.click(screen.getByTestId('manageRegionsRegionsTab'));
       await waitFor(() => {
@@ -464,8 +560,8 @@ describe('ManageRegionsModal', () => {
       fireEvent.click(screen.getByTestId('manageRegionsZoneToggle-eu'));
 
       await waitFor(() => {
-        expect(screen.getByTestId('manageRegionsCheckbox-aws::us-east-1')).toBeChecked();
-        expect(screen.getByTestId('manageRegionsCheckbox-gcp::europe-west1')).toBeChecked();
+        expect(screen.getByTestId('manageRegionsCheckbox-aws::us-east-1')).not.toBeChecked();
+        expect(screen.getByTestId('manageRegionsCheckbox-gcp::europe-west1')).not.toBeChecked();
       });
     });
 
@@ -503,8 +599,8 @@ describe('ManageRegionsModal', () => {
   });
 
   describe('Select all button', () => {
-    it('shows "Deselect all" when all are selected, and deselects all on click', async () => {
-      // No policy → all regions pre-selected.
+    it('shows "Select all" when none are selected, and selects all on click', async () => {
+      // No policy → nothing pre-selected.
       mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
         typeof useRegionPolicy
       >);
@@ -519,18 +615,24 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
+
       await waitFor(() => {
-        expect(screen.getByTestId('manageRegionsSelectAllButton')).toHaveTextContent(
-          'Deselect all'
+        expect(screen.getByTestId('manageRegionsSelectAllButton')).toHaveTextContent('Select all');
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '0 of 2 selected'
         );
-        expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
       });
 
       fireEvent.click(screen.getByTestId('manageRegionsSelectAllButton'));
 
       await waitFor(() => {
-        expect(screen.getByText('0 of 2 selected')).toBeInTheDocument();
-        expect(screen.getByTestId('manageRegionsSelectAllButton')).toHaveTextContent('Select all');
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '2 of 2 selected'
+        );
+        expect(screen.getByTestId('manageRegionsSelectAllButton')).toHaveTextContent(
+          'Deselect all'
+        );
       });
     });
 
@@ -568,7 +670,9 @@ describe('ManageRegionsModal', () => {
       fireEvent.click(screen.getByTestId('manageRegionsSelectAllButton'));
 
       await waitFor(() => {
-        expect(screen.getByText('0 of 2 selected')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '0 of 2 selected'
+        );
         expect(screen.getByTestId('manageRegionsSelectAllButton')).toHaveTextContent('Select all');
       });
     });
@@ -601,7 +705,9 @@ describe('ManageRegionsModal', () => {
 
       // Existing policy seeded → isDirty = false → Save disabled.
       await waitFor(() => {
-        expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '2 of 2 selected'
+        );
       });
 
       expect(screen.getByTestId('manageRegionsSaveButton')).toBeDisabled();
@@ -622,15 +728,16 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
-      // Default tab is Geo — switch to Regions, expand US zone, uncheck a region to make dirty.
+      toggleCustomPolicyOn();
+      // Default tab is Geo — switch to Regions, expand US zone, check a region so Save is enabled.
       fireEvent.click(screen.getByTestId('manageRegionsRegionsTab'));
       await waitFor(() => {
         expect(screen.getByTestId('manageRegionsZoneToggle-us')).toBeInTheDocument();
       });
       fireEvent.click(screen.getByTestId('manageRegionsZoneToggle-us'));
       await waitFor(() => {
-        // No policy → all selected; uncheck us-east-1 to make isDirty = true.
-        expect(screen.getByTestId('manageRegionsCheckbox-aws::us-east-1')).toBeChecked();
+        // No policy → nothing selected; check us-east-1 so a selection exists.
+        expect(screen.getByTestId('manageRegionsCheckbox-aws::us-east-1')).not.toBeChecked();
         fireEvent.click(screen.getByTestId('manageRegionsCheckbox-aws::us-east-1'));
       });
 
@@ -722,13 +829,14 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
+      toggleCustomPolicyOn();
       // Default tab is Geo — switch to Regions to make a change there.
       fireEvent.click(screen.getByTestId('manageRegionsRegionsTab'));
       await waitFor(() => {
         expect(screen.getByTestId('manageRegionsCheckbox-aws::us-east-1')).toBeInTheDocument();
       });
 
-      // Deselect a region to make the form dirty, then open confirmation.
+      // Select a region to make the form dirty, then open confirmation.
       fireEvent.click(screen.getByTestId('manageRegionsCheckbox-aws::us-east-1'));
       await waitFor(() => {
         expect(screen.getByTestId('manageRegionsSaveButton')).not.toBeDisabled();
@@ -768,7 +876,8 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
-      // Default tab is Geo — uncheck a geo (all pre-selected) to make it dirty.
+      toggleCustomPolicyOn();
+      // Default tab is Geo — check a geo (none pre-selected) to make it dirty.
       await waitFor(() => {
         expect(screen.getByTestId('geoZoneCheckbox-eu')).toBeInTheDocument();
       });
@@ -844,6 +953,153 @@ describe('ManageRegionsModal', () => {
     });
   });
 
+  describe('delete policy flow', () => {
+    it('opens the delete confirmation when the toggle is turned OFF and Save is clicked', async () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      // Existing policy → toggle ON by default. Turn it OFF.
+      fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('manageRegionsSaveButton')).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByTestId('manageRegionsSaveButton'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirmDeleteRegionPolicyModal')).toBeInTheDocument();
+      });
+
+      expect(mockDeleteMutate).not.toHaveBeenCalled();
+    });
+
+    it('does not delete the policy until the acknowledge checkbox is ticked', async () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
+      fireEvent.click(screen.getByTestId('manageRegionsSaveButton'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirmDeleteRegionPolicyModal')).toBeInTheDocument();
+      });
+
+      // Confirm button is disabled until acknowledgement.
+      const confirmButton = screen.getByTestId('confirmModalConfirmButton');
+      expect(confirmButton).toBeDisabled();
+
+      fireEvent.click(screen.getByTestId('confirmDeleteRegionPolicyAcknowledge'));
+
+      expect(confirmButton).toBeEnabled();
+      fireEvent.click(confirmButton);
+
+      expect(mockDeleteMutate).toHaveBeenCalledWith();
+    });
+
+    it('cancels the delete confirmation without deleting and leaves the parent modal open', async () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
+      fireEvent.click(screen.getByTestId('manageRegionsSaveButton'));
+
+      const deleteConfirm = await screen.findByTestId('confirmDeleteRegionPolicyModal');
+
+      // Scope the cancel lookup to the delete confirmation, otherwise the
+      // parent modal's own Cancel button would also match.
+      fireEvent.click(within(deleteConfirm).getByTestId('confirmModalCancelButton'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirmDeleteRegionPolicyModal')).not.toBeInTheDocument();
+      });
+
+      expect(mockDeleteMutate).not.toHaveBeenCalled();
+      expect(screen.getByTestId('manageRegionsModal')).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('closes both modals when delete succeeds', async () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+      mockDeleteMutate.mockImplementation(() => capturedDeleteOnSuccess?.());
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
+      fireEvent.click(screen.getByTestId('manageRegionsSaveButton'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirmDeleteRegionPolicyModal')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('confirmDeleteRegionPolicyAcknowledge'));
+      fireEvent.click(screen.getByTestId('confirmModalConfirmButton'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the delete confirmation and parent modal open when delete fails', async () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+      // Simulate a failed mutation: no onSuccess callback is invoked.
+      mockDeleteMutate.mockImplementation(() => {});
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
+      fireEvent.click(screen.getByTestId('manageRegionsSaveButton'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirmDeleteRegionPolicyModal')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('confirmDeleteRegionPolicyAcknowledge'));
+      fireEvent.click(screen.getByTestId('confirmModalConfirmButton'));
+
+      expect(mockDeleteMutate).toHaveBeenCalled();
+      expect(screen.getByTestId('confirmDeleteRegionPolicyModal')).toBeInTheDocument();
+      expect(screen.getByTestId('manageRegionsModal')).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Cancel button', () => {
     it('calls onClose when cancel is clicked', () => {
       mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
@@ -865,7 +1121,7 @@ describe('ManageRegionsModal', () => {
   });
 
   describe('Save button disabled state', () => {
-    it('is enabled when no policy exists (first-time setup)', async () => {
+    it('is disabled when no policy exists and the toggle is OFF (first-time default)', async () => {
       mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
         typeof useRegionPolicy
       >);
@@ -880,9 +1136,59 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
-      // No policy → isNewPolicy=true → Save enabled as long as at least 1 selected.
+      // No policy → toggle OFF → nothing to save yet.
       await waitFor(() => {
-        expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsSaveButton')).toBeDisabled();
+      });
+    });
+
+    it('is disabled when the toggle is switched ON with no selections (first-time setup)', async () => {
+      mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
+        typeof useRegionPolicy
+      >);
+      mockUseEisModels.mockReturnValue({
+        data: [endpointWithRegions],
+        isLoading: false,
+      } as unknown as ReturnType<typeof useEisModels>);
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      toggleCustomPolicyOn();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '0 of 2 selected'
+        );
+        expect(screen.getByTestId('manageRegionsSaveButton')).toBeDisabled();
+      });
+    });
+
+    it('is enabled once a selection is made after switching the toggle ON (first-time setup)', async () => {
+      mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
+        typeof useRegionPolicy
+      >);
+      mockUseEisModels.mockReturnValue({
+        data: [endpointWithRegions],
+        isLoading: false,
+      } as unknown as ReturnType<typeof useEisModels>);
+
+      render(
+        <Wrapper>
+          <ManageRegionsModal onClose={onClose} />
+        </Wrapper>
+      );
+
+      toggleCustomPolicyOn();
+      fireEvent.click(screen.getByTestId('manageRegionsSelectAllButton'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '2 of 2 selected'
+        );
         expect(screen.getByTestId('manageRegionsSaveButton')).not.toBeDisabled();
       });
     });
@@ -924,24 +1230,32 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
-      // No policy → Save enabled (first-time setup, all geos selected).
-      await waitFor(() => {
-        expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
-        expect(screen.getByTestId('manageRegionsSaveButton')).not.toBeDisabled();
-      });
+      toggleCustomPolicyOn();
 
-      // Deselect all → totalGeosSelected=0 → Save disabled.
-      fireEvent.click(screen.getByTestId('manageRegionsSelectAllButton'));
+      // No policy + toggle ON → nothing selected yet → Save disabled.
       await waitFor(() => {
-        expect(screen.getByText('0 of 2 selected')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '0 of 2 selected'
+        );
         expect(screen.getByTestId('manageRegionsSaveButton')).toBeDisabled();
       });
 
-      // Re-select all → Save enabled again.
+      // Select all → Save enabled.
       fireEvent.click(screen.getByTestId('manageRegionsSelectAllButton'));
       await waitFor(() => {
-        expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '2 of 2 selected'
+        );
         expect(screen.getByTestId('manageRegionsSaveButton')).not.toBeDisabled();
+      });
+
+      // Deselect all again → Save disabled.
+      fireEvent.click(screen.getByTestId('manageRegionsSelectAllButton'));
+      await waitFor(() => {
+        expect(screen.getByTestId('manageRegionsSelectionCount')).toHaveTextContent(
+          '0 of 2 selected'
+        );
+        expect(screen.getByTestId('manageRegionsSaveButton')).toBeDisabled();
       });
     });
   });
@@ -965,8 +1279,9 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
-      expect(screen.getByTestId('manageRegionsErrorCallout')).toBeInTheDocument();
-      expect(screen.getByText('Failed to load region data')).toBeInTheDocument();
+      expect(screen.getByTestId('manageRegionsErrorCallout')).toHaveTextContent(
+        'Failed to load region data'
+      );
     });
 
     it('renders a danger callout when the EIS models fetch fails', () => {
@@ -992,7 +1307,7 @@ describe('ManageRegionsModal', () => {
   });
 
   describe('info callout', () => {
-    it('renders the info callout by default', () => {
+    it('is hidden until the custom policy toggle is switched on', () => {
       mockUseRegionPolicy.mockReturnValue({ data: null, isLoading: false } as unknown as ReturnType<
         typeof useRegionPolicy
       >);
@@ -1005,6 +1320,10 @@ describe('ManageRegionsModal', () => {
           <ManageRegionsModal onClose={onClose} />
         </Wrapper>
       );
+
+      expect(screen.queryByTestId('manageRegionsCallout')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
 
       expect(screen.getByTestId('manageRegionsCallout')).toBeInTheDocument();
     });
@@ -1023,14 +1342,9 @@ describe('ManageRegionsModal', () => {
         </Wrapper>
       );
 
-      const dismissButton = screen
-        .getByTestId('manageRegionsCallout')
-        .querySelector('[data-test-subj="euiDismissCalloutButton"]');
-      expect(dismissButton).not.toBeNull();
-      if (!dismissButton) {
-        return;
-      }
-      fireEvent.click(dismissButton);
+      fireEvent.click(screen.getByTestId('manageRegionsCustomPolicyToggle'));
+
+      fireEvent.click(screen.getByTestId('manageRegionsCalloutDismiss'));
 
       expect(screen.queryByTestId('manageRegionsCallout')).not.toBeInTheDocument();
     });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/manage_regions_modal.tsx
@@ -17,6 +17,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiSpacer,
+  EuiSwitch,
   EuiTabbedContent,
   EuiText,
   useGeneratedHtmlId,
@@ -27,6 +28,7 @@ import type { UseEuiTheme } from '@elastic/eui';
 import { regionKey, isPolicyMode } from '../../utils/eis_utils';
 import { useManageRegionsState } from './use_manage_regions_state';
 import { ConfirmRegionChangeModal } from './confirm_region_change_modal';
+import { ConfirmDeleteRegionPolicyModal } from './confirm_delete_region_policy_modal';
 import { GeoTabContent } from './geo_tab_content';
 import { RegionsTabContent } from './regions_tab_content';
 
@@ -40,20 +42,27 @@ const modalStyles = ({ euiTheme }: UseEuiTheme) => css`
 
 export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose }) => {
   const modalTitleId = useGeneratedHtmlId();
+  const customPolicyToggleId = useGeneratedHtmlId({ prefix: 'manageRegionsCustomPolicyToggle' });
   const { common, regionTab, geoTab } = useManageRegionsState(onClose);
   const {
     activeTab,
     isLoading,
     isError,
     isSaving,
+    isDeleting,
     isSaveDisabled,
     isCallOutDismissed,
     showConfirmation,
+    showDeleteConfirmation,
+    useCustomPolicy,
     setActiveTab,
+    setUseCustomPolicy,
     handleDismissCallOut,
     handleRequestSave,
     handleConfirmSave,
     handleCancelConfirmation,
+    handleConfirmDelete,
+    handleCancelDeleteConfirmation,
   } = common;
 
   const filteredRegions = useMemo(
@@ -93,18 +102,25 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
     [tabs, activeTab]
   );
 
+  const isAnyConfirmationOpen = showConfirmation || showDeleteConfirmation;
+  const handleAnyCancelConfirmation = showDeleteConfirmation
+    ? handleCancelDeleteConfirmation
+    : handleCancelConfirmation;
+  const showTabContent = useCustomPolicy || isLoading;
+  const showCallOut = useCustomPolicy && !isCallOutDismissed;
+
   return (
     <>
       <EuiModal
         css={modalStyles}
-        onClose={showConfirmation ? handleCancelConfirmation : onClose}
+        onClose={isAnyConfirmationOpen ? handleAnyCancelConfirmation : onClose}
         aria-labelledby={modalTitleId}
         data-test-subj="manageRegionsModal"
       >
         <EuiModalHeader>
           <EuiModalHeaderTitle id={modalTitleId}>
             {i18n.translate('xpack.searchInferenceEndpoints.manageRegions.title', {
-              defaultMessage: 'Manage region preferences',
+              defaultMessage: 'Region preferences',
             })}
           </EuiModalHeaderTitle>
         </EuiModalHeader>
@@ -135,22 +151,36 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
             <p>
               <FormattedMessage
                 id="xpack.searchInferenceEndpoints.manageRegions.description"
-                defaultMessage="You can restrict inference calls to specific regions."
+                defaultMessage="Choose which locations can receive inference traffic: by geography or by region."
               />
             </p>
           </EuiText>
 
           <EuiSpacer size="m" />
 
-          {!isCallOutDismissed && (
+          <EuiSwitch
+            id={customPolicyToggleId}
+            checked={useCustomPolicy}
+            onChange={(e) => setUseCustomPolicy(e.target.checked)}
+            disabled={isLoading || isSaving || isDeleting}
+            label={i18n.translate(
+              'xpack.searchInferenceEndpoints.manageRegions.customPolicyToggleLabel',
+              { defaultMessage: 'Restrict inference to specific locations' }
+            )}
+            data-test-subj="manageRegionsCustomPolicyToggle"
+          />
+
+          {showCallOut && <EuiSpacer size="m" />}
+          {showCallOut && (
             <EuiCallOut
               title={i18n.translate('xpack.searchInferenceEndpoints.manageRegions.callout.title', {
                 defaultMessage: "Some models aren't available in every region.",
               })}
-              color="primary"
-              iconType="info"
+              color="warning"
+              iconType="warning"
               announceOnMount={false}
               onDismiss={handleDismissCallOut}
+              dismissButtonProps={{ 'data-test-subj': 'manageRegionsCalloutDismiss' }}
               data-test-subj="manageRegionsCallout"
             >
               <p>
@@ -161,19 +191,21 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
               </p>
             </EuiCallOut>
           )}
-          {!isCallOutDismissed && <EuiSpacer size="m" />}
 
-          <EuiTabbedContent
-            tabs={tabs}
-            selectedTab={selectedTab}
-            onTabClick={(tab) => isPolicyMode(tab.id) && setActiveTab(tab.id)}
-          />
+          {showTabContent && <EuiSpacer size="m" />}
+          {showTabContent && (
+            <EuiTabbedContent
+              tabs={tabs}
+              selectedTab={selectedTab}
+              onTabClick={(tab) => isPolicyMode(tab.id) && setActiveTab(tab.id)}
+            />
+          )}
         </EuiModalBody>
 
         <EuiModalFooter>
           <EuiButtonEmpty
-            onClick={showConfirmation ? handleCancelConfirmation : onClose}
-            isDisabled={isSaving}
+            onClick={isAnyConfirmationOpen ? handleAnyCancelConfirmation : onClose}
+            isDisabled={isSaving || isDeleting}
             data-test-subj="manageRegionsCancelButton"
           >
             {i18n.translate('xpack.searchInferenceEndpoints.manageRegions.cancelButtonLabel', {
@@ -185,7 +217,7 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
             fill
             onClick={handleRequestSave}
             isDisabled={isSaveDisabled}
-            isLoading={isSaving}
+            isLoading={isSaving || isDeleting}
             data-test-subj="manageRegionsSaveButton"
           >
             {i18n.translate('xpack.searchInferenceEndpoints.manageRegions.saveButtonLabel', {
@@ -203,6 +235,14 @@ export const ManageRegionsModal: React.FC<ManageRegionsModalProps> = ({ onClose 
           onConfirm={handleConfirmSave}
           onCancel={handleCancelConfirmation}
           isSaving={isSaving}
+        />
+      )}
+
+      {showDeleteConfirmation && (
+        <ConfirmDeleteRegionPolicyModal
+          onConfirm={handleConfirmDelete}
+          onCancel={handleCancelDeleteConfirmation}
+          isDeleting={isDeleting}
         />
       )}
     </>

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/region_selection_toolbar.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/region_selection_toolbar.tsx
@@ -28,9 +28,9 @@ export const RegionSelectionToolbar: React.FC<RegionSelectionToolbarProps> = ({
 }) => (
   <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="s" responsive={false}>
     <EuiFlexItem grow={false}>
-      <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiText size="s">
+          <EuiText size="xs" data-test-subj="manageRegionsSelectionCount">
             <strong>
               {i18n.translate('xpack.searchInferenceEndpoints.manageRegions.selectionCount', {
                 defaultMessage: '{selected} of {total} selected',
@@ -42,7 +42,6 @@ export const RegionSelectionToolbar: React.FC<RegionSelectionToolbarProps> = ({
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty
             size="xs"
-            flush="left"
             onClick={onSelectAll}
             data-test-subj="manageRegionsSelectAllButton"
           >

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/use_manage_regions_state.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/use_manage_regions_state.test.ts
@@ -9,11 +9,13 @@ import { act, renderHook } from '@testing-library/react';
 import { useManageRegionsState } from './use_manage_regions_state';
 import { useRegionPolicy } from '../../hooks/use_region_policy';
 import { useSaveRegionPolicy } from '../../hooks/use_save_region_policy';
+import { useDeleteRegionPolicy } from '../../hooks/use_delete_region_policy';
 import { useEisModels } from '../../hooks/use_eis_models';
 import * as eisUtils from '../../utils/eis_utils';
 
 jest.mock('../../hooks/use_region_policy');
 jest.mock('../../hooks/use_save_region_policy');
+jest.mock('../../hooks/use_delete_region_policy');
 jest.mock('../../hooks/use_eis_models');
 jest.mock('../../utils/eis_utils', () => ({
   ...jest.requireActual('../../utils/eis_utils'),
@@ -23,11 +25,13 @@ jest.mock('../../utils/eis_utils', () => ({
 
 const mockUseRegionPolicy = jest.mocked(useRegionPolicy);
 const mockUseSaveRegionPolicy = jest.mocked(useSaveRegionPolicy);
+const mockUseDeleteRegionPolicy = jest.mocked(useDeleteRegionPolicy);
 const mockUseEisModels = jest.mocked(useEisModels);
 const mockGetAvailableRegions = jest.mocked(eisUtils.getAvailableRegions);
 const mockGetAvailableGeos = jest.mocked(eisUtils.getAvailableGeos);
 
 const mockSaveMutate = jest.fn();
+const mockDeleteMutate = jest.fn();
 
 const usRegion = { csp: 'aws', region: 'us-east-1', geo: 'us' };
 const euRegion = { csp: 'gcp', region: 'europe-west1', geo: 'eu' };
@@ -44,6 +48,10 @@ describe('useManageRegionsState', () => {
       mutate: mockSaveMutate,
       isLoading: false,
     } as unknown as ReturnType<typeof useSaveRegionPolicy>);
+    mockUseDeleteRegionPolicy.mockReturnValue({
+      mutate: mockDeleteMutate,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDeleteRegionPolicy>);
     mockUseRegionPolicy.mockReturnValue({
       data: null,
       isLoading: false,
@@ -60,7 +68,7 @@ describe('useManageRegionsState', () => {
   // Initial checkbox seeding
   // ---------------------------------------------------------------------------
   describe('initial checkbox seeding', () => {
-    it('selects all regions when there is no existing policy', () => {
+    it('leaves regions unselected when there is no existing policy', () => {
       mockUseRegionPolicy.mockReturnValue({
         data: null,
         isLoading: false,
@@ -69,14 +77,12 @@ describe('useManageRegionsState', () => {
 
       const { result } = renderHook(() => useManageRegionsState(onClose));
 
-      expect(result.current.regionTab.checkedKeys).toEqual(
-        new Set(['aws::us-east-1', 'gcp::europe-west1'])
-      );
-      expect(result.current.regionTab.totalSelected).toBe(2);
-      expect(result.current.regionTab.allSelected).toBe(true);
+      expect(result.current.regionTab.checkedKeys.size).toBe(0);
+      expect(result.current.regionTab.totalSelected).toBe(0);
+      expect(result.current.regionTab.allSelected).toBe(false);
     });
 
-    it('selects all regions when the policy has an empty allowed_regions list', () => {
+    it('leaves regions unselected when the policy has an empty allowed_regions list', () => {
       mockUseRegionPolicy.mockReturnValue({
         data: { region_policy: { allowed_regions: [] }, created_at: '2024-01-01T00:00:00Z' },
         isLoading: false,
@@ -85,9 +91,7 @@ describe('useManageRegionsState', () => {
 
       const { result } = renderHook(() => useManageRegionsState(onClose));
 
-      expect(result.current.regionTab.checkedKeys).toEqual(
-        new Set(['aws::us-east-1', 'gcp::europe-west1'])
-      );
+      expect(result.current.regionTab.checkedKeys.size).toBe(0);
     });
 
     it('seeds only the policy regions when a partial policy exists', () => {
@@ -153,8 +157,8 @@ describe('useManageRegionsState', () => {
 
       const { result, rerender } = renderHook(() => useManageRegionsState(onClose));
 
-      // No policy → all regions seeded
-      expect(result.current.regionTab.checkedKeys.size).toBe(2);
+      // No policy → nothing seeded
+      expect(result.current.regionTab.checkedKeys.size).toBe(0);
 
       // Simulate a re-render with a different policy — syncedFromInitial is true, no re-seed
       mockUseRegionPolicy.mockReturnValue({
@@ -167,8 +171,8 @@ describe('useManageRegionsState', () => {
       } as unknown as ReturnType<typeof useRegionPolicy>);
       rerender();
 
-      // Still 2 — the seeding effect is guarded by syncedFromInitial
-      expect(result.current.regionTab.checkedKeys.size).toBe(2);
+      // Still 0 — the seeding effect is guarded by syncedFromInitial
+      expect(result.current.regionTab.checkedKeys.size).toBe(0);
     });
   });
 
@@ -206,7 +210,7 @@ describe('useManageRegionsState', () => {
       expect(result.current.geoTab.checkedGeos).toEqual(new Set(['eu']));
     });
 
-    it('seeds all geos and activates Geo tab when no policy exists (reflects "all routes allowed")', () => {
+    it('activates Geo tab with no pre-selected geos when no policy exists', () => {
       mockGetAvailableGeos.mockReturnValue(['eu', 'us']);
       mockUseRegionPolicy.mockReturnValue({
         data: null,
@@ -217,7 +221,7 @@ describe('useManageRegionsState', () => {
       const { result } = renderHook(() => useManageRegionsState(onClose));
 
       expect(result.current.common.activeTab).toBe('geo');
-      expect(result.current.geoTab.checkedGeos).toEqual(new Set(['eu', 'us']));
+      expect(result.current.geoTab.checkedGeos.size).toBe(0);
     });
 
     it('seeds geo tab with empty set when an explicit regions policy is active', () => {
@@ -249,6 +253,129 @@ describe('useManageRegionsState', () => {
       expect(result.current.geoTab.checkedGeos).toEqual(new Set(['eu']));
       // Regions tab must have nothing pre-selected — the geo policy owns the policy slot.
       expect(result.current.regionTab.checkedKeys).toEqual(new Set());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Custom-policy toggle seeding
+  // ---------------------------------------------------------------------------
+  describe('custom-policy toggle seeding', () => {
+    it('seeds useCustomPolicy=false when no policy exists', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+
+      expect(result.current.common.useCustomPolicy).toBe(false);
+      expect(result.current.common.hasExistingPolicy).toBe(false);
+      expect(result.current.common.pendingDelete).toBe(false);
+    });
+
+    it('seeds useCustomPolicy=true when an allowed_geos policy exists', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+
+      expect(result.current.common.useCustomPolicy).toBe(true);
+      expect(result.current.common.hasExistingPolicy).toBe(true);
+      expect(result.current.common.pendingDelete).toBe(false);
+    });
+
+    it('seeds useCustomPolicy=true when an allowed_regions policy exists', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: {
+          region_policy: { allowed_regions: [{ csp: 'aws', region: 'us-east-1' }] },
+          created_at: '2024-01-01T00:00:00Z',
+        },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+
+      expect(result.current.common.useCustomPolicy).toBe(true);
+      expect(result.current.common.hasExistingPolicy).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Toggle-driven dirty and pending-delete behaviour
+  // ---------------------------------------------------------------------------
+  describe('toggle-driven dirty tracking', () => {
+    it('turning toggle OFF with an existing policy makes the modal dirty and pending delete', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+      expect(result.current.common.isDirty).toBe(false);
+
+      act(() => result.current.common.setUseCustomPolicy(false));
+
+      expect(result.current.common.useCustomPolicy).toBe(false);
+      expect(result.current.common.pendingDelete).toBe(true);
+      expect(result.current.common.isDirty).toBe(true);
+      expect(result.current.common.isSaveDisabled).toBe(false);
+    });
+
+    it('turning toggle OFF with no existing policy keeps the modal clean and Save disabled', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+      // Toggle already OFF by default.
+      expect(result.current.common.useCustomPolicy).toBe(false);
+      expect(result.current.common.pendingDelete).toBe(false);
+      expect(result.current.common.isDirty).toBe(false);
+      expect(result.current.common.isSaveDisabled).toBe(true);
+    });
+
+    it('turning the toggle back ON before Save clears the pending delete', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+
+      act(() => result.current.common.setUseCustomPolicy(false));
+      expect(result.current.common.pendingDelete).toBe(true);
+
+      act(() => result.current.common.setUseCustomPolicy(true));
+      expect(result.current.common.pendingDelete).toBe(false);
+      // No selection changes → not dirty against the seeded policy.
+      expect(result.current.common.isDirty).toBe(false);
+      expect(result.current.geoTab.checkedGeos).toEqual(new Set(['eu']));
+    });
+
+    it('disables Save when an existing policy is kept ON but every selection is cleared', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+      expect(result.current.common.useCustomPolicy).toBe(true);
+
+      act(() => result.current.geoTab.onToggleGeo('eu'));
+
+      expect(result.current.geoTab.totalGeosSelected).toBe(0);
+      expect(result.current.common.pendingDelete).toBe(false);
+      expect(result.current.common.isSaveDisabled).toBe(true);
     });
   });
 
@@ -460,12 +587,34 @@ describe('useManageRegionsState', () => {
     it('showConfirmation is false initially', () => {
       const { result } = renderHook(() => useManageRegionsState(onClose));
       expect(result.current.common.showConfirmation).toBe(false);
+      expect(result.current.common.showDeleteConfirmation).toBe(false);
     });
 
-    it('handleRequestSave sets showConfirmation to true', () => {
+    it('handleRequestSave opens the PUT confirmation when a custom policy is active', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
       const { result } = renderHook(() => useManageRegionsState(onClose));
       act(() => result.current.common.handleRequestSave());
       expect(result.current.common.showConfirmation).toBe(true);
+      expect(result.current.common.showDeleteConfirmation).toBe(false);
+    });
+
+    it('handleRequestSave opens the delete confirmation when the toggle is OFF with an existing policy', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+
+      act(() => result.current.common.setUseCustomPolicy(false));
+      act(() => result.current.common.handleRequestSave());
+
+      expect(result.current.common.showDeleteConfirmation).toBe(true);
+      expect(result.current.common.showConfirmation).toBe(false);
     });
 
     it('handleCancelConfirmation sets showConfirmation back to false', () => {
@@ -473,6 +622,58 @@ describe('useManageRegionsState', () => {
       act(() => result.current.common.handleRequestSave());
       act(() => result.current.common.handleCancelConfirmation());
       expect(result.current.common.showConfirmation).toBe(false);
+    });
+
+    it('handleCancelDeleteConfirmation sets showDeleteConfirmation back to false', () => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+      act(() => result.current.common.setUseCustomPolicy(false));
+      act(() => result.current.common.handleRequestSave());
+      expect(result.current.common.showDeleteConfirmation).toBe(true);
+      act(() => result.current.common.handleCancelDeleteConfirmation());
+      expect(result.current.common.showDeleteConfirmation).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handleConfirmDelete
+  // ---------------------------------------------------------------------------
+  describe('handleConfirmDelete', () => {
+    beforeEach(() => {
+      mockUseRegionPolicy.mockReturnValue({
+        data: { region_policy: { allowed_geos: ['eu'] }, created_at: '2024-01-01T00:00:00Z' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRegionPolicy>);
+    });
+
+    it('calls deletePolicy with no arguments', () => {
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+      act(() => result.current.common.handleConfirmDelete());
+      expect(mockDeleteMutate).toHaveBeenCalledWith();
+    });
+
+    it('wires onClose into useDeleteRegionPolicy so it runs when delete succeeds', () => {
+      renderHook(() => useManageRegionsState(onClose));
+      expect(mockUseDeleteRegionPolicy).toHaveBeenCalledWith(onClose);
+    });
+
+    it('keeps the delete confirmation and parent modal open when delete fails', () => {
+      mockDeleteMutate.mockImplementation(() => {});
+      const { result } = renderHook(() => useManageRegionsState(onClose));
+
+      act(() => result.current.common.setUseCustomPolicy(false));
+      act(() => result.current.common.handleRequestSave());
+      expect(result.current.common.showDeleteConfirmation).toBe(true);
+
+      act(() => result.current.common.handleConfirmDelete());
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(result.current.common.showDeleteConfirmation).toBe(true);
     });
   });
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/use_manage_regions_state.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service/use_manage_regions_state.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRegionPolicy } from '../../hooks/use_region_policy';
 import { useSaveRegionPolicy } from '../../hooks/use_save_region_policy';
+import { useDeleteRegionPolicy } from '../../hooks/use_delete_region_policy';
 import { useEisModels } from '../../hooks/use_eis_models';
 import { getAvailableRegions, getAvailableGeos, regionKey } from '../../utils/eis_utils';
 import type { PolicyMode } from '../../types';
@@ -23,6 +24,7 @@ export const useManageRegionsState = (onClose: () => void) => {
     isError: isEndpointsError,
   } = useEisModels();
   const { mutate: savePolicy, isLoading: isSaving } = useSaveRegionPolicy();
+  const { mutate: deletePolicy, isLoading: isDeleting } = useDeleteRegionPolicy(onClose);
 
   const availableRegions = useMemo(() => getAvailableRegions(eisEndpoints ?? []), [eisEndpoints]);
   const availableGeos = useMemo(() => getAvailableGeos(eisEndpoints ?? []), [eisEndpoints]);
@@ -36,8 +38,10 @@ export const useManageRegionsState = (onClose: () => void) => {
   const [activeTab, setActiveTab] = useState<PolicyMode>('geo');
   const [syncedFromInitial, setSyncedFromInitial] = useState(false);
   const [isNewPolicy, setIsNewPolicy] = useState(false);
+  const [useCustomPolicy, setUseCustomPolicy] = useState(false);
   const [isCallOutDismissed, setIsCallOutDismissed] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
   // Seed state once both queries finish loading.
   useEffect(() => {
@@ -46,6 +50,8 @@ export const useManageRegionsState = (onClose: () => void) => {
       const seedState = computeSeedState(policy, availableRegions, availableGeos);
       setActiveTab(seedState.activeTab);
       setIsNewPolicy(seedState.isNewPolicy);
+      // Toggle is ON when a custom policy is already saved; OFF for first-time setup.
+      setUseCustomPolicy(!seedState.isNewPolicy);
       seedRegions(seedState.regionKeys);
       seedGeos(seedState.geos);
       setSyncedFromInitial(true);
@@ -66,22 +72,39 @@ export const useManageRegionsState = (onClose: () => void) => {
   const isError = isPolicyError || isEndpointsError;
   const activeSelectionIsDirty =
     activeTab === 'regions' ? regionTab.regionSelection.isDirty : geoSelection.isDirty;
-  const isDirty = syncedFromInitial && (isNewPolicy || activeSelectionIsDirty);
-  const noSelections =
-    activeTab === 'geo'
-      ? geoSelection.totalSelected === 0
-      : regionTab.regionSelection.totalSelected === 0;
-  const isSaveDisabled = isSaving || isLoading || !isDirty || noSelections;
+  const hasExistingPolicy = syncedFromInitial && !isNewPolicy;
+  const pendingDelete = hasExistingPolicy && !useCustomPolicy;
+
+  const hasUnsavedSelectionChanges = isNewPolicy || activeSelectionIsDirty;
+  const hasCustomPolicyEdits = syncedFromInitial && hasUnsavedSelectionChanges;
+  const isDirty = useCustomPolicy ? hasCustomPolicyEdits : pendingDelete;
+
+  const hasNoGeosSelected = geoSelection.totalSelected === 0;
+  const hasNoRegionsSelected = regionTab.regionSelection.totalSelected === 0;
+  const hasEmptySelection = activeTab === 'geo' ? hasNoGeosSelected : hasNoRegionsSelected;
+
+  const isBusy = isSaving || isDeleting || isLoading;
+  const requiresSelection = useCustomPolicy && hasEmptySelection;
+  const isSaveDisabled = isBusy || !isDirty || requiresSelection;
 
   // --- Confirmation flow handlers ---
   const handleRequestSave = useCallback(() => {
-    setShowConfirmation(true);
-  }, []);
+    if (pendingDelete) {
+      setShowDeleteConfirmation(true);
+    } else {
+      setShowConfirmation(true);
+    }
+  }, [pendingDelete]);
 
   const handleCancelConfirmation = useCallback(() => {
     if (isSaving) return;
     setShowConfirmation(false);
   }, [isSaving]);
+
+  const handleCancelDeleteConfirmation = useCallback(() => {
+    if (isDeleting) return;
+    setShowDeleteConfirmation(false);
+  }, [isDeleting]);
 
   const handleConfirmSave = useCallback(() => {
     if (activeTab === 'geo') {
@@ -116,6 +139,10 @@ export const useManageRegionsState = (onClose: () => void) => {
     savePolicy,
     onClose,
   ]);
+
+  const handleConfirmDelete = useCallback(() => {
+    deletePolicy();
+  }, [deletePolicy]);
 
   const handleDismissCallOut = useCallback(() => {
     setIsCallOutDismissed(true);
@@ -178,16 +205,23 @@ export const useManageRegionsState = (onClose: () => void) => {
       isLoading,
       isError,
       isSaving,
+      isDeleting,
       isDirty,
-      isNewPolicy,
+      hasExistingPolicy,
+      pendingDelete,
+      useCustomPolicy,
       isSaveDisabled,
       isCallOutDismissed,
       showConfirmation,
+      showDeleteConfirmation,
       setActiveTab,
+      setUseCustomPolicy,
       handleDismissCallOut,
       handleRequestSave,
       handleConfirmSave,
       handleCancelConfirmation,
+      handleConfirmDelete,
+      handleCancelDeleteConfirmation,
     },
     regionTab: regionTabReturn,
     geoTab: geoTabReturn,

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_delete_region_policy.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_delete_region_policy.test.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import React from 'react';
+import { useDeleteRegionPolicy } from './use_delete_region_policy';
+import { useKibana } from './use_kibana';
+import { APIRoutes } from '../../common/types';
+import { REGION_POLICY_QUERY_KEY, ROUTE_VERSIONS } from '../../common/constants';
+
+jest.mock('./use_kibana');
+
+const mockUseKibana = useKibana as jest.Mock;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
+
+describe('useDeleteRegionPolicy', () => {
+  const mockDelete = jest.fn();
+  const mockAddSuccess = jest.fn();
+  const mockAddError = jest.fn();
+  const mockAddDanger = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKibana.mockReturnValue({
+      services: {
+        http: { delete: mockDelete },
+        notifications: {
+          toasts: {
+            addSuccess: mockAddSuccess,
+            addError: mockAddError,
+            addDanger: mockAddDanger,
+          },
+        },
+      },
+    });
+  });
+
+  it('calls DELETE with the correct path and version', async () => {
+    mockDelete.mockResolvedValue({ acknowledged: true });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteRegionPolicy(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledTimes(1));
+
+    expect(mockDelete).toHaveBeenCalledWith(APIRoutes.REGION_POLICY, {
+      version: ROUTE_VERSIONS.v1,
+    });
+  });
+
+  it('shows success toast and writes the cleared policy directly to the query cache', async () => {
+    mockDelete.mockResolvedValue({ acknowledged: true });
+
+    const { queryClient } = createWrapper();
+    queryClient.setQueryData([REGION_POLICY_QUERY_KEY], {
+      region_policy: { allowed_geos: ['eu'] },
+    });
+
+    const { result } = renderHook(() => useDeleteRegionPolicy(), {
+      wrapper: ({ children }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(mockAddSuccess).toHaveBeenCalledTimes(1));
+
+    expect(mockAddSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Region preferences reset to default' })
+    );
+    expect(queryClient.getQueryData([REGION_POLICY_QUERY_KEY])).toBeNull();
+  });
+
+  it('shows error toast on generic error and leaves the query cache untouched', async () => {
+    const serverError = new Error('server error');
+    mockDelete.mockRejectedValue(serverError);
+
+    const { queryClient } = createWrapper();
+    const existingPolicy = { region_policy: { allowed_geos: ['eu'] } };
+    queryClient.setQueryData([REGION_POLICY_QUERY_KEY], existingPolicy);
+
+    const { result } = renderHook(() => useDeleteRegionPolicy(), {
+      wrapper: ({ children }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(mockAddError).toHaveBeenCalledTimes(1));
+
+    expect(mockAddError).toHaveBeenCalledWith(
+      serverError,
+      expect.objectContaining({ title: 'Failed to reset region preferences' })
+    );
+    expect(queryClient.getQueryData([REGION_POLICY_QUERY_KEY])).toBe(existingPolicy);
+  });
+
+  it('calls the onSuccess callback after a successful delete', async () => {
+    mockDelete.mockResolvedValue({ acknowledged: true });
+    const onSuccess = jest.fn();
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteRegionPolicy(onSuccess), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not call the onSuccess callback when delete fails', async () => {
+    mockDelete.mockRejectedValue(new Error('server error'));
+    const onSuccess = jest.fn();
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteRegionPolicy(onSuccess), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(mockAddError).toHaveBeenCalledTimes(1));
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows a danger toast with the reason on a 409 conflict and leaves the query cache untouched', async () => {
+    const conflictError = Object.assign(new Error('Conflict'), {
+      response: { status: 409 },
+      body: { message: 'Region policy is currently in use.' },
+    });
+    mockDelete.mockRejectedValue(conflictError);
+
+    const { queryClient } = createWrapper();
+    const existingPolicy = { region_policy: { allowed_geos: ['eu'] } };
+    queryClient.setQueryData([REGION_POLICY_QUERY_KEY], existingPolicy);
+
+    const { result } = renderHook(() => useDeleteRegionPolicy(), {
+      wrapper: ({ children }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(mockAddDanger).toHaveBeenCalledTimes(1));
+
+    expect(mockAddDanger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Can't reset region preferences",
+        text: 'Region policy is currently in use.',
+      })
+    );
+    expect(mockAddError).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData([REGION_POLICY_QUERY_KEY])).toBe(existingPolicy);
+  });
+});

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_delete_region_policy.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_delete_region_policy.ts
@@ -8,42 +8,41 @@
 import { useMutation, useQueryClient } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
 import type { IHttpFetchError, ResponseErrorBody } from '@kbn/core-http-browser';
-import type { RegionPolicyBody, RegionPolicyResponse } from '../../common/types';
 import { APIRoutes } from '../../common/types';
 import { REGION_POLICY_QUERY_KEY, ROUTE_VERSIONS } from '../../common/constants';
 import { useKibana } from './use_kibana';
 
-export const useSaveRegionPolicy = () => {
+export const useDeleteRegionPolicy = (onSuccess?: () => void) => {
   const { services } = useKibana();
   const queryClient = useQueryClient();
 
-  return useMutation<RegionPolicyResponse, IHttpFetchError<ResponseErrorBody>, RegionPolicyBody>({
-    mutationFn: async (body: RegionPolicyBody) => {
-      return services.http.put<RegionPolicyResponse>(APIRoutes.REGION_POLICY, {
-        body: JSON.stringify(body),
+  return useMutation<{ acknowledged: boolean }, IHttpFetchError<ResponseErrorBody>, void>({
+    mutationFn: async () => {
+      return services.http.delete<{ acknowledged: boolean }>(APIRoutes.REGION_POLICY, {
         version: ROUTE_VERSIONS.v1,
       });
     },
-    onSuccess: (data) => {
-      queryClient.setQueryData([REGION_POLICY_QUERY_KEY], data);
+    onSuccess: () => {
+      queryClient.setQueryData([REGION_POLICY_QUERY_KEY], null);
       services.notifications.toasts.addSuccess({
-        title: i18n.translate('xpack.searchInferenceEndpoints.regionPolicy.saveSuccess', {
-          defaultMessage: 'Region preferences saved',
+        title: i18n.translate('xpack.searchInferenceEndpoints.regionPolicy.deleteSuccess', {
+          defaultMessage: 'Region preferences reset to default',
         }),
       });
+      onSuccess?.();
     },
     onError: (err) => {
       if (err.response?.status === 409) {
         services.notifications.toasts.addDanger({
-          title: i18n.translate('xpack.searchInferenceEndpoints.regionPolicy.conflictError', {
-            defaultMessage: 'Region policy update blocked',
+          title: i18n.translate('xpack.searchInferenceEndpoints.regionPolicy.deleteConflictError', {
+            defaultMessage: "Can't reset region preferences",
           }),
           ...(err.body?.message ? { text: err.body.message } : {}),
         });
       } else {
         services.notifications.toasts.addError(err, {
-          title: i18n.translate('xpack.searchInferenceEndpoints.regionPolicy.saveError', {
-            defaultMessage: 'Failed to save region preferences',
+          title: i18n.translate('xpack.searchInferenceEndpoints.regionPolicy.deleteError', {
+            defaultMessage: 'Failed to reset region preferences',
           }),
         });
       }

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_save_region_policy.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_save_region_policy.test.ts
@@ -70,7 +70,7 @@ describe('useSaveRegionPolicy', () => {
     });
   });
 
-  it('shows success toast and invalidates query cache on success', async () => {
+  it('shows success toast and writes the saved policy directly to the query cache', async () => {
     const responseData = {
       region_policy: { allowed_regions: [{ csp: 'aws', region: 'eu-west-1' }] },
       created_at: '2026-01-01',
@@ -78,7 +78,6 @@ describe('useSaveRegionPolicy', () => {
     mockPut.mockResolvedValue(responseData);
 
     const { queryClient } = createWrapper();
-    const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useSaveRegionPolicy(), {
       wrapper: ({ children }) =>
@@ -94,9 +93,7 @@ describe('useSaveRegionPolicy', () => {
     expect(mockAddSuccess).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Region preferences saved' })
     );
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: [REGION_POLICY_QUERY_KEY] })
-    );
+    expect(queryClient.getQueryData([REGION_POLICY_QUERY_KEY])).toEqual(responseData);
   });
 
   it('shows error toast on error', async () => {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/compute_seed_state.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/compute_seed_state.test.ts
@@ -33,14 +33,14 @@ describe('computeSeedState', () => {
       expect(result.isNewPolicy).toBe(true);
     });
 
-    it('pre-selects all available regions', () => {
+    it('leaves regionKeys empty so nothing is pre-selected', () => {
       const result = computeSeedState(null, availableRegions, availableGeos);
-      expect(result.regionKeys).toEqual(new Set(['aws::us-east-1', 'gcp::europe-west1']));
+      expect(result.regionKeys.size).toBe(0);
     });
 
-    it('pre-selects all available geos', () => {
+    it('leaves geos empty so nothing is pre-selected', () => {
       const result = computeSeedState(null, availableRegions, availableGeos);
-      expect(result.geos).toEqual(new Set(['eu', 'us']));
+      expect(result.geos.size).toBe(0);
     });
   });
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/compute_seed_state.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/compute_seed_state.ts
@@ -41,10 +41,10 @@ export const computeSeedState = (
     activeTab: noPolicy ? 'geo' : 'regions',
     isNewPolicy: noPolicy,
     regionKeys: noPolicy
-      ? new Set(availableRegions.map(regionKey))
+      ? new Set<string>()
       : new Set(
           existing.map(regionKey).filter((k) => availableRegions.some((r) => regionKey(r) === k))
         ),
-    geos: noPolicy ? new Set(availableGeos) : new Set<string>(),
+    geos: new Set<string>(),
   };
 };

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/fixtures/mocks.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/fixtures/mocks.ts
@@ -112,46 +112,116 @@ export interface MockRegionPolicy {
   allowed_geos?: string[];
 }
 
-export async function mockNoRegionPolicy(page: ScoutPage) {
+export interface RegionPolicyMockCounters {
+  getRequestCount: number;
+  putRequestCount: number;
+  deleteRequestCount: number;
+}
+
+async function createRegionPolicyRouteMock(
+  page: ScoutPage,
+  handlers: {
+    get: (counters: RegionPolicyMockCounters) => { status: number; body: unknown };
+    put?: (
+      counters: RegionPolicyMockCounters,
+      requestBody: MockRegionPolicy
+    ) => { status: number; body: unknown };
+    delete?: (counters: RegionPolicyMockCounters) => { status: number; body: unknown };
+  }
+): Promise<RegionPolicyMockCounters> {
+  const counters: RegionPolicyMockCounters = {
+    getRequestCount: 0,
+    putRequestCount: 0,
+    deleteRequestCount: 0,
+  };
   await page.route(REGION_POLICY_ROUTE, async (route) => {
-    if (route.request().method() === 'GET') {
-      await route.fulfill({
-        status: 404,
-        contentType: 'application/json',
-        body: JSON.stringify({ message: 'No region policy found' }),
-      });
-    } else if (route.request().method() === 'PUT') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ acknowledged: true }),
-      });
+    const method = route.request().method();
+    if (method === 'GET') {
+      counters.getRequestCount += 1;
+      const { status, body } = handlers.get(counters);
+      await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+    } else if (method === 'PUT' && handlers.put) {
+      counters.putRequestCount += 1;
+      const requestBody = route.request().postDataJSON() as MockRegionPolicy;
+      const { status, body } = handlers.put(counters, requestBody);
+      await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+    } else if (method === 'DELETE' && handlers.delete) {
+      counters.deleteRequestCount += 1;
+      const { status, body } = handlers.delete(counters);
+      await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
     } else {
       await route.continue();
     }
   });
+  return counters;
 }
 
-export async function mockRegionPolicy(page: ScoutPage, policy: MockRegionPolicy) {
-  await page.route(REGION_POLICY_ROUTE, async (route) => {
-    if (route.request().method() === 'GET') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          region_policy: policy,
-          created_at: '2026-01-01T00:00:00Z',
-        }),
-      });
-    } else if (route.request().method() === 'PUT') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ acknowledged: true }),
-      });
-    } else {
-      await route.continue();
-    }
+// PUT /_inference/_region_policy responds with the persisted RegionPolicyResponse
+// (region_policy + created_at), matching the real ES endpoint and the shape
+// server/lib/region_policy.ts's putRegionPolicy is typed to return.
+const putRegionPolicyResponse = (requestBody: MockRegionPolicy) => ({
+  status: 200,
+  body: { region_policy: requestBody, created_at: '2026-01-01T00:00:00Z' },
+});
+
+export async function mockNoRegionPolicy(page: ScoutPage): Promise<RegionPolicyMockCounters> {
+  let currentPolicy: MockRegionPolicy | null = null;
+  return createRegionPolicyRouteMock(page, {
+    get: () =>
+      currentPolicy
+        ? {
+            status: 200,
+            body: { region_policy: currentPolicy, created_at: '2026-01-01T00:00:00Z' },
+          }
+        : { status: 404, body: { message: 'No region policy found' } },
+    put: (_counters, requestBody) => {
+      currentPolicy = requestBody;
+      return putRegionPolicyResponse(requestBody);
+    },
+    delete: () => {
+      currentPolicy = null;
+      return { status: 200, body: { acknowledged: true } };
+    },
+  });
+}
+
+export async function mockRegionPolicy(
+  page: ScoutPage,
+  policy: MockRegionPolicy
+): Promise<RegionPolicyMockCounters> {
+  let currentPolicy: MockRegionPolicy | null = policy;
+  return createRegionPolicyRouteMock(page, {
+    get: () =>
+      currentPolicy
+        ? {
+            status: 200,
+            body: { region_policy: currentPolicy, created_at: '2026-01-01T00:00:00Z' },
+          }
+        : { status: 404, body: { message: 'No region policy found' } },
+    put: (_counters, requestBody) => {
+      currentPolicy = requestBody;
+      return putRegionPolicyResponse(requestBody);
+    },
+    delete: () => {
+      currentPolicy = null;
+      return { status: 200, body: { acknowledged: true } };
+    },
+  });
+}
+
+export async function mockRegionPolicyDeleteConflict(
+  page: ScoutPage,
+  policy: MockRegionPolicy
+): Promise<RegionPolicyMockCounters> {
+  return createRegionPolicyRouteMock(page, {
+    get: () => ({
+      status: 200,
+      body: { region_policy: policy, created_at: '2026-01-01T00:00:00Z' },
+    }),
+    delete: () => ({
+      status: 409,
+      body: { message: 'Region policy is currently in use.' },
+    }),
   });
 }
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/fixtures/page_objects/eis_models_page.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/fixtures/page_objects/eis_models_page.ts
@@ -44,6 +44,7 @@ export class EisModelsPage {
   readonly manageRegionsCancelButton: Locator;
   readonly manageRegionsSaveButton: Locator;
   readonly manageRegionsCallout: Locator;
+  readonly manageRegionsCalloutDismiss: Locator;
   readonly manageRegionsErrorCallout: Locator;
   readonly manageRegionsLoading: Locator;
   readonly manageRegionsNoGeos: Locator;
@@ -52,12 +53,18 @@ export class EisModelsPage {
   readonly manageRegionsRegionsTab: Locator;
   readonly manageRegionsSelectAllButton: Locator;
   readonly manageRegionsExpandAllButton: Locator;
+  readonly manageRegionsCustomPolicyToggle: Locator;
   // Confirm Region Change Modal
   readonly confirmRegionChangeModal: Locator;
   readonly confirmRegionChangeModalGeoList: Locator;
   readonly confirmRegionChangeModalRegionList: Locator;
   readonly confirmRegionChangeSaveButton: Locator;
   readonly confirmRegionChangeCancelButton: Locator;
+  // Confirm Delete Region Policy Modal
+  readonly confirmDeleteRegionPolicyModal: Locator;
+  readonly confirmDeleteRegionPolicySaveButton: Locator;
+  readonly confirmDeleteRegionPolicyCancelButton: Locator;
+  readonly confirmDeleteRegionPolicyAcknowledge: Locator;
 
   constructor(private readonly page: ScoutPage) {
     // Header
@@ -100,6 +107,7 @@ export class EisModelsPage {
     this.manageRegionsCancelButton = this.page.testSubj.locator('manageRegionsCancelButton');
     this.manageRegionsSaveButton = this.page.testSubj.locator('manageRegionsSaveButton');
     this.manageRegionsCallout = this.page.testSubj.locator('manageRegionsCallout');
+    this.manageRegionsCalloutDismiss = this.page.testSubj.locator('manageRegionsCalloutDismiss');
     this.manageRegionsErrorCallout = this.page.testSubj.locator('manageRegionsErrorCallout');
     this.manageRegionsLoading = this.page.testSubj.locator('manageRegionsLoading');
     this.manageRegionsNoGeos = this.page.testSubj.locator('manageRegionsNoGeos');
@@ -108,12 +116,32 @@ export class EisModelsPage {
     this.manageRegionsRegionsTab = this.page.testSubj.locator('manageRegionsRegionsTab');
     this.manageRegionsSelectAllButton = this.page.testSubj.locator('manageRegionsSelectAllButton');
     this.manageRegionsExpandAllButton = this.page.testSubj.locator('manageRegionsExpandAllButton');
+    this.manageRegionsCustomPolicyToggle = this.page.testSubj.locator(
+      'manageRegionsCustomPolicyToggle'
+    );
     // Confirm Region Change Modal
     this.confirmRegionChangeModal = this.page.testSubj.locator('confirmRegionChangeModal');
     this.confirmRegionChangeModalGeoList = this.page.testSubj.locator('confirmModalGeoList');
     this.confirmRegionChangeModalRegionList = this.page.testSubj.locator('confirmModalRegionList');
-    this.confirmRegionChangeSaveButton = this.page.testSubj.locator('confirmModalConfirmButton');
-    this.confirmRegionChangeCancelButton = this.page.testSubj.locator('confirmModalCancelButton');
+    this.confirmRegionChangeSaveButton = this.confirmRegionChangeModal.locator(
+      '[data-test-subj="confirmModalConfirmButton"]'
+    );
+    this.confirmRegionChangeCancelButton = this.confirmRegionChangeModal.locator(
+      '[data-test-subj="confirmModalCancelButton"]'
+    );
+    // Confirm Delete Region Policy Modal
+    this.confirmDeleteRegionPolicyModal = this.page.testSubj.locator(
+      'confirmDeleteRegionPolicyModal'
+    );
+    this.confirmDeleteRegionPolicyAcknowledge = this.page.testSubj.locator(
+      'confirmDeleteRegionPolicyAcknowledge'
+    );
+    this.confirmDeleteRegionPolicySaveButton = this.confirmDeleteRegionPolicyModal.locator(
+      '[data-test-subj="confirmModalConfirmButton"]'
+    );
+    this.confirmDeleteRegionPolicyCancelButton = this.confirmDeleteRegionPolicyModal.locator(
+      '[data-test-subj="confirmModalCancelButton"]'
+    );
   }
 
   // --- Navigation ---

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/tests/manage_regions_modal.spec.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/tests/manage_regions_modal.spec.ts
@@ -15,6 +15,7 @@ import {
   mockNoRegionPolicy,
   mockRegionPolicy,
   mockRegionPolicyError,
+  mockRegionPolicyDeleteConflict,
   unmockRegionPolicy,
 } from '../fixtures/mocks';
 
@@ -52,55 +53,44 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
     await expect(eisModels.manageRegionsModal).toBeHidden();
   });
 
-  test('Geo tab is active by default and all geos are pre-selected', async ({ pageObjects }) => {
+  test('enabling the custom policy toggle reveals the Geo tab', async ({ pageObjects }) => {
     const { eisModels } = pageObjects;
 
     await eisModels.manageRegionsButton.click();
-    await expect(eisModels.manageRegionsModal).toBeVisible();
+    await expect(eisModels.manageRegionsLoading).toBeHidden();
 
-    await test.step('loading completes and geo tab content is visible', async () => {
-      await expect(eisModels.manageRegionsLoading).toBeHidden();
-      await expect(eisModels.manageRegionsGeoTab).toBeVisible();
-    });
-
-    await test.step('all geos from mock data are shown and checked', async () => {
-      for (const geo of ['apac', 'eu', 'us']) {
-        await expect(eisModels.geoZoneRow(geo)).toBeVisible();
-        const checkbox = eisModels.geoZoneCheckbox(geo);
-        await expect(checkbox).toBeChecked();
-      }
-    });
+    await eisModels.manageRegionsCustomPolicyToggle.click();
+    await expect(eisModels.manageRegionsGeoTab).toBeVisible();
   });
 
-  test('info callout is shown by default and is dismissible', async ({ pageObjects }) => {
+  test('info callout is hidden until the custom policy toggle is on, and is dismissible', async ({
+    pageObjects,
+  }) => {
     const { eisModels } = pageObjects;
 
     await eisModels.manageRegionsButton.click();
+    await expect(eisModels.manageRegionsCallout).toBeHidden();
+
+    await eisModels.manageRegionsCustomPolicyToggle.click();
     await expect(eisModels.manageRegionsCallout).toBeVisible();
 
-    await eisModels.manageRegionsCallout.getByRole('button', { name: /dismiss/i }).click();
+    await eisModels.manageRegionsCalloutDismiss.click();
     await expect(eisModels.manageRegionsCallout).toBeHidden();
   });
 
-  test('Save button is enabled for a new policy (all geos selected = isNewPolicy)', async ({
+  test('selecting all geos enables Save, deselecting them again disables it', async ({
     pageObjects,
   }) => {
     const { eisModels } = pageObjects;
 
     await eisModels.manageRegionsButton.click();
     await expect(eisModels.manageRegionsLoading).toBeHidden();
-
-    await expect(eisModels.manageRegionsSaveButton).toBeEnabled();
-  });
-
-  test('deselecting all geos disables the Save button', async ({ pageObjects }) => {
-    const { eisModels } = pageObjects;
-
-    await eisModels.manageRegionsButton.click();
-    await expect(eisModels.manageRegionsLoading).toBeHidden();
+    await eisModels.manageRegionsCustomPolicyToggle.click();
 
     await eisModels.manageRegionsSelectAllButton.click();
+    await expect(eisModels.manageRegionsSaveButton).toBeEnabled();
 
+    await eisModels.manageRegionsSelectAllButton.click();
     await expect(eisModels.manageRegionsSaveButton).toBeDisabled();
   });
 
@@ -111,8 +101,10 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
 
     await eisModels.manageRegionsButton.click();
     await expect(eisModels.manageRegionsLoading).toBeHidden();
+    await eisModels.manageRegionsCustomPolicyToggle.click();
 
-    await eisModels.geoZoneCheckbox('apac').click();
+    await eisModels.geoZoneCheckbox('eu').click();
+    await eisModels.geoZoneCheckbox('us').click();
     await expect(eisModels.manageRegionsSaveButton).toBeEnabled();
 
     await eisModels.manageRegionsSaveButton.click();
@@ -137,7 +129,9 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
 
     await eisModels.manageRegionsButton.click();
     await expect(eisModels.manageRegionsLoading).toBeHidden();
+    await eisModels.manageRegionsCustomPolicyToggle.click();
 
+    await eisModels.geoZoneCheckbox('eu').click();
     await eisModels.manageRegionsSaveButton.click();
     await expect(eisModels.confirmRegionChangeModal).toBeVisible();
 
@@ -152,7 +146,9 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
 
     await eisModels.manageRegionsButton.click();
     await expect(eisModels.manageRegionsLoading).toBeHidden();
+    await eisModels.manageRegionsCustomPolicyToggle.click();
 
+    await eisModels.geoZoneCheckbox('eu').click();
     await eisModels.manageRegionsSaveButton.click();
     await expect(eisModels.confirmRegionChangeModal).toBeVisible();
 
@@ -162,11 +158,39 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
     await expect(eisModels.manageRegionsModal).toBeHidden();
   });
 
+  test('reopening the modal after a save reflects the saved policy without a page reload', async ({
+    page,
+    pageObjects,
+  }) => {
+    const { eisModels } = pageObjects;
+    await mockNoRegionPolicy(page);
+
+    await eisModels.manageRegionsButton.click();
+    await expect(eisModels.manageRegionsLoading).toBeHidden();
+    await eisModels.manageRegionsCustomPolicyToggle.click();
+
+    await eisModels.geoZoneCheckbox('eu').click();
+    await eisModels.manageRegionsSaveButton.click();
+    await expect(eisModels.confirmRegionChangeModal).toBeVisible();
+    await eisModels.confirmRegionChangeSaveButton.click();
+    await expect(eisModels.manageRegionsModal).toBeHidden();
+
+    await eisModels.manageRegionsButton.click();
+    await expect(eisModels.manageRegionsLoading).toBeHidden();
+
+    await test.step('the just-saved geo is pre-selected', async () => {
+      await expect(eisModels.manageRegionsCustomPolicyToggle).toBeChecked();
+      await expect(eisModels.geoZoneCheckbox('eu')).toBeChecked();
+      await expect(eisModels.geoZoneCheckbox('apac')).not.toBeChecked();
+    });
+  });
+
   test('switching to the Regions tab shows zone accordion panels', async ({ pageObjects }) => {
     const { eisModels } = pageObjects;
 
     await eisModels.manageRegionsButton.click();
     await expect(eisModels.manageRegionsLoading).toBeHidden();
+    await eisModels.manageRegionsCustomPolicyToggle.click();
 
     await eisModels.manageRegionsRegionsTab.click();
 
@@ -188,6 +212,7 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
 
     await eisModels.manageRegionsButton.click();
     await expect(eisModels.manageRegionsLoading).toBeHidden();
+    await eisModels.manageRegionsCustomPolicyToggle.click();
 
     await eisModels.manageRegionsRegionsTab.click();
     await eisModels.manageRegionsExpandAllButton.click();
@@ -198,10 +223,10 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
       await expect(eisModels.regionCheckbox('aws::us-east-1')).toBeVisible();
     });
 
-    await test.step('all region checkboxes are checked by default (new policy)', async () => {
-      await expect(eisModels.regionCheckbox('aws::ap-southeast-1')).toBeChecked();
-      await expect(eisModels.regionCheckbox('aws::eu-west-1')).toBeChecked();
-      await expect(eisModels.regionCheckbox('aws::us-east-1')).toBeChecked();
+    await test.step('no region checkboxes are checked by default (new policy)', async () => {
+      await expect(eisModels.regionCheckbox('aws::ap-southeast-1')).not.toBeChecked();
+      await expect(eisModels.regionCheckbox('aws::eu-west-1')).not.toBeChecked();
+      await expect(eisModels.regionCheckbox('aws::us-east-1')).not.toBeChecked();
     });
   });
 
@@ -210,6 +235,7 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
 
     await eisModels.manageRegionsButton.click();
     await expect(eisModels.manageRegionsLoading).toBeHidden();
+    await eisModels.manageRegionsCustomPolicyToggle.click();
 
     await eisModels.manageRegionsRegionsTab.click();
     await eisModels.manageRegionsExpandAllButton.click();
@@ -235,6 +261,11 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
 
     await eisModels.manageRegionsButton.click();
     await expect(eisModels.manageRegionsLoading).toBeHidden();
+
+    await test.step('toggle is ON by default for an existing policy', async () => {
+      await expect(eisModels.manageRegionsCustomPolicyToggle).toBeChecked();
+      await expect(eisModels.manageRegionsGeoTab).toBeVisible();
+    });
 
     await test.step('only eu is checked', async () => {
       await expect(eisModels.geoZoneCheckbox('eu')).toBeChecked();
@@ -279,6 +310,70 @@ test.describe('Manage Region Preferences modal', { tag: [...INFERENCE_LOCAL_TAGS
 
     await test.step('Save is disabled when policy is unchanged', async () => {
       await expect(eisModels.manageRegionsSaveButton).toBeDisabled();
+    });
+  });
+
+  test('turning the toggle OFF on an existing policy triggers a DELETE after the acknowledge checkbox', async ({
+    page,
+    pageObjects,
+  }) => {
+    const { eisModels } = pageObjects;
+
+    await unmockRegionPolicy(page);
+    const counters = await mockRegionPolicy(page, { allowed_geos: ['eu'] });
+
+    await eisModels.manageRegionsButton.click();
+    await expect(eisModels.manageRegionsLoading).toBeHidden();
+
+    await eisModels.manageRegionsCustomPolicyToggle.click();
+    await eisModels.manageRegionsSaveButton.click();
+
+    await test.step('delete confirmation modal appears', async () => {
+      await expect(eisModels.confirmDeleteRegionPolicyModal).toBeVisible();
+    });
+
+    await test.step('cancelling the delete confirmation keeps the main modal open', async () => {
+      await eisModels.confirmDeleteRegionPolicyCancelButton.click();
+      await expect(eisModels.confirmDeleteRegionPolicyModal).toBeHidden();
+      await expect(eisModels.manageRegionsModal).toBeVisible();
+      expect(counters.deleteRequestCount).toBe(0);
+    });
+
+    await eisModels.manageRegionsSaveButton.click();
+    await eisModels.confirmDeleteRegionPolicyAcknowledge.click();
+    await eisModels.confirmDeleteRegionPolicySaveButton.click();
+
+    await test.step('DELETE is called and both modals close', async () => {
+      await expect.poll(() => counters.deleteRequestCount).toBe(1);
+      expect(counters.putRequestCount).toBe(0);
+      await expect(eisModels.confirmDeleteRegionPolicyModal).toBeHidden();
+      await expect(eisModels.manageRegionsModal).toBeHidden();
+    });
+  });
+
+  test('a failed delete (409 conflict) keeps both modals open for retry', async ({
+    page,
+    pageObjects,
+  }) => {
+    const { eisModels } = pageObjects;
+
+    await unmockRegionPolicy(page);
+    const counters = await mockRegionPolicyDeleteConflict(page, { allowed_geos: ['eu'] });
+
+    await eisModels.manageRegionsButton.click();
+    await expect(eisModels.manageRegionsLoading).toBeHidden();
+
+    await eisModels.manageRegionsCustomPolicyToggle.click();
+    await eisModels.manageRegionsSaveButton.click();
+    await expect(eisModels.confirmDeleteRegionPolicyModal).toBeVisible();
+
+    await eisModels.confirmDeleteRegionPolicyAcknowledge.click();
+    await eisModels.confirmDeleteRegionPolicySaveButton.click();
+
+    await test.step('DELETE is attempted but both modals stay open on conflict', async () => {
+      await expect.poll(() => counters.deleteRequestCount).toBe(1);
+      await expect(eisModels.confirmDeleteRegionPolicyModal).toBeVisible();
+      await expect(eisModels.manageRegionsModal).toBeVisible();
     });
   });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Search Inference Endpoints] Add region policy delete toggle to Manage Region Preferences modal (#282769)](https://github.com/elastic/kibana/pull/282769)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saikat Sarkar","email":"132922331+saikatsarkar056@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-06T18:05:17Z","message":"[Search Inference Endpoints] Add region policy delete toggle to Manage Region Preferences modal (#282769)\n\n## Summary\n\nPreviously, once the admin sets a custom region policy, there was no way\nto remove it from the UI. They had to fall back to a raw API call. This\nPR adds a toggle to the Manage Region Preferences modal that lets an\nadmin turn off their custom policy, confirm the change, and revert to\nthe default behavior where all regions are allowed.\n\n### Screen Recording\n\n\nhttps://github.com/user-attachments/assets/00650b65-c6cb-4244-9e78-683af1448710\n\n\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n## Release note\n\nAdds a toggle to the Manage Region Preferences modal that lets\nadministrators remove a custom region policy and revert to the default\nof allowing all regions.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Florent LB <florent.leborgne@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>\nCo-authored-by: Yan Savitski <yan.savitski@gmail.com>","sha":"6a9f39cf8cba29eac4a381bb90e6281daa5db27a","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Search","backport:version","reviewer:scout","v9.6.0","v9.5.1"],"title":"[Search Inference Endpoints] Add region policy delete toggle to Manage Region Preferences modal","number":282769,"url":"https://github.com/elastic/kibana/pull/282769","mergeCommit":{"message":"[Search Inference Endpoints] Add region policy delete toggle to Manage Region Preferences modal (#282769)\n\n## Summary\n\nPreviously, once the admin sets a custom region policy, there was no way\nto remove it from the UI. They had to fall back to a raw API call. This\nPR adds a toggle to the Manage Region Preferences modal that lets an\nadmin turn off their custom policy, confirm the change, and revert to\nthe default behavior where all regions are allowed.\n\n### Screen Recording\n\n\nhttps://github.com/user-attachments/assets/00650b65-c6cb-4244-9e78-683af1448710\n\n\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n## Release note\n\nAdds a toggle to the Manage Region Preferences modal that lets\nadministrators remove a custom region policy and revert to the default\nof allowing all regions.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Florent LB <florent.leborgne@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>\nCo-authored-by: Yan Savitski <yan.savitski@gmail.com>","sha":"6a9f39cf8cba29eac4a381bb90e6281daa5db27a"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282769","number":282769,"mergeCommit":{"message":"[Search Inference Endpoints] Add region policy delete toggle to Manage Region Preferences modal (#282769)\n\n## Summary\n\nPreviously, once the admin sets a custom region policy, there was no way\nto remove it from the UI. They had to fall back to a raw API call. This\nPR adds a toggle to the Manage Region Preferences modal that lets an\nadmin turn off their custom policy, confirm the change, and revert to\nthe default behavior where all regions are allowed.\n\n### Screen Recording\n\n\nhttps://github.com/user-attachments/assets/00650b65-c6cb-4244-9e78-683af1448710\n\n\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n## Release note\n\nAdds a toggle to the Manage Region Preferences modal that lets\nadministrators remove a custom region policy and revert to the default\nof allowing all regions.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Florent LB <florent.leborgne@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>\nCo-authored-by: Yan Savitski <yan.savitski@gmail.com>","sha":"6a9f39cf8cba29eac4a381bb90e6281daa5db27a"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->