### PR TITLE
Assign ownership of @kbn/bench and @kbn/workspaces to Kibana core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -535,7 +535,7 @@ src/platform/packages/shared/kbn-apm-utils @elastic/obs-signals-traces-team
 src/platform/packages/shared/kbn-avc-banner @elastic/security-defend-workflows
 src/platform/packages/shared/kbn-axe-config @elastic/appex-qa
 src/platform/packages/shared/kbn-background-search @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-bench @elastic/observability-ui
+src/platform/packages/shared/kbn-bench @elastic/kibana-core
 src/platform/packages/shared/kbn-cache-cli @elastic/kibana-operations
 src/platform/packages/shared/kbn-calculate-auto @elastic/actionable-obs-team
 src/platform/packages/shared/kbn-calculate-width-from-char-count @elastic/kibana-visualizations
@@ -748,7 +748,7 @@ src/platform/packages/shared/kbn-workflows @elastic/workflows-eng
 src/platform/packages/shared/kbn-workflows-library @elastic/workflows-eng
 src/platform/packages/shared/kbn-workflows-ui @elastic/workflows-eng
 src/platform/packages/shared/kbn-workflows-yaml @elastic/workflows-eng
-src/platform/packages/shared/kbn-workspaces @elastic/observability-ui
+src/platform/packages/shared/kbn-workspaces @elastic/kibana-core
 src/platform/packages/shared/kbn-xstate-utils @elastic/streams-ui
 src/platform/packages/shared/kbn-yaml-loader @elastic/fleet
 src/platform/packages/shared/kbn-zod @elastic/kibana-core

--- a/src/platform/packages/shared/kbn-bench/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-bench/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/bench",
-  "owner": "@elastic/observability-ui",
+  "owner": "@elastic/kibana-core",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-bench/moon.yml
+++ b/src/platform/packages/shared/kbn-bench/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/bench'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/observability-ui'
+  defaultOwner: '@elastic/kibana-core'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/bench'
   description: Moon project for @kbn/bench
   channel: ''
-  owner: '@elastic/observability-ui'
+  owner: '@elastic/kibana-core'
   sourceRoot: src/platform/packages/shared/kbn-bench
 dependsOn:
   - '@kbn/repo-info'

--- a/src/platform/packages/shared/kbn-workspaces/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-workspaces/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/workspaces",
-  "owner": "@elastic/observability-ui",
+  "owner": "@elastic/kibana-core",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-workspaces/moon.yml
+++ b/src/platform/packages/shared/kbn-workspaces/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/workspaces'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/observability-ui'
+  defaultOwner: '@elastic/kibana-core'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/workspaces'
   description: Moon project for @kbn/workspaces
   channel: ''
-  owner: '@elastic/observability-ui'
+  owner: '@elastic/kibana-core'
   sourceRoot: src/platform/packages/shared/kbn-workspaces
 dependsOn:
   - '@kbn/repo-info'


### PR DESCRIPTION
As discussed with @jloleysens, these packages were initially created by observability but are now primarily used by core.