### PR TITLE
[9.5] [sigevents] Fallback to empty query object (#283638)

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/routes/internal/events/route.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/routes/internal/events/route.ts
@@ -79,7 +79,7 @@ const eventsSearchRoute = createServerRoute({
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
-    const { status, stream, search, ...rest } = params.query;
+    const { status, stream, search, ...rest } = params.query ?? {};
 
     return getEventClient().findLatestPaginated({
       ...rest,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[sigevents] Fallback to empty query object (#283638)](https://github.com/elastic/kibana/pull/283638)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Lacabane","email":"kevin.lacabane@elastic.co"},"sourceCommit":{"committedDate":"2026-08-07T12:00:38Z","message":"[sigevents] Fallback to empty query object (#283638)\n\n`GET /internal/significant_events/events` crashes with a 500 when called\nwith no query parameters. The underlying request parameter parser can\nreturn `undefined` for empty query objects, causing the destructure in\nthe handler to throw. The fix defaults `params.query` to an empty\nobject.\n\n```\nTypeError: Cannot destructure property 'status' of 'params.query' as it is undefined.\n    at handler (.../significant-events-plugin/server/routes/internal/events/route.js:101:7)\n    at processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at wrappedHandler (.../kbn-server-route-repository/src/register_routes.js:62:13)\n    at handle (.../kbn-core-http-router-server-internal/src/route.js:165:26)\n    at handler (.../kbn-core-http-router-server-internal/src/route.js:56:14)\n    at Router.handle (.../kbn-core-http-router-server-internal/src/router.js:134:30)\n```","sha":"e0fd5082df058ed35957d76dbd266a1d02987c87","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Feature:SigEvents","Team:SigEvents","v9.5.0","v9.6.0"],"title":"[sigevents] Fallback to empty query object","number":283638,"url":"https://github.com/elastic/kibana/pull/283638","mergeCommit":{"message":"[sigevents] Fallback to empty query object (#283638)\n\n`GET /internal/significant_events/events` crashes with a 500 when called\nwith no query parameters. The underlying request parameter parser can\nreturn `undefined` for empty query objects, causing the destructure in\nthe handler to throw. The fix defaults `params.query` to an empty\nobject.\n\n```\nTypeError: Cannot destructure property 'status' of 'params.query' as it is undefined.\n    at handler (.../significant-events-plugin/server/routes/internal/events/route.js:101:7)\n    at processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at wrappedHandler (.../kbn-server-route-repository/src/register_routes.js:62:13)\n    at handle (.../kbn-core-http-router-server-internal/src/route.js:165:26)\n    at handler (.../kbn-core-http-router-server-internal/src/route.js:56:14)\n    at Router.handle (.../kbn-core-http-router-server-internal/src/router.js:134:30)\n```","sha":"e0fd5082df058ed35957d76dbd266a1d02987c87"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283638","number":283638,"mergeCommit":{"message":"[sigevents] Fallback to empty query object (#283638)\n\n`GET /internal/significant_events/events` crashes with a 500 when called\nwith no query parameters. The underlying request parameter parser can\nreturn `undefined` for empty query objects, causing the destructure in\nthe handler to throw. The fix defaults `params.query` to an empty\nobject.\n\n```\nTypeError: Cannot destructure property 'status' of 'params.query' as it is undefined.\n    at handler (.../significant-events-plugin/server/routes/internal/events/route.js:101:7)\n    at processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at wrappedHandler (.../kbn-server-route-repository/src/register_routes.js:62:13)\n    at handle (.../kbn-core-http-router-server-internal/src/route.js:165:26)\n    at handler (.../kbn-core-http-router-server-internal/src/route.js:56:14)\n    at Router.handle (.../kbn-core-http-router-server-internal/src/router.js:134:30)\n```","sha":"e0fd5082df058ed35957d76dbd266a1d02987c87"}}]}] BACKPORT-->