### PR TITLE
fix: use small size for View connection details button on ES Get started

### DIFF
--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/elasticsearch_connection_details.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/elasticsearch_connection_details.tsx
@@ -69,6 +69,7 @@ export const ElasticsearchConnectionDetails = () => {
                 target="_blank"
                 onClick={() => openWiredConnectionDetails()}
                 color="text"
+                size="s"
                 aria-label={i18n.translate(
                   'xpack.searchGettingStarted.elasticsearchConnectionDetails.viewDetails',
                   {


### PR DESCRIPTION
## Summary

- On the Elasticsearch Get started page, the **View connection details** button rendered at the default (medium) size next to smaller neighboring controls.
- Sets `size="s"` on that `EuiButtonEmpty` so it matches the adjacent API key / endpoint controls.

Related: https://elastic.slack.com/archives/C0BL79C9KK5/p1785530846212549

## Test plan

- [ ] Open `http://localhost:5601/app/elasticsearch/getting_started`
- [ ] Confirm **View connection details** is the same small size as the neighboring buttons in the connection details row
- [ ] Confirm click still opens the connection details flyout