### PR TITLE
[cli] Make plugin downloader tests hermetic to proxy env vars

### DIFF
--- a/src/cli/plugin/install/download.test.js
+++ b/src/cli/plugin/install/download.test.js
@@ -33,6 +33,28 @@ describe('kibana cli', function () {
     };
     const logger = new Logger(settings);
 
+    // The downloader resolves proxies with `proxy-from-env`, which reads every
+    // `*_proxy` variable in either case (`http_proxy`, `HTTPS_PROXY`,
+    // `npm_config_proxy`, `all_proxy`, `no_proxy`, ...). An ambient proxy in the
+    // environment therefore both reroutes the request and adds a "Picked up proxy
+    // ... from environment variable." log line, which shifts the positional
+    // `logger.log` assertions below. Scrub them for the whole suite so the tests
+    // depend only on what they set themselves.
+    const originalProxyEnv = {};
+
+    beforeAll(function () {
+      for (const key of Object.keys(process.env)) {
+        if (/_proxy$/i.test(key)) {
+          originalProxyEnv[key] = process.env[key];
+          delete process.env[key];
+        }
+      }
+    });
+
+    afterAll(function () {
+      Object.assign(process.env, originalProxyEnv);
+    });
+
     function expectWorkingPathEmpty() {
       const files = globby.sync('**/*', { cwd: testWorkingPath, onlyFiles: false });
       expect(files).toEqual([]);


### PR DESCRIPTION
`src/cli/plugin/install/downloaders/http.js` resolves proxies with `proxy-from-env` and logs "Picked up proxy ... from environment variable." whenever one is found. `proxy-from-env` reads every `*_proxy` variable in both lower and upper case, so an ambient `HTTP_PROXY` on the machine running the tests prepends an extra `logger.log` call and shifts the positional assertions in the `download` block, failing:

  ● kibana cli › plugin downloader › download › should loop through bad urls
    Expected pattern: /badfile2.tar.gz/
    Received string:  "Picked up proxy ... from environment variable."

The existing cleanup only deleted the lowercase names, and only inside the nested `proxy support` block, so it never protected the rest of the suite.

Snapshot and clear every `*_proxy` variable for the whole suite, restoring them afterwards, so the tests depend only on what they set themselves.

Surfaced by a CI experiment that routes agent egress through a proxy, where `HTTP_PROXY` is set for the whole job.

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->