### PR TITLE
[Visualize FTR] Remove duplicate pie chart run and restore heatmap legacy library coverage

### DIFF
--- a/src/platform/test/functional/apps/visualize/group2/_heatmap_chart.ts
+++ b/src/platform/test/functional/apps/visualize/group2/_heatmap_chart.ts
@@ -11,7 +11,15 @@ import expect from '@kbn/expect';
 
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 
-export default function ({ getService, getPageObjects }: FtrProviderContext) {
+interface HeatmapChartTestOptions {
+  /** Whether to exercise the deprecated vislib heatmap instead of the elastic-charts one. */
+  isLegacyChart: boolean;
+}
+
+export const heatmapChartTests = (
+  { getService, getPageObjects }: FtrProviderContext,
+  { isLegacyChart }: HeatmapChartTestOptions
+) => {
   const log = getService('log');
   const inspector = getService('inspector');
   const { visualize, visEditor, visChart, timePicker } = getPageObjects([
@@ -23,13 +31,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('heatmap chart', function indexPatternCreation() {
     const vizName1 = 'Visualization HeatmapChart';
-    let isNewChartsLibraryEnabled = false;
 
     before(async function () {
-      isNewChartsLibraryEnabled = await visChart.isNewChartsLibraryEnabled(
-        'visualization:visualize:legacyHeatmapChartsLibrary'
-      );
-      await visualize.initTests(!isNewChartsLibraryEnabled);
+      await visualize.initTests(isLegacyChart);
+      // Which heatmap vis type gets registered is decided at plugin setup, so the browser has to
+      // reload for the charts library setting written above to take effect.
+      await visualize.gotoVisualizationLandingPage({ forceRefresh: true });
       log.debug('navigateToApp visualize');
       await visualize.navigateToNewAggBasedVisualization();
       log.debug('clickHeatmapChart');
@@ -43,7 +50,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('Field = @timestamp');
       await visEditor.selectField('@timestamp');
       // leaving Interval set to Auto
-      await visEditor.clickGo(!isNewChartsLibraryEnabled);
+      await visEditor.clickGo(isLegacyChart);
     });
 
     it('should save and load', async function () {
@@ -90,11 +97,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('should show 4 color ranges as default colorNumbers param', async function () {
       const legends = await visChart.getLegendEntries();
       let expectedLegends = [];
-      if (isNewChartsLibraryEnabled) {
+      if (isLegacyChart) {
+        expectedLegends = ['0 - 400', '400 - 800', '800 - 1,200', '1,200 - 1,600'];
+      } else {
         // the bands are different because we always scale to data bounds in the implementation
         expectedLegends = ['27 - 379.5', '379.5 - 732', '732 - 1,084.5', '1,084.5 - 1,437'];
-      } else {
-        expectedLegends = ['0 - 400', '400 - 800', '800 - 1,200', '1,200 - 1,600'];
       }
       expect(legends).to.eql(expectedLegends);
     });
@@ -102,12 +109,21 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('should show 6 color ranges if changed on options', async function () {
       await visEditor.clickOptionsTab();
       await visEditor.changeHeatmapColorNumbers(6);
-      await visEditor.clickGo(!isNewChartsLibraryEnabled);
+      await visEditor.clickGo(isLegacyChart);
       await visChart.waitForVisualizationRenderingStabilized();
 
       const legends = await visChart.getLegendEntries();
       let expectedLegends = [];
-      if (isNewChartsLibraryEnabled) {
+      if (isLegacyChart) {
+        expectedLegends = [
+          '0 - 267',
+          '267 - 534',
+          '534 - 800',
+          '800 - 1,067',
+          '1,067 - 1,334',
+          '1,334 - 1,600',
+        ];
+      } else {
         // the bands are different because we always scale to data bounds in the implementation
         expectedLegends = [
           '27 - 262',
@@ -116,15 +132,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           '732 - 967',
           '967 - 1,202',
           '1,202 - 1,437',
-        ];
-      } else {
-        expectedLegends = [
-          '0 - 267',
-          '267 - 534',
-          '534 - 800',
-          '800 - 1,067',
-          '1,067 - 1,334',
-          '1,334 - 1,600',
         ];
       }
       expect(legends).to.eql(expectedLegends);
@@ -143,12 +150,23 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('customize 2 last ranges');
       await visEditor.setCustomRangeByIndex(6, '650', '720');
       await visEditor.setCustomRangeByIndex(7, '800', '905');
-      await visEditor.clickGo(!isNewChartsLibraryEnabled);
+      await visEditor.clickGo(isLegacyChart);
 
       await visChart.waitForVisualizationRenderingStabilized();
       const legends = await visChart.getLegendEntries();
       let expectedLegends = [];
-      if (isNewChartsLibraryEnabled) {
+      if (isLegacyChart) {
+        expectedLegends = [
+          '0 - 100',
+          '100 - 200',
+          '200 - 300',
+          '300 - 400',
+          '400 - 500',
+          '500 - 600',
+          '650 - 720',
+          '800 - 905',
+        ];
+      } else {
         expectedLegends = [
           '0 - 100',
           '100 - 200',
@@ -161,19 +179,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           '720 - 800',
           '800 - 905',
         ];
-      } else {
-        expectedLegends = [
-          '0 - 100',
-          '100 - 200',
-          '200 - 300',
-          '300 - 400',
-          '400 - 500',
-          '500 - 600',
-          '650 - 720',
-          '800 - 905',
-        ];
       }
       expect(legends).to.eql(expectedLegends);
     });
   });
+};
+
+export default function (context: FtrProviderContext) {
+  heatmapChartTests(context, { isLegacyChart: true });
 }

--- a/src/platform/test/functional/apps/visualize/group2/index.ts
+++ b/src/platform/test/functional/apps/visualize/group2/index.ts
@@ -22,7 +22,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.uiSettings.update({
         'histogram:maxBars': 100,
-        'visualization:visualize:legacyHeatmapChartsLibrary': true,
       });
       await browser.refresh();
 

--- a/src/platform/test/functional/apps/visualize/replaced_vislib_chart_types_1/_heatmap_chart.ts
+++ b/src/platform/test/functional/apps/visualize/replaced_vislib_chart_types_1/_heatmap_chart.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+import { heatmapChartTests } from '../group2/_heatmap_chart';
+
+// The same suite runs against the legacy vislib heatmap in group2.
+export default function (context: FtrProviderContext) {
+  heatmapChartTests(context, { isLegacyChart: false });
+}

--- a/src/platform/test/functional/apps/visualize/replaced_vislib_chart_types_1/index.ts
+++ b/src/platform/test/functional/apps/visualize/replaced_vislib_chart_types_1/index.ts
@@ -38,7 +38,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./_area_chart'));
     loadTestFile(require.resolve('./_line_chart_split_series'));
     loadTestFile(require.resolve('./_line_chart_split_chart'));
-    loadTestFile(require.resolve('../group8/_pie_chart'));
-    loadTestFile(require.resolve('../group2/_heatmap_chart'));
+    loadTestFile(require.resolve('./_heatmap_chart'));
   });
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/283626

## Summary
- Remove the duplicate pie chart load from `replaced_vislib_chart_types_1` (same path as `group8`; no library flag left).
- Refactor heatmap into a shared suite with an explicit `isLegacyChart` option so `group2` covers legacy and `replaced_vislib_chart_types_1` covers the new library.
- Reload after `initTests` so the heatmap vis type registration picks up the setting.

## Test plan
- [ ] `group2` heatmap passes with legacy library
- [ ] `replaced_vislib_chart_types_1` heatmap passes with new library
- [ ] `group8` pie still runs (unchanged)


Made with [Cursor](https://cursor.com)