### PR TITLE
[Context Engine] POC: verify KIs at creation via context-engine.verifyKi workflow step

### DIFF
--- a/x-pack/platform/plugins/shared/context_engine/common/step_types/verify_ki_step.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/step_types/verify_ki_step.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { StepCategory } from '@kbn/workflows';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { z } from '@kbn/zod/v4';
+
+/**
+ * Step type ID for the verify knowledge item (KI) workflow step.
+ */
+export const VerifyKiStepTypeId = 'context-engine.verifyKi';
+
+const MAX_KI_KEYWORD_LENGTH = 1024;
+const MAX_KI_DESCRIPTION_LENGTH = 10_000;
+const MAX_KI_CONTENT_LENGTH = 100_000;
+const MAX_KI_TAGS = 100;
+
+const VerifyKiInputSchema = z.object({
+  ki: z
+    .looseObject({
+      type: z.string().max(MAX_KI_KEYWORD_LENGTH).optional().describe('The knowledge item type.'),
+      title: z.string().max(MAX_KI_KEYWORD_LENGTH).optional().describe('The knowledge item title.'),
+      description: z
+        .string()
+        .max(MAX_KI_DESCRIPTION_LENGTH)
+        .optional()
+        .describe('The knowledge item description.'),
+      content: z
+        .string()
+        .max(MAX_KI_CONTENT_LENGTH)
+        .optional()
+        .describe(
+          'The knowledge item content. Fenced ```esql code blocks are extracted and verified.'
+        ),
+      tags: z
+        .array(z.string().max(MAX_KI_KEYWORD_LENGTH))
+        .max(MAX_KI_TAGS)
+        .optional()
+        .describe('Tags associated with the knowledge item.'),
+      attributes: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe(
+          'Additional knowledge item attributes. An `esql` attribute is extracted and verified.'
+        ),
+    })
+    .describe('The candidate knowledge item (KI) document to verify.'),
+});
+
+const VerifyKiOutputSchema = z.object({
+  valid: z.boolean().describe('`true` when no verifier reported the knowledge item as invalid.'),
+  results: z
+    .array(
+      z.object({
+        verifier: z.string().describe('Id of the verifier that produced this result.'),
+        status: z
+          .enum(['valid', 'invalid', 'skipped'])
+          .describe(
+            '`valid` when all checks passed, `invalid` when at least one check failed, `skipped` when the verifier does not apply.'
+          ),
+        messages: z.array(z.string()).describe('Details about the verification outcome.'),
+      })
+    )
+    .describe('Per-verifier verification results.'),
+});
+
+export type VerifyKiInput = z.infer<typeof VerifyKiInputSchema>;
+export type VerifyKiOutput = z.infer<typeof VerifyKiOutputSchema>;
+
+/**
+ * Common step definition for the verify KI step, shared between the server
+ * handler and the public (editor) definition.
+ */
+export const verifyKiStepCommonDefinition: CommonStepDefinition<
+  typeof VerifyKiInputSchema,
+  typeof VerifyKiOutputSchema
+> = {
+  id: VerifyKiStepTypeId,
+  category: StepCategory.Elasticsearch,
+  label: i18n.translate('xpack.contextEngine.verifyKiStep.label', {
+    defaultMessage: 'Verify Knowledge Item',
+  }),
+  description: i18n.translate('xpack.contextEngine.verifyKiStep.description', {
+    defaultMessage: 'Verify a candidate knowledge item (KI) before it is persisted to an AI index.',
+  }),
+  documentation: {
+    details: i18n.translate('xpack.contextEngine.verifyKiStep.documentation.details', {
+      defaultMessage:
+        'Runs the registered knowledge item verifiers against a candidate KI and reports whether it is valid. The ES|QL verifier extracts ES|QL queries from fenced code blocks in the KI content and from the `esql` attribute, validates that they parse, and confirms they execute successfully. Use the `valid` output to gate whether the KI is persisted to an AI index.',
+    }),
+    examples: [
+      `## Verify a KI before indexing it
+\`\`\`yaml
+- name: verify_ki
+  type: ${VerifyKiStepTypeId}
+  with:
+    ki:
+      type: access_pattern
+      title: "Find slow requests"
+      content: |
+        Use this query to find slow requests:
+        \`\`\`esql
+        FROM logs-* | WHERE duration > 1000 | LIMIT 100
+        \`\`\`
+\`\`\``,
+    ],
+  },
+  inputSchema: VerifyKiInputSchema,
+  outputSchema: VerifyKiOutputSchema,
+};

