### PR TITLE
[8.19] [kbn-evals] Remove Arize Phoenix executor and @arizeai/phoenix-client dependency (#281472)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -40,7 +40,6 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/migrator-test-kit',
   '@kbn/evals',
   '@kbn/evals-extensions',
-  '@kbn/evals-phoenix-executor',
   '@kbn/performance-testing-dataset-extractor',
 
   // Lint


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[kbn-evals] Remove Arize Phoenix executor and @arizeai/phoenix-client dependency (#281472)](https://github.com/elastic/kibana/pull/281472)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Arturo Lidueña","email":"arturo.liduena@elastic.co"},"sourceCommit":{"committedDate":"2026-08-07T07:52:53Z","message":"[kbn-evals] Remove Arize Phoenix executor and @arizeai/phoenix-client dependency (#281472)\n\nCloses https://github.com/elastic/kibana/issues/254970\n\n ## Summary\nRemoves the `@kbn/evals-phoenix-executor` package and the\n`@arizeai/phoenix-client` dependency from kbn-evals\n\n## Background\nThe evaluation framework originally launched with Arize Phoenix as its\nprimary backend for dataset storage and experiment orchestration. A\nparallel in-Kibana executor (`KibanaEvalsClient`) was subsequently\nbuilt, storing datasets and scores directly in Elasticsearch and making\nthe Phoenix path redundant for all practical CI and local runs. The\nPhoenix executor was only activated via `KBN_EVALS_EXECUTOR=phoenix`,\nwhich was never set in CI.\n\n## What changed\n- `@kbn/evals-phoenix-executor` package deleted in full\n- `@arizeai/phoenix-client` removed from `package.json` and `yarn.lock`\n- All eval suites updated to use the base `@kbn/evals` executor\ndirectly, removing the `withPhoenixExecutor` wrapper\n- `KBN_EVALS_EXECUTOR`, `PHOENIX_BASE_URL`, and `PHOENIX_API_KEY`\nenvironment variables removed from the CLI and documentation\n- External dataset evaluations updated to reference Elasticsearch as the\nsource of truth instead of Phoenix\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4805c316e29abb538f34e0dde2de08a45d34e214","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","kbn-evals","evals:smoke-tests","v9.6.0"],"title":"[kbn-evals] Remove Arize Phoenix executor and @arizeai/phoenix-client dependency","number":281472,"url":"https://github.com/elastic/kibana/pull/281472","mergeCommit":{"message":"[kbn-evals] Remove Arize Phoenix executor and @arizeai/phoenix-client dependency (#281472)\n\nCloses https://github.com/elastic/kibana/issues/254970\n\n ## Summary\nRemoves the `@kbn/evals-phoenix-executor` package and the\n`@arizeai/phoenix-client` dependency from kbn-evals\n\n## Background\nThe evaluation framework originally launched with Arize Phoenix as its\nprimary backend for dataset storage and experiment orchestration. A\nparallel in-Kibana executor (`KibanaEvalsClient`) was subsequently\nbuilt, storing datasets and scores directly in Elasticsearch and making\nthe Phoenix path redundant for all practical CI and local runs. The\nPhoenix executor was only activated via `KBN_EVALS_EXECUTOR=phoenix`,\nwhich was never set in CI.\n\n## What changed\n- `@kbn/evals-phoenix-executor` package deleted in full\n- `@arizeai/phoenix-client` removed from `package.json` and `yarn.lock`\n- All eval suites updated to use the base `@kbn/evals` executor\ndirectly, removing the `withPhoenixExecutor` wrapper\n- `KBN_EVALS_EXECUTOR`, `PHOENIX_BASE_URL`, and `PHOENIX_API_KEY`\nenvironment variables removed from the CLI and documentation\n- External dataset evaluations updated to reference Elasticsearch as the\nsource of truth instead of Phoenix\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4805c316e29abb538f34e0dde2de08a45d34e214"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281472","number":281472,"mergeCommit":{"message":"[kbn-evals] Remove Arize Phoenix executor and @arizeai/phoenix-client dependency (#281472)\n\nCloses https://github.com/elastic/kibana/issues/254970\n\n ## Summary\nRemoves the `@kbn/evals-phoenix-executor` package and the\n`@arizeai/phoenix-client` dependency from kbn-evals\n\n## Background\nThe evaluation framework originally launched with Arize Phoenix as its\nprimary backend for dataset storage and experiment orchestration. A\nparallel in-Kibana executor (`KibanaEvalsClient`) was subsequently\nbuilt, storing datasets and scores directly in Elasticsearch and making\nthe Phoenix path redundant for all practical CI and local runs. The\nPhoenix executor was only activated via `KBN_EVALS_EXECUTOR=phoenix`,\nwhich was never set in CI.\n\n## What changed\n- `@kbn/evals-phoenix-executor` package deleted in full\n- `@arizeai/phoenix-client` removed from `package.json` and `yarn.lock`\n- All eval suites updated to use the base `@kbn/evals` executor\ndirectly, removing the `withPhoenixExecutor` wrapper\n- `KBN_EVALS_EXECUTOR`, `PHOENIX_BASE_URL`, and `PHOENIX_API_KEY`\nenvironment variables removed from the CLI and documentation\n- External dataset evaluations updated to reference Elasticsearch as the\nsource of truth instead of Phoenix\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4805c316e29abb538f34e0dde2de08a45d34e214"}}]}] BACKPORT-->