### PR TITLE
[sigevents] Fallback to empty query object

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/routes/internal/events/route.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/routes/internal/events/route.ts
@@ -114,7 +114,7 @@ const eventsSearchRoute = createServerRoute({
 
     await assertSignificantEventsAccess({ server, licensing });
 
-    const { status, stream, search, severity, ...rest } = params.query;
+    const { status, stream, search, severity, ...rest } = params.query ?? {};
 
     return getEventClient().findLatestByCurrentStatePaginated({
       ...rest,


### PR DESCRIPTION
`GET /internal/significant_events/events` crashes with a 500 when called with no query parameters. The underlying request parameter parser can return `undefined` for empty query objects, causing the destructure in the handler to throw. The fix defaults `params.query` to an empty object.

```
TypeError: Cannot destructure property 'status' of 'params.query' as it is undefined.
    at handler (.../significant-events-plugin/server/routes/internal/events/route.js:101:7)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at wrappedHandler (.../kbn-server-route-repository/src/register_routes.js:62:13)
    at handle (.../kbn-core-http-router-server-internal/src/route.js:165:26)
    at handler (.../kbn-core-http-router-server-internal/src/route.js:56:14)
    at Router.handle (.../kbn-core-http-router-server-internal/src/router.js:134:30)
```

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->