--- a/x-pack/platform/plugins/shared/context_engine/common/step_types/verify_ki_step.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/step_types/verify_ki_step.ts
@@ -53,15 +53,19 @@ const VerifyKiInputSchema = z.object({
 });
 
 const VerifyKiOutputSchema = z.object({
-  valid: z.boolean().describe('`true` when no verifier reported the knowledge item as invalid.'),
+  verdict: z
+    .enum(['valid', 'invalid', 'indeterminate'])
+    .describe(
+      '`invalid` when any verifier reported the knowledge item as invalid, `indeterminate` when no verifier reported invalid but at least one could not complete its check, `valid` otherwise.'
+    ),
   results: z
     .array(
       z.object({
         verifier: z.string().describe('Id of the verifier that produced this result.'),
         status: z
-          .enum(['valid', 'invalid', 'skipped'])
+          .enum(['valid', 'invalid', 'skipped', 'error'])
           .describe(
-            '`valid` when all checks passed, `invalid` when at least one check failed, `skipped` when the verifier does not apply.'
+            '`valid` when all checks passed, `invalid` when at least one check failed, `skipped` when the verifier does not apply, `error` when the verifier could not complete its check.'
           ),
         messages: z.array(z.string()).describe('Details about the verification outcome.'),
       })
@@ -91,7 +95,7 @@ export const verifyKiStepCommonDefinition: CommonStepDefinition<
   documentation: {
     details: i18n.translate('xpack.contextEngine.verifyKiStep.documentation.details', {
       defaultMessage:
-        'Runs the registered knowledge item verifiers against a candidate KI and reports whether it is valid. The ES|QL verifier extracts ES|QL queries from fenced code blocks in the KI content and from the `esql` attribute, validates that they parse, and confirms they execute successfully. Use the `valid` output to gate whether the KI is persisted to an AI index.',
+        'Runs the registered knowledge item verifiers against a candidate KI and reports a verdict. The ES|QL verifier extracts ES|QL queries from fenced code blocks in the KI content and from the `esql` attribute, validates that they parse, and confirms they execute successfully. Use the `verdict` output to gate whether the KI is persisted to an AI index; `indeterminate` means verification could not be completed and is not a judgment on the KI.',
     }),
     examples: [
       `## Verify a KI before indexing it

--- a/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
+++ b/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
@@ -33,7 +33,8 @@ consts:
   sourceIndex: poc-national-parks
   aiIndexBackingIndex: ai-index-idx-poc-verified-kis
   candidateKis:
-    - type: access_pattern
+    - id: find-canyon-parks
+      type: access_pattern
       title: Find canyon parks
       description: How to find parks in the canyon category
       tags: ['poc']
@@ -42,7 +43,8 @@ consts:
         ```esql
         FROM poc-national-parks | WHERE category == "canyon" | LIMIT 10
         ```
-    - type: access_pattern
+    - id: broken-access-pattern
+      type: access_pattern
       title: Broken access pattern
       description: This KI contains ES|QL that does not parse
       tags: ['poc']
@@ -58,11 +60,15 @@ steps:
     type: elasticsearch.bulk
     with:
       index: '{{ consts.sourceIndex }}'
+      # Explicit _ids keep the seed idempotent across workflow runs.
       operations:
+        - index: { _id: grand-canyon }
         - name: 'Grand Canyon National Park'
           category: 'canyon'
+        - index: { _id: zion }
         - name: 'Zion National Park'
           category: 'canyon'
+        - index: { _id: yosemite }
         - name: 'Yosemite National Park'
           category: 'mountain'
   - name: process_candidates
@@ -81,6 +87,8 @@ steps:
             type: elasticsearch.index
             with:
               index: '{{ consts.aiIndexBackingIndex }}'
+              # Explicit id keeps persistence idempotent across workflow runs.
+              id: '{{ foreach.item.id }}'
               # document must be a YAML object with templates only at the leaves:
               # the step's `with` schema is a union, and the workflow validator
               # cannot suppress a whole-object template (`${{ }}`) inside a union.
@@ -117,7 +125,7 @@ The same `context-engine.verifyKi` step composes into a standalone sweep workflo
 A KI that was valid at creation can fail later for external reasons. To demo that, first break one: delete the source index the "Find canyon parks" KI queries (or index a KI with bad ES|QL directly, simulating an out-of-workflow write):
 
 ```
-POST ai-index-idx-poc-verified-kis/_doc?refresh=true
+PUT ai-index-idx-poc-verified-kis/_doc/externally-added-broken?refresh=true
 {
   "type": "access_pattern",
   "title": "Externally added, broken",

--- a/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
+++ b/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
@@ -110,9 +110,97 @@ GET ai-index-idx-poc-verified-kis/_search
 
 Only the "Find canyon parks" KI is present. The workflow execution log shows the rejected KI with the parse errors from the ES|QL verifier.
 
+## Part 2: Re-verify existing KIs and hard-delete failures (human in the loop)
+
+The same `context-engine.verifyKi` step composes into a standalone sweep workflow that re-verifies KIs already in the AI index and hard-deletes the ones that no longer pass — with a `waitForApproval` gate before every delete. This covers the on-demand re-trigger and externally-added-KI sweep cases from the verification automation epic, and the hard-delete recommendation (with human in the loop) from the exclusion epic.
+
+A KI that was valid at creation can fail later for external reasons. To demo that, first break one: delete the source index the "Find canyon parks" KI queries (or index a KI with bad ES|QL directly, simulating an out-of-workflow write):
+
+```
+POST ai-index-idx-poc-verified-kis/_doc?refresh=true
+{
+  "type": "access_pattern",
+  "title": "Externally added, broken",
+  "content": "```esql\nFROM poc-national-parks | WHERE | LIMIT\n```",
+  "tags": ["poc"]
+}
+```
+
+Then create and run:
+
+```yaml
+version: '1'
+name: POC - Re-verify existing KIs
+description: |
+  Sweeps an AI index backing index, re-verifies each KI with
+  context-engine.verifyKi, and hard-deletes failures after human approval.
+enabled: true
+tags: ['poc', 'context-engine']
+consts:
+  aiIndexBackingIndex: ai-index-idx-poc-verified-kis
+triggers:
+  - type: manual # use a scheduled trigger for a recurring sweep
+steps:
+  - name: fetch_kis
+    type: elasticsearch.search
+    with:
+      index: '{{ consts.aiIndexBackingIndex }}'
+      size: 100
+      query:
+        match_all: {}
+  - name: reverify_kis
+    type: foreach
+    foreach: '${{ steps.fetch_kis.output.hits.hits }}'
+    steps:
+      - name: verify_ki
+        type: context-engine.verifyKi
+        with:
+          ki: '${{ foreach.item._source }}'
+      - name: gate_ki
+        type: if
+        condition: 'steps.verify_ki.output.valid : false'
+        steps:
+          - name: request_delete_approval
+            type: waitForApproval
+            timeout: 24h
+            with:
+              message: |-
+                KI "{{ foreach.item._source.title }}" ({{ foreach.item._id }}) failed re-verification: {{ steps.verify_ki.output.results | json: 2 }}. Approve hard delete?
+              approveLabel: Delete KI
+              rejectLabel: Keep KI
+          - name: gate_delete
+            type: if
+            condition: 'steps.request_delete_approval.output.response.approved : true'
+            steps:
+              - name: delete_ki
+                type: elasticsearch.bulk
+                with:
+                  index: '{{ consts.aiIndexBackingIndex }}'
+                  operations:
+                    - delete:
+                        _id: '{{ foreach.item._id }}'
+              - name: log_deleted
+                type: console
+                with:
+                  message: 'KI "{{ foreach.item._source.title }}" hard-deleted (approved by {{ steps.request_delete_approval.output.respondedBy }})'
+            else:
+              - name: log_kept
+                type: console
+                with:
+                  message: 'KI "{{ foreach.item._source.title }}" failed re-verification but deletion was rejected'
+```
+
+The run pauses at `request_delete_approval` for each failing KI; approve or reject from the workflow execution view. After approving, the broken KI is gone from the index and the valid one is untouched.
+
+Caveats for anything past a POC:
+
+- The ES|QL verifier fails a KI on *execution* errors too, which can be transient (source index temporarily missing, permissions). Parse errors are strong delete signals; execution errors are weaker. Before automating deletes without HITL, the verifier result should distinguish the two so the delete gate can be stricter.
+- `elasticsearch.search` is capped at `size` here; a real sweep needs pagination.
+- `waitForApproval` is tech preview.
+
 ## Notes / follow-ups
 
 - The step is opt-in per workflow, matching the M2 scope ("initially we want to verify before persisting, opt in").
 - The verifier framework is the extension point: additional verifiers (groundedness, entailment, TTL) register through `KiVerifierRegistry` without changes to the step.
 - The step definition approval file (`workflows_extensions` Scout gate) is intentionally not included in this POC branch; it is required before merging.
-- On-demand re-verification, sweeps for externally added KIs, and stale handling are out of scope for this POC.
+- Stale handling (criteria and TTLs) is out of scope for this POC; the Part 2 sweep is the mechanism it would plug into.

--- a/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
+++ b/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
@@ -81,7 +81,7 @@ steps:
             type: elasticsearch.index
             with:
               index: '{{ consts.aiIndexBackingIndex }}'
-              body: '${{ foreach.item }}'
+              document: '${{ foreach.item }}'
           - name: log_persisted
             type: console
             with:

--- a/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
+++ b/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
@@ -1,0 +1,110 @@
+# POC: Verify KIs at creation
+
+This POC demonstrates the M2 "verify before persist" requirement for the KI Schema, Lifecycle & Verification workstream ([workstream](https://github.com/elastic/search-team/issues/15526), [verification framework](https://github.com/elastic/search-team/issues/15640), [verification automation](https://github.com/elastic/search-team/issues/15641)).
+
+Candidate knowledge items (KIs) are verified by the `context-engine.verifyKi` workflow step before they are persisted to an AI index. KIs that fail verification are never written.
+
+## What's included
+
+- **Verification framework** (`server/ki_verification/`) — a `KiVerifierRegistry` to register verifiers, a `KiVerificationService` that applies them to a candidate KI, and the first verifier:
+  - **ES|QL verifier** — extracts ES|QL from fenced ` ```esql ` blocks in the KI `content` and from the `esql` attribute, validates that each query parses (`validateQuery` from `@kbn/esql-language`, no round-trip), then confirms it executes (`<query> | LIMIT 0` must return 200, even with empty results).
+- **`context-engine.verifyKi` workflow step** — runs the verifiers against a candidate KI and outputs `{ valid, results }`. Verification failures are step *output*, not step errors, so workflows can branch on `valid`.
+
+No verification metadata is written to the KI record, and no retrieval-side changes are needed: with verify-before-persist, everything in the AI index passed verification by construction.
+
+## Demo
+
+1. Start ES and Kibana from this branch.
+2. Enable the feature gates in Stack Management → Advanced Settings: `contextEngine:enabled` (and ensure Workflows is available).
+3. Create the workflow below (Management → Workflows → Create), then run it manually.
+
+The workflow seeds a small source index, then processes two candidate KIs: one whose ES|QL is valid, and one whose ES|QL does not parse. Only the valid one lands in `ai-index-idx-poc-verified-kis`.
+
+```yaml
+version: '1'
+name: POC - Verify KIs at creation
+description: |
+  Verifies candidate knowledge items with context-engine.verifyKi before
+  persisting them to an AI index backing index. Candidates that fail
+  verification are rejected and logged, not persisted.
+enabled: true
+tags: ['poc', 'context-engine']
+consts:
+  sourceIndex: poc-national-parks
+  aiIndexBackingIndex: ai-index-idx-poc-verified-kis
+  candidateKis:
+    - type: access_pattern
+      title: Find canyon parks
+      description: How to find parks in the canyon category
+      tags: ['poc']
+      content: |
+        To list canyon parks, run:
+        ```esql
+        FROM poc-national-parks | WHERE category == "canyon" | LIMIT 10
+        ```
+    - type: access_pattern
+      title: Broken access pattern
+      description: This KI contains ES|QL that does not parse
+      tags: ['poc']
+      content: |
+        This query is broken:
+        ```esql
+        FROM poc-national-parks | WHERE | LIMIT
+        ```
+triggers:
+  - type: manual
+steps:
+  - name: create_source_data
+    type: elasticsearch.bulk
+    with:
+      index: '{{ consts.sourceIndex }}'
+      operations:
+        - name: 'Grand Canyon National Park'
+          category: 'canyon'
+        - name: 'Zion National Park'
+          category: 'canyon'
+        - name: 'Yosemite National Park'
+          category: 'mountain'
+  - name: process_candidates
+    type: foreach
+    foreach: '${{ consts.candidateKis }}'
+    steps:
+      - name: verify_ki
+        type: context-engine.verifyKi
+        with:
+          ki: '${{ foreach.item }}'
+      - name: gate_ki
+        type: if
+        condition: 'steps.verify_ki.output.valid : true'
+        steps:
+          - name: persist_ki
+            type: elasticsearch.index
+            with:
+              index: '{{ consts.aiIndexBackingIndex }}'
+              body: '${{ foreach.item }}'
+          - name: log_persisted
+            type: console
+            with:
+              message: 'KI "{{ foreach.item.title }}" verified and persisted to {{ consts.aiIndexBackingIndex }}'
+        else:
+          - name: log_rejected
+            type: console
+            with:
+              message: |-
+                KI "{{ foreach.item.title }}" failed verification and was NOT persisted: {{ steps.verify_ki.output.results | json: 2 }}
+```
+
+4. Verify the outcome:
+
+```
+GET ai-index-idx-poc-verified-kis/_search
+```
+
+Only the "Find canyon parks" KI is present. The workflow execution log shows the rejected KI with the parse errors from the ES|QL verifier.
+
+## Notes / follow-ups
+
+- The step is opt-in per workflow, matching the M2 scope ("initially we want to verify before persisting, opt in").
+- The verifier framework is the extension point: additional verifiers (groundedness, entailment, TTL) register through `KiVerifierRegistry` without changes to the step.
+- The step definition approval file (`workflows_extensions` Scout gate) is intentionally not included in this POC branch; it is required before merging.
+- On-demand re-verification, sweeps for externally added KIs, and stale handling are out of scope for this POC.

--- a/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
+++ b/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
@@ -8,7 +8,7 @@ Candidate knowledge items (KIs) are verified by the `context-engine.verifyKi` wo
 
 - **Verification framework** (`server/ki_verification/`) — a `KiVerifierRegistry` to register verifiers, a `KiVerificationService` that applies them to a candidate KI, and the first verifier:
   - **ES|QL verifier** — extracts ES|QL from fenced ` ```esql ` blocks in the KI `content` and from the `esql` attribute, validates that each query parses (`validateQuery` from `@kbn/esql-language`, no round-trip), then confirms it executes (`<query> | LIMIT 0` must return 200, even with empty results).
-- **`context-engine.verifyKi` workflow step** — runs the verifiers against a candidate KI and outputs `{ valid, results }`. Verification failures are step *output*, not step errors, so workflows can branch on `valid`.
+- **`context-engine.verifyKi` workflow step** — runs the verifiers against a candidate KI and outputs `{ verdict, results }`. The verdict is `valid`, `invalid`, or `indeterminate` (no verifier reported invalid, but at least one could not complete its check — e.g. auth failures or timeouts — so no judgment on the KI). Verification failures are step *output*, not step errors, so workflows can branch on `verdict`.
 
 No verification metadata is written to the KI record, and no retrieval-side changes are needed: with verify-before-persist, everything in the AI index passed verification by construction.
 
@@ -75,7 +75,7 @@ steps:
           ki: '${{ foreach.item }}'
       - name: gate_ki
         type: if
-        condition: 'steps.verify_ki.output.valid : true'
+        condition: 'steps.verify_ki.output.verdict : "valid"'
         steps:
           - name: persist_ki
             type: elasticsearch.index
@@ -158,7 +158,7 @@ steps:
           ki: '${{ foreach.item._source }}'
       - name: gate_ki
         type: if
-        condition: 'steps.verify_ki.output.valid : false'
+        condition: 'steps.verify_ki.output.verdict : "invalid"'
         steps:
           - name: request_delete_approval
             type: waitForApproval
@@ -192,9 +192,10 @@ steps:
 
 The run pauses at `request_delete_approval` for each failing KI; approve or reject from the workflow execution view. After approving, the broken KI is gone from the index and the valid one is untouched.
 
+The delete gate only fires on an `invalid` verdict. When verification cannot be completed (the runner lacks permissions, Elasticsearch is unavailable, a timeout), the verdict is `indeterminate` and the KI is left alone — deletion never triggers on a failure to verify. A real sweep would add an `indeterminate` branch that logs or alerts.
+
 Caveats for anything past a POC:
 
-- The ES|QL verifier fails a KI on *execution* errors too, which can be transient (source index temporarily missing, permissions). Parse errors are strong delete signals; execution errors are weaker. Before automating deletes without HITL, the verifier result should distinguish the two so the delete gate can be stricter.
 - `elasticsearch.search` is capped at `size` here; a real sweep needs pagination.
 - `waitForApproval` is tech preview.
 

--- a/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
+++ b/x-pack/platform/plugins/shared/context_engine/dev_docs/verify_ki_poc.md
@@ -81,7 +81,15 @@ steps:
             type: elasticsearch.index
             with:
               index: '{{ consts.aiIndexBackingIndex }}'
-              document: '${{ foreach.item }}'
+              # document must be a YAML object with templates only at the leaves:
+              # the step's `with` schema is a union, and the workflow validator
+              # cannot suppress a whole-object template (`${{ }}`) inside a union.
+              document:
+                type: '{{ foreach.item.type }}'
+                title: '{{ foreach.item.title }}'
+                description: '{{ foreach.item.description }}'
+                content: '{{ foreach.item.content }}'
+                tags: '${{ foreach.item.tags }}'
           - name: log_persisted
             type: console
             with:

--- a/x-pack/platform/plugins/shared/context_engine/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/context_engine/kibana.jsonc
@@ -8,7 +8,14 @@
     "id": "contextEngine",
     "server": true,
     "browser": true,
-    "requiredPlugins": ["actions", "features", "share", "esql", "triggersActionsUi"],
+    "requiredPlugins": [
+      "actions",
+      "features",
+      "share",
+      "esql",
+      "triggersActionsUi",
+      "workflowsExtensions"
+    ],
     "optionalPlugins": ["console", "workflowsManagement"],
     "requiredBundles": ["kibanaReact", "actions"]
   }

--- a/x-pack/platform/plugins/shared/context_engine/public/eui_icons.d.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/eui_icons.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+declare module '@elastic/eui/es/components/icon/assets/*' {
+  import type * as React from 'react';
+
+  interface SVGRProps {
+    title?: string;
+    titleId?: string;
+  }
+  export const icon: ({
+    title,
+    titleId,
+    ...props
+  }: React.SVGProps<SVGSVGElement> & SVGRProps) => React.JSX.Element;
+  export {};
+}

--- a/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
@@ -20,6 +20,7 @@ import { i18n } from '@kbn/i18n';
 import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
 import { from, map, switchMap } from 'rxjs';
 import { CONTEXT_ENGINE_APP_ID, CONTEXT_ENGINE_APP_PATH } from '../common/features';
+import { registerWorkflowSteps } from './step_types';
 import type {
   ContextEnginePluginSetup,
   ContextEnginePluginStart,
@@ -48,8 +49,13 @@ export class ContextEnginePlugin
 {
   constructor(_context: PluginInitializerContext) {}
 
-  setup(core: CoreSetup<ContextEngineStartDependencies>): ContextEnginePluginSetup {
+  setup(
+    core: CoreSetup<ContextEngineStartDependencies>,
+    setupDeps: ContextEngineSetupDependencies
+  ): ContextEnginePluginSetup {
     const startServices = core.getStartServices();
+
+    registerWorkflowSteps(setupDeps.workflowsExtensions);
 
     core.application.register({
       id: CONTEXT_ENGINE_APP_ID,

--- a/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
@@ -55,7 +55,13 @@ export class ContextEnginePlugin
   ): ContextEnginePluginSetup {
     const startServices = core.getStartServices();
 
-    registerWorkflowSteps(setupDeps.workflowsExtensions);
+    registerWorkflowSteps({
+      workflowsExtensions: setupDeps.workflowsExtensions,
+      getCoreStart: async () => {
+        const [coreStart] = await startServices;
+        return coreStart;
+      },
+    });
 
     core.application.register({
       id: CONTEXT_ENGINE_APP_ID,

--- a/x-pack/platform/plugins/shared/context_engine/public/step_types/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/step_types/index.ts
@@ -5,12 +5,22 @@
  * 2.0.
  */
 
+import type { CoreStart } from '@kbn/core/public';
+import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
 import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 
-export function registerWorkflowSteps(
-  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup
-): void {
-  workflowsExtensions.registerStepDefinition(() =>
-    import('./verify_ki_step').then((m) => m.verifyKiStepDefinition)
-  );
+export function registerWorkflowSteps({
+  workflowsExtensions,
+  getCoreStart,
+}: {
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup;
+  getCoreStart: () => Promise<CoreStart>;
+}): void {
+  workflowsExtensions.registerStepDefinition(async () => {
+    const coreStart = await getCoreStart();
+    if (!coreStart.uiSettings.get<boolean>(CONTEXT_ENGINE_ENABLED_SETTING_ID, false)) {
+      return undefined;
+    }
+    return import('./verify_ki_step').then((m) => m.verifyKiStepDefinition);
+  });
 }

--- a/x-pack/platform/plugins/shared/context_engine/public/step_types/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/step_types/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+
+export function registerWorkflowSteps(
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup
+): void {
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./verify_ki_step').then((m) => m.verifyKiStepDefinition)
+  );
+}

--- a/x-pack/platform/plugins/shared/context_engine/public/step_types/verify_ki_step.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/step_types/verify_ki_step.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { verifyKiStepCommonDefinition } from '../../common/step_types/verify_ki_step';
+
+export const verifyKiStepDefinition = createPublicStepDefinition({
+  ...verifyKiStepCommonDefinition,
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/check_circle').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+});

--- a/x-pack/platform/plugins/shared/context_engine/public/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/types.ts
@@ -8,6 +8,7 @@
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ContextEnginePluginSetup {}
@@ -15,8 +16,9 @@ export interface ContextEnginePluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ContextEnginePluginStart {}
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ContextEngineSetupDependencies {}
+export interface ContextEngineSetupDependencies {
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup;
+}
 
 export interface ContextEngineStartDependencies {
   share: SharePluginStart;

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { KiVerifierRegistry } from './registry';
+import { KiVerificationService } from './service';
+import { createEsqlVerifier } from './verifiers/esql_verifier';
+
+export type {
+  KnowledgeItemCandidate,
+  KiVerifierStatus,
+  KiVerifierResult,
+  KiVerifierContext,
+  KiVerificationLogger,
+  KiVerifier,
+  KiVerificationSummary,
+} from './types';
+export { KiVerifierRegistry } from './registry';
+export { KiVerificationService } from './service';
+export { createEsqlVerifier } from './verifiers/esql_verifier';
+
+export const createKiVerificationService = (): KiVerificationService => {
+  const registry = new KiVerifierRegistry();
+  registry.register(createEsqlVerifier());
+  return new KiVerificationService(registry);
+};

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
@@ -17,6 +17,7 @@ export type {
   KiVerificationLogger,
   KiVerifier,
   KiVerificationSummary,
+  KiVerificationVerdict,
 } from './types';
 export { KiVerifierRegistry } from './registry';
 export { KiVerificationService } from './service';

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KiVerifier } from './types';
+
+export class KiVerifierRegistry {
+  private readonly verifiers = new Map<string, KiVerifier>();
+
+  register(verifier: KiVerifier): void {
+    if (this.verifiers.has(verifier.id)) {
+      throw new Error(`KI verifier '${verifier.id}' is already registered`);
+    }
+    this.verifiers.set(verifier.id, verifier);
+  }
+
+  getAll(): KiVerifier[] {
+    return [...this.verifiers.values()];
+  }
+}

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.test.ts
@@ -33,32 +33,48 @@ describe('KiVerificationService', () => {
     return new KiVerificationService(registry);
   };
 
-  it('returns valid when all verifiers pass', async () => {
+  it('returns a valid verdict when all verifiers pass', async () => {
     const service = makeService([makeVerifier('a', 'valid'), makeVerifier('b', 'valid')]);
 
     const summary = await service.verify({}, context);
 
-    expect(summary.valid).toBe(true);
+    expect(summary.verdict).toBe('valid');
     expect(summary.results).toHaveLength(2);
   });
 
-  it('returns invalid when any verifier fails', async () => {
+  it('returns an invalid verdict when any verifier fails', async () => {
     const service = makeService([makeVerifier('a', 'valid'), makeVerifier('b', 'invalid')]);
 
     const summary = await service.verify({}, context);
 
-    expect(summary.valid).toBe(false);
+    expect(summary.verdict).toBe('invalid');
   });
 
-  it('does not count skipped verifiers against validity', async () => {
+  it('does not count skipped verifiers against the verdict', async () => {
     const service = makeService([makeVerifier('a', 'skipped'), makeVerifier('b', 'valid')]);
 
     const summary = await service.verify({}, context);
 
-    expect(summary.valid).toBe(true);
+    expect(summary.verdict).toBe('valid');
   });
 
-  it('records a throwing verifier as invalid without throwing and logs a warning', async () => {
+  it('returns an indeterminate verdict when a verifier errors and none report invalid', async () => {
+    const service = makeService([makeVerifier('a', 'valid'), makeVerifier('b', 'error')]);
+
+    const summary = await service.verify({}, context);
+
+    expect(summary.verdict).toBe('indeterminate');
+  });
+
+  it('reports invalid over indeterminate when both occur', async () => {
+    const service = makeService([makeVerifier('a', 'error'), makeVerifier('b', 'invalid')]);
+
+    const summary = await service.verify({}, context);
+
+    expect(summary.verdict).toBe('invalid');
+  });
+
+  it('records a throwing verifier as error without throwing and logs a warning', async () => {
     const throwing: KiVerifier = {
       id: 'broken',
       verify: jest.fn().mockRejectedValue(new Error('boom')),
@@ -67,10 +83,10 @@ describe('KiVerificationService', () => {
 
     const summary = await service.verify({}, context);
 
-    expect(summary.valid).toBe(false);
+    expect(summary.verdict).toBe('indeterminate');
     expect(summary.results[0]).toEqual({
       verifier: 'broken',
-      status: 'invalid',
+      status: 'error',
       messages: ['boom'],
     });
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { KiVerifierRegistry } from './registry';
+import { KiVerificationService } from './service';
+import type { KiVerifier, KiVerifierContext, KiVerifierStatus } from './types';
+
+const makeVerifier = (id: string, status: KiVerifierStatus): KiVerifier => ({
+  id,
+  verify: jest.fn().mockResolvedValue({ verifier: id, status, messages: [] }),
+});
+
+describe('KiVerificationService', () => {
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let context: KiVerifierContext;
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    context = {
+      esClient: elasticsearchServiceMock.createElasticsearchClient(),
+      logger,
+    };
+  });
+
+  const makeService = (verifiers: KiVerifier[]): KiVerificationService => {
+    const registry = new KiVerifierRegistry();
+    verifiers.forEach((verifier) => registry.register(verifier));
+    return new KiVerificationService(registry);
+  };
+
+  it('returns valid when all verifiers pass', async () => {
+    const service = makeService([makeVerifier('a', 'valid'), makeVerifier('b', 'valid')]);
+
+    const summary = await service.verify({}, context);
+
+    expect(summary.valid).toBe(true);
+    expect(summary.results).toHaveLength(2);
+  });
+
+  it('returns invalid when any verifier fails', async () => {
+    const service = makeService([makeVerifier('a', 'valid'), makeVerifier('b', 'invalid')]);
+
+    const summary = await service.verify({}, context);
+
+    expect(summary.valid).toBe(false);
+  });
+
+  it('does not count skipped verifiers against validity', async () => {
+    const service = makeService([makeVerifier('a', 'skipped'), makeVerifier('b', 'valid')]);
+
+    const summary = await service.verify({}, context);
+
+    expect(summary.valid).toBe(true);
+  });
+
+  it('records a throwing verifier as invalid without throwing and logs a warning', async () => {
+    const throwing: KiVerifier = {
+      id: 'broken',
+      verify: jest.fn().mockRejectedValue(new Error('boom')),
+    };
+    const service = makeService([throwing, makeVerifier('a', 'valid')]);
+
+    const summary = await service.verify({}, context);
+
+    expect(summary.valid).toBe(false);
+    expect(summary.results[0]).toEqual({
+      verifier: 'broken',
+      status: 'invalid',
+      messages: ['boom'],
+    });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('preserves registration order in results', async () => {
+    const service = makeService([
+      makeVerifier('first', 'valid'),
+      makeVerifier('second', 'skipped'),
+      makeVerifier('third', 'invalid'),
+    ]);
+
+    const summary = await service.verify({}, context);
+
+    expect(summary.results.map(({ verifier }) => verifier)).toEqual(['first', 'second', 'third']);
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.ts
@@ -28,12 +28,15 @@ export class KiVerificationService {
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         context.logger.warn(`KI verifier '${verifier.id}' failed: ${errorMessage}`);
-        results.push({ verifier: verifier.id, status: 'invalid', messages: [errorMessage] });
+        results.push({ verifier: verifier.id, status: 'error', messages: [errorMessage] });
       }
     }
 
+    const hasInvalid = results.some((result) => result.status === 'invalid');
+    const hasError = results.some((result) => result.status === 'error');
+
     return {
-      valid: results.every((result) => result.status !== 'invalid'),
+      verdict: hasInvalid ? 'invalid' : hasError ? 'indeterminate' : 'valid',
       results,
     };
   }

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KiVerifierRegistry } from './registry';
+import type {
+  KiVerificationSummary,
+  KiVerifierContext,
+  KiVerifierResult,
+  KnowledgeItemCandidate,
+} from './types';
+
+export class KiVerificationService {
+  constructor(private readonly registry: KiVerifierRegistry) {}
+
+  async verify(
+    ki: KnowledgeItemCandidate,
+    context: KiVerifierContext
+  ): Promise<KiVerificationSummary> {
+    const results: KiVerifierResult[] = [];
+
+    for (const verifier of this.registry.getAll()) {
+      try {
+        results.push(await verifier.verify(ki, context));
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        context.logger.warn(`KI verifier '${verifier.id}' failed: ${errorMessage}`);
+        results.push({ verifier: verifier.id, status: 'invalid', messages: [errorMessage] });
+      }
+    }
+
+    return {
+      valid: results.every((result) => result.status !== 'invalid'),
+      results,
+    };
+  }
+}

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/types.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+/**
+ * A candidate knowledge item (KI) to verify before it is persisted to an AI
+ * index. The fields mirror the base AI index mappings (`ai-index@mappings`).
+ */
+export interface KnowledgeItemCandidate {
+  type?: string;
+  title?: string;
+  description?: string;
+  content?: string;
+  tags?: string[];
+  attributes?: Record<string, unknown>;
+}
+
+export type KiVerifierStatus = 'valid' | 'invalid' | 'skipped';
+
+export interface KiVerifierResult {
+  /** Id of the verifier that produced this result. */
+  verifier: string;
+  /**
+   * `valid` when all checks passed, `invalid` when at least one check failed,
+   * and `skipped` when the verifier does not apply to the KI.
+   */
+  status: KiVerifierStatus;
+  messages: string[];
+}
+
+/**
+ * Minimal logger contract, satisfied by both core `Logger` and the workflow
+ * step handler logger.
+ */
+export interface KiVerificationLogger {
+  warn(message: string): void;
+}
+
+export interface KiVerifierContext {
+  esClient: ElasticsearchClient;
+  logger: KiVerificationLogger;
+  abortSignal?: AbortSignal;
+}
+
+export interface KiVerifier {
+  readonly id: string;
+  verify(ki: KnowledgeItemCandidate, context: KiVerifierContext): Promise<KiVerifierResult>;
+}
+
+export interface KiVerificationSummary {
+  /** `false` when any verifier reported `invalid`. */
+  valid: boolean;
+  results: KiVerifierResult[];
+}

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/types.ts
@@ -20,14 +20,15 @@ export interface KnowledgeItemCandidate {
   attributes?: Record<string, unknown>;
 }
 
-export type KiVerifierStatus = 'valid' | 'invalid' | 'skipped';
+export type KiVerifierStatus = 'valid' | 'invalid' | 'skipped' | 'error';
 
 export interface KiVerifierResult {
   /** Id of the verifier that produced this result. */
   verifier: string;
   /**
    * `valid` when all checks passed, `invalid` when at least one check failed,
-   * and `skipped` when the verifier does not apply to the KI.
+   * `skipped` when the verifier does not apply to the KI, and `error` when the
+   * verifier could not complete its check (no judgment on the KI).
    */
   status: KiVerifierStatus;
   messages: string[];
@@ -52,8 +53,14 @@ export interface KiVerifier {
   verify(ki: KnowledgeItemCandidate, context: KiVerifierContext): Promise<KiVerifierResult>;
 }
 
+/**
+ * `invalid` when any verifier reported the KI as invalid, `indeterminate` when
+ * no verifier reported invalid but at least one could not complete its check,
+ * `valid` otherwise.
+ */
+export type KiVerificationVerdict = 'valid' | 'invalid' | 'indeterminate';
+
 export interface KiVerificationSummary {
-  /** `false` when any verifier reported `invalid`. */
-  valid: boolean;
+  verdict: KiVerificationVerdict;
   results: KiVerifierResult[];
 }

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/verifiers/esql_verifier.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/verifiers/esql_verifier.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { errors } from '@elastic/elasticsearch';
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { createEsqlVerifier } from './esql_verifier';
 import type { KiVerifierContext } from '../types';
@@ -46,8 +47,16 @@ describe('createEsqlVerifier', () => {
     expect(esClient.esql.query).not.toHaveBeenCalled();
   });
 
-  it('returns invalid when execution against Elasticsearch fails', async () => {
-    esClient.esql.query.mockRejectedValue(new Error('index_not_found_exception'));
+  it('returns invalid when Elasticsearch rejects the query with a 400', async () => {
+    esClient.esql.query.mockRejectedValue(
+      new errors.ResponseError({
+        statusCode: 400,
+        headers: {},
+        meta: {} as never,
+        body: { error: { type: 'verification_exception', reason: 'Unknown index [my-index]' } },
+        warnings: null,
+      })
+    );
 
     const result = await verifier.verify(
       { content: '```esql\nFROM my-index | LIMIT 10\n```' },
@@ -55,7 +64,59 @@ describe('createEsqlVerifier', () => {
     );
 
     expect(result.status).toBe('invalid');
-    expect(result.messages[0]).toContain('index_not_found_exception');
+    expect(result.messages[0]).toContain('Invalid ES|QL query');
+  });
+
+  it('returns error when execution fails for reasons other than query rejection', async () => {
+    esClient.esql.query.mockRejectedValue(
+      new errors.ResponseError({
+        statusCode: 403,
+        headers: {},
+        meta: {} as never,
+        body: { error: { type: 'security_exception', reason: 'action unauthorized' } },
+        warnings: null,
+      })
+    );
+
+    const result = await verifier.verify(
+      { content: '```esql\nFROM my-index | LIMIT 10\n```' },
+      context
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.messages[0]).toContain('Could not verify ES|QL query');
+  });
+
+  it('returns error when execution fails with a non-response error', async () => {
+    esClient.esql.query.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const result = await verifier.verify(
+      { content: '```esql\nFROM my-index | LIMIT 10\n```' },
+      context
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.messages[0]).toContain('ECONNREFUSED');
+  });
+
+  it('reports invalid over error when different queries fail differently', async () => {
+    esClient.esql.query.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const result = await verifier.verify(
+      {
+        content: [
+          '```esql',
+          'FROM my-index | LIMIT 10',
+          '```',
+          '```esql',
+          'FROM | WHERE',
+          '```',
+        ].join('\n'),
+      },
+      context
+    );
+
+    expect(result.status).toBe('invalid');
   });
 
   it('returns skipped when the KI contains no ES|QL', async () => {

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/verifiers/esql_verifier.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/verifiers/esql_verifier.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { createEsqlVerifier } from './esql_verifier';
+import type { KiVerifierContext } from '../types';
+
+describe('createEsqlVerifier', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+  let context: KiVerifierContext;
+  const verifier = createEsqlVerifier();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+    context = {
+      esClient,
+      logger: loggingSystemMock.createLogger(),
+    };
+  });
+
+  it('returns valid for a fenced block with a valid query and executes it with LIMIT 0', async () => {
+    const result = await verifier.verify(
+      { content: 'Use this query:\n```esql\nFROM my-index | LIMIT 10\n```\n' },
+      context
+    );
+
+    expect(result.status).toBe('valid');
+    expect(result.messages).toEqual(['Verified 1 ES|QL query(ies)']);
+    expect(esClient.esql.query).toHaveBeenCalledWith(
+      { query: 'FROM my-index | LIMIT 10\n| LIMIT 0' },
+      expect.objectContaining({ requestTimeout: '10s' })
+    );
+  });
+
+  it('returns invalid for a syntactically invalid query without executing it', async () => {
+    const result = await verifier.verify({ content: '```esql\nFROM | WHERE\n```' }, context);
+
+    expect(result.status).toBe('invalid');
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toContain('FROM | WHERE');
+    expect(esClient.esql.query).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid when execution against Elasticsearch fails', async () => {
+    esClient.esql.query.mockRejectedValue(new Error('index_not_found_exception'));
+
+    const result = await verifier.verify(
+      { content: '```esql\nFROM my-index | LIMIT 10\n```' },
+      context
+    );
+
+    expect(result.status).toBe('invalid');
+    expect(result.messages[0]).toContain('index_not_found_exception');
+  });
+
+  it('returns skipped when the KI contains no ES|QL', async () => {
+    const result = await verifier.verify(
+      { title: 'No queries here', content: 'Just some text.' },
+      context
+    );
+
+    expect(result).toEqual({
+      verifier: 'esql',
+      status: 'skipped',
+      messages: ['No ES|QL queries found in knowledge item'],
+    });
+    expect(esClient.esql.query).not.toHaveBeenCalled();
+  });
+
+  it('verifies a query from attributes.esql', async () => {
+    const result = await verifier.verify(
+      { attributes: { esql: 'FROM my-index | LIMIT 10' } },
+      context
+    );
+
+    expect(result.status).toBe('valid');
+    expect(esClient.esql.query).toHaveBeenCalledWith(
+      { query: 'FROM my-index | LIMIT 10\n| LIMIT 0' },
+      expect.objectContaining({ requestTimeout: '10s' })
+    );
+  });
+
+  it('returns invalid when one of multiple fenced blocks is broken', async () => {
+    const result = await verifier.verify(
+      {
+        content: [
+          '```esql',
+          'FROM my-index | LIMIT 10',
+          '```',
+          'And a broken one:',
+          '```esql',
+          'FROM | WHERE',
+          '```',
+        ].join('\n'),
+      },
+      context
+    );
+
+    expect(result.status).toBe('invalid');
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toContain('FROM | WHERE');
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/verifiers/esql_verifier.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/verifiers/esql_verifier.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { errors } from '@elastic/elasticsearch';
 import { validateQuery } from '@kbn/esql-language';
 import type {
   KiVerifier,
@@ -35,10 +36,18 @@ const extractQueries = (ki: KnowledgeItemCandidate): string[] => {
   return queries;
 };
 
-const verifyQuery = async (query: string, context: KiVerifierContext): Promise<string[]> => {
-  const { errors } = await validateQuery(query);
-  if (errors.length > 0) {
-    return errors.map((error) => ('text' in error ? error.text : error.message));
+interface QueryCheck {
+  outcome: 'valid' | 'invalid' | 'error';
+  messages: string[];
+}
+
+const checkQuery = async (query: string, context: KiVerifierContext): Promise<QueryCheck> => {
+  const { errors: validationErrors } = await validateQuery(query);
+  if (validationErrors.length > 0) {
+    return {
+      outcome: 'invalid',
+      messages: validationErrors.map((error) => ('text' in error ? error.text : error.message)),
+    };
   }
 
   try {
@@ -46,9 +55,17 @@ const verifyQuery = async (query: string, context: KiVerifierContext): Promise<s
       { query: `${query}\n| LIMIT 0` },
       { signal: context.abortSignal, requestTimeout: '10s' }
     );
-    return [];
+    return { outcome: 'valid', messages: [] };
   } catch (error) {
-    return [error instanceof Error ? error.message : String(error)];
+    const message = error instanceof Error ? error.message : String(error);
+    // A 400 means Elasticsearch rejected the query itself (parsing or
+    // verification, e.g. an unknown index or column), so the KI is invalid.
+    // Anything else (auth, timeouts, availability) means the check could not
+    // be completed and is no judgment on the KI.
+    if (error instanceof errors.ResponseError && error.statusCode === 400) {
+      return { outcome: 'invalid', messages: [message] };
+    }
+    return { outcome: 'error', messages: [message] };
   }
 };
 
@@ -66,15 +83,21 @@ export const createEsqlVerifier = (): KiVerifier => ({
     }
 
     const failures: string[] = [];
+    const checkErrors: string[] = [];
     for (const query of queries) {
-      const errorMessages = await verifyQuery(query, context);
-      if (errorMessages.length > 0) {
-        failures.push(`Invalid ES|QL query "${query}": ${errorMessages.join('; ')}`);
+      const { outcome, messages } = await checkQuery(query, context);
+      if (outcome === 'invalid') {
+        failures.push(`Invalid ES|QL query "${query}": ${messages.join('; ')}`);
+      } else if (outcome === 'error') {
+        checkErrors.push(`Could not verify ES|QL query "${query}": ${messages.join('; ')}`);
       }
     }
 
     if (failures.length > 0) {
       return { verifier: 'esql', status: 'invalid', messages: failures };
+    }
+    if (checkErrors.length > 0) {
+      return { verifier: 'esql', status: 'error', messages: checkErrors };
     }
 
     return {

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/verifiers/esql_verifier.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/verifiers/esql_verifier.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateQuery } from '@kbn/esql-language';
+import type {
+  KiVerifier,
+  KiVerifierContext,
+  KiVerifierResult,
+  KnowledgeItemCandidate,
+} from '../types';
+
+const ESQL_FENCED_BLOCK_REGEX = /```esql\s*\n([\s\S]*?)```/gi;
+
+const extractQueries = (ki: KnowledgeItemCandidate): string[] => {
+  const queries: string[] = [];
+
+  const attributeQuery = ki.attributes?.esql;
+  if (typeof attributeQuery === 'string' && attributeQuery.trim().length > 0) {
+    queries.push(attributeQuery.trim());
+  }
+
+  if (ki.content) {
+    for (const match of ki.content.matchAll(ESQL_FENCED_BLOCK_REGEX)) {
+      const query = match[1].trim();
+      if (query.length > 0) {
+        queries.push(query);
+      }
+    }
+  }
+
+  return queries;
+};
+
+const verifyQuery = async (query: string, context: KiVerifierContext): Promise<string[]> => {
+  const { errors } = await validateQuery(query);
+  if (errors.length > 0) {
+    return errors.map((error) => ('text' in error ? error.text : error.message));
+  }
+
+  try {
+    await context.esClient.esql.query(
+      { query: `${query}\n| LIMIT 0` },
+      { signal: context.abortSignal, requestTimeout: '10s' }
+    );
+    return [];
+  } catch (error) {
+    return [error instanceof Error ? error.message : String(error)];
+  }
+};
+
+export const createEsqlVerifier = (): KiVerifier => ({
+  id: 'esql',
+  async verify(ki, context): Promise<KiVerifierResult> {
+    const queries = extractQueries(ki);
+
+    if (queries.length === 0) {
+      return {
+        verifier: 'esql',
+        status: 'skipped',
+        messages: ['No ES|QL queries found in knowledge item'],
+      };
+    }
+
+    const failures: string[] = [];
+    for (const query of queries) {
+      const errorMessages = await verifyQuery(query, context);
+      if (errorMessages.length > 0) {
+        failures.push(`Invalid ES|QL query "${query}": ${errorMessages.join('; ')}`);
+      }
+    }
+
+    if (failures.length > 0) {
+      return { verifier: 'esql', status: 'invalid', messages: failures };
+    }
+
+    return {
+      verifier: 'esql',
+      status: 'valid',
+      messages: [`Verified ${queries.length} ES|QL query(ies)`],
+    };
+  },
+});

--- a/x-pack/platform/plugins/shared/context_engine/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/plugin.ts
@@ -43,7 +43,16 @@ export class ContextEnginePlugin
   ): ContextEnginePluginSetup {
     registerFeatures({ features: setupDeps.features });
 
-    registerWorkflowSteps(setupDeps.workflowsExtensions);
+    registerWorkflowSteps({
+      workflowsExtensions: setupDeps.workflowsExtensions,
+      isContextEngineEnabled: async (request) => {
+        const [coreStart] = await coreSetup.getStartServices();
+        const uiSettings = coreStart.uiSettings.asScopedToClient(
+          coreStart.savedObjects.getScopedClient(request)
+        );
+        return (await uiSettings.get<boolean>(CONTEXT_ENGINE_ENABLED_SETTING_ID)) ?? false;
+      },
+    });
 
     const router = coreSetup.http.createRouter();
     registerAiIndexRoutes({

--- a/x-pack/platform/plugins/shared/context_engine/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/plugin.ts
@@ -15,6 +15,7 @@ import type {
   ContextEngineStartDependencies,
 } from './types';
 import { registerFeatures } from './features';
+import { registerWorkflowSteps } from './step_types';
 import { registerAiIndexRoutes } from './routes/ai_indices';
 import { AiIndexService } from './ai_indices/service';
 import { AiIndexRegistry } from './ai_indices/registry';
@@ -41,6 +42,8 @@ export class ContextEnginePlugin
     setupDeps: ContextEngineSetupDependencies
   ): ContextEnginePluginSetup {
     registerFeatures({ features: setupDeps.features });
+
+    registerWorkflowSteps(setupDeps.workflowsExtensions);
 
     const router = coreSetup.http.createRouter();
     registerAiIndexRoutes({

--- a/x-pack/platform/plugins/shared/context_engine/server/step_types/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/step_types/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+
+export function registerWorkflowSteps(
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup
+): void {
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./verify_ki_step').then((m) => m.verifyKiStepDefinition)
+  );
+}

--- a/x-pack/platform/plugins/shared/context_engine/server/step_types/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/step_types/index.ts
@@ -6,11 +6,17 @@
  */
 
 import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import type { VerifyKiStepDependencies } from './verify_ki_step';
 
-export function registerWorkflowSteps(
-  workflowsExtensions: WorkflowsExtensionsServerPluginSetup
-): void {
+export function registerWorkflowSteps({
+  workflowsExtensions,
+  isContextEngineEnabled,
+}: VerifyKiStepDependencies & {
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
+}): void {
   workflowsExtensions.registerStepDefinition(() =>
-    import('./verify_ki_step').then((m) => m.verifyKiStepDefinition)
+    import('./verify_ki_step').then((m) =>
+      m.createVerifyKiStepDefinition({ isContextEngineEnabled })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/context_engine/server/step_types/verify_ki_step.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/step_types/verify_ki_step.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { verifyKiStepCommonDefinition } from '../../common/step_types/verify_ki_step';
+import { createKiVerificationService } from '../ki_verification';
+
+/**
+ * Verify KI step server-side definition.
+ *
+ * Runs the registered knowledge item verifiers against the candidate KI and
+ * returns the verification summary. Verification failures are reported in the
+ * step output rather than as step errors, so workflows can branch on `valid`.
+ */
+export const verifyKiStepDefinition = createServerStepDefinition({
+  ...verifyKiStepCommonDefinition,
+  handler: async (context) => {
+    const service = createKiVerificationService();
+    const output = await service.verify(context.input.ki, {
+      esClient: context.contextManager.getScopedEsClient(),
+      logger: context.logger,
+      abortSignal: context.abortSignal,
+    });
+    return { output };
+  },
+});

--- a/x-pack/platform/plugins/shared/context_engine/server/step_types/verify_ki_step.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/step_types/verify_ki_step.ts
@@ -5,26 +5,46 @@
  * 2.0.
  */
 
+import type { KibanaRequest } from '@kbn/core/server';
+import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { ExecutionError } from '@kbn/workflows/server';
 import { verifyKiStepCommonDefinition } from '../../common/step_types/verify_ki_step';
 import { createKiVerificationService } from '../ki_verification';
+
+export interface VerifyKiStepDependencies {
+  isContextEngineEnabled: (request: KibanaRequest) => Promise<boolean>;
+}
 
 /**
  * Verify KI step server-side definition.
  *
  * Runs the registered knowledge item verifiers against the candidate KI and
  * returns the verification summary. Verification failures are reported in the
- * step output rather than as step errors, so workflows can branch on `valid`.
+ * step output rather than as step errors, so workflows can branch on `verdict`.
  */
-export const verifyKiStepDefinition = createServerStepDefinition({
-  ...verifyKiStepCommonDefinition,
-  handler: async (context) => {
-    const service = createKiVerificationService();
-    const output = await service.verify(context.input.ki, {
-      esClient: context.contextManager.getScopedEsClient(),
-      logger: context.logger,
-      abortSignal: context.abortSignal,
-    });
-    return { output };
-  },
-});
+export const createVerifyKiStepDefinition = ({
+  isContextEngineEnabled,
+}: VerifyKiStepDependencies) =>
+  createServerStepDefinition({
+    ...verifyKiStepCommonDefinition,
+    handler: async (context) => {
+      const isEnabled = await isContextEngineEnabled(context.contextManager.getFakeRequest());
+      if (!isEnabled) {
+        return {
+          error: new ExecutionError({
+            type: 'ContextEngineDisabledError',
+            message: `The Context Engine is disabled. Enable the '${CONTEXT_ENGINE_ENABLED_SETTING_ID}' advanced setting to use this step.`,
+          }),
+        };
+      }
+
+      const service = createKiVerificationService();
+      const output = await service.verify(context.input.ki, {
+        esClient: context.contextManager.getScopedEsClient(),
+        logger: context.logger,
+        abortSignal: context.abortSignal,
+      });
+      return { output };
+    },
+  });

--- a/x-pack/platform/plugins/shared/context_engine/server/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/types.ts
@@ -7,6 +7,7 @@
 
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
 import type { AiIndexProperties } from '../common/http_api/ai_indices';
 
 export interface ContextEnginePluginSetup {
@@ -18,6 +19,7 @@ export interface ContextEnginePluginStart {}
 
 export interface ContextEngineSetupDependencies {
   features: FeaturesPluginSetup;
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
 }
 
 export interface ContextEngineStartDependencies {

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -30,6 +30,7 @@
     "@kbn/i18n-react",
     "@kbn/kibana-react-plugin",
     "@kbn/esql",
+    "@kbn/esql-language",
     "@kbn/es-query",
     "@kbn/share-plugin",
     "@kbn/triggers-actions-ui-plugin",
@@ -40,6 +41,9 @@
     "@kbn/deeplinks-workflows",
     "@kbn/deeplinks-management",
     "@kbn/code-editor",
-    "@kbn/ui-callout"
+    "@kbn/ui-callout",
+    "@kbn/workflows",
+    "@kbn/workflows-extensions",
+    "@kbn/zod"
   ]
 }


### PR DESCRIPTION
## Summary

POC for the M2 "verify before persist" requirement of the KI Schema, Lifecycle & Verification workstream: candidate knowledge items (KIs) are verified by a workflow step before they are persisted to an AI index, and KIs that fail verification are never written.

What's included (all in `x-pack/platform/plugins/shared/context_engine`):

- **Rule-based KI verification framework** (`server/ki_verification/`): `KiVerifierRegistry` to register verifiers, `KiVerificationService` to apply them to a candidate KI, and the first verifier:
  - **ES|QL verifier** — extracts ES|QL from fenced ` ```esql ` blocks in the KI `content` and from the `esql` attribute, validates each query parses (`validateQuery` from `@kbn/esql-language`, no round-trip), then confirms it executes (`<query> | LIMIT 0` must succeed, even with empty results).
- **`context-engine.verifyKi` workflow step** (registered via `@kbn/workflows-extensions`): runs the verifiers against a candidate KI and outputs `{ valid, results }`. Verification failure is step output, not a step error, so KI-creation workflows branch on `valid` to gate persistence. Opt-in per workflow.
- **Demo** (`dev_docs/verify_ki_poc.md`): a workflow that processes two candidate KIs (one valid, one with ES|QL that doesn't parse); only the valid one is persisted to the AI index backing index.

By design (POC scope decisions):
- No verification metadata is written to the KI record.
- No retrieval-side changes: with verify-before-persist, everything in the AI index passed verification by construction.
- On-demand re-verification, sweeps for externally added KIs, and stale handling are out of scope.

Not included (required before merge): the workflows step-definition approval file (`workflows_extensions` Scout gate) and workflows-eng sign-off.

### Checklist

- [x] Unit tests added for the verification framework and ES|QL verifier (11 tests; full plugin suite passes: 374/374)
- [x] i18n added for step label/description/documentation
- [ ] Step definition approval file + `@elastic/workflows-eng` review (intentionally deferred; POC)

### Identify risks

POC only — not intended to merge as-is. The new workflow step is registered behind the existing `workflowsExtensions` registration flow and is inert unless used in a workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)