### PR TITLE
[Entity Store] Fix stale cascade target assertion in related.user alias resolution test

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/run.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/run.test.ts
@@ -224,7 +224,7 @@ describe('runRelatedUserAliasResolution', () => {
         }),
       })
     );
-    expect(cascadeLinkEntities).toHaveBeenCalledWith('user:ad', ['user:seed@example.com@entra_id']);
+    expect(cascadeLinkEntities).toHaveBeenCalledWith('user:seed@example.com@entra_id', ['user:ad']);
     expect(result.lastRun).toMatchObject({ linksCreated: 1 });
   });
 


### PR DESCRIPTION
## Summary

Fixes a failing Jest test left behind by #280870.

That PR changed `runRelatedUserAliasResolution` so the **seed IDP entity is always the cascade-link target** (instead of namespace-priority selection), and updated the `cascadeLinkEntities` assertions in `run.test.ts` accordingly — but missed one. The `keeps display_name for intentional display-name bridging after dropping fragments` test (added in #280868) still asserted the old candidate-as-target direction:

```
- Expected: cascadeLinkEntities('user:ad', ['user:seed@example.com@entra_id'])
+ Received: cascadeLinkEntities('user:seed@example.com@entra_id', ['user:ad'])
```

This PR flips that single assertion to the seed-as-target direction, matching the implementation and the sibling tests.

### Verification

`node scripts/jest x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/run.test.ts` — 12/12 passing (was 11/12).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios