### PR TITLE
[Scout] More lenient configuration for validated ES client instances

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/cli/update_test_config_stats.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/cli/update_test_config_stats.ts
@@ -21,11 +21,12 @@ export const updateTestConfigStats: Command<void> = {
   name: 'update-test-config-stats',
   description: `Fetch latest test config stats from Scout test events and store them locally under ${SCOUT_TEST_CONFIG_STATS_PATH}`,
   flags: {
-    string: ['esURL', 'esAPIKey', 'lookbackDays', 'branch', 'pipelineSlug'],
+    string: ['esURL', 'esAPIKey', 'esMaxRetries', 'lookbackDays', 'branch', 'pipelineSlug'],
     boolean: ['verifyTLSCerts'],
     default: {
       esURL: SCOUT_REPORTER_ES_URL,
       esAPIKey: SCOUT_REPORTER_ES_API_KEY,
+      esMaxRetries: '2',
       verifyTLSCerts: SCOUT_REPORTER_ES_VERIFY_CERTS,
       lookbackDays: '1',
       pipelineSlug: 'kibana-pull-request',
@@ -33,6 +34,7 @@ export const updateTestConfigStats: Command<void> = {
     help: `
     --esURL           (required)  Elasticsearch URL [env: SCOUT_REPORTER_ES_URL]
     --esAPIKey        (required)  Elasticsearch API Key [env: SCOUT_REPORTER_ES_API_KEY]
+    --esMaxRetries    (optional)  How many times should Elasticsearch API requests be retried (default: 2)
     --verifyTLSCerts  (optional)  Verify TLS certificates [env: SCOUT_REPORTER_ES_VERIFY_CERTS]
     --lookbackDays    (optional)  How many days to look back when aggregating stats (default: 1)
     --branch          (optional)  Only look at events from a particular branch
@@ -52,6 +54,7 @@ export const updateTestConfigStats: Command<void> = {
         tls: {
           rejectUnauthorized: flagsReader.boolean('verifyTLSCerts'),
         },
+        maxRetries: flagsReader.requiredNumber('esMaxRetries'),
       },
       { log, cli: true }
     );

--- a/src/platform/packages/private/kbn-scout-reporting/src/helpers/elasticsearch.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/helpers/elasticsearch.ts
@@ -31,7 +31,7 @@ export async function getValidatedESClient(
   const { log, cli = false } = helperSettings;
   const es = new ESClient({
     Connection: HttpConnection,
-    requestTimeout: 30_000,
+    requestTimeout: 60_000,
     ...esClientOptions,
   });
 


### PR DESCRIPTION
## Summary

The goal is to reduce the count of occurences where CI stumbles in timeouts caused by slow remote ES instances. For Scout, this usually happens when shared environments are experiencing high traffic.

The validated ES client helper will now apply a `60s` default request timeout instead of `30s`. Also, the Scout CLI for updating test config stats will retry unsuccessful ES requests a couple of times. 

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->